### PR TITLE
feat: added Ethereum RPC error codes

### DIFF
--- a/src/ethereum.rs
+++ b/src/ethereum.rs
@@ -5,6 +5,65 @@ use web3::types::{BlockNumber, H256};
 pub mod contract;
 pub mod starknet;
 
+/// List of semi-official Ethereum RPC errors taken from EIP-1474 (which is stagnant).
+///
+/// The issue of standardizing the Ethereum RPC seems to now be taking
+/// place here: https://github.com/eea-oasis/eth1.x-JSON-RPC-API-standard/issues.
+///
+/// EIP-1474:
+///     https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md#error-codes
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum RpcErrorCode {
+    ParseError,
+    InvalidRequest,
+    MethodNotFound,
+    InvalidParams,
+    InternalError,
+    InvalidInput,
+    ResourceNotFound,
+    ResourceUnavailable,
+    TransactionRejected,
+    MethodNotSupported,
+    LimitExceeded,
+    JsonRpcVersion,
+}
+
+impl RpcErrorCode {
+    pub fn code(&self) -> i64 {
+        match self {
+            RpcErrorCode::ParseError => -32700,
+            RpcErrorCode::InvalidRequest => -32600,
+            RpcErrorCode::MethodNotFound => -32601,
+            RpcErrorCode::InvalidParams => -32602,
+            RpcErrorCode::InternalError => -32603,
+            RpcErrorCode::InvalidInput => -32000,
+            RpcErrorCode::ResourceNotFound => -32001,
+            RpcErrorCode::ResourceUnavailable => -32002,
+            RpcErrorCode::TransactionRejected => -32003,
+            RpcErrorCode::MethodNotSupported => -32004,
+            RpcErrorCode::LimitExceeded => -32005,
+            RpcErrorCode::JsonRpcVersion => -32006,
+        }
+    }
+
+    pub fn reason(&self) -> &str {
+        match self {
+            RpcErrorCode::ParseError => "Invalid JSON",
+            RpcErrorCode::InvalidRequest => "JSON is not a valid request object",
+            RpcErrorCode::MethodNotFound => "Method does not exist",
+            RpcErrorCode::InvalidParams => "Invalid method parameters",
+            RpcErrorCode::InternalError => "Internal JSON-RPC error",
+            RpcErrorCode::InvalidInput => "Missing or invalid parameters",
+            RpcErrorCode::ResourceNotFound => "Requested resource not found",
+            RpcErrorCode::ResourceUnavailable => "Requested resource not available",
+            RpcErrorCode::TransactionRejected => "Transaction creation failed",
+            RpcErrorCode::MethodNotSupported => "Method is not implemented",
+            RpcErrorCode::LimitExceeded => "Request exceeds defined limit",
+            RpcErrorCode::JsonRpcVersion => "Version of JSON-RPC protocol is not supported",
+        }
+    }
+}
+
 pub enum BlockId {
     Latest,
     Earliest,


### PR DESCRIPTION
Small PR, introducing Ethereum RPC error codes. This primarily just lets us check for query limit exceeded by code, instead of checking the message string. Finding them was painful, so I want to keep them around in-case we need the others at some point.

The RPC error codes themselves are only semi-official -- their EIP is stagnant, but it seems these are followed by most node implementations (and definitely Geth and Infura).