### PR TITLE
Smaller changes

### DIFF
--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -11,8 +11,10 @@ async fn main() {
     // TODO: pick the correct sequencer based on the Ethereum chain.
     let sequencer = sequencer::Client::new(pathfinder_lib::ethereum::Chain::Goerli).unwrap();
 
-    let (_handle, local_addr) = rpc::run_server(config.http_rpc_addr, storage, sequencer)
-        .expect("⚠️ Failed to start HTTP-RPC server");
+    let api = rpc::api::RpcApi::new(storage, sequencer);
+
+    let (_handle, local_addr) =
+        rpc::run_server(config.http_rpc_addr, api).expect("⚠️ Failed to start HTTP-RPC server");
     println!("📡 HTTP-RPC server started on: {}", local_addr);
     let () = std::future::pending().await;
 }

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -45,6 +45,18 @@ pub struct ContractCode {
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct EntryPoint(pub StarkHash);
 
+impl EntryPoint {
+    /// Returns a new EntryPoint which has been truncated to fit from Keccak256 digest of input.
+    ///
+    /// See: <https://starknet.io/documentation/contracts/#function_selector>
+    pub fn hashed(input: &[u8]) -> Self {
+        use sha3::Digest;
+        EntryPoint(crate::state::contract_hash::truncated_keccak(
+            <[u8; 32]>::from(sha3::Keccak256::digest(input)),
+        ))
+    }
+}
+
 /// A single parameter passed to a StarkNet `call`.
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CallParam(pub StarkHash);

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -13,8 +13,6 @@ use crate::{
             BlockHashOrTag, BlockNumberOrTag,
         },
     },
