### PR TITLE
state update and transition logs

### DIFF
--- a/examples/fact_retrieval.rs
+++ b/examples/fact_retrieval.rs
@@ -25,7 +25,7 @@
 use std::{collections::HashMap, str::FromStr};
 
 use clap::Arg;
-use pathfinder_lib::ethereum::starknet::{Log, Starknet};
+use pathfinder_lib::ethereum::starknet::{Starknet, StarknetLog};
 use web3::{
     transports::WebSocket,
     types::{BlockNumber, TransactionId, H256},
@@ -57,12 +57,13 @@ async fn main() {
     let mut facts = HashMap::new();
     let mut mempages = HashMap::new();
     logs.into_iter().for_each(|log| match log {
-        Log::Fact(fact) => {
-            facts.insert(fact.hash, fact.mempage_hashes);
+        StarknetLog::Fact(fact) => {
+            facts.insert(fact.data.hash, fact.data.mempage_hashes);
         }
-        Log::Mempage(mempage) => {
-            mempages.insert(mempage.hash, mempage.origin.transaction_hash);
+        StarknetLog::Mempage(mempage) => {
+            mempages.insert(mempage.data.hash, mempage.origin.transaction_hash);
         }
+        _ => {}
     });
 
     // Identify the memory page logs of the fact we are interested in.

--- a/resources/contracts/core_impl.json
+++ b/resources/contracts/core_impl.json
@@ -240,6 +240,13 @@
     },
     {
         "inputs": [],
+        "name": "finalize",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
         "name": "identify",
         "outputs": [
             {
@@ -266,6 +273,19 @@
     },
     {
         "inputs": [],
+        "name": "isFinalized",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
         "name": "isFrozen",
         "outputs": [
             {
@@ -274,7 +294,7 @@
                 "type": "bool"
             }
         ],
-        "stateMutability": "pure",
+        "stateMutability": "view",
         "type": "function"
     },
     {
@@ -335,6 +355,19 @@
         "type": "function"
     },
     {
+        "inputs": [],
+        "name": "programHash",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
         "inputs": [
             {
                 "internalType": "address",
@@ -373,6 +406,19 @@
                 "type": "bytes32"
             }
         ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "newProgramHash",
+                "type": "uint256"
+            }
+        ],
+        "name": "setProgramHash",
+        "outputs": [],
         "stateMutability": "nonpayable",
         "type": "function"
     },
@@ -487,21 +533,14 @@
                 "type": "uint256[]"
             },
             {
-                "components": [
-                    {
-                        "internalType": "uint256",
-                        "name": "onchainDataHash",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "uint256",
-                        "name": "onchainDataSize",
-                        "type": "uint256"
-                    }
-                ],
-                "internalType": "struct OnchainDataFactTreeEncoder.DataAvailabilityFact",
-                "name": "data_availability_fact",
-                "type": "tuple"
+                "internalType": "uint256",
+                "name": "onchainDataHash",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "onchainDataSize",
+                "type": "uint256"
             }
         ],
         "name": "updateState",

--- a/resources/contracts/gps_statement_verifier.json
+++ b/resources/contracts/gps_statement_verifier.json
@@ -1,5 +1,26 @@
 [
     {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "bootloaderProgramContract",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "memoryPageFactRegistry_",
+                "type": "address"
+            },
+            {
+                "internalType": "address[]",
+                "name": "cairoVerifierContracts",
+                "type": "address[]"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
         "anonymous": false,
         "inputs": [
             {
@@ -19,7 +40,84 @@
         "type": "event"
     },
     {
-        "constant": true,
+        "inputs": [],
+        "name": "PAGE_INFO_ADDRESS_OFFSET",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "PAGE_INFO_HASH_OFFSET",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "PAGE_INFO_SIZE",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "PAGE_INFO_SIZE_IN_BYTES",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "PAGE_INFO_SIZE_OFFSET",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "hasRegisteredFact",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
         "inputs": [],
         "name": "identify",
         "outputs": [
@@ -29,8 +127,59 @@
                 "type": "string"
             }
         ],
-        "payable": false,
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "fact",
+                "type": "bytes32"
+            }
+        ],
+        "name": "isValid",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
         "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256[]",
+                "name": "proofParams",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "proof",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "taskMetadata",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "cairoAuxInput",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "cairoVerifierId",
+                "type": "uint256"
+            }
+        ],
+        "name": "verifyProofAndRegister",
+        "outputs": [],
+        "stateMutability": "nonpayable",
         "type": "function"
     }
 ]

--- a/resources/contracts/memory_page_fact_registry.json
+++ b/resources/contracts/memory_page_fact_registry.json
@@ -25,7 +25,63 @@
         "type": "event"
     },
     {
-        "constant": false,
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "factHash",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "memoryHash",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "prod",
+                "type": "uint256"
+            }
+        ],
+        "name": "LogMemoryPageFactRegular",
+        "type": "event"
+    },
+    {
+        "inputs": [],
+        "name": "hasRegisteredFact",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "fact",
+                "type": "bytes32"
+            }
+        ],
+        "name": "isValid",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
         "inputs": [
             {
                 "internalType": "uint256",
@@ -71,7 +127,50 @@
                 "type": "uint256"
             }
         ],
-        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256[]",
+                "name": "memoryPairs",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "z",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "alpha",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "prime",
+                "type": "uint256"
+            }
+        ],
+        "name": "registerRegularMemoryPage",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "factHash",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "uint256",
+                "name": "memoryHash",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "prod",
+                "type": "uint256"
+            }
+        ],
         "stateMutability": "nonpayable",
         "type": "function"
     }

