### PR TITLE
test: fix wrong literal

### DIFF
--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -943,7 +943,9 @@ mod tests {
             let abi = rets[0].abi.to_string();
             assert_eq!(
                 abi,
-                r#""[{"inputs":[{"name":"address","type":"felt"},{"name":"value","type":"felt"}],"name":"increase_value","outputs":[],"type":"function"},{"inputs":[{"name":"contract_address","type":"felt"},{"name":"address","type":"felt"},{"name":"value","type":"felt"}],"name":"call_increase_value","outputs":[],"type":"function"},{"inputs":[{"name":"address","type":"felt"}],"name":"get_value","outputs":[{"name":"res","type":"felt"}],"type":"function"}]""#
+                // this should not have the quotes because that'd be in json:
+                // `"abi":"\"[{....}]\""`
+                r#"[{"inputs":[{"name":"address","type":"felt"},{"name":"value","type":"felt"}],"name":"increase_value","outputs":[],"type":"function"},{"inputs":[{"name":"contract_address","type":"felt"},{"name":"address","type":"felt"},{"name":"value","type":"felt"}],"name":"call_increase_value","outputs":[],"type":"function"},{"inputs":[{"name":"address","type":"felt"}],"name":"get_value","outputs":[{"name":"res","type":"felt"}],"type":"function"}]"#
             );
             assert_eq!(rets[0].bytecode.len(), 132);
         }


### PR DESCRIPTION
This was always broken, I must've caused this while trusting for the tests to be run on CI but this is skipped.