### PR TITLE
Reorder block updates

### DIFF
--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use web3::types::{H160, H256};
 
 /// The address of a StarkNet contract.
-#[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize, Eq, Hash)]
 pub struct ContractAddress(pub StarkHash);
 
 /// The salt of a StarkNet contract address.

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -739,7 +739,7 @@ impl From<(ContractUpdate, DeployedContract)> for CombinedUpdateDeploy {
 impl CombinedUpdateDeploy {
     fn split(self) -> (ContractUpdate, DeployedContract) {
         let u = ContractUpdate {
-            address: self.address.clone(),
+            address: self.address,
             storage_updates: self.storage_updates,
         };
         let d = DeployedContract {
@@ -1126,13 +1126,13 @@ mod tests {
             tree_updates,
             vec![
                 TreeUpdate::Update(Some(already_deployed_update)),
-                TreeUpdate::Deploy(fifth_deploy.clone(), ExistsAlready),
+                TreeUpdate::Deploy(fifth_deploy, ExistsAlready),
                 TreeUpdate::UpdateDeploy(
-                    CombinedUpdateDeploy::from((one_update, one_deploy.clone())),
+                    CombinedUpdateDeploy::from((one_update, one_deploy)),
                     FetchedNth(0)
                 ),
                 TreeUpdate::Deploy(two_deploy, UsingNthFetched(0)),
-                TreeUpdate::Deploy(three_deploy.clone(), FetchedNth(1)),
+                TreeUpdate::Deploy(three_deploy, FetchedNth(1)),
             ]
         );
 

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -838,10 +838,7 @@ impl std::cmp::Ord for FetchOrder {
 impl FetchOrder {
     /// Returns true if this fetch order implies that a network request should be done
     fn implies_fetch(&self) -> bool {
-        match self {
-            FetchOrder::FetchedNth(_) => true,
-            _ => false,
-        }
+        matches!(self, FetchOrder::FetchedNth(_))
     }
 }
 


### PR DESCRIPTION
Reorders tree updates so that they are:

1. updates to existing contracts
2. deploys and updates of already downloaded contracts
3. deploy and updates of first downloaded contract
4. deploy and updates of first downloaded contracts clones
5. deploy and updates of next downloaded contract
6. deploy and updates of next downloaded contracts clones

Point of the reordering is to do as much as possible work before beginning to await for processed (fetched, extracted, compressed) contracts.

In process of doing that, the `Vec<FetchExtractContract>` no longer needs to hold more than the `ContractAddress`, and it's no longer passed through as-is, so every deployed contract will not have any messaging overhead. Messages still need to be sent in order.

More of the process could be moved to TreeUpdate type, but didn't start doing this yet at least. Held off splitting this to files to get some feedback if we should go into this direction at all.