### PR TITLE
fix: block_by_name, error mapping, nonce field

### DIFF
--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -298,7 +298,7 @@ mod tests {
         use crate::rpc::types::{reply::Block, request::BlockResponseScope, BlockHashOrTag, Tag};
 
         #[tokio::test]
-        #[ignore = "Currently gives 502"]
+        #[ignore = "Currently gives 502/503"]
         async fn genesis() {
             let params = rpc_params!(BlockHashOrTag::Hash(*GENESIS_BLOCK_HASH));
             client_request::<Block>("starknet_getBlockByHash", params)
@@ -399,6 +399,7 @@ mod tests {
         use crate::rpc::types::{reply::Block, request::BlockResponseScope, BlockNumberOrTag, Tag};
 
         #[tokio::test]
+        #[ignore = "Currently gives 502/503"]
         async fn genesis() {
             let params = rpc_params!(BlockNumberOrTag::Number(0));
             client_request::<Block>("starknet_getBlockByNumber", params)
@@ -708,7 +709,7 @@ mod tests {
         use crate::rpc::types::{reply::Transaction, BlockHashOrTag, Tag};
 
         #[tokio::test]
-        #[ignore = "Currently gives 502"]
+        #[ignore = "Currently gives 502/503"]
         async fn genesis() {
             let params = rpc_params!(BlockHashOrTag::Hash(*GENESIS_BLOCK_HASH), 0u64);
             client_request::<Transaction>("starknet_getTransactionByBlockHashAndIndex", params)
@@ -784,6 +785,7 @@ mod tests {
         use crate::rpc::types::{reply::Transaction, BlockNumberOrTag, Tag};
 
         #[tokio::test]
+        #[ignore = "Currently gives 502/503"]
         async fn genesis() {
             let params = rpc_params!(BlockNumberOrTag::Number(0), 0);
             client_request::<Transaction>("starknet_getTransactionByBlockNumberAndIndex", params)
@@ -951,7 +953,7 @@ mod tests {
         use crate::rpc::types::{BlockHashOrTag, Tag};
 
         #[tokio::test]
-        #[ignore = "Currently gives 502"]
+        #[ignore = "Currently gives 502/503"]
         async fn genesis() {
             let params = rpc_params!(BlockHashOrTag::Hash(*GENESIS_BLOCK_HASH));
             client_request::<u64>("starknet_getBlockTransactionCountByHash", params)
@@ -1017,6 +1019,7 @@ mod tests {
         use crate::rpc::types::{BlockNumberOrTag, Tag};
 
         #[tokio::test]
+        #[ignore = "Currently gives 502/503"]
         async fn genesis() {
             let params = rpc_params!(BlockNumberOrTag::Number(0));
             client_request::<u64>("starknet_getBlockTransactionCountByNumber", params)

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -274,7 +274,9 @@ impl RpcApi {
             .0
             .block_by_hash(BlockHashOrTag::Tag(Tag::Latest))
             .await?;
-        Ok(block.block_number)
+        // The default value should actually never happen as block_number is None only
+        // in a pending block.
+        Ok(block.block_number.unwrap_or_default())
     }
 
     /// Return the currently configured StarkNet chain id.

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -210,12 +210,12 @@ pub mod reply {
             Self {
                 block_hash: block.block_hash.unwrap_or_default(),
                 parent_hash: block.parent_block_hash,
-                block_number: block.block_number,
+                block_number: block.block_number.unwrap_or_default(),
                 status: block.status.into(),
                 // TODO should be sequencer identity
                 sequencer: H160::zero(),
                 // TODO check if state_root is the new root
-                new_root: block.state_root,
+                new_root: block.state_root.unwrap_or_default(),
                 // TODO where to get it from
                 old_root: H256::zero(),
                 accepted_time: block.timestamp,

--- a/crates/pathfinder/src/sequencer/error.rs
+++ b/crates/pathfinder/src/sequencer/error.rs
@@ -24,7 +24,9 @@ impl From<SequencerError> for rpc::Error {
                 rpc::Error::Call(rpc::CallError::Failed(e.into()))
             }
             SequencerError::StarknetError(e) => match e.code {
-                StarknetErrorCode::OutOfRangeBlockHash | StarknetErrorCode::BlockNotFound => {
+                StarknetErrorCode::OutOfRangeBlockHash | StarknetErrorCode::BlockNotFound
+                    if e.message.contains("Block hash") =>
+                {
                     RpcErrorCode::InvalidBlockHash.into()
                 }
                 StarknetErrorCode::OutOfRangeContractAddress
@@ -37,9 +39,7 @@ impl From<SequencerError> for rpc::Error {
                 StarknetErrorCode::EntryPointNotFound => {
                     RpcErrorCode::InvalidMessageSelector.into()
                 }
-                StarknetErrorCode::MalformedRequest
-                    if e.message.contains("Block ID should be in the range") =>
-                {
+                StarknetErrorCode::BlockNotFound if e.message.contains("Block number") => {
                     RpcErrorCode::InvalidBlockNumber.into()
                 }
                 _ => rpc::Error::Call(rpc::CallError::Failed(e.into())),

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -12,12 +12,15 @@ use web3::types::{H256, U256};
 #[serde(deny_unknown_fields)]
 pub struct Block {
     #[serde_as(as = "Option<H256AsRelaxedHexStr>")]
+    #[serde(default)]
     pub block_hash: Option<H256>,
-    pub block_number: u64,
+    #[serde(default)]
+    pub block_number: Option<u64>,
     #[serde_as(as = "H256AsRelaxedHexStr")]
     pub parent_block_hash: H256,
-    #[serde_as(as = "H256AsRelaxedHexStr")]
-    pub state_root: H256,
+    #[serde_as(as = "Option<H256AsRelaxedHexStr>")]
+    #[serde(default)]
+    pub state_root: Option<H256>,
     pub status: Status,
     pub timestamp: u64,
     pub transaction_receipts: Vec<transaction::Receipt>,
@@ -241,6 +244,9 @@ pub mod transaction {
         pub selector: H256,
         #[serde_as(as = "H256AsRelaxedHexStr")]
         pub to_address: H256,
+        #[serde_as(as = "Option<H256AsRelaxedHexStr>")]
+        #[serde(default)]
+        pub nonce: Option<H256>,
     }
 
     /// Represents deserialized L2 to L1 message.


### PR DESCRIPTION
It turned out that using `get_block_hash_by_id` was already deprecated a long time ago (`get_block?blockNumber=` was introduced in mid December '21), hence we got the wrong hashes when querying by block number.

By the way I fixed some things that changed in the last few days:
- error mapping,
- I finally spotted a `nonce` field in the L1 to L2 message,
- more fields are now optional since pending block does not supply those values anyway 