### PR TITLE
Upgrade storage

### DIFF
--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -26,7 +26,7 @@ pedersen = { path = "../pedersen" }
 reqwest = { version = "0.11.4", features = ["json"] }
 rusqlite = { version = "0.26.1", features = ["bundled"] }
 serde = { version = "1.0.130", features = ["derive"] }
-serde_json = "1.0.68"
+serde_json = { version = "1.0.68", features = ["raw_value"] }
 serde_with = "1.9.4"
 thiserror = "1.0.30"
 tokio = "1.11.0"

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -1,12 +1,18 @@
-use pathfinder_lib::{config, rpc};
+use pathfinder_lib::{config, rpc, sequencer, storage::Storage};
 
 #[tokio::main]
 async fn main() {
     println!("🏁 Starting node.");
     let config =
         config::Configuration::parse_cmd_line_and_cfg_file().expect("Configuration failed");
-    let (_handle, local_addr) =
-        rpc::run_server(config.http_rpc_addr).expect("⚠️ Failed to start HTTP-RPC server");
+
+    // TODO: get database path from configuration
+    let storage = Storage::migrate("database.sqlite".into()).unwrap();
+    // TODO: pick the correct sequencer based on the Ethereum chain.
+    let sequencer = sequencer::Client::goerli().unwrap();
+
+    let (_handle, local_addr) = rpc::run_server(config.http_rpc_addr, storage, sequencer)
+        .expect("⚠️ Failed to start HTTP-RPC server");
     println!("📡 HTTP-RPC server started on: {}", local_addr);
     let () = std::future::pending().await;
 }

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -34,6 +34,13 @@ pub struct ContractStateHash(pub StarkHash);
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ContractRoot(pub StarkHash);
 
+/// A Starknet contract's bytecode and ABI.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ContractCode {
+    pub bytecode: Vec<StarkHash>,
+    pub abi: String,
+}
+
 /// Entry point of a StarkNet `call`.
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct EntryPoint(pub StarkHash);

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -230,7 +230,7 @@ impl RpcApi {
 
         match code {
             Some(code) => Ok(code),
-            None => todo!("Contract missing error code 20"),
+            None => Err(ErrorCode::ContractNotFound.into()),
         }
     }
 

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -1,16 +1,18 @@
 //! Implementation of JSON-RPC endpoints.
 use crate::{
     core::{
-        CallResultValue, ContractAddress, StarknetChainId, StarknetProtocolVersion,
+        CallResultValue, ContractAddress, ContractCode, StarknetChainId, StarknetProtocolVersion,
         StarknetTransactionHash, StarknetTransactionIndex, StorageAddress, StorageValue,
     },
     rpc::types::{
-        reply::{Block, Code, ErrorCode, StateUpdate, Syncing, Transaction, TransactionReceipt},
+        reply::{Block, ErrorCode, StateUpdate, Syncing, Transaction, TransactionReceipt},
         request::{BlockResponseScope, Call},
         BlockHashOrTag, BlockNumberOrTag, Tag,
     },
-    sequencer::{reply as raw, Client},
+    sequencer::{self, reply as raw},
+    storage::{self, Storage},
 };
