### PR TITLE
ci: add test, fmt and clippy jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+          toolchain: stable
           override: true
           components: rustfmt
       - uses: Swatinem/rust-cache@v1
@@ -52,3 +53,17 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+  dep-sort:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - run: |
+          cargo install cargo-sort
+          cargo sort --check


### PR DESCRIPTION
Currently each step is a separate job. The downside is that this requires a checkout and build for each job. This shouldn't be too expensive currently since our project is small and we use caching. We can monitor and see how bad this is, but I expect it to take a few minutes max.

Positives are that the jobs run in parallel and make it easier what failed on the dashboard.

Currently only executes on Ubuntu, we can expand this to a matrix once we know what we need to support.