### PR TITLE
Add tracing in some parts

### DIFF
--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -33,7 +33,7 @@ thiserror = "1.0.30"
 tokio = "1.11.0"
 toml = "0.5.8"
 tracing = "0.1.31"
-tracing-subscriber = "0.3.9"
+tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
 web3 = "0.17.0"
 zstd = "0.10"
 

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -32,6 +32,8 @@ sha3 = "0.9"
 thiserror = "1.0.30"
 tokio = "1.11.0"
 toml = "0.5.8"
+tracing = "0.1.31"
+tracing-subscriber = "0.3.9"
 web3 = "0.17.0"
 zstd = "0.10"
 
@@ -39,3 +41,5 @@ zstd = "0.10"
 assert_matches = "1.5.0"
 pretty_assertions = "1.0.0"
 tempfile = "3"
+# log crate should be handled through tracing-subscriber if needed
+test-log = { version = "0.2.8", default-features = false, features = ["trace"] }

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -3,6 +3,9 @@ use tracing::info;
 
 #[tokio::main]
 async fn main() {
+    if std::env::var_os("RUST_LOG").is_none() {
+        std::env::set_var("RUST_LOG", "info");
+    }
     tracing_subscriber::fmt::init();
 
     info!("🏁 Starting node.");

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -1,8 +1,11 @@
 use pathfinder_lib::{cairo, config, rpc, sequencer, storage::Storage};
+use tracing::info;
 
 #[tokio::main]
 async fn main() {
-    println!("🏁 Starting node.");
+    tracing_subscriber::fmt::init();
+
+    info!("🏁 Starting node.");
     let config =
         config::Configuration::parse_cmd_line_and_cfg_file().expect("Configuration failed");
 
@@ -26,6 +29,6 @@ async fn main() {
 
     let (_handle, local_addr) =
         rpc::run_server(config.http_rpc_addr, api).expect("⚠️ Failed to start HTTP-RPC server");
-    println!("📡 HTTP-RPC server started on: {}", local_addr);
+    info!("📡 HTTP-RPC server started on: {}", local_addr);
     let () = std::future::pending().await;
 }

--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -32,7 +32,7 @@ pub use service::start;
 /// Handle to the python executors work queue. Cloneable and shareable.
 #[derive(Clone)]
 pub struct Handle {
-    command_tx: mpsc::Sender<Command>,
+    command_tx: mpsc::Sender<(Command, tracing::Span)>,
 }
 
 impl Handle {
@@ -42,10 +42,13 @@ impl Handle {
         call: Call,
         at_block: BlockHashOrTag,
     ) -> Result<Vec<CallResultValue>, CallFailure> {
+        use tracing::field::Empty;
         let (tx, rx) = oneshot::channel();
 
+        let continued_span = tracing::info_span!("ext_py_call", pid = Empty);
+
         self.command_tx
-            .send((call, at_block, tx))
+            .send(((call, at_block, tx), continued_span))
             .await
             .map_err(|_| CallFailure::Shutdown)?;
 
@@ -146,7 +149,7 @@ mod tests {
             conn.execute("pragma user_version = 0", []).unwrap();
         }
 
-        let (_work_tx, work_rx) = tokio::sync::mpsc::channel::<super::Command>(1);
+        let (_work_tx, work_rx) = tokio::sync::mpsc::channel(1);
         let work_rx = tokio::sync::Mutex::new(work_rx);
         let (status_tx, _status_rx) = tokio::sync::mpsc::channel(1);
         let (_shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel(1);

--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -137,7 +137,7 @@ mod tests {
     use std::path::PathBuf;
     use tokio::sync::oneshot;
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[ignore]
     async fn start_with_wrong_database_schema_fails() {
         let db_file = tempfile::NamedTempFile::new().unwrap();
@@ -165,7 +165,7 @@ mod tests {
         println!("{:?}", err.unwrap_err());
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[ignore] // these tests require that you've entered into python venv
     async fn call_like_in_python_ten_times() {
         use futures::stream::StreamExt;

--- a/crates/pathfinder/src/cairo/ext_py/service.rs
+++ b/crates/pathfinder/src/cairo/ext_py/service.rs
@@ -18,6 +18,7 @@ use tracing::{info, trace, warn};
 /// - user has compatible python, 3.7+ should work just fine
 ///
 /// Returns an error if executing calls in a sub-process is not supported.
+#[tracing::instrument(name = "ext_py", skip_all, fields(%count))]
 pub async fn start(
     database_path: PathBuf,
     count: std::num::NonZeroUsize,
@@ -31,17 +32,20 @@ pub async fn start(
     let (status_tx, mut status_rx) = mpsc::channel(1);
     // this will never need to become deeper
     let (child_shutdown_tx, _) = broadcast::channel(1);
-    let command_rx: SharedReceiver<Command> = Arc::new(Mutex::new(command_rx));
+    let command_rx: SharedReceiver<(Command, tracing::Span)> = Arc::new(Mutex::new(command_rx));
 
     // TODO: might be better to use tokio's JoinSet?
     let mut joinhandles = futures::stream::FuturesUnordered::new();
 
-    let jh = tokio::task::spawn(launch_python(
-        database_path.clone(),
-        Arc::clone(&command_rx),
-        status_tx.clone(),
-        child_shutdown_tx.subscribe(),
-    ));
+    let jh = tokio::task::spawn(
+        launch_python(
+            database_path.clone(),
+            Arc::clone(&command_rx),
+            status_tx.clone(),
+            child_shutdown_tx.subscribe(),
+        )
+        .in_current_span(),
+    );
 
     joinhandles.push(jh);
 
@@ -72,75 +76,81 @@ pub async fn start(
         command_tx: command_tx.clone(),
     };
 
-    let jh = tokio::task::spawn(async move {
-        const WAIT_BEFORE_SPAWN: std::time::Duration = std::time::Duration::from_secs(1);
+    let jh = tokio::task::spawn(
+        async move {
+            const WAIT_BEFORE_SPAWN: std::time::Duration = std::time::Duration::from_secs(1);
 
-        // use a sleep activated periodically before launching new processes
-        // not to overwhelm the system
-        let wait_before_spawning = tokio::time::sleep(WAIT_BEFORE_SPAWN);
-        tokio::pin!(wait_before_spawning);
+            // use a sleep activated periodically before launching new processes
+            // not to overwhelm the system
+            let wait_before_spawning = tokio::time::sleep(WAIT_BEFORE_SPAWN);
+            tokio::pin!(wait_before_spawning);
 
-        tokio::pin!(stop_flag);
+            tokio::pin!(stop_flag);
 
-        loop {
-            let mut spawn = false;
-            tokio::select! {
-                _ = &mut stop_flag => {
-                    // this should be enough to kick everyone off the locking, queue receiving
-                    let _ = child_shutdown_tx.send(());
-                    let _ = joinhandles.into_future().await;
-                    // just exit
-                    return;
-                }
-                Some(evt) = status_rx.recv() => {
-                    match evt {
-                        SubProcessEvent::ProcessLaunched(_) => {},
-                        SubProcessEvent::CommandHandled(_pid, timings, status) => {
-                            trace!(?status, ?timings, "Command handled");
-                        },
+            loop {
+                let mut spawn = false;
+                tokio::select! {
+                    _ = &mut stop_flag => {
+                        // this should be enough to kick everyone off the locking, queue receiving
+                        let _ = child_shutdown_tx.send(());
+                        let _ = joinhandles.into_future().await;
+                        // just exit
+                        return;
                     }
-                },
-                Some(res) = joinhandles.next() => {
-                    let allow_spawn_right_away = match res {
-                        Ok(Ok((pid, exit_status, exit_reason))) => {
-                            info!(%pid, ?exit_status, ?exit_reason, "Subprocess exited");
-                            true
-                        },
-                        Ok(Err(error)) => {
-                            warn!(error = %error, "Subprocess failed");
-                            true
-                        },
-                        Err(join_error) => {
-                            warn!(error = %join_error, "Subprocess exited unexpectedly");
-                            false
-                        },
-                    };
-                    // println!("one of our python processes have expired: {_maybe_info:?}");
-                    // we should spawn it immediatedly if empty
-                    spawn = allow_spawn_right_away && joinhandles.is_empty();
+                    Some(evt) = status_rx.recv() => {
+                        match evt {
+                            SubProcessEvent::ProcessLaunched(_) => {},
+                            SubProcessEvent::CommandHandled(pid, timings, status) => {
+                                trace!(%pid, ?status, ?timings, "Command handled");
+                            },
+                        }
+                    },
+                    Some(res) = joinhandles.next() => {
+                        let allow_spawn_right_away = match res {
+                            Ok(Ok((pid, exit_status, exit_reason))) => {
+                                info!(%pid, ?exit_status, ?exit_reason, "Subprocess exited");
+                                true
+                            },
+                            Ok(Err(error)) => {
+                                warn!(error = %error, "Subprocess failed");
+                                true
+                            },
+                            Err(join_error) => {
+                                warn!(error = %join_error, "Subprocess exited unexpectedly");
+                                false
+                            },
+                        };
+                        // println!("one of our python processes have expired: {_maybe_info:?}");
+                        // we should spawn it immediatedly if empty
+                        spawn = allow_spawn_right_away && joinhandles.is_empty();
+                    }
+                    _ = &mut wait_before_spawning => {
+                        // spawn if needed
+                        spawn = count.get() > joinhandles.len();
+                    }
                 }
-                _ = &mut wait_before_spawning => {
-                    // spawn if needed
-                    spawn = count.get() > joinhandles.len();
+
+                if spawn {
+                    let jh = tokio::task::spawn(
+                        launch_python(
+                            database_path.clone(),
+                            Arc::clone(&command_rx),
+                            status_tx.clone(),
+                            child_shutdown_tx.subscribe(),
+                        )
+                        .in_current_span(),
+                    );
+
+                    joinhandles.push(jh);
+                } else if count.get() > joinhandles.len() && wait_before_spawning.is_elapsed() {
+                    wait_before_spawning
+                        .as_mut()
+                        .reset(tokio::time::Instant::now() + WAIT_BEFORE_SPAWN);
                 }
-            }
-
-            if spawn {
-                let jh = tokio::task::spawn(launch_python(
-                    database_path.clone(),
-                    Arc::clone(&command_rx),
-                    status_tx.clone(),
-                    child_shutdown_tx.subscribe(),
-                ));
-
-                joinhandles.push(jh);
-            } else if count.get() > joinhandles.len() && wait_before_spawning.is_elapsed() {
-                wait_before_spawning
-                    .as_mut()
-                    .reset(tokio::time::Instant::now() + WAIT_BEFORE_SPAWN);
             }
         }
-    });
+        .in_current_span(),
+    );
 
     Ok((handle, jh))
 }

--- a/crates/pathfinder/src/cairo/ext_py/sub_process.rs
+++ b/crates/pathfinder/src/cairo/ext_py/sub_process.rs
@@ -85,7 +85,9 @@ pub(super) async fn launch_python(
             at_block: &at_block,
         };
 
-        if let Err(e) = serde_json::to_writer(std::io::Cursor::new(&mut command_buffer), &cmd) {
+        let mut cursor = std::io::Cursor::new(&mut command_buffer);
+
+        if let Err(e) = serde_json::to_writer(&mut cursor, &cmd) {
             eprintln!("Failed to render command {cmd:?} as json: {e:?}");
             let _ = response.send(Err(CallFailure::Internal(
                 "Failed to render command as json",

--- a/crates/pathfinder/src/cairo/ext_py/sub_process.rs
+++ b/crates/pathfinder/src/cairo/ext_py/sub_process.rs
@@ -154,11 +154,11 @@ pub(super) async fn launch_python(
 
         let _ = response.send(sent_response);
 
-        if status_updates
+        let send_res = status_updates
             .send(SubProcessEvent::CommandHandled(pid, timings, status))
-            .await
-            .is_err()
-        {
+            .await;
+
+        if send_res.is_err() {
             break SubprocessExitReason::ClosedChannel;
         }
 

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -21,11 +21,50 @@ use jsonrpsee::{
 };
 use std::{net::SocketAddr, result::Result};
 
+/// Helper wrapper for attaching spans to rpc method implementations
+struct RpcModuleWrapper<Context>(jsonrpsee::RpcModule<Context>);
+
+impl<Context: Send + Sync + 'static> RpcModuleWrapper<Context> {
+    /// This wrapper helper adds a tracing span around all rpc methods with name = method_name.
+    ///
+    /// It could do more, for example trace the outputs, durations.
+    ///
+    /// This is the only one method provided at the moment, because it's the only one used. If you
+    /// need to use some other `register_*` method from [`jsonrpsee::RpcModule`], just add it to
+    /// this wrapper.
+    fn register_async_method<R, Fun, Fut>(
+        &mut self,
+        method_name: &'static str,
+        callback: Fun,
+    ) -> Result<jsonrpsee::utils::server::rpc_module::MethodResourcesBuilder, jsonrpsee::types::Error>
+    where
+        R: ::serde::Serialize + Send + Sync + 'static,
+        Fut: std::future::Future<Output = Result<R, Error>> + Send,
+        Fun: (Fn(jsonrpsee::types::v2::Params<'static>, std::sync::Arc<Context>) -> Fut)
+            + Copy
+            + Send
+            + Sync
+            + 'static,
+    {
+        use tracing::Instrument;
+
+        self.0.register_async_method(method_name, move |p, c| {
+            // why info here? it's the same used in warp tracing filter for example.
+            let span = tracing::info_span!("rpc_method", name = method_name);
+            callback(p, c).instrument(span)
+        })
+    }
+
+    fn into_inner(self) -> jsonrpsee::RpcModule<Context> {
+        self.0
+    }
+}
+
 /// Starts the HTTP-RPC server.
 pub fn run_server(addr: SocketAddr, api: RpcApi) -> Result<(HttpServerHandle, SocketAddr), Error> {
     let server = HttpServerBuilder::default().build(addr)?;
     let local_addr = server.local_addr()?;
-    let mut module = RpcModule::new(api);
+    let mut module = RpcModuleWrapper(RpcModule::new(api));
     module.register_async_method("starknet_getBlockByHash", |params, context| async move {
         #[derive(Debug, Deserialize)]
         pub struct NamedArgs {
@@ -187,6 +226,7 @@ pub fn run_server(addr: SocketAddr, api: RpcApi) -> Result<(HttpServerHandle, So
     module.register_async_method("starknet_syncing", |_, context| async move {
         context.chain_id().await
     })?;
+    let module = module.into_inner();
     server.start(module).map(|handle| (handle, local_addr))
 }
 

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -278,12 +278,10 @@ mod tests {
                         if sleep_time_ms > MAX_SLEEP_TIME_MS {
                             return Err(e);
                         }
+                        let d = Duration::from_millis(sleep_time_ms);
                         // Give the sequencer api some slack and then retry
-                        eprintln!(
-                            "Got HTTP 429, retrying after {} seconds...",
-                            sleep_time_ms / 1000
-                        );
-                        tokio::time::sleep(Duration::from_millis(sleep_time_ms)).await;
+                        eprintln!("Got HTTP 429, retrying after {:?} ...", d);
+                        tokio::time::sleep(d).await;
                         sleep_time_ms *= 2;
                     }
                     _ => return Err(e),

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -81,6 +81,7 @@ impl Client {
     }
 
     /// Gets block by number.
+    #[tracing::instrument(skip(self))]
     pub async fn block_by_number(
         &self,
         block_number: BlockNumberOrTag,
@@ -95,6 +96,7 @@ impl Client {
     }
 
     /// Gets block by number with the specified timeout.
+    #[tracing::instrument(skip(self))]
     pub async fn block_by_number_with_timeout(
         &self,
         block_number: BlockNumberOrTag,
@@ -111,6 +113,7 @@ impl Client {
     }
 
     /// Get block by hash.
+    #[tracing::instrument(skip(self))]
     pub async fn block_by_hash(
         &self,
         block_hash: BlockHashOrTag,
@@ -125,6 +128,7 @@ impl Client {
     }
 
     /// Performs a `call` on contract's function. Call result is not stored in L2, as opposed to `invoke`.
+    #[tracing::instrument(skip(self))]
     pub async fn call(
         &self,
         payload: request::Call,
@@ -137,6 +141,7 @@ impl Client {
     }
 
     /// Gets full contract definition.
+    #[tracing::instrument(skip(self))]
     pub async fn full_contract(
         &self,
         contract_addr: ContractAddress,
@@ -155,6 +160,7 @@ impl Client {
     }
 
     /// Gets storage value associated with a `key` for a prticular contract.
+    #[tracing::instrument(skip(self))]
     pub async fn storage(
         &self,
         contract_addr: ContractAddress,
@@ -180,6 +186,7 @@ impl Client {
     }
 
     /// Gets transaction by hash.
+    #[tracing::instrument(skip(self))]
     pub async fn transaction(
         &self,
         transaction_hash: StarknetTransactionHash,
@@ -196,6 +203,7 @@ impl Client {
     }
 
     /// Gets transaction status by transaction hash.
+    #[tracing::instrument(skip(self))]
     pub async fn transaction_status(
         &self,
         transaction_hash: StarknetTransactionHash,
@@ -212,6 +220,7 @@ impl Client {
     }
 
     /// Gets state update for a particular block hash.
+    #[tracing::instrument(skip(self))]
     pub async fn state_update_by_hash(
         &self,
         block_hash: BlockHashOrTag,
@@ -226,6 +235,7 @@ impl Client {
     }
 
     /// Gets state update for a particular block number.
+    #[tracing::instrument(skip(self))]
     pub async fn state_update_by_number(
         &self,
         block_number: BlockNumberOrTag,
@@ -242,6 +252,7 @@ impl Client {
     }
 
     /// Gets addresses of the Ethereum contracts crucial to Starknet operation.
+    #[tracing::instrument(skip(self))]
     pub async fn eth_contract_addresses(
         &self,
     ) -> Result<reply::EthContractAddresses, SequencerError> {
@@ -261,6 +272,7 @@ impl Client {
             .expect("Base URL is valid")
             .extend(&["feeder_gateway", path_segment]);
         query_url.query_pairs_mut().extend_pairs(params);
+        tracing::trace!(%query_url);
         query_url
     }
 }


### PR DESCRIPTION
This PR adds `tracing` usage such:

- with missing `RUST_LOG` env variable `info` is used
- rpc methods are wrapped in spans which tell the name of rpc method
    - there's no access to more information from jsonrpsee
- sequencer calls have all `#[instrument]`'d span
- ext_py is the one with mostly missing tracing, and it required some changes
    - it might be interesting to see how the span is continued in the worker process
    - there's no "normal" logging however, an example is provided for demoing this