+use anyhow::Context;
 use jsonrpsee::types::{
     error::{CallError, Error},
     RpcResult,
@@ -28,21 +30,21 @@ fn transaction_index_not_found(index: usize) -> Error {
 /// Implements JSON-RPC endpoints.
 ///
 /// __TODO__ directly calls [sequencer::Client](crate::sequencer::Client) until storage is implemented.
-pub struct RpcApi(Client);
-
-impl Default for RpcApi {
-    fn default() -> Self {
-        let module = Client::goerli().expect("failed to initialize sequencer client");
-        Self(module)
-    }
+pub struct RpcApi {
+    storage: Storage,
+    sequencer: sequencer::Client,
 }
 
 /// Based on [the Starknet operator API spec](https://github.com/starkware-libs/starknet-adrs/blob/master/api/starknet_operator_api_openrpc.json).
 impl RpcApi {
+    pub fn new(storage: Storage, sequencer: sequencer::Client) -> Self {
+        Self { storage, sequencer }
+    }
+
     /// Helper function.
     async fn get_raw_block_by_hash(&self, block_hash: BlockHashOrTag) -> RpcResult<raw::Block> {
         // TODO get this from storage
-        let block = self.0.block_by_hash(block_hash).await?;
+        let block = self.sequencer.block_by_hash(block_hash).await?;
         Ok(block)
     }
 
@@ -64,7 +66,7 @@ impl RpcApi {
         &self,
         block_number: BlockNumberOrTag,
     ) -> RpcResult<raw::Block> {
-        let block = self.0.block_by_number(block_number).await?;
+        let block = self.sequencer.block_by_number(block_number).await?;
         Ok(block)
     }
 
@@ -108,7 +110,10 @@ impl RpcApi {
         key: StorageAddress,
         block_hash: BlockHashOrTag,
     ) -> RpcResult<StorageValue> {
-        let storage_val = self.0.storage(contract_address, key, block_hash).await?;
+        let storage_val = self
+            .sequencer
+            .storage(contract_address, key, block_hash)
+            .await?;
         Ok(storage_val)
     }
 
@@ -118,7 +123,7 @@ impl RpcApi {
         transaction_hash: StarknetTransactionHash,
     ) -> RpcResult<raw::Transaction> {
         // TODO get this from storage
-        let txn = self.0.transaction(transaction_hash).await?;
+        let txn = self.sequencer.transaction(transaction_hash).await?;
         if txn.status == raw::Status::NotReceived {
             return Err(ErrorCode::InvalidTransactionHash.into());
         }
@@ -263,14 +268,14 @@ impl RpcApi {
         request: Call,
         block_hash: BlockHashOrTag,
     ) -> RpcResult<Vec<CallResultValue>> {
-        let call = self.0.call(request.into(), block_hash).await?;
+        let call = self.sequencer.call(request.into(), block_hash).await?;
         Ok(call.result)
     }
 
     /// Get the most recent accepted block number.
     pub async fn block_number(&self) -> RpcResult<u64> {
         let block = self
-            .0
+            .sequencer
             .block_by_hash(BlockHashOrTag::Tag(Tag::Latest))
             .await?;
         let number = block.block_number.ok_or(anyhow::anyhow!(

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -5,7 +5,7 @@ pub mod request;
 
 use self::error::StarknetError;
 use crate::{
-    core::{ContractAddress, StarknetTransactionHash, StorageAddress, StorageValue},
+    core::{ContractAddress, ContractCode, StarknetTransactionHash, StorageAddress, StorageValue},
     rpc::types::{BlockHashOrTag, BlockNumberOrTag, Tag},
     sequencer::error::SequencerError,
 };
@@ -151,7 +151,7 @@ impl Client {
         &self,
         contract_addr: ContractAddress,
         block_hash: BlockHashOrTag,
-    ) -> Result<reply::Code, SequencerError> {
+    ) -> Result<ContractCode, SequencerError> {
         let (tag, hash) = block_hash_str(block_hash);
         let resp = self
             .inner
@@ -164,7 +164,12 @@ impl Client {
             ))
             .send()
             .await?;
-        parse(resp).await
+        let code = parse::<reply::Code>(resp).await?;
+
+        Ok(ContractCode {
+            bytecode: code.bytecode,
+            abi: code.abi,
+        })
     }
 
     /// Gets full contract definition.
@@ -799,7 +804,6 @@ mod tests {
 
     mod code {
         use super::*;
-        use crate::sequencer::reply::Code;
         use pretty_assertions::assert_eq;
 
         #[tokio::test]
@@ -812,9 +816,9 @@ mod tests {
             .unwrap();
             assert_eq!(
                 result,
-                Code {
-                    abi: vec![],
-                    bytecode: vec![]
+                ContractCode {
+                    abi: String::new(),
+                    bytecode: Vec::new(),
                 }
             );
         }

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -168,7 +168,7 @@ impl Client {
 
         Ok(ContractCode {
             bytecode: code.bytecode,
-            abi: code.abi,
+            abi: code.abi.to_string(),
         })
     }
 

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -1,7 +1,8 @@
 //! Structures used for deserializing replies from Starkware's sequencer REST API.
 use crate::core::{
-    ByteCodeWord, CallResultValue, GlobalRoot, StarknetBlockHash, StarknetBlockNumber,
+    CallResultValue, GlobalRoot, StarknetBlockHash, StarknetBlockNumber,
 };
+use pedersen::StarkHash;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DefaultOnError};
 
@@ -76,8 +77,8 @@ pub struct Code {
     // Unknown block hash results in empty abi represented as a JSON
     // object, instead of a JSON array
     #[serde_as(deserialize_as = "DefaultOnError")]
-    pub abi: Vec<code::Abi>,
-    pub bytecode: Vec<ByteCodeWord>,
+    pub abi: String,
+    pub bytecode: Vec<StarkHash>,
 }
 
 /// Types used when deserializing L2 contract related data.

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -2,7 +2,7 @@
 use crate::core::{CallResultValue, GlobalRoot, StarknetBlockHash, StarknetBlockNumber};
 use pedersen::StarkHash;
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, DefaultOnError};
+use serde_with::serde_as;
 
 /// Used to deserialize replies to [Client::block_by_hash](crate::sequencer::Client::block_by_hash) and
 /// [Client::block_by_number](crate::sequencer::Client::block_by_number).
@@ -68,14 +68,10 @@ pub mod call {
 }
 
 /// Used to deserialize a reply from [Client::code](crate::sequencer::Client::code).
-#[serde_as]
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Code {
-    // Unknown block hash results in empty abi represented as a JSON
-    // object, instead of a JSON array
-    #[serde_as(deserialize_as = "DefaultOnError")]
-    pub abi: String,
+    pub abi: Box<serde_json::value::RawValue>,
     pub bytecode: Vec<StarkHash>,
 }
 
@@ -327,5 +323,26 @@ pub mod transaction {
         pub code: String,
         pub error_message: String,
         pub tx_id: u64,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn code() {
+        let abi = r#"[{"inputs": [{"name": "amount", "type": "felt"}], "name": "increase_balance", "outputs": [], "type": "function"}, {"inputs": [], "name": "get_balance", "outputs": [{"name": "res", "type": "felt"}], "stateMutability": "view", "type": "function"}]"#;
+        let bytecode = vec![
+            StarkHash::from_hex_str("0x123").unwrap(),
+            StarkHash::from_hex_str("0x4567890").unwrap(),
+        ];
+        let encoded_bytecode = serde_json::to_string(&bytecode).unwrap();
+        let encoded = format!("{{ \"abi\": {}, \"bytecode\": {} }}", abi, encoded_bytecode);
+
+        let code = serde_json::from_str::<Code>(&encoded).unwrap();
+
+        assert_eq!(code.bytecode, bytecode);
+        assert_eq!(code.abi.get(), abi);
     }
 }

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -1,7 +1,5 @@
 //! Structures used for deserializing replies from Starkware's sequencer REST API.
-use crate::core::{
-    CallResultValue, GlobalRoot, StarknetBlockHash, StarknetBlockNumber,
-};
+use crate::core::{CallResultValue, GlobalRoot, StarknetBlockHash, StarknetBlockNumber};
 use pedersen::StarkHash;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DefaultOnError};

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -440,9 +440,9 @@ mod tests {
 
         let sequencer = sequencer::Client::goerli().unwrap();
 
-        let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+        let storage = crate::storage::Storage::in_memory().unwrap();
+        let mut conn = storage.connection().unwrap();
         let transaction = conn.transaction().unwrap();
-        crate::storage::migrate_database(&transaction).unwrap();
 
         let transport = create_test_transport(crate::ethereum::Chain::Goerli).await;
 

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -336,26 +336,11 @@ async fn deploy_contract(
 
     // TODO: verify contract hash (waiting on contract definition API change).
 
-    let byte_code = code
-        .bytecode
-        .into_iter()
-        .flat_map(|bytes32| bytes32.0.to_be_bytes())
-        .collect::<Vec<u8>>();
-
-    // TODO: Unsure on how to encode / decode this reliably.
-    let abi = "todo".as_bytes();
     // TODO: This is not available from sequencer yet.
     let definition = "does not exist".as_bytes();
 
-    ContractsTable::insert(
-        db,
-        contract.address,
-        contract.hash,
-        &byte_code,
-        abi,
-        definition,
-    )
-    .context("Inserting contract information into contracts table")?;
+    ContractsTable::insert(db, contract.address, contract.hash, code, definition)
+        .context("Inserting contract information into contracts table")?;
     Ok(())
 }
 


### PR DESCRIPTION
The main feature of this PR is adding a dedicated storage / database entry-point. This allows creating / migrating the database and passing the resulting entry-point to the components that require it e.g. RPC and sync process.

This entry-point has been added to the RPC component, and the `get_code` call has been updated to use it. The other calls have not been updated; want feedback before we move on to doing more.

In addition, a simplified `ContractCode` using `String` for its ABI has been added and used instead. As I understand it, only the contract definition needs to be understood / parsed so for now this is okay.