### PR TITLE
fix(logs): log fetching breaks upon reaching HEAD

### DIFF
--- a/crates/pathfinder/src/ethereum/log/fetch/forward.rs
+++ b/crates/pathfinder/src/ethereum/log/fetch/forward.rs
@@ -153,7 +153,9 @@ where
                 }
             }
 
-            self.last_known = logs.last().cloned();
+            if let Some(last) = logs.last() {
+                self.last_known = Some(last.clone());
+            }
 
             return Ok(logs);
         }


### PR DESCRIPTION
The log fetcher updated its internal state even when no logs are found.

This condition occurs when no further logs are available i.e. when reaching the HEAD of the chain.

The backwards log fetcher does not have this issue as it can never reach HEAD.