### PR TITLE
Call rpc implementation using cairo-lang from python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,6 @@ jobs:
           source .venv/bin/activate
           pip install --upgrade pip
           pip install --requirement requirements-dev.txt
-          pip install cairo-lang==0.7.1
 
       - name: Test (python)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,21 +74,34 @@ jobs:
       - name: Prepare py/
         run: |
           cd py
+          python -m venv .venv
+          source .venv/bin/activate
           pip install --upgrade pip
           pip install --requirement requirements-dev.txt
           pip install cairo-lang==0.7.1
 
       - name: Test (python)
         run: |
+          source py/.venv/bin/activate
           cd py
           pytest
 
       - name: Formatting (python)
         run: |
+          source py/.venv/bin/activate
           cd py
           black --check src/
 
       - name: Lints (python)
         run: |
+          source py/.venv/bin/activate
           cd py
           flake8 src/
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Integration (rust)
+        run: |
+          source py/.venv/bin/activate
+          timeout 5m cargo test -p pathfinder -- cairo::ext_py --ignored

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           cd py
           pip install --upgrade pip
           pip install --requirement requirements-dev.txt
-          pip install cairo-lang==0.7.0
+          pip install cairo-lang==0.7.1
 
       - name: Test (python)
         run: |

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -38,3 +38,4 @@ zstd = "0.10"
 [dev-dependencies]
 assert_matches = "1.5.0"
 pretty_assertions = "1.0.0"
