### PR TITLE
feat: add pedersen hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,14 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0.44"
 bigdecimal = { version = "0.3.0", features = ["serde"] }
+# paritys scale codec locks us here
+bitvec = "0.20.4"
 clap = "2.33.3"
 enum-iterator = "0.7.0"
 # Use our fork of ff. ff currently causes a bitvec-funty clash with our ethereum deps.
 # We've modified ff to not rely on bitvec (note that ff features are broken: https://github.com/zkcrypto/ff/issues/69).
 # We can use normal ff once it and `ethabi` (via `web3`) play nice.
-ff = { git = "https://github.com/eqlabs/ff", branch = "derive_bitvec", default-features = false, features = ["derive", "alloc"]}
+ff = { git = "https://github.com/eqlabs/ff", branch = "derive_bitvec", default-features = false, features = ["derive", "alloc"] }
 hex = "0.4.3"
 home = "0.5.3"
 # The latest stable revision on master for which jsonrpsee::proc_macros worked fine.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,4 +45,9 @@ web3 = "0.17.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
+criterion = "0.3"
 pretty_assertions = "1.0.0"
+
+[[bench]]
+name = "pedersen"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ anyhow = "1.0.44"
 bigdecimal = { version = "0.3.0", features = ["serde"] }
 clap = "2.33.3"
 enum-iterator = "0.7.0"
+# Use our fork of ff. ff currently causes a bitvec-funty clash with our ethereum deps.
+# We've modified ff to not rely on bitvec (note that ff features are broken: https://github.com/zkcrypto/ff/issues/69).
+# We can use normal ff once it and `ethabi` (via `web3`) play nice.
+ff = { git = "https://github.com/eqlabs/ff", branch = "derive_bitvec", default-features = false, features = ["derive", "alloc"]}
 hex = "0.4.3"
 home = "0.5.3"
 # The latest stable revision on master for which jsonrpsee::proc_macros worked fine.

