### PR TITLE
feat(ethereum): logs now support mainnet chain

### DIFF
--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -9,7 +9,7 @@ async fn main() {
     // TODO: get database path from configuration
     let storage = Storage::migrate("database.sqlite".into()).unwrap();
     // TODO: pick the correct sequencer based on the Ethereum chain.
-    let sequencer = sequencer::Client::goerli().unwrap();
+    let sequencer = sequencer::Client::new(pathfinder_lib::ethereum::Chain::Goerli).unwrap();
 
     let (_handle, local_addr) = rpc::run_server(config.http_rpc_addr, storage, sequencer)
         .expect("⚠️ Failed to start HTTP-RPC server");

--- a/crates/pathfinder/src/ethereum.rs
+++ b/crates/pathfinder/src/ethereum.rs
@@ -145,7 +145,7 @@ impl TryFrom<&web3::types::Log> for EthOrigin {
 /// Identifies the Ethereum [Chain] behind the given Ethereum transport.
 ///
 /// Will error if it's not one of the valid Starknet [Chain] variants.
-pub async fn chain<T: Transport>(transport: Web3<T>) -> anyhow::Result<Chain> {
+pub async fn chain<T: Transport>(transport: &Web3<T>) -> anyhow::Result<Chain> {
     match transport.eth().chain_id().await? {
         id if id == U256::from(1u32) => Ok(Chain::Mainnet),
         id if id == U256::from(5u32) => Ok(Chain::Goerli),
@@ -202,7 +202,7 @@ pub mod test {
         async fn goerli() {
             let expected_chain = Chain::Goerli;
             let transport = create_test_transport(expected_chain);
-            let chain = chain(transport).await.unwrap();
+            let chain = chain(&transport).await.unwrap();
 
             assert_eq!(chain, expected_chain);
         }
@@ -211,7 +211,7 @@ pub mod test {
         async fn mainnet() {
             let expected_chain = Chain::Mainnet;
             let transport = create_test_transport(expected_chain);
-            let chain = chain(transport).await.unwrap();
+            let chain = chain(&transport).await.unwrap();
 
             assert_eq!(chain, expected_chain);
         }

--- a/crates/pathfinder/src/ethereum/contract.rs
+++ b/crates/pathfinder/src/ethereum/contract.rs
@@ -5,43 +5,40 @@ use web3::types::H160;
 
 use crate::ethereum::Chain;
 
-pub struct StarknetCoreAddress(pub H160);
-pub struct StarknetGpsAddress(pub H160);
-pub struct StarknetMempageAddress(pub H160);
-
 /// Groups the Starknet contract addresses for a specific chain.
 pub struct ContractAddresses {
-    pub core: StarknetCoreAddress,
-    pub gps: StarknetGpsAddress,
-    pub mempage: StarknetMempageAddress,
+    pub core: H160,
+    pub gps: H160,
+    pub mempage: H160,
 }
 
 /// Starknet contract addresses on L1 Mainnet.
 const MAINNET_ADDRESSES: ContractAddresses = ContractAddresses {
-    core: StarknetCoreAddress(H160([
+    core: H160([
         198, 98, 196, 16, 192, 236, 247, 71, 84, 63, 91, 169, 6, 96, 246, 171, 235, 217, 200, 196,
-    ])),
-    gps: StarknetGpsAddress(H160([
+    ]),
+    gps: H160([
         71, 49, 36, 80, 179, 172, 139, 91, 142, 36, 122, 107, 182, 213, 35, 231, 96, 91, 219, 96,
-    ])),
-    mempage: StarknetMempageAddress(H160([
+    ]),
+    mempage: H160([
         198, 98, 196, 16, 192, 236, 247, 71, 84, 63, 91, 169, 6, 96, 246, 171, 235, 217, 200, 196,
-    ])),
+    ]),
 };
 
 /// Starknet contract addresses on L1 Goerli.
 const GOERLI_ADDRESSES: ContractAddresses = ContractAddresses {
-    core: StarknetCoreAddress(H160([
+    core: H160([
         222, 41, 208, 96, 212, 89, 1, 251, 25, 237, 108, 110, 149, 158, 178, 45, 134, 38, 112, 142,
-    ])),
-    gps: StarknetGpsAddress(H160([
+    ]),
+    gps: H160([
         94, 243, 201, 128, 191, 151, 15, 206, 91, 188, 33, 120, 53, 116, 62, 169, 240, 56, 143, 79,
-    ])),
-    mempage: StarknetMempageAddress(H160([
+    ]),
+    mempage: H160([
         116, 55, 137, 255, 47, 248, 43, 251, 144, 112, 9, 201, 145, 26, 125, 166, 54, 211, 79, 167,
-    ])),
+    ]),
 };
 
+/// Returns the Starknet contract addresses for the given L1 chain.
 pub fn addresses(chain: Chain) -> ContractAddresses {
     match chain {
         Chain::Mainnet => MAINNET_ADDRESSES,
@@ -144,7 +141,7 @@ mod tests {
 
                 let core_proxy = web3::contract::Contract::from_json(
                     transport.eth(),
-                    GOERLI_ADDRESSES.core.0,
+                    GOERLI_ADDRESSES.core,
                     CORE_PROXY_ABI,
                 )
                 .unwrap();
@@ -183,7 +180,7 @@ mod tests {
 
                 let core_proxy = web3::contract::Contract::from_json(
                     transport.eth(),
-                    MAINNET_ADDRESSES.core.0,
+                    MAINNET_ADDRESSES.core,
                     CORE_PROXY_ABI,
                 )
                 .unwrap();
@@ -214,19 +211,19 @@ mod tests {
             #[test]
             fn core() {
                 let expect = H160::from_str("0xde29d060D45901Fb19ED6C6e959EB22d8626708e").unwrap();
-                assert_eq!(GOERLI_ADDRESSES.core.0, expect);
+                assert_eq!(GOERLI_ADDRESSES.core, expect);
             }
 
             #[test]
             fn gps() {
                 let expect = H160::from_str("0x5EF3C980Bf970FcE5BbC217835743ea9f0388f4F").unwrap();
-                assert_eq!(GOERLI_ADDRESSES.gps.0, expect);
+                assert_eq!(GOERLI_ADDRESSES.gps, expect);
             }
 
             #[test]
             fn mempage() {
                 let expect = H160::from_str("0x743789ff2fF82Bfb907009C9911a7dA636D34FA7").unwrap();
-                assert_eq!(GOERLI_ADDRESSES.mempage.0, expect);
+                assert_eq!(GOERLI_ADDRESSES.mempage, expect);
             }
         }
 
@@ -237,19 +234,19 @@ mod tests {
             #[test]
             fn core() {
                 let expect = H160::from_str("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4").unwrap();
-                assert_eq!(MAINNET_ADDRESSES.core.0, expect);
+                assert_eq!(MAINNET_ADDRESSES.core, expect);
             }
 
             #[test]
             fn gps() {
                 let expect = H160::from_str("0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60").unwrap();
-                assert_eq!(MAINNET_ADDRESSES.gps.0, expect);
+                assert_eq!(MAINNET_ADDRESSES.gps, expect);
             }
 
             #[test]
             fn mempage() {
                 let expect = H160::from_str("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4").unwrap();
-                assert_eq!(MAINNET_ADDRESSES.mempage.0, expect);
+                assert_eq!(MAINNET_ADDRESSES.mempage, expect);
             }
         }
     }

--- a/crates/pathfinder/src/ethereum/contract.rs
+++ b/crates/pathfinder/src/ethereum/contract.rs
@@ -1,14 +1,53 @@
-use std::str::FromStr;
+// use std::str::FromStr;
 
 use web3::ethabi::{Contract, Event, Function};
 use web3::types::H160;
 
-/// The address of Starknet's core contract (proxy).
-const CORE_PROXY_ADDR: &str = "0xde29d060D45901Fb19ED6C6e959EB22d8626708e";
-/// The address of Starknet's general purpose solver contract.
-const GPS_ADDR: &str = "0x5EF3C980Bf970FcE5BbC217835743ea9f0388f4F";
-/// The address of Starknet's memory page contract.
-const MEMPAGE_ADDR: &str = "0x743789ff2fF82Bfb907009C9911a7dA636D34FA7";
+use crate::ethereum::Chain;
+
+pub struct StarknetCoreAddress(pub H160);
+pub struct StarknetGpsAddress(pub H160);
+pub struct StarknetMempageAddress(pub H160);
+
+/// Groups the Starknet contract addresses for a specific chain.
+pub struct ContractAddresses {
+    pub core: StarknetCoreAddress,
+    pub gps: StarknetGpsAddress,
+    pub mempage: StarknetMempageAddress,
+}
+
+/// Starknet contract addresses on L1 Mainnet.
+const MAINNET_ADDRESSES: ContractAddresses = ContractAddresses {
+    core: StarknetCoreAddress(H160([
+        198, 98, 196, 16, 192, 236, 247, 71, 84, 63, 91, 169, 6, 96, 246, 171, 235, 217, 200, 196,
+    ])),
+    gps: StarknetGpsAddress(H160([
+        71, 49, 36, 80, 179, 172, 139, 91, 142, 36, 122, 107, 182, 213, 35, 231, 96, 91, 219, 96,
+    ])),
+    mempage: StarknetMempageAddress(H160([
+        198, 98, 196, 16, 192, 236, 247, 71, 84, 63, 91, 169, 6, 96, 246, 171, 235, 217, 200, 196,
+    ])),
+};
+
+/// Starknet contract addresses on L1 Goerli.
+const GOERLI_ADDRESSES: ContractAddresses = ContractAddresses {
+    core: StarknetCoreAddress(H160([
+        222, 41, 208, 96, 212, 89, 1, 251, 25, 237, 108, 110, 149, 158, 178, 45, 134, 38, 112, 142,
+    ])),
+    gps: StarknetGpsAddress(H160([
+        94, 243, 201, 128, 191, 151, 15, 206, 91, 188, 33, 120, 53, 116, 62, 169, 240, 56, 143, 79,
+    ])),
+    mempage: StarknetMempageAddress(H160([
+        116, 55, 137, 255, 47, 248, 43, 251, 144, 112, 9, 201, 145, 26, 125, 166, 54, 211, 79, 167,
+    ])),
+};
+
+pub fn addresses(chain: Chain) -> ContractAddresses {
+    match chain {
+        Chain::Mainnet => MAINNET_ADDRESSES,
+        Chain::Goerli => GOERLI_ADDRESSES,
+    }
+}
 
 const CORE_IMPL_ABI: &[u8] = include_bytes!(concat!(
     env!("CARGO_MANIFEST_DIR"),
@@ -26,10 +65,6 @@ const MEMPAGE_ABI: &[u8] = include_bytes!(concat!(
 ));
 
 lazy_static::lazy_static!(
-    pub static ref CORE_CONTRACT_ADDRESS: H160 = H160::from_str(CORE_PROXY_ADDR).expect("Core contract address failed to parse");
-    pub static ref GPS_CONTRACT_ADDRESS: H160 = H160::from_str(GPS_ADDR).expect("GPS contract address failed to parse");
-    pub static ref MEMPAGE_CONTRACT_ADDRESS: H160 = H160::from_str(MEMPAGE_ADDR).expect("Mempage contract address failed to parse");
-
     pub static ref STATE_UPDATE_EVENT: Event = core_contract().event("LogStateUpdate")
             .expect("LogStateUpdate event not found in core contract ABI").to_owned();
     pub static ref STATE_TRANSITION_FACT_EVENT: Event = core_contract().event("LogStateTransitionFact")
@@ -58,6 +93,7 @@ fn mempage_contract() -> Contract {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::str::FromStr;
 
     mod contract {
         use web3::{
@@ -84,62 +120,137 @@ mod tests {
             let _contract = mempage_contract();
         }
 
-        #[tokio::test]
-        async fn core_impl() {
-            // Checks that Starknet's core proxy contract still points to the same
-            // core implementation contract. If this address changes, we should
-            // update the address and more importantly, the ABI.
+        mod core_impl {
+            use super::*;
+            use pretty_assertions::assert_eq;
 
-            // The current address of Starknet's core contract implementation.
-            const CORE_IMPL_ADDR: &str = "0xe267213b0749bb94c575f6170812c887330d9ce3";
-            let expect_addr = H160::from_str(CORE_IMPL_ADDR).unwrap();
+            #[tokio::test]
+            async fn goerli() {
+                // Checks that Starknet's core proxy contract still points to the same
+                // core implementation contract. If this address changes, we should
+                // update the address and more importantly, the ABI.
 
-            // The proxy's ABI.
-            const CORE_PROXY_ABI: &[u8] = include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/resources/contracts/core_proxy.json"
-            ));
+                // The current address of Starknet's core contract implementation.
+                const CORE_IMPL_ADDR: &str = "0xe267213b0749bb94c575f6170812c887330d9ce3";
+                let expect_addr = H160::from_str(CORE_IMPL_ADDR).unwrap();
 
-            let transport = create_test_transport(Chain::Goerli);
+                // The proxy's ABI.
+                const CORE_PROXY_ABI: &[u8] = include_bytes!(concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/resources/contracts/core_proxy.json"
+                ));
 
-            let core_proxy = web3::contract::Contract::from_json(
-                transport.eth(),
-                *CORE_CONTRACT_ADDRESS,
-                CORE_PROXY_ABI,
-            )
-            .unwrap();
+                let transport = create_test_transport(Chain::Goerli);
 
-            let impl_addr: H160 = core_proxy
-                .query(
-                    "implementation",
-                    (),
-                    None,
-                    Options::default(),
-                    Some(BlockId::Number(BlockNumber::Latest)),
+                let core_proxy = web3::contract::Contract::from_json(
+                    transport.eth(),
+                    GOERLI_ADDRESSES.core.0,
+                    CORE_PROXY_ABI,
                 )
-                .await
                 .unwrap();
 
-            pretty_assertions::assert_eq!(impl_addr, expect_addr);
+                let impl_addr: H160 = core_proxy
+                    .query(
+                        "implementation",
+                        (),
+                        None,
+                        Options::default(),
+                        Some(BlockId::Number(BlockNumber::Latest)),
+                    )
+                    .await
+                    .unwrap();
+
+                assert_eq!(impl_addr, expect_addr);
+            }
+
+            #[tokio::test]
+            async fn mainnet() {
+                // Checks that Starknet's core proxy contract still points to the same
+                // core implementation contract. If this address changes, we should
+                // update the address and more importantly, the ABI.
+
+                // The current address of Starknet's core contract implementation.
+                const CORE_IMPL_ADDR: &str = "0x944960b90381d76368aece61f269bd99fffd627e";
+                let expect_addr = H160::from_str(CORE_IMPL_ADDR).unwrap();
+
+                // The proxy's ABI.
+                const CORE_PROXY_ABI: &[u8] = include_bytes!(concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/resources/contracts/core_proxy.json"
+                ));
+
+                let transport = create_test_transport(Chain::Mainnet);
+
+                let core_proxy = web3::contract::Contract::from_json(
+                    transport.eth(),
+                    MAINNET_ADDRESSES.core.0,
+                    CORE_PROXY_ABI,
+                )
+                .unwrap();
+
+                let impl_addr: H160 = core_proxy
+                    .query(
+                        "implementation",
+                        (),
+                        None,
+                        Options::default(),
+                        Some(BlockId::Number(BlockNumber::Latest)),
+                    )
+                    .await
+                    .unwrap();
+
+                assert_eq!(impl_addr, expect_addr);
+            }
         }
     }
 
     mod address {
         use super::*;
 
-        #[test]
-        fn core() {
-            let _addr = *CORE_CONTRACT_ADDRESS;
+        mod goerli {
+            use super::*;
+            use pretty_assertions::assert_eq;
+
+            #[test]
+            fn core() {
+                let expect = H160::from_str("0xde29d060D45901Fb19ED6C6e959EB22d8626708e").unwrap();
+                assert_eq!(GOERLI_ADDRESSES.core.0, expect);
+            }
+
+            #[test]
+            fn gps() {
+                let expect = H160::from_str("0x5EF3C980Bf970FcE5BbC217835743ea9f0388f4F").unwrap();
+                assert_eq!(GOERLI_ADDRESSES.gps.0, expect);
+            }
+
+            #[test]
+            fn mempage() {
+                let expect = H160::from_str("0x743789ff2fF82Bfb907009C9911a7dA636D34FA7").unwrap();
+                assert_eq!(GOERLI_ADDRESSES.mempage.0, expect);
+            }
         }
 
-        #[test]
-        fn gps() {
-            let _addr = *GPS_CONTRACT_ADDRESS;
-        }
+        mod mainnet {
+            use super::*;
+            use pretty_assertions::assert_eq;
 
-        #[test]
-        fn memory_page() {
-            let _addr = *MEMPAGE_CONTRACT_ADDRESS;
+            #[test]
+            fn core() {
+                let expect = H160::from_str("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4").unwrap();
+                assert_eq!(MAINNET_ADDRESSES.core.0, expect);
+            }
+
+            #[test]
+            fn gps() {
+                let expect = H160::from_str("0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60").unwrap();
+                assert_eq!(MAINNET_ADDRESSES.gps.0, expect);
+            }
+
+            #[test]
+            fn mempage() {
+                let expect = H160::from_str("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4").unwrap();
+                assert_eq!(MAINNET_ADDRESSES.mempage.0, expect);
+            }
         }
     }
 

--- a/crates/pathfinder/src/ethereum/log/fetch.rs
+++ b/crates/pathfinder/src/ethereum/log/fetch.rs
@@ -2,14 +2,13 @@ use web3::types::{H160, H256};
 
 use crate::ethereum::{
     contract::{
-        CORE_CONTRACT_ADDRESS, GPS_CONTRACT_ADDRESS, MEMORY_PAGE_FACT_CONTINUOUS_EVENT,
-        MEMORY_PAGE_HASHES_EVENT, MEMPAGE_CONTRACT_ADDRESS, STATE_TRANSITION_FACT_EVENT,
+        MEMORY_PAGE_FACT_CONTINUOUS_EVENT, MEMORY_PAGE_HASHES_EVENT, STATE_TRANSITION_FACT_EVENT,
         STATE_UPDATE_EVENT,
     },
     log::{
         MemoryPageFactContinuousLog, MemoryPagesHashesLog, StateTransitionFactLog, StateUpdateLog,
     },
-    EthOrigin,
+    Chain, EthOrigin,
 };
 
 mod backward;
@@ -42,7 +41,7 @@ where
 ///     - [MemoryPagesHashesLog]
 ///     - [MemoryPageFactContinuousLog]
 pub trait MetaLog: TryFrom<web3::types::Log, Error = anyhow::Error> {
-    fn contract_address() -> H160;
+    fn contract_address(chain: Chain) -> H160;
 
     fn signature() -> H256;
 
@@ -50,8 +49,8 @@ pub trait MetaLog: TryFrom<web3::types::Log, Error = anyhow::Error> {
 }
 
 impl MetaLog for StateUpdateLog {
-    fn contract_address() -> H160 {
-        *CORE_CONTRACT_ADDRESS
+    fn contract_address(chain: Chain) -> H160 {
+        crate::ethereum::contract::addresses(chain).core.0
     }
 
     fn signature() -> H256 {
@@ -64,8 +63,8 @@ impl MetaLog for StateUpdateLog {
 }
 
 impl MetaLog for StateTransitionFactLog {
-    fn contract_address() -> web3::types::H160 {
-        *CORE_CONTRACT_ADDRESS
+    fn contract_address(chain: Chain) -> web3::types::H160 {
+        crate::ethereum::contract::addresses(chain).core.0
     }
 
     fn signature() -> H256 {
@@ -78,8 +77,8 @@ impl MetaLog for StateTransitionFactLog {
 }
 
 impl MetaLog for MemoryPagesHashesLog {
-    fn contract_address() -> web3::types::H160 {
-        *GPS_CONTRACT_ADDRESS
+    fn contract_address(chain: Chain) -> web3::types::H160 {
+        crate::ethereum::contract::addresses(chain).gps.0
     }
 
     fn signature() -> H256 {
@@ -92,8 +91,8 @@ impl MetaLog for MemoryPagesHashesLog {
 }
 
 impl MetaLog for MemoryPageFactContinuousLog {
-    fn contract_address() -> web3::types::H160 {
-        *MEMPAGE_CONTRACT_ADDRESS
+    fn contract_address(chain: Chain) -> web3::types::H160 {
+        crate::ethereum::contract::addresses(chain).mempage.0
     }
 
     fn signature() -> H256 {

--- a/crates/pathfinder/src/ethereum/log/fetch.rs
+++ b/crates/pathfinder/src/ethereum/log/fetch.rs
@@ -50,7 +50,7 @@ pub trait MetaLog: TryFrom<web3::types::Log, Error = anyhow::Error> {
 
 impl MetaLog for StateUpdateLog {
     fn contract_address(chain: Chain) -> H160 {
-        crate::ethereum::contract::addresses(chain).core.0
+        crate::ethereum::contract::addresses(chain).core
     }
 
     fn signature() -> H256 {
@@ -64,7 +64,7 @@ impl MetaLog for StateUpdateLog {
 
 impl MetaLog for StateTransitionFactLog {
     fn contract_address(chain: Chain) -> web3::types::H160 {
-        crate::ethereum::contract::addresses(chain).core.0
+        crate::ethereum::contract::addresses(chain).core
     }
 
     fn signature() -> H256 {
@@ -78,7 +78,7 @@ impl MetaLog for StateTransitionFactLog {
 
 impl MetaLog for MemoryPagesHashesLog {
     fn contract_address(chain: Chain) -> web3::types::H160 {
-        crate::ethereum::contract::addresses(chain).gps.0
+        crate::ethereum::contract::addresses(chain).gps
     }
 
     fn signature() -> H256 {
@@ -92,7 +92,7 @@ impl MetaLog for MemoryPagesHashesLog {
 
 impl MetaLog for MemoryPageFactContinuousLog {
     fn contract_address(chain: Chain) -> web3::types::H160 {
-        crate::ethereum::contract::addresses(chain).mempage.0
+        crate::ethereum::contract::addresses(chain).mempage
     }
 
     fn signature() -> H256 {

--- a/crates/pathfinder/src/ethereum/log/fetch/forward.rs
+++ b/crates/pathfinder/src/ethereum/log/fetch/forward.rs
@@ -4,7 +4,10 @@ use web3::{
     Transport, Web3,
 };
 
-use crate::ethereum::log::{fetch::MetaLog, get_logs, GetLogsError};
+use crate::ethereum::{
+    log::{fetch::MetaLog, get_logs, GetLogsError},
+    Chain,
+};
 
 /// Fetches consecutive logs of type T from L1, accounting for chain
 /// reorganisations.
@@ -39,9 +42,9 @@ where
     /// If `last_known` is [None] then the starting point is genesis.
     ///
     /// In other words, the first log returned will be the one after `last_known`.
-    pub fn new(last_known: Option<T>) -> Self {
+    pub fn new(last_known: Option<T>, chain: Chain) -> Self {
         let base_filter = FilterBuilder::default()
-            .address(vec![T::contract_address()])
+            .address(vec![T::contract_address(chain)])
             .topics(Some(vec![T::signature()]), None, None, None);
 
         Self {
@@ -218,8 +221,9 @@ mod tests {
             block_number: StarknetBlockNumber(0),
         };
 
-        let mut root_fetcher = LogFetcher::<StateUpdateLog>::new(Some(starknet_genesis_log));
-        let transport = create_test_transport(crate::ethereum::Chain::Goerli);
+        let chain = crate::ethereum::Chain::Goerli;
+        let mut root_fetcher = LogFetcher::<StateUpdateLog>::new(Some(starknet_genesis_log), chain);
+        let transport = create_test_transport(chain);
         let mut block_number = 1;
 
         let logs = root_fetcher.fetch(&transport).await.unwrap();

--- a/crates/pathfinder/src/ethereum/state_update/retrieve.rs
+++ b/crates/pathfinder/src/ethereum/state_update/retrieve.rs
@@ -27,7 +27,7 @@ pub async fn retrieve_transition_fact<T: Transport>(
     // as pairs. So we query the same block.
     let addresses = crate::ethereum::contract::addresses(chain);
     let filter = FilterBuilder::default()
-        .address(vec![addresses.core.0])
+        .address(vec![addresses.core])
         .topics(
             Some(vec![STATE_TRANSITION_FACT_EVENT.signature()]),
             None,

--- a/crates/pathfinder/src/ethereum/state_update/retrieve.rs
+++ b/crates/pathfinder/src/ethereum/state_update/retrieve.rs
@@ -8,23 +8,26 @@ use web3::{
 };
 
 use crate::ethereum::{
-    contract::{CORE_CONTRACT_ADDRESS, REGISTER_MEMORY_PAGE_FUNCTION, STATE_TRANSITION_FACT_EVENT},
+    contract::{REGISTER_MEMORY_PAGE_FUNCTION, STATE_TRANSITION_FACT_EVENT},
     log::{
         BackwardFetchError, BackwardLogFetcher, EitherMetaLog, MemoryPageFactContinuousLog,
         MemoryPagesHashesLog, StateTransitionFactLog, StateUpdateLog,
     },
     state_update::RetrieveStateUpdateError,
+    Chain,
 };
 
 /// Retrieves the [StateTransitionFactLog] associated with the given [StateUpdateLog].
 pub async fn retrieve_transition_fact<T: Transport>(
     transport: &Web3<T>,
     state_update: StateUpdateLog,
+    chain: Chain,
 ) -> Result<StateTransitionFactLog, RetrieveStateUpdateError> {
     // StateTransitionFactLog and StateUpdateLog are always emitted
     // as pairs. So we query the same block.
+    let addresses = crate::ethereum::contract::addresses(chain);
     let filter = FilterBuilder::default()
-        .address(vec![*CORE_CONTRACT_ADDRESS])
+        .address(vec![addresses.core.0])
         .topics(
             Some(vec![STATE_TRANSITION_FACT_EVENT.signature()]),
             None,
@@ -56,11 +59,13 @@ pub async fn retrieve_transition_fact<T: Transport>(
 pub async fn retrieve_mempage_hashes<T: Transport>(
     transport: &Web3<T>,
     fact: StateTransitionFactLog,
+    chain: Chain,
 ) -> Result<MemoryPagesHashesLog, RetrieveStateUpdateError> {
     let fact_hash = fact.fact_hash;
 
     let mut fetcher = BackwardLogFetcher::<StateTransitionFactLog, MemoryPagesHashesLog>::new(
         EitherMetaLog::Left(fact),
+        chain,
     );
 
     loop {
@@ -86,6 +91,7 @@ pub async fn retrieve_mempage_hashes<T: Transport>(
 pub async fn retrieve_memory_page_logs<T: Transport>(
     transport: &Web3<T>,
     mempage_hashes: MemoryPagesHashesLog,
+    chain: Chain,
 ) -> Result<Vec<MemoryPageFactContinuousLog>, RetrieveStateUpdateError> {
     let hashes = mempage_hashes.mempage_hashes.clone();
     let mut required_hashes = hashes.iter().cloned().collect::<HashSet<_>>();
@@ -93,6 +99,7 @@ pub async fn retrieve_memory_page_logs<T: Transport>(
 
     let mut fetcher = BackwardLogFetcher::<MemoryPagesHashesLog, MemoryPageFactContinuousLog>::new(
         EitherMetaLog::Left(mempage_hashes),
+        chain,
     );
 
     loop {

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -202,6 +202,7 @@ mod tests {
     use super::*;
     use crate::{
         core::{StarknetChainId, StarknetProtocolVersion},
+        ethereum::Chain,
         rpc::run_server,
         sequencer::test_utils::*,
     };
@@ -234,7 +235,7 @@ mod tests {
         loop {
             // Restart the server each time (and implicitly the sequencer client, which actually does the job)
             let storage = Storage::in_memory().unwrap();
-            let sequencer = sequencer::Client::goerli().unwrap();
+            let sequencer = sequencer::Client::new(Chain::Goerli).unwrap();
             let (__handle, addr) = run_server(*LOCALHOST, storage, sequencer).unwrap();
             match client(addr).request::<Out>(method, params.clone()).await {
                 Ok(r) => return Ok(r),
@@ -562,7 +563,7 @@ mod tests {
             #[tokio::test]
             async fn real_data() {
                 let storage = Storage::migrate("desync.sqlite".into()).unwrap();
-                let sequencer = sequencer::Client::goerli().unwrap();
+                let sequencer = sequencer::Client::new(Chain::Goerli).unwrap();
                 let (__handle, addr) = run_server(*LOCALHOST, storage, sequencer).unwrap();
                 let params = rpc_params!(
                     *VALID_CONTRACT_ADDR,
@@ -835,7 +836,7 @@ mod tests {
         #[tokio::test]
         async fn returns_not_found_if_we_dont_know_about_the_contract() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = sequencer::Client::goerli().unwrap();
+            let sequencer = sequencer::Client::new(Chain::Goerli).unwrap();
             let (__handle, addr) = run_server(
                 SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)),
                 storage,
@@ -911,7 +912,7 @@ mod tests {
                 tx.commit().unwrap();
             }
 
-            let sequencer = sequencer::Client::goerli().unwrap();
+            let sequencer = sequencer::Client::new(Chain::Goerli).unwrap();
             let (__handle, addr) = run_server(
                 SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)),
                 storage,
@@ -1235,7 +1236,7 @@ mod tests {
     #[tokio::test]
     async fn block_number() {
         let storage = Storage::in_memory().unwrap();
-        let sequencer = sequencer::Client::goerli().unwrap();
+        let sequencer = sequencer::Client::new(Chain::Goerli).unwrap();
         let (_handle, addr) = run_server(*LOCALHOST, storage, sequencer).unwrap();
         let params = rpc_params!();
         client(addr)
@@ -1248,7 +1249,7 @@ mod tests {
     #[should_panic]
     async fn chain_id() {
         let storage = Storage::in_memory().unwrap();
-        let sequencer = sequencer::Client::goerli().unwrap();
+        let sequencer = sequencer::Client::new(Chain::Goerli).unwrap();
         let (_handle, addr) = run_server(*LOCALHOST, storage, sequencer).unwrap();
         let params = rpc_params!();
         client(addr)
@@ -1261,7 +1262,7 @@ mod tests {
     #[should_panic]
     async fn pending_transactions() {
         let storage = Storage::in_memory().unwrap();
-        let sequencer = sequencer::Client::goerli().unwrap();
+        let sequencer = sequencer::Client::new(Chain::Goerli).unwrap();
         let (_handle, addr) = run_server(*LOCALHOST, storage, sequencer).unwrap();
         let params = rpc_params!();
         client(addr)
@@ -1274,7 +1275,7 @@ mod tests {
     #[should_panic]
     async fn protocol_version() {
         let storage = Storage::in_memory().unwrap();
-        let sequencer = sequencer::Client::goerli().unwrap();
+        let sequencer = sequencer::Client::new(Chain::Goerli).unwrap();
         let (_handle, addr) = run_server(*LOCALHOST, storage, sequencer).unwrap();
         let params = rpc_params!();
         client(addr)
@@ -1287,7 +1288,7 @@ mod tests {
     #[should_panic]
     async fn syncing() {
         let storage = Storage::in_memory().unwrap();
-        let sequencer = sequencer::Client::goerli().unwrap();
+        let sequencer = sequencer::Client::new(Chain::Goerli).unwrap();
         let (_handle, addr) = run_server(*LOCALHOST, storage, sequencer).unwrap();
         let params = rpc_params!();
         use crate::rpc::types::reply::Syncing;


### PR DESCRIPTION
This PR adds support for mainnet contract addresses. As a consequence, we can now fetch logs etc for the Starknet mainnet chain. Previously this only worked correctly for Goerli.

A consequence of this change is that the `Chain` type must now be passed around to many locations. This is why so many files are touched -- but most of them are minor changes.

There is probably a more elegant solution to this, probably by creating a type more similar to the `Sequencer` which owns its chain parameter. But since the current functions are mostly free functions, this meant passing the chain parameter downwards.