### PR TITLE
feat(example): handle L1 reorgs

### DIFF
--- a/crates/pathfinder/examples/reorg_detection.rs
+++ b/crates/pathfinder/examples/reorg_detection.rs
@@ -1,0 +1,199 @@
+//! An example which showcases how to handle L1 chain reorganisations.
+//!
+//! The intent is to follow the L1 chain and keep a set amount of local history.
+//! This local history should be maintained even when L1 chain reorganisations occur.
+
+use std::{collections::VecDeque, io::Write, time::Duration};
+
+use reqwest::Url;
+use web3::{
+    transports::Http,
+    types::{Block, BlockId, BlockNumber, H256},
+    Web3,
+};
+
+#[tokio::main]
+async fn main() {
+    let w3 = setup_transport();
+    /// The maximum amount of blocks to keep.
+    const MAX_HISTORY: usize = 128;
+
+    let mut history = VecDeque::with_capacity(MAX_HISTORY + 1);
+
+    loop {
+        if history.is_empty() {
+            let block = init_local_head(&w3, MAX_HISTORY as u64).await;
+            history.push_back(block.clone());
+        }
+        // Safe as we always check empty above.
+        let latest_local = history.back().unwrap();
+
+        match get_next_block(&w3, latest_local).await {
+            Ok(block) => {
+                let block_no = block.number.unwrap();
+                history.push_back(block);
+
+                // Only keep MAX_HISTORY elements.
+                if history.len() > MAX_HISTORY {
+                    history.pop_front();
+                }
+
+                println!(
+                    "Downloaded block {} (history length: {})",
+                    block_no,
+                    history.len()
+                );
+            }
+            Err(_reorg) => {
+                let old_length = history.len();
+                handle_reorg(&w3, &mut history).await;
+                let new_length = history.len();
+
+                println!(
+                    "Reorg event, deleted {} most recent blocks (out of {})",
+                    old_length - new_length,
+                    old_length
+                );
+            }
+        }
+    }
+}
+
+/// Downloads a block `depth` away from the latest on chain.
+async fn init_local_head(w3: &Web3<Http>, depth: u64) -> Block<H256> {
+    let l1_latest = w3
+        .eth()
+        .block_number()
+        .await
+        .expect("Failed to get latest block number from Ethereum");
+
+    // Start back a bit so that we don't have to wait to fill up history.
+    let local_head = l1_latest - depth;
+    let local_head = w3
+        .eth()
+        .block(BlockId::Number(BlockNumber::Number(local_head)))
+        .await
+        .expect("Failed to read block")
+        .expect("Earliest block is missing");
+
+    local_head
+}
+
+/// Handles L1 chain reorgs, by deleting history until we are back in sync
+/// with the L1 chain.
+async fn handle_reorg(w3: &Web3<Http>, history: &mut VecDeque<Block<H256>>) {
+    let mut delete_count = 0;
+    for block in history.iter().rev() {
+        let number = block.number.unwrap();
+        let number = BlockId::Number(BlockNumber::Number(number));
+        let l1_block = w3.eth().block(number).await.unwrap();
+
+        if let Some(l1_block) = l1_block {
+            if &l1_block == block {
+                break;
+            }
+        }
+
+        delete_count += 1;
+    }
+
+    for _ in 0..delete_count {
+        history.pop_back();
+    }
+}
+
+/// Indicates that a reorg occurred.
+struct Reorg;
+
+/// Retrieve the next block from L1. If we have reached L1 HEAD, will poll until
+/// next block is available.
+///
+/// Returns [Err(Reorg)] if an L1 chain reorganization occurred.
+async fn get_next_block(w3: &Web3<Http>, local_head: &Block<H256>) -> Result<Block<H256>, Reorg> {
+    let local_number = local_head.number.expect("Block should have number");
+    let next_block = local_number + 1u64;
+    let next_block = BlockId::Number(BlockNumber::Number(next_block));
+
+    // A tracker to allow better printing.
+    let mut sleep_mode = false;
+
+    loop {
+        match w3
+            .eth()
+            .block(next_block)
+            .await
+            .expect("Failed to read block")
+        {
+            Some(block) => match block.parent_hash == local_head.hash.unwrap() {
+                true => {
+                    if sleep_mode {
+                        println!();
+                    }
+                    return Ok(block);
+                }
+                false => {
+                    if sleep_mode {
+                        println!();
+                    }
+                    return Err(Reorg);
+                }
+            },
+            None => {
+                // Block does not exist, this could be because we have reach the HEAD, or because
+                // there was a reorg and the requested block number is far ahead of reality.
+                let l1_latest = w3
+                    .eth()
+                    .block_number()
+                    .await
+                    .expect("Failed to get latest block number from Ethereum");
+
+                match l1_latest < local_number {
+                    true => {
+                        if sleep_mode {
+                            println!();
+                        }
+                        return Err(Reorg);
+                    }
+                    false => {
+                        match sleep_mode {
+                            true => {
+                                print!(".");
+                                std::io::stdout().flush().unwrap();
+                            }
+                            false => {
+                                sleep_mode = true;
+                                print!("No new block, sleeping ");
+                                std::io::stdout().flush().unwrap();
+                            }
+                        }
+
+                        tokio::time::sleep(Duration::from_secs(5)).await;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Creates the Ethereum conntection for the Goerli test network,
+/// using the `PATHFINDER_ETHEREUM_HTTP_GOERLI_xxx` environment
+/// variables.
+fn setup_transport() -> Web3<Http> {
+    let key_prefix = "PATHFINDER_ETHEREUM_HTTP_GOERLI";
+
+    let url_key = format!("{}_URL", key_prefix);
+    let password_key = format!("{}_PASSWORD", key_prefix);
+
+    let url = std::env::var(&url_key)
+        .unwrap_or_else(|_| panic!("Ethereum URL environment var not set {url_key}"));
+
+    let password = std::env::var(password_key).ok();
+
+    let mut url = url.parse::<Url>().expect("Bad Ethereum URL");
+    url.set_password(password.as_deref()).unwrap();
+
+    let client = reqwest::Client::builder().build().unwrap();
+    let transport = Http::with_client(client, url);
+
+    Web3::new(transport)
+}

--- a/crates/pathfinder/examples/reorg_detection.rs
+++ b/crates/pathfinder/examples/reorg_detection.rs
@@ -18,7 +18,7 @@ async fn main() {
     /// The maximum amount of blocks to keep.
     const MAX_HISTORY: usize = 128;
 
-    let mut history = VecDeque::with_capacity(MAX_HISTORY + 1);
+    let mut history = VecDeque::with_capacity(MAX_HISTORY);
 
     loop {
         if history.is_empty() {
@@ -31,12 +31,13 @@ async fn main() {
         match get_next_block(&w3, latest_local).await {
             Ok(block) => {
                 let block_no = block.number.unwrap();
-                history.push_back(block);
 
                 // Only keep MAX_HISTORY elements.
-                if history.len() > MAX_HISTORY {
+                if history.len() + 1 > MAX_HISTORY {
                     history.pop_front();
                 }
+
+                history.push_back(block);
 
                 println!(
                     "Downloaded block {} (history length: {})",

--- a/crates/pathfinder/src/ethereum.rs
+++ b/crates/pathfinder/src/ethereum.rs
@@ -172,7 +172,7 @@ pub mod test {
     ///
     /// Mainnet: PATHFINDER_ETHEREUM_HTTP_MAINNET_URL
     ///          PATHFINDER_ETHEREUM_HTTP_MAINNET_PASSWORD (optional)
-    pub async fn create_test_transport(chain: Chain) -> Web3<Http> {
+    pub fn create_test_transport(chain: Chain) -> Web3<Http> {
         let key_prefix = match chain {
             Chain::Mainnet => "PATHFINDER_ETHEREUM_HTTP_MAINNET",
             Chain::Goerli => "PATHFINDER_ETHEREUM_HTTP_GOERLI",
@@ -201,7 +201,7 @@ pub mod test {
         #[tokio::test]
         async fn goerli() {
             let expected_chain = Chain::Goerli;
-            let transport = create_test_transport(expected_chain).await;
+            let transport = create_test_transport(expected_chain);
             let chain = chain(transport).await.unwrap();
 
             assert_eq!(chain, expected_chain);
@@ -210,7 +210,7 @@ pub mod test {
         #[tokio::test]
         async fn mainnet() {
             let expected_chain = Chain::Mainnet;
-            let transport = create_test_transport(expected_chain).await;
+            let transport = create_test_transport(expected_chain);
             let chain = chain(transport).await.unwrap();
 
             assert_eq!(chain, expected_chain);

--- a/crates/pathfinder/src/ethereum/contract.rs
+++ b/crates/pathfinder/src/ethereum/contract.rs
@@ -100,7 +100,7 @@ mod tests {
                 "/resources/contracts/core_proxy.json"
             ));
 
-            let transport = create_test_transport(Chain::Goerli).await;
+            let transport = create_test_transport(Chain::Goerli);
 
             let core_proxy = web3::contract::Contract::from_json(
                 transport.eth(),

--- a/crates/pathfinder/src/ethereum/log/fetch/backward.rs
+++ b/crates/pathfinder/src/ethereum/log/fetch/backward.rs
@@ -221,7 +221,7 @@ mod tests {
             EitherMetaLog::Left(update_log.clone()),
         );
 
-        let transport = create_test_transport(crate::ethereum::Chain::Goerli).await;
+        let transport = create_test_transport(crate::ethereum::Chain::Goerli);
         let logs = fetcher.fetch(&transport).await.unwrap();
         let mut block_number = update_log.block_number.0 - 1;
         for log in logs {

--- a/crates/pathfinder/src/ethereum/log/fetch/forward.rs
+++ b/crates/pathfinder/src/ethereum/log/fetch/forward.rs
@@ -219,7 +219,7 @@ mod tests {
         };
 
         let mut root_fetcher = LogFetcher::<StateUpdateLog>::new(Some(starknet_genesis_log));
-        let transport = create_test_transport(crate::ethereum::Chain::Goerli).await;
+        let transport = create_test_transport(crate::ethereum::Chain::Goerli);
         let mut block_number = 1;
 
         let logs = root_fetcher.fetch(&transport).await.unwrap();

--- a/crates/pathfinder/src/ethereum/state_update.rs
+++ b/crates/pathfinder/src/ethereum/state_update.rs
@@ -138,7 +138,7 @@ mod tests {
             block_number: StarknetBlockNumber(16407),
         };
 
-        let transport = create_test_transport(crate::ethereum::Chain::Goerli).await;
+        let transport = create_test_transport(crate::ethereum::Chain::Goerli);
         let update = StateUpdate::retrieve(&transport, update_log).await.unwrap();
 
         let expected = StateUpdate {

--- a/crates/pathfinder/src/ethereum/state_update/state_root.rs
+++ b/crates/pathfinder/src/ethereum/state_update/state_root.rs
@@ -19,7 +19,7 @@ mod tests {
     async fn genesis() {
         // The first state root retrieved should be the genesis event,
         // with a sequence number of 0.
-        let transport = create_test_transport(Chain::Goerli).await;
+        let transport = create_test_transport(Chain::Goerli);
 
         let mut uut = StateRootFetcher::new(None);
         let first_fetch = uut.fetch(&transport).await.unwrap();
@@ -47,7 +47,7 @@ mod tests {
             // Seed with a incorrect update at the L1 genesis block.
             // This should get interpretted as a reorg once the correct
             // first L2 update log is found.
-            let transport = create_test_transport(Chain::Goerli).await;
+            let transport = create_test_transport(Chain::Goerli);
 
             // Note that block_number must be 0 so that we pull all of L1 history.
             // This makes the test robust against L2 changes, updates or deployments
@@ -77,7 +77,7 @@ mod tests {
             // Seed with an origin beyond the current L1 chain state.
             // This should be interpreted as a reorg as this update
             // won't be found.
-            let transport = create_test_transport(Chain::Goerli).await;
+            let transport = create_test_transport(Chain::Goerli);
 
             let latest_on_chain = transport.eth().block_number().await.unwrap().as_u64();
 

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -464,7 +464,7 @@ mod tests {
         let mut conn = storage.connection().unwrap();
         let transaction = conn.transaction().unwrap();
 
-        let transport = create_test_transport(crate::ethereum::Chain::Goerli).await;
+        let transport = create_test_transport(crate::ethereum::Chain::Goerli);
 
         update(
             &transport,


### PR DESCRIPTION
This PR adds an example which demonstrates how L1 chain reorgs can be:

1. detected and,
2. synchronised with local history

Includes a minor async removal from a test function.

~So far I haven't spotted a reorg an action yet, so lets not merge until that does occur.~