### PR TITLE
feat(storage): foreign key type

### DIFF
--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -252,7 +252,7 @@ async fn update<T: Transport>(
     let block_hash = block.block_hash.context("Sequencer block hash missing")?;
 
     // Persist new global root et al to database.
-    EthereumBlocksTable::insert(
+    let block_hash_fk = EthereumBlocksTable::insert(
         db,
         update_log.origin.block.hash,
         update_log.origin.block.number,
@@ -261,7 +261,7 @@ async fn update<T: Transport>(
 
     EthereumTransactionsTable::insert(
         db,
-        update_log.origin.block.hash,
+        block_hash_fk,
         update_log.origin.transaction.hash,
         update_log.origin.transaction.index,
     )

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -4,6 +4,7 @@
 
 mod contract;
 mod ethereum;
+mod foreign_key;
 pub mod merkle_tree;
 mod state;
 
@@ -13,6 +14,7 @@ use std::sync::Mutex;
 
 pub use contract::{ContractCodeTable, ContractsTable};
 pub use ethereum::{EthereumBlocksTable, EthereumTransactionsTable};
+pub use foreign_key::ForeignKey;
 pub use state::{ContractsStateTable, GlobalStateRecord, GlobalStateTable};
 
 use anyhow::Context;

--- a/crates/pathfinder/src/storage/foreign_key.rs
+++ b/crates/pathfinder/src/storage/foreign_key.rs
@@ -1,0 +1,52 @@
+/// An opaque wrapper type that is used to describe foreign-key constraints.
+///
+/// Storage tables should return [ForeignKey<T>] (if required) for insert and get
+/// operations. This in turn lets another table require this type for its foreign-key
+/// to enforce that the user has checked that it exists.
+pub struct ForeignKey<T>(pub(super) T);
+
+impl<T> std::ops::Deref for ForeignKey<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> Clone for ForeignKey<T>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T> Copy for ForeignKey<T> where T: Copy {}
+
+impl<T> Default for ForeignKey<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<T> std::fmt::Debug for ForeignKey<T>
+where
+    T: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("ForeignKey").field(&self.0).finish()
+    }
+}
+
+impl<T> std::fmt::Display for ForeignKey<T>
+where
+    T: std::fmt::Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("ForeignKey({})", &self.0))
+    }
+}

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -403,7 +403,7 @@ mod tests {
                     eth_log_index: EthereumLogIndex(99),
                 };
 
-                storage::EthereumBlocksTable::insert(
+                let eth_block_hash_fk = storage::EthereumBlocksTable::insert(
                     &transaction,
                     record.eth_block_hash,
                     record.eth_block_number,
@@ -412,7 +412,7 @@ mod tests {
 
                 storage::EthereumTransactionsTable::insert(
                     &transaction,
-                    record.eth_block_hash,
+                    eth_block_hash_fk,
                     record.eth_tx_hash,
                     record.eth_tx_index,
                 )
@@ -498,19 +498,19 @@ mod tests {
                 storage::migrate_database(&transaction).unwrap();
 
                 // Insert Ethereum data
-                storage::EthereumBlocksTable::insert(
+                let block_hash_fk_1 = storage::EthereumBlocksTable::insert(
                     &transaction,
                     first.eth_block_hash,
                     first.eth_block_number,
                 )
                 .unwrap();
-                storage::EthereumBlocksTable::insert(
+                let block_hash_fk_2 = storage::EthereumBlocksTable::insert(
                     &transaction,
                     second.eth_block_hash,
                     second.eth_block_number,
                 )
                 .unwrap();
-                storage::EthereumBlocksTable::insert(
+                let block_hash_fk_3 = storage::EthereumBlocksTable::insert(
                     &transaction,
                     third.eth_block_hash,
                     third.eth_block_number,
@@ -519,21 +519,21 @@ mod tests {
 
                 storage::EthereumTransactionsTable::insert(
                     &transaction,
-                    first.eth_block_hash,
+                    block_hash_fk_1,
                     first.eth_tx_hash,
                     first.eth_tx_index,
                 )
                 .unwrap();
                 storage::EthereumTransactionsTable::insert(
                     &transaction,
-                    second.eth_block_hash,
+                    block_hash_fk_2,
                     second.eth_tx_hash,
                     second.eth_tx_index,
                 )
                 .unwrap();
                 storage::EthereumTransactionsTable::insert(
                     &transaction,
-                    third.eth_block_hash,
+                    block_hash_fk_3,
                     third.eth_tx_hash,
                     third.eth_tx_index,
                 )


### PR DESCRIPTION
This demonstrates a prototype for a new constraint type -- `ForeignKey<T>`. It allows us to add foreign-key constraints to table inserts. This requires the user to demonstrate that the foreign key does already exist before being allowed to insert it as a foreign key in another table.

For example, given the following two tables:
```
Child:     |  ID  |
Parent:    |  ID, child.id  |
```
we can do this:
```rust
impl Parent {
    fn insert(parent_id: ParentId, child_id: ForeignKey<ChildID>) {
        // do insertation
    }
}

impl Child {
    fn insert(child_id: ChildID) -> ForeignKey<ChildID> {
        // do insertion
        ForeignKey(child_id)
    }

    fn get(child_id: ChildID) -> Option<ForeignKey<ChildID>> {
        match id_exists(child_id) {
            true => Some(ForeignKey(child_id)),
            false => None,
        }
    }
}

fn usage() {
    // This can only be obtained by either `Child::get` or `Child::insert`
    let child_fk = Child::get(example_id).unwrap();
    Parent::insert(example_parent, child_fk);
}
```

I've only shown its usage in the Ethereum block table.

Looking for feedback on usefulness i.e. worth adding or no?

Ideally one would also add in the constraint that the `ForeignKey` should be generated and used within the same database transaction to strengthen the requirement, but I'm unsure on how to achieve that. 