### PR TITLE
Ethereum chain identification and websocket removal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,10 @@ jobs:
       # An Ethereum access point is required for some L1 StarkNet contract tests.
       # This sets it to secret values stored in the repository, which prevents
       # leaking it in code.
-      STARKNET_ETHEREUM_WEBSOCKET_URL: ${{ secrets.STARKNET_ETHEREUM_WEBSOCKET_URL }}
-      STARKNET_ETHEREUM_PASSWORD: ${{ secrets.STARKNET_ETHEREUM_PASSWORD }}
+      PATHFINDER_ETHEREUM_HTTP_GOERLI_URL:       ${{ secrets.PATHFINDER_ETHEREUM_HTTP_GOERLI_URL }}
+      PATHFINDER_ETHEREUM_HTTP_GOERLI_PASSWORD:  ${{ secrets.PATHFINDER_ETHEREUM_HTTP_GOERLI_PASSWORD }}
+      PATHFINDER_ETHEREUM_HTTP_MAINNET_URL:      ${{ secrets.PATHFINDER_ETHEREUM_HTTP_MAINNET_URL }}
+      PATHFINDER_ETHEREUM_HTTP_MAINNET_PASSWORD: ${{ secrets.PATHFINDER_ETHEREUM_HTTP_MAINNET_PASSWORD }}
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@stable

--- a/README.md
+++ b/README.md
@@ -85,11 +85,26 @@ Invoke `cargo build -p pathfinder` from the project root.
 
 ### Testing
 
-Some of our tests require access to an archive Ethereum node. If you want to run these tests you will require setting the environment variable `STARKNET_ETHEREUM_WEBSOCKET_URL` to the websocket address of a Goerli full node. Infura provides such nodes for free (on Goerli testnet), and is what we currently use for our own CI.
+Some of our tests require access to an __archive__ Ethereum node on the Goerli chain. To run these tests you will need to set the following environment variables:
+
+```bash
+PATHFINDER_ETHEREUM_HTTP_GOERLI_URL       # HTTP(S) endpoint for Goerli chain
+PATHFINDER_ETHEREUM_HTTP_GOERLI_PASSWORD  # HTTP(S) password for Goerli chain (optional)
+```
+
+Infura provides such nodes for free (on Goerli testnet), and is what we currently use for our own CI.
+
+In addition, the tests also require access to a __non-archive__ Ethereum node on Mainnet. To run these tests you will need to set the following environment variables:
+
+```bash
+PATHFINDER_ETHEREUM_HTTP_MAINNET_URL       # HTTP(S) endpoint for Mainnet chain
+PATHFINDER_ETHEREUM_HTTP_MAINNET_PASSWORD  # HTTP(S) password for Mainnet chain (optional)
+```
 
 Example with an Infura node:
 ```
-export STARKNET_ETHEREUM_WEBSOCKET_URL=wss://goerli.infura.io/ws/v3/<project-id>
+export PATHFINDER_ETHEREUM_HTTP_GOERLI_URL=https://goerli.infura.io/ws/v3/<project-id>
+export PATHFINDER_ETHEREUM_HTTP_MAINNET_URL=https://mainnet.infura.io/ws/v3/<project-id>
 ```
 
 Run the tests (invoke from project root):

