### PR TITLE
ci: skip sequencer and rpc tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: -- --skip rpc --skip sequencer
 
   clippy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is a temporary solution until the RPC and sequencer gets updated.