### PR TITLE
Separate nodestorage from merkletree

### DIFF
--- a/crates/pathfinder/src/state/merkle_tree.rs
+++ b/crates/pathfinder/src/state/merkle_tree.rs
@@ -120,7 +120,7 @@ impl<T: NodeStorage + Default> Default for MerkleTree<T> {
     /// Initializes a fresh empty MerkleTree on the defined storage implementation.
     fn default() -> Self {
         Self::new(Default::default(), StarkHash::ZERO).expect(
-            "Since called with ZERO as root, there should not had been a query, and thus no error",
+            "Since called with ZERO as root, there should not have been a query, and therefore no error",
         )
     }
 }

--- a/crates/pathfinder/src/state/merkle_tree.rs
+++ b/crates/pathfinder/src/state/merkle_tree.rs
@@ -57,14 +57,26 @@ use crate::storage::merkle_tree::{
 
 use pedersen::StarkHash;
 
+/// Backing storage for [`MerkleTree`].
+///
+/// Default implementation and persistent implementation is the [`RcNodeStorage`]. Testing/future
+/// implementations include [`HashMap`](std::collections::HashMap) and `()` based implementations
+/// where the backing storage is not persistent, or doesn't exist at all. The nodes will still be
+/// visitable in-memory.
 pub trait NodeStorage {
+    /// Find a persistent node during a traversal from the storage.
     fn get(&self, key: StarkHash) -> anyhow::Result<Option<PersistedNode>>;
 
+    /// Insert or ignore if already exists `node` to storage under the given `key`.
+    ///
+    /// This does not imply incrementing the nodes ref count.
     fn upsert(&self, key: StarkHash, node: PersistedNode) -> anyhow::Result<()>;
 
+    /// Decrement previously stored `key`'s reference count. This shouldn't fail for key not found.
     #[cfg(test)]
     fn decrement_ref_count(&self, key: StarkHash) -> anyhow::Result<()>;
 
+    /// Increment previously stored `key`'s reference count. This shouldn't fail for key not found.
     fn increment_ref_count(&self, key: StarkHash) -> anyhow::Result<()>;
 }
 

--- a/crates/pathfinder/src/state/state_tree.rs
+++ b/crates/pathfinder/src/state/state_tree.rs
@@ -10,12 +10,13 @@ use crate::{
         ContractAddress, ContractRoot, ContractStateHash, GlobalRoot, StorageAddress, StorageValue,
     },
     state::merkle_tree::MerkleTree,
+    storage::merkle_tree::RcNodeStorage,
 };
 
 /// A Binary Merkle-Patricia Tree which contains
 /// the storage state of all StarkNet contracts.
 pub struct ContractsStateTree<'a> {
-    tree: MerkleTree<'a>,
+    tree: MerkleTree<RcNodeStorage<'a>>,
 }
 
 impl<'a> ContractsStateTree<'a> {
@@ -45,7 +46,7 @@ impl<'a> ContractsStateTree<'a> {
 /// A Binary Merkle-Patricia Tree which contains
 /// the global state of StarkNet.
 pub struct GlobalStateTree<'a> {
-    tree: MerkleTree<'a>,
+    tree: MerkleTree<RcNodeStorage<'a>>,
 }
 
 impl<'a> GlobalStateTree<'a> {

--- a/crates/pathfinder/src/storage/merkle_tree.rs
+++ b/crates/pathfinder/src/storage/merkle_tree.rs
@@ -61,6 +61,25 @@ pub struct RcNodeStorage<'a> {
     table: String,
 }
 
+impl<'a> crate::state::merkle_tree::NodeStorage for RcNodeStorage<'a> {
+    fn get(&self, key: StarkHash) -> anyhow::Result<Option<PersistedNode>> {
+        self.get(key)
+    }
+
+    fn upsert(&self, key: StarkHash, node: PersistedNode) -> anyhow::Result<()> {
+        self.upsert(key, node)
+    }
+
+    #[cfg(test)]
+    fn decrement_ref_count(&self, key: StarkHash) -> anyhow::Result<()> {
+        RcNodeStorage::decrement_ref_count(self, key)
+    }
+
+    fn increment_ref_count(&self, key: StarkHash) -> anyhow::Result<()> {
+        self.increment_ref_count(key)
+    }
+}
+
 /// A binary node which can be read / written from an [RcNodeStorage].
 #[derive(Debug, Clone, PartialEq)]
 pub struct PersistedBinaryNode {


### PR DESCRIPTION
This PR separates a `trait NodeStorage` from the MerkleTree implementation. Originally done for fuzzing in `tree_tool` branch, but it's most likely useful with the upcoming block hashing, which will still need configured depth=64.

Included is one additional backing implementations for `()`. There's a `RefCell<HashMap<_, _>>` in `tree_tool`, since only `()` should be needed for transaction trie.

The old api is kept for not requiring changes anywhere else:
- `MerkleTree::<RcNodeStorage<'_>>::load` still exists
- `MerkleTree::<T: NodeStorage + Default>::default()` is added
- `MerkleTree::<T>::commit_mut(&mut self)` is added next to `commit(self)` which just doesn't consume self