--- a/src/bin/pathfinder.rs
+++ b/src/bin/pathfinder.rs
@@ -1,10 +1,4 @@
-use web3::{transports::WebSocket, Web3};
-
-use pathfinder_lib::{
-    config,
-    ethereum::{starknet::CoreContract, BlockId},
-    rpc,
-};
+use pathfinder_lib::{config, rpc};
 
 #[tokio::main]
 async fn main() {
@@ -12,20 +6,6 @@ async fn main() {
 
     let config =
         config::Configuration::parse_cmd_line_and_cfg_file().expect("Configuration failed");
-
-    let websocket = WebSocket::new(config.ethereum.url.as_str())
-        .await
-        .expect("Failed to open Ethereum websocket");
-    let websocket = Web3::new(websocket);
-
-    let l1_core_contract = CoreContract::load(websocket);
-
-    let state_root = l1_core_contract
-        .state_root(BlockId::Latest)
-        .await
-        .expect("Failed to query L1 state root");
-
-    println!("The latest state root hash is: {:#16x}", state_root);
 
     rpc::run_server(config.http_rpc_addr)
         .await

--- a/src/ethereum.rs
+++ b/src/ethereum.rs
@@ -152,15 +152,15 @@ mod test {
         StarknetTransaction {
             origin: EthOrigin {
                 block_hash: H256::from_str(
-                    "0x17c7105d8d2c9e0b8e6a8ce9ba845889146a69443d90850d14d809af89009b82",
+                    "0xdc6802921731b3c9db21366af5c178ea208fd32ed3c5cd47ee20d49f46087f69",
                 )
                 .unwrap(),
-                block_number: 5806884,
+                block_number: 5858259,
                 transaction_hash: H256::from_str(
-                    "0x93f9609808869a6360cd734fae6cd1792fed0b79e45b2e05836f5353ab4a2ce3",
+                    "0x39587b08226798e3132015b0d1957a14f37fd550ffe6716d0a1823acd5839515",
                 )
                 .unwrap(),
-                transaction_index: 10,
+                transaction_index: 26,
             },
             log_index: 0,
         }
@@ -173,15 +173,15 @@ mod test {
         StarknetTransaction {
             origin: EthOrigin {
                 block_hash: H256::from_str(
-                    "0x17c7105d8d2c9e0b8e6a8ce9ba845889146a69443d90850d14d809af89009b82",
+                    "0x31ed206024a3368bc562f8e566a8728f031aadbe378ee333408608e0642675e9",
                 )
                 .unwrap(),
-                block_number: 5806884,
+                block_number: 5858173,
                 transaction_hash: H256::from_str(
-                    "0x573354d51d28514519b8fe8604e1ef5152a608aa6bfc8fb59fe5dbb89a5a9cd1",
+                    "0x01d8c2d121f8b7e617c1f9167274794cc1ccc91c9b070bc9e66c614cfd41084a",
                 )
                 .unwrap(),
-                transaction_index: 11,
+                transaction_index: 26,
             },
             log_index: 1,
         }

--- a/src/ethereum/starknet.rs
+++ b/src/ethereum/starknet.rs
@@ -1,6 +1,7 @@
 //! Provides abstractions to interface with StarkNet's Ethereum contracts and events.
 mod contract;
 mod fact;
+mod state_root;
 
 pub use contract::*;
 use fact::*;

--- a/src/ethereum/starknet.rs
+++ b/src/ethereum/starknet.rs
@@ -191,12 +191,13 @@ impl Starknet {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, str::FromStr};
+    use std::str::FromStr;
 
     use crate::ethereum::test::{
         create_test_websocket, fact_test_tx, mempage_test_tx, retrieve_log,
     };
     use assert_matches::assert_matches;
+    use pretty_assertions::assert_eq;
     use web3::types::H256;
 
     use super::*;
@@ -226,7 +227,7 @@ mod tests {
         let log = retrieve_log(&mempage_tx).await;
         let mempage_log = starknet.parse_log(&log).unwrap();
 
-        assert_matches!(mempage_log, Log::Mempage(..));
+        assert_matches!(mempage_log, StarknetLog::Mempage(..));
     }
 
     #[tokio::test]
@@ -238,21 +239,21 @@ mod tests {
         let log = retrieve_log(&fact_tx).await;
         let fact_log = starknet.parse_log(&log).unwrap();
 
-        assert_matches!(fact_log, Log::Fact(..));
+        assert_matches!(fact_log, StarknetLog::Fact(..));
     }
 
     #[cfg(test)]
     mod retrieve_logs {
         use super::*;
+        use pretty_assertions::assert_eq;
 
         #[tokio::test]
         async fn ok() {
             let ws = create_test_websocket().await;
             let starknet = Starknet::load(ws);
-            // The block the StarkNet core contract was deployed with.
-            // Use this to retrieve a small set of logs.
-            let to = 5745469;
-            let from = to + 10;
+
+            let from = 5864142;
+            let to = 5864142 - 100;
 
             let result = starknet
                 .retrieve_logs(
@@ -262,7 +263,7 @@ mod tests {
                 .await;
 
             let logs = result.unwrap();
-            assert_eq!(logs.len(), 12);
+            assert_eq!(logs.len(), 84);
         }
 
         #[tokio::test]
@@ -286,12 +287,20 @@ mod tests {
         let ws = create_test_websocket().await;
         let starknet = Starknet::load(ws);
 
+        // A fact containing both contract deploments and storage updates.
+        //
+        // Randomly chosen using:
+        //  https://goerli.etherscan.io/address/0x67D629978274b4E1e07256Ec2ef39185bb3d4D0d#events
         let fact_hash =
-            H256::from_str("0x983e4a7350a46070642a1ba0e6df4b097d527633c1ef256a2140c9ad0f264587")
+            H256::from_str("0xbf3b7d196393ee7b5ddddf6e219830c65cc94b4afa5af613ec94a7ed651c2813")
                 .unwrap();
 
-        let from = 5742000;
-        let to = from + 10_000;
+        // Block number containing this fact update.
+        let to = 5876654;
+        // Memory pages logs are emitted in blocks prior to the update.
+        // So we need to retrieve logs from a range to ensure we get all
+        // the required logs for this fact.
+        let from = to - 10_000;
 
         let logs = starknet
             .retrieve_logs(
@@ -301,122 +310,88 @@ mod tests {
             .await
             .unwrap();
 
-        let mut facts = HashMap::new();
-        let mut mempages = HashMap::new();
-
-        logs.iter().for_each(|log| match log {
-            Log::Fact(fact) => {
-                facts.insert(fact.hash, fact.mempage_hashes.clone());
-            }
-            Log::Mempage(mempage) => {
-                mempages.insert(mempage.hash, mempage.origin.transaction_hash);
-            }
-        });
-
-        let fact_mempages = facts.get(&fact_hash).unwrap();
-
-        let tx = fact_mempages
+        // Find our fact hash in the logs
+        let fact = logs
             .iter()
-            .map(|mp| {
-                let t = mempages.get(mp).unwrap();
-                TransactionId::Hash(*t)
+            .find_map(|log| match log {
+                StarknetLog::Fact(f) if f.data.hash == fact_hash => Some(f.clone()),
+                _ => None,
+            })
+            .unwrap();
+
+        // Collect memory page logs that belong to our fact
+        let mempage_txs = logs
+            .iter()
+            .filter_map(|log| match log {
+                StarknetLog::Mempage(mempage)
+                    if fact.data.mempage_hashes.contains(&mempage.data.hash) =>
+                {
+                    let tx = mempage.origin.transaction_hash;
+                    Some(TransactionId::Hash(tx))
+                }
+                _ => None,
             })
             .collect::<Vec<_>>();
 
-        let fact = starknet.retrieve_fact(&tx).await.unwrap();
+        let fact = starknet.retrieve_fact(&mempage_txs).await.unwrap();
 
         let expected = Fact {
             deployed_contracts: vec![
                 DeployedContract {
-                    address: U256::from_str(
-                        "0x55231fadef974ea197e68c99fdb1896a3793e3db35f7fac120ae11bd7ae221",
-                    )
-                    .unwrap(),
-                    hash: U256::from_str(
-                        "0x2f42c7edbed0fabd97d566fa27674df17bd0f36b888c55fb6d69f5db98201ed",
-                    )
-                    .unwrap(),
-                    call_data: vec![
-                        U256::from_str(
-                            "0x567aaf5e66bde341cbd4582e9c275ad9bc1de92fa57a9b9d02b75f14433259",
-                        )
-                        .unwrap(),
-                        U256::from_str(
-                            "0x30435903dcd550c23d5c7b80a3c2b80971e1e3107e49938e0a1f884eaf45416",
-                        )
-                        .unwrap(),
-                    ],
+                    address: U256::from_dec_str("2005238406252901036683599278926811665941308458283132997267154497601833857461").unwrap(),
+                    hash: U256::from_dec_str("2175195626185073029849142407296785061642163892759228526742429373445244228408").unwrap(),
+                    call_data: vec![],
                 },
                 DeployedContract {
-                    address: U256::from_str(
-                        "0x85f7a619508eb9b6035ef700c5a2b32ce7d98781a9aa5f951aa5f73d78ca18",
-                    )
-                    .unwrap(),
-                    hash: U256::from_str(
-                        "0x4f279979402f0a86770030d520010242f5d18c731a43a126d3d416eee036e0a",
-                    )
-                    .unwrap(),
-                    call_data: vec![U256::from(2), U256::from(1), U256::from(2)],
+                    address: U256::from_dec_str("1380657829967356330790660033071345383611153364290931023546902339385807484883").unwrap(),
+                    hash: U256::from_dec_str("2175195626185073029849142407296785061642163892759228526742429373445244228408").unwrap(),
+                    call_data: vec![],
                 },
             ],
             contract_updates: vec![
                 ContractUpdate {
-                    address: U256::from_str(
-                        "0x4095069acd316ec7d0fb479e2a22b6c80fdefa36eb9aa2d98770393a2f0793",
-                    )
-                    .unwrap(),
-                    storage_updates: vec![StorageUpdate {
-                        address: U256::from_str(
-                            "0x415768d4e7426fcae576c82580903e277c028ace66a738ba50b333b4dba2a0",
-                        ).unwrap(),
-                        value: U256::from_dec_str("1436351082076388378937592820583595915390412612503470928012048545736083828717").unwrap(),
-                    }],
+                    address: U256::from_dec_str("1380657829967356330790660033071345383611153364290931023546902339385807484883").unwrap(),
+                    storage_updates: vec![]
                 },
                 ContractUpdate {
-                    address: U256::from_str(
-                        "0x55231fadef974ea197e68c99fdb1896a3793e3db35f7fac120ae11bd7ae221",
-                    )
-                    .unwrap(),
-                    storage_updates: vec![StorageUpdate {
-                        address: U256::from_str(
-                            "0x567aaf5e66bde341cbd4582e9c275ad9bc1de92fa57a9b9d02b75f14433259",
-                        ).unwrap(),
-                        value: U256::from_dec_str("1364375615306131238293526755218258502029326963887457755108602545788322862102").unwrap(),
-                    }],
+                    address: U256::from_dec_str("1755069831273166072366458588985965223979686686906815766019613573637758579966").unwrap(),
+                    storage_updates: vec![
+                        StorageUpdate {
+                            address: U256::from_dec_str("814079005391940027390129862062157285361348684878695833898695909074510122245").unwrap(),
+                            value: U256::from_dec_str("2145888722024684049935776658900472878504765045824615012672687402235959174952").unwrap()
+                        },
+                        StorageUpdate {
+                            address: U256::from_dec_str("1410752890141599390055702225444248987277077018130707938554244692172889272177").unwrap(),
+                            value: U256::from(0)
+                        },
+                        StorageUpdate {
+                            address: U256::from_dec_str("1563672576422918850564506150092036819309968525068313502302455251173901598124").unwrap(),
+                            value: U256::from(11)
+                        },
+                        StorageUpdate {
+                            address: U256::from_dec_str("1788136559461238800386522850547867498833152733095516909793758980120885021902").unwrap(),
+                            value: U256::from(0)
+                        }
+                    ]
                 },
                 ContractUpdate {
-                    address: U256::from_str(
-                        "0x85f7a619508eb9b6035ef700c5a2b32ce7d98781a9aa5f951aa5f73d78ca18",
-                    )
-                    .unwrap(),
-                    storage_updates: vec![StorageUpdate {
-                        address: U256::from_str(
-                            "0xd3492e64be829d49fe51f410d37fa2cf87aabd7a0dc2c85946067e2d61412f",
-                        ).unwrap(),
-                        value: U256::from(2),
-                    },
-                    StorageUpdate {
-                        address: U256::from_str(
-                            "0xd3492e64be829d49fe51f410d37fa2cf87aabd7a0dc2c85946067e2d614130",
-                        ).unwrap(),
-                        value: U256::from(3),
-                    }],
+                    address: U256::from_dec_str("2005238406252901036683599278926811665941308458283132997267154497601833857461").unwrap(),
+                    storage_updates: vec![]
                 },
                 ContractUpdate {
-                    address: U256::from_str(
-                        "0x308136cc7250bdb051ae19abf9133f4d8982966146ee334a7f4aa57c4fe334f",
-                    )
-                    .unwrap(),
-                    storage_updates: vec![],
-                },
-                ContractUpdate {
-                    address: U256::from_str(
-                        "0x730dad481c14b223102383eb2dced32d2478926bc20fe01a3c5f6b0dea8bc94",
-                    )
-                    .unwrap(),
-                    storage_updates: vec![],
-                },
-            ],
+                    address: U256::from_dec_str("2211333340133722854231389664684920138369167001212521106227823317724820414359").unwrap(),
+                    storage_updates: vec![
+                        StorageUpdate {
+                            address: U256::from_dec_str("2433998266483775785325659667502784461255680180764730822921086061280079738301").unwrap(),
+                            value: U256::from_dec_str("447000000000000000000").unwrap()
+                        },
+                        StorageUpdate {
+                            address: U256::from_dec_str("3303413371309657170411995174561851664035014984988022984254662524842095446428").unwrap(),
+                            value: U256::from_dec_str("500000000000000000000").unwrap()
+                        }
+                    ]
+                }
+            ]
         };
 
         assert_eq!(fact, expected);

--- a/src/ethereum/starknet/contract.rs
+++ b/src/ethereum/starknet/contract.rs
@@ -2,6 +2,73 @@ mod core;
 mod gps;
 mod mempage;
 
-pub use self::core::CoreContract;
+use std::marker::PhantomData;
+
+use anyhow::Context;
+use web3::ethabi::Event;
+use web3::ethabi::RawLog;
+use web3::types::H256;
+use web3::types::U256;
+
+use crate::ethereum::EthOrigin;
+
+pub use self::core::*;
 pub use self::gps::*;
 pub use self::mempage::*;
+
+/// A [StarknetEvent] which can parse logs emitted by this event.
+pub struct StarknetEvent<T>
+where
+    T: TryFrom<web3::ethabi::Log, Error = anyhow::Error>,
+{
+    event: Event,
+    log_type: PhantomData<T>,
+}
+
+impl<T> StarknetEvent<T>
+where
+    T: TryFrom<web3::ethabi::Log, Error = anyhow::Error>,
+{
+    pub fn new(event: Event) -> Self {
+        Self {
+            event,
+            log_type: PhantomData {},
+        }
+    }
+
+    /// This event's signature. Can be used to identify an Ethereum log by comparing to its first topic.
+    pub fn signature(&self) -> H256 {
+        self.event.signature()
+    }
+
+    /// Parses an Ethereum log.
+    pub fn parse_log(&self, log: &web3::types::Log) -> anyhow::Result<LogWithOrigin<T>> {
+        let origin = EthOrigin::try_from(log)?;
+        let log_index = log.log_index.context("log index missing")?;
+
+        let log = RawLog {
+            topics: log.topics.clone(),
+            data: log.data.0.clone(),
+        };
+
+        let log = self.event.parse_log(log)?;
+        let data = T::try_from(log)?;
+
+        Ok(LogWithOrigin {
+            origin,
+            data,
+            log_index,
+        })
+    }
+}
+
+/// A parsed Starknet log with its [Ethereum origin](EthOrigin).
+#[derive(Debug, Clone, PartialEq)]
+pub struct LogWithOrigin<T>
+where
+    T: TryFrom<web3::ethabi::Log, Error = anyhow::Error>,
+{
+    pub origin: EthOrigin,
+    pub log_index: U256,
+    pub data: T,
+}

--- a/src/ethereum/starknet/contract/core.rs
+++ b/src/ethereum/starknet/contract/core.rs
@@ -12,16 +12,7 @@
 
 use std::str::FromStr;
 
-use web3::{
-    contract::{Contract, Options},
-    transports::WebSocket,
-    types::{H160, U256},
-    Web3,
-};
-
-use anyhow::Result;
-
-use crate::ethereum::BlockId;
+use web3::{transports::WebSocket, types::H160, Web3};
 
 /// The address of the core StarkNet contract (proxy).
 const CORE_PROXY_ADDR: &str = "0x67D629978274b4E1e07256Ec2ef39185bb3d4D0d";
@@ -39,7 +30,7 @@ const CORE_IMPL_ABI: &[u8] = include_bytes!(concat!(
 ));
 
 pub struct CoreContract {
-    contract: Contract<WebSocket>,
+    pub address: H160,
 }
 
 impl CoreContract {
@@ -50,45 +41,19 @@ impl CoreContract {
         // Note: It's possible to support both proxy and impl ABI by
         //       combining the json of both. However, we don't really
         //       care about the proxy's ABI currently.
-        let addr = H160::from_str(CORE_PROXY_ADDR).unwrap();
-        let contract = Contract::from_json(ws.eth(), addr, CORE_IMPL_ABI).unwrap();
+        let address = H160::from_str(CORE_PROXY_ADDR).unwrap();
 
-        CoreContract { contract }
-    }
-
-    /// Returns the StarkNet state root at [BlockId].
-    pub async fn state_root(&self, block: BlockId) -> Result<U256> {
-        Ok(self
-            .contract
-            .query(
-                "stateRoot",
-                (),
-                None,
-                Options::default(),
-                Some(block.into()),
-            )
-            .await?)
-    }
-
-    /// Returns the StarkNet sequence number at [BlockId].
-    pub async fn sequence_number(&self, block: BlockId) -> Result<U256> {
-        Ok(self
-            .contract
-            .query(
-                "stateSequenceNumber",
-                (),
-                None,
-                Options::default(),
-                Some(block.into()),
-            )
-            .await?)
+        CoreContract { address }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::ethereum::test::create_test_websocket_transport;
-    use web3::{contract::Options, types::Address};
+    use crate::ethereum::{test::create_test_websocket_transport, BlockId};
+    use web3::{
+        contract::{Contract, Options},
+        types::Address,
+    };
 
     use super::*;
 
@@ -116,34 +81,5 @@ mod tests {
         let impl_addr = H160::from_str(CORE_IMPL_ADDR).unwrap();
 
         assert_eq!(dbg!(resp), impl_addr);
-    }
-
-    #[tokio::test]
-    async fn sequence_number() {
-        let block = BlockId::Number(5812351);
-        let expected = U256::from(10712);
-
-        let ws = create_test_websocket_transport().await;
-        let contract = CoreContract::load(ws);
-
-        let sequence_number = contract.sequence_number(block).await.unwrap();
-
-        assert_eq!(sequence_number, expected);
-    }
-
-    #[tokio::test]
-    async fn state_root() {
-        let block = BlockId::Number(5812351);
-        let expected = U256::from_dec_str(
-            "1724604860892884760768923826804298080954001104771551712720979626020277290307",
-        )
-        .unwrap();
-
-        let ws = create_test_websocket_transport().await;
-        let contract = CoreContract::load(ws);
-
-        let state_root = contract.state_root(block).await.unwrap();
-
-        assert_eq!(state_root, expected);
     }
 }

--- a/src/ethereum/starknet/contract/core.rs
+++ b/src/ethereum/starknet/contract/core.rs
@@ -12,7 +12,16 @@
 
 use std::str::FromStr;
 
-use web3::{transports::WebSocket, types::H160, Web3};
+use web3::{
+    contract::{tokens::Tokenizable, Contract},
+    transports::WebSocket,
+    types::{H160, H256, U256},
+    Web3,
+};
+
+use anyhow::{Context, Result};
+
+use crate::ethereum::{get_log_param, starknet::StarknetEvent};
 
 /// The address of the core StarkNet contract (proxy).
 const CORE_PROXY_ADDR: &str = "0xde29d060D45901Fb19ED6C6e959EB22d8626708e";
@@ -31,6 +40,61 @@ const CORE_IMPL_ABI: &[u8] = include_bytes!(concat!(
 
 pub struct CoreContract {
     pub address: H160,
+    pub state_transition_event: StarknetEvent<StateTransitionFactLog>,
+    pub state_update_event: StarknetEvent<StateUpdateLog>,
+}
+
+/// Log emitted identifying the [FactLog](super::FactLog) which led to the
+/// state transition.
+///
+/// This log will always be emitted before [StateUpdateLog] (and in the same
+/// transaction).
+#[derive(Debug)]
+pub struct StateTransitionFactLog {
+    pub fact_hash: H256,
+}
+
+/// Log emitted when the L1 Starknet state has been updated. Specifies the
+/// new global root and sequence number.
+///
+/// This log will always be emitted together with [StateTransitionFactLog],
+/// in the same transaction.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StateUpdateLog {
+    pub global_root: U256,
+    pub sequence_number: U256,
+}
+
+impl TryFrom<web3::ethabi::Log> for StateTransitionFactLog {
+    type Error = anyhow::Error;
+
+    fn try_from(log: web3::ethabi::Log) -> Result<Self, Self::Error> {
+        let fact_hash = H256::from_token(get_log_param(&log, "stateTransitionFact")?.value)
+            .context("fact hash could not be parsed")?;
+
+        Ok(Self { fact_hash })
+    }
+}
+
+impl TryFrom<web3::ethabi::Log> for StateUpdateLog {
+    type Error = anyhow::Error;
+
+    fn try_from(log: web3::ethabi::Log) -> Result<Self, Self::Error> {
+        let global_root = get_log_param(&log, "globalRoot")?
+            .value
+            .into_uint()
+            .context("global root could not be parsed")?;
+
+        let sequence_number = get_log_param(&log, "sequenceNumber")?
+            .value
+            .into_int()
+            .context("sequence number could not be parsed")?;
+
+        Ok(Self {
+            global_root,
+            sequence_number,
+        })
+    }
 }
 
 impl CoreContract {
@@ -42,18 +106,31 @@ impl CoreContract {
         //       combining the json of both. However, we don't really
         //       care about the proxy's ABI currently.
         let address = H160::from_str(CORE_PROXY_ADDR).unwrap();
+        let contract = Contract::from_json(ws.eth(), address, CORE_IMPL_ABI).unwrap();
 
-        CoreContract { address }
+        let state_transition_event = contract
+            .abi()
+            .event("LogStateTransitionFact")
+            .unwrap()
+            .clone();
+
+        let state_update_event = contract.abi().event("LogStateUpdate").unwrap().clone();
+
+        CoreContract {
+            address,
+            state_transition_event: StarknetEvent::new(state_transition_event),
+            state_update_event: StarknetEvent::new(state_update_event),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::ethereum::{test::create_test_websocket_transport, BlockId};
-    use web3::{
-        contract::{Contract, Options},
-        types::Address,
+    use crate::ethereum::{
+        test::{create_test_websocket_transport, retrieve_log, StarknetTransaction},
+        BlockId, EthOrigin,
     };
+    use web3::{contract::Options, types::Address};
 
     use super::*;
 
@@ -81,5 +158,60 @@ mod tests {
         let impl_addr = H160::from_str(CORE_IMPL_ADDR).unwrap();
 
         assert_eq!(dbg!(resp), impl_addr);
+    }
+
+    // An Ethereum transaction containing both [StateUpdateLog] and [StateTransitionFactLog]
+    // (since these are emitted as pairs).
+    fn log_test_tx() -> EthOrigin {
+        EthOrigin {
+            block_hash: H256::from_str(
+                "0x4fb0ff4e87c763447ac11c7d263081292057e09bdcc7400a5badb5539eafa130",
+            )
+            .unwrap(),
+            block_number: 5859227,
+            transaction_hash: H256::from_str(
+                "0x6fca7b2f652bcb5ce56dd582fa1a77c6b653277ef7f6ae3127afa836c69275d1",
+            )
+            .unwrap(),
+            transaction_index: 1,
+        }
+    }
+
+    #[tokio::test]
+    async fn parse_state_update_log() {
+        let ws = create_test_websocket_transport().await;
+        let contract = CoreContract::load(ws.clone());
+
+        let test_tx = StarknetTransaction {
+            origin: log_test_tx(),
+            log_index: 1,
+        };
+
+        let log = retrieve_log(&test_tx).await;
+
+        let signature = *log.topics.first().unwrap();
+        assert_eq!(contract.state_update_event.signature(), signature);
+
+        let state_update_log = contract.state_update_event.parse_log(&log).unwrap();
+        assert_eq!(state_update_log.origin, test_tx.origin);
+    }
+
+    #[tokio::test]
+    async fn parse_state_transition_log() {
+        let ws = create_test_websocket_transport().await;
+        let contract = CoreContract::load(ws.clone());
+
+        let test_tx = StarknetTransaction {
+            origin: log_test_tx(),
+            log_index: 0,
+        };
+
+        let log = retrieve_log(&test_tx).await;
+
+        let signature = *log.topics.first().unwrap();
+        assert_eq!(contract.state_transition_event.signature(), signature);
+
+        let state_transition_log = contract.state_transition_event.parse_log(&log).unwrap();
+        assert_eq!(state_transition_log.origin, test_tx.origin);
     }
 }

--- a/src/ethereum/starknet/contract/core.rs
+++ b/src/ethereum/starknet/contract/core.rs
@@ -15,9 +15,9 @@ use std::str::FromStr;
 use web3::{transports::WebSocket, types::H160, Web3};
 
 /// The address of the core StarkNet contract (proxy).
-const CORE_PROXY_ADDR: &str = "0x67D629978274b4E1e07256Ec2ef39185bb3d4D0d";
+const CORE_PROXY_ADDR: &str = "0xde29d060D45901Fb19ED6C6e959EB22d8626708e";
 /// The address of the core contract implementation.
-const CORE_IMPL_ADDR: &str = "0x4e5e71dc0eb7a6ddc3f6030542a327c0db849397";
+const CORE_IMPL_ADDR: &str = "0xF10EfCF03796D38E0f6c5b87c471368e6E0DC674";
 
 const CORE_PROXY_ABI: &[u8] = include_bytes!(concat!(
     env!("CARGO_MANIFEST_DIR"),

--- a/src/ethereum/starknet/contract/gps.rs
+++ b/src/ethereum/starknet/contract/gps.rs
@@ -14,7 +14,7 @@ use web3::{
 
 use crate::ethereum::{get_log_param, EthOrigin};
 
-const GPS_ADDR: &str = "0xB02D49C4d89f0CeA504C4C93934E7fC66e20A257";
+const GPS_ADDR: &str = "0x5EF3C980Bf970FcE5BbC217835743ea9f0388f4F";
 const GPS_ABI: &[u8] = include_bytes!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/resources/contracts/gps_statement_verifier.json"

--- a/src/ethereum/starknet/contract/mempage.rs
+++ b/src/ethereum/starknet/contract/mempage.rs
@@ -6,13 +6,13 @@ use std::{convert::TryFrom, str::FromStr};
 use anyhow::{Context, Result};
 use web3::{
     contract::Contract,
-    ethabi::{Event, Function, RawLog},
+    ethabi::Function,
     transports::WebSocket,
     types::{Transaction, H160, H256, U256},
     Web3,
 };
 
-use crate::ethereum::{get_log_param, EthOrigin};
+use crate::ethereum::{get_log_param, starknet::StarknetEvent};
 
 const MEMPAGE_ADDR: &str = "0x743789ff2fF82Bfb907009C9911a7dA636D34FA7";
 const MEMPAGE_ABI: &[u8] = include_bytes!(concat!(
@@ -21,27 +21,36 @@ const MEMPAGE_ABI: &[u8] = include_bytes!(concat!(
 ));
 
 /// Abstraction for StarkNet's Memory Page contract. It can be used to
-/// identify and parse generic Ethereum logs into [MempageLogs](MempageLog)
-/// using its [MempageEvent].
+/// identify and parse generic Ethereum logs into [MempageLogs](MempageLog).
 pub struct MempageContract {
     pub address: H160,
     mempage_register_function: Function,
-    pub mempage_event: MempageEvent,
-}
-
-/// Parses StarkNet [MempageLogs](MempageLog) emitted by [MempageContract].
-pub struct MempageEvent {
-    event: Event,
+    pub mempage_event: StarknetEvent<MempageLog>,
 }
 
 /// An Ethereum log representing a StarkNet memory page.
 ///
 /// The actual memory page data is contained in the origin
 /// transaction's input data.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct MempageLog {
-    pub origin: EthOrigin,
     pub hash: H256,
+}
+
+impl TryFrom<web3::ethabi::Log> for MempageLog {
+    type Error = anyhow::Error;
+
+    fn try_from(log: web3::ethabi::Log) -> Result<Self, Self::Error> {
+        let hash = get_log_param(&log, "memoryHash")?
+            .value
+            .into_uint()
+            .context("mempage hash could not be cast to U256")?;
+        let mut bytes = vec![0; 32];
+        hash.to_big_endian(&mut bytes);
+        let hash = H256::from_slice(&bytes);
+
+        Ok(Self { hash })
+    }
 }
 
 impl MempageContract {
@@ -49,7 +58,7 @@ impl MempageContract {
     pub fn load(ws: Web3<WebSocket>) -> MempageContract {
         let address = H160::from_str(MEMPAGE_ADDR).unwrap();
         let contract = Contract::from_json(ws.eth(), address, MEMPAGE_ABI).unwrap();
-        let event = contract
+        let mempage_event = contract
             .abi()
             .event("LogMemoryPageFactContinuous")
             .unwrap()
@@ -60,9 +69,11 @@ impl MempageContract {
             .unwrap()
             .clone();
 
+        let mempage_event = StarknetEvent::new(mempage_event);
+
         MempageContract {
             address,
-            mempage_event: MempageEvent { event },
+            mempage_event,
             mempage_register_function: function,
         }
     }
@@ -96,35 +107,6 @@ impl MempageContract {
                     .context("values element could not be cast to U256")
             })
             .collect()
-    }
-}
-
-impl MempageEvent {
-    /// The [MempageEvent's](MempageEvent) signature. Can be used
-    /// to identify an Ethereum log by comparing to its first topic.
-    pub fn signature(&self) -> H256 {
-        self.event.signature()
-    }
-
-    /// Parses an Ethereum log into a [MempageLog].
-    pub fn parse_log(&self, log: &web3::types::Log) -> Result<MempageLog> {
-        let origin = EthOrigin::try_from(log)?;
-
-        let log = RawLog {
-            topics: log.topics.clone(),
-            data: log.data.0.clone(),
-        };
-
-        let log = self.event.parse_log(log)?;
-        let hash = get_log_param(&log, "memoryHash")?
-            .value
-            .into_uint()
-            .context("mempage hash could not be cast to uint")?;
-        let mut be_bytes = vec![0u8; 32];
-        hash.to_big_endian(&mut be_bytes);
-        let hash = H256::from_slice(&be_bytes);
-
-        Ok(MempageLog { hash, origin })
     }
 }
 

--- a/src/ethereum/starknet/contract/mempage.rs
+++ b/src/ethereum/starknet/contract/mempage.rs
@@ -24,7 +24,7 @@ const MEMPAGE_ABI: &[u8] = include_bytes!(concat!(
 /// identify and parse generic Ethereum logs into [MempageLogs](MempageLog)
 /// using its [MempageEvent].
 pub struct MempageContract {
-    contract: Contract<WebSocket>,
+    pub address: H160,
     mempage_register_function: Function,
     pub mempage_event: MempageEvent,
 }
@@ -47,8 +47,8 @@ pub struct MempageLog {
 impl MempageContract {
     /// Creates a new [MempageContract].
     pub fn load(ws: Web3<WebSocket>) -> MempageContract {
-        let addr = H160::from_str(MEMPAGE_ADDR).unwrap();
-        let contract = Contract::from_json(ws.eth(), addr, MEMPAGE_ABI).unwrap();
+        let address = H160::from_str(MEMPAGE_ADDR).unwrap();
+        let contract = Contract::from_json(ws.eth(), address, MEMPAGE_ABI).unwrap();
         let event = contract
             .abi()
             .event("LogMemoryPageFactContinuous")
@@ -61,15 +61,10 @@ impl MempageContract {
             .clone();
 
         MempageContract {
-            contract,
+            address,
             mempage_event: MempageEvent { event },
             mempage_register_function: function,
         }
-    }
-
-    /// The [MempageContract's](MempageContract) address.
-    pub fn address(&self) -> H160 {
-        self.contract.address()
     }
 
     pub fn decode_mempage(&self, transaction: &Transaction) -> Result<Vec<U256>> {
@@ -150,7 +145,7 @@ mod tests {
     #[tokio::test]
     async fn address() {
         let ws = create_test_websocket_transport().await;
-        let address = MempageContract::load(ws).address();
+        let address = MempageContract::load(ws).address;
         let expected = H160::from_str(MEMPAGE_ADDR).unwrap();
 
         assert_eq!(address, expected);

--- a/src/ethereum/starknet/contract/mempage.rs
+++ b/src/ethereum/starknet/contract/mempage.rs
@@ -14,7 +14,7 @@ use web3::{
 
 use crate::ethereum::{get_log_param, EthOrigin};
 
-const MEMPAGE_ADDR: &str = "0xb609Eba1DC0298A984Fa8a34528966E997C5BB13";
+const MEMPAGE_ADDR: &str = "0x743789ff2fF82Bfb907009C9911a7dA636D34FA7";
 const MEMPAGE_ABI: &[u8] = include_bytes!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/resources/contracts/memory_page_fact_registry.json"

--- a/src/ethereum/starknet/state_root.rs
+++ b/src/ethereum/starknet/state_root.rs
@@ -1,0 +1,294 @@
+use std::{collections::VecDeque, time::Duration};
+
+use web3::{transports::WebSocket, types::BlockNumber, Web3};
+
+use crate::ethereum::starknet::{
+    contract::{LogWithOrigin, StateUpdateLog},
+    CoreContract, GetLogsError,
+};
+
+/// Provides a reorg aware stream of L2 state update logs.
+///
+/// ## Important
+///
+/// [StateRootStream] keeps an internal buffer of update logs.
+/// Once these are exhausted, a new set of logs are retrieved from
+/// L1. **Only** at this point can reorgs be detected. This implies
+/// that although this buffer was valid when retrieved, that in the
+/// interim a reorg could have occurred invalidating this buffer.
+///
+/// The implication is that your other L1 / L2 queries will
+/// still need to be reorg aware.
+pub struct StateRootStream {
+    last: Option<LogWithOrigin<StateUpdateLog>>,
+    core_contract: CoreContract,
+    websocket: Web3<WebSocket>,
+    buffer: VecDeque<LogWithOrigin<StateUpdateLog>>,
+    stride: u64,
+}
+
+#[derive(Debug)]
+pub enum GetRootError {
+    /// An L1 chain reorganisation occurred. At the very least
+    /// the last update returned is no longer valid.
+    Reorg,
+    Other(anyhow::Error),
+}
+
+impl From<anyhow::Error> for GetRootError {
+    fn from(err: anyhow::Error) -> Self {
+        GetRootError::Other(err)
+    }
+}
+
+impl From<web3::Error> for GetRootError {
+    fn from(err: web3::Error) -> Self {
+        GetRootError::Other(anyhow::anyhow!("Unexpected error: {}", err))
+    }
+}
+
+impl StateRootStream {
+    /// Creates a new [StateRootStream].
+    ///
+    /// `last_known` should be set to the last known valid [StateUpdateLog],
+    /// or [None] if you are starting from scratch.
+    pub fn new(
+        websocket: Web3<WebSocket>,
+        last_known: Option<LogWithOrigin<StateUpdateLog>>,
+    ) -> Self {
+        let core_contract = CoreContract::load(websocket.clone());
+
+        Self {
+            last: last_known,
+            buffer: VecDeque::new(),
+            core_contract,
+            websocket,
+            stride: 100_000,
+        }
+    }
+
+    /// Returns the next [StateUpdateLog].
+    ///
+    /// If [GetRootError::Reorg] is returned, this [StateRootStream] will no longer
+    /// be valid and should be discarded. One sensible reaction is to validate your
+    /// state and purge whatever has been reorg'd away. Then create a new [StateRootStream]
+    /// starting with your new valid state.
+    pub async fn next(&mut self) -> Result<LogWithOrigin<StateUpdateLog>, GetRootError> {
+        if self.buffer.is_empty() {
+            self.buffer = self.retrieve_logs().await?;
+        }
+        // SAFETY: unwrap is safe due to the above empty check and that
+        // retrieve_next_updates will only return once there is a new update.
+        let last = self.buffer.pop_front().unwrap();
+        self.last = Some(last.clone());
+        Ok(last)
+    }
+
+    /// Gets the next batch of [StateUpdateLog] from L1. Checks that
+    /// `self.last` is still valid and no reorg occurred.
+    ///
+    /// ## Reorg detection
+    ///
+    /// We include the last known log's block in the query. If there was
+    /// no reorg then we will receive this log as part of the result set.
+    ///
+    /// ## Dealing with Infura's cap error
+    ///
+    /// Infura responds with an error if the query is too large, and would
+    /// result in more than 10 000 logs. To deal with this, we use a binary
+    /// search like query range. We need at least 2 logs (1 is the last known)
+    /// to have a new update.
+    async fn retrieve_logs(
+        &mut self,
+    ) -> Result<VecDeque<LogWithOrigin<StateUpdateLog>>, GetRootError> {
+        let from_block = self
+            .last
+            .as_ref()
+            .map(|update| update.origin.block_number)
+            .unwrap_or_default();
+
+        // The largest stride we are allowed to take. This gets
+        // set if we encounter the Infura result cap error.
+        //
+        // Allows us to perform a binary search of the query range space.
+        let mut stride_cap = None;
+
+        loop {
+            let to_block = from_block.saturating_add(self.stride);
+
+            let mut logs = match self.get_logs(from_block, to_block).await {
+                Ok(logs) => logs,
+                Err(GetLogsError::QueryLimit) => {
+                    // Infura result cap error. We need to reduce our query range.
+                    stride_cap = Some(self.stride);
+                    self.stride = (self.stride / 2).max(1);
+
+                    continue;
+                }
+                Err(GetLogsError::Other(other)) => return Err(GetRootError::Other(other)),
+            };
+
+            // Check for reorgs. Only required if there was a last known update to validate.
+            if let Some(last) = self.last.as_ref() {
+                // We queried for logs starting from the same block as last known. We need to account
+                // for logs that occurred in the same block and transaction, but with a smaller log index.
+                //
+                // If the last known log is not in the set then we have a reorg event.
+                loop {
+                    match logs.pop_front() {
+                        // Log from the same origin point, but smaller log index.
+                        Some(log)
+                            if log.origin == last.origin && log.log_index < last.log_index =>
+                        {
+                            continue
+                        }
+                        // Log found. Yay!
+                        Some(log) if &log == last => break,
+                        _ => return Err(GetRootError::Reorg),
+                    }
+                }
+            }
+
+            // At this point we have validated and removed the last known log.
+            // If there are no new logs then either:
+            //  1. there are no new logs on L1, or
+            //  2. we need to increase our stride
+            if logs.is_empty() {
+                let latest_on_chain = self.websocket.eth().block_number().await?.as_u64();
+
+                if to_block <= latest_on_chain {
+                    // Increase stride. Account for stride cap (binary search style)
+                    // so that we don't run into a cycle of:
+                    //  1. No logs, increase stride
+                    //  2. Infura result cap, reduce stride
+                    match stride_cap {
+                        Some(max) => self.stride = (self.stride.saturating_add(max + 1)) / 2,
+                        None => self.stride = self.stride.saturating_mul(2),
+                    }
+                } else {
+                    // No new logs on L1, sleep and try again..
+                    const SLEEP: Duration = Duration::from_secs(5);
+                    tokio::time::sleep(SLEEP).await;
+                }
+
+                continue;
+            }
+
+            return Ok(logs);
+        }
+    }
+
+    /// Helper function that retrieves and parses the [StateUpdateLogs](StateUpdateLog) from L1.
+    async fn get_logs(
+        &self,
+        from: u64,
+        to: u64,
+    ) -> Result<VecDeque<LogWithOrigin<StateUpdateLog>>, GetLogsError> {
+        let log_filter = web3::types::FilterBuilder::default()
+            .address(vec![self.core_contract.address])
+            .topics(
+                Some(vec![self.core_contract.state_update_event.signature()]),
+                None,
+                None,
+                None,
+            )
+            .from_block(BlockNumber::Number(from.into()))
+            .to_block(BlockNumber::Number(to.into()))
+            .build();
+
+        let logs = self
+            .websocket
+            .eth()
+            .logs(log_filter)
+            .await?
+            .iter()
+            .map(|log| self.core_contract.state_update_event.parse_log(log))
+            .collect::<Result<VecDeque<_>, _>>()?;
+
+        Ok(logs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+    use web3::types::{H256, U256};
+
+    use crate::ethereum::{test::create_test_websocket, EthOrigin};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn genesis() {
+        // The first state root retrieved should be the genesis event,
+        // with a sequence number of 0.
+        let ws = create_test_websocket().await;
+        let ws = Web3::new(ws);
+
+        let mut uut = StateRootStream::new(ws, None);
+        let genesis_root = uut.next().await.unwrap();
+
+        assert_eq!(genesis_root.data.sequence_number, U256::from(0));
+    }
+
+    mod reorg {
+        use super::*;
+
+        #[tokio::test]
+        async fn block_replaced() {
+            // Seed with a incorrect update at the L1 genesis block.
+            // This should get interpretted as a reorg once the correct
+            // first L2 update log is found.
+            let ws = create_test_websocket().await;
+            let ws = Web3::new(ws);
+
+            // Note that block_number must be 0 so that we pull all of L1 history.
+            // This makes the test robust against L2 changes, updates or deployments
+            // on other chains. (since we don't know when L2 history on L1 starts).
+            let not_genesis = LogWithOrigin {
+                origin: EthOrigin {
+                    block_hash: H256::from_low_u64_le(10),
+                    block_number: 0,
+                    transaction_hash: H256::from_low_u64_le(1123),
+                    transaction_index: 12,
+                },
+                data: StateUpdateLog {
+                    global_root: U256::from(12354),
+                    sequence_number: U256::from(3),
+                },
+                log_index: U256::from(12),
+            };
+
+            let mut uut = StateRootStream::new(ws, Some(not_genesis));
+            assert_matches!(uut.next().await, Err(GetRootError::Reorg));
+        }
+
+        #[tokio::test]
+        async fn block_removed() {
+            // Seed with an origin beyond the current L1 chain state.
+            // This should be interpretted as a reorg as this update
+            // won't be found.
+            let ws = create_test_websocket().await;
+            let ws = Web3::new(ws);
+
+            let latest_on_chain = ws.eth().block_number().await.unwrap().as_u64();
+
+            let not_genesis = LogWithOrigin {
+                origin: EthOrigin {
+                    block_hash: H256::from_low_u64_le(10),
+                    block_number: latest_on_chain + 500,
+                    transaction_hash: H256::from_low_u64_le(1123),
+                    transaction_index: 12,
+                },
+                data: StateUpdateLog {
+                    global_root: U256::from(12354),
+                    sequence_number: U256::from(3),
+                },
+                log_index: U256::from(12),
+            };
+
+            let mut uut = StateRootStream::new(ws, Some(not_genesis));
+            assert_matches!(uut.next().await, Err(GetRootError::Reorg));
+        }
+    }
+}


### PR DESCRIPTION
The main focus of this PR is twofold:

1. Support state update and state transition logs
2. A mechanism for retrieving a stream of state update logs from L1, while checking for reorgs

Unfortunately, there is quite a bit of refactoring as collateral damage. And this is an area that needs further refactoring still (I had previously added a bunch of abstractions that I now know is not required). I would suggest not focusing too much on these parts if possible.

The main thing I would like some thoughts on, is the approach used for the [state update stream](https://github.com/eqlabs/pathfinder/pull/34/files#diff-89971bac4a720b97e52dbbb50390385b7281b308bcfd9c14b31ee4ac95984e90).