### PR TITLE
ci: enable clippy dead code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v1
-      - run: cargo clippy --workspace --all-targets -- -D warnings -A dead-code
+      - run: cargo clippy --workspace --all-targets -- -D warnings
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/crates/pathfinder/src/ethereum.rs
+++ b/crates/pathfinder/src/ethereum.rs
@@ -29,52 +29,52 @@ pub enum Chain {
 ///     https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md#error-codes
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum RpcErrorCode {
-    ParseError,
-    InvalidRequest,
-    MethodNotFound,
-    InvalidParams,
-    InternalError,
-    InvalidInput,
-    ResourceNotFound,
-    ResourceUnavailable,
-    TransactionRejected,
-    MethodNotSupported,
+    _ParseError,
+    _InvalidRequest,
+    _MethodNotFound,
+    _InvalidParams,
+    _InternalError,
+    _InvalidInput,
+    _ResourceNotFound,
+    _ResourceUnavailable,
+    _TransactionRejected,
+    _MethodNotSupported,
     LimitExceeded,
-    JsonRpcVersion,
+    _JsonRpcVersion,
 }
 
 impl RpcErrorCode {
     fn code(&self) -> i64 {
         match self {
-            RpcErrorCode::ParseError => -32700,
-            RpcErrorCode::InvalidRequest => -32600,
-            RpcErrorCode::MethodNotFound => -32601,
-            RpcErrorCode::InvalidParams => -32602,
-            RpcErrorCode::InternalError => -32603,
-            RpcErrorCode::InvalidInput => -32000,
-            RpcErrorCode::ResourceNotFound => -32001,
-            RpcErrorCode::ResourceUnavailable => -32002,
-            RpcErrorCode::TransactionRejected => -32003,
-            RpcErrorCode::MethodNotSupported => -32004,
+            RpcErrorCode::_ParseError => -32700,
+            RpcErrorCode::_InvalidRequest => -32600,
+            RpcErrorCode::_MethodNotFound => -32601,
+            RpcErrorCode::_InvalidParams => -32602,
+            RpcErrorCode::_InternalError => -32603,
+            RpcErrorCode::_InvalidInput => -32000,
+            RpcErrorCode::_ResourceNotFound => -32001,
+            RpcErrorCode::_ResourceUnavailable => -32002,
+            RpcErrorCode::_TransactionRejected => -32003,
+            RpcErrorCode::_MethodNotSupported => -32004,
             RpcErrorCode::LimitExceeded => -32005,
-            RpcErrorCode::JsonRpcVersion => -32006,
+            RpcErrorCode::_JsonRpcVersion => -32006,
         }
     }
 
-    fn reason(&self) -> &str {
+    fn _reason(&self) -> &str {
         match self {
-            RpcErrorCode::ParseError => "Invalid JSON",
-            RpcErrorCode::InvalidRequest => "JSON is not a valid request object",
-            RpcErrorCode::MethodNotFound => "Method does not exist",
-            RpcErrorCode::InvalidParams => "Invalid method parameters",
-            RpcErrorCode::InternalError => "Internal JSON-RPC error",
-            RpcErrorCode::InvalidInput => "Missing or invalid parameters",
-            RpcErrorCode::ResourceNotFound => "Requested resource not found",
-            RpcErrorCode::ResourceUnavailable => "Requested resource not available",
-            RpcErrorCode::TransactionRejected => "Transaction creation failed",
-            RpcErrorCode::MethodNotSupported => "Method is not implemented",
+            RpcErrorCode::_ParseError => "Invalid JSON",
+            RpcErrorCode::_InvalidRequest => "JSON is not a valid request object",
+            RpcErrorCode::_MethodNotFound => "Method does not exist",
+            RpcErrorCode::_InvalidParams => "Invalid method parameters",
+            RpcErrorCode::_InternalError => "Internal JSON-RPC error",
+            RpcErrorCode::_InvalidInput => "Missing or invalid parameters",
+            RpcErrorCode::_ResourceNotFound => "Requested resource not found",
+            RpcErrorCode::_ResourceUnavailable => "Requested resource not available",
+            RpcErrorCode::_TransactionRejected => "Transaction creation failed",
+            RpcErrorCode::_MethodNotSupported => "Method is not implemented",
             RpcErrorCode::LimitExceeded => "Request exceeds defined limit",
-            RpcErrorCode::JsonRpcVersion => "Version of JSON-RPC protocol is not supported",
+            RpcErrorCode::_JsonRpcVersion => "Version of JSON-RPC protocol is not supported",
         }
     }
 }

--- a/crates/pathfinder/src/state/merkle_tree.rs
+++ b/crates/pathfinder/src/state/merkle_tree.rs
@@ -77,7 +77,7 @@ impl<'a> MerkleTree<'a> {
     ///
     /// This allows for multiple instances of the same tree state to be committed,
     /// without deleting all of them in a single call.
-    pub fn delete(self) -> anyhow::Result<()> {
+    pub fn _delete(self) -> anyhow::Result<()> {
         match self.root.borrow().hash() {
             Some(hash) if hash != StarkHash::ZERO => self
                 .storage
@@ -1030,7 +1030,7 @@ mod tests {
                 let root2 = uut.commit().unwrap();
 
                 let uut = MerkleTree::load("test".to_string(), &transaction, root1).unwrap();
-                uut.delete().unwrap();
+                uut._delete().unwrap();
 
                 let uut = MerkleTree::load("test".to_string(), &transaction, root0).unwrap();
                 assert_eq!(uut.get(key0).unwrap(), val0);
@@ -1118,7 +1118,7 @@ mod tests {
                 let root2 = uut.commit().unwrap();
 
                 let uut = MerkleTree::load("test".to_string(), &transaction, root1).unwrap();
-                uut.delete().unwrap();
+                uut._delete().unwrap();
 
                 let uut = MerkleTree::load("test".to_string(), &transaction, root0).unwrap();
                 assert_eq!(uut.get(key0).unwrap(), val0);
@@ -1157,19 +1157,19 @@ mod tests {
             assert_eq!(root0, root2);
 
             let uut = MerkleTree::load("test".to_string(), &transaction, root0).unwrap();
-            uut.delete().unwrap();
+            uut._delete().unwrap();
 
             let uut = MerkleTree::load("test".to_string(), &transaction, root0).unwrap();
             assert_eq!(uut.get(key).unwrap(), val);
 
             let uut = MerkleTree::load("test".to_string(), &transaction, root0).unwrap();
-            uut.delete().unwrap();
+            uut._delete().unwrap();
 
             let uut = MerkleTree::load("test".to_string(), &transaction, root0).unwrap();
             assert_eq!(uut.get(key).unwrap(), val);
 
             let uut = MerkleTree::load("test".to_string(), &transaction, root0).unwrap();
-            uut.delete().unwrap();
+            uut._delete().unwrap();
 
             // This should fail since the root has been deleted.
             MerkleTree::load("test".to_string(), &transaction, root0).unwrap_err();

--- a/crates/pathfinder/src/state/state_tree.rs
+++ b/crates/pathfinder/src/state/state_tree.rs
@@ -26,7 +26,7 @@ impl<'a> ContractsStateTree<'a> {
         Ok(Self { tree })
     }
 
-    pub fn get(&self, address: StorageAddress) -> anyhow::Result<StorageValue> {
+    pub fn _get(&self, address: StorageAddress) -> anyhow::Result<StorageValue> {
         let value = self.tree.get(address.0)?;
         Ok(StorageValue(value))
     }


### PR DESCRIPTION
This PR marks unused constants and functions `_xxx` and enables `clippy:dead_code` lint again.

This was originally disabled while developing disconnected components, but these have since mostly been integrated.

Fixes #95. 