### PR TITLE
ci: pre-compile cairo tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,4 +104,5 @@ jobs:
       - name: Integration (rust)
         run: |
           source py/.venv/bin/activate
+          cargo test --no-run --p pathfinder
           timeout 5m cargo test -p pathfinder -- cairo::ext_py --ignored

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,5 +104,5 @@ jobs:
       - name: Integration (rust)
         run: |
           source py/.venv/bin/activate
-          cargo test --no-run --p pathfinder
+          cargo test --no-run -p pathfinder
           timeout 5m cargo test -p pathfinder -- cairo::ext_py --ignored


### PR DESCRIPTION
The current 5min timeout includes compilation time which causes test failures depending on build cache.