### PR TITLE
feat: updated ethereum for `0.7` changes

### DIFF
--- a/crates/pathfinder/examples/fact_retrieval.rs
+++ b/crates/pathfinder/examples/fact_retrieval.rs
@@ -34,7 +34,7 @@ use web3::{transports::Http, types::FilterBuilder, Web3};
 
 #[tokio::main]
 async fn main() {
-    let (transport, block_hash, seq_no) = parse_cli_args();
+    let (transport, block_hash, block_no) = parse_cli_args();
 
     // Get the state update event at the given block.
     let filter = FilterBuilder::default()
@@ -47,7 +47,7 @@ async fn main() {
     let update_log = logs
         .into_iter()
         .map(|log| StateUpdateLog::try_from(log).expect("state update log parsing failed"))
-        .find(|log| log.sequence_number == seq_no)
+        .find(|log| log.block_number == block_no)
         .expect("state update log not found");
 
     let state_update = StateUpdate::retrieve(&transport, update_log)

--- a/crates/pathfinder/resources/contracts/core_impl.json
+++ b/crates/pathfinder/resources/contracts/core_impl.json
@@ -50,6 +50,12 @@
                 "internalType": "uint256[]",
                 "name": "payload",
                 "type": "uint256[]"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "nonce",
+                "type": "uint256"
             }
         ],
         "name": "ConsumedMessageToL2",
@@ -106,6 +112,12 @@
                 "internalType": "uint256[]",
                 "name": "payload",
                 "type": "uint256[]"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "nonce",
+                "type": "uint256"
             }
         ],
         "name": "LogMessageToL2",
@@ -207,7 +219,7 @@
             {
                 "indexed": false,
                 "internalType": "int256",
-                "name": "sequenceNumber",
+                "name": "blockNumber",
                 "type": "int256"
             }
         ],
@@ -311,6 +323,19 @@
                 "internalType": "bool",
                 "name": "",
                 "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "l1ToL2MessageNonce",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
             }
         ],
         "stateMutability": "view",
@@ -483,12 +508,12 @@
     },
     {
         "inputs": [],
-        "name": "stateRoot",
+        "name": "stateBlockNumber",
         "outputs": [
             {
-                "internalType": "uint256",
+                "internalType": "int256",
                 "name": "",
-                "type": "uint256"
+                "type": "int256"
             }
         ],
         "stateMutability": "view",
@@ -496,12 +521,12 @@
     },
     {
         "inputs": [],
-        "name": "stateSequenceNumber",
+        "name": "stateRoot",
         "outputs": [
             {
-                "internalType": "int256",
+                "internalType": "uint256",
                 "name": "",
-                "type": "int256"
+                "type": "uint256"
             }
         ],
         "stateMutability": "view",
@@ -522,11 +547,6 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "int256",
-                "name": "sequenceNumber",
-                "type": "int256"
-            },
             {
                 "internalType": "uint256[]",
                 "name": "programOutput",

--- a/crates/pathfinder/src/ethereum/contract.rs
+++ b/crates/pathfinder/src/ethereum/contract.rs
@@ -91,7 +91,7 @@ mod tests {
             // update the address and more importantly, the ABI.
 
             // The current address of Starknet's core contract implementation.
-            const CORE_IMPL_ADDR: &str = "0xF10EfCF03796D38E0f6c5b87c471368e6E0DC674";
+            const CORE_IMPL_ADDR: &str = "0xe267213b0749bb94c575f6170812c887330d9ce3";
             let expect_addr = H160::from_str(CORE_IMPL_ADDR).unwrap();
 
             // The proxy's ABI.

--- a/crates/pathfinder/src/ethereum/log.rs
+++ b/crates/pathfinder/src/ethereum/log.rs
@@ -18,7 +18,7 @@ use crate::ethereum::{EthOrigin, RpcErrorCode};
 pub struct StateUpdateLog {
     pub origin: EthOrigin,
     pub global_root: U256,
-    pub sequence_number: U256,
+    pub block_number: U256,
 }
 
 /// Links a [StateUpdateLog] event to its data -- which is contained

--- a/crates/pathfinder/src/ethereum/log/parse.rs
+++ b/crates/pathfinder/src/ethereum/log/parse.rs
@@ -29,14 +29,14 @@ impl TryFrom<web3::types::Log> for StateUpdateLog {
             .into_uint()
             .context("global root could not be parsed")?;
 
-        let sequence_number = get_log_param(&log, "sequenceNumber")?
+        let block_number = get_log_param(&log, "blockNumber")?
             .value
             .into_int()
             .context("sequence number could not be parsed")?;
 
         Ok(Self {
             global_root,
-            sequence_number,
+            block_number,
             origin,
         })
     }
@@ -187,7 +187,7 @@ mod tests {
             let result = StateUpdateLog::try_from(log).unwrap();
             assert_eq!(result.origin, origin);
             assert_eq!(result.global_root, root);
-            assert_eq!(result.sequence_number, sequence);
+            assert_eq!(result.block_number, sequence);
         }
 
         #[test]

--- a/crates/pathfinder/src/ethereum/state_update.rs
+++ b/crates/pathfinder/src/ethereum/state_update.rs
@@ -122,7 +122,7 @@ mod tests {
                 "518441586592570845566219848761263100073689884954357429195191348826336924551",
             )
             .unwrap(),
-            sequence_number: U256::from(16407),
+            block_number: U256::from(16407),
         };
 
         let transport = create_test_websocket_transport().await;

--- a/crates/pathfinder/src/ethereum/state_update/state_root.rs
+++ b/crates/pathfinder/src/ethereum/state_update/state_root.rs
@@ -23,7 +23,7 @@ mod tests {
         let first_fetch = uut.fetch(&ws).await.unwrap();
         let first = first_fetch.first().expect("Should be at least one log");
 
-        assert_eq!(first.sequence_number, U256::from(0));
+        assert_eq!(first.block_number, U256::from(0));
     }
 
     mod reorg {
@@ -57,7 +57,7 @@ mod tests {
                     log_index: 11.into(),
                 },
                 global_root: 12354.into(),
-                sequence_number: 3.into(),
+                block_number: 3.into(),
             };
 
             let mut uut = StateRootFetcher::new(Some(not_genesis));
@@ -87,7 +87,7 @@ mod tests {
                     log_index: 11.into(),
                 },
                 global_root: 12354.into(),
-                sequence_number: 3.into(),
+                block_number: 3.into(),
             };
 
             let mut uut = StateRootFetcher::new(Some(not_genesis));


### PR DESCRIPTION
The `0.7` upgrade included a change to the StarkNet L1 core contract implementation. The core contract consists of a proxy contract, which points to the actual implementation contract. The proxy remains the same, but the implementation address and ABI were updated as part of the upgrade.

The only ABI change that we care about, was the change in the `StateUpdateLog`. Thankfully it is just a cosmetic change - `sequenceNumber` became `blockNumber`. And thankfully we can still parse the logs from the previous contract (with `sequenceNumber`) using the current contract (with `blockNumber`). I presume this is because the parameter names don't matter, only the types and amounts.

PR change log
- updated the contract ABI
- updated internal naming to match starknet naming (`sequence_number` -> `block_number` etc).
- updated implementation address test (this test lets us know if the implementation contract changes -- as it did now)