### PR TITLE
refactor and update storage

### DIFF
--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -5,26 +5,33 @@
 use pedersen::StarkHash;
 
 /// The address of a StarkNet contract.
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ContractAddress(pub StarkHash);
 
 /// The hash of a StarkNet contract.
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ContractHash(pub StarkHash);
 
 /// The hash of StarkNet contract's state. This is the value stored
 /// in the global state tree.
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ContractStateHash(pub StarkHash);
 
 /// The commitment root of a StarkNet contract. This is the entry-point
 /// for a contract's state at a specific point in time via the contract
 /// state tree.
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ContractRoot(pub StarkHash);
 
 /// The address of a storage element for a StarkNet contract.
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct StorageAddress(pub StarkHash);
 
 /// The value of a storage element for a StarkNet contract.
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct StorageValue(pub StarkHash);
 
 /// The commitment root of the global StarkNet state. This is the entry-point
 /// for the global state at a specific point in time via the global state tree.
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct GlobalRoot(pub StarkHash);

--- a/crates/pathfinder/src/storage/contract.rs
+++ b/crates/pathfinder/src/storage/contract.rs
@@ -1,0 +1,140 @@
+use crate::{
+    core::{ContractAddress, ContractHash},
+    storage::{DB_VERSION_CURRENT, DB_VERSION_EMPTY},
+};
+
+use pedersen::StarkHash;
+use rusqlite::{named_params, OptionalExtension, Transaction};
+
+/// Migrates the [ContractsTable] to the [current version](DB_VERSION_CURRENT).
+pub fn migrate(transaction: &Transaction, from_version: u32) -> anyhow::Result<()> {
+    ContractsTable::migrate(transaction, from_version)
+}
+
+/// Stores StarkNet contract information, specifically a contract's
+///
+/// - [address](ContractAddress)
+/// - [hash](ContractHash)
+/// - byte code
+/// - ABI
+/// - definition
+pub struct ContractsTable {}
+
+impl ContractsTable {
+    const TABLE: &'static str = "contracts";
+
+    /// Migrates the [ContractsTable] from the given version to [DB_VERSION_CURRENT].
+    fn migrate(transaction: &Transaction, from_version: u32) -> anyhow::Result<()> {
+        match from_version {
+            DB_VERSION_EMPTY => {} // Fresh database, continue to create table.
+            DB_VERSION_CURRENT => return Ok(()), // Table is already correct.
+            other => anyhow::bail!("Unknown database version: {}", other),
+        }
+
+        transaction.execute(
+            &format!(
+                r"CREATE TABLE {}(
+                    address    BLOB PRIMARY KEY,
+                    hash       BLOB NOT NULL,
+                    code       BLOB,
+                    abi        BLOB,
+                    definition BLOB
+                )",
+                Self::TABLE
+            ),
+            [],
+        )?;
+
+        Ok(())
+    }
+
+    /// Insert a contract into the table. Will fail if the contract address is already populated.
+    pub fn insert(
+        transaction: &Transaction,
+        address: ContractAddress,
+        hash: ContractHash,
+        code: &[u8],
+        abi: &[u8],
+        definition: &[u8],
+    ) -> anyhow::Result<()> {
+        transaction.execute(
+            &format!(
+                r"INSERT INTO {} ( address,  hash, code,   abi,  definition)
+                          VALUES (:address, :hash, :code, :abi, :definition)",
+                Self::TABLE
+            ),
+            named_params! {
+                ":address": &address.0.to_be_bytes()[..],
+                ":hash": &hash.0.to_be_bytes()[..],
+                ":code": code,
+                ":abi": abi,
+                ":definition": definition,
+            },
+        )?;
+        Ok(())
+    }
+
+    /// Gets the specificed contract's hash.
+    pub fn get_hash(
+        transaction: &Transaction,
+        address: ContractAddress,
+    ) -> anyhow::Result<Option<ContractHash>> {
+        let bytes: Option<Vec<u8>> = transaction
+            .query_row(
+                &format!("SELECT hash FROM {} WHERE address = :address", Self::TABLE),
+                named_params! {
+                    ":address": &address.0.to_be_bytes()[..]
+                },
+                |row| row.get("hash"),
+            )
+            .optional()?;
+
+        let bytes = match bytes {
+            Some(bytes) => bytes,
+            None => return Ok(None),
+        };
+
+        let bytes: [u8; 32] = match bytes.try_into() {
+            Ok(bytes) => bytes,
+            Err(bytes) => anyhow::bail!("Bad contract hash length: {}", bytes.len()),
+        };
+
+        let hash = StarkHash::from_be_bytes(bytes)?;
+        let hash = ContractHash(hash);
+
+        Ok(Some(hash))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_hash() {
+        let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+        let transaction = conn.transaction().unwrap();
+
+        ContractsTable::migrate(&transaction, DB_VERSION_EMPTY).unwrap();
+
+        let address = ContractAddress(StarkHash::from_hex_str("abc").unwrap());
+        let hash = ContractHash(StarkHash::from_hex_str("123").unwrap());
+        let code = vec![0, 1, 2, 3, 4];
+        let abi = vec![54, 62, 71];
+        let definition = vec![9, 13, 25];
+
+        ContractsTable::insert(
+            &transaction,
+            address,
+            hash,
+            &code[..],
+            &abi[..],
+            &definition[..],
+        )
+        .unwrap();
+
+        let result = ContractsTable::get_hash(&transaction, address).unwrap();
+
+        assert_eq!(result, Some(hash));
+    }
+}

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -1,0 +1,129 @@
+use pedersen::StarkHash;
+use rusqlite::{named_params, OptionalExtension, Transaction};
+
+use crate::{
+    core::{ContractHash, ContractRoot, ContractStateHash},
+    storage::{DB_VERSION_CURRENT, DB_VERSION_EMPTY},
+};
+
+/// Migrates the [ContractsStateTable] to the [current version](DB_VERSION_CURRENT).
+pub fn migrate(transaction: &Transaction, from_version: u32) -> anyhow::Result<()> {
+    ContractsStateTable::migrate(transaction, from_version)
+}
+
+/// Stores the contract state hash along with its preimage. This is useful to
+/// map between the global state tree and the contracts tree.
+///
+/// Specifically it stores
+///
+/// - [contract state hash](ContractStateHash)
+/// - [contract hash](ContractHash)
+/// - [contract root](ContractRoot)
+pub struct ContractsStateTable {}
+
+impl ContractsStateTable {
+    const TABLE: &'static str = "contract_states";
+
+    /// Migrates the [ContractsStateTable] from the given version to [DB_VERSION_CURRENT].
+    fn migrate(transaction: &Transaction, from_version: u32) -> anyhow::Result<()> {
+        match from_version {
+            DB_VERSION_EMPTY => {} // Fresh database, continue to create table.
+            DB_VERSION_CURRENT => return Ok(()), // Table is already correct.
+            other => anyhow::bail!("Unknown database version: {}", other),
+        }
+
+        transaction.execute(
+            &format!(
+                r"CREATE TABLE {} (
+                    state_hash BLOB PRIMARY KEY,
+                    hash       BLOB NOT NULL,
+                    root       BLOB NOT NULL
+                )",
+                Self::TABLE
+            ),
+            [],
+        )?;
+
+        Ok(())
+    }
+
+    /// Insert a state hash into the table. Does nothing if the state hash already exists.
+    pub fn insert(
+        transaction: &Transaction,
+        state_hash: ContractStateHash,
+        hash: ContractHash,
+        root: ContractRoot,
+    ) -> anyhow::Result<()> {
+        transaction.execute(
+            &format!(
+                r"INSERT INTO {} ( state_hash,  hash,  root)
+                          VALUES (:state_hash, :hash, :root)",
+                Self::TABLE
+            ),
+            named_params! {
+                ":state_hash": &state_hash.0.to_be_bytes()[..],
+                ":hash": &hash.0.to_be_bytes()[..],
+                ":root": &root.0.to_be_bytes()[..],
+            },
+        )?;
+        Ok(())
+    }
+
+    /// Gets the root associated with the given state hash, or [None]
+    /// if it does not exist.
+    pub fn get_root(
+        transaction: &Transaction,
+        state_hash: ContractStateHash,
+    ) -> anyhow::Result<Option<ContractRoot>> {
+        let bytes: Option<Vec<u8>> = transaction
+            .query_row(
+                &format!(
+                    "SELECT root FROM {} WHERE state_hash = :state_hash",
+                    Self::TABLE
+                ),
+                named_params! {
+                    ":state_hash": &state_hash.0.to_be_bytes()[..]
+                },
+                |row| row.get("root"),
+            )
+            .optional()?;
+
+        let bytes = match bytes {
+            Some(bytes) => bytes,
+            None => return Ok(None),
+        };
+
+        let bytes: [u8; 32] = match bytes.try_into() {
+            Ok(bytes) => bytes,
+            Err(bytes) => anyhow::bail!("Bad contract root length: {}", bytes.len()),
+        };
+
+        let root = StarkHash::from_be_bytes(bytes)?;
+        let root = ContractRoot(root);
+
+        Ok(Some(root))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_root() {
+        let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+        let transaction = conn.transaction().unwrap();
+
+        ContractsStateTable::migrate(&transaction, DB_VERSION_EMPTY).unwrap();
+
+        let state_hash = ContractStateHash(StarkHash::from_hex_str("abc").unwrap());
+        let hash = ContractHash(StarkHash::from_hex_str("123").unwrap());
+        let root = ContractRoot(StarkHash::from_hex_str("def").unwrap());
+
+        ContractsStateTable::insert(&transaction, state_hash, hash, root).unwrap();
+
+        let result = ContractsStateTable::get_root(&transaction, state_hash).unwrap();
+
+        assert_eq!(result, Some(root));
+    }
+}


### PR DESCRIPTION
This PR essentially removes all the table prototypes we had before (these weren't in use yet).

It keeps the foreign key and migration logic (more or less), and adds support for storing contract information as well as contract state hashes (with its pre-image).

There are still many tables missing, but we can add those as we need them.

I'm looking for early feedback on the general storage layout and design before repeating the same style on the other tables.