### PR TITLE
Add global state storage support

### DIFF
--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -3,21 +3,27 @@
 //!
 //! This includes many trivial wrappers around [StarkHash] which help by providing additional type safety.
 use pedersen::StarkHash;
+use web3::types::H256;
 
 /// The address of a StarkNet contract.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ContractAddress(pub StarkHash);
 
-/// The hash of a StarkNet contract.
+/// A StarkNet contract's hash. This is a hash over a contract's
+/// deployment properties e.g. code and ABI.
+///
+/// Not to be confused with [ContractStateHash].
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ContractHash(pub StarkHash);
 
-/// The hash of StarkNet contract's state. This is the value stored
+/// A StarkNet contract's state hash. This is the value stored
 /// in the global state tree.
+///
+/// Not to be confused with [ContractHash].
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ContractStateHash(pub StarkHash);
 
-/// The commitment root of a StarkNet contract. This is the entry-point
+/// A commitment root of a StarkNet contract. This is the entry-point
 /// for a contract's state at a specific point in time via the contract
 /// state tree.
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -31,7 +37,35 @@ pub struct StorageAddress(pub StarkHash);
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct StorageValue(pub StarkHash);
 
-/// The commitment root of the global StarkNet state. This is the entry-point
+/// A commitment root of the global StarkNet state. This is the entry-point
 /// for the global state at a specific point in time via the global state tree.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct GlobalRoot(pub StarkHash);
+
+/// A StarkNet block hash.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct StarknetBlockHash(pub StarkHash);
+
+/// A StarkNet block number.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct StarknetBlockNumber(pub u64);
+
+/// An Ethereum block hash.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct EthereumBlockHash(pub H256);
+
+/// An Ethereum block number.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct EthereumBlockNumber(pub u64);
+
+/// An Ethereum transaction hash.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct EthereumTransactionHash(pub H256);
+
+/// An Ethereum transaction's index within a block.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct EthereumTransactionIndex(pub u64);
+
+/// An Ethereum log's index within a block.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct EthereumLogIndex(pub u64);

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -9,6 +9,7 @@ mod state;
 
 pub use contract::ContractsTable;
 pub use ethereum::{EthereumBlocksTable, EthereumTransactionsTable};
+pub use state::{ContractsStateTable, GlobalStateRecord, GlobalStateTable};
 
 use anyhow::Context;
 use rusqlite::Transaction;