-    sequencer,
-    storage::Storage,
 };
 use ::serde::Deserialize;
 use jsonrpsee::{
@@ -24,14 +22,9 @@ use jsonrpsee::{
 use std::{net::SocketAddr, result::Result};
 
 /// Starts the HTTP-RPC server.
-pub fn run_server(
-    addr: SocketAddr,
-    storage: Storage,
-    sequencer: sequencer::Client,
-) -> Result<(HttpServerHandle, SocketAddr), Error> {
+pub fn run_server(addr: SocketAddr, api: RpcApi) -> Result<(HttpServerHandle, SocketAddr), Error> {
     let server = HttpServerBuilder::default().build(addr)?;
     let local_addr = server.local_addr()?;
-    let api = RpcApi::new(storage, sequencer);
     let mut module = RpcModule::new(api);
     module.register_async_method("starknet_getBlockByHash", |params, context| async move {
         #[derive(Debug, Deserialize)]
@@ -204,7 +197,9 @@ mod tests {
         core::{StarknetChainId, StarknetProtocolVersion},
         ethereum::Chain,
         rpc::run_server,
+        sequencer,
         sequencer::test_utils::*,
+        storage::Storage,
     };
     use assert_matches::assert_matches;
     use jsonrpsee::{
@@ -236,7 +231,8 @@ mod tests {
             // Restart the server each time (and implicitly the sequencer client, which actually does the job)
             let storage = Storage::in_memory().unwrap();
             let sequencer = sequencer::Client::new(Chain::Goerli).unwrap();
-            let (__handle, addr) = run_server(*LOCALHOST, storage, sequencer).unwrap();
+            let api = RpcApi::new(storage, sequencer);
+            let (__handle, addr) = run_server(*LOCALHOST, api).unwrap();
             match client(addr).request::<Out>(method, params.clone()).await {
                 Ok(r) => return Ok(r),
                 Err(e) => match &e {
@@ -564,7 +560,8 @@ mod tests {
             async fn real_data() {
                 let storage = Storage::migrate("desync.sqlite".into()).unwrap();
                 let sequencer = sequencer::Client::new(Chain::Goerli).unwrap();
-                let (__handle, addr) = run_server(*LOCALHOST, storage, sequencer).unwrap();
+                let api = RpcApi::new(storage, sequencer);
+                let (__handle, addr) = run_server(*LOCALHOST, api).unwrap();
                 let params = rpc_params!(
                     *VALID_CONTRACT_ADDR,
                     *VALID_KEY,
@@ -834,12 +831,8 @@ mod tests {
         async fn returns_not_found_if_we_dont_know_about_the_contract() {
             let storage = Storage::in_memory().unwrap();
             let sequencer = sequencer::Client::new(Chain::Goerli).unwrap();
-            let (__handle, addr) = run_server(
-                SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)),
-                storage,
-                sequencer,
-            )
-            .unwrap();
+            let api = RpcApi::new(storage, sequencer);
+            let (__handle, addr) = run_server(*LOCALHOST, api).unwrap();
 
             let not_found = client(addr)
                 .request::<Code>(
@@ -908,12 +901,8 @@ mod tests {
             }
 
             let sequencer = sequencer::Client::new(Chain::Goerli).unwrap();
-            let (__handle, addr) = run_server(
-                SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)),
-                storage,
-                sequencer,
-            )
-            .unwrap();
+            let api = RpcApi::new(storage, sequencer);
+            let (__handle, addr) = run_server(*LOCALHOST, api).unwrap();
 
             let client = client(addr);
 
@@ -1232,7 +1221,8 @@ mod tests {
     async fn block_number() {
         let storage = Storage::in_memory().unwrap();
         let sequencer = sequencer::Client::new(Chain::Goerli).unwrap();
-        let (_handle, addr) = run_server(*LOCALHOST, storage, sequencer).unwrap();
+        let api = RpcApi::new(storage, sequencer);
+        let (__handle, addr) = run_server(*LOCALHOST, api).unwrap();
         let params = rpc_params!();
         client(addr)
             .request::<u64>("starknet_blockNumber", params)
@@ -1245,7 +1235,8 @@ mod tests {
     async fn chain_id() {
         let storage = Storage::in_memory().unwrap();
         let sequencer = sequencer::Client::new(Chain::Goerli).unwrap();
-        let (_handle, addr) = run_server(*LOCALHOST, storage, sequencer).unwrap();
+        let api = RpcApi::new(storage, sequencer);
+        let (__handle, addr) = run_server(*LOCALHOST, api).unwrap();
         let params = rpc_params!();
         client(addr)
             .request::<StarknetChainId>("starknet_chainId", params)
@@ -1258,7 +1249,8 @@ mod tests {
     async fn pending_transactions() {
         let storage = Storage::in_memory().unwrap();
         let sequencer = sequencer::Client::new(Chain::Goerli).unwrap();
-        let (_handle, addr) = run_server(*LOCALHOST, storage, sequencer).unwrap();
+        let api = RpcApi::new(storage, sequencer);
+        let (__handle, addr) = run_server(*LOCALHOST, api).unwrap();
         let params = rpc_params!();
         client(addr)
             .request::<()>("starknet_pendingTransactions", params)
@@ -1271,7 +1263,8 @@ mod tests {
     async fn protocol_version() {
         let storage = Storage::in_memory().unwrap();
         let sequencer = sequencer::Client::new(Chain::Goerli).unwrap();
-        let (_handle, addr) = run_server(*LOCALHOST, storage, sequencer).unwrap();
+        let api = RpcApi::new(storage, sequencer);
+        let (__handle, addr) = run_server(*LOCALHOST, api).unwrap();
         let params = rpc_params!();
         client(addr)
             .request::<StarknetProtocolVersion>("starknet_protocolVersion", params)
@@ -1284,7 +1277,8 @@ mod tests {
     async fn syncing() {
         let storage = Storage::in_memory().unwrap();
         let sequencer = sequencer::Client::new(Chain::Goerli).unwrap();
-        let (_handle, addr) = run_server(*LOCALHOST, storage, sequencer).unwrap();
+        let api = RpcApi::new(storage, sequencer);
+        let (__handle, addr) = run_server(*LOCALHOST, api).unwrap();
         let params = rpc_params!();
         use crate::rpc::types::reply::Syncing;
         client(addr)

--- a/crates/pathfinder/src/state/contract_hash.rs
+++ b/crates/pathfinder/src/state/contract_hash.rs
@@ -206,7 +206,7 @@ impl HashChain {
 
 /// See:
 /// <https://github.com/starkware-libs/cairo-lang/blob/64a7f6aed9757d3d8d6c28bd972df73272b0cb0a/src/starkware/starknet/public/abi.py#L21-L26>
-fn truncated_keccak(mut plain: [u8; 32]) -> StarkHash {
+pub(crate) fn truncated_keccak(mut plain: [u8; 32]) -> StarkHash {
     // python code masks with (2**250 - 1) which starts 0x03 and is followed by 31 0xff in be
     // truncation is needed not to overflow the field element.
     plain[0] &= 0x03;

--- a/crates/pathfinder/src/state/contract_hash.rs
+++ b/crates/pathfinder/src/state/contract_hash.rs
@@ -490,3 +490,23 @@ mod json {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn truncated_keccak_matches_pythonic() {
+        use super::truncated_keccak;
+        use pedersen::StarkHash;
+        use sha3::{Digest, Keccak256};
+        let all_set = Keccak256::digest(&[0xffu8; 32]);
+        assert!(all_set[0] > 0xf);
+        let truncated = truncated_keccak(all_set.into());
+        assert_eq!(
+            truncated,
+            StarkHash::from_hex_str(
+                "01c584056064687e149968cbab758a3376d22aedc6a55823d1b3ecbee81b8fb9"
+            )
+            .unwrap()
+        );
+    }
+}


### PR DESCRIPTION
Smaller preparatory changes before the larger PR.

* Simplify the state building in get_code tests
* add EntryPoint::hashed because why not (used in call tests)
* pull RpcApi creation out of `run_server`
* test case

The RpcApi creation will save me from editing all of the places where `run_server` is called again, and I can't really see any reason why it should be created by `run_server`.