--- a/crates/pathfinder/examples/fact_retrieval.rs
+++ b/crates/pathfinder/examples/fact_retrieval.rs
@@ -86,16 +86,16 @@ fn parse_cli_args() -> (Web3<Http>, EthereumBlockHash, StarknetBlockNumber) {
                 .long("url")
                 .short("u")
                 .takes_value(true)
-                .value_name("URL")
+                .value_name("HTTP(S) URL")
                 .long_help(r#"This should point to the HTTP RPC endpoint of your Ethereum entry-point, typically a local Ethereum client or a hosted gateway service such as Infura or Cloudflare.
 
 Examples:
-    infura: wss://goerli.infura.io/ws/v3/<PROJECT_ID>
-    geth:   wss://localhost:8545"#));
+    infura: https://goerli.infura.io/ws/v3/<PROJECT_ID>
+    geth:   https://localhost:8545"#));
 
     let args = cli.get_matches();
 
-    let url = args.value_of("url").expect("websocket url is required");
+    let url = args.value_of("url").expect("Ethereum HTTP url is required");
     let block = args.value_of("block").expect("block hash is required");
     let seq_no = args
         .value_of("seq-no")

--- a/crates/pathfinder/examples/fact_retrieval.rs
+++ b/crates/pathfinder/examples/fact_retrieval.rs
@@ -90,7 +90,7 @@ fn parse_cli_args() -> (Web3<Http>, EthereumBlockHash, StarknetBlockNumber) {
                 .long_help(r#"This should point to the HTTP RPC endpoint of your Ethereum entry-point, typically a local Ethereum client or a hosted gateway service such as Infura or Cloudflare.
 
 Examples:
-    infura: https://goerli.infura.io/ws/v3/<PROJECT_ID>
+    infura: https://goerli.infura.io/v3/<PROJECT_ID>
     geth:   https://localhost:8545"#));
 
     let args = cli.get_matches();

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -14,7 +14,7 @@ const DEFAULT_HTTP_RPC_ADDR: &str = "127.0.0.1:9545";
 #[derive(Debug, PartialEq, Clone, Copy, Hash, Eq, IntoEnumIterator)]
 pub enum ConfigOption {
     /// The Ethereum URL.
-    EthereumWebsocketUrl,
+    EthereumHttpUrl,
     /// The Ethereum user.
     EthereumUser,
     /// The Ethereum password.
@@ -26,7 +26,7 @@ pub enum ConfigOption {
 impl Display for ConfigOption {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ConfigOption::EthereumWebsocketUrl => f.write_str("Ethereum websocket URL"),
+            ConfigOption::EthereumHttpUrl => f.write_str("Ethereum HTTP URL"),
             ConfigOption::EthereumUser => f.write_str("Ethereum user"),
             ConfigOption::EthereumPassword => f.write_str("Ethereum password"),
             ConfigOption::HttpRpcAddress => f.write_str("HTTP-RPC socket address"),

--- a/crates/pathfinder/src/config/builder.rs
+++ b/crates/pathfinder/src/config/builder.rs
@@ -39,7 +39,7 @@ impl ConfigBuilder {
         use super::DEFAULT_HTTP_RPC_ADDR;
 
         // Required parameters.
-        let eth_url = self.take_required(ConfigOption::EthereumWebsocketUrl)?;
+        let eth_url = self.take_required(ConfigOption::EthereumHttpUrl)?;
         let http_rpc_addr = self
             .take_required(ConfigOption::HttpRpcAddress)
             .unwrap_or_else(|_| DEFAULT_HTTP_RPC_ADDR.to_owned());
@@ -194,14 +194,14 @@ mod tests {
 
     mod try_build {
         /// List of [ConfigOption]'s that must be set for [ConfigBuilder] to produce a [Configuration].
-        const REQUIRED: &[ConfigOption] = &[ConfigOption::EthereumWebsocketUrl];
+        const REQUIRED: &[ConfigOption] = &[ConfigOption::EthereumHttpUrl];
 
         use super::*;
 
         /// Some options expect a specific type of value.
         fn get_valid_value(option: ConfigOption) -> String {
             match option {
-                ConfigOption::EthereumWebsocketUrl => "http://localhost",
+                ConfigOption::EthereumHttpUrl => "http://localhost",
                 _ => "value",
             }
             .to_owned()

--- a/crates/pathfinder/src/config/cli.rs
+++ b/crates/pathfinder/src/config/cli.rs
@@ -42,7 +42,7 @@ where
     let http_rpc_addr = args.value_of(HTTP_RPC_ADDR_KEY).map(|s| s.to_owned());
 
     let cfg = ConfigBuilder::default()
-        .with(ConfigOption::EthereumWebsocketUrl, ethereum_url)
+        .with(ConfigOption::EthereumHttpUrl, ethereum_url)
         .with(ConfigOption::EthereumUser, ethereum_user)
         .with(ConfigOption::EthereumPassword, ethereum_password)
         .with(ConfigOption::HttpRpcAddress, http_rpc_addr);
@@ -62,9 +62,9 @@ fn clap_app() -> clap::App<'static, 'static> {
             format!("HTTP-RPC listening address [default: {}]", DEFAULT_HTTP_RPC_ADDR);
     }
 
-    clap::App::new("Equilibrium StarkNet Node")
+    clap::App::new("Pathfinder StarkNet Node")
         .version(crate_version!())
-        .about("A StarkNet node")
+        .about("A StarkNet node implemented by Equilibrium. https://github.com/eqlabs/pathfinder")
         .arg(
             Arg::with_name(CONFIG_KEY)
                 .short("c")
@@ -93,11 +93,11 @@ fn clap_app() -> clap::App<'static, 'static> {
                 .long(ETH_URL_KEY)
                 .help("Ethereum API URL")
                 .takes_value(true)
-                .value_name("URL")
-                .long_help(r#"This should point to the websocket RPC endpoint of your Ethereum entry-point, typically a local Ethereum light client or a hosted gateway service such as Infura or Cloudflare.
+                .value_name("HTTP URL")
+                .long_help(r#"This should point to the HTTP RPC endpoint of your Ethereum entry-point, typically a local Ethereum light client or a hosted gateway service such as Infura or Cloudflare.
 Examples:
-    infura: wss://goerli.infura.io/ws/v3/<PROJECT_ID>
-    geth:   wss://localhost:8545"#))
+    infura: https://goerli.infura.io/ws/v3/<PROJECT_ID>
+    geth:   https://localhost:8545"#))
         .arg(
             Arg::with_name(HTTP_RPC_ADDR_KEY)
                 .long(HTTP_RPC_ADDR_KEY)
@@ -119,7 +119,7 @@ mod tests {
     fn ethereum_url_long() {
         let value = "value".to_owned();
         let (_, mut cfg) = parse_args(vec!["bin name", "--ethereum.url", &value]).unwrap();
-        assert_eq!(cfg.take(ConfigOption::EthereumWebsocketUrl), Some(value));
+        assert_eq!(cfg.take(ConfigOption::EthereumHttpUrl), Some(value));
     }
 
     #[test]

--- a/crates/pathfinder/src/config/cli.rs
+++ b/crates/pathfinder/src/config/cli.rs
@@ -96,7 +96,7 @@ fn clap_app() -> clap::App<'static, 'static> {
                 .value_name("HTTP URL")
                 .long_help(r#"This should point to the HTTP RPC endpoint of your Ethereum entry-point, typically a local Ethereum light client or a hosted gateway service such as Infura or Cloudflare.
 Examples:
-    infura: https://goerli.infura.io/ws/v3/<PROJECT_ID>
+    infura: https://goerli.infura.io/v3/<PROJECT_ID>
     geth:   https://localhost:8545"#))
         .arg(
             Arg::with_name(HTTP_RPC_ADDR_KEY)

--- a/crates/pathfinder/src/config/file.rs
+++ b/crates/pathfinder/src/config/file.rs
@@ -31,7 +31,7 @@ impl FileConfig {
         use crate::config::ConfigOption;
         let builder = match self.ethereum {
             Some(eth) => ConfigBuilder::default()
-                .with(ConfigOption::EthereumWebsocketUrl, eth.url)
+                .with(ConfigOption::EthereumHttpUrl, eth.url)
                 .with(ConfigOption::EthereumUser, eth.user)
                 .with(ConfigOption::EthereumPassword, eth.password),
             None => ConfigBuilder::default(),
@@ -67,7 +67,7 @@ mod tests {
         let value = "value".to_owned();
         let toml = format!(r#"ethereum.url = "{}""#, value);
         let mut cfg = config_from_str(&toml).unwrap();
-        assert_eq!(cfg.take(ConfigOption::EthereumWebsocketUrl), Some(value));
+        assert_eq!(cfg.take(ConfigOption::EthereumHttpUrl), Some(value));
     }
 
     #[test]
@@ -102,7 +102,7 @@ password = "{}""#,
 
         let mut cfg = config_from_str(&toml).unwrap();
         assert_eq!(cfg.take(ConfigOption::EthereumUser), Some(user));
-        assert_eq!(cfg.take(ConfigOption::EthereumWebsocketUrl), Some(url));
+        assert_eq!(cfg.take(ConfigOption::EthereumHttpUrl), Some(url));
         assert_eq!(cfg.take(ConfigOption::EthereumPassword), Some(password));
     }
 

--- a/crates/pathfinder/src/ethereum.rs
+++ b/crates/pathfinder/src/ethereum.rs
@@ -11,7 +11,7 @@ pub mod contract;
 pub mod log;
 pub mod state_update;
 
-/// Ethereum network chains runnings Starknet.
+/// Ethereum network chains running Starknet.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Chain {
     /// The Ethereum mainnet chain.
@@ -161,7 +161,7 @@ pub mod test {
     use web3::transports::Http;
     use web3::Web3;
 
-    /// Creates a [Web3<Htttp>] transport from the Ethereum endpoint specified by the relevant environment variables.
+    /// Creates a [Web3<Http>] transport from the Ethereum endpoint specified by the relevant environment variables.
     ///
     /// Requires an environment variable for both the URL and (optional) password.
     ///

--- a/crates/pathfinder/src/ethereum.rs
+++ b/crates/pathfinder/src/ethereum.rs
@@ -1,13 +1,11 @@
 use std::convert::TryFrom;
 
 use anyhow::{Context, Result};
-use web3::{
-    types::{H256, U256},
-    Transport, Web3,
-};
+use web3::{types::U256, Transport, Web3};
 
 use crate::core::{
-    EthereumBlockHash, EthereumBlockNumber, EthereumTransactionHash, EthereumTransactionIndex, EthereumLogIndex,
+    EthereumBlockHash, EthereumBlockNumber, EthereumLogIndex, EthereumTransactionHash,
+    EthereumTransactionIndex,
 };
 pub mod contract;
 pub mod log;
@@ -160,23 +158,8 @@ pub mod test {
     use super::*;
 
     use reqwest::Url;
-    use web3::transports::{Http, WebSocket};
+    use web3::transports::Http;
     use web3::Web3;
-
-    /// Creates a [Web3<WebSocket>] as specified by [create_test_websocket].
-    pub async fn create_test_websocket_transport() -> Web3<WebSocket> {
-        web3::Web3::new(create_test_websocket().await)
-    }
-
-    /// Creates a [WebSocket] which connects to the Ethereum node specified by
-    /// the `STARKNET_ETHEREUM_WEBSOCKET_URL` environment variable.
-    pub async fn create_test_websocket() -> WebSocket {
-        let url = std::env::var("STARKNET_ETHEREUM_WEBSOCKET_URL").expect(
-            "Ethereum websocket URL environment var not set (STARKNET_ETHEREUM_WEBSOCKET_URL)",
-        );
-
-        WebSocket::new(&url).await.unwrap()
-    }
 
     /// Creates a [Web3<Htttp>] transport from the Ethereum endpoint specified by the relevant environment variables.
     ///

--- a/crates/pathfinder/src/ethereum/contract.rs
+++ b/crates/pathfinder/src/ethereum/contract.rs
@@ -57,8 +57,6 @@ fn mempage_contract() -> Contract {
 
 #[cfg(test)]
 mod tests {
-    use crate::ethereum::test::create_test_websocket_transport;
-
     use super::*;
 
     mod contract {
@@ -66,6 +64,8 @@ mod tests {
             contract::Options,
             types::{BlockId, BlockNumber},
         };
+
+        use crate::ethereum::{test::create_test_transport, Chain};
 
         use super::*;
 
@@ -100,7 +100,7 @@ mod tests {
                 "/resources/contracts/core_proxy.json"
             ));
 
-            let transport = create_test_websocket_transport().await;
+            let transport = create_test_transport(Chain::Goerli).await;
 
             let core_proxy = web3::contract::Contract::from_json(
                 transport.eth(),

--- a/crates/pathfinder/src/ethereum/state_update.rs
+++ b/crates/pathfinder/src/ethereum/state_update.rs
@@ -97,15 +97,11 @@ mod tests {
     use pretty_assertions::assert_eq;
     use web3::types::H256;
 
-    use crate::{
-        core::{
-            EthereumBlockHash, EthereumBlockNumber, EthereumLogIndex, EthereumTransactionHash,
-            EthereumTransactionIndex, GlobalRoot, StarknetBlockNumber,
-        },
-        ethereum::{
-            test::create_test_websocket_transport, BlockOrigin, EthOrigin, TransactionOrigin,
-        },
+    use crate::core::{
+        EthereumBlockHash, EthereumBlockNumber, EthereumLogIndex, EthereumTransactionHash,
+        EthereumTransactionIndex, GlobalRoot, StarknetBlockNumber,
     };
+    use crate::ethereum::{test::create_test_transport, BlockOrigin, EthOrigin, TransactionOrigin};
 
     use super::*;
 
@@ -142,7 +138,7 @@ mod tests {
             block_number: StarknetBlockNumber(16407),
         };
 
-        let transport = create_test_websocket_transport().await;
+        let transport = create_test_transport(crate::ethereum::Chain::Goerli).await;
         let update = StateUpdate::retrieve(&transport, update_log).await.unwrap();
 
         let expected = StateUpdate {

--- a/crates/pathfinder/src/ethereum/state_update/state_root.rs
+++ b/crates/pathfinder/src/ethereum/state_update/state_root.rs
@@ -19,10 +19,10 @@ mod tests {
     async fn genesis() {
         // The first state root retrieved should be the genesis event,
         // with a sequence number of 0.
-        let ws = create_test_transport(Chain::Goerli).await;
+        let transport = create_test_transport(Chain::Goerli).await;
 
         let mut uut = StateRootFetcher::new(None);
-        let first_fetch = uut.fetch(&ws).await.unwrap();
+        let first_fetch = uut.fetch(&transport).await.unwrap();
         let first = first_fetch.first().expect("Should be at least one log");
 
         assert_eq!(first.block_number, StarknetBlockNumber(0));
@@ -47,7 +47,7 @@ mod tests {
             // Seed with a incorrect update at the L1 genesis block.
             // This should get interpretted as a reorg once the correct
             // first L2 update log is found.
-            let ws = create_test_transport(Chain::Goerli).await;
+            let transport = create_test_transport(Chain::Goerli).await;
 
             // Note that block_number must be 0 so that we pull all of L1 history.
             // This makes the test robust against L2 changes, updates or deployments
@@ -69,7 +69,7 @@ mod tests {
             };
 
             let mut uut = StateRootFetcher::new(Some(not_genesis));
-            assert_matches!(uut.fetch(&ws).await, Err(FetchError::Reorg));
+            assert_matches!(uut.fetch(&transport).await, Err(FetchError::Reorg));
         }
 
         #[tokio::test]
@@ -77,9 +77,9 @@ mod tests {
             // Seed with an origin beyond the current L1 chain state.
             // This should be interpreted as a reorg as this update
             // won't be found.
-            let ws = create_test_transport(Chain::Goerli).await;
+            let transport = create_test_transport(Chain::Goerli).await;
 
-            let latest_on_chain = ws.eth().block_number().await.unwrap().as_u64();
+            let latest_on_chain = transport.eth().block_number().await.unwrap().as_u64();
 
             let not_genesis = StateUpdateLog {
                 origin: EthOrigin {
@@ -98,7 +98,7 @@ mod tests {
             };
 
             let mut uut = StateRootFetcher::new(Some(not_genesis));
-            assert_matches!(uut.fetch(&ws).await, Err(FetchError::Reorg));
+            assert_matches!(uut.fetch(&transport).await, Err(FetchError::Reorg));
         }
     }
 }

--- a/crates/pathfinder/src/ethereum/state_update/state_root.rs
+++ b/crates/pathfinder/src/ethereum/state_update/state_root.rs
@@ -5,10 +5,13 @@ pub type StateRootFetcher = LogFetcher<StateUpdateLog>;
 
 #[cfg(test)]
 mod tests {
-    use crate::{core::StarknetBlockNumber, ethereum::test::create_test_websocket};
     use assert_matches::assert_matches;
     use pretty_assertions::assert_eq;
-    use web3::Web3;
+
+    use crate::{
+        core::StarknetBlockNumber,
+        ethereum::{test::create_test_transport, Chain},
+    };
 
     use super::*;
 
@@ -16,8 +19,7 @@ mod tests {
     async fn genesis() {
         // The first state root retrieved should be the genesis event,
         // with a sequence number of 0.
-        let ws = create_test_websocket().await;
-        let ws = Web3::new(ws);
+        let ws = create_test_transport(Chain::Goerli).await;
 
         let mut uut = StateRootFetcher::new(None);
         let first_fetch = uut.fetch(&ws).await.unwrap();
@@ -45,8 +47,7 @@ mod tests {
             // Seed with a incorrect update at the L1 genesis block.
             // This should get interpretted as a reorg once the correct
             // first L2 update log is found.
-            let ws = create_test_websocket().await;
-            let ws = Web3::new(ws);
+            let ws = create_test_transport(Chain::Goerli).await;
 
             // Note that block_number must be 0 so that we pull all of L1 history.
             // This makes the test robust against L2 changes, updates or deployments
@@ -76,8 +77,7 @@ mod tests {
             // Seed with an origin beyond the current L1 chain state.
             // This should be interpreted as a reorg as this update
             // won't be found.
-            let ws = create_test_websocket().await;
-            let ws = Web3::new(ws);
+            let ws = create_test_transport(Chain::Goerli).await;
 
             let latest_on_chain = ws.eth().block_number().await.unwrap().as_u64();
 

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -371,7 +371,7 @@ mod tests {
             EthereumBlockHash, EthereumBlockNumber, EthereumLogIndex, EthereumTransactionHash,
             EthereumTransactionIndex, StarknetBlockNumber,
         },
-        ethereum::test::create_test_websocket_transport,
+        ethereum::test::create_test_transport,
     };
 
     use super::*;
@@ -451,7 +451,7 @@ mod tests {
         let transaction = conn.transaction().unwrap();
         crate::storage::migrate_database(&transaction).unwrap();
 
-        let transport = create_test_websocket_transport().await;
+        let transport = create_test_transport(crate::ethereum::Chain::Goerli).await;
 
         update(
             &transport,


### PR DESCRIPTION
This PR adds support for identifying the Ethereum chain. This will allow us to determine which network we are on.

In addition, I've replaced WebSockets with HTTP transports for the Ethereum endpoints. The original reason for using WebSockets was to utilize the pub/sub functionality. This proved to not be useful. Web3 support for WebSockets is also limited -- doesn't support setting passwords or user-agents.

Our internals are written to be transport agnostic, so this refactor mainly targets user configuration and CI / test setup.

I've also added the required CI secrets internally. Note that you will require new environment variables to run the tests locally (see README.md).