@@ -37,6 +38,7 @@ pub fn migrate_database(transaction: &Transaction) -> anyhow::Result<()> {
     // Migrate all the tables.
     contract::migrate(transaction, version).context("Failed to migrate contracts table")?;
     ethereum::migrate(transaction, version).context("Failed to migrate Ethereum tables")?;
+    state::migrate(transaction, version).context("Failed to migrate StarkNet state tables")?;
 
     // Update the pragma schema.
     transaction

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -3,11 +3,12 @@
 //! Currently this consists of a Sqlite backend implementation.
 
 mod contract;
+mod ethereum;
 pub mod merkle_tree;
 mod state;
 
 pub use contract::ContractsTable;
-pub use state::ContractsStateTable;
+pub use ethereum::{EthereumBlocksTable, EthereumTransactionsTable};
 
 use anyhow::Context;
 use rusqlite::Transaction;
@@ -35,7 +36,7 @@ pub fn migrate_database(transaction: &Transaction) -> anyhow::Result<()> {
 
     // Migrate all the tables.
     contract::migrate(transaction, version).context("Failed to migrate contracts table")?;
-    state::migrate(transaction, version).context("Failed to migrate contract states table")?;
+    ethereum::migrate(transaction, version).context("Failed to migrate Ethereum tables")?;
 
     // Update the pragma schema.
     transaction

--- a/crates/pathfinder/src/storage/ethereum.rs
+++ b/crates/pathfinder/src/storage/ethereum.rs
@@ -1,0 +1,125 @@
+use anyhow::Context;
+use rusqlite::{named_params, Transaction};
+
+use crate::{
+    core::{
+        EthereumBlockHash, EthereumBlockNumber, EthereumTransactionHash, EthereumTransactionIndex,
+    },
+    storage::{DB_VERSION_CURRENT, DB_VERSION_EMPTY},
+};
+
+/// Migrates [GlobalStateTable] and [ContractsStateTable] to the [current version](DB_VERSION_CURRENT).
+pub fn migrate(transaction: &Transaction, from_version: u32) -> anyhow::Result<()> {
+    EthereumBlocksTable::migrate(transaction, from_version)
+        .context("Failed to migrate the Ethereum blocks table")?;
+    EthereumTransactionsTable::migrate(transaction, from_version)
+        .context("Failed to migrate the Ethereum transactionns table")
+}
+
+/// Stores basic information about an Ethereum block, enough to descibe it as a unique point
+/// of origin. This lets us link StarkNet information to a point in Ethereum's history.
+///
+/// Specifically, this stores an Ethereum block's
+/// - [block hash](EthereumBlockHash)
+/// - [block number](EthereumBlockNumber)
+pub struct EthereumBlocksTable {}
+
+impl EthereumBlocksTable {
+    /// Migrates the [EthereumBlocksTable] from the given version to [DB_VERSION_CURRENT].
+    fn migrate(transaction: &Transaction, from_version: u32) -> anyhow::Result<()> {
+        match from_version {
+            DB_VERSION_EMPTY => {} // Fresh database, continue to create table.
+            DB_VERSION_CURRENT => return Ok(()), // Table is already correct.
+            other => anyhow::bail!("Unknown database version: {}", other),
+        }
+
+        transaction.execute(
+            r"CREATE TABLE ethereum_blocks (
+                    ethereum_block_hash   BLOB PRIMARY KEY,
+                    ethereum_block_number INTEGER NOT NULL
+                )",
+            [],
+        )?;
+
+        Ok(())
+    }
+
+    /// Inserts a new Ethereum block with the given [hash](EthereumBlockHash) and [number](EthereumBlockNumber).
+    ///
+    /// Does nothing if the hash already exists.
+    pub fn insert(
+        transaction: &Transaction,
+        hash: EthereumBlockHash,
+        number: EthereumBlockNumber,
+    ) -> anyhow::Result<()> {
+        transaction.execute(
+            r"INSERT INTO ethereum_blocks ( ethereum_block_hash,  ethereum_block_number)
+                                       VALUES (:ethereum_block_hash, :ethereum_block_number)
+                                       ON CONFLICT DO NOTHING",
+            named_params! {
+                ":ethereum_block_hash": hash.0.as_bytes(),
+                ":ethereum_block_number": number.0,
+            },
+        )?;
+        Ok(())
+    }
+}
+
+/// Stores basic information about an Ethereum transaction, enough to descibe it as a unique point
+/// of origin. This lets us link StarkNet information to a point in Ethereum's history.
+///
+/// Specifically, this stores an Ethereum transactions
+/// - [transaction hash](EthereumTransactionHash)
+/// - [transaction index](EthereumTransactionIndex)
+/// - [block hash](EthereumBlockHash)
+pub struct EthereumTransactionsTable {}
+
+impl EthereumTransactionsTable {
+    /// Migrates the [EthereumTransactionsTable] from the given version to [DB_VERSION_CURRENT].
+    fn migrate(transaction: &Transaction, from_version: u32) -> anyhow::Result<()> {
+        match from_version {
+            DB_VERSION_EMPTY => {} // Fresh database, continue to create table.
+            DB_VERSION_CURRENT => return Ok(()), // Table is already correct.
+            other => anyhow::bail!("Unknown database version: {}", other),
+        }
+
+        // TODO: consider ON DELETE CASCADE when we start cleaning up. Don't forget to document if we use it.
+        transaction.execute(
+            r"CREATE TABLE ethereum_transactions (
+                    ethereum_transaction_hash    BLOB PRIMARY KEY,
+                    ethereum_transaction_index   INTEGER NOT NULL,
+                    ethereum_block_hash          BLOB NOT NULL,
+
+                    FOREIGN KEY(ethereum_block_hash) REFERENCES ethereum_blocks(ethereum_block_hash)
+                )",
+            [],
+        )?;
+
+        Ok(())
+    }
+
+    /// Insert a new Ethereum transaction.
+    ///
+    /// Does nothing if the ethereum hash already exists.
+    ///
+    /// Note that [block_hash](EthereumBlockHash) must reference an
+    /// Ethereum block stored in [EthereumBlocksTable].
+    pub fn insert(
+        transaction: &Transaction,
+        block_hash: EthereumBlockHash,
+        tx_hash: EthereumTransactionHash,
+        tx_index: EthereumTransactionIndex,
+    ) -> anyhow::Result<()> {
+        transaction.execute(
+            r"INSERT INTO ethereum_transactions ( ethereum_transaction_hash,  ethereum_transaction_index,  ethereum_block_hash)
+                                             VALUES (:ethereum_transaction_hash, :ethereum_transaction_index, :ethereum_block_hash)
+                                             ON CONFLICT DO NOTHING",
+            named_params! {
+                ":ethereum_transaction_hash": tx_hash.0.as_bytes(),
+                ":ethereum_transaction_index": tx_index.0,
+                ":ethereum_block_hash": block_hash.0.as_bytes(),
+            },
+        )?;
+        Ok(())
+    }
+}

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -1,14 +1,206 @@
+use anyhow::Context;
 use pedersen::StarkHash;
 use rusqlite::{named_params, OptionalExtension, Transaction};
