### PR TITLE
Faster curve with projective coordinates

### DIFF
--- a/crates/pedersen/src/curve.rs
+++ b/crates/pedersen/src/curve.rs
@@ -359,7 +359,7 @@ pub const PEDERSEN_P4: ProjectivePoint = ProjectivePoint {
 mod tests {
     use super::*;
 
-    mod to_le_bits_rev {
+    mod field {
         use super::*;
         use pretty_assertions::assert_eq;
 

--- a/crates/pedersen/src/field.rs
+++ b/crates/pedersen/src/field.rs
@@ -34,16 +34,51 @@ impl FieldElement {
     }
 }
 
-/// A point on an elliptic curve over [FieldElement].
+/// Montgomery representation of one
+pub const FIELD_ONE: FieldElement = FieldElement([
+    18446744073709551585,
+    18446744073709551615,
+    18446744073709551615,
+    576460752303422960,
+]);
+/// Montgomery representation of two
+pub const FIELD_TWO: FieldElement = FieldElement([
+    18446744073709551553,
+    18446744073709551615,
+    18446744073709551615,
+    576460752303422416,
+]);
+/// Montgomery representation of three
+pub const FIELD_THREE: FieldElement = FieldElement([
+    18446744073709551521,
+    18446744073709551615,
+    18446744073709551615,
+    576460752303421872,
+]);
+
+/// An affine point on an elliptic curve over [FieldElement].
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CurvePoint {
+pub struct AffinePoint {
     pub x: FieldElement,
     pub y: FieldElement,
     pub infinity: bool,
 }
 
-impl CurvePoint {
-    fn identity() -> CurvePoint {
+impl From<&ProjectivePoint> for AffinePoint {
+    fn from(p: &ProjectivePoint) -> Self {
+        let zinv = p.z.invert().unwrap();
+        let x = p.x * zinv;
+        let y = p.y * zinv;
+        AffinePoint {
+            x,
+            y,
+            infinity: false,
+        }
+    }
+}
+
+impl AffinePoint {
+    pub fn identity() -> AffinePoint {
         Self {
             x: FieldElement::zero(),
             y: FieldElement::zero(),
@@ -51,36 +86,36 @@ impl CurvePoint {
         }
     }
 
-    fn double(&self) -> CurvePoint {
+    pub fn double(&mut self) {
         if self.infinity {
-            return self.clone();
+            return;
         }
 
         // l = (3x^2+a)/2y with a=1 from stark curve
         let lambda = {
-            let two = FieldElement::one() + FieldElement::one();
-            let three = two + FieldElement::one();
-            let dividend = three * (self.x * self.x) + FieldElement::one();
-            let divisor_inv = (two * self.y).invert().unwrap();
+            let dividend = FIELD_THREE * (self.x * self.x) + FieldElement::one();
+            let divisor_inv = (FIELD_TWO * self.y).invert().unwrap();
             dividend * divisor_inv
         };
 
         let result_x = (lambda * lambda) - self.x - self.x;
-        let result_y = lambda * (self.x - result_x) - self.y;
-
-        CurvePoint {
-            x: result_x,
-            y: result_y,
-            infinity: false,
-        }
+        self.y = lambda * (self.x - result_x) - self.y;
+        self.x = result_x;
     }
 
-    pub fn add(&self, other: &CurvePoint) -> CurvePoint {
-        if self.infinity {
-            return other.clone();
-        }
+    pub fn add(&mut self, other: &AffinePoint) {
         if other.infinity {
-            return self.clone();
+            return;
+        }
+        if self.infinity {
+            self.x = other.x;
+            self.y = other.y;
+            self.infinity = other.infinity;
+            return;
+        }
+        if self.x == other.x {
+            self.double();
+            return;
         }
 
         // l = (y2-y1)/(x2-x1)
@@ -91,30 +126,147 @@ impl CurvePoint {
         };
 
         let result_x = (lambda * lambda) - self.x - other.x;
-        let result_y = lambda * (self.x - result_x) - self.y;
-
-        CurvePoint {
-            x: result_x,
-            y: result_y,
-            infinity: false,
-        }
+        self.y = lambda * (self.x - result_x) - self.y;
+        self.x = result_x;
     }
 
-    pub fn multiply(&self, bits: &BitSlice<Lsb0, u64>) -> CurvePoint {
-        let mut product = CurvePoint::identity();
+    pub fn multiply(&self, bits: &BitSlice<Lsb0, u64>) -> AffinePoint {
+        let mut product = AffinePoint::identity();
         for b in bits.iter().rev() {
-            product = product.double();
+            product.double();
             if *b {
-                product = product.add(self);
+                product.add(self);
             }
         }
-
         product
     }
 }
 
+/// A projective point on an elliptic curve over [FieldElement].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProjectivePoint {
+    pub x: FieldElement,
+    pub y: FieldElement,
+    pub z: FieldElement,
+    pub infinity: bool,
+}
+
+impl From<&AffinePoint> for ProjectivePoint {
+    fn from(p: &AffinePoint) -> Self {
+        let x = p.x;
+        let y = p.y;
+        let z = FIELD_ONE;
+        ProjectivePoint {
+            x,
+            y,
+            z,
+            infinity: false,
+        }
+    }
+}
+
+impl ProjectivePoint {
+    pub fn identity() -> ProjectivePoint {
+        Self {
+            x: FieldElement::zero(),
+            y: FieldElement::zero(),
+            z: FIELD_ONE,
+            infinity: true,
+        }
+    }
+
+    pub fn double(&mut self) {
+        if self.infinity {
+            return;
+        }
+
+        // t=3x^2+az^2 with a=1 from stark curve
+        let t = FIELD_THREE * self.x * self.x + self.z * self.z;
+        let u = FIELD_TWO * self.y * self.z;
+        let v = FIELD_TWO * u * self.x * self.y;
+        let w = t * t - FIELD_TWO * v;
+
+        let uy = u * self.y;
+
+        let x = u * w;
+        let y = t * (v - w) - FIELD_TWO * uy * uy;
+        let z = u * u * u;
+
+        self.x = x;
+        self.y = y;
+        self.z = z;
+    }
+
+    pub fn add(&mut self, other: &ProjectivePoint) {
+        if other.infinity {
+            return;
+        }
+        if self.infinity {
+            self.x = other.x;
+            self.y = other.y;
+            self.z = other.z;
+            self.infinity = other.infinity;
+            return;
+        }
+        let u0 = self.x * other.z;
+        let u1 = other.x * self.z;
+        if u0 == u1 {
+            self.double();
+            return;
+        }
+
+        let t0 = self.y * other.z;
+        let t1 = other.y * self.z;
+        let t = t0 - t1;
+
+        let u = u0 - u1;
+        let u2 = u * u;
+
+        let v = self.z * other.z;
+        let w = t * t * v - u2 * (u0 + u1);
+        let u3 = u * u2;
+
+        let x = u * w;
+        let y = t * (u0 * u2 - w) - t0 * u3;
+        let z = u3 * v;
+
+        self.x = x;
+        self.y = y;
+        self.z = z;
+    }
+
+    pub fn multiply(&self, bits: &BitSlice<Lsb0, u64>) -> ProjectivePoint {
+        let mut product = ProjectivePoint::identity();
+        for b in bits.iter().rev() {
+            product.double();
+            if *b {
+                product.add(self);
+            }
+        }
+        product
+    }
+}
+
+/// Montgomery representation of the Stark curve generator G.
+pub const CURVE_G: ProjectivePoint = ProjectivePoint {
+    x: FieldElement([
+        14484022957141291997,
+        5884444832209845738,
+        299981207024966779,
+        232005955912912577,
+    ]),
+    y: FieldElement([
+        6241159653446987914,
+        664812301889158119,
+        18147424675297964973,
+        405578048423154473,
+    ]),
+    z: FIELD_ONE,
+    infinity: false,
+};
+
 /// Montgomery representation of the Stark curve constant P0.
-pub const PEDERSEN_P0: CurvePoint = CurvePoint {
+pub const PEDERSEN_P0: ProjectivePoint = ProjectivePoint {
     x: FieldElement([
         1933903796324928314,
         7739989395386261137,
@@ -127,11 +279,12 @@ pub const PEDERSEN_P0: CurvePoint = CurvePoint {
         4798858472748676776,
         81375596133053150,
     ]),
+    z: FIELD_ONE,
     infinity: false,
 };
 
 /// Montgomery representation of the Stark curve constant P1.
-pub const PEDERSEN_P1: CurvePoint = CurvePoint {
+pub const PEDERSEN_P1: ProjectivePoint = ProjectivePoint {
     x: FieldElement([
         3602345268353203007,
         13758484295849329960,
@@ -144,11 +297,12 @@ pub const PEDERSEN_P1: CurvePoint = CurvePoint {
         433857700841878496,
         368891789801938570,
     ]),
+    z: FIELD_ONE,
     infinity: false,
 };
 
 /// Montgomery representation of the Stark curve constant P2.
-pub const PEDERSEN_P2: CurvePoint = CurvePoint {
+pub const PEDERSEN_P2: ProjectivePoint = ProjectivePoint {
     x: FieldElement([
         16491878934996302286,
         12382025591154462459,
@@ -161,11 +315,12 @@ pub const PEDERSEN_P2: CurvePoint = CurvePoint {
         5191292837124484988,
         285630633187035523,
     ]),
+    z: FIELD_ONE,
     infinity: false,
 };
 
 /// Montgomery representation of the Stark curve constant P3.
-pub const PEDERSEN_P3: CurvePoint = CurvePoint {
+pub const PEDERSEN_P3: ProjectivePoint = ProjectivePoint {
     x: FieldElement([
         1203723169299412240,
         18195981508842736832,
@@ -178,11 +333,12 @@ pub const PEDERSEN_P3: CurvePoint = CurvePoint {
         11088962269971685343,
         161068411212710156,
     ]),
+    z: FIELD_ONE,
     infinity: false,
 };
 
 /// Montgomery representation of the Stark curve constant P4.
-pub const PEDERSEN_P4: CurvePoint = CurvePoint {
+pub const PEDERSEN_P4: ProjectivePoint = ProjectivePoint {
     x: FieldElement([
         1145636535101238356,
         10664803185694787051,
@@ -195,6 +351,7 @@ pub const PEDERSEN_P4: CurvePoint = CurvePoint {
         6033691581221864148,
         345457391846365716,
     ]),
+    z: FIELD_ONE,
     infinity: false,
 };
 
@@ -207,7 +364,7 @@ mod tests {
         use pretty_assertions::assert_eq;
 
         #[test]
-        fn zero() {
+        fn bits_zero() {
             let zero = FieldElement::zero().into_bits();
             let expected = BitArray::<Lsb0, [u64; 4]>::default();
 
@@ -215,7 +372,7 @@ mod tests {
         }
 
         #[test]
-        fn one() {
+        fn bits_one() {
             let one = FieldElement::one().into_bits();
 
             let mut expected = BitArray::<Lsb0, [u64; 4]>::default();
@@ -225,7 +382,7 @@ mod tests {
         }
 
         #[test]
-        fn two() {
+        fn bits_two() {
             let two = (FieldElement::one() + FieldElement::one()).into_bits();
 
             let mut expected = BitArray::<Lsb0, [u64; 4]>::default();
@@ -233,33 +390,51 @@ mod tests {
 
             assert_eq!(two, expected);
         }
+
+        #[test]
+        fn const_one_two_three() {
+            let one = FieldElement::from(1);
+            let two = FieldElement::from(2);
+            let three = FieldElement::from(3);
+            assert_eq!(FIELD_ONE, one);
+            assert_eq!(FIELD_TWO, two);
+            assert_eq!(FIELD_THREE, three);
+        }
     }
 
     mod curve {
         use super::*;
         use pretty_assertions::assert_eq;
 
-        fn curve_from_xy_str(x: &str, y: &str) -> CurvePoint {
+        fn affine_from_xy_str(x: &str, y: &str) -> AffinePoint {
             let x = FieldElement::from_str_vartime(x).expect("Curve x-value invalid");
             let y = FieldElement::from_str_vartime(y).expect("Curve y-value invalid");
-            CurvePoint {
+            AffinePoint {
                 x,
                 y,
                 infinity: false,
             }
         }
 
-        fn curve_generator() -> CurvePoint {
-            curve_from_xy_str(
-                "874739451078007766457464989774322083649278607533249481151382481072868806602",
-                "152666792071518830868575557812948353041420400780739481342941381225525861407",
-            )
+        fn projective_from_xy_str(x: &str, y: &str) -> ProjectivePoint {
+            let x = FieldElement::from_str_vartime(x).expect("Curve x-value invalid");
+            let y = FieldElement::from_str_vartime(y).expect("Curve y-value invalid");
+            ProjectivePoint {
+                x,
+                y,
+                z: FIELD_ONE,
+                infinity: false,
+            }
         }
 
         #[test]
-        fn double() {
-            let g_double = curve_generator().double();
-            let expected = curve_from_xy_str(
+        fn projective_double() {
+            let g_double = {
+                let mut g = CURVE_G;
+                g.double();
+                AffinePoint::from(&g)
+            };
+            let expected = affine_from_xy_str(
                 "3324833730090626974525872402899302150520188025637965566623476530814354734325",
                 "3147007486456030910661996439995670279305852583596209647900952752170983517249",
             );
@@ -267,11 +442,14 @@ mod tests {
         }
 
         #[test]
-        fn double_and_add() {
-            let g = curve_generator();
-            let g_double = g.double();
-            let g_triple = g_double.add(&g);
-            let expected = curve_from_xy_str(
+        fn projective_double_and_add() {
+            let g_triple = {
+                let mut g = CURVE_G;
+                g.double();
+                g.add(&CURVE_G);
+                AffinePoint::from(&g)
+            };
+            let expected = affine_from_xy_str(
                 "1839793652349538280924927302501143912227271479439798783640887258675143576352",
                 "3564972295958783757568195431080951091358810058262272733141798511604612925062",
             );
@@ -279,12 +457,11 @@ mod tests {
         }
 
         #[test]
-        fn multiply() {
-            let three =
-                (FieldElement::one() + FieldElement::one() + FieldElement::one()).into_bits();
-            let g = curve_generator();
-            let g_triple = g.multiply(&three);
-            let expected = curve_from_xy_str(
+        fn projective_multiply() {
+            let three = FIELD_THREE.into_bits();
+            let g = CURVE_G;
+            let g_triple = AffinePoint::from(&g.multiply(&three));
+            let expected = affine_from_xy_str(
                 "1839793652349538280924927302501143912227271479439798783640887258675143576352",
                 "3564972295958783757568195431080951091358810058262272733141798511604612925062",
             );
@@ -292,52 +469,70 @@ mod tests {
         }
 
         #[test]
-        fn p0() {
-            let expected = curve_from_xy_str(
+        fn affine_projective_multiply() {
+            let three = FIELD_THREE.into_bits();
+
+            let ag = AffinePoint::from(&CURVE_G);
+            let ag_triple = ag.multiply(&three);
+
+            let pg = ProjectivePoint::from(&ag);
+            let pg_triple = pg.multiply(&three);
+
+            let result = AffinePoint::from(&pg_triple);
+            assert_eq!(ag_triple.x, result.x);
+        }
+
+        #[test]
+        fn const_generator() {
+            let expected = projective_from_xy_str(
+                "874739451078007766457464989774322083649278607533249481151382481072868806602",
+                "152666792071518830868575557812948353041420400780739481342941381225525861407",
+            );
+            assert_eq!(CURVE_G, expected);
+        }
+
+        #[test]
+        fn const_p0() {
+            let expected = projective_from_xy_str(
                 "2089986280348253421170679821480865132823066470938446095505822317253594081284",
                 "1713931329540660377023406109199410414810705867260802078187082345529207694986",
             );
-
             assert_eq!(PEDERSEN_P0, expected);
         }
 
         #[test]
-        fn p1() {
-            let expected = curve_from_xy_str(
+        fn const_p1() {
+            let expected = projective_from_xy_str(
                 "996781205833008774514500082376783249102396023663454813447423147977397232763",
                 "1668503676786377725805489344771023921079126552019160156920634619255970485781",
             );
-
             assert_eq!(PEDERSEN_P1, expected);
         }
 
         #[test]
-        fn p2() {
-            let expected = curve_from_xy_str(
+        fn const_p2() {
+            let expected = projective_from_xy_str(
                 "2251563274489750535117886426533222435294046428347329203627021249169616184184",
                 "1798716007562728905295480679789526322175868328062420237419143593021674992973",
             );
-
             assert_eq!(PEDERSEN_P2, expected);
         }
 
         #[test]
-        fn p3() {
-            let expected = curve_from_xy_str(
+        fn const_p3() {
+            let expected = projective_from_xy_str(
                 "2138414695194151160943305727036575959195309218611738193261179310511854807447",
                 "113410276730064486255102093846540133784865286929052426931474106396135072156",
             );
-
             assert_eq!(PEDERSEN_P3, expected);
         }
 
         #[test]
-        fn p4() {
-            let expected = curve_from_xy_str(
+        fn const_p4() {
+            let expected = projective_from_xy_str(
                 "2379962749567351885752724891227938183011949129833673362440656643086021394946",
                 "776496453633298175483985398648758586525933812536653089401905292063708816422",
             );
-
             assert_eq!(PEDERSEN_P4, expected);
         }
     }

--- a/crates/pedersen/src/lib.rs
+++ b/crates/pedersen/src/lib.rs
@@ -1,8 +1,8 @@
-pub mod field;
+pub mod curve;
 
 use std::error::Error;
 
-use crate::field::{
+use crate::curve::{
     AffinePoint, FieldElement, FieldElementRepr, PEDERSEN_P0, PEDERSEN_P1, PEDERSEN_P2,
     PEDERSEN_P3, PEDERSEN_P4,
 };

--- a/crates/pedersen/src/lib.rs
+++ b/crates/pedersen/src/lib.rs
@@ -1,9 +1,10 @@
-mod field;
+pub mod field;
 
 use std::error::Error;
 
 use crate::field::{
-    FieldElement, FieldElementRepr, PEDERSEN_P0, PEDERSEN_P1, PEDERSEN_P2, PEDERSEN_P3, PEDERSEN_P4,
+    AffinePoint, FieldElement, FieldElementRepr, PEDERSEN_P0, PEDERSEN_P1, PEDERSEN_P2,
+    PEDERSEN_P3, PEDERSEN_P4,
 };
 
 use bitvec::{order::Msb0, slice::BitSlice, view::BitView};
@@ -88,25 +89,18 @@ impl std::ops::Add for StarkHash {
 ///
 /// [Starknet Pedersen hash]: https://docs.starkware.co/starkex-v3/crypto/pedersen-hash-function
 pub fn pedersen_hash(a: StarkHash, b: StarkHash) -> StarkHash {
-    let mut result = PEDERSEN_P0.clone();
     let a = FieldElement::from(a).into_bits();
     let b = FieldElement::from(b).into_bits();
 
-    // Add a_low * P1
-    let tmp = PEDERSEN_P1.multiply(&a[..248]);
-    result = result.add(&tmp);
+    // Compute hash
+    let mut accumulator = PEDERSEN_P0;
+    accumulator.add(&PEDERSEN_P1.multiply(&a[..248])); // Add a_low * P1
+    accumulator.add(&PEDERSEN_P2.multiply(&a[248..252])); // Add a_high * P2
+    accumulator.add(&PEDERSEN_P3.multiply(&b[..248])); // Add b_low * P3
+    accumulator.add(&PEDERSEN_P4.multiply(&b[248..252])); // Add b_high * P4
 
-    // Add a_high * P2
-    let tmp = PEDERSEN_P2.multiply(&a[248..252]);
-    result = result.add(&tmp);
-
-    // Add b_low * P3
-    let tmp = PEDERSEN_P3.multiply(&b[..248]);
-    result = result.add(&tmp);
-
-    // Add b_high * P4
-    let tmp = PEDERSEN_P4.multiply(&b[248..252]);
-    result = result.add(&tmp);
+    // Convert to affine
+    let result = AffinePoint::from(&accumulator);
 
     // Return x-coordinate
     StarkHash::from(result.x)


### PR DESCRIPTION
Modified the curve to in-place ops. and added projective coordinates -- improving time for Pedersen hash about 10x.