### PR TITLE
Better get code

### DIFF
--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -11,7 +11,6 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.44"
-bigdecimal = { version = "0.3.0", features = ["serde"] }
 # paritys scale codec locks us here
 bitvec = "0.20.4"
 bytes = "1.1.0"

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -41,6 +41,25 @@ pub struct ContractCode {
     pub abi: String,
 }
 
+/// A Starknet contract's definition.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ContractDefinition {
+    pub abi: String,
+    pub program: contract_definition::Program,
+}
+
+// Starknet contract definition related sub structures.
+pub mod contract_definition {
+    use super::StarkHash;
+    use serde::{Deserialize, Serialize};
+
+    /// A Starknet contract's definition "program".
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    pub struct Program {
+        pub bytecode: Vec<StarkHash>,
+    }
+}
+
 /// Entry point of a StarkNet `call`.
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct EntryPoint(pub StarkHash);

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -43,7 +43,7 @@ pub struct ContractCode {
 
 /// A Starknet contract's definition.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ContractDefinition {
+pub struct LiteContractDefinition {
     pub abi: String,
     pub program: contract_definition::Program,
 }

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -18,46 +18,39 @@ pub struct ContractAddressSalt(pub StarkHash);
 /// deployment properties e.g. code and ABI.
 ///
 /// Not to be confused with [ContractStateHash].
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ContractHash(pub StarkHash);
 
 /// A StarkNet contract's state hash. This is the value stored
 /// in the global state tree.
 ///
 /// Not to be confused with [ContractHash].
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ContractStateHash(pub StarkHash);
 
 /// A commitment root of a StarkNet contract. This is the entry-point
 /// for a contract's state at a specific point in time via the contract
 /// state tree.
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ContractRoot(pub StarkHash);
 
-/// A Starknet contract's bytecode and ABI.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// A Starknet contract's bytecode and ABI. The `abi` field contains a raw JSON string
+/// hence the entire struct __will not deserialize from JSON properly__ and thus __does not__
+/// `#[derive(Deserialize)]`.
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ContractCode {
-    pub bytecode: Vec<StarkHash>,
     pub abi: String,
+    pub bytecode: Vec<StarkHash>,
 }
 
-/// A Starknet contract's definition.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// A Starknet contract's definition. Stores only those fields from a full contract definition
+/// that are currently used by Pathfinder. The `abi` field contains a raw JSON string
+/// hence the entire struct __will not deserialize from JSON properly__ and thus __does not__
+/// `#[derive(Deserialize)]`.
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct LiteContractDefinition {
     pub abi: String,
-    pub program: contract_definition::Program,
-}
-
-// Starknet contract definition related sub structures.
-pub mod contract_definition {
-    use super::StarkHash;
-    use serde::{Deserialize, Serialize};
-
-    /// A Starknet contract's definition "program".
-    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-    pub struct Program {
-        pub bytecode: Vec<StarkHash>,
-    }
+    pub bytecode: Vec<StarkHash>,
 }
 
 /// Entry point of a StarkNet `call`.

--- a/crates/pathfinder/src/rpc/serde.rs
+++ b/crates/pathfinder/src/rpc/serde.rs
@@ -4,7 +4,6 @@ use crate::core::{
     CallParam, CallSignatureElem, ConstructorParam, EthereumAddress, EventData, EventKey,
     L1ToL2MessagePayloadElem, L2ToL1MessagePayloadElem, TransactionSignatureElem,
 };
-use bigdecimal::BigDecimal;
 use num_bigint::{BigInt, BigUint, Sign};
 use pedersen::{HexParseError, OverflowError, StarkHash};
 use serde_with::serde_conv;
@@ -83,8 +82,7 @@ fn starkhash_from_biguint(b: BigUint) -> Result<StarkHash, OverflowError> {
 pub fn starkhash_to_dec_str(h: &StarkHash) -> String {
     let b = h.to_be_bytes();
     let b = BigInt::from_bytes_be(Sign::Plus, &b);
-    let b = BigDecimal::from(b);
-    b.to_string()
+    b.to_str_radix(10)
 }
 
 /// A helper conversion function. Only use with __sequencer API related types__.

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -173,7 +173,7 @@ impl Client {
     }
 
     /// Gets full contract definition.
-    pub async fn full_contract(
+    pub async fn contract_definition(
         &self,
         contract_addr: ContractAddress,
     ) -> Result<bytes::Bytes, SequencerError> {
@@ -831,14 +831,14 @@ mod tests {
         }
     }
 
-    mod full_contract {
+    mod contract_definition {
         use super::*;
         use pretty_assertions::assert_eq;
 
         #[tokio::test]
         async fn invalid_contract_address() {
             let error =
-                retry_on_rate_limiting!(client().full_contract(*INVALID_CONTRACT_ADDR).await)
+                retry_on_rate_limiting!(client().contract_definition(*INVALID_CONTRACT_ADDR).await)
                     .unwrap_err();
             assert_matches!(
                 error,
@@ -848,8 +848,9 @@ mod tests {
 
         #[tokio::test]
         async fn success() {
-            let bytes = retry_on_rate_limiting!(client().full_contract(*VALID_CONTRACT_ADDR).await)
-                .unwrap();
+            let bytes =
+                retry_on_rate_limiting!(client().contract_definition(*VALID_CONTRACT_ADDR).await)
+                    .unwrap();
             // Fast sanity check
             // TODO replace with something more meaningful once we figure out the structure to deserialize to
             assert_eq!(bytes.len(), 53032);

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -6,8 +6,8 @@ pub mod request;
 use self::error::StarknetError;
 use crate::{
     core::{
-        contract_definition, ContractAddress, ContractCode, LiteContractDefinition,
-        StarknetTransactionHash, StorageAddress, StorageValue,
+        ContractAddress, ContractCode, LiteContractDefinition, StarknetTransactionHash,
+        StorageAddress, StorageValue,
     },
     rpc::types::{BlockHashOrTag, BlockNumberOrTag, Tag},
     sequencer::error::SequencerError,
@@ -190,9 +190,7 @@ impl Client {
         let def = parse::<reply::LiteContractDefinition>(resp).await?;
         Ok(LiteContractDefinition {
             abi: def.abi.to_string(),
-            program: contract_definition::Program {
-                bytecode: def.program.bytecode,
-            },
+            bytecode: def.program.bytecode,
         })
     }
 
@@ -854,12 +852,12 @@ mod tests {
 
         #[tokio::test]
         async fn success() {
-            let resp =
+            let def =
                 retry_on_rate_limiting!(client().contract_definition(*VALID_CONTRACT_ADDR).await)
                     .unwrap();
             // Fast sanity check
             // TODO replace with something more meaningful once we figure out the structure to deserialize to
-            assert_eq!(resp.program.bytecode.len(), 106);
+            assert_eq!(def.bytecode.len(), 106);
         }
     }
 

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -6,7 +6,7 @@ pub mod request;
 use self::error::StarknetError;
 use crate::{
     core::{
-        contract_definition, ContractAddress, ContractCode, ContractDefinition,
+        contract_definition, ContractAddress, ContractCode, LiteContractDefinition,
         StarknetTransactionHash, StorageAddress, StorageValue,
     },
     rpc::types::{BlockHashOrTag, BlockNumberOrTag, Tag},
@@ -178,7 +178,7 @@ impl Client {
     pub async fn contract_definition(
         &self,
         contract_addr: ContractAddress,
-    ) -> Result<ContractDefinition, SequencerError> {
+    ) -> Result<LiteContractDefinition, SequencerError> {
         let resp = self
             .inner
             .get(self.build_query(
@@ -187,8 +187,8 @@ impl Client {
             ))
             .send()
             .await?;
-        let def = parse::<reply::ContractDefinition>(resp).await?;
-        Ok(ContractDefinition {
+        let def = parse::<reply::LiteContractDefinition>(resp).await?;
+        Ok(LiteContractDefinition {
             abi: def.abi.to_string(),
             program: contract_definition::Program {
                 bytecode: def.program.bytecode,

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -76,7 +76,8 @@ pub struct Code {
 }
 
 /// Used to deserialize a reply from [Client::contract_definition](crate::sequencer::Client::contract_definition).
-#[derive(Clone, Debug, Deserialize, Serialize)]
+/// Stores only those fields from a full contract definition that are currently used by Pathfinder.
+#[derive(Clone, Debug, Deserialize)]
 pub struct LiteContractDefinition {
     pub abi: Box<serde_json::value::RawValue>,
     pub program: contract_definition::Program,
@@ -85,9 +86,9 @@ pub struct LiteContractDefinition {
 /// Types used when deserializing L2 contract definition related data.
 pub mod contract_definition {
     use super::StarkHash;
-    use serde::{Deserialize, Serialize};
+    use serde::Deserialize;
 
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize)]
     pub struct Program {
         #[serde(rename = "data")]
         pub bytecode: Vec<StarkHash>,

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -75,6 +75,25 @@ pub struct Code {
     pub bytecode: Vec<StarkHash>,
 }
 
+/// Used to deserialize a reply from [Client::contract_definition](crate::sequencer::Client::contract_definition).
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ContractDefinition {
+    pub abi: Box<serde_json::value::RawValue>,
+    pub program: contract_definition::Program,
+}
+
+/// Types used when deserializing L2 contract definition related data.
+pub mod contract_definition {
+    use super::StarkHash;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct Program {
+        #[serde(rename = "data")]
+        pub bytecode: Vec<StarkHash>,
+    }
+}
+
 /// Types used when deserializing L2 contract related data.
 pub mod code {
     use serde::{Deserialize, Serialize};

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -77,7 +77,7 @@ pub struct Code {
 
 /// Used to deserialize a reply from [Client::contract_definition](crate::sequencer::Client::contract_definition).
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct ContractDefinition {
+pub struct LiteContractDefinition {
     pub abi: Box<serde_json::value::RawValue>,
     pub program: contract_definition::Program,
 }

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -6,7 +6,10 @@ use rusqlite::{Connection, Transaction};
 use web3::{Transport, Web3};
 
 use crate::{
-    core::{ContractHash, ContractRoot, ContractStateHash, GlobalRoot, StarknetBlockTimestamp},
+    core::{
+        ContractCode, ContractHash, ContractRoot, ContractStateHash, GlobalRoot,
+        StarknetBlockTimestamp,
+    },
     ethereum::{
         log::{FetchError, StateUpdateLog},
         state_update::{
@@ -15,7 +18,7 @@ use crate::{
         },
         BlockOrigin, EthOrigin, TransactionOrigin,
     },
-    rpc::types::{BlockHashOrTag, BlockNumberOrTag, Tag},
+    rpc::types::BlockNumberOrTag,
     sequencer,
     state::state_tree::{ContractsStateTree, GlobalStateTree},
     storage::{
@@ -329,10 +332,14 @@ async fn deploy_contract(
     sequencer: &sequencer::Client,
 ) -> anyhow::Result<()> {
     // Download code and ABI from the sequencer.
-    let code = sequencer
-        .code(contract.address, BlockHashOrTag::Tag(Tag::Latest))
+    let definition = sequencer
+        .contract_definition(contract.address)
         .await
         .context("Download contract code and ABI from sequencer")?;
+    let code = ContractCode {
+        abi: definition.abi,
+        bytecode: definition.program.bytecode,
+    };
 
     // TODO: verify contract hash (waiting on contract definition API change).
 

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -338,7 +338,7 @@ async fn deploy_contract(
         .context("Download contract code and ABI from sequencer")?;
     let code = ContractCode {
         abi: definition.abi,
-        bytecode: definition.program.bytecode,
+        bytecode: definition.bytecode,
     };
 
     // TODO: verify contract hash (waiting on contract definition API change).


### PR DESCRIPTION
Use `sequencer::Client::contract_definition` instead of `code`.