+use web3::types::H256;
 
 use crate::{
-    core::{ContractHash, ContractRoot, ContractStateHash},
+    core::{
+        ContractHash, ContractRoot, ContractStateHash, EthereumBlockHash, EthereumBlockNumber,
+        EthereumLogIndex, EthereumTransactionHash, EthereumTransactionIndex, GlobalRoot,
+        StarknetBlockHash, StarknetBlockNumber,
+    },
     storage::{DB_VERSION_CURRENT, DB_VERSION_EMPTY},
 };
 
-/// Migrates the [ContractsStateTable] to the [current version](DB_VERSION_CURRENT).
+/// Migrates [GlobalStateTable] and [ContractsStateTable] to the [current version](DB_VERSION_CURRENT).
 pub fn migrate(transaction: &Transaction, from_version: u32) -> anyhow::Result<()> {
+    GlobalStateTable::migrate(transaction, from_version)
+        .context("Failed to migrate the global state table")?;
     ContractsStateTable::migrate(transaction, from_version)
+        .context("Failed to migrate the contracts state table")
+}
+
+/// Stores descriptions of the global StarkNet state. This data contains
+/// StarkNet block metadata as well as the origin point on Ethereum.
+///
+/// For more specific information, see [GlobalStateTable].
+pub struct GlobalStateTable {}
+
+/// A StarkNet global state record from [GlobalStateTable] along with the Ethereum
+/// point of origin for this record.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GlobalStateRecord {
+    /// The StarkNet block number of this state.
+    pub block_number: StarknetBlockNumber,
+    /// The StarkNet block hash of this state.
+    pub block_hash: StarknetBlockHash,
+    /// The StarkNet global root of this state.
+    pub global_root: GlobalRoot,
+    /// The Ethereum block number this StarkNet state was confirmed on.
+    pub eth_block_number: EthereumBlockNumber,
+    /// The Ethereum block hash this StarkNet state was confirmed on.
+    pub eth_block_hash: EthereumBlockHash,
+    /// The Ethereum transaction's hash this StarkNet state was confirmed on.
+    pub eth_tx_hash: EthereumTransactionHash,
+    /// The Ethereum transaction's index this StarkNet state was confirmed on.
+    pub eth_tx_index: EthereumTransactionIndex,
+    /// StarkNet state updates are emitted as log events by the Ethereum StarkNet core contract.
+    /// This is the log index linked to this StarkNet state.
+    pub eth_log_index: EthereumLogIndex,
+}
+
+impl GlobalStateTable {
+    /// Migrates the [GlobalStateTable] from the given version to [DB_VERSION_CURRENT].
+    fn migrate(transaction: &Transaction, from_version: u32) -> anyhow::Result<()> {
+        match from_version {
+            DB_VERSION_EMPTY => {} // Fresh database, continue to create table.
+            DB_VERSION_CURRENT => return Ok(()), // Table is already correct.
+            other => anyhow::bail!("Unknown database version: {}", other),
+        }
+
+        // TODO: consider ON DELETE CASCADE when we start cleaning up. Don't forget to document if we use it.
+        transaction.execute(
+            r"CREATE TABLE global_state (
+                    starknet_block_hash       BLOB PRIMARY KEY,
+                    starknet_block_number     INTEGER NOT NULL,
+                    starknet_global_root      BLOB NOT NULL,
+                    ethereum_transaction_hash BLOB NOT NULL,
+                    ethereum_log_index        INTEGER NOT NULL,
+
+                    FOREIGN KEY(ethereum_transaction_hash) REFERENCES ethereum_transactions(ethereum_transaction_hash)
+                )",
+            [],
+        )?;
+
+        Ok(())
+    }
+
+    /// Inserts a new StarkNet global state.
+    ///
+    /// Does nothing if the [StarkNet block hash](StarknetBlockHash) already exists.
+    ///
+    /// Note that the [EthereumTransactionHash] must reference a valid transaction hash
+    /// stored in [EthereumTransactionsTable](crate::storage::EthereumTransactionsTable).
+    pub fn insert(
+        transaction: &Transaction,
+        block_number: StarknetBlockNumber,
+        block_hash: StarknetBlockHash,
+        global_root: GlobalRoot,
+        eth_transaction: EthereumTransactionHash,
+        eth_log_index: EthereumLogIndex,
+    ) -> anyhow::Result<()> {
+        transaction.execute(
+            r"INSERT INTO global_state (
+                    starknet_block_number,
+                    starknet_block_hash,
+                    starknet_global_root,
+                    ethereum_transaction_hash,
+                    ethereum_log_index
+                ) VALUES (
+                    :starknet_block_number,
+                    :starknet_block_hash,
+                    :starknet_global_root,
+                    :ethereum_transaction_hash,
+                    :ethereum_log_index
+                ) ON CONFLICT DO NOTHING
+            ",
+            named_params! {
+                    ":starknet_block_number": block_number.0,
+                    ":starknet_block_hash": &block_hash.0.to_be_bytes()[..],
+                    ":starknet_global_root": &global_root.0.to_be_bytes()[..],
+                    ":ethereum_transaction_hash": eth_transaction.0.as_bytes(),
+                    ":ethereum_log_index": eth_log_index.0,
+            },
+        )?;
+        Ok(())
+    }
+
+    /// Retrieves the latest global StarkNet state from the [GlobalStateTable]. Latest is defined as the
+    /// record with the largest [StarknetBlockNumber].
+    pub fn get_latest_state(
+        transaction: &Transaction,
+    ) -> anyhow::Result<Option<GlobalStateRecord>> {
+        let row = transaction
+            .query_row(
+                r"SELECT * FROM global_state
+                    NATURAL JOIN ethereum_transactions
+                    NATURAL JOIN ethereum_blocks
+                    ORDER BY starknet_block_number DESC
+                    LIMIT 1",
+                [],
+                |row| {
+                    let block_number = StarknetBlockNumber(row.get("starknet_block_number")?);
+                    let eth_block_number = EthereumBlockNumber(row.get("ethereum_block_number")?);
+                    let tx_index = EthereumTransactionIndex(row.get("ethereum_transaction_index")?);
+                    let log_index = EthereumLogIndex(row.get("ethereum_log_index")?);
+
+                    // Unfortunately there is no way to return a non-rusqlite error here so can't convert these yet.
+                    let block_hash: Vec<u8> = row.get("starknet_block_hash")?;
+                    let root: Vec<u8> = row.get("starknet_global_root")?;
+                    let eth_block_hash: Vec<u8> = row.get("ethereum_block_hash")?;
+                    let tx_hash: Vec<u8> = row.get("ethereum_transaction_hash")?;
+
+                    Ok((
+                        block_number,
+                        block_hash,
+                        root,
+                        eth_block_number,
+                        eth_block_hash,
+                        tx_hash,
+                        tx_index,
+                        log_index,
+                    ))
+                },
+            )
+            .optional()?;
+
+        let row = row.map(
+            |(
+                block_number,
+                block_hash,
+                global_root,
+                eth_block_number,
+                eth_block_hash,
+                eth_tx_hash,
+                eth_tx_index,
+                eth_log_index,
+            )|
+             -> anyhow::Result<GlobalStateRecord> {
+                let block_hash = StarkHash::from_be_slice(&block_hash)
+                    .context("Failed to parse StarkNet block hash")?;
+                let global_root = StarkHash::from_be_slice(&global_root)
+                    .context("Failed to parse StarkNet global state root")?;
+
+                fn vec_to_h256(bytes: Vec<u8>) -> anyhow::Result<H256> {
+                    let bytes: [u8; 32] = match bytes.try_into() {
+                        Ok(bytes) => bytes,
+                        Err(bad_len) => {
+                            anyhow::bail!("Expected exactly 32 bytes but got {}", bad_len.len())
+                        }
+                    };
+                    Ok(H256(bytes))
+                }
+
+                let eth_tx_hash = vec_to_h256(eth_tx_hash)
+                    .context("Failed to parse Ethereum transaction hash")?;
+                let eth_block_hash =
+                    vec_to_h256(eth_block_hash).context("Failed to parse Ethereum block hash")?;
+
+                Ok(GlobalStateRecord {
+                    block_number,
+                    block_hash: StarknetBlockHash(block_hash),
+                    global_root: GlobalRoot(global_root),
+                    eth_block_number,
+                    eth_block_hash: EthereumBlockHash(eth_block_hash),
+                    eth_tx_hash: EthereumTransactionHash(eth_tx_hash),
+                    eth_tx_index,
+                    eth_log_index,
+                })
+            },
+        );
+
+        row.transpose()
+    }
 }
 
 /// Stores the contract state hash along with its preimage. This is useful to
