### PR TITLE
fix(sequencer): upgrade to alpha4 API, block related changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -- --skip rpc --skip sequencer
 
   clippy:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,10 @@ enum-iterator = "0.7.0"
 # Use our fork of ff. ff currently causes a bitvec-funty clash with our ethereum deps.
 # We've modified ff to not rely on bitvec (note that ff features are broken: https://github.com/zkcrypto/ff/issues/69).
 # We can use normal ff once it and `ethabi` (via `web3`) play nice.
-ff = { git = "https://github.com/eqlabs/ff", branch = "derive_bitvec", default-features = false, features = ["derive", "alloc"] }
+ff = { git = "https://github.com/eqlabs/ff", branch = "derive_bitvec", default-features = false, features = [
+    "derive",
+    "alloc",
+] }
 hex = "0.4.3"
 home = "0.5.3"
 # The latest stable revision on master for which jsonrpsee::proc_macros worked fine.

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -124,6 +124,7 @@ mod tests {
         }
 
         #[tokio::test]
+        #[ignore = "currently causes HTTP 504"]
         async fn latest() {
             let (srv, addr) = build_server();
             spawn_server(srv).await;

--- a/src/rpc/rpc_trait.rs
+++ b/src/rpc/rpc_trait.rs
@@ -8,7 +8,6 @@ use crate::{
     sequencer::{reply, request::Call},
 };
 use jsonrpsee::{proc_macros::rpc, types::error::Error};
-use web3::types::U256;
 
 /// TODO
 /// Add proper output structs as per spec.
@@ -50,16 +49,6 @@ pub trait RpcApi {
         contract_address: relaxed::H256,
         key: relaxed::H256,
         block_hash: BlockHashOrTag,
-    ) -> Result<relaxed::H256, Error>;
-
-    /// Get the value of the storage at the given address and key.
-    /// A __temporary replacement__ for [get_storage_at](RpcApiServer::get_storage_at) until we know how to calculate block hash.
-    #[method(name = "getStorageAtByBlockNumber")]
-    async fn get_storage_at_by_block_number(
-        &self,
-        contract_address: relaxed::H256,
-        key: relaxed::H256,
-        block_number: BlockNumberOrTag,
     ) -> Result<relaxed::H256, Error>;
 
     /// Get the details and status of a submitted transaction.
@@ -147,7 +136,7 @@ pub trait RpcApi {
 
     /// Get the most recent accepted block number.
     #[method(name = "blockNumber")]
-    async fn block_number(&self) -> Result<U256, Error>;
+    async fn block_number(&self) -> Result<u64, Error>;
 
     /// Return the currently configured StarkNet chain id.
     #[method(name = "chainId")]

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -1,7 +1,7 @@
-use crate::serde::{H256AsRelaxedHexStr, U256AsBigDecimal};
+use crate::serde::H256AsRelaxedHexStr;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use web3::types::{H256, U256};
+use web3::types::H256;
 
 /// Special tag used when specifying the latest block.
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -27,7 +27,7 @@ pub enum BlockHashOrTag {
 #[serde(untagged)]
 #[serde(deny_unknown_fields)]
 pub enum BlockNumberOrTag {
-    Number(#[serde_as(as = "U256AsBigDecimal")] U256),
+    Number(u64),
     Tag(Tag),
 }
 
@@ -40,7 +40,7 @@ pub mod relaxed {
     use web3::types;
 
     #[serde_as]
-    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+    #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
     pub struct H256(#[serde_as(as = "H256AsRelaxedHexStr")] types::H256);
 
     impl From<types::H256> for H256 {

--- a/src/sequencer/reply.rs
+++ b/src/sequencer/reply.rs
@@ -239,7 +239,7 @@ pub mod starknet {
 #[serde(untagged)]
 #[serde(deny_unknown_fields)]
 pub enum TransactionReply {
-    Transaction(Transaction),
+    Transaction(Box<Transaction>),
     Error(starknet::Error),
 }
 
@@ -248,7 +248,7 @@ impl TryFrom<TransactionReply> for Transaction {
 
     fn try_from(value: TransactionReply) -> Result<Self, Self::Error> {
         match value {
-            TransactionReply::Transaction(t) => Ok(t),
+            TransactionReply::Transaction(t) => Ok(*t),
             TransactionReply::Error(e) => Err(anyhow::Error::new(e)),
         }
     }

--- a/src/sequencer/reply.rs
+++ b/src/sequencer/reply.rs
@@ -32,13 +32,11 @@ impl TryFrom<BlockReply> for Block {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct Block {
-    #[serde_as(as = "U256AsBigDecimal")]
-    pub block_id: U256,
-    #[serde_as(as = "DefaultOnError<Option<U256AsBigDecimal>>")]
-    #[serde(default)]
-    pub previous_block_id: Option<U256>,
-    #[serde_as(as = "U256AsBigDecimal")]
-    pub sequence_number: U256,
+    #[serde_as(as = "Option<H256AsRelaxedHexStr>")]
+    pub block_hash: Option<H256>,
+    pub block_number: u64,
+    #[serde_as(as = "H256AsRelaxedHexStr")]
+    pub parent_block_hash: H256,
     #[serde_as(as = "H256AsRelaxedHexStr")]
     pub state_root: H256,
     pub status: block::Status,
@@ -124,6 +122,9 @@ impl TryFrom<CodeReply> for Code {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct Code {
+    // Unknown block hash results in empty abi represented as a JSON
+    // object, instead of a JSON array
+    #[serde_as(deserialize_as = "DefaultOnError")]
     pub abi: Vec<code::Abi>,
     #[serde_as(as = "Vec<H256AsRelaxedHexStr>")]
     pub bytecode: Vec<H256>,
@@ -224,18 +225,44 @@ pub mod starknet {
         TransactionFailed,
         #[serde(rename = "StarknetErrorCode.UNINITIALIZED_CONTRACT")]
         UninitializedContract,
+        #[serde(rename = "StarknetErrorCode.OUT_OF_RANGE_BLOCK_HASH")]
+        OutOfRangeBlockHash,
+        #[serde(rename = "StarknetErrorCode.OUT_OF_RANGE_TRANSACTION_HASH")]
+        OutOfRangeTransactionHash,
+        #[serde(rename = "StarkErrorCode.MALFORMED_REQUEST")]
+        MalformedRequest,
     }
 }
 
-/// Used to deserialize a reply from [Client::transaction](crate::sequencer::Client::transaction).
+/// Used to deserialize replies to [Client::transaction](crate::sequencer::Client::transaction).
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+#[serde(deny_unknown_fields)]
+pub enum TransactionReply {
+    Transaction(Transaction),
+    Error(starknet::Error),
+}
+
+impl TryFrom<TransactionReply> for Transaction {
+    type Error = anyhow::Error;
+
+    fn try_from(value: TransactionReply) -> Result<Self, Self::Error> {
+        match value {
+            TransactionReply::Transaction(t) => Ok(t),
+            TransactionReply::Error(e) => Err(anyhow::Error::new(e)),
+        }
+    }
+}
+
+/// Actual transaction data from [TransactionReply].
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct Transaction {
-    #[serde_as(as = "Option<U256AsBigDecimal>")]
+    #[serde_as(as = "Option<H256AsRelaxedHexStr>")]
     #[serde(default)]
-    pub block_id: Option<U256>,
+    pub block_hash: Option<H256>,
     #[serde_as(as = "Option<U256AsBigDecimal>")]
     #[serde(default)]
     pub block_number: Option<U256>,
@@ -243,26 +270,40 @@ pub struct Transaction {
     #[serde(default)]
     pub transaction: Option<transaction::Transaction>,
     #[serde(default)]
-    pub transaction_failure_reason: Option<transaction::Failure>,
-    #[serde(default)]
     pub transaction_index: Option<u64>,
-    #[serde_as(as = "H256AsRelaxedHexStr")]
-    pub transaction_hash: H256,
 }
 
-/// Used to deserialize a reply from [Client::transaction_status](crate::sequencer::Client::transaction_status).
+/// Used to deserialize replies to [Client::transaction_status](crate::sequencer::Client::transaction_status).
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+#[serde(deny_unknown_fields)]
+pub enum TransactionStatusReply {
+    TransactionStatus(TransactionStatus),
+    Error(starknet::Error),
+}
+
+impl TryFrom<TransactionStatusReply> for TransactionStatus {
+    type Error = anyhow::Error;
+
+    fn try_from(value: TransactionStatusReply) -> Result<Self, Self::Error> {
+        match value {
+            TransactionStatusReply::TransactionStatus(t) => Ok(t),
+            TransactionStatusReply::Error(e) => Err(anyhow::Error::new(e)),
+        }
+    }
+}
+
+/// Actual transaction data from [TransactionStatusReply].
 #[serde_as]
 #[skip_serializing_none]
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct TransactionStatus {
-    #[serde_as(as = "Option<U256AsBigDecimal>")]
+    #[serde_as(as = "Option<H256AsRelaxedHexStr>")]
     #[serde(default)]
-    pub block_id: Option<U256>,
+    pub block_hash: Option<H256>,
     #[serde(default)]
     pub tx_status: Option<transaction::Status>,
-    #[serde(default)]
-    pub tx_failure_reason: Option<transaction::Failure>,
 }
 
 /// Types used when deserializing L2 transaction related data.
@@ -356,16 +397,16 @@ pub mod transaction {
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     #[serde(deny_unknown_fields)]
     pub struct Receipt {
-        #[serde_as(as = "U256AsBigDecimal")]
-        pub block_id: U256,
-        #[serde_as(as = "U256AsBigDecimal")]
-        pub block_number: U256,
+        #[serde_as(as = "H256AsRelaxedHexStr")]
+        pub block_hash: H256,
+        pub block_number: u64,
         pub execution_resources: ExecutionResources,
+        pub l1_to_l2_consumed_message: Option<L1ToL2Message>,
         pub l2_to_l1_messages: Vec<L2ToL1Message>,
         pub status: Status,
-        pub transaction_index: u64,
         #[serde_as(as = "H256AsRelaxedHexStr")]
         pub transaction_hash: H256,
+        pub transaction_index: u64,
     }
 
     /// Represents deserialized object containing L2 contract address and transaction type.
@@ -378,7 +419,7 @@ pub mod transaction {
         pub r#type: Type,
     }
 
-    /// L2 transaction status values.
+    /// Transaction status values.
     #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
     #[serde(deny_unknown_fields)]
     pub enum Status {
@@ -390,8 +431,10 @@ pub mod transaction {
         Pending,
         #[serde(rename = "REJECTED")]
         Rejected,
-        #[serde(rename = "ACCEPTED_ONCHAIN")]
-        AcceptedOnChain,
+        #[serde(rename = "ACCEPTED_ON_L1")]
+        AcceptedOnL1,
+        #[serde(rename = "ACCEPTED_ON_L2")]
+        AcceptedOnL2,
         #[serde(rename = "REVERTED")]
         Reverted,
     }
@@ -405,9 +448,6 @@ pub mod transaction {
         #[serde_as(as = "Option<Vec<U256AsDecimalStr>>")]
         #[serde(default)]
         pub calldata: Option<Vec<U256>>,
-        #[serde_as(as = "Option<H256AsRelaxedHexStr>")]
-        #[serde(default)]
-        pub caller_address: Option<H256>,
         #[serde_as(as = "Option<Vec<U256AsDecimalStr>>")]
         #[serde(default)]
         pub constructor_calldata: Option<Vec<U256>>,
@@ -416,17 +456,17 @@ pub mod transaction {
         #[serde_as(as = "Option<H256AsRelaxedHexStr>")]
         #[serde(default)]
         pub contract_address_salt: Option<H256>,
+        #[serde(default)]
+        pub entry_point_type: Option<EntryPointType>,
         #[serde_as(as = "Option<H256AsRelaxedHexStr>")]
         #[serde(default)]
         pub entry_point_selector: Option<H256>,
-        #[serde(default)]
-        pub entry_point_type: Option<EntryPointType>,
-        pub r#type: Type,
         #[serde_as(as = "Option<Vec<U256AsDecimalStr>>")]
         #[serde(default)]
         pub signature: Option<Vec<U256>>,
         #[serde_as(as = "H256AsRelaxedHexStr")]
         pub transaction_hash: H256,
+        pub r#type: Type,
     }
 
     /// Describes L2 transaction types.


### PR DESCRIPTION
Upgrade sequencer client to handle alpha4 api changes. At the moment the main problem are gateway timeouts on the sequencer side, so tests which tend to get 504 most of the time are ignored until this is resolved. 