### PR TITLE
ref(ethereum): remove contract address requirement

### DIFF
--- a/crates/pathfinder/examples/fact_retrieval.rs
+++ b/crates/pathfinder/examples/fact_retrieval.rs
@@ -42,7 +42,6 @@ async fn main() {
     // Get the state update event at the given block.
     let filter = FilterBuilder::default()
         .block_hash(block_hash.0)
-        .address(vec![StateUpdateLog::contract_address()])
         .topics(Some(vec![StateUpdateLog::signature()]), None, None, None)
         .build();
     let logs = transport.eth().logs(filter).await.unwrap();

--- a/crates/pathfinder/src/ethereum/contract.rs
+++ b/crates/pathfinder/src/ethereum/contract.rs
@@ -1,14 +1,4 @@
-use std::str::FromStr;
-
 use web3::ethabi::{Contract, Event, Function};
-use web3::types::H160;
-
-/// The address of Starknet's core contract (proxy).
-const CORE_PROXY_ADDR: &str = "0xde29d060D45901Fb19ED6C6e959EB22d8626708e";
-/// The address of Starknet's general purpose solver contract.
-const GPS_ADDR: &str = "0x5EF3C980Bf970FcE5BbC217835743ea9f0388f4F";
-/// The address of Starknet's memory page contract.
-const MEMPAGE_ADDR: &str = "0x743789ff2fF82Bfb907009C9911a7dA636D34FA7";
 
 const CORE_IMPL_ABI: &[u8] = include_bytes!(concat!(
     env!("CARGO_MANIFEST_DIR"),
@@ -26,10 +16,6 @@ const MEMPAGE_ABI: &[u8] = include_bytes!(concat!(
 ));
 
 lazy_static::lazy_static!(
-    pub static ref CORE_CONTRACT_ADDRESS: H160 = H160::from_str(CORE_PROXY_ADDR).expect("Core contract address failed to parse");
-    pub static ref GPS_CONTRACT_ADDRESS: H160 = H160::from_str(GPS_ADDR).expect("GPS contract address failed to parse");
-    pub static ref MEMPAGE_CONTRACT_ADDRESS: H160 = H160::from_str(MEMPAGE_ADDR).expect("Mempage contract address failed to parse");
-
     pub static ref STATE_UPDATE_EVENT: Event = core_contract().event("LogStateUpdate")
             .expect("LogStateUpdate event not found in core contract ABI").to_owned();
     pub static ref STATE_TRANSITION_FACT_EVENT: Event = core_contract().event("LogStateTransitionFact")
@@ -60,13 +46,6 @@ mod tests {
     use super::*;
 
     mod contract {
-        use web3::{
-            contract::Options,
-            types::{BlockId, BlockNumber},
-        };
-
-        use crate::ethereum::{test::create_test_transport, Chain};
-
         use super::*;
 
         #[test]
@@ -82,64 +61,6 @@ mod tests {
         #[test]
         fn mempage() {
             let _contract = mempage_contract();
-        }
-
-        #[tokio::test]
-        async fn core_impl() {
-            // Checks that Starknet's core proxy contract still points to the same
-            // core implementation contract. If this address changes, we should
-            // update the address and more importantly, the ABI.
-
-            // The current address of Starknet's core contract implementation.
-            const CORE_IMPL_ADDR: &str = "0xe267213b0749bb94c575f6170812c887330d9ce3";
-            let expect_addr = H160::from_str(CORE_IMPL_ADDR).unwrap();
-
-            // The proxy's ABI.
-            const CORE_PROXY_ABI: &[u8] = include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/resources/contracts/core_proxy.json"
-            ));
-
-            let transport = create_test_transport(Chain::Goerli);
-
-            let core_proxy = web3::contract::Contract::from_json(
-                transport.eth(),
-                *CORE_CONTRACT_ADDRESS,
-                CORE_PROXY_ABI,
-            )
-            .unwrap();
-
-            let impl_addr: H160 = core_proxy
-                .query(
-                    "implementation",
-                    (),
-                    None,
-                    Options::default(),
-                    Some(BlockId::Number(BlockNumber::Latest)),
-                )
-                .await
-                .unwrap();
-
-            pretty_assertions::assert_eq!(impl_addr, expect_addr);
-        }
-    }
-
-    mod address {
-        use super::*;
-
-        #[test]
-        fn core() {
-            let _addr = *CORE_CONTRACT_ADDRESS;
-        }
-
-        #[test]
-        fn gps() {
-            let _addr = *GPS_CONTRACT_ADDRESS;
-        }
-
-        #[test]
-        fn memory_page() {
-            let _addr = *MEMPAGE_CONTRACT_ADDRESS;
         }
     }
 

--- a/crates/pathfinder/src/ethereum/log/fetch.rs
+++ b/crates/pathfinder/src/ethereum/log/fetch.rs
@@ -1,9 +1,8 @@
-use web3::types::{H160, H256};
+use web3::types::H256;
 
 use crate::ethereum::{
     contract::{
-        CORE_CONTRACT_ADDRESS, GPS_CONTRACT_ADDRESS, MEMORY_PAGE_FACT_CONTINUOUS_EVENT,
-        MEMORY_PAGE_HASHES_EVENT, MEMPAGE_CONTRACT_ADDRESS, STATE_TRANSITION_FACT_EVENT,
+        MEMORY_PAGE_FACT_CONTINUOUS_EVENT, MEMORY_PAGE_HASHES_EVENT, STATE_TRANSITION_FACT_EVENT,
         STATE_UPDATE_EVENT,
     },
     log::{
@@ -42,18 +41,12 @@ where
 ///     - [MemoryPagesHashesLog]
 ///     - [MemoryPageFactContinuousLog]
 pub trait MetaLog: TryFrom<web3::types::Log, Error = anyhow::Error> {
-    fn contract_address() -> H160;
-
     fn signature() -> H256;
 
     fn origin(&self) -> &EthOrigin;
 }
 
 impl MetaLog for StateUpdateLog {
-    fn contract_address() -> H160 {
-        *CORE_CONTRACT_ADDRESS
-    }
-
     fn signature() -> H256 {
         STATE_UPDATE_EVENT.signature()
     }
@@ -64,10 +57,6 @@ impl MetaLog for StateUpdateLog {
 }
 
 impl MetaLog for StateTransitionFactLog {
-    fn contract_address() -> web3::types::H160 {
-        *CORE_CONTRACT_ADDRESS
-    }
-
     fn signature() -> H256 {
         STATE_TRANSITION_FACT_EVENT.signature()
     }
@@ -78,10 +67,6 @@ impl MetaLog for StateTransitionFactLog {
 }
 
 impl MetaLog for MemoryPagesHashesLog {
-    fn contract_address() -> web3::types::H160 {
-        *GPS_CONTRACT_ADDRESS
-    }
-
     fn signature() -> H256 {
         MEMORY_PAGE_HASHES_EVENT.signature()
     }
@@ -92,10 +77,6 @@ impl MetaLog for MemoryPagesHashesLog {
 }
 
 impl MetaLog for MemoryPageFactContinuousLog {
-    fn contract_address() -> web3::types::H160 {
-        *MEMPAGE_CONTRACT_ADDRESS
-    }
-
     fn signature() -> H256 {
         MEMORY_PAGE_FACT_CONTINUOUS_EVENT.signature()
     }

--- a/crates/pathfinder/src/ethereum/log/fetch/backward.rs
+++ b/crates/pathfinder/src/ethereum/log/fetch/backward.rs
@@ -57,9 +57,12 @@ where
     ///
     /// In other words, the first log returned will be the one *before* `last_known`.
     pub fn new(last_known: EitherMetaLog<L, R>) -> Self {
-        let base_filter = FilterBuilder::default()
-            .address(vec![L::contract_address(), R::contract_address()])
-            .topics(Some(vec![L::signature(), R::signature()]), None, None, None);
+        let base_filter = FilterBuilder::default().topics(
+            Some(vec![L::signature(), R::signature()]),
+            None,
+            None,
+            None,
+        );
 
         Self {
             last_known,

--- a/crates/pathfinder/src/ethereum/log/fetch/forward.rs
+++ b/crates/pathfinder/src/ethereum/log/fetch/forward.rs
@@ -40,9 +40,8 @@ where
     ///
     /// In other words, the first log returned will be the one after `last_known`.
     pub fn new(last_known: Option<T>) -> Self {
-        let base_filter = FilterBuilder::default()
-            .address(vec![T::contract_address()])
-            .topics(Some(vec![T::signature()]), None, None, None);
+        let base_filter =
+            FilterBuilder::default().topics(Some(vec![T::signature()]), None, None, None);
 
         Self {
             last_known,

--- a/crates/pathfinder/src/ethereum/state_update/retrieve.rs
+++ b/crates/pathfinder/src/ethereum/state_update/retrieve.rs
@@ -8,7 +8,7 @@ use web3::{
 };
 
 use crate::ethereum::{
-    contract::{CORE_CONTRACT_ADDRESS, REGISTER_MEMORY_PAGE_FUNCTION, STATE_TRANSITION_FACT_EVENT},
+    contract::{REGISTER_MEMORY_PAGE_FUNCTION, STATE_TRANSITION_FACT_EVENT},
     log::{
         BackwardFetchError, BackwardLogFetcher, EitherMetaLog, MemoryPageFactContinuousLog,
         MemoryPagesHashesLog, StateTransitionFactLog, StateUpdateLog,
@@ -24,7 +24,6 @@ pub async fn retrieve_transition_fact<T: Transport>(
     // StateTransitionFactLog and StateUpdateLog are always emitted
     // as pairs. So we query the same block.
     let filter = FilterBuilder::default()
-        .address(vec![*CORE_CONTRACT_ADDRESS])
         .topics(
             Some(vec![STATE_TRANSITION_FACT_EVENT.signature()]),
             None,


### PR DESCRIPTION
This PR removes the requirement for knowing the Starknet L1 contract addresses.

The addresses were used to filter Starknet logs, but this can be achieved using the logs topics only (which are also being used).

Managing and retrieving the contract addresses for the different chains is painful, so not requiring them at all will be nice.

A potential downside is that L1 queries can possibly take longer -- this is difficult to ascertain though. I've had the opposite experience where adding more filters slowed down the queries. Something to keep an eye on.