--- a/benches/pedersen.rs
+++ b/benches/pedersen.rs
@@ -1,0 +1,24 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use ff::PrimeField;
+use pathfinder_lib::pedersen::{pedersen_hash, Fp};
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    // these are the test vectors also used in tests
+    let e0 = Fp::from_str_vartime(
+        "1740729136829561885683894917751815192814966525555656371386868611731128807883",
+    )
+    .unwrap();
+    let e1 = Fp::from_str_vartime(
+        "919869093895560023824014392670608914007817594969197822578496829435657368346",
+    )
+    .unwrap();
+
+    c.bench_function("pedersen_hash", |b| {
+        b.iter(|| {
+            black_box(pedersen_hash(e0, e1));
+        });
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod ethereum;
+pub mod pedersen;
 pub mod rpc;
 pub mod sequencer;
 pub mod serde;

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -5,7 +5,6 @@ use ff::{Field, PrimeField};
 #[PrimeFieldModulus = "3618502788666131213697322783095070105623107215331596699973092056135872020481"]
 #[PrimeFieldGenerator = "7"]
 #[PrimeFieldReprEndianness = "little"]
-
 pub struct H256([u64; 4]);
 
 pub fn pedersen_hash(a: &H256, b: &H256) -> H256 {
@@ -58,7 +57,7 @@ impl Bit {
 }
 
 /// A point on an elliptic curve over [H251].
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct CurvePoint {
     x: H256,
     y: H256,
@@ -94,7 +93,7 @@ impl CurvePoint {
 
     fn double(&self) -> CurvePoint {
         if self.infinity {
-            return *self;
+            return self.clone();
         }
 
         // l = (3x^2+a)/2y with a=1 from stark curve
@@ -118,10 +117,10 @@ impl CurvePoint {
 
     fn add(&self, other: &CurvePoint) -> CurvePoint {
         if self.infinity {
-            return *other;
+            return other.clone();
         }
         if other.infinity {
-            return *self;
+            return self.clone();
         }
 
         // l = (y2-y1)/(x2-x1)
@@ -193,7 +192,7 @@ impl Default for PedersenHash {
 impl PedersenHash {
     fn hash(&self, a: &H256, b: &H256) -> H256 {
         // Add P0
-        let mut result = self.p0;
+        let mut result = self.p0.clone();
 
         // Add a_low * P1
         let mut tmp = CurvePoint::identity();

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -5,17 +5,9 @@ use ff::{Field, PrimeField};
 #[PrimeFieldModulus = "3618502788666131213697322783095070105623107215331596699973092056135872020481"]
 #[PrimeFieldGenerator = "7"]
 #[PrimeFieldReprEndianness = "little"]
-pub struct H256([u64; 4]);
+pub struct Fp([u64; 4]);
 
-pub fn pedersen_hash(a: &H256, b: &H256) -> H256 {
-    PEDERSEN_HASHER.hash(a, b)
-}
-
-lazy_static::lazy_static!(
-    static ref PEDERSEN_HASHER: PedersenHash = PedersenHash::default();
-);
-
-impl H256 {
+impl Fp {
     /// Returns the i'th bit. Panic's if `i` is out of bounds.
     fn get_bit(&self, i: usize) -> Bit {
         let mut r = *self;
@@ -59,36 +51,18 @@ impl Bit {
 /// A point on an elliptic curve over [H251].
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct CurvePoint {
-    x: H256,
-    y: H256,
+    x: Fp,
+    y: Fp,
     infinity: bool,
 }
 
 impl CurvePoint {
     fn identity() -> CurvePoint {
         Self {
-            x: H256::zero(),
-            y: H256::zero(),
+            x: Fp::zero(),
+            y: Fp::zero(),
             infinity: true,
         }
-    }
-
-    fn from_xy_str(x: &str, y: &str) -> CurvePoint {
-        let x = H256::from_str_vartime(x).expect("Curve x-value invalid");
-        let y = H256::from_str_vartime(y).expect("Curve y-value invalid");
-
-        CurvePoint {
-            x,
-            y,
-            infinity: false,
-        }
-    }
-
-    fn generator() -> CurvePoint {
-        Self::from_xy_str(
-            "874739451078007766457464989774322083649278607533249481151382481072868806602",
-            "152666792071518830868575557812948353041420400780739481342941381225525861407",
-        )
     }
 
     fn double(&self) -> CurvePoint {
@@ -98,9 +72,9 @@ impl CurvePoint {
 
         // l = (3x^2+a)/2y with a=1 from stark curve
         let lambda = {
-            let two = H256::one() + H256::one();
-            let three = two + H256::one();
-            let dividend = three * (self.x * self.x) + H256::one();
+            let two = Fp::one() + Fp::one();
+            let three = two + Fp::one();
+            let dividend = three * (self.x * self.x) + Fp::one();
             let divisor_inv = (two * self.y).invert().unwrap();
             dividend * divisor_inv
         };
@@ -140,7 +114,7 @@ impl CurvePoint {
         }
     }
 
-    fn mul(&self, magnitude: &H256) -> CurvePoint {
+    fn mul(&self, magnitude: &Fp) -> CurvePoint {
         let mut result = CurvePoint::identity();
         for i in 0..256 {
             result = result.double();
@@ -152,103 +126,141 @@ impl CurvePoint {
     }
 }
 
-/// Pedersen hasher
-#[derive(Clone, Debug)]
-struct PedersenHash {
-    p0: CurvePoint,
-    p1: CurvePoint,
-    p2: CurvePoint,
-    p3: CurvePoint,
-    p4: CurvePoint,
-}
+const PEDERSEN_P0: CurvePoint = CurvePoint {
+    x: Fp([
+        1933903796324928314,
+        7739989395386261137,
+        1641324389046377921,
+        316327189671755572,
+    ]),
+    y: Fp([
+        14252083571674603243,
+        12587053260418384210,
+        4798858472748676776,
+        81375596133053150,
+    ]),
+    infinity: false,
+};
 
-impl Default for PedersenHash {
-    fn default() -> Self {
-        PedersenHash {
-            p0: CurvePoint::from_xy_str(
-                "2089986280348253421170679821480865132823066470938446095505822317253594081284",
-                "1713931329540660377023406109199410414810705867260802078187082345529207694986",
-            ),
-            p1: CurvePoint::from_xy_str(
-                "996781205833008774514500082376783249102396023663454813447423147977397232763",
-                "1668503676786377725805489344771023921079126552019160156920634619255970485781",
-            ),
-            p2: CurvePoint::from_xy_str(
-                "2251563274489750535117886426533222435294046428347329203627021249169616184184",
-                "1798716007562728905295480679789526322175868328062420237419143593021674992973",
-            ),
-            p3: CurvePoint::from_xy_str(
-                "2138414695194151160943305727036575959195309218611738193261179310511854807447",
-                "113410276730064486255102093846540133784865286929052426931474106396135072156",
-            ),
-            p4: CurvePoint::from_xy_str(
-                "2379962749567351885752724891227938183011949129833673362440656643086021394946",
-                "776496453633298175483985398648758586525933812536653089401905292063708816422",
-            ),
+const PEDERSEN_P1: CurvePoint = CurvePoint {
+    x: Fp([
+        3602345268353203007,
+        13758484295849329960,
+        518715844721862878,
+        241691544791834578,
+    ]),
+    y: Fp([
+        13441546676070136227,
+        13001553326386915570,
+        433857700841878496,
+        368891789801938570,
+    ]),
+    infinity: false,
+};
+const PEDERSEN_P2: CurvePoint = CurvePoint {
+    x: Fp([
+        16491878934996302286,
+        12382025591154462459,
+        10043949394709899044,
+        253000153565733272,
+    ]),
+    y: Fp([
+        13950428914333633429,
+        2545498000137298346,
+        5191292837124484988,
+        285630633187035523,
+    ]),
+    infinity: false,
+};
+const PEDERSEN_P3: CurvePoint = CurvePoint {
+    x: Fp([
+        1203723169299412240,
+        18195981508842736832,
+        12916675983929588442,
+        338510149841406402,
+    ]),
+    y: Fp([
+        12352616181161700245,
+        11743524503750604092,
+        11088962269971685343,
+        161068411212710156,
+    ]),
+    infinity: false,
+};
+const PEDERSEN_P4: CurvePoint = CurvePoint {
+    x: Fp([
+        1145636535101238356,
+        10664803185694787051,
+        299781701614706065,
+        425493972656615276,
+    ]),
+    y: Fp([
+        8187986478389849302,
+        4428713245976508844,
+        6033691581221864148,
+        345457391846365716,
+    ]),
+    infinity: false,
+};
+
+pub fn pedersen_hash(a: &Fp, b: &Fp) -> Fp {
+    let mut result = PEDERSEN_P0.clone();
+
+    // Add a_low * P1
+    let mut tmp = CurvePoint::identity();
+    for i in 0..248 {
+        tmp = tmp.double();
+        if a.get_bit(248 - 1 - i).is_one() {
+            tmp = tmp.add(&PEDERSEN_P1);
         }
     }
-}
+    result = result.add(&tmp);
 
-impl PedersenHash {
-    fn hash(&self, a: &H256, b: &H256) -> H256 {
-        // Add P0
-        let mut result = self.p0.clone();
-
-        // Add a_low * P1
-        let mut tmp = CurvePoint::identity();
-        for i in 0..248 {
-            tmp = tmp.double();
-            if a.get_bit(248 - 1 - i).is_one() {
-                tmp = tmp.add(&self.p1);
-            }
+    // Add a_high * P2
+    let mut tmp = CurvePoint::identity();
+    for i in 0..4 {
+        tmp = tmp.double();
+        if a.get_bit(252 - 1 - i).is_one() {
+            tmp = tmp.add(&PEDERSEN_P2);
         }
-        result = result.add(&tmp);
-
-        // Add a_high * P2
-        let mut tmp = CurvePoint::identity();
-        for i in 0..4 {
-            tmp = tmp.double();
-            if a.get_bit(252 - 1 - i).is_one() {
-                tmp = tmp.add(&self.p2);
-            }
-        }
-        result = result.add(&tmp);
-
-        // Add b_low * P3
-        let mut tmp = CurvePoint::identity();
-        for i in 0..248 {
-            tmp = tmp.double();
-            if b.get_bit(248 - 1 - i).is_one() {
-                tmp = tmp.add(&self.p3);
-            }
-        }
-        result = result.add(&tmp);
-
-        // Add b_high * P4
-        let mut tmp = CurvePoint::identity();
-        for i in 0..4 {
-            tmp = tmp.double();
-            if b.get_bit(252 - 1 - i).is_one() {
-                tmp = tmp.add(&self.p4);
-            }
-        }
-        result = result.add(&tmp);
-
-        // Return x-coordinate
-        result.x
     }
+    result = result.add(&tmp);
+
+    // Add b_low * P3
+    let mut tmp = CurvePoint::identity();
+    for i in 0..248 {
+        tmp = tmp.double();
+        if b.get_bit(248 - 1 - i).is_one() {
+            tmp = tmp.add(&PEDERSEN_P3);
+        }
+    }
+    result = result.add(&tmp);
+
+    // Add b_high * P4
+    let mut tmp = CurvePoint::identity();
+    for i in 0..4 {
+        tmp = tmp.double();
+        if b.get_bit(252 - 1 - i).is_one() {
+            tmp = tmp.add(&PEDERSEN_P4);
+        }
+    }
+    result = result.add(&tmp);
+
+    // Return x-coordinate
+    result.x
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
 
     mod get_bit {
         use super::*;
 
         #[test]
         fn zero() {
-            let zero = H256::zero();
+            let zero = Fp::zero();
             for i in 0..=255 {
                 assert!(zero.get_bit(i).is_zero(), "bit {}", i);
             }
@@ -256,7 +268,7 @@ mod tests {
 
         #[test]
         fn one() {
-            let one = H256::one();
+            let one = Fp::one();
             assert!(one.get_bit(0).is_one());
             for i in 1..=255 {
                 assert!(one.get_bit(i).is_zero(), "bit {}", i);
@@ -265,7 +277,7 @@ mod tests {
 
         #[test]
         fn two() {
-            let two = H256::one() + H256::one();
+            let two = Fp::one() + Fp::one();
             assert!(two.get_bit(0).is_zero());
             assert!(two.get_bit(1).is_one());
             for i in 2..=255 {
@@ -276,21 +288,29 @@ mod tests {
 
     mod curve {
         use super::*;
+        use pretty_assertions::assert_eq;
 
-        #[test]
-        fn generator() {
-            let g = CurvePoint::generator();
-            let expected = CurvePoint::from_xy_str(
+        fn curve_from_xy_str(x: &str, y: &str) -> CurvePoint {
+            let x = Fp::from_str_vartime(x).expect("Curve x-value invalid");
+            let y = Fp::from_str_vartime(y).expect("Curve y-value invalid");
+            CurvePoint {
+                x,
+                y,
+                infinity: false,
+            }
+        }
+
+        fn curve_generator() -> CurvePoint {
+            curve_from_xy_str(
                 "874739451078007766457464989774322083649278607533249481151382481072868806602",
                 "152666792071518830868575557812948353041420400780739481342941381225525861407",
-            );
-            assert_eq!(g, expected);
+            )
         }
 
         #[test]
         fn double() {
-            let g_double = CurvePoint::generator().double();
-            let expected = CurvePoint::from_xy_str(
+            let g_double = curve_generator().double();
+            let expected = curve_from_xy_str(
                 "3324833730090626974525872402899302150520188025637965566623476530814354734325",
                 "3147007486456030910661996439995670279305852583596209647900952752170983517249",
             );
@@ -299,10 +319,10 @@ mod tests {
 
         #[test]
         fn double_and_add() {
-            let g = CurvePoint::generator();
+            let g = curve_generator();
             let g_double = g.double();
             let g_triple = g_double.add(&g);
-            let expected = CurvePoint::from_xy_str(
+            let expected = curve_from_xy_str(
                 "1839793652349538280924927302501143912227271479439798783640887258675143576352",
                 "3564972295958783757568195431080951091358810058262272733141798511604612925062",
             );
@@ -311,20 +331,86 @@ mod tests {
 
         #[test]
         fn mul() {
-            let three = H256::one() + H256::one() + H256::one();
-            let g = CurvePoint::generator();
+            let three = Fp::one() + Fp::one() + Fp::one();
+            let g = curve_generator();
             let g_triple = g.mul(&three);
-            let expected = CurvePoint::from_xy_str(
+            let expected = curve_from_xy_str(
                 "1839793652349538280924927302501143912227271479439798783640887258675143576352",
                 "3564972295958783757568195431080951091358810058262272733141798511604612925062",
             );
             assert_eq!(g_triple, expected);
         }
+
+        #[test]
+        fn p0() {
+            let expected = curve_from_xy_str(
+                "2089986280348253421170679821480865132823066470938446095505822317253594081284",
+                "1713931329540660377023406109199410414810705867260802078187082345529207694986",
+            );
+
+            assert_eq!(PEDERSEN_P0, expected);
+        }
+
+        #[test]
+        fn p1() {
+            let expected = curve_from_xy_str(
+                "996781205833008774514500082376783249102396023663454813447423147977397232763",
+                "1668503676786377725805489344771023921079126552019160156920634619255970485781",
+            );
+
+            assert_eq!(PEDERSEN_P1, expected);
+        }
+
+        #[test]
+        fn p2() {
+            let expected = curve_from_xy_str(
+                "2251563274489750535117886426533222435294046428347329203627021249169616184184",
+                "1798716007562728905295480679789526322175868328062420237419143593021674992973",
+            );
+
+            assert_eq!(PEDERSEN_P2, expected);
+        }
+
+        #[test]
+        fn p3() {
+            let expected = curve_from_xy_str(
+                "2138414695194151160943305727036575959195309218611738193261179310511854807447",
+                "113410276730064486255102093846540133784865286929052426931474106396135072156",
+            );
+
+            assert_eq!(PEDERSEN_P3, expected);
+        }
+
+        #[test]
+        fn p4() {
+            let expected = curve_from_xy_str(
+                "2379962749567351885752724891227938183011949129833673362440656643086021394946",
+                "776496453633298175483985398648758586525933812536653089401905292063708816422",
+            );
+
+            assert_eq!(PEDERSEN_P4, expected);
+        }
     }
 
     #[test]
-    #[ignore = "we need test data for the pedersen hash"]
     fn hash() {
-        todo!("Get test data for pedersen hash");
+        // Test vector from https://github.com/starkware-libs/crypto-cpp/blob/master/src/starkware/crypto/pedersen_hash_test.cc
+        let a = Fp::from_str_vartime(
+            "1740729136829561885683894917751815192814966525555656371386868611731128807883",
+        )
+        .unwrap();
+        let b = Fp::from_str_vartime(
+            "919869093895560023824014392670608914007817594969197822578496829435657368346",
+        )
+        .unwrap();
+
+        let hash = pedersen_hash(&a, &b);
+
+        let expected = Fp::from_str_vartime(
+            "1382171651951541052082654537810074813456022260470662576358627909045455537762",
+        )
+        .unwrap();
+
+        assert_eq!(hash, expected);
     }
 }

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -11,18 +11,26 @@ pub struct Fp([u64; 4]);
 impl Fp {
     /// Transforms [Fp] into little endian bit representation.
     fn into_bits(mut self) -> BitArray<Lsb0, [u64; 4]> {
-        self.mont_reduce(
-            self.0[0usize],
-            self.0[1usize],
-            self.0[2usize],
-            self.0[3usize],
-            0,
-            0,
-            0,
-            0,
-        );
+        #[cfg(not(target_endian = "little"))]
+        {
+            todo!("untested and probably unimplemented: big-endian targets")
+        }
 
-        self.0.into()
+        #[cfg(target_endian = "little")]
+        {
+            self.mont_reduce(
+                self.0[0usize],
+                self.0[1usize],
+                self.0[2usize],
+                self.0[3usize],
+                0,
+                0,
+                0,
+                0,
+            );
+
+            self.0.into()
+        }
     }
 }
 

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -1,0 +1,331 @@
+use ff::{Field, PrimeField};
+
+/// The field primitive used by [PedersenHash]
+#[derive(PrimeField)]
+#[PrimeFieldModulus = "3618502788666131213697322783095070105623107215331596699973092056135872020481"]
+#[PrimeFieldGenerator = "7"]
+#[PrimeFieldReprEndianness = "little"]
+
+pub struct H256([u64; 4]);
+
+pub fn pedersen_hash(a: &H256, b: &H256) -> H256 {
+    PEDERSEN_HASHER.hash(a, b)
+}
+
+lazy_static::lazy_static!(
+    static ref PEDERSEN_HASHER: PedersenHash = PedersenHash::default();
+);
+
+impl H256 {
+    /// Returns the i'th bit. Panic's if `i` is out of bounds.
+    fn get_bit(&self, i: usize) -> Bit {
+        let mut r = *self;
+        r.mont_reduce(
+            self.0[0usize],
+            self.0[1usize],
+            self.0[2usize],
+            self.0[3usize],
+            0,
+            0,
+            0,
+            0,
+        );
+
+        let outer = i / 64;
+        let inner = i % 64;
+
+        match (r.0[outer] >> inner) & 0b1 {
+            0 => Bit::Zero,
+            _ => Bit::One,
+        }
+    }
+}
+
+#[derive(PartialEq, Clone, Copy)]
+enum Bit {
+    One,
+    Zero,
+}
+
+impl Bit {
+    fn is_one(&self) -> bool {
+        *self == Bit::One
+    }
+
+    fn is_zero(&self) -> bool {
+        !self.is_one()
+    }
+}
+
+/// A point on an elliptic curve over [H251].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct CurvePoint {
+    x: H256,
+    y: H256,
+    infinity: bool,
+}
+
+impl CurvePoint {
+    fn identity() -> CurvePoint {
+        Self {
+            x: H256::zero(),
+            y: H256::zero(),
+            infinity: true,
+        }
+    }
+
+    fn from_xy_str(x: &str, y: &str) -> CurvePoint {
+        let x = H256::from_str_vartime(x).expect("Curve x-value invalid");
+        let y = H256::from_str_vartime(y).expect("Curve y-value invalid");
+
+        CurvePoint {
+            x,
+            y,
+            infinity: false,
+        }
+    }
+
+    fn generator() -> CurvePoint {
+        Self::from_xy_str(
+            "874739451078007766457464989774322083649278607533249481151382481072868806602",
+            "152666792071518830868575557812948353041420400780739481342941381225525861407",
+        )
+    }
+
+    fn double(&self) -> CurvePoint {
+        if self.infinity {
+            return *self;
+        }
+
+        // l = (3x^2+a)/2y with a=1 from stark curve
+        let lambda = {
+            let two = H256::one() + H256::one();
+            let three = two + H256::one();
+            let dividend = three * (self.x * self.x) + H256::one();
+            let divisor_inv = (two * self.y).invert().unwrap();
+            dividend * divisor_inv
+        };
+
+        let result_x = (lambda * lambda) - self.x - self.x;
+        let result_y = lambda * (self.x - result_x) - self.y;
+
+        CurvePoint {
+            x: result_x,
+            y: result_y,
+            infinity: false,
+        }
+    }
+
+    fn add(&self, other: &CurvePoint) -> CurvePoint {
+        if self.infinity {
+            return *other;
+        }
+        if other.infinity {
+            return *self;
+        }
+
+        // l = (y2-y1)/(x2-x1)
+        let lambda = {
+            let dividend = other.y - self.y;
+            let divisor_inv = (other.x - self.x).invert().unwrap();
+            dividend * divisor_inv
+        };
+
+        let result_x = (lambda * lambda) - self.x - other.x;
+        let result_y = lambda * (self.x - result_x) - self.y;
+
+        CurvePoint {
+            x: result_x,
+            y: result_y,
+            infinity: false,
+        }
+    }
+
+    fn mul(&self, magnitude: &H256) -> CurvePoint {
+        let mut result = CurvePoint::identity();
+        for i in 0..256 {
+            result = result.double();
+            if magnitude.get_bit(255 - i).is_one() {
+                result = result.add(self);
+            }
+        }
+        result
+    }
+}
+
+/// Pedersen hasher
+#[derive(Clone, Debug)]
+struct PedersenHash {
+    p0: CurvePoint,
+    p1: CurvePoint,
+    p2: CurvePoint,
+    p3: CurvePoint,
+    p4: CurvePoint,
+}
+
+impl Default for PedersenHash {
+    fn default() -> Self {
+        PedersenHash {
+            p0: CurvePoint::from_xy_str(
+                "2089986280348253421170679821480865132823066470938446095505822317253594081284",
+                "1713931329540660377023406109199410414810705867260802078187082345529207694986",
+            ),
+            p1: CurvePoint::from_xy_str(
+                "996781205833008774514500082376783249102396023663454813447423147977397232763",
+                "1668503676786377725805489344771023921079126552019160156920634619255970485781",
+            ),
+            p2: CurvePoint::from_xy_str(
+                "2251563274489750535117886426533222435294046428347329203627021249169616184184",
+                "1798716007562728905295480679789526322175868328062420237419143593021674992973",
+            ),
+            p3: CurvePoint::from_xy_str(
+                "2138414695194151160943305727036575959195309218611738193261179310511854807447",
+                "113410276730064486255102093846540133784865286929052426931474106396135072156",
+            ),
+            p4: CurvePoint::from_xy_str(
+                "2379962749567351885752724891227938183011949129833673362440656643086021394946",
+                "776496453633298175483985398648758586525933812536653089401905292063708816422",
+            ),
+        }
+    }
+}
+
+impl PedersenHash {
+    fn hash(&self, a: &H256, b: &H256) -> H256 {
+        // Add P0
+        let mut result = self.p0;
+
+        // Add a_low * P1
+        let mut tmp = CurvePoint::identity();
+        for i in 0..248 {
+            tmp = tmp.double();
+            if a.get_bit(248 - 1 - i).is_one() {
+                tmp = tmp.add(&self.p1);
+            }
+        }
+        result = result.add(&tmp);
+
+        // Add a_high * P2
+        let mut tmp = CurvePoint::identity();
+        for i in 0..4 {
+            tmp = tmp.double();
+            if a.get_bit(252 - 1 - i).is_one() {
+                tmp = tmp.add(&self.p2);
+            }
+        }
+        result = result.add(&tmp);
+
+        // Add b_low * P3
+        let mut tmp = CurvePoint::identity();
+        for i in 0..248 {
+            tmp = tmp.double();
+            if b.get_bit(248 - 1 - i).is_one() {
+                tmp = tmp.add(&self.p3);
+            }
+        }
+        result = result.add(&tmp);
+
+        // Add b_high * P4
+        let mut tmp = CurvePoint::identity();
+        for i in 0..4 {
+            tmp = tmp.double();
+            if b.get_bit(252 - 1 - i).is_one() {
+                tmp = tmp.add(&self.p4);
+            }
+        }
+        result = result.add(&tmp);
+
+        // Return x-coordinate
+        result.x
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod get_bit {
+        use super::*;
+
+        #[test]
+        fn zero() {
+            let zero = H256::zero();
+            for i in 0..=255 {
+                assert!(zero.get_bit(i).is_zero(), "bit {}", i);
+            }
+        }
+
+        #[test]
+        fn one() {
+            let one = H256::one();
+            assert!(one.get_bit(0).is_one());
+            for i in 1..=255 {
+                assert!(one.get_bit(i).is_zero(), "bit {}", i);
+            }
+        }
+
+        #[test]
+        fn two() {
+            let two = H256::one() + H256::one();
+            assert!(two.get_bit(0).is_zero());
+            assert!(two.get_bit(1).is_one());
+            for i in 2..=255 {
+                assert!(two.get_bit(i).is_zero(), "bit {}", i);
+            }
+        }
+    }
+
+    mod curve {
+        use super::*;
+
+        #[test]
+        fn generator() {
+            let g = CurvePoint::generator();
+            let expected = CurvePoint::from_xy_str(
+                "874739451078007766457464989774322083649278607533249481151382481072868806602",
+                "152666792071518830868575557812948353041420400780739481342941381225525861407",
+            );
+            assert_eq!(g, expected);
+        }
+
+        #[test]
+        fn double() {
+            let g_double = CurvePoint::generator().double();
+            let expected = CurvePoint::from_xy_str(
+                "3324833730090626974525872402899302150520188025637965566623476530814354734325",
+                "3147007486456030910661996439995670279305852583596209647900952752170983517249",
+            );
+            assert_eq!(g_double, expected);
+        }
+
+        #[test]
+        fn double_and_add() {
+            let g = CurvePoint::generator();
+            let g_double = g.double();
+            let g_triple = g_double.add(&g);
+            let expected = CurvePoint::from_xy_str(
+                "1839793652349538280924927302501143912227271479439798783640887258675143576352",
+                "3564972295958783757568195431080951091358810058262272733141798511604612925062",
+            );
+            assert_eq!(g_triple, expected);
+        }
+
+        #[test]
+        fn mul() {
+            let three = H256::one() + H256::one() + H256::one();
+            let g = CurvePoint::generator();
+            let g_triple = g.mul(&three);
+            let expected = CurvePoint::from_xy_str(
+                "1839793652349538280924927302501143912227271479439798783640887258675143576352",
+                "3564972295958783757568195431080951091358810058262272733141798511604612925062",
+            );
+            assert_eq!(g_triple, expected);
+        }
+    }
+
+    #[test]
+    #[ignore = "we need test data for the pedersen hash"]
+    fn hash() {
+        todo!("Get test data for pedersen hash");
+    }
+}

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -34,7 +34,7 @@ impl Fp {
     }
 }
 
-/// A point on an elliptic curve over [H251].
+/// A point on an elliptic curve over [Fp].
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct CurvePoint {
     x: Fp,

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -122,6 +122,7 @@ impl CurvePoint {
     }
 }
 
+/// Montgomery representation of the Stark curve constant P0.
 const PEDERSEN_P0: CurvePoint = CurvePoint {
     x: Fp([
         1933903796324928314,
@@ -138,6 +139,7 @@ const PEDERSEN_P0: CurvePoint = CurvePoint {
     infinity: false,
 };
 
+/// Montgomery representation of the Stark curve constant P1.
 const PEDERSEN_P1: CurvePoint = CurvePoint {
     x: Fp([
         3602345268353203007,
@@ -153,6 +155,8 @@ const PEDERSEN_P1: CurvePoint = CurvePoint {
     ]),
     infinity: false,
 };
+
+/// Montgomery representation of the Stark curve constant P2.
 const PEDERSEN_P2: CurvePoint = CurvePoint {
     x: Fp([
         16491878934996302286,
@@ -168,6 +172,8 @@ const PEDERSEN_P2: CurvePoint = CurvePoint {
     ]),
     infinity: false,
 };
+
+/// Montgomery representation of the Stark curve constant P3.
 const PEDERSEN_P3: CurvePoint = CurvePoint {
     x: Fp([
         1203723169299412240,
@@ -183,6 +189,8 @@ const PEDERSEN_P3: CurvePoint = CurvePoint {
     ]),
     infinity: false,
 };
+
+/// Montgomery representation of the Stark curve constant P4.
 const PEDERSEN_P4: CurvePoint = CurvePoint {
     x: Fp([
         1145636535101238356,
@@ -199,6 +207,7 @@ const PEDERSEN_P4: CurvePoint = CurvePoint {
     infinity: false,
 };
 
+/// Performs the Stark Pedersen hash on `a` and `b`.
 pub fn pedersen_hash(a: Fp, b: Fp) -> Fp {
     let mut result = PEDERSEN_P0.clone();
     let a = a.into_bits();


### PR DESCRIPTION
This is an initial, not-optimized version with only basic testing.

More test cases are required before we are comfortable it is correct.

Note: `ff` dependency is reliant on a [fork I made](https://github.com/eqlabs/ff/tree/derive_bitvec) in order to work-around the `bitvec`-`funty` nonsense.