### PR TITLE
Proper RPC reply types and error codes

### DIFF
--- a/rpc_examples.sh
+++ b/rpc_examples.sh
@@ -40,8 +40,8 @@ rpc_call '[{"jsonrpc":"2.0","id":"14","method":"starknet_getBlockTransactionCoun
 {"jsonrpc":"2.0","id":"16","method":"starknet_getBlockTransactionCountByNumber","params":["latest"]},
 {"jsonrpc":"2.0","id":"17","method":"starknet_getBlockTransactionCountByNumber","params":[21348]}]'
 
-rpc_call '{"jsonrpc":"2.0","id":"18","method":"starknet_call","params":[{"calldata":[1234],"contract_address":"0x6fbd460228d843b7fbef670ff15607bf72e19fa94de21e29811ada167b4ca39",
-"entry_point_selector":"0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320","signature":[]}, "latest"]}'
+rpc_call '{"jsonrpc":"2.0","id":"18","method":"starknet_call","params":[{"calldata":["0x1234"],"contractAddress":"0x6fbd460228d843b7fbef670ff15607bf72e19fa94de21e29811ada167b4ca39",
+"entry_point_selector":"0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320"}, "latest"]}'
 
 rpc_call '{"jsonrpc":"2.0","id":"19","method":"starknet_blockNumber"}'
 

