### PR TITLE
feat(py): cairo-lang generator for main trees

### DIFF
--- a/py/README.md
+++ b/py/README.md
@@ -3,6 +3,9 @@
 This directory will host the code to call contracts using `cairo-lang` python package, and other utilities:
 
 - src/generate_test_storage_tree.py -- generates the patricia tree for a single contract from stdin
+- src/generate_test_global_tree.py -- generates the main patricia tree from stdin
+
+See files for usage instructions.
 
 ## Development
 

--- a/py/src/generate_test_global_tree.py
+++ b/py/src/generate_test_global_tree.py
@@ -55,10 +55,9 @@ async def generate_root_and_nodes(input):
     updates = {}
 
     for (contract_address, contract_hash, contract_commitment_tree_root) in input:
-        contract_hash = contract_hash.to_bytes(32, "big")
-        contract_commitment_tree_root = contract_commitment_tree_root.to_bytes(
-            32, "big"
-        )
+        assert type(contract_address) == int
+        assert type(contract_hash) == bytes, f"{type(contract_hash)}"
+        assert type(contract_commitment_tree_root) == bytes
 
         updates[contract_address] = await ContractState.create(
             contract_hash,
@@ -91,7 +90,7 @@ def parse_line(s):
     s = s.strip()
     [addr, c_hash, c_root_hash] = s.split(maxsplit=2)
     # TODO: maybe map would work?
-    return (parse_value(addr), parse_value(c_hash), parse_value(c_root_hash))
+    return (parse_value(addr), parse_bytes(c_hash), parse_bytes(c_root_hash))
 
 
 def parse_value(s):
@@ -104,6 +103,17 @@ def parse_value(s):
         return int.from_bytes(data, "big")
 
     return int(s)
+
+
+def parse_bytes(s):
+    if s.startswith("0x"):
+        hex = s[2:]
+        if len(hex) == 0:
+            return (0).to_bytes(32, "big")
+        assert len(hex) % 2 == 0, f"unsupported: odd length ({len(hex)}) hex input"
+        return bytes.fromhex(hex)
+
+    return int(s).to_bytes(32, "big")
 
 
 if __name__ == "__main__":

--- a/py/src/generate_test_global_tree.py
+++ b/py/src/generate_test_global_tree.py
@@ -1,5 +1,13 @@
 # # generate_global_tree.py
 #
+# usage example (sending nodes in stderr to /dev/null):
+#
+# $ python src/generate_test_global_tree.py <<'EOF' 2>/dev/null
+# 978257171231527130811587576456504820066317852047211009343890029541393479136 0x02ff4903e17f87b298ded00c44bfeb22874c5f73be2ced8f1d9d9556fb509779 0x0287ac1196abb9501ac540b88e74b6a2b9476903c3f7e85e71d573c997ce1e5b
+# 2216396239273623009628046076940816512923808178401142985552926513489037661413 0x02ff4903e17f87b298ded00c44bfeb22874c5f73be2ced8f1d9d9556fb509779 0x0000000000000000000000000000000000000000000000000000000000000000
+# EOF
+# 05b4ca9e1caff46ebf6416f6d7192a9e562a6cf193b4fe73c30bf7d8062f0e13 # stdin
+#
 # read stdin for lines of "contract_address contract_state_hash commitment_tree_root", after closing
 # stdin will report a root hash on stdout for this global storage merkle tree.
 # nodes will be dumped on stderr.
@@ -9,7 +17,7 @@
 # - hex for big endian integers (whatever accepted by bytes.fromhex) with 0x prefix
 # - base 10 integers
 #
-# No input validation is done for keys or values.
+# No input validation is done for keys or values; they could be too large for example.
 #
 # does not accept any arguments.
 

--- a/py/src/test_generate_test_global_tree.py
+++ b/py/src/test_generate_test_global_tree.py
@@ -1,0 +1,58 @@
+from generate_test_global_tree import generate_root_and_nodes, parse_value
+import asyncio
+
+
+def test_existing_example():
+    contract_address = parse_value(
+        "0x0797a50901fb5f57c8f231f5ce3b312851adc4b178dd557da00f6fd4d2dce006"
+    )
+    contract_hash = parse_value(
+        "0x02ff4903e17f87b298ded00c44bfeb22874c5f73be2ced8f1d9d9556fb509779"
+    )
+    contract_commitment_tree_root = parse_value(
+        "0x04fb440e8ca9b74fc12a22ebffe0bc0658206337897226117b985434c239c028"
+    )
+
+    (root, nodes) = asyncio.run(
+        generate_root_and_nodes(
+            [(contract_address, contract_hash, contract_commitment_tree_root)]
+        )
+    )
+
+    assert root == bytes.fromhex(
+        "07b3590ce37bfe958d1b1066e05969834e5cea6fca10724f62924523bdafc7ee"
+    )
+    assert len(nodes) == 2
+    print(
+        nodes[
+            b"contract_state:"
+            + bytes.fromhex(
+                "07161b591c893836263a64f2a7e0d829c92f6956148a60ce5e99a3f55c7973f3"
+            )
+        ]
+    )
+    print("this shows that the values are different way around; does that matter?")
+    # this is flaky wip
+    print(
+        bytes.fromhex(
+            # json, not roundtripping through int with parse_value
+            "7b22636f6e74726163745f68617368223a202230326666343930336531376638376232393864656430306334346266656232323837346335663733626532636564386631643964393535366662353039373739222c202273746f726167655f636f6d6d69746d656e745f74726565223a207b22686569676874223a203235312c2022726f6f74223a202230346662343430653863613962373466633132613232656266666530626330363538323036333337383937323236313137623938353433346332333963303238227d7d"
+        )
+    )
+    assert nodes[
+        b"contract_state:"
+        + bytes.fromhex(
+            "07161b591c893836263a64f2a7e0d829c92f6956148a60ce5e99a3f55c7973f3"
+        )
+    ] == bytes.fromhex(
+        # json, not roundtripping through int with parse_value
+        "7b22636f6e74726163745f68617368223a202230326666343930336531376638376232393864656430306334346266656232323837346335663733626532636564386631643964393535366662353039373739222c202273746f726167655f636f6d6d69746d656e745f74726565223a207b22686569676874223a203235312c2022726f6f74223a202230346662343430653863613962373466633132613232656266666530626330363538323036333337383937323236313137623938353433346332333963303238227d7d"
+    )
+    assert nodes[
+        b"patricia_node:"
+        + bytes.fromhex(
+            "07b3590ce37bfe958d1b1066e05969834e5cea6fca10724f62924523bdafc7ee"
+        )
+    ] == bytes.fromhex(
+        "07161b591c893836263a64f2a7e0d829c92f6956148a60ce5e99a3f55c7973f30797a50901fb5f57c8f231f5ce3b312851adc4b178dd557da00f6fd4d2dce006fb"
+    )

--- a/py/src/test_generate_test_global_tree.py
+++ b/py/src/test_generate_test_global_tree.py
@@ -40,3 +40,65 @@ def test_existing_example():
     assert nodes[pn_key] == bytes.fromhex(
         "07161b591c893836263a64f2a7e0d829c92f6956148a60ce5e99a3f55c7973f30797a50901fb5f57c8f231f5ce3b312851adc4b178dd557da00f6fd4d2dce006fb"
     )
+
+
+def test_existing_example_of_two():
+
+    c_hash = bytes.fromhex(
+        "02ff4903e17f87b298ded00c44bfeb22874c5f73be2ced8f1d9d9556fb509779"
+    )
+    first_root = bytes.fromhex(
+        "0287ac1196abb9501ac540b88e74b6a2b9476903c3f7e85e71d573c997ce1e5b"
+    )
+
+    input = [
+        (
+            978257171231527130811587576456504820066317852047211009343890029541393479136,
+            c_hash,
+            first_root,
+        ),
+        (
+            2216396239273623009628046076940816512923808178401142985552926513489037661413,
+            c_hash,
+            (0).to_bytes(32, "big"),
+        ),
+    ]
+
+    (root, nodes) = asyncio.run(generate_root_and_nodes(input))
+
+    assert root == bytes.fromhex(
+        "05b4ca9e1caff46ebf6416f6d7192a9e562a6cf193b4fe73c30bf7d8062f0e13"
+    )
+
+    assert len(nodes) == 5
+
+    expected_contract_states = [
+        "0624c583dc39acbe616dacfec32cc6daf56c754e645008cd58136db126525ba8",
+        "032226432c9e57372cb07542bb0c3b3f502e2784ccfd26deaa8dad398cecb5d4",
+    ]
+
+    expected_pt_nodes = [
+        (
+            "0789650716d1a126a537fa5f32a3e794ce87347df439fbe862624064f13876c2",
+            "0624c583dc39acbe616dacfec32cc6daf56c754e645008cd58136db126525ba80229ac872a344da1032254ffe7b8f6324b436a761c7a63efa68bddfa63f8b5e0fa",
+        ),
+        (
+            "02ffc18b80a602a01211f692ec5fb9a818b8fbe6271da8521f4fe4309ae96641",
+            "032226432c9e57372cb07542bb0c3b3f502e2784ccfd26deaa8dad398cecb5d400e66f91a1784d761964de85a8fd55f6cce24ff756262f9cbc404329bcf294e5fa",
+        ),
+        (
+            "05b4ca9e1caff46ebf6416f6d7192a9e562a6cf193b4fe73c30bf7d8062f0e13",
+            "0789650716d1a126a537fa5f32a3e794ce87347df439fbe862624064f13876c202ffc18b80a602a01211f692ec5fb9a818b8fbe6271da8521f4fe4309ae96641",
+        ),
+    ]
+
+    for k in expected_contract_states:
+        k = b"contract_state:" + bytes.fromhex(k)
+        assert k in nodes
+        # same as before: don't look into value
+
+    for k, v in expected_pt_nodes:
+        k = b"patricia_node:" + bytes.fromhex(k)
+        v = bytes.fromhex(v)
+
+        assert nodes[k] == v

--- a/py/src/test_generate_test_global_tree.py
+++ b/py/src/test_generate_test_global_tree.py
@@ -1,4 +1,4 @@
-from generate_test_global_tree import generate_root_and_nodes, parse_value
+from generate_test_global_tree import generate_root_and_nodes, parse_value, parse_bytes
 import asyncio
 
 
@@ -6,10 +6,10 @@ def test_existing_example():
     contract_address = parse_value(
         "0x0797a50901fb5f57c8f231f5ce3b312851adc4b178dd557da00f6fd4d2dce006"
     )
-    contract_hash = parse_value(
+    contract_hash = parse_bytes(
         "0x02ff4903e17f87b298ded00c44bfeb22874c5f73be2ced8f1d9d9556fb509779"
     )
-    contract_commitment_tree_root = parse_value(
+    contract_commitment_tree_root = parse_bytes(
         "0x04fb440e8ca9b74fc12a22ebffe0bc0658206337897226117b985434c239c028"
     )
 

--- a/py/src/test_generate_test_global_tree.py
+++ b/py/src/test_generate_test_global_tree.py
@@ -22,37 +22,21 @@ def test_existing_example():
     assert root == bytes.fromhex(
         "07b3590ce37bfe958d1b1066e05969834e5cea6fca10724f62924523bdafc7ee"
     )
+
     assert len(nodes) == 2
-    print(
-        nodes[
-            b"contract_state:"
-            + bytes.fromhex(
-                "07161b591c893836263a64f2a7e0d829c92f6956148a60ce5e99a3f55c7973f3"
-            )
-        ]
+
+    cs_key = b"contract_state:" + bytes.fromhex(
+        "07161b591c893836263a64f2a7e0d829c92f6956148a60ce5e99a3f55c7973f3"
     )
-    print("this shows that the values are different way around; does that matter?")
-    # this is flaky wip
-    print(
-        bytes.fromhex(
-            # json, not roundtripping through int with parse_value
-            "7b22636f6e74726163745f68617368223a202230326666343930336531376638376232393864656430306334346266656232323837346335663733626532636564386631643964393535366662353039373739222c202273746f726167655f636f6d6d69746d656e745f74726565223a207b22686569676874223a203235312c2022726f6f74223a202230346662343430653863613962373466633132613232656266666530626330363538323036333337383937323236313137623938353433346332333963303238227d7d"
-        )
+
+    # we don't care about this contents; it's json but it's order is not stable
+    # so we cannot really do byte per byte equals
+    assert cs_key in nodes
+
+    pn_key = b"patricia_node:" + bytes.fromhex(
+        "07b3590ce37bfe958d1b1066e05969834e5cea6fca10724f62924523bdafc7ee"
     )
-    assert nodes[
-        b"contract_state:"
-        + bytes.fromhex(
-            "07161b591c893836263a64f2a7e0d829c92f6956148a60ce5e99a3f55c7973f3"
-        )
-    ] == bytes.fromhex(
-        # json, not roundtripping through int with parse_value
-        "7b22636f6e74726163745f68617368223a202230326666343930336531376638376232393864656430306334346266656232323837346335663733626532636564386631643964393535366662353039373739222c202273746f726167655f636f6d6d69746d656e745f74726565223a207b22686569676874223a203235312c2022726f6f74223a202230346662343430653863613962373466633132613232656266666530626330363538323036333337383937323236313137623938353433346332333963303238227d7d"
-    )
-    assert nodes[
-        b"patricia_node:"
-        + bytes.fromhex(
-            "07b3590ce37bfe958d1b1066e05969834e5cea6fca10724f62924523bdafc7ee"
-        )
-    ] == bytes.fromhex(
+
+    assert nodes[pn_key] == bytes.fromhex(
         "07161b591c893836263a64f2a7e0d829c92f6956148a60ce5e99a3f55c7973f30797a50901fb5f57c8f231f5ce3b312851adc4b178dd557da00f6fd4d2dce006fb"
     )


### PR DESCRIPTION
Tests pass:
- single contract tree
- two instances of the same contract tree

Contract state json is just expected to exist, not asserted. We don't need to care about this cairo-lang impl detail.