+tempfile = "3"

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -1,4 +1,4 @@
-use pathfinder_lib::{config, rpc, sequencer, storage::Storage};
+use pathfinder_lib::{cairo, config, rpc, sequencer, storage::Storage};
 
 #[tokio::main]
 async fn main() {
@@ -10,7 +10,19 @@ async fn main() {
     let storage = Storage::migrate("database.sqlite".into()).unwrap();
     // TODO: pass the correct value from ethereum::chain.
     let sequencer = sequencer::Client::new(pathfinder_lib::ethereum::Chain::Goerli).unwrap();
-    let api = rpc::api::RpcApi::new(storage, sequencer, pathfinder_lib::ethereum::Chain::Goerli);
+
+    // TODO: the error could be recovered, but currently it's required for startup. There should
+    // not be other reason for the start to fail than python script not firing up.
+    let (call_handle, _jh) = cairo::ext_py::start(
+        storage.path().into(),
+        std::num::NonZeroUsize::new(2).unwrap(),
+        futures::future::pending(),
+    )
+    .await
+    .unwrap();
+
+    let api = rpc::api::RpcApi::new(storage, sequencer, pathfinder_lib::ethereum::Chain::Goerli)
+        .with_call_handling(call_handle);
 
     let (_handle, local_addr) =
         rpc::run_server(config.http_rpc_addr, api).expect("⚠️ Failed to start HTTP-RPC server");

--- a/crates/pathfinder/src/cairo.rs
+++ b/crates/pathfinder/src/cairo.rs
@@ -1,0 +1,1 @@
+pub mod ext_py;

--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -134,6 +134,7 @@ mod tests {
     use tokio::sync::oneshot;
 
     #[tokio::test]
+    #[ignore] // these tests require that you've entered into python venv
     async fn call_like_in_python() {
         let db_file = tempfile::NamedTempFile::new().unwrap();
 
@@ -194,13 +195,12 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore] // these tests require that you've entered into python venv
     async fn call_like_in_python_ten_times() {
         use futures::stream::StreamExt;
 
         let db_file = tempfile::NamedTempFile::new().unwrap();
 
-        // in python we recreate the schema, but without foreign keys on the global state
-        // here we cannot do a similar thing... but we can turn them off.
         let s = crate::storage::Storage::migrate(PathBuf::from(db_file.path())).unwrap();
 
         let mut conn = s.connection().unwrap();
@@ -224,7 +224,9 @@ mod tests {
         .await
         .unwrap();
 
-        let mut jhs = (0..10)
+        let count = 10;
+
+        let mut jhs = (0..count)
             .map(move |_| {
                 tokio::task::spawn({
                     let handle = handle.clone();
@@ -251,7 +253,7 @@ mod tests {
             })
             .collect::<futures::stream::FuturesUnordered<_>>();
 
-        for _ in 0..10 {
+        for _ in 0..count {
             jhs.next().await.unwrap().unwrap();
         }
 

--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -109,6 +109,7 @@ enum SubprocessExitReason {
     UnrecoverableIO,
     Shutdown,
     Death,
+    Cancellation,
 }
 
 /// Errors which can happen during an RPC alike round with the subprocess.

--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -102,7 +102,7 @@ enum SubProcessEvent {
     CommandHandled(u32, Option<Timings>, Status),
 }
 
-/// The reason the [`launch_python`] exited.
+/// The reason the [`sub_process::launch_python`] exited.
 #[derive(Debug)]
 enum SubprocessExitReason {
     ClosedChannel,

--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -118,7 +118,7 @@ enum SubprocessError {
     IO,
     /// Python sent us invalid response
     InvalidJson(serde_json::Error),
-    /// Python sent us a reseponse we couldn't understand
+    /// Python sent us a response we couldn't understand
     InvalidResponse,
 }
 

--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -1,0 +1,365 @@
+//! External python process pool for execute calls.
+//!
+//! The python processes are executing `$REPO_ROOT/py/src/call.py` and communicate over by sending
+//! and receiving json + `'\n'`. Main entry point is the [`service::start`] which manages running
+//! given number of N processes. The python script uses sqlite to read pathfinder's database, which
+//! should not cause issues in WAL mode.
+//!
+//! Use of the call functionality happens through [`Handle::call`], which hands out futures in
+//! exchange for [`Call`] and [`BlockHashOrTag`], former selects the contract and method to call,
+//! latter selectes "when" to call it on the history. None of the block or tags are resolved over
+//! at rust side, because transactions cannot carry over between processes.
+//!
+//! While the python script does attempt to resolve "latest", it probably needs fixing. To make it
+//! support "pending", a feature needs to be added which flushes the "open" pending to a
+//! global_state, and after that, calls can be made to it's `block_hash` for which we probably need
+//! to add an alternative way to use a hash directly rather as a root than assume it's a block hash.
+
+use crate::core::CallResultValue;
+use crate::rpc::types::{request::Call, BlockHashOrTag};
+use std::sync::Arc;
+use tokio::sync::{mpsc, oneshot, Mutex};
+
+mod de;
+use de::{ErrorKind, Status, Timings};
+
+mod ser;
+mod sub_process;
+
+mod service;
+pub use service::start;
+
+/// Handle to the python executors work queue. Cloneable and shareable.
+#[derive(Clone)]
+pub struct Handle {
+    command_tx: mpsc::Sender<Command>,
+}
+
+impl Handle {
+    /// Execute the given call on the python cairo-lang executors.
+    pub async fn call(
+        &self,
+        call: Call,
+        at_block: BlockHashOrTag,
+    ) -> Result<Vec<CallResultValue>, CallFailure> {
+        let (tx, rx) = oneshot::channel();
+
+        self.command_tx
+            .send((call, at_block, tx))
+            .await
+            .map_err(|_| CallFailure::Shutdown)?;
+
+        match rx.await {
+            Ok(x) => x,
+            Err(_closed) => Err(CallFailure::Shutdown),
+        }
+    }
+}
+
+/// Reasons for a call to fail.
+#[derive(Debug)]
+pub enum CallFailure {
+    /// The requested block could not be found.
+    NoSuchBlock,
+    /// The called top-level contract could not be found.
+    NoSuchContract,
+    /// `cairo-lang` failed the call, string has the exception name.
+    ExecutionFailed(String),
+    /// Internal, opaque-ish failure reason, none of them signal an issue with the call.
+    Internal(&'static str),
+    /// Channel related issue or shutting down.
+    Shutdown,
+}
+
+impl From<ErrorKind> for CallFailure {
+    fn from(e: ErrorKind) -> Self {
+        use ErrorKind::*;
+        match e {
+            NoSuchBlock => CallFailure::NoSuchBlock,
+            NoSuchContract => CallFailure::NoSuchContract,
+            InvalidSchemaVersion => CallFailure::Internal("Wrong database version"),
+            InvalidCommand => CallFailure::Internal("Invalid json sent"),
+        }
+    }
+}
+
+/// Alias for the "mpmc" queue. Flume could had been used, but this is probably as fast as it needs
+/// to be.
+type SharedReceiver<T> = Arc<Mutex<mpsc::Receiver<T>>>;
+
+/// Alias for the type used to transfer commands over to executors.
+type Command = (
+    Call,
+    BlockHashOrTag,
+    oneshot::Sender<Result<Vec<CallResultValue>, CallFailure>>,
+);
+
+/// Informational events from python process executors.
+#[derive(Debug)]
+enum SubProcessEvent {
+    ProcessLaunched(u32),
+    Failure(Option<u32>, anyhow::Error),
+    CommandHandled(u32, Option<Timings>, Status),
+}
+
+/// The reason the [`launch_python`] exited.
+#[derive(Debug)]
+enum SubprocessExitReason {
+    ClosedChannel,
+    UnrecoverableIO,
+    Shutdown,
+    Death,
+}
+
+/// Errors which can happen during an RPC alike round with the subprocess.
+enum SubprocessError {
+    /// Input or output related issues; most likely a broken pipe due to child process dying.
+    IO,
+    /// Python sent us invalid response
+    InvalidJson(serde_json::Error),
+    /// Python sent us a reseponse we couldn't understand
+    InvalidResponse,
+}
+
+impl From<std::io::Error> for SubprocessError {
+    fn from(_: std::io::Error) -> Self {
+        SubprocessError::IO
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pedersen::StarkHash;
+    use std::path::PathBuf;
+    use tokio::sync::oneshot;
+
+    #[tokio::test]
+    async fn call_like_in_python() {
+        let db_file = tempfile::NamedTempFile::new().unwrap();
+
+        // in python we recreate the schema, but without foreign keys on the global state
+        // here we cannot do a similar thing... but we can turn them off.
+        let s = crate::storage::Storage::migrate(PathBuf::from(db_file.path())).unwrap();
+
+        let mut conn = s.connection().unwrap();
+        conn.execute("PRAGMA foreign_keys = off", []).unwrap();
+        let tx = conn.transaction().unwrap();
+        fill_example_state(&tx);
+        tx.commit().unwrap();
+
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+        let (handle, jh) = super::start(
+            PathBuf::from(db_file.path()),
+            std::num::NonZeroUsize::new(1).unwrap(),
+            async move {
+                let _ = shutdown_rx.await;
+            },
+        )
+        .await
+        .unwrap();
+
+        let res = handle
+            .call(
+                super::Call {
+                    contract_address: crate::core::ContractAddress(
+                        StarkHash::from_hex_str(
+                            "057dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374",
+                        )
+                        .unwrap(),
+                    ),
+                    calldata: vec![crate::core::CallParam(
+                        StarkHash::from_hex_str("84").unwrap(),
+                    )],
+                    entry_point_selector: crate::core::EntryPoint::hashed(&b"get_value"[..]),
+                },
+                super::BlockHashOrTag::Hash(crate::core::StarknetBlockHash(
+                    StarkHash::from_be_slice(&b"some blockhash somewhere"[..]).unwrap(),
+                )),
+            )
+            .await;
+
+        assert_eq!(
+            &res.unwrap(),
+            &[crate::core::CallResultValue(
+                StarkHash::from_hex_str("3").unwrap()
+            )]
+        );
+
+        drop(handle);
+
+        shutdown_tx.send(()).unwrap();
+
+        jh.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn call_like_in_python_ten_times() {
+        use futures::stream::StreamExt;
+
+        let db_file = tempfile::NamedTempFile::new().unwrap();
+
+        // in python we recreate the schema, but without foreign keys on the global state
+        // here we cannot do a similar thing... but we can turn them off.
+        let s = crate::storage::Storage::migrate(PathBuf::from(db_file.path())).unwrap();
+
+        let mut conn = s.connection().unwrap();
+        conn.execute("PRAGMA foreign_keys = off", []).unwrap();
+
+        let tx = conn.transaction().unwrap();
+
+        fill_example_state(&tx);
+
+        tx.commit().unwrap();
+
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+        let (handle, jh) = super::start(
+            PathBuf::from(db_file.path()),
+            std::num::NonZeroUsize::new(2).unwrap(),
+            async move {
+                let _ = shutdown_rx.await;
+            },
+        )
+        .await
+        .unwrap();
+
+        let mut jhs = (0..10)
+            .map(move |_| {
+                tokio::task::spawn({
+                    let handle = handle.clone();
+                    async move {
+                        handle.call(
+                            super::Call {
+                                contract_address: crate::core::ContractAddress(
+                                    StarkHash::from_hex_str(
+                                        "057dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374",
+                                    )
+                                    .unwrap(),
+                                ),
+                                calldata: vec![crate::core::CallParam(
+                                    StarkHash::from_hex_str("84").unwrap(),
+                                )],
+                                entry_point_selector: crate::core::EntryPoint::hashed(&b"get_value"[..]),
+                            },
+                            super::BlockHashOrTag::Hash(crate::core::StarknetBlockHash(
+                                StarkHash::from_be_slice(&b"some blockhash somewhere"[..]).unwrap(),
+                            ))
+                        ).await.unwrap();
+                    }
+                })
+            })
+            .collect::<futures::stream::FuturesUnordered<_>>();
+
+        for _ in 0..10 {
+            jhs.next().await.unwrap().unwrap();
+        }
+
+        shutdown_tx.send(()).unwrap();
+
+        jh.await.unwrap();
+    }
+
+    fn fill_example_state(tx: &rusqlite::Transaction) {
+        let contract_definition = zstd::decode_all(std::io::Cursor::new(include_bytes!(
+            "../../fixtures/contract_definition.json.zst"
+        )))
+        .unwrap();
+
+        let address = StarkHash::from_hex_str(
+            "057dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374",
+        )
+        .unwrap();
+        let expected_hash = StarkHash::from_hex_str(
+            "050b2148c0d782914e0b12a1a32abe5e398930b7e914f82c65cb7afce0a0ab9b",
+        )
+        .unwrap();
+
+        let (abi, bytecode, hash) =
+            crate::state::contract_hash::extract_abi_code_hash(&*contract_definition).unwrap();
+
+        assert_eq!(hash, expected_hash);
+
+        crate::storage::ContractCodeTable::insert(
+            tx,
+            crate::core::ContractHash(hash),
+            &abi,
+            &bytecode,
+            &contract_definition,
+        )
+        .unwrap();
+
+        crate::storage::ContractsTable::insert(
+            tx,
+            crate::core::ContractAddress(address),
+            crate::core::ContractHash(hash),
+        )
+        .unwrap();
+
+        // this will create the table, not created by migration
+        crate::state::state_tree::ContractsStateTree::load(
+            tx,
+            crate::core::ContractRoot(StarkHash::ZERO),
+        )
+        .unwrap();
+
+        crate::state::state_tree::GlobalStateTree::load(
+            tx,
+            crate::core::GlobalRoot(StarkHash::ZERO),
+        )
+        .unwrap();
+
+        tx.execute("insert into tree_contracts (hash, data, ref_count) values (?1, ?2, 1)",
+            rusqlite::params![
+                &hex::decode("04fb440e8ca9b74fc12a22ebffe0bc0658206337897226117b985434c239c028").unwrap()[..],
+                &hex::decode("00000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000084fb").unwrap()[..],
+            ]).unwrap();
+
+        tx.execute(
+            "insert into contract_states (state_hash, hash, root) values (?1, ?2, ?3)",
+            rusqlite::params![
+                &hex::decode("002e9723e54711aec56e3fb6ad1bb8272f64ec92e0a43a20feed943b1d4f73c5")
+                    .unwrap()[..],
+                &hex::decode("050b2148c0d782914e0b12a1a32abe5e398930b7e914f82c65cb7afce0a0ab9b")
+                    .unwrap()[..],
+                &hex::decode("04fb440e8ca9b74fc12a22ebffe0bc0658206337897226117b985434c239c028")
+                    .unwrap()[..],
+            ],
+        )
+        .unwrap();
+
+        tx.execute(
+            "insert into tree_global (hash, data, ref_count) values (?1, ?2, 1)",
+            rusqlite::params![
+                &hex::decode("0704dfcbc470377c68e6f5ffb83970ebd0d7c48d5b8d2f4ed61a24e795e034bd").unwrap()[..],
+                &hex::decode("002e9723e54711aec56e3fb6ad1bb8272f64ec92e0a43a20feed943b1d4f73c5057dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374fb").unwrap()[..],
+            ],
+        )
+        .unwrap();
+
+        tx.execute(
+            "insert into global_state (starknet_block_hash, starknet_block_number, starknet_block_timestamp, starknet_global_root, ethereum_transaction_hash, ethereum_log_index) values (?1, 1, 1, ?, ?, 1)",
+            rusqlite::params![
+                &StarkHash::from_be_slice(&b"some blockhash somewhere"[..]).unwrap().to_be_bytes()[..],
+                &hex::decode("0704dfcbc470377c68e6f5ffb83970ebd0d7c48d5b8d2f4ed61a24e795e034bd").unwrap()[..],
+                &StarkHash::from_be_slice(&b"some ethereum hash"[..]).unwrap().to_be_bytes()[..],
+            ]
+        )
+        .unwrap();
+
+        if false {
+            let mut stmt = tx
+                .prepare("select starknet_block_hash from global_state")
+                .unwrap();
+            let mut rows = stmt.query([]).unwrap();
+            while let Some(row) = rows.next().unwrap() {
+                let first = row.get_ref(0).expect("get column");
+
+                println!("{:?}", first);
+
+                let first = first.as_blob().expect("cannot read it as a blob");
+                println!("{}", hex::encode(first));
+            }
+        }
+    }
+}

--- a/crates/pathfinder/src/cairo/ext_py/de.rs
+++ b/crates/pathfinder/src/cairo/ext_py/de.rs
@@ -1,0 +1,127 @@
+//! The json deserializable types
+
+use super::{CallFailure, SubprocessError};
+use crate::core::CallResultValue;
+
+/// The python loop currently responds with these four possibilities. An enum would be more
+/// appropriate.
+///
+/// This is [`ChildResponse::refine`]'d into [`RefinedChildResponse`]
+#[derive(serde::Deserialize, Debug)]
+#[allow(unused)]
+pub(crate) struct ChildResponse<'a> {
+    /// Describes the outcome with three alternatives (good, known error, unknown error)
+    status: Status,
+    /// Head of the raw exception message limited to 197 first characters and an three dots for
+    /// longer. Probably okay to give as a hint in the internal error message.
+    #[serde(borrow)]
+    exception: Option<std::borrow::Cow<'a, str>>,
+    /// Enumeration of "known errors", present when `status` is [`Status::Error`].
+    kind: Option<ErrorKind>,
+    /// Timing information, possibly available.
+    #[serde(default)]
+    timings: Timings,
+    /// The real output from the contract when `status` is [`Status::Ok`].
+    #[serde(default)]
+    output: Vec<CallResultValue>,
+}
+
+impl<'a> ChildResponse<'a> {
+    pub(super) fn refine(mut self) -> Result<RefinedChildResponse<'a>, SubprocessError> {
+        match (&self.status, &mut self.kind, &mut self.exception) {
+            (Status::Ok, None, None) => Ok(RefinedChildResponse {
+                status: RefinedStatus::Ok(self.output),
+                timings: self.timings,
+            }),
+            (Status::Error, x @ Some(_), None) => Ok(RefinedChildResponse {
+                status: RefinedStatus::Error(x.take().unwrap()),
+                timings: self.timings,
+            }),
+            (Status::Failed, None, s @ &mut Some(_)) => Ok(RefinedChildResponse {
+                status: RefinedStatus::Failed(s.take().unwrap()),
+                timings: self.timings,
+            }),
+            // these should not happen, so turn them into similar as serde_json errors
+            _ => Err(SubprocessError::InvalidResponse),
+        }
+    }
+}
+
+impl RefinedChildResponse<'_> {
+    pub fn into_messages(
+        self,
+    ) -> (
+        Option<Timings>,
+        Status,
+        Result<Vec<CallResultValue>, CallFailure>,
+    ) {
+        match self {
+            RefinedChildResponse {
+                timings,
+                status: RefinedStatus::Ok(x),
+            } => (Some(timings), Status::Ok, Ok(x)),
+            RefinedChildResponse {
+                timings,
+                status: RefinedStatus::Error(e),
+            } => (Some(timings), Status::Error, Err(CallFailure::from(e))),
+            RefinedChildResponse {
+                timings,
+                status: RefinedStatus::Failed(s),
+            } => (
+                Some(timings),
+                Status::Failed,
+                Err(CallFailure::ExecutionFailed(s.to_string())),
+            ),
+        }
+    }
+}
+
+/// Different kinds of errors the python side recognizes.
+#[derive(serde::Deserialize, Debug)]
+pub enum ErrorKind {
+    #[serde(rename = "NO_SUCH_BLOCK")]
+    NoSuchBlock,
+    #[serde(rename = "NO_SUCH_CONTRACT")]
+    NoSuchContract,
+    #[serde(rename = "INVALID_SCHEMA_VERSION")]
+    InvalidSchemaVersion,
+    #[serde(rename = "INVALID_INPUT")]
+    InvalidCommand,
+}
+
+#[derive(serde::Deserialize, PartialEq, Debug)]
+pub enum Status {
+    /// No errors
+    #[serde(rename = "ok")]
+    Ok,
+    /// Known error happened
+    #[serde(rename = "error")]
+    Error,
+    /// Any of the cairo-lang errors happened
+    #[serde(rename = "failed")]
+    Failed,
+}
+
+/// Just something python internally recorded, so we'd know at least something.
+/// No plans aside from logging for now for the data.
+#[derive(serde::Deserialize, Debug, Default)]
+#[allow(unused)]
+pub struct Timings {
+    /// Time it took to parse, before opening the transaction.
+    parsing: Option<f64>,
+    /// Time it took to find the tree root, and execute.
+    execution: Option<f64>,
+}
+
+/// The format we'd prefer to process instead of [`ChildResponse`].
+pub struct RefinedChildResponse<'a> {
+    status: RefinedStatus<'a>,
+    timings: Timings,
+}
+
+/// More sensible alternative to [`Status`].
+pub enum RefinedStatus<'a> {
+    Ok(Vec<CallResultValue>),
+    Error(ErrorKind),
+    Failed(std::borrow::Cow<'a, str>),
+}

--- a/crates/pathfinder/src/cairo/ext_py/ser.rs
+++ b/crates/pathfinder/src/cairo/ext_py/ser.rs
@@ -1,0 +1,13 @@
+//! The json serializable types
+
+use crate::core::{CallParam, ContractAddress, EntryPoint};
+use crate::rpc::types::BlockHashOrTag;
+
+/// The command we send to the python loop.
+#[derive(serde::Serialize, Debug)]
+pub struct ChildCommand<'a> {
+    pub contract_address: &'a ContractAddress,
+    pub calldata: &'a [CallParam],
+    pub entry_point_selector: &'a EntryPoint,
+    pub at_block: &'a BlockHashOrTag,
+}

--- a/crates/pathfinder/src/cairo/ext_py/service.rs
+++ b/crates/pathfinder/src/cairo/ext_py/service.rs
@@ -1,0 +1,119 @@
+//! Starting and maintaining processes, and the main entry point
+
+use super::{sub_process::launch_python, Command, Handle, SharedReceiver, SubProcessEvent};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::{broadcast, mpsc, Mutex};
+
+/// Starts to maintain a pool of `count` sub-processes which execute the calls.
+///
+/// In general, the launching currently assumes:
+///
+/// - user has entered the python virtual environment created for this project per instructions
+/// under `$REPO_ROOT/py/README.md`
+/// - `call.py` can be found from the `$VIRTUAL_ENV/../src/call.py`
+/// - user has compatible python, 3.7+ should work just fine
+///
+/// Returns an error if executing calls in a sub-process is not supported.
+pub async fn start(
+    database_path: PathBuf,
+    count: std::num::NonZeroUsize,
+    stop_flag: impl std::future::Future<Output = ()> + Send + 'static,
+) -> anyhow::Result<(Handle, tokio::task::JoinHandle<()>)> {
+    // channel sizes are conservative but probably enough for many workers; should investigate mpmc
+    // if the lock overhead on command_rx before making these deeper.
+    let (command_tx, command_rx) = mpsc::channel(1);
+    let (status_tx, mut status_rx) = mpsc::channel(1);
+    // this will never need to become deeper
+    let (child_shutdown_tx, _) = broadcast::channel(1);
+    let command_rx: SharedReceiver<Command> = Arc::new(Mutex::new(command_rx));
+
+    // TODO: might be better to use tokio's JoinSet?
+    let mut joinhandles = futures::stream::FuturesUnordered::new();
+
+    let jh = tokio::task::spawn(launch_python(
+        database_path.clone(),
+        Arc::clone(&command_rx),
+        status_tx.clone(),
+        child_shutdown_tx.subscribe(),
+    ));
+
+    joinhandles.push(jh);
+
+    match status_rx.recv().await {
+        Some(SubProcessEvent::ProcessLaunched(_pid)) => {
+            // good, now we can launch the other processes requested later
+        }
+        Some(SubProcessEvent::Failure(_maybe_pid, e)) => {
+            return Err(e.context("Launch first python executor"));
+        }
+        Some(SubProcessEvent::CommandHandled(..)) => {
+            unreachable!("first message must not be CommandHandled");
+        }
+        None => unreachable!("the status_tx exists"),
+    }
+
+    let handle = Handle {
+        command_tx: command_tx.clone(),
+    };
+
+    let jh = tokio::task::spawn(async move {
+        use futures::stream::StreamExt;
+        const WAIT_BEFORE_SPAWN: std::time::Duration = std::time::Duration::from_secs(1);
+
+        // use a sleep activated periodically before launching new processes
+        // not to overwhelm the system
+        let wait_before_spawning = tokio::time::sleep(WAIT_BEFORE_SPAWN);
+        tokio::pin!(wait_before_spawning);
+
+        tokio::pin!(stop_flag);
+
+        loop {
+            let mut spawn = false;
+            tokio::select! {
+                _ = &mut stop_flag => {
+                    // this should be enough to kick everyone off the locking, queue receiving
+                    let _ = child_shutdown_tx.send(());
+                    let _ = joinhandles.into_future().await;
+                    // just exit
+                    return;
+                }
+                Some(evt) = status_rx.recv() => {
+                    match evt {
+                        SubProcessEvent::ProcessLaunched(_) => {},
+                        SubProcessEvent::CommandHandled(_pid, timings, status) => {
+                            println!("{status:?}: {timings:?}");
+                        },
+                        SubProcessEvent::Failure(..) => { /* this is really needed just for startup */ },
+                    }
+                },
+                Some(_maybe_info) = joinhandles.next() => {
+                    println!("one of our python processes have expired: {_maybe_info:?}");
+                    // we should spawn it immediatedly if empty
+                    spawn = joinhandles.is_empty();
+                }
+                _ = &mut wait_before_spawning => {
+                    // spawn if needed
+                    spawn = count.get() > joinhandles.len();
+                }
+            }
+
+            if spawn {
+                let jh = tokio::task::spawn(launch_python(
+                    database_path.clone(),
+                    Arc::clone(&command_rx),
+                    status_tx.clone(),
+                    child_shutdown_tx.subscribe(),
+                ));
+
+                joinhandles.push(jh);
+            } else if count.get() > joinhandles.len() && wait_before_spawning.is_elapsed() {
+                wait_before_spawning
+                    .as_mut()
+                    .reset(tokio::time::Instant::now() + WAIT_BEFORE_SPAWN);
+            }
+        }
+    });
+
+    Ok((handle, jh))
+}

--- a/crates/pathfinder/src/cairo/ext_py/sub_process.rs
+++ b/crates/pathfinder/src/cairo/ext_py/sub_process.rs
@@ -1,0 +1,303 @@
+//! Launching and communication with the subprocess
+
+use super::{
+    de::{ChildResponse, RefinedChildResponse, Status},
+    ser::ChildCommand,
+    CallFailure, Command, SharedReceiver, SubProcessEvent, SubprocessError, SubprocessExitReason,
+};
+use anyhow::Context;
+use std::path::PathBuf;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, ChildStdout};
+use tokio::sync::{broadcast, mpsc};
+
+/// Launches a python subprocess, and executes calls on it until shutdown is initiated.
+///
+/// If the python process is killed, reaping it and restarting new one is handled by [`super::start`],
+/// similarly to spawning this as a task usually handled.
+///
+/// Launching happens in two stages, similar to the python process. Initially we only launch, then
+/// read `"ready\n"` from the subprocess and after that enter the loop where we contend for the
+/// commands.
+pub(super) async fn launch_python(
+    database_path: PathBuf,
+    commands: SharedReceiver<Command>,
+    status_updates: mpsc::Sender<SubProcessEvent>,
+    mut shutdown_rx: broadcast::Receiver<()>,
+) -> Option<(u32, Option<std::process::ExitStatus>, SubprocessExitReason)> {
+    let (mut child, pid, mut input, mut output, mut buffer) = match spawn(database_path).await {
+        Ok(tuple) => tuple,
+        Err(e) => {
+            let e = e.context("Failed to start python subprocess");
+            let _ = status_updates.send(SubProcessEvent::Failure(None, e)).await;
+            return None;
+        }
+    };
+
+    if status_updates
+        .send(SubProcessEvent::ProcessLaunched(pid))
+        .await
+        .is_err()
+    {
+        drop(input);
+        return None;
+    }
+
+    let mut command_buffer = Vec::new();
+
+    let exit_reason = loop {
+        let command = async {
+            let mut locked = commands.lock().await;
+            locked.recv().await
+        };
+
+        tokio::pin!(command);
+
+        let (call, at_block, response) = tokio::select! {
+            // locking is not cancellation safe BUT if the race is lost we don't retry so no
+            // worries on that.
+            maybe_command = &mut command => match maybe_command {
+                Some(tuple) => tuple,
+                None => break SubprocessExitReason::Shutdown,
+            },
+            _ = child.wait() => {
+                // if the python process was killed while we were awaiting for new commands, it
+                // would be zombie until we notice it has died. The wait can be called many times,
+                // and it'll return immediatedly at the top level.
+                break SubprocessExitReason::Death;
+            }
+            _ = shutdown_rx.recv() => {
+                break SubprocessExitReason::Shutdown;
+            },
+        };
+
+        command_buffer.clear();
+
+        let cmd = ChildCommand {
+            contract_address: &call.contract_address,
+            calldata: &call.calldata,
+            entry_point_selector: &call.entry_point_selector,
+            at_block: &at_block,
+        };
+
+        if let Err(e) = serde_json::to_writer(std::io::Cursor::new(&mut command_buffer), &cmd) {
+            eprintln!("Failed to render command {cmd:?} as json: {e:?}");
+            let _ = response.send(Err(CallFailure::Internal(
+                "Failed to render command as json",
+            )));
+            continue;
+        }
+
+        // using tokio::select to race against the shutdown_rx requires additional block to release
+        // the &mut borrow on buffer to have it printed/logged
+        let res = {
+            // AsyncWriteExt::write_all used in the rpc_round is not cancellation safe, but
+            // similar to above, if we lose the race, will kill the subprocess and get out.
+            let rpc_op = rpc_round(&command_buffer, &mut input, &mut output, &mut buffer);
+            tokio::pin!(rpc_op);
+
+            tokio::select! {
+                res = &mut rpc_op => res,
+                _ = shutdown_rx.recv() => {
+                    break SubprocessExitReason::Shutdown;
+                },
+                // no need to await for child dying here, because the event would close the childs
+                // stdout and thus break our read_line and thus return a SubprocessError::IO and
+                // we'd break out.
+            }
+        };
+
+        let (timings, status, sent_response) = match res {
+            Ok(resp) => resp.into_messages(),
+            Err(SubprocessError::InvalidJson(e)) => {
+                // buffer still holds the response... might be good for debugging
+                // this doesn't however mess up our line at once, so no worries.
+                // TODO: log better
+                eprintln!("failed to parse json: {e} on buffer: {buffer:?}");
+                (
+                    None,
+                    Status::Failed,
+                    Err(CallFailure::Internal("Invalid json received")),
+                )
+            }
+            Err(SubprocessError::InvalidResponse) => {
+                eprintln!("failed to understand parsed json on buffer: {buffer:?}");
+                (
+                    None,
+                    Status::Failed,
+                    Err(CallFailure::Internal("Invalid json received")),
+                )
+            }
+            Err(SubprocessError::IO) => {
+                let error = CallFailure::Internal("Input/output");
+                let _ = response.send(Err(error));
+
+                // TODO: consider if we'd just retry; put this back into the queue?
+                break SubprocessExitReason::UnrecoverableIO;
+            }
+        };
+
+        let _ = response.send(sent_response);
+
+        if status_updates
+            .send(SubProcessEvent::CommandHandled(pid, timings, status))
+            .await
+            .is_err()
+        {
+            break SubprocessExitReason::ClosedChannel;
+        }
+
+        if !output.buffer().is_empty() {
+            // some garbage was left in, it shouldn't have; there are extra printlns and we must
+            // assume we've gone out of sync now.
+            // FIXME: log this, hasn't happened.
+            break SubprocessExitReason::UnrecoverableIO;
+        }
+    };
+
+    // important to close up the stdin not to deadlock
+    drop(input);
+    drop(output);
+
+    // give the subprocess a bit of time, since it might be less risky/better for sqlite to
+    // exit/cleanup properly
+    let sleep = tokio::time::sleep(std::time::Duration::from_millis(1000));
+    tokio::pin!(sleep);
+
+    let exit_status = tokio::select! {
+        _ = &mut sleep => {
+            match child.kill().await {
+                Ok(()) => {}
+                Err(e) => println!("Killing python subprocess failed, possibly a race? {e:?}"),
+            }
+
+            // kill already await the child, so there's not much to await here, we should just get the
+            // fused response.
+            match child.wait().await {
+                Ok(status) => Some(status),
+                Err(e) => {
+                    eprintln!("wait on child pid failed: {e:?}");
+                    None
+                }
+            }
+        }
+        exit_status = child.wait() => {
+            exit_status.ok()
+        }
+    };
+
+    Some((pid, exit_status, exit_reason))
+}
+
+async fn spawn(
+    database_path: PathBuf,
+) -> anyhow::Result<(Child, u32, ChildStdin, BufReader<ChildStdout>, String)> {
+    // there is not intentionally any std::fs::exists calls to avoid bringing any TOCTOU issues.
+    let virtual_env = std::env::var_os("VIRTUAL_ENV")
+        .context("VIRTUAL_ENV is not defined; has the user activated virtual environment")?;
+
+    // FIXME: use choom, add something over /proc/self/oom_score_adj ?
+    let mut python_exe = PathBuf::from(&virtual_env);
+    python_exe.push("bin");
+    python_exe.push("python");
+
+    // we assume that VIRTUAL_ENV is at the base of the `py/` directory
+    let mut call_py = PathBuf::from(&virtual_env);
+    call_py.push("..");
+    call_py.push("src");
+    call_py.push("call.py");
+
+    let mut command = tokio::process::Command::new(python_exe);
+
+    command
+        .arg(call_py)
+        .arg(database_path)
+        .env("VIRTUAL_ENV", virtual_env)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .kill_on_drop(true);
+
+    let _inherit_stderr = false;
+
+    #[cfg(debug_assertions)]
+    let _inherit_stderr = true;
+
+    if _inherit_stderr {
+        // in case the file doesn't exist it would be reported here ... probably cannot leave it
+        // like this. exit code 2 is for the python file not being found.
+        //
+        // debug info is a great upside, but for example CTRL-C gets to the child processses as
+        // well, and python will print a stacktrace when an SIGINT happens, which might be
+        // confusing for users, who had just ran a rust program.
+        command.stderr(std::process::Stdio::inherit());
+    } else {
+        command.stderr(std::process::Stdio::null());
+    }
+
+    let mut child = command
+        .spawn()
+        .context("Failed to spawn the new python process; this should only happen when the session is at it's process limit on unix.")?;
+
+    let pid = match child.id() {
+        Some(pid) => pid,
+        None => todo!("child spawned but exited before reading pid"),
+    };
+
+    let input = child.stdin.take().expect("stdin was piped");
+    let output = child.stdout.take().expect("stdout was piped");
+
+    // default buffer is fine for us ... but this is double buffering, for no good reason
+    // it could actually be destroyed even between runs, because the buffer should be empty
+    let mut output = BufReader::new(output);
+    let mut buffer = String::new();
+
+    // reasons for this part to error out:
+    // - invalid schema version
+    // - some other pythonic thing happens, for example, no call.py found
+    let read = output
+        .read_line(&mut buffer)
+        .await
+        .context("Failed to read 'ready' from python process")?;
+
+    anyhow::ensure!(read == 6, "failed to read ready from python process");
+    anyhow::ensure!(
+        // buffer will contain the newline, which doesn't bother serde_json
+        buffer.trim() == "ready",
+        "failed to read ready from python process, read: {buffer:?}"
+    );
+    buffer.clear();
+
+    Ok((child, pid, input, output, buffer))
+}
+
+/// Run a round of writing out the request, and reading a sane response type.
+async fn rpc_round<'a>(
+    cmd: &[u8],
+    input: &mut tokio::process::ChildStdin,
+    output: &mut tokio::io::BufReader<tokio::process::ChildStdout>,
+    buffer: &'a mut String,
+) -> Result<RefinedChildResponse<'a>, SubprocessError> {
+    // TODO: using a vectored write here would make most sense, but alas, advancing [IoSlice]'s is
+    // still unstable. it could be copied, but we'd still lack `write_vectored_all`.
+    //
+    // note: write_all are not cancellation safe, and we call this from tokio::select! see callsite
+    // for more discussion.
+    input.write_all(cmd).await?;
+    input.write_all(&b"\n"[..]).await?;
+    input.flush().await?;
+
+    // the read buffer is cleared very late to allow logging the output in case of an error.
+    buffer.clear();
+
+    let read = output.read_line(buffer).await?;
+
+    if read == 0 {
+        // EOF
+        return Err(SubprocessError::IO);
+    }
+
+    let resp =
+        serde_json::from_str::<ChildResponse>(buffer).map_err(SubprocessError::InvalidJson)?;
+
+    resp.refine()
+}

--- a/crates/pathfinder/src/cairo/ext_py/sub_process.rs
+++ b/crates/pathfinder/src/cairo/ext_py/sub_process.rs
@@ -28,6 +28,12 @@ pub(super) async fn launch_python(
     let (mut child, pid, mut input, mut output, mut buffer) = match spawn(database_path).await {
         Ok(tuple) => tuple,
         Err(e) => {
+            // the idea of notifying with this is instead of SubprocessExitReason was that it would
+            // be distinguisable from simply the joinhandle returning.. I don't think it makes any
+            // sense.
+            //
+            // what's more, it might be blocking other progress events.
+            // FIXME: use a task return value instead.
             let e = e.context("Failed to start python subprocess");
             let _ = status_updates.send(SubProcessEvent::Failure(None, e)).await;
             return None;

--- a/crates/pathfinder/src/cairo/ext_py/sub_process.rs
+++ b/crates/pathfinder/src/cairo/ext_py/sub_process.rs
@@ -111,7 +111,7 @@ pub(super) async fn launch_python(
                 // we'd break out.
                 _ = response.closed() => {
                     // attempt to guard against a call that essentially freezes up the python for
-                    // how many minutes. by keeping our eye on this, we'll give the higher level a
+                    // how many minutes. by keeping our eye on this, we'll give the caller a
                     // chance to set timeouts, which will drop the futures.
                     //
                     // breaking out here will end up killing the python. it's probably the safest

--- a/crates/pathfinder/src/cairo/ext_py/sub_process.rs
+++ b/crates/pathfinder/src/cairo/ext_py/sub_process.rs
@@ -51,6 +51,8 @@ pub(super) async fn launch_python(
 
     let mut command_buffer = Vec::new();
 
+    // TODO: Why not have an outer loop to respawn a process fast? The idea occured during review.
+    // Currently the "policy" over respawning is controlled by the "service" in `super::start`.
     let exit_reason = loop {
         let command = async {
             let mut locked = commands.lock().await;

--- a/crates/pathfinder/src/cairo/ext_py/sub_process.rs
+++ b/crates/pathfinder/src/cairo/ext_py/sub_process.rs
@@ -261,10 +261,9 @@ async fn spawn(
         .spawn()
         .context("Failed to spawn the new python process; this should only happen when the session is at it's process limit on unix.")?;
 
-    let pid = match child.id() {
-        Some(pid) => pid,
-        None => todo!("child spawned but exited before reading pid"),
-    };
+    // why care about the pid? it could be logged, and used to identify process activity, thought
+    // these should be easy to spot otherwise as well.
+    let pid = child.id().expect("The child pid should had been available after a successful start before waiting for it's status");
 
     let input = child.stdin.take().expect("stdin was piped");
     let output = child.stdout.take().expect("stdout was piped");

--- a/crates/pathfinder/src/lib.rs
+++ b/crates/pathfinder/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cairo;
 pub mod config;
 pub mod core;
 pub mod ethereum;

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -104,6 +104,10 @@ impl Storage {
 
         Self::migrate(database_path)
     }
+
+    pub fn path(&self) -> &Path {
+        &self.database_path
+    }
 }
 
 /// Migrates the database to the latest version. This __MUST__ be called

--- a/py/README.md
+++ b/py/README.md
@@ -31,7 +31,7 @@ $ PIP_REQUIRE_VIRTUALENV=true pip install -r requirements-dev.txt
 Finally install the only real dependency, which cannot currently be managed by lock files:
 
 ```bash
-$ PIP_REQUIRE_VIRTUALENV=true pip install cairo-lang==0.7.0
+$ PIP_REQUIRE_VIRTUALENV=true pip install cairo-lang==0.7.1
 ```
 
 ## Testing

--- a/py/README.md
+++ b/py/README.md
@@ -4,6 +4,8 @@ This directory will host the code to call contracts using `cairo-lang` python pa
 
 - src/generate_test_storage_tree.py -- generates the patricia tree for a single contract from stdin
 - src/generate_test_global_tree.py -- generates the main patricia tree from stdin
+- src/compute_contract_hash.py -- similar to `cargo run -p pathfinder --bin compute_contract_hash`
+- src/call.py -- python side of `pathfinder_lib:cairo::ext_py` in pathfinder database
 
 See files for usage instructions.
 

--- a/py/README.md
+++ b/py/README.md
@@ -28,11 +28,7 @@ Then install development tools:
 $ PIP_REQUIRE_VIRTUALENV=true pip install -r requirements-dev.txt
 ```
 
-Finally install the only real dependency, which cannot currently be managed by lock files:
-
-```bash
-$ PIP_REQUIRE_VIRTUALENV=true pip install cairo-lang==0.7.1
-```
+That is currently the only list we have, and it doesn't have too large extras.
 
 ## Testing
 

--- a/py/requirements-dev.in
+++ b/py/requirements-dev.in
@@ -4,3 +4,4 @@ pip-tools==6.4.0
 pytest==6.2.5
 flake8==4.0.1
 black==21.12b0
+zstandard==0.17.0

--- a/py/requirements-dev.in
+++ b/py/requirements-dev.in
@@ -1,5 +1,7 @@
 # see README.md
-# cairo-lang==0.7.1
+cairo-lang==0.7.1
+# We don't use rlp directly, however this needs to be defined for it to help pip-compile
+eth-rlp==0.2.1
 pip-tools==6.4.0
 pytest==6.2.5
 flake8==4.0.1

--- a/py/requirements-dev.in
+++ b/py/requirements-dev.in
@@ -1,5 +1,5 @@
 # see README.md
-# cairo-lang==0.7.0
+# cairo-lang==0.7.1
 pip-tools==6.4.0
 pytest==6.2.5
 flake8==4.0.1

--- a/py/requirements-dev.txt
+++ b/py/requirements-dev.txt
@@ -4,54 +4,229 @@
 #
 #    pip-compile requirements-dev.in
 #
+aiohttp==3.8.1
+    # via
+    #   cairo-lang
+    #   web3
+aiosignal==1.2.0
+    # via aiohttp
+async-timeout==4.0.2
+    # via aiohttp
 attrs==21.4.0
-    # via pytest
+    # via
+    #   aiohttp
+    #   jsonschema
+    #   pytest
+base58==2.1.1
+    # via multiaddr
+bitarray==1.2.2
+    # via eth-account
 black==21.12b0
     # via -r requirements-dev.in
+cachetools==5.0.0
+    # via cairo-lang
+cairo-lang==0.7.1
+    # via -r requirements-dev.in
+certifi==2021.10.8
+    # via requests
+charset-normalizer==2.0.12
+    # via
+    #   aiohttp
+    #   requests
 click==8.0.3
     # via
     #   black
     #   pip-tools
+cytoolz==0.11.2
+    # via
+    #   eth-keyfile
+    #   eth-utils
+ecdsa==0.17.0
+    # via cairo-lang
+eth-abi==2.1.1
+    # via
+    #   eth-account
+    #   web3
+eth-account==0.5.7
+    # via web3
+eth-hash[pycryptodome]==0.3.2
+    # via
+    #   cairo-lang
+    #   eth-utils
+    #   web3
+eth-keyfile==0.5.1
+    # via eth-account
+eth-keys==0.3.4
+    # via
+    #   eth-account
+    #   eth-keyfile
+eth-rlp==0.2.1
+    # via
+    #   -r requirements-dev.in
+    #   eth-account
+eth-typing==2.3.0
+    # via
+    #   eth-abi
+    #   eth-keys
+    #   eth-utils
+    #   web3
+eth-utils==1.10.0
+    # via
+    #   eth-abi
+    #   eth-account
+    #   eth-keyfile
+    #   eth-keys
+    #   eth-rlp
+    #   rlp
+    #   web3
+fastecdsa==2.2.3
+    # via cairo-lang
 flake8==4.0.1
     # via -r requirements-dev.in
+frozendict==1.2
+    # via cairo-lang
+frozenlist==1.3.0
+    # via
+    #   aiohttp
+    #   aiosignal
+hexbytes==0.2.2
+    # via
+    #   eth-account
+    #   eth-rlp
+    #   web3
+idna==3.3
+    # via
+    #   requests
+    #   yarl
 iniconfig==1.1.1
     # via pytest
+ipfshttpclient==0.8.0a2
+    # via web3
+jsonschema==3.2.0
+    # via web3
+lark-parser==0.12.0
+    # via cairo-lang
+lru-dict==1.1.7
+    # via web3
+marshmallow==3.14.1
+    # via
+    #   cairo-lang
+    #   marshmallow-dataclass
+    #   marshmallow-enum
+    #   marshmallow-oneofschema
+marshmallow-dataclass==8.5.3
+    # via cairo-lang
+marshmallow-enum==1.5.1
+    # via cairo-lang
+marshmallow-oneofschema==3.0.1
+    # via cairo-lang
 mccabe==0.6.1
     # via flake8
+mpmath==1.2.1
+    # via
+    #   cairo-lang
+    #   sympy
+multiaddr==0.0.9
+    # via ipfshttpclient
+multidict==6.0.2
+    # via
+    #   aiohttp
+    #   yarl
 mypy-extensions==0.4.3
-    # via black
+    # via
+    #   black
+    #   typing-inspect
+netaddr==0.8.0
+    # via multiaddr
+numpy==1.22.2
+    # via cairo-lang
 packaging==21.3
     # via pytest
+parsimonious==0.8.1
+    # via eth-abi
 pathspec==0.9.0
     # via black
 pep517==0.12.0
     # via pip-tools
 pip-tools==6.4.0
     # via -r requirements-dev.in
+pipdeptree==2.2.1
+    # via cairo-lang
 platformdirs==2.5.0
     # via black
 pluggy==1.0.0
     # via pytest
+prometheus-client==0.13.1
+    # via cairo-lang
+protobuf==3.19.4
+    # via web3
 py==1.11.0
     # via pytest
 pycodestyle==2.8.0
     # via flake8
+pycryptodome==3.14.1
+    # via
+    #   eth-hash
+    #   eth-keyfile
 pyflakes==2.4.0
     # via flake8
 pyparsing==3.0.7
     # via packaging
+pyrsistent==0.18.1
+    # via jsonschema
 pytest==6.2.5
-    # via -r requirements-dev.in
+    # via
+    #   -r requirements-dev.in
+    #   cairo-lang
+    #   pytest-asyncio
+pytest-asyncio==0.18.1
+    # via cairo-lang
+pyyaml==6.0
+    # via cairo-lang
+requests==2.27.1
+    # via
+    #   ipfshttpclient
+    #   web3
+rlp==2.0.1
+    # via
+    #   eth-account
+    #   eth-rlp
+six==1.16.0
+    # via
+    #   ecdsa
+    #   jsonschema
+    #   multiaddr
+    #   parsimonious
+sympy==1.9
+    # via cairo-lang
 toml==0.10.2
     # via pytest
 tomli==1.2.3
     # via
     #   black
     #   pep517
+toolz==0.11.2
+    # via cytoolz
+typeguard==2.13.3
+    # via cairo-lang
 typing-extensions==4.1.1
-    # via black
+    # via
+    #   black
+    #   typing-inspect
+typing-inspect==0.7.1
+    # via marshmallow-dataclass
+urllib3==1.26.8
+    # via requests
+varint==1.0.2
+    # via multiaddr
+web3==5.28.0
+    # via cairo-lang
+websockets==9.1
+    # via web3
 wheel==0.37.1
     # via pip-tools
+yarl==1.7.2
+    # via aiohttp
 zstandard==0.17.0
     # via -r requirements-dev.in
 

--- a/py/requirements-dev.txt
+++ b/py/requirements-dev.txt
@@ -28,7 +28,7 @@ pep517==0.12.0
     # via pip-tools
 pip-tools==6.4.0
     # via -r requirements-dev.in
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via black
 pluggy==1.0.0
     # via pytest
@@ -38,7 +38,7 @@ pycodestyle==2.8.0
     # via flake8
 pyflakes==2.4.0
     # via flake8
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
 pytest==6.2.5
     # via -r requirements-dev.in
@@ -48,10 +48,12 @@ tomli==1.2.3
     # via
     #   black
     #   pep517
-typing-extensions==4.0.1
+typing-extensions==4.1.1
     # via black
 wheel==0.37.1
     # via pip-tools
+zstandard==0.17.0
+    # via -r requirements-dev.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -251,12 +251,12 @@ class NoSuchBlock(Exception):
 
 class NoSuchContract(Exception):
     def __init__(self):
-        super().__init__(f"Could not find the contract")
+        super().__init__("Could not find the contract")
 
 
 class UnexpectedSchemaVersion(Exception):
     def __init__(self):
-        super().__init__(f"Schema mismatch, is this pathfinders database file?")
+        super().__init__("Schema mismatch, is this pathfinders database file?")
 
 
 class InvalidInput(Exception):

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -1,0 +1,427 @@
+import sys
+import json
+import time
+import sqlite3
+import asyncio
+from starkware.starkware_utils.error_handling import WebFriendlyException
+
+
+def main():
+    """
+    Loops on stdin, reads json commands from lines, outputs single json as a response.
+    Starts by outputting "ready"
+    """
+    [_myname, db] = sys.argv
+
+    # make sure that regardless of the interesting platform we communicate sanely to pathfinder
+    sys.stdin.reconfigure(encoding="utf-8")
+    sys.stdout.reconfigure(encoding="utf-8")
+    # stderr should not be used
+
+    with sqlite3.connect(db) as connection:
+        connection.isolation_level = None
+
+        # TODO: add a "command" of sorts for initial checkup
+        connection.execute("BEGIN")
+        if not check_schema(connection):
+            sys.exit(1)
+        connection.rollback()
+
+        # whenever communicating with the other process, it's important to flush manually
+        # even though "the general wisdom" is to flush on '\n', python seems to only do it
+        # if it didn't add the newline to the written out string.
+        print("ready", flush=True)
+        do_loop(connection, sys.stdin, sys.stdout)
+
+
+def do_loop(connection, input_gen, output_file):
+
+    required = {
+        # FIXME: this should be hash_or_latest
+        "at_block": int_hash_or_latest,
+        "contract_address": hash_or_int,
+        "entry_point_selector": string_or_int,
+        "calldata": list_of_hash_or_int,
+    }
+
+    optional = {"caller_address": hash_or_int, "signature": hash_or_int}
+
+    for line in input_gen:
+        if line == "" or line.startswith("#"):
+            continue
+
+        out = {"status": "ok"}
+
+        started_at = time.time()
+        parsed_at = None
+
+        try:
+            command = parse_command(json.loads(line), required, optional)
+
+            parsed_at = time.time()
+
+            connection.execute("BEGIN")
+
+            if not check_schema(connection):
+                raise UnexpectedSchemaVersion
+
+            (block_info, global_root) = resolve_block(connection, command["at_block"])
+
+            output = asyncio.run(
+                do_call(
+                    SqliteAdapter(connection),
+                    global_root,
+                    command["contract_address"],
+                    command["entry_point_selector"],
+                    command["calldata"],
+                    command.get("caller_address", 0),
+                    command.get("signature", None),
+                    block_info,
+                )
+            )
+            # retdata is List[int] at least in 0.7.0
+            # however we need to render it as hex strings, so we can just deserialize it easily
+            out["output"] = list(
+                map(lambda x: "0x" + x.to_bytes(32, "big").hex(), output.retdata)
+            )
+        except NoSuchBlock:
+            out = {"status": "error", "kind": "NO_SUCH_BLOCK"}
+        except NoSuchContract:
+            out = {"status": "error", "kind": "NO_SUCH_CONTRACT"}
+        except UnexpectedSchemaVersion:
+            out = {"status": "error", "kind": "INVALID_SCHEMA_VERSION"}
+        except InvalidInput:
+            out = {"status": "error", "kind": "INVALID_INPUT"}
+        except WebFriendlyException as e:
+            # this is hopefully something we can give to the user
+            out = {"status": "failed", "exception": str(e.code)}
+        except Exception as e:
+            stringified = str(e)
+            if len(stringified) > 200:
+                stringified = stringified[:197] + "..."
+            out = {"status": "failed", "exception": stringified}
+        finally:
+            connection.rollback()
+
+            completed_at = time.time()
+            timings = {}
+
+            if parsed_at is not None and started_at < parsed_at:
+                timings["parsing"] = parsed_at - started_at
+
+            if parsed_at is not None and parsed_at < completed_at:
+                timings["execution"] = completed_at - parsed_at
+
+            out["timings"] = timings
+
+            print(json.dumps(out), file=output_file, flush=True)
+
+
+def parse_command(command, required, optional):
+    # it would be nice to use marshmallow but before we can lock with
+    # cairo-lang we cannot really add common dependencies
+    missing = required.keys() - command.keys()
+    assert len(missing) == 0, f"missing keys from command: {missing}"
+
+    extra = set()
+
+    converted = dict()
+
+    for k, v in command.items():
+        conv = required.get(k, None)
+        if conv is None:
+            conv = optional.get(k, None)
+        if conv is None:
+            extra += k
+            continue
+
+        try:
+            converted[k] = conv(v)
+        except Exception:
+            raise InvalidInput(k)
+
+    assert len(extra) == 0, f"extra keys from command: {extra}"
+
+    return converted
+
+
+def int_hash_or_latest(s):
+    if type(s) == int:
+        return s
+    if s == "latest":
+        return s
+    if s == "pending":
+        # this is allowed in the rpc api but pathfinder doesn't create the blocks
+        # this should had never come to us
+        raise NoSuchBlock(s)
+    assert s[0:2] == "0x"
+    return len_safe_hex(s)
+
+
+def hash_or_int(s):
+    if type(s) == int:
+        return s
+    if s.startswith("0x"):
+        return int.from_bytes(len_safe_hex(s), "big")
+    return int(s, 10)
+
+
+def len_safe_hex(s):
+    """
+    Over at the RPC side which pathfinder supports, sometimes hex without
+    leading zeros is needed, so they could come over to python as well.
+    bytes.fromhex doesn't support odd length hex, it gives a non-hex character
+    error.
+    """
+    if s.startswith("0x"):
+        s = s[2:]
+    if len(s) % 2 == 1:
+        s = "0" + s
+    return bytes.fromhex(s)
+
+
+def string_or_int(s):
+    if type(s) == int:
+        return s
+
+    if type(s) == str:
+        if s.startswith("0x"):
+            return hash_or_int(s)
+        # not sure if this should be supported but strings get ran through the
+        # truncated keccak
+        return s
+
+    raise TypeError(f"expected string or int, not {type(s)}")
+
+
+def list_of_hash_or_int(s):
+    assert type(s) == list, f"Expected list, got {type(s)}"
+    return list(map(hash_or_int, s))
+
+
+def check_schema(connection):
+    global first
+    assert connection.in_transaction
+    cursor = connection.execute("select user_version from pragma_user_version")
+    assert cursor is not None, "there has to be an user_version defined in the database"
+
+    [version] = next(cursor)
+    return version == 2
+
+
+def resolve_block(connection, at_block):
+    from starkware.starknet.business_logic.state import BlockInfo
+
+    # FIXME: at least latest is wrong, and will be more wrong in the upcoming changes to schema
+
+    if at_block == "latest":
+        cursor = connection.execute(
+            "select starknet_block_number, starknet_block_timestamp, starknet_global_root from global_state order by starknet_block_number desc limit 1"
+        )
+    elif type(at_block) == int:
+        cursor = connection.execute(
+            "select starknet_block_number, starknet_block_timestamp, starknet_global_root from global_state where starknet_block_number = ?",
+            [at_block],
+        )
+    else:
+        assert type(at_block) == bytes, f"expected bytes, got {type(at_block)}"
+        if len(at_block) < 32:
+            # left pad it, as the fields in db are fixed length for this occasion
+            at_block = b"\x00" * (32 - len(at_block)) + at_block
+
+        cursor = connection.execute(
+            "select starknet_block_number, starknet_block_timestamp, starknet_global_root from global_state where starknet_block_hash = ?",
+            [at_block],
+        )
+
+    try:
+        [(block_number, block_time, global_root)] = cursor
+        return (
+            BlockInfo(block_number, block_time),
+            global_root,
+        )
+    except Exception:
+        raise NoSuchBlock(at_block)
+
+
+class NoSuchBlock(Exception):
+    def __init__(self, at_block):
+        super().__init__(f"Could not find the block by: {at_block}")
+
+
+class NoSuchContract(Exception):
+    def __init__(self):
+        super().__init__(f"Could not find the contract")
+
+
+class UnexpectedSchemaVersion(Exception):
+    def __init__(self):
+        super().__init__(f"Schema mismatch, is this pathfinders database file?")
+
+
+class InvalidInput(Exception):
+    def __init__(self, key):
+        super().__init__(f"Invalid input for key: {key}")
+
+
+class SqliteAdapter:
+    """
+    Reads from pathfinders' database to give cairo-lang call implementation the nodes as needed
+    however using a single transaction.
+    """
+
+    def __init__(self, connection):
+        assert connection.in_transaction, "first query should had started a transaction"
+        self.connection = connection
+        pass
+
+    async def get_value(self, key):
+        """
+        Get value invoked by some storage thing from cairo-lang. The caller
+        will assert that the values returned are not None, which sometimes
+        bubbles up, or gets wrapped in a StarkException.
+        """
+        # all keys have this structure
+        [prefix, suffix] = key.split(b":", maxsplit=1)
+
+        # cases handled in the order of appereance
+        if prefix == b"patricia_node":
+            return self.fetch_patricia_node(suffix)
+
+        if prefix == b"contract_state":
+            return self.fetch_contract_state(suffix)
+
+        if prefix == b"contract_definition_fact":
+            return self.fetch_contract_definition(suffix)
+
+        if prefix == b"starknet_storage_leaf":
+            return self.fetch_storage_leaf(suffix)
+
+        assert False, f"unknown prefix: {prefix}"
+
+    def fetch_patricia_node(self, suffix):
+        cursor = self.connection.execute(
+            "select data from tree_contracts where hash = ?", [suffix]
+        )
+
+        [only] = next(cursor, [None])
+
+        if only is None:
+            # maybe UNION could be used here?
+            cursor = self.connection.execute(
+                "select data from tree_global where hash = ?", [suffix]
+            )
+            [only] = next(cursor, [None])
+
+        return only
+
+    def fetch_contract_state(self, suffix):
+        cursor = self.connection.execute(
+            "select hash, root from contract_states where state_hash = ?", [suffix]
+        )
+
+        # FIXME: this is really wonky, esp with the tuple returning query, the
+        # first if is None is probably never hit.
+
+        only = next(cursor, [None, None])
+
+        [h, root] = only
+
+        if h is None or root is None:
+            if suffix == b"\x00" * 32:
+                # this means that they went looking for a leaf in the patricia tree
+                # but couldn't find anything which is signalled by many zeros key
+                raise NoSuchContract
+            return None
+
+        return (
+            b'{"storage_commitment_tree": {"root": "'
+            + root.hex().encode("utf-8")
+            + b'", "height": 251}, "contract_hash": "'
+            + h.hex().encode("utf-8")
+            + b'"}'
+        )
+
+    def fetch_contract_definition(self, suffix):
+        import itertools
+        import zstandard
+
+        # assert False, "we must rebuild the full json out of our columns"
+        cursor = self.connection.execute(
+            "select definition from contract_code where hash = ?", [suffix]
+        )
+        [only] = next(cursor, [None])
+
+        if only is None:
+            return None
+
+        # pathfinder stores zstd compressed json blobs
+        decompressor = zstandard.ZstdDecompressor()
+        only = decompressor.decompress(only)
+
+        # cairo-lang expects a ContractDefinitionFact, however we store just
+        # the contract definition over at pathfinder (from get_full_contract)
+        # so we need to wrap it up here. itertools is suggested by the manuals,
+        # so lets hope it's the most efficient thing.
+        #
+        # there might be a better way to do this, since cairo-lang seems to
+        # expect the returned value to have method called decode, but it's not
+        # like we could fake streaming decompression
+        return bytes(itertools.chain(b'{"contract_definition":', only, b"}"))
+
+    def fetch_storage_leaf(self, suffix):
+        # these are "stored" under their keys where key == value; this
+        # follows from the inheritance structure inside cairo-lang
+        return suffix
+
+
+async def do_call(
+    adapter,
+    root,
+    contract_address,
+    selector,
+    calldata,
+    caller_address,
+    signature,
+    block_info,
+):
+    """
+    Loads all of the cairo-lang parts needed for the call. Dirties the internal
+    cairo-lang state which does not matter, because the state will be thrown
+    out.
+    """
+    from starkware.storage.internal_proxy_storage import InternalProxyStorage
+    from starkware.starknet.business_logic.state import (
+        SharedState,
+        StateSelector,
+    )
+    from starkware.starknet.definitions.general_config import StarknetGeneralConfig
+    from starkware.storage.storage import FactFetchingContext
+    from starkware.starkware_utils.commitment_tree.patricia_tree.patricia_tree import (
+        PatriciaTree,
+    )
+    from starkware.cairo.lang.vm.crypto import pedersen_hash_func
+    from starkware.starknet.testing.state import StarknetState
+
+    general_config = StarknetGeneralConfig()
+
+    # hook up the sqlite adapter
+    adapter = InternalProxyStorage(adapter)
+    ffc = FactFetchingContext(storage=adapter, hash_func=pedersen_hash_func)
+
+    # the root tree has to always be height=251
+    shared_state = SharedState(PatriciaTree(root=root, height=251), block_info)
+    state_selector = StateSelector(contract_addresses={contract_address})
+    carried_state = await shared_state.get_filled_carried_state(
+        ffc, state_selector=state_selector
+    )
+
+    state = StarknetState(state=carried_state, general_config=general_config)
+
+    return await state.invoke_raw(
+        contract_address, selector, calldata, caller_address, signature
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -1,0 +1,326 @@
+from call import do_call, do_loop, SqliteAdapter
+import sqlite3
+import asyncio
+import io
+import json
+from starkware.starknet.business_logic.state import BlockInfo
+
+
+# this is from 64a7f6aed9757d3d8d6c28bd972df73272b0cb0a of cairo-lang
+# with needless parts ripped out of it
+SIMPLIFIED_TEST_CONTRACT = """
+%lang starknet
+
+from starkware.starknet.common.syscalls import (storage_read, storage_write)
+
+@contract_interface
+namespace MyContract:
+    func increase_value(address : felt, value : felt):
+    end
+end
+
+@external
+func increase_value{syscall_ptr : felt*}(address : felt, value : felt):
+    let (res) = storage_read(address=address)
+    return storage_write(address=address, value=res + value)
+end
+
+@external
+func call_increase_value{syscall_ptr : felt*, range_check_ptr}(
+        contract_address : felt, address : felt, value : felt):
+    MyContract.increase_value(contract_address=contract_address, address=address, value=value)
+    return ()
+end
+
+@external
+func get_value{syscall_ptr : felt*}(address : felt) -> (res : felt):
+    return storage_read(address=address)
+end
+"""
+
+
+def inmemory_with_tables():
+    con = sqlite3.connect(":memory:")
+    con.isolation_level = None
+
+    cur = con.execute("BEGIN")
+    cur.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS tree_global (
+            hash        BLOB PRIMARY KEY,
+            data        BLOB,
+            ref_count   INTEGER
+        );
+
+        CREATE TABLE IF NOT EXISTS tree_contracts (
+            hash        BLOB PRIMARY KEY,
+            data        BLOB,
+            ref_count   INTEGER
+        );
+
+        CREATE TABLE contract_states (
+            state_hash BLOB PRIMARY KEY,
+            hash       BLOB NOT NULL,
+            root       BLOB NOT NULL
+        );
+
+        CREATE TABLE contracts (
+            address    BLOB PRIMARY KEY,
+            hash       BLOB NOT NULL
+        );
+
+        CREATE TABLE contract_code (
+            hash       BLOB PRIMARY KEY,
+            bytecode   BLOB,
+            abi        BLOB,
+            definition BLOB
+        );
+
+        -- This is missing the foreign key definition
+        CREATE TABLE global_state (
+            starknet_block_hash       BLOB PRIMARY KEY,
+            starknet_block_number     INTEGER NOT NULL,
+            starknet_block_timestamp  INTEGER NOT NULL,
+            starknet_global_root      BLOB NOT NULL,
+            ethereum_transaction_hash BLOB NOT NULL,
+            ethereum_log_index        INTEGER NOT NULL
+        );
+        """
+    )
+
+    # strangely this cannot be pulled into the script, maybe pragmas have
+    # different kind of semantics than what is normally executed, would explain
+    # the similar behaviour of sqlite3 .dump and restore.
+    cur.execute("pragma user_version = 2;")
+
+    con.commit()
+    return con
+
+
+def populate_test_contract_with_132_on_3(con):
+    """
+    Populates a situation created with cairo-lang contract_test.py where
+    the test contract has been deployed and it's memory address 132 has been
+    written as 3.
+    """
+
+    # this cannot be changed without recomputing the global state root
+    contract_address = (
+        2483955865838519930787573649413589905962103032695051953168137837593959392116
+    )
+    cur = con.execute("BEGIN")
+
+    def pad(b):
+        assert len(b) <= 32
+        return b"\x00" * (32 - len(b)) + b
+
+    cur.execute(
+        "insert into contract_code (hash, definition) values (?, ?)",
+        [
+            bytes.fromhex(
+                "050b2148c0d782914e0b12a1a32abe5e398930b7e914f82c65cb7afce0a0ab9b"
+            ),
+            compile_test_contract(),
+        ],
+    )
+    cur.execute(
+        "insert into contracts (address, hash) values (?, ?)",
+        [
+            (contract_address).to_bytes(32, "big"),
+            bytes.fromhex(
+                "050b2148c0d782914e0b12a1a32abe5e398930b7e914f82c65cb7afce0a0ab9b"
+            ),
+        ],
+    )
+
+    cur.execute(
+        "insert into tree_contracts (hash, data, ref_count) values (?, ?, 1)",
+        [
+            bytes.fromhex(
+                "04fb440e8ca9b74fc12a22ebffe0bc0658206337897226117b985434c239c028"
+            ),
+            bytes.fromhex(
+                "00000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000084fb"
+            ),
+        ],
+    )
+
+    cur.execute(
+        "insert into contract_states (state_hash, hash, root) values (?, ?, ?)",
+        [
+            bytes.fromhex(
+                "002e9723e54711aec56e3fb6ad1bb8272f64ec92e0a43a20feed943b1d4f73c5"
+            ),
+            bytes.fromhex(
+                "050b2148c0d782914e0b12a1a32abe5e398930b7e914f82c65cb7afce0a0ab9b"
+            ),
+            bytes.fromhex(
+                "04fb440e8ca9b74fc12a22ebffe0bc0658206337897226117b985434c239c028"
+            ),
+        ],
+    )
+
+    cur.execute(
+        "insert into tree_global (hash, data, ref_count) values (?, ?, 1)",
+        [
+            bytes.fromhex(
+                "0704dfcbc470377c68e6f5ffb83970ebd0d7c48d5b8d2f4ed61a24e795e034bd"
+            ),
+            bytes.fromhex(
+                "002e9723e54711aec56e3fb6ad1bb8272f64ec92e0a43a20feed943b1d4f73c5057dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374fb"
+            ),
+        ],
+    )
+
+    cur.execute(
+        """insert into global_state (starknet_block_hash, starknet_block_number, starknet_block_timestamp, starknet_global_root, ethereum_transaction_hash, ethereum_log_index)
+        values (?, 1, 1, ?, ?, 1)""",
+        [
+            pad(b"some blockhash somewhere"),
+            bytes.fromhex(
+                "0704dfcbc470377c68e6f5ffb83970ebd0d7c48d5b8d2f4ed61a24e795e034bd"
+            ),
+            pad(b"some ethereum hash"),
+        ],
+    )
+
+    con.commit()
+    return contract_address
+
+
+def compile_test_contract():
+    from starkware.starknet.compiler.compile import compile_starknet_codes
+    from starkware.starknet.business_logic.state_objects import (
+        ContractDefinitionFact,
+    )
+    import zstandard
+
+    raw = compile_starknet_codes(
+        [(SIMPLIFIED_TEST_CONTRACT, "-")], debug_info=False
+    ).serialize()
+    # we use 10 over at pathfinder, but for tests 1 is probably better
+    compressor = zstandard.ZstdCompressor(level=1)
+    return compressor.compress(raw)
+
+
+def default_132_on_3_scenario(con, input_jsons):
+    output_catcher = io.StringIO()
+
+    do_loop(con, input_jsons, output_catcher)
+
+    output = output_catcher.getvalue()
+
+    print(output)
+
+    def strip_timings(loaded_json):
+        del loaded_json["timings"]
+        return loaded_json
+
+    output = [strip_timings(json.loads(line)) for line in output.splitlines()]
+
+    if len(output) == 1:
+        output = output[0]
+
+    return output
+
+
+def test_success():
+    con = inmemory_with_tables()
+    contract_address = populate_test_contract_with_132_on_3(con)
+
+    output = default_132_on_3_scenario(
+        con,
+        [
+            f'{{ "at_block": 1, "contract_address": {contract_address}, "entry_point_selector": "get_value", "calldata": [132] }}',
+            f'{{ "at_block": "0x{(b"some blockhash somewhere").hex()}", "contract_address": {contract_address}, "entry_point_selector": "get_value", "calldata": [132] }}',
+            f'{{ "at_block": "latest", "contract_address": {contract_address}, "entry_point_selector": "get_value", "calldata": [132] }}',
+        ],
+    )
+
+    [number, block_hash, latest] = output
+    expected = {"status": "ok", "output": ["0x" + (3).to_bytes(32, "big").hex()]}
+
+    assert number == expected == block_hash == latest
+
+
+def test_called_contract_not_found():
+    con = inmemory_with_tables()
+    contract_address = populate_test_contract_with_132_on_3(con)
+
+    # con.execute("delete from contract_code")
+    # con.execute("delete from contracts")
+    # con.execute("delete from contract_states")
+    # con.commit()
+
+    output = default_132_on_3_scenario(
+        con,
+        [
+            f'{{ "at_block": 1, "contract_address": {contract_address + 1}, "entry_point_selector": "get_value", "calldata": [132] }}'
+        ],
+    )
+
+    # TODO: this should probably be understood to a nicer one
+    assert output == {"status": "error", "kind": "NO_SUCH_CONTRACT"}
+
+
+def test_nested_called_contract_not_found():
+    con = inmemory_with_tables()
+    contract_address = populate_test_contract_with_132_on_3(con)
+
+    output = default_132_on_3_scenario(
+        con,
+        [
+            # call neighbouring contract, which doesn't exist in the global state tree
+            f'{{ "at_block": 1, "contract_address": {contract_address}, "entry_point_selector": "call_increase_value", "calldata": [{contract_address - 1}, 132, 4] }}'
+        ],
+    )
+
+    # the original exception message is too long
+
+    assert output == {
+        "status": "failed",
+        "exception": "StarknetErrorCode.TRANSACTION_FAILED",
+    }
+
+
+def test_invalid_schema_version():
+    con = inmemory_with_tables()
+    contract_address = populate_test_contract_with_132_on_3(con)
+
+    con.execute("pragma user_version = 0")
+    con.commit()
+
+    output = default_132_on_3_scenario(
+        con,
+        [
+            f'{{ "at_block": 1, "contract_address": {contract_address}, "entry_point_selector": "get_value", "calldata": [132] }}'
+        ],
+    )
+
+    assert output == {"status": "error", "kind": "INVALID_SCHEMA_VERSION"}
+
+
+def test_no_such_block():
+    con = inmemory_with_tables()
+    contract_address = populate_test_contract_with_132_on_3(con)
+
+    con.execute("delete from global_state")
+    con.commit()
+
+    output = default_132_on_3_scenario(
+        con,
+        (
+            # there's only block 1
+            f'{{ "at_block": 99999999999, "contract_address": {contract_address}, "entry_point_selector": "get_value", "calldata": [132] }}',
+            f'{{ "at_block": "0x{(b"no such block").hex()}", "contract_address": {contract_address}, "entry_point_selector": "get_value", "calldata": [132] }}',
+            f'{{ "at_block": "latest", "contract_address": {contract_address}, "entry_point_selector": "get_value", "calldata": [132] }}',
+        ),
+    )
+
+    [number, block_hash, latest] = output
+
+    expected = {"status": "error", "kind": "NO_SUCH_BLOCK"}
+
+    assert number == expected
+    assert block_hash == expected
+    assert latest == expected

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -1,9 +1,7 @@
-from call import do_call, do_loop, SqliteAdapter
+from call import do_loop
 import sqlite3
-import asyncio
 import io
 import json
-from starkware.starknet.business_logic.state import BlockInfo
 
 
 # this is from 64a7f6aed9757d3d8d6c28bd972df73272b0cb0a of cairo-lang
@@ -190,9 +188,6 @@ def populate_test_contract_with_132_on_3(con):
 
 def compile_test_contract():
     from starkware.starknet.compiler.compile import compile_starknet_codes
-    from starkware.starknet.business_logic.state_objects import (
-        ContractDefinitionFact,
-    )
     import zstandard
 
     # FIXME: use crates/pathfinder/fixtures/contract_definition.json.zst here, it's the same.

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -195,6 +195,8 @@ def compile_test_contract():
     )
     import zstandard
 
+    # FIXME: use crates/pathfinder/fixtures/contract_definition.json.zst here, it's the same.
+
     raw = compile_starknet_codes(
         [(SIMPLIFIED_TEST_CONTRACT, "-")], debug_info=False
     ).serialize()


### PR DESCRIPTION
Follow-up on #110.

As said in the commit message, this cannot be yet tested, we need to sync with L2 info to get those compared sequencer responses going and then to find the good states to test in.

I don't think I managed any add linuxisms (but was close, thinking about `choom`) but I have no clue if this could work under windows. Mac os would probably work.

Serialization in the communication is very naive, partly because we cannot use the schema-libraries over at python, and partly because I don't know how to do the best practices thing. So we end up having these refined statuses and responses.