### PR TITLE
fix: log fetchers do not update internal state

### DIFF
--- a/crates/pathfinder/src/ethereum/log/fetch.rs
+++ b/crates/pathfinder/src/ethereum/log/fetch.rs
@@ -21,11 +21,11 @@ pub use forward::*;
 /// May contain one of two types of [MetaLog].
 ///
 /// Used by [BackwardLogFetcher].
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum EitherMetaLog<L, R>
 where
-    L: MetaLog + PartialEq + std::fmt::Debug,
-    R: MetaLog + PartialEq + std::fmt::Debug,
+    L: MetaLog + PartialEq + std::fmt::Debug + Clone,
+    R: MetaLog + PartialEq + std::fmt::Debug + Clone,
 {
     Left(L),
     Right(R),
@@ -107,8 +107,8 @@ impl MetaLog for MemoryPageFactContinuousLog {
 
 impl<L, R> TryFrom<web3::types::Log> for EitherMetaLog<L, R>
 where
-    L: MetaLog + PartialEq + std::fmt::Debug,
-    R: MetaLog + PartialEq + std::fmt::Debug,
+    L: MetaLog + PartialEq + std::fmt::Debug + Clone,
+    R: MetaLog + PartialEq + std::fmt::Debug + Clone,
 {
     type Error = anyhow::Error;
 
@@ -124,8 +124,8 @@ where
 
 impl<L, R> EitherMetaLog<L, R>
 where
-    L: MetaLog + PartialEq + std::fmt::Debug,
-    R: MetaLog + PartialEq + std::fmt::Debug,
+    L: MetaLog + PartialEq + std::fmt::Debug + Clone,
+    R: MetaLog + PartialEq + std::fmt::Debug + Clone,
 {
     fn origin(&self) -> &EthOrigin {
         match self {

--- a/crates/pathfinder/src/ethereum/log/fetch/backward.rs
+++ b/crates/pathfinder/src/ethereum/log/fetch/backward.rs
@@ -40,8 +40,8 @@ impl From<web3::error::Error> for BackwardFetchError {
 /// at some log type A, but search backwards for all logs of type B.
 pub struct BackwardLogFetcher<L, R>
 where
-    L: MetaLog + PartialEq + std::fmt::Debug,
-    R: MetaLog + PartialEq + std::fmt::Debug,
+    L: MetaLog + PartialEq + std::fmt::Debug + Clone,
+    R: MetaLog + PartialEq + std::fmt::Debug + Clone,
 {
     last_known: EitherMetaLog<L, R>,
     stride: u64,
@@ -50,8 +50,8 @@ where
 
 impl<L, R> BackwardLogFetcher<L, R>
 where
-    L: MetaLog + PartialEq + std::fmt::Debug,
-    R: MetaLog + PartialEq + std::fmt::Debug,
+    L: MetaLog + PartialEq + std::fmt::Debug + Clone,
+    R: MetaLog + PartialEq + std::fmt::Debug + Clone,
 {
     /// Creates a [LogFetcher](super::forward::LogFetcher) which fetches logs starting from `last_known`'s origin on L1.
     ///
@@ -151,6 +151,9 @@ where
                     return Err(BackwardFetchError::GenesisReached);
                 }
             }
+
+            // unwrap is safe due to the is_empty check above.
+            self.last_known = logs.last().unwrap().clone();
 
             return Ok(logs);
         }

--- a/crates/pathfinder/src/ethereum/log/fetch/backward.rs
+++ b/crates/pathfinder/src/ethereum/log/fetch/backward.rs
@@ -159,3 +159,87 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::str::FromStr;
+
+    use pedersen::StarkHash;
+    use web3::types::H256;
+
+    use crate::{
+        core::{
+            EthereumBlockHash, EthereumBlockNumber, EthereumLogIndex, EthereumTransactionHash,
+            EthereumTransactionIndex, GlobalRoot, StarknetBlockNumber,
+        },
+        ethereum::{
+            log::StateUpdateLog, test::create_test_transport, BlockOrigin, EthOrigin,
+            TransactionOrigin,
+        },
+    };
+
+    #[tokio::test]
+    async fn consistency() {
+        // We use StateUpdateLog because it comes with a handy block number
+        // we can use to check for sequentiality.
+        let update_log = StateUpdateLog {
+            origin: EthOrigin {
+                block: BlockOrigin {
+                    hash: EthereumBlockHash(
+                        H256::from_str(
+                            "0x0b3208a115098a1654a092b35c8668794c23ddfef35100c83d59fb9b5993bfbb",
+                        )
+                        .unwrap(),
+                    ),
+                    number: EthereumBlockNumber(5904264),
+                },
+                transaction: TransactionOrigin {
+                    hash: EthereumTransactionHash(
+                        H256::from_str(
+                            "0xcdbfab0ca513e6b1c0eee89adb60478e7c8ea4d80edbddc470be41c630ae67c4",
+                        )
+                        .unwrap(),
+                    ),
+                    index: EthereumTransactionIndex(7),
+                },
+                log_index: EthereumLogIndex(17),
+            },
+            global_root: GlobalRoot(
+                StarkHash::from_hex_str(
+                    "0x05EA3EB34039C870869FD7E6E51B46C10A289AA88A8887E8DA8F1009D84EA98B",
+                )
+                .unwrap(),
+            ),
+            block_number: StarknetBlockNumber(7690),
+        };
+
+        // We use the same log type twice; this shouldn't matter and let's us check
+        // the block number sequence.
+        let mut fetcher = BackwardLogFetcher::<StateUpdateLog, StateUpdateLog>::new(
+            EitherMetaLog::Left(update_log.clone()),
+        );
+
+        let transport = create_test_transport(crate::ethereum::Chain::Goerli).await;
+        let logs = fetcher.fetch(&transport).await.unwrap();
+        let mut block_number = update_log.block_number.0 - 1;
+        for log in logs {
+            let log = match log {
+                EitherMetaLog::Left(log) => log,
+                EitherMetaLog::Right(log) => log,
+            };
+            assert_eq!(log.block_number.0, block_number, "First fetch");
+            block_number -= 1;
+        }
+        let logs = fetcher.fetch(&transport).await.unwrap();
+        for log in logs {
+            let log = match log {
+                EitherMetaLog::Left(log) => log,
+                EitherMetaLog::Right(log) => log,
+            };
+            assert_eq!(log.block_number.0, block_number, "Second fetch");
+            block_number -= 1;
+        }
+    }
+}

--- a/crates/pathfinder/src/ethereum/log/fetch/forward.rs
+++ b/crates/pathfinder/src/ethereum/log/fetch/forward.rs
@@ -10,7 +10,7 @@ use crate::ethereum::log::{fetch::MetaLog, get_logs, GetLogsError};
 /// reorganisations.
 pub struct LogFetcher<T>
 where
-    T: MetaLog + PartialEq + std::fmt::Debug,
+    T: MetaLog + PartialEq + std::fmt::Debug + Clone,
 {
     last_known: Option<T>,
     stride: u64,
@@ -33,7 +33,7 @@ impl From<anyhow::Error> for FetchError {
 
 impl<T> LogFetcher<T>
 where
-    T: MetaLog + PartialEq + std::fmt::Debug,
+    T: MetaLog + PartialEq + std::fmt::Debug + Clone,
 {
     /// Creates a [LogFetcher] which fetches logs starting from `last_known`'s origin on L1.
     /// If `last_known` is [None] then the starting point is genesis.
@@ -152,6 +152,8 @@ where
                     continue;
                 }
             }
+
+            self.last_known = logs.last().cloned();
 
             return Ok(logs);
         }


### PR DESCRIPTION
The log fetchers rely on fetching logs from the last retrieved log. This last retrieved log was not updated on a successful fetch, so the fetch process would loop over and over at the same spot.