### PR TITLE
Get storage at

### DIFF
--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -4,10 +4,11 @@ pub mod serde;
 pub mod types;
 
 use crate::{
-    core::{ContractAddress, StarknetTransactionHash, StarknetTransactionIndex, StorageAddress},
+    core::{ContractAddress, StarknetTransactionHash, StarknetTransactionIndex},
     rpc::{
         api::RpcApi,
         types::{
+            request::OverflowingStorageAddress,
             request::{BlockResponseScope, Call},
             BlockHashOrTag, BlockNumberOrTag,
         },
@@ -75,7 +76,8 @@ pub fn run_server(
         #[derive(Debug, Deserialize)]
         pub struct NamedArgs {
             pub contract_address: ContractAddress,
-            pub key: StorageAddress,
+            // Accept overflowing type here to report INVALID_STORAGE_KEY properly
+            pub key: OverflowingStorageAddress,
             pub block_hash: BlockHashOrTag,
         }
         let params = params.parse::<NamedArgs>()?;

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -124,9 +124,15 @@ impl RpcApi {
         use pedersen::StarkHash;
 
         let key = StorageAddress(StarkHash::from_be_bytes(key.0.to_fixed_bytes()).map_err(
+            // Report that the value is >= than the field modulus
             // Use explicit typing in closure arg to force compiler error should error variants ever be expanded
             |_e: OverflowError| Error::from(ErrorCode::InvalidStorageKey),
         )?);
+
+        if key.0.has_more_than_251_bits() {
+            // Report that the value is more than 251 bits
+            return Err(Error::from(ErrorCode::InvalidStorageKey));
+        }
 
         if let BlockHashOrTag::Tag(Tag::Pending) = block_hash {
             // Pending request is always forwarded

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -36,7 +36,7 @@ pub struct RpcApi {
     sequencer: sequencer::Client,
 }
 
-/// Based on [the Starknet operator API spec](https://github.com/starkware-libs/starknet-adrs/blob/master/api/starknet_operator_api_openrpc.json).
+/// Based on [the Starknet operator API spec](https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json).
 impl RpcApi {
     pub fn new(storage: Storage, sequencer: sequencer::Client) -> Self {
         Self { storage, sequencer }
@@ -106,10 +106,8 @@ impl RpcApi {
     /// `block_hash` is the [Hash](crate::rpc::types::BlockHashOrTag::Hash) or [Tag](crate::rpc::types::BlockHashOrTag::Tag)
     /// of the requested block.
     ///
-    /// We are using overflowing type for `key` to be able to correctly report
-    /// [`INVALID_STORAGE_KEY`](https://github.com/starkware-libs/starknet-specs/blob/64044c2c8be136b6fdf7f13896ea0422bf211a74/api/starknet_api_openrpc.json#L1043)
-    /// as per
-    /// [StarkNet RPC spec](https://github.com/starkware-libs/starknet-specs/blob/64044c2c8be136b6fdf7f13896ea0422bf211a74/api/starknet_api_openrpc.json#L144),
+    /// We are using overflowing type for `key` to be able to correctly report `INVALID_STORAGE_KEY` as per
+    /// [StarkNet RPC spec](https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json),
     /// otherwise we would report [-32602](https://www.jsonrpc.org/specification#error_object).
     pub async fn get_storage_at(
         &self,
@@ -212,8 +210,7 @@ impl RpcApi {
             .map_err(internal_server_error)?;
 
         // ContractsStateTree::get() will return zero if the value is still not found (and we know the key is valid),
-        // which is consistent with the specification:
-        // https://github.com/starkware-libs/starknet-specs/blob/64044c2c8be136b6fdf7f13896ea0422bf211a74/api/starknet_api_openrpc.json#L136)
+        // which is consistent with the specification.
         let storage_val = contract_state_tree
             .get(key)
             .context("Get value from contract state tree")

--- a/crates/pathfinder/src/rpc/serde.rs
+++ b/crates/pathfinder/src/rpc/serde.rs
@@ -9,7 +9,7 @@ use num_bigint::{BigInt, BigUint, Sign};
 use pedersen::{HexParseError, OverflowError, StarkHash};
 use serde_with::serde_conv;
 use std::str::FromStr;
-use web3::types::H160;
+use web3::types::{H160, H256};
 
 serde_conv!(
     pub CallParamAsDecimalStr,
@@ -72,6 +72,13 @@ serde_with::serde_conv!(
     EthereumAddress,
     |serialize_me: &EthereumAddress| bytes_to_hex_str(serialize_me.0.as_bytes()),
     |s: &str| bytes_from_hex_str::<{ H160::len_bytes() }>(s).map(|b| EthereumAddress(H160::from(b)))
+);
+
+serde_with::serde_conv!(
+    pub H256AsNoLeadingZerosHexStr,
+    H256,
+    |serialize_me: &H256| bytes_to_hex_str(serialize_me.as_bytes()),
+    |s: &str| bytes_from_hex_str::<{ H256::len_bytes() }>(s).map(H256::from)
 );
 
 /// A helper conversion function. Only use with __sequencer API related types__.

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -56,14 +56,13 @@ pub mod request {
     };
     use serde::{Deserialize, Serialize};
     use serde_with::serde_as;
+    use web3::types::H256;
 
     /// The address of a storage element for a StarkNet contract.
-    /// __This type is not checked for field elment overflow__ in contrast to [`StorageAddress`](crate::core::StorageAddress).
+    /// __This type is not checked for 251 bits overflow__ in contrast to [`TruncatedStorageAddress`].
     #[serde_as]
     #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
-    pub struct OverflowingStorageAddress(
-        #[serde_as(as = "H256AsNoLeadingZerosHexStr")] pub web3::types::H256,
-    );
+    pub struct OverflowingStorageAddress(#[serde_as(as = "H256AsNoLeadingZerosHexStr")] pub H256);
 
     /// Contains parameters passed to `starknet_call`.
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -50,8 +50,20 @@ pub enum BlockNumberOrTag {
 
 /// Groups all strictly input types of the RPC API.
 pub mod request {
-    use crate::core::{CallParam, ContractAddress, EntryPoint};
+    use crate::{
+        core::{CallParam, ContractAddress, EntryPoint},
+        rpc::serde::H256AsNoLeadingZerosHexStr,
+    };
     use serde::{Deserialize, Serialize};
+    use serde_with::serde_as;
+
+    /// The address of a storage element for a StarkNet contract.
+    /// __This type is not checked for field elment overflow__ in contrast to [`StorageAddress`](crate::core::StorageAddress).
+    #[serde_as]
+    #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
+    pub struct OverflowingStorageAddress(
+        #[serde_as(as = "H256AsNoLeadingZerosHexStr")] pub web3::types::H256,
+    );
 
     /// Contains parameters passed to `starknet_call`.
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -238,7 +238,7 @@ pub mod test_utils {
     use crate::{
         core::{
             CallParam, ContractAddress, EntryPoint, StarknetBlockHash, StarknetBlockNumber,
-            StarknetTransactionHash, StarknetTransactionIndex, StorageAddress,
+            StarknetTransactionHash, StarknetTransactionIndex, StorageAddress, StorageValue,
         },
         rpc::types::{BlockHashOrTag, BlockNumberOrTag},
     };
@@ -260,6 +260,7 @@ pub mod test_utils {
     impl_from_hex_str!(StarknetBlockHash);
     impl_from_hex_str!(StarknetTransactionHash);
     impl_from_hex_str!(StorageAddress);
+    impl_from_hex_str!(StorageValue);
 
     lazy_static::lazy_static! {
         pub static ref GENESIS_BLOCK_NUMBER: BlockNumberOrTag = BlockNumberOrTag::Number(StarknetBlockNumber(0u64));

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -29,7 +29,7 @@ use tokio::sync::{mpsc, oneshot};
 pub(crate) mod contract_hash;
 mod merkle_node;
 mod merkle_tree;
-mod state_tree;
+pub(crate) mod state_tree;
 
 pub use contract_hash::compute_contract_hash;
 

--- a/crates/pathfinder/src/state/state_tree.rs
+++ b/crates/pathfinder/src/state/state_tree.rs
@@ -26,7 +26,7 @@ impl<'a> ContractsStateTree<'a> {
         Ok(Self { tree })
     }
 
-    pub fn _get(&self, address: StorageAddress) -> anyhow::Result<StorageValue> {
+    pub fn get(&self, address: StorageAddress) -> anyhow::Result<StorageValue> {
         let value = self.tree.get(address.0)?;
         Ok(StorageValue(value))
     }

--- a/crates/pedersen/src/hash.rs
+++ b/crates/pedersen/src/hash.rs
@@ -110,6 +110,13 @@ impl StarkHash {
 
         Ok(Self(bytes))
     }
+
+    /// Returns true if the value of [Starkhash] is larger than `2^251 - 1`.
+    /// Every [StarkHash] that is used to traverse a Merkle  Patricia Tree
+    /// must not exceed 251 bits, since 251 is the height of the tree.
+    pub fn has_more_than_251_bits(&self) -> bool {
+        self.0[0] & 0b1111_1000 > 0
+    }
 }
 
 impl std::ops::Add for StarkHash {
@@ -603,6 +610,26 @@ mod tests {
         fn max() {
             let hash = StarkHash::from_hex_str(MAX).unwrap();
             assert_eq!(hash.to_hex_str(), MAX);
+        }
+    }
+
+    mod has_more_than_251_bits {
+        use super::*;
+
+        #[test]
+        fn has_251_bits() {
+            let mut bytes = [0xFFu8; 32];
+            bytes[0] = 0x07;
+            let h = StarkHash::from_be_bytes(bytes).unwrap();
+            assert!(!h.has_more_than_251_bits());
+        }
+
+        #[test]
+        fn has_252_bits() {
+            let mut bytes = [0u8; 32];
+            bytes[0] = 0x08;
+            let h = StarkHash::from_be_bytes(bytes).unwrap();
+            assert!(h.has_more_than_251_bits());
         }
     }
 }


### PR DESCRIPTION
* `pending` is forwarded to the sequencer
* in  other cases read from storage
* some tests marked `todo!()` until we can mock state in an easier way
* "real data" test left as is for the time being, as it's not run in the CI anyway
