### PR TITLE
Minor test cleanup

### DIFF
--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -302,7 +302,6 @@ mod tests {
         use crate::rpc::types::{reply::Block, request::BlockResponseScope, BlockHashOrTag, Tag};
 
         #[tokio::test]
-        #[ignore = "Currently gives 502/503"]
         async fn genesis() {
             let params = rpc_params!(*GENESIS_BLOCK_HASH);
             client_request::<Block>("starknet_getBlockByHash", params)
@@ -391,7 +390,6 @@ mod tests {
         use crate::rpc::types::{reply::Block, request::BlockResponseScope, BlockNumberOrTag, Tag};
 
         #[tokio::test]
-        #[ignore = "Currently gives 502/503"]
         async fn genesis() {
             let params = rpc_params!(*GENESIS_BLOCK_NUMBER);
             client_request::<Block>("starknet_getBlockByNumber", params)
@@ -563,6 +561,7 @@ mod tests {
             use super::*;
 
             #[tokio::test]
+            #[ignore = "this is actually a manual test"]
             async fn real_data() {
                 let storage = Storage::migrate("desync.sqlite".into()).unwrap();
                 let sequencer = sequencer::Client::new(Chain::Goerli).unwrap();
@@ -576,7 +575,7 @@ mod tests {
                     .request::<StorageValue>("starknet_getStorageAt", params)
                     .await
                     .unwrap();
-                assert_eq!(value, StorageValue::from_hex_str("0x123456").unwrap());
+                assert_eq!(value, StorageValue::from_hex_str("0x1E240").unwrap());
             }
 
             #[tokio::test]
@@ -649,7 +648,6 @@ mod tests {
         use crate::rpc::types::{reply::Transaction, BlockHashOrTag, Tag};
 
         #[tokio::test]
-        #[ignore = "Currently gives 502/503"]
         async fn genesis() {
             let params = rpc_params!(*GENESIS_BLOCK_HASH, *VALID_TX_INDEX);
             client_request::<Transaction>("starknet_getTransactionByBlockHashAndIndex", params)
@@ -715,7 +713,6 @@ mod tests {
         use crate::rpc::types::{reply::Transaction, BlockNumberOrTag, Tag};
 
         #[tokio::test]
-        #[ignore = "Currently gives 502/503"]
         async fn genesis() {
             let params = rpc_params!(*GENESIS_BLOCK_NUMBER, *VALID_TX_INDEX);
             client_request::<Transaction>("starknet_getTransactionByBlockNumberAndIndex", params)
@@ -962,7 +959,6 @@ mod tests {
         use crate::rpc::types::{BlockHashOrTag, Tag};
 
         #[tokio::test]
-        #[ignore = "Currently gives 502/503"]
         async fn genesis() {
             let params = rpc_params!(*GENESIS_BLOCK_HASH);
             client_request::<u64>("starknet_getBlockTransactionCountByHash", params)
@@ -1016,7 +1012,6 @@ mod tests {
         use crate::rpc::types::{BlockNumberOrTag, Tag};
 
         #[tokio::test]
-        #[ignore = "Currently gives 502/503"]
         async fn genesis() {
             let params = rpc_params!(*GENESIS_BLOCK_NUMBER);
             client_request::<u64>("starknet_getBlockTransactionCountByNumber", params)

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -561,7 +561,7 @@ mod tests {
             use super::*;
 
             #[tokio::test]
-            #[ignore = "this is actually a manual test"]
+            #[ignore = "This is a manual test and will be removed once state mocking facilities are ready."]
             async fn real_data() {
                 let storage = Storage::migrate("desync.sqlite".into()).unwrap();
                 let sequencer = sequencer::Client::new(Chain::Goerli).unwrap();
@@ -580,14 +580,12 @@ mod tests {
 
             #[tokio::test]
             #[ignore = "Until the test is actually implemented."]
-
             async fn positional_args() {
                 todo!("Add the test once state mocking is easy");
             }
 
             #[tokio::test]
             #[ignore = "Until the test is actually implemented."]
-
             async fn named_args() {
                 todo!("Add the test once state mocking is easy");
             }

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -536,11 +536,13 @@ mod tests {
         }
 
         #[tokio::test]
+        #[ignore = "Until the test is actually implemented."]
         async fn non_existent_contract_address() {
             todo!("Add the test once state mocking is easy");
         }
 
         #[tokio::test]
+        #[ignore = "Until the test is actually implemented."]
         async fn pre_deploy_block_hash() {
             todo!("Add the test once state mocking is easy");
         }
@@ -578,11 +580,15 @@ mod tests {
             }
 
             #[tokio::test]
+            #[ignore = "Until the test is actually implemented."]
+
             async fn positional_args() {
                 todo!("Add the test once state mocking is easy");
             }
 
             #[tokio::test]
+            #[ignore = "Until the test is actually implemented."]
+
             async fn named_args() {
                 todo!("Add the test once state mocking is easy");
             }

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -477,7 +477,6 @@ mod tests {
         }
 
         #[tokio::test]
-        // #[ignore = "Currently gives 502/503"]
         async fn block_without_block_hash_field() {
             retry_on_rate_limiting!(
                 client()
@@ -539,7 +538,6 @@ mod tests {
         }
 
         #[tokio::test]
-        // #[ignore = "Currently gives 502/503"]
         async fn contains_receipts_without_status_field() {
             retry_on_rate_limiting!(
                 client()
@@ -594,7 +592,6 @@ mod tests {
         }
 
         #[tokio::test]
-        // #[ignore = "Currently gives 502/503"]
         async fn contains_receipts_without_status_field() {
             retry_on_rate_limiting!(
                 client()

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -416,37 +416,40 @@ mod tests {
         }};
     }
 
-    #[tokio::test]
-    #[ignore = "Currently gives 502/503"]
-    async fn genesis_block() {
-        let by_hash =
-            retry_on_rate_limiting!(client().block_by_hash(*GENESIS_BLOCK_HASH).await).unwrap();
-        let by_number =
-            retry_on_rate_limiting!(client().block_by_number(*GENESIS_BLOCK_NUMBER).await).unwrap();
-        assert_eq!(by_hash, by_number);
-    }
+    mod block_by_number_matches_by_hash_on {
+        use super::*;
 
-    #[tokio::test]
-    // Temporary replacement for the `genesis_block` test, which essentially does the same
-    async fn block_number_matches_block_hash() {
-        let by_hash = retry_on_rate_limiting!(
-            client()
-                .block_by_hash(BlockHashOrTag::Hash(
-                    StarknetBlockHash::from_hex_str(
-                        "0x07187d565e5563658f2b88a9000c6eb84692dcd90a8ab7d8fe75d768205d9b66"
-                    )
-                    .unwrap()
-                ))
-                .await
-        )
-        .unwrap();
-        let by_number = retry_on_rate_limiting!(
-            client()
-                .block_by_number(BlockNumberOrTag::Number(StarknetBlockNumber(50000)))
-                .await
-        )
-        .unwrap();
-        assert_eq!(by_hash, by_number);
+        #[tokio::test]
+        async fn genesis() {
+            let by_hash =
+                retry_on_rate_limiting!(client().block_by_hash(*GENESIS_BLOCK_HASH).await).unwrap();
+            let by_number =
+                retry_on_rate_limiting!(client().block_by_number(*GENESIS_BLOCK_NUMBER).await)
+                    .unwrap();
+            assert_eq!(by_hash, by_number);
+        }
+
+        #[tokio::test]
+        async fn specific_block() {
+            let by_hash = retry_on_rate_limiting!(
+                client()
+                    .block_by_hash(BlockHashOrTag::Hash(
+                        StarknetBlockHash::from_hex_str(
+                            "0x07187d565e5563658f2b88a9000c6eb84692dcd90a8ab7d8fe75d768205d9b66"
+                        )
+                        .unwrap()
+                    ))
+                    .await
+            )
+            .unwrap();
+            let by_number = retry_on_rate_limiting!(
+                client()
+                    .block_by_number(BlockNumberOrTag::Number(StarknetBlockNumber(50000)))
+                    .await
+            )
+            .unwrap();
+            assert_eq!(by_hash, by_number);
+        }
     }
 
     mod block_by_hash {
@@ -474,7 +477,7 @@ mod tests {
         }
 
         #[tokio::test]
-        #[ignore = "Currently gives 502/503"]
+        // #[ignore = "Currently gives 502/503"]
         async fn block_without_block_hash_field() {
             retry_on_rate_limiting!(
                 client()
@@ -536,7 +539,7 @@ mod tests {
         }
 
         #[tokio::test]
-        #[ignore = "Currently gives 502/503"]
+        // #[ignore = "Currently gives 502/503"]
         async fn contains_receipts_without_status_field() {
             retry_on_rate_limiting!(
                 client()
@@ -591,7 +594,7 @@ mod tests {
         }
 
         #[tokio::test]
-        #[ignore = "Currently gives 502/503"]
+        // #[ignore = "Currently gives 502/503"]
         async fn contains_receipts_without_status_field() {
             retry_on_rate_limiting!(
                 client()
@@ -939,7 +942,7 @@ mod tests {
         }
     }
 
-    mod state_update_matches_on {
+    mod state_update_by_number_matches_by_hash_on {
         use super::*;
         use pretty_assertions::assert_eq;
 

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -1038,7 +1038,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore] // this is manual testing only, but we should really use the binary for this
+    #[ignore = "this is manual testing only, but we should really use the binary for this"]
     async fn go_sync() {
         let database =
             crate::storage::Storage::migrate(std::path::PathBuf::from("test.sqlite")).unwrap();


### PR DESCRIPTION
- remove `#[ignore]` for tests which seem to work now
- add `#[ignore]` for tests marked with `todo!()`