### PR TITLE
ref(merkle): get and load now use Option

### DIFF
--- a/crates/pathfinder/src/state/merkle_node.rs
+++ b/crates/pathfinder/src/state/merkle_node.rs
@@ -151,17 +151,6 @@ impl Node {
         }
     }
 
-    /// Returns true if the node represents an empty node -- this is defined as a node
-    /// with the [StarkHash::ZERO].
-    ///
-    /// This can occur for the root node in an empty graph.
-    pub fn is_empty(&self) -> bool {
-        match self {
-            Node::Unresolved(hash) => hash == &StarkHash::ZERO,
-            _ => false,
-        }
-    }
-
     pub fn is_binary(&self) -> bool {
         matches!(self, Node::Binary(..))
     }

--- a/crates/pathfinder/src/state/state_tree.rs
+++ b/crates/pathfinder/src/state/state_tree.rs
@@ -19,16 +19,18 @@ pub struct ContractsStateTree<'a> {
 }
 
 impl<'a> ContractsStateTree<'a> {
-    pub fn load(transaction: &'a Transaction, root: ContractRoot) -> anyhow::Result<Self> {
+    /// Loads a [ContractsStateTree] with the given root. Use [None] to create an empty tree.
+    pub fn load(transaction: &'a Transaction, root: Option<ContractRoot>) -> anyhow::Result<Self> {
         // TODO: move the string into storage.
-        let tree = MerkleTree::load("tree_contracts".to_string(), transaction, root.0)?;
+        let root = root.map(|val| val.0);
+        let tree = MerkleTree::load("tree_contracts".to_string(), transaction, root)?;
 
         Ok(Self { tree })
     }
 
-    pub fn _get(&self, address: StorageAddress) -> anyhow::Result<StorageValue> {
-        let value = self.tree.get(address.0)?;
-        Ok(StorageValue(value))
+    pub fn _get(&self, address: StorageAddress) -> anyhow::Result<Option<StorageValue>> {
+        let value = self.tree.get(address.0)?.map(StorageValue);
+        Ok(value)
     }
 
     pub fn set(&mut self, address: StorageAddress, value: StorageValue) -> anyhow::Result<()> {
@@ -49,16 +51,18 @@ pub struct GlobalStateTree<'a> {
 }
 
 impl<'a> GlobalStateTree<'a> {
-    pub fn load(transaction: &'a Transaction, root: GlobalRoot) -> anyhow::Result<Self> {
+    /// Loads a [GlobalStateTree] with the given root. Use [None] to create an empty tree.
+    pub fn load(transaction: &'a Transaction, root: Option<GlobalRoot>) -> anyhow::Result<Self> {
         // TODO: move the string into storage.
-        let tree = MerkleTree::load("tree_global".to_string(), transaction, root.0)?;
+        let root = root.map(|val| val.0);
+        let tree = MerkleTree::load("tree_global".to_string(), transaction, root)?;
 
         Ok(Self { tree })
     }
 
-    pub fn get(&self, address: ContractAddress) -> anyhow::Result<ContractStateHash> {
-        let value = self.tree.get(address.0)?;
-        Ok(ContractStateHash(value))
+    pub fn get(&self, address: ContractAddress) -> anyhow::Result<Option<ContractStateHash>> {
+        let value = self.tree.get(address.0)?.map(ContractStateHash);
+        Ok(value)
     }
 
     pub fn set(


### PR DESCRIPTION
This PR changes the Merkle tree API to use `Option` to indicate missing or empty states. Currently, `ZERO` is used to indicate these states, ~but this makes it impossible to distinguish between missing or set to 0 values. This is in particular a problem for the RPC functionality as it needs to determine if a contract exists~ (see closing comment, this is not true).

In contrast, `set` still uses `ZERO` to indicate deletion. Should I change this as well?

The tests pass; but a careful eye is still required as this is difficult code.