@@ -98,21 +290,202 @@ impl ContractsStateTable {
 mod tests {
     use super::*;
 
-    #[test]
-    fn get_root() {
-        let mut conn = rusqlite::Connection::open_in_memory().unwrap();
-        let transaction = conn.transaction().unwrap();
+    mod global {
+        use std::str::FromStr;
 
-        ContractsStateTable::migrate(&transaction, DB_VERSION_EMPTY).unwrap();
+        use crate::storage::{self};
 
-        let state_hash = ContractStateHash(StarkHash::from_hex_str("abc").unwrap());
-        let hash = ContractHash(StarkHash::from_hex_str("123").unwrap());
-        let root = ContractRoot(StarkHash::from_hex_str("def").unwrap());
+        use super::*;
 
-        ContractsStateTable::insert(&transaction, state_hash, hash, root).unwrap();
+        mod insert {
+            use super::*;
 
-        let result = ContractsStateTable::get_root(&transaction, state_hash).unwrap();
+            #[test]
+            fn fails_if_eth_origin_missing() {
+                let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+                let transaction = conn.transaction().unwrap();
 
-        assert_eq!(result, Some(root));
+                // The table is joined with the Ethereum block and transaction tables,
+                // so we have to create the full database.
+                storage::migrate_database(&transaction).unwrap();
+
+                GlobalStateTable::insert(
+                    &transaction,
+                    StarknetBlockNumber(10),
+                    StarknetBlockHash(StarkHash::from_hex_str("123").unwrap()),
+                    GlobalRoot(StarkHash::from_hex_str("111").unwrap()),
+                    EthereumTransactionHash(H256::from_str(&"abca".repeat(64 / 4)).unwrap()),
+                    EthereumLogIndex(99),
+                )
+                .unwrap_err();
+            }
+        }
+
+        mod get_latest {
+            use super::*;
+
+            #[test]
+            fn some() {
+                let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+                let transaction = conn.transaction().unwrap();
+
+                // Data to insert
+                let first = GlobalStateRecord {
+                    block_number: StarknetBlockNumber(10),
+                    block_hash: StarknetBlockHash(StarkHash::from_hex_str("123").unwrap()),
+                    global_root: GlobalRoot(StarkHash::from_hex_str("111").unwrap()),
+                    eth_block_number: EthereumBlockNumber(2003),
+                    eth_block_hash: EthereumBlockHash(
+                        H256::from_str(&"abca".repeat(64 / 4)).unwrap(),
+                    ),
+                    eth_tx_hash: EthereumTransactionHash(
+                        H256::from_str(&"defa".repeat(64 / 4)).unwrap(),
+                    ),
+                    eth_tx_index: EthereumTransactionIndex(14),
+                    eth_log_index: EthereumLogIndex(99),
+                };
+
+                let second = GlobalStateRecord {
+                    block_number: StarknetBlockNumber(11),
+                    block_hash: StarknetBlockHash(StarkHash::from_hex_str("3512234").unwrap()),
+                    global_root: GlobalRoot(StarkHash::from_hex_str("9371").unwrap()),
+                    eth_block_number: EthereumBlockNumber(98123),
+                    eth_block_hash: EthereumBlockHash(
+                        H256::from_str(&"267ddfec".repeat(64 / 8)).unwrap(),
+                    ),
+                    eth_tx_hash: EthereumTransactionHash(
+                        H256::from_str(&"897ffeda".repeat(64 / 8)).unwrap(),
+                    ),
+                    eth_tx_index: EthereumTransactionIndex(84),
+                    eth_log_index: EthereumLogIndex(31004),
+                };
+
+                let third = GlobalStateRecord {
+                    block_number: StarknetBlockNumber(12),
+                    block_hash: StarknetBlockHash(StarkHash::from_hex_str("35aac12234").unwrap()),
+                    global_root: GlobalRoot(StarkHash::from_hex_str("937addd1").unwrap()),
+                    eth_block_number: EthereumBlockNumber(11298123),
+                    eth_block_hash: EthereumBlockHash(
+                        H256::from_str(&"333eefec".repeat(64 / 8)).unwrap(),
+                    ),
+                    eth_tx_hash: EthereumTransactionHash(
+                        H256::from_str(&"333ffeda".repeat(64 / 8)).unwrap(),
+                    ),
+                    eth_tx_index: EthereumTransactionIndex(84),
+                    eth_log_index: EthereumLogIndex(31004),
+                };
+
+                // The table is joined with the Ethereum block and transaction tables,
+                // so we have to create the full database.
+                storage::migrate_database(&transaction).unwrap();
+
+                // Insert Ethereum data
+                storage::EthereumBlocksTable::insert(
+                    &transaction,
+                    first.eth_block_hash,
+                    first.eth_block_number,
+                )
+                .unwrap();
+                storage::EthereumBlocksTable::insert(
+                    &transaction,
+                    second.eth_block_hash,
+                    second.eth_block_number,
+                )
+                .unwrap();
+                storage::EthereumBlocksTable::insert(
+                    &transaction,
+                    third.eth_block_hash,
+                    third.eth_block_number,
+                )
+                .unwrap();
+
+                storage::EthereumTransactionsTable::insert(
+                    &transaction,
+                    first.eth_block_hash,
+                    first.eth_tx_hash,
+                    first.eth_tx_index,
+                )
+                .unwrap();
+                storage::EthereumTransactionsTable::insert(
+                    &transaction,
+                    second.eth_block_hash,
+                    second.eth_tx_hash,
+                    second.eth_tx_index,
+                )
+                .unwrap();
+                storage::EthereumTransactionsTable::insert(
+                    &transaction,
+                    third.eth_block_hash,
+                    third.eth_tx_hash,
+                    third.eth_tx_index,
+                )
+                .unwrap();
+
+                // Insert StarkNet state data out of order.
+                GlobalStateTable::insert(
+                    &transaction,
+                    first.block_number,
+                    first.block_hash,
+                    first.global_root,
+                    first.eth_tx_hash,
+                    first.eth_log_index,
+                )
+                .unwrap();
+                GlobalStateTable::insert(
+                    &transaction,
+                    third.block_number,
+                    third.block_hash,
+                    third.global_root,
+                    third.eth_tx_hash,
+                    third.eth_log_index,
+                )
+                .unwrap();
+                GlobalStateTable::insert(
+                    &transaction,
+                    second.block_number,
+                    second.block_hash,
+                    second.global_root,
+                    second.eth_tx_hash,
+                    second.eth_log_index,
+                )
+                .unwrap();
+
+                let latest = GlobalStateTable::get_latest_state(&transaction).unwrap();
+                assert_eq!(latest, Some(third));
+            }
+
+            #[test]
+            fn none() {
+                let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+                let transaction = conn.transaction().unwrap();
+
+                storage::migrate_database(&transaction).unwrap();
+
+                let latest = GlobalStateTable::get_latest_state(&transaction).unwrap();
+                assert_eq!(latest, None);
+            }
+        }
+    }
+
+    mod contracts {
+        use super::*;
+
+        #[test]
+        fn get_root() {
+            let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+            let transaction = conn.transaction().unwrap();
+
+            ContractsStateTable::migrate(&transaction, DB_VERSION_EMPTY).unwrap();
+
+            let state_hash = ContractStateHash(StarkHash::from_hex_str("abc").unwrap());
+            let hash = ContractHash(StarkHash::from_hex_str("123").unwrap());
+            let root = ContractRoot(StarkHash::from_hex_str("def").unwrap());
+
+            ContractsStateTable::insert(&transaction, state_hash, hash, root).unwrap();
+
+            let result = ContractsStateTable::get_root(&transaction, state_hash).unwrap();
+
+            assert_eq!(result, Some(root));
+        }
     }
 }


### PR DESCRIPTION
This PR primarily adds support for storing global StarkNet state.

A state update needs to be linked to its origin point on Ethereum. Specifically, we need to track which Ethereum log created the state update. To enable the tracking I've created two Ethereum tables, `ethereum_blocks` and `ethereum_transactions`. The transactions table references (foreign key) the block table.

The global state table then links to a specific Ethereum transaction (which in turn links to the Ethereum block).

I separated out the blocks and transactions because in the future we will likely have more information referencing these as well. In addition there can be many logs per transaction and many transactions per block. So it made sense to normalize them.