### PR TITLE
chore(py): upgrade cairo-lang==0.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           cd py
           pip install --upgrade pip
           pip install --requirement requirements-dev.txt
-          pip install cairo-lang==0.6.2
+          pip install cairo-lang==0.7.0
 
       - name: Test (python)
         run: |

--- a/py/README.md
+++ b/py/README.md
@@ -31,7 +31,7 @@ $ PIP_REQUIRE_VIRTUALENV=true pip install -r requirements-dev.txt
 Finally install the only real dependency, which cannot currently be managed by lock files:
 
 ```bash
-$ PIP_REQUIRE_VIRTUALENV=true pip install cairo-lang==0.6.2
+$ PIP_REQUIRE_VIRTUALENV=true pip install cairo-lang==0.7.0
 ```
 
 ## Testing

--- a/py/requirements-dev.in
+++ b/py/requirements-dev.in
@@ -1,5 +1,5 @@
 # see README.md
-# cairo-lang==0.6.2
+# cairo-lang==0.7.0
 pip-tools==6.4.0
 pytest==6.2.5
 flake8==4.0.1


### PR DESCRIPTION
Keeping this upgrade separate from others. Maybe it works to highlight how the version is currently managed (in README.md and ci.yml) :)