--- a/src/ethereum/log/fetch/backward.rs
+++ b/src/ethereum/log/fetch/backward.rs
@@ -53,7 +53,7 @@ where
     L: MetaLog + PartialEq + std::fmt::Debug,
     R: MetaLog + PartialEq + std::fmt::Debug,
 {
-    /// Creates a [LogFetcher] which fetches logs starting from `last_known`'s origin on L1.
+    /// Creates a [LogFetcher](super::forward::LogFetcher) which fetches logs starting from `last_known`'s origin on L1.
     ///
     /// In other words, the first log returned will be the one *before* `last_known`.
     pub fn new(last_known: EitherMetaLog<L, R>) -> Self {

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -225,7 +225,6 @@ mod tests {
         }
 
         #[tokio::test]
-        // #[ignore = "currently causes HTTP 504"]
         async fn latest() {
             let (_handle, addr) = run_server(*LOCALHOST).unwrap();
             let params = rpc_params!(BlockNumberOrTag::Tag(Tag::Latest));

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -162,10 +162,7 @@ mod tests {
 
     mod get_block_by_hash {
         use super::*;
-        use crate::{
-            rpc::types::{BlockHashOrTag, Tag},
-            sequencer::reply::BlockReply,
-        };
+        use crate::rpc::types::{reply::Block, BlockHashOrTag, Tag};
 
         #[tokio::test]
         #[ignore = "currently causes HTTP 504"]
@@ -173,7 +170,7 @@ mod tests {
             let (_handle, addr) = run_server(*LOCALHOST).unwrap();
             let params = rpc_params!(BlockHashOrTag::Hash(*GENESIS_BLOCK_HASH));
             client(addr)
-                .request::<BlockReply>("starknet_getBlockByHash", params)
+                .request::<Block>("starknet_getBlockByHash", params)
                 .await
                 .unwrap();
         }
@@ -183,7 +180,7 @@ mod tests {
             let (_handle, addr) = run_server(*LOCALHOST).unwrap();
             let params = rpc_params!(BlockHashOrTag::Tag(Tag::Latest));
             client(addr)
-                .request::<BlockReply>("starknet_getBlockByHash", params)
+                .request::<Block>("starknet_getBlockByHash", params)
                 .await
                 .unwrap();
         }
@@ -193,7 +190,7 @@ mod tests {
             let (_handle, addr) = run_server(*LOCALHOST).unwrap();
             let params = rpc_params!(BlockHashOrTag::Hash(*UNKNOWN_BLOCK_HASH));
             let reply = client(addr)
-                .request::<BlockReply>("starknet_getBlockByHash", params)
+                .request::<Block>("starknet_getBlockByHash", params)
                 .await
                 .unwrap_err();
             assert_matches!(
@@ -209,7 +206,7 @@ mod tests {
             let (_handle, addr) = run_server(*LOCALHOST).unwrap();
             let params = rpc_params!(BlockHashOrTag::Hash(*INVALID_BLOCK_HASH));
             let reply = client(addr)
-                .request::<BlockReply>("starknet_getBlockByHash", params)
+                .request::<Block>("starknet_getBlockByHash", params)
                 .await
                 .unwrap_err();
             assert_matches!(
@@ -223,17 +220,14 @@ mod tests {
 
     mod get_block_by_number {
         use super::*;
-        use crate::{
-            rpc::types::{BlockNumberOrTag, Tag},
-            sequencer::reply::BlockReply,
-        };
+        use crate::rpc::types::{reply::Block, BlockNumberOrTag, Tag};
 
         #[tokio::test]
         async fn genesis() {
             let (_handle, addr) = run_server(*LOCALHOST).unwrap();
             let params = rpc_params!(BlockNumberOrTag::Number(0));
             client(addr)
-                .request::<BlockReply>("starknet_getBlockByNumber", params)
+                .request::<Block>("starknet_getBlockByNumber", params)
                 .await
                 .unwrap();
         }
@@ -243,7 +237,7 @@ mod tests {
             let (_handle, addr) = run_server(*LOCALHOST).unwrap();
             let params = rpc_params!(BlockNumberOrTag::Tag(Tag::Latest));
             client(addr)
-                .request::<BlockReply>("starknet_getBlockByNumber", params)
+                .request::<Block>("starknet_getBlockByNumber", params)
                 .await
                 .unwrap();
         }
@@ -253,7 +247,7 @@ mod tests {
             let (_handle, addr) = run_server(*LOCALHOST).unwrap();
             let params = rpc_params!(BlockNumberOrTag::Number(u64::MAX));
             let reply = client(addr)
-                .request::<BlockReply>("starknet_getBlockByNumber", params)
+                .request::<Block>("starknet_getBlockByNumber", params)
                 .await
                 .unwrap_err();
             assert_matches!(

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -365,10 +365,16 @@ mod tests {
                 *VALID_KEY,
                 BlockHashOrTag::Hash(*UNKNOWN_BLOCK_HASH)
             );
-            client(addr)
+            let reply = client(addr)
                 .request::<starknet::Error>("starknet_getStorageAt", params)
                 .await
                 .unwrap_err();
+            assert_matches!(
+                reply,
+                Error::Request(s) => {
+                    assert_eq!(s, r#"{"jsonrpc":"2.0","error":{"code":-32024,"message":"Invalid block hash"},"id":0}"#.to_owned())
+                }
+            );
         }
 
         #[tokio::test]
@@ -377,12 +383,18 @@ mod tests {
             let params = rpc_params!(
                 *VALID_CONTRACT_ADDR,
                 *VALID_KEY,
-                BlockHashOrTag::Hash(H256::zero())
+                BlockHashOrTag::Hash(*INVALID_BLOCK_HASH)
             );
-            client(addr)
+            let reply = client(addr)
                 .request::<starknet::Error>("starknet_getStorageAt", params)
                 .await
                 .unwrap_err();
+            assert_matches!(
+                reply,
+                Error::Request(s) => {
+                    assert_eq!(s, r#"{"jsonrpc":"2.0","error":{"code":-32024,"message":"Invalid block hash"},"id":0}"#.to_owned())
+                }
+            );
         }
 
         #[tokio::test]

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -120,10 +120,7 @@ pub fn run_server(addr: SocketAddr) -> Result<(HttpServerHandle, SocketAddr), Er
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        rpc::{run_server, types::relaxed},
-        sequencer::reply::starknet,
-    };
+    use crate::rpc::{run_server, types::relaxed};
     use assert_matches::assert_matches;
     use jsonrpsee::{
         http_client::{HttpClient, HttpClientBuilder},

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -192,20 +192,32 @@ mod tests {
         async fn not_found() {
             let (_handle, addr) = run_server(*LOCALHOST).unwrap();
             let params = rpc_params!(BlockHashOrTag::Hash(*UNKNOWN_BLOCK_HASH));
-            client(addr)
+            let reply = client(addr)
                 .request::<starknet::Error>("starknet_getBlockByHash", params)
                 .await
                 .unwrap_err();
+            assert_matches!(
+                reply,
+                Error::Request(s) => {
+                    assert_eq!(s, r#"{"jsonrpc":"2.0","error":{"code":-32024,"message":"Invalid block hash"},"id":0}"#.to_owned())
+                }
+            );
         }
 
         #[tokio::test]
         async fn invalid_block_hash() {
             let (_handle, addr) = run_server(*LOCALHOST).unwrap();
             let params = rpc_params!(BlockHashOrTag::Hash(*INVALID_BLOCK_HASH));
-            client(addr)
+            let reply = client(addr)
                 .request::<starknet::Error>("starknet_getBlockByHash", params)
                 .await
                 .unwrap_err();
+            assert_matches!(
+                reply,
+                Error::Request(s) => {
+                    assert_eq!(s, r#"{"jsonrpc":"2.0","error":{"code":-32024,"message":"Invalid block hash"},"id":0}"#.to_owned())
+                }
+            );
         }
     }
 
@@ -634,20 +646,32 @@ mod tests {
         async fn invalid() {
             let (_handle, addr) = run_server(*LOCALHOST).unwrap();
             let params = rpc_params!(BlockHashOrTag::Hash(*INVALID_BLOCK_HASH));
-            client(addr)
+            let reply = client(addr)
                 .request::<starknet::Error>("starknet_getBlockTransactionCountByHash", params)
                 .await
                 .unwrap_err();
+            assert_matches!(
+                reply,
+                Error::Request(s) => {
+                    assert_eq!(s, r#"{"jsonrpc":"2.0","error":{"code":-32024,"message":"Invalid block hash"},"id":0}"#.to_owned())
+                }
+            );
         }
 
         #[tokio::test]
         async fn unknown() {
             let (_handle, addr) = run_server(*LOCALHOST).unwrap();
             let params = rpc_params!(BlockHashOrTag::Hash(*UNKNOWN_BLOCK_HASH));
-            client(addr)
+            let reply = client(addr)
                 .request::<starknet::Error>("starknet_getBlockTransactionCountByHash", params)
                 .await
                 .unwrap_err();
+            assert_matches!(
+                reply,
+                Error::Request(s) => {
+                    assert_eq!(s, r#"{"jsonrpc":"2.0","error":{"code":-32024,"message":"Invalid block hash"},"id":0}"#.to_owned())
+                }
+            );
         }
     }
 
@@ -679,10 +703,16 @@ mod tests {
         async fn invalid() {
             let (_handle, addr) = run_server(*LOCALHOST).unwrap();
             let params = rpc_params!(BlockNumberOrTag::Number(u64::MAX));
-            client(addr)
+            let reply = client(addr)
                 .request::<starknet::Error>("starknet_getBlockTransactionCountByNumber", params)
                 .await
                 .unwrap_err();
+            assert_matches!(
+                reply,
+                Error::Request(s) => {
+                    assert_eq!(s, r#"{"jsonrpc":"2.0","error":{"code":-32025,"message":"Invalid block number"},"id":0}"#.to_owned())
+                }
+            );
         }
     }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -588,14 +588,14 @@ mod tests {
 
     mod get_transaction_receipt {
         use super::*;
-        use crate::sequencer::reply::TransactionStatus;
+        use crate::rpc::types::reply::TransactionReceipt;
 
         #[tokio::test]
         async fn accepted() {
             let (_handle, addr) = run_server(*LOCALHOST).unwrap();
             let params = rpc_params!(*VALID_TX_HASH);
             client(addr)
-                .request::<TransactionStatus>("starknet_getTransactionReceipt", params)
+                .request::<TransactionReceipt>("starknet_getTransactionReceipt", params)
                 .await
                 .unwrap();
         }
@@ -604,20 +604,32 @@ mod tests {
         async fn invalid() {
             let (_handle, addr) = run_server(*LOCALHOST).unwrap();
             let params = rpc_params!(*INVALID_TX_HASH);
-            client(addr)
-                .request::<TransactionStatus>("starknet_getTransactionReceipt", params)
+            let reply = client(addr)
+                .request::<TransactionReceipt>("starknet_getTransactionReceipt", params)
                 .await
                 .unwrap_err();
+            assert_matches!(
+                reply,
+                Error::Request(s) => {
+                    assert_eq!(s, r#"{"jsonrpc":"2.0","error":{"code":-32025,"message":"Invalid transaction hash"},"id":0}"#.to_owned())
+                }
+            );
         }
 
         #[tokio::test]
         async fn unknown() {
             let (_handle, addr) = run_server(*LOCALHOST).unwrap();
             let params = rpc_params!(*UNKNOWN_TX_HASH);
-            client(addr)
-                .request::<TransactionStatus>("starknet_getTransactionReceipt", params)
+            let reply = client(addr)
+                .request::<TransactionReceipt>("starknet_getTransactionReceipt", params)
                 .await
-                .unwrap();
+                .unwrap_err();
+            assert_matches!(
+                reply,
+                Error::Request(s) => {
+                    assert_eq!(s, r#"{"jsonrpc":"2.0","error":{"code":-32025,"message":"Invalid transaction hash"},"id":0}"#.to_owned())
+                }
+            );
         }
     }
 

--- a/src/rpc/api.rs
+++ b/src/rpc/api.rs
@@ -3,11 +3,12 @@ use crate::{
     rpc::types::{
         relaxed,
         reply::{Block, Code, ErrorCode, StateUpdate, Syncing, Transaction, TransactionReceipt},
+        request::Call,
         BlockHashOrTag, BlockNumberOrTag,
     },
     sequencer::{
         reply as raw, reply::starknet::Error as RawError,
-        reply::starknet::ErrorCode as RawErrorCode, request::Call, Client,
+        reply::starknet::ErrorCode as RawErrorCode, Client,
     },
 };
 use jsonrpsee::types::error::{CallError, Error};
@@ -310,7 +311,7 @@ impl RpcApi {
         };
         let call = self
             .0
-            .call(request, block_hash)
+            .call(request.into(), block_hash)
             .await
             .map_err(|e| -> Error {
                 match e.downcast_ref::<RawError>() {

--- a/src/rpc/api.rs
+++ b/src/rpc/api.rs
@@ -2,7 +2,7 @@
 use crate::{
     rpc::types::{
         relaxed,
-        reply::{Block, Code, ErrorCode, Syncing, Transaction},
+        reply::{Block, Code, ErrorCode, StateUpdate, Syncing, Transaction},
         BlockHashOrTag, BlockNumberOrTag,
     },
     sequencer::{
@@ -106,7 +106,10 @@ impl RpcApi {
         Ok(block.into())
     }
 
-    pub async fn get_state_update_by_hash(&self, block_hash: BlockHashOrTag) -> Result<(), Error> {
+    pub async fn get_state_update_by_hash(
+        &self,
+        block_hash: BlockHashOrTag,
+    ) -> Result<StateUpdate, Error> {
         // TODO get this from storage or directly from L1
         match block_hash {
             BlockHashOrTag::Tag(_) => todo!("Implement L1 state diff retrieval."),

--- a/src/rpc/api.rs
+++ b/src/rpc/api.rs
@@ -183,9 +183,6 @@ impl RpcApi {
     ) -> Result<Transaction, Error> {
         // TODO get this from storage
         let txn = self.get_raw_transaction_by_hash(transaction_hash).await?;
-        if txn.status == raw::transaction::Status::NotReceived {
-            return Err(invalid_transaction_hash());
-        }
         Ok(txn.into())
     }
 

--- a/src/rpc/api.rs
+++ b/src/rpc/api.rs
@@ -1,6 +1,6 @@
 //! Implementation of JSON-RPC endpoints.
 use crate::{
-    rpc::types::{relaxed, BlockHashOrTag, BlockNumberOrTag, Syncing},
+    rpc::types::{relaxed, reply::Syncing, BlockHashOrTag, BlockNumberOrTag},
     sequencer::{reply, request::Call, Client},
 };
 use jsonrpsee::types::error::{CallError, Error};

--- a/src/rpc/api.rs
+++ b/src/rpc/api.rs
@@ -110,6 +110,9 @@ impl RpcApi {
                             ErrorCode::ContractNotFound.into()
                         }
                         SeqErrorCode::OutOfRangeStorageKey => ErrorCode::InvalidStorageKey.into(),
+                        SeqErrorCode::OutOfRangeBlockHash | SeqErrorCode::BlockNotFound => {
+                            ErrorCode::InvalidBlockHash.into()
+                        }
                         _ => e.into(),
                     },
                     None => e.into(),

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -166,8 +166,8 @@ pub mod reply {
         #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
         #[serde(deny_unknown_fields)]
         pub struct StateDiff {
-            storage_diffs: Vec<u32>,
-            contracts: Vec<u32>,
+            storage_diffs: Vec<StorageDiff>,
+            contracts: Vec<Contract>,
         }
 
         /// L2 storage diff.

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -89,6 +89,8 @@ pub mod request {
 
 /// Groups all strictly output types of the RPC API.
 pub mod reply {
+    // At the moment both reply types are the same for get_code, hence the re-export
+    pub use crate::sequencer::reply::Code;
     use crate::{
         sequencer::reply as seq, sequencer::reply::block::Status as SeqStatus,
         serde::H256AsRelaxedHexStr,
@@ -97,7 +99,7 @@ pub mod reply {
     use serde::{Deserialize, Serialize};
     use serde_with::serde_as;
     use std::convert::From;
-    use web3::types::{H160, H256, U256};
+    use web3::types::{H160, H256};
 
     /// L2 Block status as returned by the RPC API.
     #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -317,6 +319,26 @@ pub mod reply {
                     },
                 },
                 None => Self::default(),
+            }
+        }
+    }
+
+    impl From<seq::transaction::Transaction> for Transaction {
+        fn from(txn: seq::transaction::Transaction) -> Self {
+            Self {
+                txn_hash: txn.transaction_hash,
+                contract_address: txn.contract_address,
+                entry_point_selector: txn.entry_point_selector.unwrap_or_default(),
+                calldata: match txn.calldata {
+                    Some(cd) => cd
+                        .iter()
+                        .map(|d| {
+                            let x: [u8; 32] = (*d).into();
+                            x.into()
+                        })
+                        .collect(),
+                    None => vec![],
+                },
             }
         }
     }

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -177,27 +177,18 @@ pub mod reply {
     /// Starkware specific RPC error codes.
     #[derive(Copy, Clone, Debug, PartialEq)]
     pub enum ErrorCode {
-        // "Failed to write transaction"
         FailedToReceiveTransaction = -32001,
-        // "Contract not found"
         ContractNotFound = -32020,
-        // "Invalid message selector"
         InvalidMessageSelector = -32021,
-        // "Invalid call data"
         InvalidCallData = -32022,
-        // "Invalid storage key"
         InvalidStorageKey = -32023,
-        // "Invalid block hash"
         InvalidBlockHash = -32024,
-        // "Invalid block number"
         InvalidBlockNumber = -32025,
-        // "Contract error"
         ContractError = -32040,
     }
 
     impl ErrorCode {
-        // "Invalid transaction hash"
-        // TODO jsonrpsee::types::CallError
+        // Workaround for a duplicate error code value
         #[allow(non_upper_case_globals)]
         pub const InvalidTransactionHash: ErrorCode = ErrorCode::InvalidBlockNumber;
     }

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -120,7 +120,7 @@ pub mod reply {
     impl From<SeqStatus> for BlockStatus {
         fn from(status: SeqStatus) -> Self {
             match status {
-                // TODO klis: this is a wild guess right now
+                // TODO verify this mapping with Starkware
                 SeqStatus::AcceptedOnL1 => BlockStatus::AcceptedOnChain,
                 SeqStatus::AcceptedOnL2 => BlockStatus::Proven,
                 SeqStatus::NotReceived => BlockStatus::Rejected,
@@ -177,6 +177,9 @@ pub mod reply {
     }
 
     /// Starkware specific RPC error codes.
+    // TODO verify with Starkware how `sequencer::reply::starknet::ErrorCode` should
+    // map to the values below in all JSON-RPC API methods. Also verify if
+    // the mapping should be method-specific or common for all methods.
     #[derive(Copy, Clone, Debug, PartialEq)]
     pub enum ErrorCode {
         FailedToReceiveTransaction = -32001,
@@ -354,7 +357,7 @@ pub mod reply {
             Self {
                 txn_hash: receipt.transaction_hash,
                 status: receipt.status.into(),
-                // TODO
+                // TODO at the moment not available in sequencer replies
                 status_data: String::new(),
                 messages_sent: receipt
                     .l2_to_l1_messages
@@ -454,7 +457,7 @@ pub mod reply {
     impl From<seq::transaction::Status> for TransactionStatus {
         fn from(status: SeqStatus) -> Self {
             match status {
-                // TODO klis: this is a wild guess right now
+                // TODO verify this mapping with Starkware
                 SeqStatus::AcceptedOnL1 => TransactionStatus::AcceptedOnChain,
                 SeqStatus::AcceptedOnL2 => TransactionStatus::AcceptedOnChain,
                 SeqStatus::NotReceived => TransactionStatus::Unknown,

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -59,6 +59,12 @@ pub mod relaxed {
             &self.0
         }
     }
+
+    impl From<crate::sequencer::reply::Call> for Vec<H256> {
+        fn from(call: crate::sequencer::reply::Call) -> Self {
+            call.result.into_iter().map(|x| H256::from(x)).collect()
+        }
+    }
 }
 
 /// Groups all strictly input types of the RPC API.

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -95,7 +95,7 @@ pub mod reply {
             highest_block: BlockStatus,
         }
 
-        /// Represents highest block status.
+        /// Represents block status.
         #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
         #[serde(deny_unknown_fields)]
         pub enum BlockStatus {
@@ -137,6 +137,11 @@ pub mod reply {
         ContractNotFound = -32020,
         InvaldStorageKey = -32023,
         InvalidBlockNumber = -32025,
+    }
+
+    impl ErrorCode {
+        #[allow(non_upper_case_globals)]
+        pub const InvalidTransactionHash: ErrorCode = ErrorCode::InvalidBlockNumber;
     }
 
     /// L2 state update as returned by the RPC API.
@@ -193,5 +198,78 @@ pub mod reply {
             #[serde_as(as = "H256AsRelaxedHexStr")]
             contract_hash: H256,
         }
+    }
+
+    /// L2 transaction as returned by the RPC API.
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+    #[serde(deny_unknown_fields)]
+    pub struct Transaction {
+        #[serde_as(as = "H256AsRelaxedHexStr")]
+        txn_hash: H256,
+        #[serde_as(as = "H256AsRelaxedHexStr")]
+        #[serde(rename = "contractAddress")]
+        contract_address: H256,
+        #[serde_as(as = "H256AsRelaxedHexStr")]
+        entry_point_selector: H256,
+        #[serde_as(as = "Vec<H256AsRelaxedHexStr>")]
+        calldata: Vec<H256>,
+    }
+
+    /// L2 transaction receipt as returned by the RPC API.
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+    #[serde(deny_unknown_fields)]
+    pub struct TransactionReceipt {
+        #[serde_as(as = "H256AsRelaxedHexStr")]
+        txn_hash: H256,
+        status: TransactionStatus,
+        status_data: String,
+        messages_sent: Vec<transaction_receipt::MessageToL1>,
+        l1_origin_message: transaction_receipt::MessageToL2,
+    }
+
+    /// Transaction receipt related substructures.
+    pub mod transaction_receipt {
+        use crate::serde::{H160AsRelaxedHexStr, H256AsRelaxedHexStr};
+        use serde::{Deserialize, Serialize};
+        use serde_with::serde_as;
+        use web3::types::{H160, H256};
+
+        #[serde_as]
+        #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+        #[serde(deny_unknown_fields)]
+        pub struct MessageToL1 {
+            #[serde_as(as = "H256AsRelaxedHexStr")]
+            to_address: H256,
+            #[serde_as(as = "Vec<H256AsRelaxedHexStr>")]
+            payload: Vec<H256>,
+        }
+
+        #[serde_as]
+        #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+        #[serde(deny_unknown_fields)]
+        pub struct MessageToL2 {
+            #[serde_as(as = "H160AsRelaxedHexStr")]
+            from_address: H160,
+            #[serde_as(as = "Vec<H256AsRelaxedHexStr>")]
+            payload: Vec<H256>,
+        }
+    }
+
+    /// Represents transaction status.
+    #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+    #[serde(deny_unknown_fields)]
+    pub enum TransactionStatus {
+        #[serde(rename = "UNKNOWN")]
+        Unknown,
+        #[serde(rename = "RECEIVED")]
+        Received,
+        #[serde(rename = "PENDING")]
+        Pending,
+        #[serde(rename = "ACCEPTED_ONCHAIN")]
+        AcceptedOnChain,
+        #[serde(rename = "REJECTED")]
+        Rejected,
     }
 }

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -134,7 +134,9 @@ pub mod reply {
     /// Starkware specific RPC error codes.
     #[derive(Copy, Clone, Debug, PartialEq)]
     pub enum ErrorCode {
-        InalidBlockNumber = -32025,
+        ContractNotFound = -32020,
+        InvaldStorageKey = -32023,
+        InvalidBlockNumber = -32025,
     }
 
     /// L2 state update as returned by the RPC API.

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -32,6 +32,7 @@ pub enum BlockNumberOrTag {
 }
 
 /// Contains hash type wrappers enabling deserialization via `*AsRelaxedHexStr`.
+/// Which allows for skipping leading zeros in serialized hex strings.
 pub mod relaxed {
     use crate::serde::H256AsRelaxedHexStr;
     use serde::{Deserialize, Serialize};
@@ -60,45 +61,49 @@ pub mod relaxed {
     }
 }
 
-/// Describes Starknet's syncing status RPC reply.
-#[serde_as]
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(untagged)]
-#[serde(deny_unknown_fields)]
-pub enum Syncing {
-    False(bool),
-    Status(syncing::Status),
-}
-
-pub mod syncing {
-    use crate::serde::H256AsRelaxedHexStr;
+/// Groups all strictly output types of the RPC API.
+pub mod reply {
     use serde::{Deserialize, Serialize};
-    use serde_with::serde_as;
-    use web3::types::H256;
 
-    /// Represents Starknet node syncing status.
-    #[serde_as]
-    #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+    /// Describes Starknet's syncing status RPC reply.
+    #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+    #[serde(untagged)]
     #[serde(deny_unknown_fields)]
-    pub struct Status {
-        #[serde_as(as = "H256AsRelaxedHexStr")]
-        starting_block: H256,
-        #[serde_as(as = "H256AsRelaxedHexStr")]
-        current_block: H256,
-        highest_block: HighestBlock,
+    pub enum Syncing {
+        False(bool),
+        Status(syncing::Status),
     }
 
-    /// Represents highest block status.
-    #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
-    #[serde(deny_unknown_fields)]
-    pub enum HighestBlock {
-        #[serde(rename = "PENDING")]
-        Pending,
-        #[serde(rename = "PROVEN")]
-        Proven,
-        #[serde(rename = "ACCEPTED_ONCHAIN")]
-        AcceptedOnChain,
-        #[serde(rename = "REJECTED")]
-        Rejected,
+    pub mod syncing {
+        use crate::serde::H256AsRelaxedHexStr;
+        use serde::{Deserialize, Serialize};
+        use serde_with::serde_as;
+        use web3::types::H256;
+
+        /// Represents Starknet node syncing status.
+        #[serde_as]
+        #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+        #[serde(deny_unknown_fields)]
+        pub struct Status {
+            #[serde_as(as = "H256AsRelaxedHexStr")]
+            starting_block: H256,
+            #[serde_as(as = "H256AsRelaxedHexStr")]
+            current_block: H256,
+            highest_block: BlockStatus,
+        }
+
+        /// Represents highest block status.
+        #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+        #[serde(deny_unknown_fields)]
+        pub enum BlockStatus {
+            #[serde(rename = "PENDING")]
+            Pending,
+            #[serde(rename = "PROVEN")]
+            Proven,
+            #[serde(rename = "ACCEPTED_ONCHAIN")]
+            AcceptedOnChain,
+            #[serde(rename = "REJECTED")]
+            Rejected,
+        }
     }
 }

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -63,7 +63,10 @@ pub mod relaxed {
 
 /// Groups all strictly output types of the RPC API.
 pub mod reply {
+    use crate::serde::H256AsRelaxedHexStr;
     use serde::{Deserialize, Serialize};
+    use serde_with::serde_as;
+    use web3::types::{H160, H256};
 
     /// Describes Starknet's syncing status RPC reply.
     #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -104,6 +107,89 @@ pub mod reply {
             AcceptedOnChain,
             #[serde(rename = "REJECTED")]
             Rejected,
+        }
+    }
+
+    /// L2 Block as returned by the RPC API.
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+    #[serde(deny_unknown_fields)]
+    pub struct Block {
+        #[serde_as(as = "H256AsRelaxedHexStr")]
+        block_hash: H256,
+        #[serde_as(as = "H256AsRelaxedHexStr")]
+        parent_hash: H256,
+        block_number: u64,
+        status: syncing::BlockStatus,
+        sequencer: H160,
+        #[serde_as(as = "H256AsRelaxedHexStr")]
+        new_root: H256,
+        #[serde_as(as = "H256AsRelaxedHexStr")]
+        old_root: H256,
+        accepted_time: u64,
+        #[serde_as(as = "Vec<H256AsRelaxedHexStr>")]
+        transactions: Vec<H256>,
+    }
+
+    /// Starkware specific RPC error codes.
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    pub enum ErrorCode {
+        InalidBlockNumber = -32025,
+    }
+
+    /// L2 state update as returned by the RPC API.
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+    #[serde(deny_unknown_fields)]
+    pub struct StateUpdate {
+        #[serde_as(as = "H256AsRelaxedHexStr")]
+        block_hash: H256,
+        #[serde_as(as = "H256AsRelaxedHexStr")]
+        new_root: H256,
+        #[serde_as(as = "H256AsRelaxedHexStr")]
+        old_root: H256,
+        accepted_time: u64,
+        state_diff: state_update::StateDiff,
+    }
+
+    /// State update related substructures.
+    pub mod state_update {
+        use crate::serde::H256AsRelaxedHexStr;
+        use serde::{Deserialize, Serialize};
+        use serde_with::serde_as;
+        use web3::types::H256;
+
+        /// L2 state diff.
+        #[serde_as]
+        #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+        #[serde(deny_unknown_fields)]
+        pub struct StateDiff {
+            storage_diffs: Vec<u32>,
+            contracts: Vec<u32>,
+        }
+
+        /// L2 storage diff.
+        #[serde_as]
+        #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+        #[serde(deny_unknown_fields)]
+        pub struct StorageDiff {
+            #[serde_as(as = "H256AsRelaxedHexStr")]
+            address: H256,
+            #[serde_as(as = "H256AsRelaxedHexStr")]
+            key: H256,
+            #[serde_as(as = "H256AsRelaxedHexStr")]
+            value: H256,
+        }
+
+        /// L2 contract data within state diff.
+        #[serde_as]
+        #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+        #[serde(deny_unknown_fields)]
+        pub struct Contract {
+            #[serde_as(as = "H256AsRelaxedHexStr")]
+            address: H256,
+            #[serde_as(as = "H256AsRelaxedHexStr")]
+            contract_hash: H256,
         }
     }
 }

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -61,6 +61,26 @@ pub mod relaxed {
     }
 }
 
+/// Groups all strictly input types of the RPC API.
+pub mod request {
+    use crate::serde::H256AsRelaxedHexStr;
+    use serde::{Deserialize, Serialize};
+    use serde_with::serde_as;
+    use web3::types::H256;
+
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+    pub struct Call {
+        #[serde(rename = "contractAddress")]
+        #[serde_as(as = "H256AsRelaxedHexStr")]
+        pub contract_address: H256,
+        #[serde_as(as = "Vec<H256AsRelaxedHexStr>")]
+        pub calldata: Vec<H256>,
+        #[serde_as(as = "H256AsRelaxedHexStr")]
+        pub entry_point_selector: H256,
+    }
+}
+
 /// Groups all strictly output types of the RPC API.
 pub mod reply {
     use crate::serde::H256AsRelaxedHexStr;

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -1,3 +1,4 @@
+//! Data structures used by the JSON-RPC API methods.
 use crate::serde::H256AsRelaxedHexStr;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -74,6 +75,7 @@ pub mod request {
     use serde_with::serde_as;
     use web3::types::H256;
 
+    /// Contains parameters passed to `starknet_call`.
     #[serde_as]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     pub struct Call {
@@ -378,6 +380,7 @@ pub mod reply {
         use std::convert::From;
         use web3::types::{H160, H256};
 
+        /// Message sent from L2 to L1.
         #[serde_as]
         #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
         #[serde(deny_unknown_fields)]
@@ -404,6 +407,7 @@ pub mod reply {
             }
         }
 
+        /// Message sent from L1 to L2.
         #[serde_as]
         #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
         #[serde(deny_unknown_fields)]
@@ -471,6 +475,7 @@ pub mod reply {
         Status(syncing::Status),
     }
 
+    /// Starknet's syncing status substructures.
     pub mod syncing {
         use super::BlockStatus;
         use crate::serde::H256AsRelaxedHexStr;

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -62,7 +62,7 @@ pub mod relaxed {
 
     impl From<crate::sequencer::reply::Call> for Vec<H256> {
         fn from(call: crate::sequencer::reply::Call) -> Self {
-            call.result.into_iter().map(|x| H256::from(x)).collect()
+            call.result.into_iter().map(H256::from).collect()
         }
     }
 }
@@ -366,7 +366,7 @@ pub mod reply {
                 messages_sent: receipt
                     .l2_to_l1_messages
                     .iter()
-                    .map(|m| transaction_receipt::MessageToL1::from(m))
+                    .map(transaction_receipt::MessageToL1::from)
                     .collect(),
                 l1_origin_message: match receipt.l1_to_l2_consumed_message {
                     Some(m) => m.into(),

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -90,46 +90,18 @@ pub mod reply {
     use std::convert::From;
     use web3::types::{H160, H256};
 
-    /// Describes Starknet's syncing status RPC reply.
-    #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-    #[serde(untagged)]
+    /// L2 Block status as returned by the RPC API.
+    #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
     #[serde(deny_unknown_fields)]
-    pub enum Syncing {
-        False(bool),
-        Status(syncing::Status),
-    }
-
-    pub mod syncing {
-        use crate::serde::H256AsRelaxedHexStr;
-        use serde::{Deserialize, Serialize};
-        use serde_with::serde_as;
-        use web3::types::H256;
-
-        /// Represents Starknet node syncing status.
-        #[serde_as]
-        #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
-        #[serde(deny_unknown_fields)]
-        pub struct Status {
-            #[serde_as(as = "H256AsRelaxedHexStr")]
-            starting_block: H256,
-            #[serde_as(as = "H256AsRelaxedHexStr")]
-            current_block: H256,
-            highest_block: BlockStatus,
-        }
-
-        /// Represents block status.
-        #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
-        #[serde(deny_unknown_fields)]
-        pub enum BlockStatus {
-            #[serde(rename = "PENDING")]
-            Pending,
-            #[serde(rename = "PROVEN")]
-            Proven,
-            #[serde(rename = "ACCEPTED_ONCHAIN")]
-            AcceptedOnChain,
-            #[serde(rename = "REJECTED")]
-            Rejected,
-        }
+    pub enum BlockStatus {
+        #[serde(rename = "PENDING")]
+        Pending,
+        #[serde(rename = "PROVEN")]
+        Proven,
+        #[serde(rename = "ACCEPTED_ONCHAIN")]
+        AcceptedOnChain,
+        #[serde(rename = "REJECTED")]
+        Rejected,
     }
 
     /// L2 Block as returned by the RPC API.
@@ -142,7 +114,7 @@ pub mod reply {
         #[serde_as(as = "H256AsRelaxedHexStr")]
         parent_hash: H256,
         block_number: u64,
-        status: syncing::BlockStatus,
+        status: BlockStatus,
         sequencer: H160,
         #[serde_as(as = "H256AsRelaxedHexStr")]
         new_root: H256,
@@ -334,5 +306,34 @@ pub mod reply {
         AcceptedOnChain,
         #[serde(rename = "REJECTED")]
         Rejected,
+    }
+
+    /// Describes Starknet's syncing status RPC reply.
+    #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+    #[serde(untagged)]
+    #[serde(deny_unknown_fields)]
+    pub enum Syncing {
+        False(bool),
+        Status(syncing::Status),
+    }
+
+    pub mod syncing {
+        use super::BlockStatus;
+        use crate::serde::H256AsRelaxedHexStr;
+        use serde::{Deserialize, Serialize};
+        use serde_with::serde_as;
+        use web3::types::H256;
+
+        /// Represents Starknet node syncing status.
+        #[serde_as]
+        #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+        #[serde(deny_unknown_fields)]
+        pub struct Status {
+            #[serde_as(as = "H256AsRelaxedHexStr")]
+            starting_block: H256,
+            #[serde_as(as = "H256AsRelaxedHexStr")]
+            current_block: H256,
+            highest_block: BlockStatus,
+        }
     }
 }

--- a/src/sequencer.rs
+++ b/src/sequencer.rs
@@ -196,7 +196,7 @@ mod tests {
     lazy_static::lazy_static! {
         static ref GENESIS_BLOCK_HASH: H256 = H256::from_str("0x07d328a71faf48c5c3857e99f20a77b18522480956d1cd5bff1ff2df3c8b427b").unwrap();
         static ref INVALID_BLOCK_HASH: H256 = H256::from_str("0x13d8d8bb5716cd3f16e54e3a6ff1a50542461d9022e5f4dec7a4b064041ab8d7").unwrap();
-        static ref UNKNOWN_BLOCK_HASH: H256 = H256::from_str("0x017adea6567a9f605d5011ac915bdda56dc1db37e17a7057b3dd7fa99c4ba30b").unwrap();
+        static ref UNKNOWN_BLOCK_HASH: H256 = H256::from_str("0x03c85a69453e63fd475424ecc70438bd855cd76e6f0d5dec0d0dd56e0f7a771c").unwrap();
         static ref CONTRACT_BLOCK_HASH: H256 = H256::from_str("0x03871c8a0c3555687515a07f365f6f5b1d8c2ae953f7844575b8bde2b2efed27").unwrap();
         static ref VALID_TX_HASH: H256 = H256::from_str("0x0493d8fab73af67e972788e603aee18130facd3c7685f16084ecd98b07153e24").unwrap();
         static ref INVALID_TX_HASH: H256 = H256::from_str("0x1493d8fab73af67e972788e603aee18130facd3c7685f16084ecd98b07153e24").unwrap();
@@ -229,6 +229,7 @@ mod tests {
         }
 
         #[tokio::test]
+        #[ignore = "currently causes HTTP 504"]
         async fn block_without_block_hash_field() {
             client()
                 .block(

--- a/src/sequencer.rs
+++ b/src/sequencer.rs
@@ -229,7 +229,6 @@ mod tests {
         }
 
         #[tokio::test]
-        #[ignore = "currently causes HTTP 504"]
         async fn block_without_block_hash_field() {
             client()
                 .block(

--- a/src/sequencer/reply.rs
+++ b/src/sequencer/reply.rs
@@ -77,7 +77,7 @@ impl TryFrom<CallReply> for Call {
 #[serde(deny_unknown_fields)]
 pub struct Call {
     #[serde_as(as = "Vec<H256AsRelaxedHexStr>")]
-    result: Vec<H256>,
+    pub result: Vec<H256>,
 }
 
 /// Types used when deserializing L2 call related data.

--- a/src/sequencer/request.rs
+++ b/src/sequencer/request.rs
@@ -1,6 +1,10 @@
 //! Structures used for serializing requests to Starkware's sequencer REST API.
-use crate::serde::{H256AsRelaxedHexStr, U256AsBigDecimal};
+use crate::{
+    rpc::types::request as rpc,
+    serde::{H256AsRelaxedHexStr, U256AsBigDecimal},
+};
 use serde::{Deserialize, Serialize};
+use std::convert::From;
 use web3::types::{H256, U256};
 
 /// Used to serialize payload for [Client::call](crate::sequencer::Client::call).
@@ -15,4 +19,22 @@ pub struct Call {
     pub entry_point_selector: H256,
     #[serde_as(as = "Vec<U256AsBigDecimal>")]
     pub signature: Vec<U256>,
+}
+
+impl From<rpc::Call> for Call {
+    fn from(call: rpc::Call) -> Self {
+        Call {
+            contract_address: call.contract_address,
+            calldata: call
+                .calldata
+                .into_iter()
+                .map(|x| {
+                    let x: [u8; 32] = x.into();
+                    x.into()
+                })
+                .collect(),
+            entry_point_selector: call.entry_point_selector,
+            signature: vec![],
+        }
+    }
 }


### PR DESCRIPTION
This PR adds:
- proper reply types for JSON-RPC methods, which means that each method will not return sequencer API specific structs anymore, but perform appropriate mapping instead,
- Starkware specific error codes, as described in the spec.
