### PR TITLE
Deduplicate contract definitions in the db

### DIFF
--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -225,7 +225,7 @@ impl RpcApi {
             .context("Opening database connection")?;
         let tx = db.transaction().context("Creating database transaction")?;
 
-        let code = storage::ContractsTable::get_code(&tx, contract_address)
+        let code = storage::ContractCodeTable::get_code(&tx, contract_address)
             .context("Fetching code from database")?;
 
         match code {

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -19,7 +19,7 @@ use crate::{
     sequencer,
     state::state_tree::{ContractsStateTree, GlobalStateTree},
     storage::{
-        ContractAddressesTable, ContractsStateTable, ContractsTable, EthereumBlocksTable,
+        ContractCodeTable, ContractsStateTable, ContractsTable, EthereumBlocksTable,
         EthereumTransactionsTable, GlobalStateRecord, GlobalStateTable,
     },
 };
@@ -317,8 +317,8 @@ async fn update_contract_state(
         .context("Apply contract storage tree changes")?;
 
     // Calculate contract state hash, update global state tree and persist pre-image.
-    let contract_hash = ContractAddressesTable::get_hash(db, update.address)
-        .context("Read contract hash from contract addresses table")?
+    let contract_hash = ContractsTable::get_hash(db, update.address)
+        .context("Read contract hash from contracts table")?
         .context("Contract hash is missing from contracts table")?;
     let contract_state_hash = calculate_contract_state_hash(contract_hash, new_contract_root);
 
@@ -328,7 +328,7 @@ async fn update_contract_state(
     Ok(contract_state_hash)
 }
 
-/// Inserts a newly deployed Starknet contract into [ContractsTable].
+/// Inserts a newly deployed Starknet contract into [ContractCodeTable].
 pub(crate) fn deploy_contract(
     contract: DeployedContract,
     db: &Transaction<'_>,
@@ -346,11 +346,11 @@ pub(crate) fn deploy_contract(
         hash,
     );
 
-    ContractsTable::insert(db, contract.hash, &abi, &code, &contract_definition)
-        .context("Inserting contract information into contracts table")?;
+    ContractCodeTable::insert(db, contract.hash, &abi, &code, &contract_definition)
+        .context("Inserting contract information into contract code table")?;
 
-    ContractAddressesTable::insert(db, contract.address, contract.hash)
-        .context("Inserting contract hash into contract addresses table")?;
+    ContractsTable::insert(db, contract.address, contract.hash)
+        .context("Inserting contract hash into contracts table")?;
 
     Ok(())
 }

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 #[cfg(test)]
 use std::sync::Mutex;
 
-pub use contract::{ContractAddressesTable, ContractsTable};
+pub use contract::{ContractCodeTable, ContractsTable};
 pub use ethereum::{EthereumBlocksTable, EthereumTransactionsTable};
 pub use state::{ContractsStateTable, GlobalStateRecord, GlobalStateTable};
 
@@ -199,20 +199,18 @@ mod tests {
             .execute(
                 r"INSERT INTO contracts_v1 (address, hash, bytecode, abi, definition)
                     SELECT
-                        contract_addresses.address,
-                        contracts.hash,
-                        contracts.bytecode,
-                        contracts.abi,
-                        contracts.definition
-                    FROM contract_addresses
-                    JOIN contracts ON contract_addresses.hash = contracts.hash",
+                        contracts.address,
+                        contract_code.hash,
+                        contract_code.bytecode,
+                        contract_code.abi,
+                        contract_code.definition
+                    FROM contracts
+                    JOIN contract_code ON contracts.hash = contract_code.hash",
                 [],
             )
             .unwrap();
-        transaction
-            .execute("DROP TABLE contract_addresses", [])
-            .unwrap();
         transaction.execute("DROP TABLE contracts", []).unwrap();
+        transaction.execute("DROP TABLE contract_code", []).unwrap();
         transaction
             .execute("ALTER TABLE contracts_v1 RENAME TO contracts", [])
             .unwrap();

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -116,15 +116,33 @@ fn migrate_database(transaction: &Transaction) -> anyhow::Result<()> {
         DB_VERSION_CURRENT
     );
 
-    // Migrate all the tables.
-    contract::migrate(transaction, version).context("Failed to migrate contracts table")?;
-    ethereum::migrate(transaction, version).context("Failed to migrate Ethereum tables")?;
-    state::migrate(transaction, version).context("Failed to migrate StarkNet state tables")?;
+    // Migrate incrementally, increasing the version by 1 at a time
+    for from_version in version..DB_VERSION_CURRENT {
+        match from_version {
+            DB_VERSION_EMPTY => migrate_from_0_to_1(transaction)?,
+            _ => unreachable!("Database version constraint was already checked!"),
+        }
+    }
 
-    // Update the pragma schema.
-    transaction
-        .pragma_update(None, VERSION_KEY, DB_VERSION_CURRENT)
-        .context("Failed to update the schema version number")
+    // Update the pragma schema if necessary
+    if version < DB_VERSION_CURRENT {
+        transaction
+            .pragma_update(None, VERSION_KEY, DB_VERSION_CURRENT)
+            .context("Failed to update the schema version number")?;
+    }
+
+    Ok(())
+}
+
+/// Creates database tables for version 1
+fn migrate_from_0_to_1(transaction: &Transaction) -> anyhow::Result<()> {
+    // Migrate all the tables.
+    contract::migrate_from_0_to_1(transaction)
+        .context("Failed to migrate StarkNet contract tables to version 1")?;
+    ethereum::migrate_from_0_to_1(transaction)
+        .context("Failed to migrate Ethereum tables to version 1")?;
+    state::migrate_from_0_to_1(transaction)
+        .context("Failed to migrate StarkNet state tables to version 1")
 }
 
 /// Returns the current schema version of the existing database,

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -178,19 +178,14 @@ mod tests {
         assert_eq!(version, DB_VERSION_EMPTY);
     }
 
-    mod full_migration {
-        use super::*;
-        use pretty_assertions::assert_eq;
+    #[test]
+    fn full_migration() {
+        let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+        let transaction = conn.transaction().unwrap();
 
-        #[test]
-        fn from_empty() {
-            let mut conn = rusqlite::Connection::open_in_memory().unwrap();
-            let transaction = conn.transaction().unwrap();
-
-            migrate_database(&transaction).unwrap();
-            let version = schema_version(&transaction).unwrap();
-            assert_eq!(version, DB_VERSION_CURRENT);
-        }
+        migrate_database(&transaction).unwrap();
+        let version = schema_version(&transaction).unwrap();
+        assert_eq!(version, DB_VERSION_CURRENT);
     }
 
     #[test]

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 #[cfg(test)]
 use std::sync::Mutex;
 
-pub use contract::ContractsTable;
+pub use contract::{ContractAddressesTable, ContractsTable};
 pub use ethereum::{EthereumBlocksTable, EthereumTransactionsTable};
 pub use state::{ContractsStateTable, GlobalStateRecord, GlobalStateTable};
 

--- a/crates/pathfinder/src/storage/contract.rs
+++ b/crates/pathfinder/src/storage/contract.rs
@@ -44,7 +44,7 @@ impl ContractsTable {
                 transaction.execute(CREATE_CONTRACTS_TABLE, [])?;
                 // Populate the new contracts table with data
                 transaction.execute(
-                    r"INSERT INTO contracts (hash, bytecode, abi, definition)
+                    r"INSERT OR IGNORE INTO contracts (hash, bytecode, abi, definition)
                     SELECT DISTINCT hash, bytecode, abi, definition FROM contracts_v1",
                     [],
                 )?;

--- a/crates/pathfinder/src/storage/contract.rs
+++ b/crates/pathfinder/src/storage/contract.rs
@@ -57,8 +57,7 @@ impl ContractCodeTable {
 
         transaction.execute(
             r"INSERT INTO contract_code ( hash,  bytecode,  abi,  definition)
-                             VALUES (:hash, :bytecode, :abi, :definition)
-                             ON CONFLICT DO NOTHING",
+                             VALUES (:hash, :bytecode, :abi, :definition)",
             named_params! {
                 ":hash": &hash.0.to_be_bytes()[..],
                 ":bytecode": bytecode,

--- a/crates/pathfinder/src/storage/ethereum.rs
+++ b/crates/pathfinder/src/storage/ethereum.rs
@@ -5,7 +5,7 @@ use crate::{
     core::{
         EthereumBlockHash, EthereumBlockNumber, EthereumTransactionHash, EthereumTransactionIndex,
     },
-    storage::{DB_VERSION_1, DB_VERSION_CURRENT, DB_VERSION_EMPTY},
+    storage::{DB_VERSION_CURRENT, DB_VERSION_EMPTY},
 };
 
 /// Migrates [GlobalStateTable] and [ContractsStateTable] to the [current version](DB_VERSION_CURRENT).
@@ -29,7 +29,7 @@ impl EthereumBlocksTable {
     fn migrate(transaction: &Transaction, from_version: u32) -> anyhow::Result<()> {
         match from_version {
             DB_VERSION_EMPTY => {} // Fresh database, continue to create table.
-            DB_VERSION_1 | DB_VERSION_CURRENT => return Ok(()), // Table is already correct.
+            DB_VERSION_CURRENT => return Ok(()), // Table is already correct.
             other => anyhow::bail!("Unknown database version: {}", other),
         }
 
@@ -79,7 +79,7 @@ impl EthereumTransactionsTable {
     fn migrate(transaction: &Transaction, from_version: u32) -> anyhow::Result<()> {
         match from_version {
             DB_VERSION_EMPTY => {} // Fresh database, continue to create table.
-            DB_VERSION_1 | DB_VERSION_CURRENT => return Ok(()), // Table is already correct.
+            DB_VERSION_CURRENT => return Ok(()), // Table is already correct.
             other => anyhow::bail!("Unknown database version: {}", other),
         }
 

--- a/crates/pathfinder/src/storage/ethereum.rs
+++ b/crates/pathfinder/src/storage/ethereum.rs
@@ -5,7 +5,7 @@ use crate::{
     core::{
         EthereumBlockHash, EthereumBlockNumber, EthereumTransactionHash, EthereumTransactionIndex,
     },
-    storage::{DB_VERSION_CURRENT, DB_VERSION_EMPTY},
+    storage::{DB_VERSION_1, DB_VERSION_CURRENT, DB_VERSION_EMPTY},
 };
 
 /// Migrates [GlobalStateTable] and [ContractsStateTable] to the [current version](DB_VERSION_CURRENT).
@@ -29,7 +29,7 @@ impl EthereumBlocksTable {
     fn migrate(transaction: &Transaction, from_version: u32) -> anyhow::Result<()> {
         match from_version {
             DB_VERSION_EMPTY => {} // Fresh database, continue to create table.
-            DB_VERSION_CURRENT => return Ok(()), // Table is already correct.
+            DB_VERSION_1 | DB_VERSION_CURRENT => return Ok(()), // Table is already correct.
             other => anyhow::bail!("Unknown database version: {}", other),
         }
 
@@ -79,7 +79,7 @@ impl EthereumTransactionsTable {
     fn migrate(transaction: &Transaction, from_version: u32) -> anyhow::Result<()> {
         match from_version {
             DB_VERSION_EMPTY => {} // Fresh database, continue to create table.
-            DB_VERSION_CURRENT => return Ok(()), // Table is already correct.
+            DB_VERSION_1 | DB_VERSION_CURRENT => return Ok(()), // Table is already correct.
             other => anyhow::bail!("Unknown database version: {}", other),
         }
 

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -9,7 +9,7 @@ use crate::{
         EthereumLogIndex, EthereumTransactionHash, EthereumTransactionIndex, GlobalRoot,
         StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp,
     },
-    storage::{DB_VERSION_CURRENT, DB_VERSION_EMPTY},
+    storage::{DB_VERSION_1, DB_VERSION_CURRENT, DB_VERSION_EMPTY},
 };
 
 /// Migrates [GlobalStateTable] and [ContractsStateTable] to the [current version](DB_VERSION_CURRENT).
@@ -58,7 +58,7 @@ impl GlobalStateTable {
     fn migrate(transaction: &Transaction, from_version: u32) -> anyhow::Result<()> {
         match from_version {
             DB_VERSION_EMPTY => {} // Fresh database, continue to create table.
-            DB_VERSION_CURRENT => return Ok(()), // Table is already correct.
+            DB_VERSION_1 | DB_VERSION_CURRENT => return Ok(()), // Table is already correct.
             other => anyhow::bail!("Unknown database version: {}", other),
         }
 
@@ -274,7 +274,7 @@ impl ContractsStateTable {
     fn migrate(transaction: &Transaction, from_version: u32) -> anyhow::Result<()> {
         match from_version {
             DB_VERSION_EMPTY => {} // Fresh database, continue to create table.
-            DB_VERSION_CURRENT => return Ok(()), // Table is already correct.
+            DB_VERSION_1 | DB_VERSION_CURRENT => return Ok(()), // Table is already correct.
             other => anyhow::bail!("Unknown database version: {}", other),
         }
 

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -9,7 +9,7 @@ use crate::{
         EthereumLogIndex, EthereumTransactionHash, EthereumTransactionIndex, GlobalRoot,
         StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp,
     },
-    storage::{DB_VERSION_1, DB_VERSION_CURRENT, DB_VERSION_EMPTY},
+    storage::{DB_VERSION_CURRENT, DB_VERSION_EMPTY},
 };
 
 /// Migrates [GlobalStateTable] and [ContractsStateTable] to the [current version](DB_VERSION_CURRENT).
@@ -58,7 +58,7 @@ impl GlobalStateTable {
     fn migrate(transaction: &Transaction, from_version: u32) -> anyhow::Result<()> {
         match from_version {
             DB_VERSION_EMPTY => {} // Fresh database, continue to create table.
-            DB_VERSION_1 | DB_VERSION_CURRENT => return Ok(()), // Table is already correct.
+            DB_VERSION_CURRENT => return Ok(()), // Table is already correct.
             other => anyhow::bail!("Unknown database version: {}", other),
         }
 
@@ -274,7 +274,7 @@ impl ContractsStateTable {
     fn migrate(transaction: &Transaction, from_version: u32) -> anyhow::Result<()> {
         match from_version {
             DB_VERSION_EMPTY => {} // Fresh database, continue to create table.
-            DB_VERSION_1 | DB_VERSION_CURRENT => return Ok(()), // Table is already correct.
+            DB_VERSION_CURRENT => return Ok(()), // Table is already correct.
             other => anyhow::bail!("Unknown database version: {}", other),
         }
 


### PR DESCRIPTION
* Contract address to contract hash mapping is kept in a separate table now.
* I added this v1 to v2 migration "exercise" in this PR to essentially have a look at whatever problems could be encountered when considering coding such a migration. In all honesty I think it could be removed as rework to the very PR, so as not to increase the number of available versions artificially.