### PR TITLE
fix(sequencer::Client): fix bugs exposed in fuzz tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.44"
-bigdecimal = { version = "0.2.0", features = ["serde"] }
+bigdecimal = { version = "0.3.0", features = ["serde"] }
 clap = "2.33.3"
 enum-iterator = "0.7.0"
 hex = "0.4.3"

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -27,7 +27,7 @@ pub fn parse_cmd_line() -> (Option<String>, ConfigBuilder) {
 }
 
 /// A wrapper around [clap::App]'s `get_matches_from_safe()` which returns
-/// a [ConfigOptions].
+/// a [ConfigOption].
 fn parse_args<I, T>(args: I) -> clap::Result<(Option<String>, ConfigBuilder)>
 where
     I: IntoIterator<Item = T>,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -56,9 +56,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_block_by_hash_latest() {
+    async fn get_block_by_hash_earliest_latest() {
         let (srv, addr) = build_server();
         spawn_server(srv).await;
+        client(addr)
+            .get_block_by_hash("earliest".to_owned())
+            .await
+            .expect("Call failed");
         client(addr)
             .get_block_by_hash("latest".to_owned())
             .await
@@ -81,15 +85,19 @@ mod tests {
         let (srv, addr) = build_server();
         spawn_server(srv).await;
         client(addr)
+            .get_block_by_number("earliest".to_owned())
+            .await
+            .expect("Call failed");
+        client(addr)
             .get_block_by_number("latest".to_owned())
             .await
             .expect("Call failed");
         client(addr)
-            .get_block_by_number("0x1000".to_owned())
+            .get_block_by_number("0x4e58".to_owned())
             .await
             .expect("Call failed");
         client(addr)
-            .get_block_by_number("0xa38e".to_owned())
+            .get_block_by_number("0xaadc".to_owned())
             .await
             .expect("Call failed");
     }
@@ -109,16 +117,31 @@ mod tests {
     async fn get_transaction_by_number() {
         let (srv, addr) = build_server();
         spawn_server(srv).await;
+        // An example of a rejected txn
         client(addr)
-            .get_transaction_by_number("0x23c86".to_owned())
+            .get_transaction_by_number("0x27ae3".to_owned())
+            .await
+            .expect("Call failed");
+        // Txn containing a L1 to L2 message
+        client(addr)
+            .get_transaction_by_number("0x2d98c".to_owned())
+            .await
+            .expect("Call failed");
+        // A quite recent txn
+        client(addr)
+            .get_transaction_by_number("0x43967".to_owned())
             .await
             .expect("Call failed");
     }
 
     #[tokio::test]
-    async fn get_transaction_by_latest_block_hash_and_index() {
+    async fn get_transaction_by_earliest_latest_block_hash_and_index() {
         let (srv, addr) = build_server();
         spawn_server(srv).await;
+        client(addr)
+            .get_transaction_by_block_hash_and_index("earliest".to_owned(), 0)
+            .await
+            .expect("Call failed");
         client(addr)
             .get_transaction_by_block_hash_and_index("latest".to_owned(), 0)
             .await
@@ -140,6 +163,10 @@ mod tests {
     async fn get_transaction_by_block_number_and_index() {
         let (srv, addr) = build_server();
         spawn_server(srv).await;
+        client(addr)
+            .get_transaction_by_block_number_and_index("earliest".to_owned(), 0)
+            .await
+            .expect("Call failed");
         client(addr)
             .get_transaction_by_block_number_and_index("latest".to_owned(), 0)
             .await

--- a/src/sequencer.rs
+++ b/src/sequencer.rs
@@ -147,14 +147,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn block_by_id_and_latest() {
-        let client = client();
-        client
-            .block(U256::from(17187))
+    async fn latest_block() {
+        client()
+            .latest_block()
             .await
             .expect("Correctly deserialized reply");
-        client
-            .latest_block()
+    }
+
+    #[tokio::test]
+    async fn block() {
+        // The genesis block, previous_block_id is -1
+        client()
+            .block(U256::zero())
+            .await
+            .expect("Correctly deserialized reply");
+        // This block contains a txn which includes a L1 to L2 message
+        client()
+            .block(U256::from(20056))
+            .await
+            .expect("Correctly deserialized reply");
+        // A quite recent block
+        client()
+            .block(U256::from(43740))
             .await
             .expect("Correctly deserialized reply");
     }
@@ -210,16 +224,48 @@ mod tests {
 
     #[tokio::test]
     async fn transaction() {
+        // The first txn
         client()
-            .transaction(U256::from(146566))
+            .transaction(U256::zero())
+            .await
+            .expect("Correctly deserialized reply");
+        // An example of a rejected txn
+        client()
+            .transaction(U256::from(162531))
+            .await
+            .expect("Correctly deserialized reply");
+        // Txn containing a L1 to L2 message
+        client()
+            .transaction(U256::from(186764))
+            .await
+            .expect("Correctly deserialized reply");
+        // A quite recent txn
+        client()
+            .transaction(U256::from(276839))
             .await
             .expect("Correctly deserialized reply");
     }
 
     #[tokio::test]
     async fn transaction_status() {
+        // The first txn
         client()
-            .transaction_status(U256::from(146566))
+            .transaction_status(U256::zero())
+            .await
+            .expect("Correctly deserialized reply");
+        // An example of a rejected txn
+        client()
+            .transaction_status(U256::from(162531))
+            .await
+            .expect("Correctly deserialized reply");
+        // Txn containing a L1 to L2 message
+        client()
+            .transaction_status(U256::from(186764))
+            .await
+            .expect("Correctly deserialized reply");
+        // A quite recent txn
+        client()
+            .transaction_status(U256::from(276839))
             .await
             .expect("Correctly deserialized reply");
     }


### PR DESCRIPTION
Plug the holes in the client which were exposed when running naive fuzz tests. Some fields are used in rare circumstances like rejecting a transaction.