### PR TITLE
fix(sequencer): clean up sequencer error types

### DIFF
--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -24,6 +24,7 @@ rusqlite = { version = "0.26.1", features = ["bundled"] }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 serde_with = "1.9.4"
+thiserror = "1.0.30"
 tokio = "1.11.0"
 toml = "0.5.8"
 web3 = "0.17.0"

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -268,6 +268,8 @@ pub mod reply {
         // Workaround for a duplicate error code value
         #[allow(non_upper_case_globals)]
         pub const InvalidTransactionHash: ErrorCode = ErrorCode::InvalidBlockNumber;
+        #[allow(non_upper_case_globals)]
+        pub const InvalidTransactionHashStr: &'static str = "Invalid transaction hash";
     }
 
     impl std::string::ToString for ErrorCode {

--- a/crates/pathfinder/src/sequencer/error.rs
+++ b/crates/pathfinder/src/sequencer/error.rs
@@ -1,0 +1,103 @@
+//! Sequencer related error types.
+use crate::rpc::types::reply::ErrorCode as RpcErrorCode;
+use jsonrpsee::types as rpc;
+use serde::{Deserialize, Serialize};
+
+/// Sequencer errors.
+#[derive(Debug, thiserror::Error)]
+pub enum SequencerError {
+    /// All errors related to parsing sequencer replies that should
+    /// be in the JSON format.
+    #[error("Failed to parse sequencer reply JSON: {0}")]
+    DeserializationError(#[from] serde_json::Error),
+    /// All errors related to parsing sequencer replies that
+    /// are not related to JSON handling.
+    #[error("Failed to parse a non-JSON sequencer reply: {0}")]
+    ParseError(#[from] anyhow::Error),
+    /// Starknet specific errors.
+    #[error("Starknet error: {0}")]
+    StarknetError(#[from] StarknetError),
+    /// Networking and protocol related errors.
+    #[error("Sequencer transport error: {0}")]
+    TransportError(#[from] reqwest::Error),
+}
+
+impl From<SequencerError> for rpc::Error {
+    fn from(e: SequencerError) -> Self {
+        match e {
+            SequencerError::DeserializationError(e) => {
+                rpc::Error::Call(rpc::CallError::Failed(e.into()))
+            }
+            SequencerError::ParseError(e) => rpc::Error::Call(rpc::CallError::Failed(e)),
+            SequencerError::StarknetError(e) => match e.code {
+                StarknetErrorCode::OutOfRangeBlockHash | StarknetErrorCode::BlockNotFound => {
+                    RpcErrorCode::InvalidBlockHash.into()
+                }
+                StarknetErrorCode::OutOfRangeContractAddress
+                | StarknetErrorCode::UninitializedContract => RpcErrorCode::ContractNotFound.into(),
+                StarknetErrorCode::OutOfRangeTransactionHash => {
+                    rpc::Error::Call(rpc::CallError::Custom {
+                        code: RpcErrorCode::InvalidTransactionHash as i32,
+                        message: RpcErrorCode::InvalidTransactionHashStr.to_owned(),
+                        data: None,
+                    })
+                }
+                StarknetErrorCode::OutOfRangeStorageKey => RpcErrorCode::InvalidStorageKey.into(),
+                StarknetErrorCode::TransactionFailed => RpcErrorCode::InvalidCallData.into(),
+                StarknetErrorCode::EntryPointNotFound => {
+                    RpcErrorCode::InvalidMessageSelector.into()
+                }
+                StarknetErrorCode::MalformedRequest
+                    if e.message.contains("Block ID should be in the range") =>
+                {
+                    RpcErrorCode::InvalidBlockNumber.into()
+                }
+                _ => rpc::Error::Call(rpc::CallError::Failed(e.into())),
+            },
+            SequencerError::TransportError(e) => rpc::Error::Call(rpc::CallError::Failed(e.into())),
+        }
+    }
+}
+
+/// Used for deserializing specific Starknet sequencer error data.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct StarknetError {
+    pub code: StarknetErrorCode,
+    pub message: String,
+    // The `problems` field is intentionally omitted here
+    // Let's deserialize it if it proves necessary
+}
+
+impl std::error::Error for StarknetError {}
+
+impl std::fmt::Display for StarknetError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// Represents starknet specific error codes reported by the sequencer.
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub enum StarknetErrorCode {
+    #[serde(rename = "StarknetErrorCode.BLOCK_NOT_FOUND")]
+    BlockNotFound,
+    #[serde(rename = "StarknetErrorCode.ENTRY_POINT_NOT_FOUND_IN_CONTRACT")]
+    EntryPointNotFound,
+    #[serde(rename = "StarknetErrorCode.OUT_OF_RANGE_CONTRACT_ADDRESS")]
+    OutOfRangeContractAddress,
+    #[serde(rename = "StarknetErrorCode.OUT_OF_RANGE_CONTRACT_STORAGE_KEY")]
+    OutOfRangeStorageKey,
+    #[serde(rename = "StarkErrorCode.SCHEMA_VALIDATION_ERROR")]
+    SchemaValidationError,
+    #[serde(rename = "StarknetErrorCode.TRANSACTION_FAILED")]
+    TransactionFailed,
+    #[serde(rename = "StarknetErrorCode.UNINITIALIZED_CONTRACT")]
+    UninitializedContract,
+    #[serde(rename = "StarknetErrorCode.OUT_OF_RANGE_BLOCK_HASH")]
+    OutOfRangeBlockHash,
+    #[serde(rename = "StarknetErrorCode.OUT_OF_RANGE_TRANSACTION_HASH")]
+    OutOfRangeTransactionHash,
+    #[serde(rename = "StarkErrorCode.MALFORMED_REQUEST")]
+    MalformedRequest,
+}

--- a/crates/pathfinder/src/sequencer/error.rs
+++ b/crates/pathfinder/src/sequencer/error.rs
@@ -6,14 +6,9 @@ use serde::{Deserialize, Serialize};
 /// Sequencer errors.
 #[derive(Debug, thiserror::Error)]
 pub enum SequencerError {
-    /// All errors related to parsing sequencer replies that should
-    /// be in the JSON format.
-    #[error("Failed to parse sequencer reply JSON: {0}")]
+    /// All errors related to deserializing sequencer replies.
+    #[error("Failed to deserialize sequencer reply: {0}")]
     DeserializationError(#[from] serde_json::Error),
-    /// All errors related to parsing sequencer replies that
-    /// are not related to JSON handling.
-    #[error("Failed to parse a non-JSON sequencer reply: {0}")]
-    ParseError(#[from] anyhow::Error),
     /// Starknet specific errors.
     #[error("Starknet error: {0}")]
     StarknetError(#[from] StarknetError),
@@ -28,7 +23,6 @@ impl From<SequencerError> for rpc::Error {
             SequencerError::DeserializationError(e) => {
                 rpc::Error::Call(rpc::CallError::Failed(e.into()))
             }
-            SequencerError::ParseError(e) => rpc::Error::Call(rpc::CallError::Failed(e)),
             SequencerError::StarknetError(e) => match e.code {
                 StarknetErrorCode::OutOfRangeBlockHash | StarknetErrorCode::BlockNotFound => {
                     RpcErrorCode::InvalidBlockHash.into()

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -1,36 +1,11 @@
 //! Structures used for deserializing replies from Starkware's sequencer REST API.
-use super::error::{SequencerError, StarknetError};
-use crate::{
-    rpc::types::relaxed,
-    serde::{H256AsRelaxedHexStr, U256AsBigDecimal},
-};
+use crate::serde::{H256AsRelaxedHexStr, U256AsBigDecimal};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, skip_serializing_none, DefaultOnError};
-use std::convert::TryFrom;
 use web3::types::{H256, U256};
 
 /// Used to deserialize replies to [Client::block_by_hash](crate::sequencer::Client::block_by_hash) and
 /// [Client::block_by_number](crate::sequencer::Client::block_by_number).
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(untagged)]
-#[serde(deny_unknown_fields)]
-pub enum BlockReply {
-    Block(Block),
-    Error(StarknetError),
-}
-
-impl TryFrom<BlockReply> for Block {
-    type Error = SequencerError;
-
-    fn try_from(value: BlockReply) -> Result<Self, Self::Error> {
-        match value {
-            BlockReply::Block(b) => Ok(b),
-            BlockReply::Error(e) => Err(SequencerError::StarknetError(e)),
-        }
-    }
-}
-
-/// Actual block data from [BlockReply].
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -54,47 +29,7 @@ pub mod block {
     pub type Status = super::transaction::Status;
 }
 
-/// Used to deserialize replies to the `get_block_hash_by_id` query.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(untagged)]
-#[serde(deny_unknown_fields)]
-pub enum BlockHashReply {
-    Hash(relaxed::H256),
-    Error(StarknetError),
-}
-
-impl TryFrom<BlockHashReply> for relaxed::H256 {
-    type Error = SequencerError;
-
-    fn try_from(value: BlockHashReply) -> Result<Self, Self::Error> {
-        match value {
-            BlockHashReply::Hash(b) => Ok(b),
-            BlockHashReply::Error(e) => Err(SequencerError::StarknetError(e)),
-        }
-    }
-}
-
 /// Used to deserialize a reply from [Client::call](crate::sequencer::Client::call).
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(untagged)]
-#[serde(deny_unknown_fields)]
-pub enum CallReply {
-    Call(Call),
-    Error(StarknetError),
-}
-
-impl TryFrom<CallReply> for Call {
-    type Error = SequencerError;
-
-    fn try_from(value: CallReply) -> Result<Self, Self::Error> {
-        match value {
-            CallReply::Call(c) => Ok(c),
-            CallReply::Error(e) => Err(SequencerError::StarknetError(e)),
-        }
-    }
-}
-
-/// Actual call data from [CallReply].
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -121,27 +56,6 @@ pub mod call {
 }
 
 /// Used to deserialize a reply from [Client::code](crate::sequencer::Client::code).
-#[serde_as]
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(untagged)]
-#[serde(deny_unknown_fields)]
-pub enum CodeReply {
-    Code(Code),
-    Error(StarknetError),
-}
-
-impl TryFrom<CodeReply> for Code {
-    type Error = SequencerError;
-
-    fn try_from(value: CodeReply) -> Result<Self, Self::Error> {
-        match value {
-            CodeReply::Code(c) => Ok(c),
-            CodeReply::Error(e) => Err(SequencerError::StarknetError(e)),
-        }
-    }
-}
-
-/// Actual code data from [CodeReply].
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -209,47 +123,7 @@ pub mod code {
     }
 }
 
-/// Used to deserialize replies to [Client::storage](crate::sequencer::Client::storage).
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(untagged)]
-#[serde(deny_unknown_fields)]
-pub enum StorageReply {
-    Value(relaxed::H256),
-    Error(StarknetError),
-}
-
-impl TryFrom<StorageReply> for relaxed::H256 {
-    type Error = SequencerError;
-
-    fn try_from(value: StorageReply) -> Result<Self, Self::Error> {
-        match value {
-            StorageReply::Value(b) => Ok(b),
-            StorageReply::Error(e) => Err(SequencerError::StarknetError(e)),
-        }
-    }
-}
-
 /// Used to deserialize replies to [Client::transaction](crate::sequencer::Client::transaction).
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(untagged)]
-#[serde(deny_unknown_fields)]
-pub enum TransactionReply {
-    Transaction(Box<Transaction>),
-    Error(StarknetError),
-}
-
-impl TryFrom<TransactionReply> for Transaction {
-    type Error = SequencerError;
-
-    fn try_from(value: TransactionReply) -> Result<Self, Self::Error> {
-        match value {
-            TransactionReply::Transaction(t) => Ok(*t),
-            TransactionReply::Error(e) => Err(SequencerError::StarknetError(e)),
-        }
-    }
-}
-
-/// Actual transaction data from [TransactionReply].
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -269,26 +143,6 @@ pub struct Transaction {
 }
 
 /// Used to deserialize replies to [Client::transaction_status](crate::sequencer::Client::transaction_status).
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(untagged)]
-#[serde(deny_unknown_fields)]
-pub enum TransactionStatusReply {
-    TransactionStatus(TransactionStatus),
-    Error(StarknetError),
-}
-
-impl TryFrom<TransactionStatusReply> for TransactionStatus {
-    type Error = SequencerError;
-
-    fn try_from(value: TransactionStatusReply) -> Result<Self, Self::Error> {
-        match value {
-            TransactionStatusReply::TransactionStatus(t) => Ok(t),
-            TransactionStatusReply::Error(e) => Err(SequencerError::StarknetError(e)),
-        }
-    }
-}
-
-/// Actual transaction data from [TransactionStatusReply].
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -1,4 +1,5 @@
 //! Structures used for deserializing replies from Starkware's sequencer REST API.
+use super::error::{SequencerError, StarknetError};
 use crate::serde::{H256AsRelaxedHexStr, U256AsBigDecimal};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, skip_serializing_none, DefaultOnError};
@@ -12,16 +13,16 @@ use web3::types::{H256, U256};
 #[serde(deny_unknown_fields)]
 pub enum BlockReply {
     Block(Block),
-    Error(starknet::Error),
+    Error(StarknetError),
 }
 
 impl TryFrom<BlockReply> for Block {
-    type Error = anyhow::Error;
+    type Error = SequencerError;
 
     fn try_from(value: BlockReply) -> Result<Self, Self::Error> {
         match value {
             BlockReply::Block(b) => Ok(b),
-            BlockReply::Error(e) => Err(anyhow::Error::new(e)),
+            BlockReply::Error(e) => Err(SequencerError::StarknetError(e)),
         }
     }
 }
@@ -56,16 +57,16 @@ pub mod block {
 #[serde(deny_unknown_fields)]
 pub enum CallReply {
     Call(Call),
-    Error(starknet::Error),
+    Error(StarknetError),
 }
 
 impl TryFrom<CallReply> for Call {
-    type Error = anyhow::Error;
+    type Error = SequencerError;
 
     fn try_from(value: CallReply) -> Result<Self, Self::Error> {
         match value {
             CallReply::Call(c) => Ok(c),
-            CallReply::Error(e) => Err(anyhow::Error::new(e)),
+            CallReply::Error(e) => Err(SequencerError::StarknetError(e)),
         }
     }
 }
@@ -103,16 +104,16 @@ pub mod call {
 #[serde(deny_unknown_fields)]
 pub enum CodeReply {
     Code(Code),
-    Error(starknet::Error),
+    Error(StarknetError),
 }
 
 impl TryFrom<CodeReply> for Code {
-    type Error = anyhow::Error;
+    type Error = SequencerError;
 
     fn try_from(value: CodeReply) -> Result<Self, Self::Error> {
         match value {
             CodeReply::Code(c) => Ok(c),
-            CodeReply::Error(e) => Err(anyhow::Error::new(e)),
+            CodeReply::Error(e) => Err(SequencerError::StarknetError(e)),
         }
     }
 }
@@ -185,71 +186,22 @@ pub mod code {
     }
 }
 
-pub mod starknet {
-    use serde::{Deserialize, Serialize};
-    use serde_with::skip_serializing_none;
-
-    /// Used for deserializing specific Starknet sequencer error data.
-    #[skip_serializing_none]
-    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-    pub struct Error {
-        pub code: ErrorCode,
-        pub message: String,
-        // The `problems` field is intentionally omitted here
-        // Let's deserialize it if it proves necessary
-    }
-
-    impl std::error::Error for Error {}
-
-    impl std::fmt::Display for Error {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{:?}", self)
-        }
-    }
-
-    /// Represents error codes reported by the sequencer.
-    #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
-    #[serde(deny_unknown_fields)]
-    pub enum ErrorCode {
-        #[serde(rename = "StarknetErrorCode.BLOCK_NOT_FOUND")]
-        BlockNotFound,
-        #[serde(rename = "StarknetErrorCode.ENTRY_POINT_NOT_FOUND_IN_CONTRACT")]
-        EntryPointNotFound,
-        #[serde(rename = "StarknetErrorCode.OUT_OF_RANGE_CONTRACT_ADDRESS")]
-        OutOfRangeContractAddress,
-        #[serde(rename = "StarknetErrorCode.OUT_OF_RANGE_CONTRACT_STORAGE_KEY")]
-        OutOfRangeStorageKey,
-        #[serde(rename = "StarkErrorCode.SCHEMA_VALIDATION_ERROR")]
-        SchemaValidationError,
-        #[serde(rename = "StarknetErrorCode.TRANSACTION_FAILED")]
-        TransactionFailed,
-        #[serde(rename = "StarknetErrorCode.UNINITIALIZED_CONTRACT")]
-        UninitializedContract,
-        #[serde(rename = "StarknetErrorCode.OUT_OF_RANGE_BLOCK_HASH")]
-        OutOfRangeBlockHash,
-        #[serde(rename = "StarknetErrorCode.OUT_OF_RANGE_TRANSACTION_HASH")]
-        OutOfRangeTransactionHash,
-        #[serde(rename = "StarkErrorCode.MALFORMED_REQUEST")]
-        MalformedRequest,
-    }
-}
-
 /// Used to deserialize replies to [Client::transaction](crate::sequencer::Client::transaction).
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 #[serde(deny_unknown_fields)]
 pub enum TransactionReply {
     Transaction(Box<Transaction>),
-    Error(starknet::Error),
+    Error(StarknetError),
 }
 
 impl TryFrom<TransactionReply> for Transaction {
-    type Error = anyhow::Error;
+    type Error = SequencerError;
 
     fn try_from(value: TransactionReply) -> Result<Self, Self::Error> {
         match value {
             TransactionReply::Transaction(t) => Ok(*t),
-            TransactionReply::Error(e) => Err(anyhow::Error::new(e)),
+            TransactionReply::Error(e) => Err(SequencerError::StarknetError(e)),
         }
     }
 }
@@ -279,16 +231,16 @@ pub struct Transaction {
 #[serde(deny_unknown_fields)]
 pub enum TransactionStatusReply {
     TransactionStatus(TransactionStatus),
-    Error(starknet::Error),
+    Error(StarknetError),
 }
 
 impl TryFrom<TransactionStatusReply> for TransactionStatus {
-    type Error = anyhow::Error;
+    type Error = SequencerError;
 
     fn try_from(value: TransactionStatusReply) -> Result<Self, Self::Error> {
         match value {
             TransactionStatusReply::TransactionStatus(t) => Ok(t),
-            TransactionStatusReply::Error(e) => Err(anyhow::Error::new(e)),
+            TransactionStatusReply::Error(e) => Err(SequencerError::StarknetError(e)),
         }
     }
 }


### PR DESCRIPTION
This is an attempt to clean up how sequencer errors are handled.
* I grouped the types of errors into 4 categories.
* `anyhow::Error` is only used as a vehicle for various parsing errors which are not `serde_json` specific and cannot be really wrapped in the latter.
* Moreover the rpc code has become simpler as there is now a single point of converting sequencer errors into `jsonrpsee::types::Error`.
* Oh, and starknet specific errors have to be handled in a special way as they are accompanied by HTTP status code 500.

Lemme know what you think.