### PR TITLE
rpc: re-enable get_storage_at

### DIFF
--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -12,7 +12,7 @@ use crate::{
         BlockHashOrTag, BlockNumberOrTag, Tag,
     },
     sequencer::{self, reply as raw},
-    storage::{self, Storage},
+    storage::Storage,
 };
 use anyhow::Context;
 use jsonrpsee::types::{
@@ -119,108 +119,103 @@ impl RpcApi {
     /// otherwise we would report [-32602](https://www.jsonrpc.org/specification#error_object).
     pub async fn get_storage_at(
         &self,
-        _contract_address: ContractAddress,
-        _key: OverflowingStorageAddress,
-        _block_hash: BlockHashOrTag,
+        contract_address: ContractAddress,
+        key: OverflowingStorageAddress,
+        block_hash: BlockHashOrTag,
     ) -> RpcResult<StorageValue> {
-        todo!("Fix to use new schema tables");
-        // use crate::{
-        //     state::state_tree::{ContractsStateTree, GlobalStateTree},
-        //     storage::ContractsStateTable,
-        // };
-        // use pedersen::StarkHash;
+        use crate::{
+            core::StorageAddress,
+            state::state_tree::{ContractsStateTree, GlobalStateTree},
+            storage::{ContractsStateTable, StarknetBlocksBlockId, StarknetBlocksTable},
+        };
+        use pedersen::{OverflowError, StarkHash};
 
-        // let key = StorageAddress(StarkHash::from_be_bytes(key.0.to_fixed_bytes()).map_err(
-        //     // Report that the value is >= than the field modulus
-        //     // Use explicit typing in closure arg to force compiler error should error variants ever be expanded
-        //     |_e: OverflowError| Error::from(ErrorCode::InvalidStorageKey),
-        // )?);
+        let key = StorageAddress(StarkHash::from_be_bytes(key.0.to_fixed_bytes()).map_err(
+            // Report that the value is >= than the field modulus
+            // Use explicit typing in closure arg to force compiler error should error variants ever be expanded
+            |_e: OverflowError| Error::from(ErrorCode::InvalidStorageKey),
+        )?);
 
-        // if key.0.has_more_than_251_bits() {
-        //     // Report that the value is more than 251 bits
-        //     return Err(Error::from(ErrorCode::InvalidStorageKey));
-        // }
+        if key.0.has_more_than_251_bits() {
+            // Report that the value is more than 251 bits
+            return Err(Error::from(ErrorCode::InvalidStorageKey));
+        }
 
-        // if let BlockHashOrTag::Tag(Tag::Pending) = block_hash {
-        //     // Pending request is always forwarded
-        //     return Ok(self
-        //         .sequencer
-        //         .storage(contract_address, key, block_hash)
-        //         .await?);
-        // }
+        let block_id = match block_hash {
+            BlockHashOrTag::Hash(hash) => hash.into(),
+            BlockHashOrTag::Tag(Tag::Latest) => StarknetBlocksBlockId::Latest,
+            BlockHashOrTag::Tag(Tag::Pending) => {
+                return Ok(self
+                    .sequencer
+                    .storage(contract_address, key, block_hash)
+                    .await?);
+            }
+        };
 
-        // let storage = self.storage.clone();
+        let storage = self.storage.clone();
 
-        // let jh = tokio::task::spawn_blocking(move || {
-        //     let mut db = storage
-        //         .connection()
-        //         .context("Opening database connection")
-        //         .map_err(internal_server_error)?;
+        let jh = tokio::task::spawn_blocking(move || {
+            let mut db = storage
+                .connection()
+                .context("Opening database connection")
+                .map_err(internal_server_error)?;
 
-        //     let tx = db
-        //         .transaction()
-        //         .context("Creating database transaction")
-        //         .map_err(internal_server_error)?;
+            let tx = db
+                .transaction()
+                .context("Creating database transaction")
+                .map_err(internal_server_error)?;
 
-        //     // Use internal_server_error to indicate that the process of querying for a particular block failed,
-        //     // which is not the same as being sure that the block is not in the db.
-        //     let global_root = match block_hash {
-        //         BlockHashOrTag::Hash(hash) => GlobalStateTable::get_root_at_block_hash(&tx, hash)
-        //             .map_err(internal_server_error)?,
-        //         BlockHashOrTag::Tag(tag) => match tag {
-        //             Tag::Latest => {
-        //                 GlobalStateTable::get_latest_root(&tx).map_err(internal_server_error)?
-        //             }
-        //             Tag::Pending => unreachable!("Pending has already been handled above"),
-        //         },
-        //     }
-        //     // Since the db query succeeded in execution, we can now report if the block hash was indeed not found
-        //     // by using a dedicated error code from the RPC API spec
-        //     .ok_or_else(|| Error::from(ErrorCode::InvalidBlockHash))?;
+            // Use internal_server_error to indicate that the process of querying for a particular block failed,
+            // which is not the same as being sure that the block is not in the db.
+            let global_root = StarknetBlocksTable::get_root(&tx, block_id)
+                .map_err(internal_server_error)?
+                // Since the db query succeeded in execution, we can now report if the block hash was indeed not found
+                // by using a dedicated error code from the RPC API spec
+                .ok_or_else(|| Error::from(ErrorCode::InvalidBlockHash))?;
 
-        //     let global_state_tree = GlobalStateTree::load(&tx, global_root)
-        //         .context("Global state tree")
-        //         .map_err(internal_server_error)?;
+            let global_state_tree = GlobalStateTree::load(&tx, global_root)
+                .context("Global state tree")
+                .map_err(internal_server_error)?;
 
-        //     let contract_state_hash = global_state_tree
-        //         .get(contract_address)
-        //         .context("Get contract state hash from global state tree")
-        //         .map_err(internal_server_error)?;
+            let contract_state_hash = global_state_tree
+                .get(contract_address)
+                .context("Get contract state hash from global state tree")
+                .map_err(internal_server_error)?;
 
-        //     // There is a dedicated error code for a non-existent contract in the RPC API spec, so use it.
-        //     if contract_state_hash.0 == StarkHash::ZERO {
-        //         return Err(Error::from(ErrorCode::ContractNotFound));
-        //     }
+            // There is a dedicated error code for a non-existent contract in the RPC API spec, so use it.
+            if contract_state_hash.0 == StarkHash::ZERO {
+                return Err(Error::from(ErrorCode::ContractNotFound));
+            }
 
-        //     let contract_state_root = ContractsStateTable::get_root(&tx, contract_state_hash)
-        //         .context("Get contract state root")
-        //         .map_err(internal_server_error)?
-        //         .ok_or_else(|| {
-        //             internal_server_error(anyhow::anyhow!(
-        //                 "Contract state root not found for contract state hash {}",
-        //                 contract_state_hash.0
-        //             ))
-        //         })?;
+            let contract_state_root = ContractsStateTable::get_root(&tx, contract_state_hash)
+                .context("Get contract state root")
+                .map_err(internal_server_error)?
+                .ok_or_else(|| {
+                    internal_server_error(anyhow::anyhow!(
+                        "Contract state root not found for contract state hash {}",
+                        contract_state_hash.0
+                    ))
+                })?;
 
-        //     let contract_state_tree = ContractsStateTree::load(&tx, contract_state_root)
-        //         .context("Load contract state tree")
-        //         .map_err(internal_server_error)?;
+            let contract_state_tree = ContractsStateTree::load(&tx, contract_state_root)
+                .context("Load contract state tree")
+                .map_err(internal_server_error)?;
 
-        //     // ContractsStateTree::get() will return zero if the value is still not found (and we know the key is valid),
-        //     // which is consistent with the specification.
-        //     let storage_val = contract_state_tree
-        //         .get(key)
-        //         .context("Get value from contract state tree")
-        //         .map_err(internal_server_error)?;
+            // ContractsStateTree::get() will return zero if the value is still not found (and we know the key is valid),
+            // which is consistent with the specification.
+            let storage_val = contract_state_tree
+                .get(key)
+                .context("Get value from contract state tree")
+                .map_err(internal_server_error)?;
 
-        //     Ok(storage_val)
-        // });
+            Ok(storage_val)
+        });
 
-        // jh.await
-        //     .context("Database read panic or shutting down")
-        //     .map_err(internal_server_error)
-        //     // flatten is unstable
-        //     .and_then(|x| x)
+        jh.await
+            .context("Database read panic or shutting down")
+            .map_err(internal_server_error)
+            // flatten is unstable
+            .and_then(|x| x)
     }
 
     /// Helper function.
@@ -329,6 +324,8 @@ impl RpcApi {
     /// Get the code of a specific contract.
     /// `contract_address` is the address of the contract to read from.
     pub async fn get_code(&self, contract_address: ContractAddress) -> RpcResult<ContractCode> {
+        use crate::storage::ContractCodeTable;
+
         let storage = self.storage.clone();
 
         let jh = tokio::task::spawn_blocking(move || {
@@ -337,7 +334,7 @@ impl RpcApi {
                 .context("Opening database connection")?;
             let tx = db.transaction().context("Creating database transaction")?;
 
-            let code = storage::ContractCodeTable::get_code(&tx, contract_address)
+            let code = ContractCodeTable::get_code(&tx, contract_address)
                 .context("Fetching code from database")?;
 
             match code {

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -19,7 +19,8 @@ use std::sync::Mutex;
 pub use contract::{ContractCodeTable, ContractsTable};
 pub use ethereum::{EthereumBlocksTable, EthereumTransactionsTable};
 pub use state::{
-    BlockId, ContractsStateTable, L1StateTable, RefsTable, StarknetBlock, StarknetBlocksTable,
+    ContractsStateTable, L1StateTable, L1TableBlockId, RefsTable, StarknetBlock,
+    StarknetBlocksBlockId, StarknetBlocksTable,
 };
 
 use anyhow::Context;

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -16,6 +16,7 @@ use crate::{
 /// Contains the [L1 Starknet update logs](StateUpdateLog).
 pub struct L1StateTable {}
 
+/// Identifies block in some [L1StateTable] queries.
 pub enum L1TableBlockId {
     Number(StarknetBlockNumber),
     Latest,
@@ -28,6 +29,7 @@ impl From<StarknetBlockNumber> for L1TableBlockId {
 }
 
 impl L1StateTable {
+    /// Inserts a new [update](StateUpdateLog), fails if it already exists.
     pub fn insert(connection: &Connection, update: &StateUpdateLog) -> anyhow::Result<()> {
         connection
             .execute(
@@ -73,6 +75,7 @@ impl L1StateTable {
         Ok(())
     }
 
+    /// Returns the [root](GlobalRoot) of the given block.
     pub fn get_root(
         connection: &Connection,
         block: L1TableBlockId,
@@ -106,6 +109,7 @@ impl L1StateTable {
         Ok(Some(starknet_global_root))
     }
 
+    /// Returns the [update](StateUpdateLog) of the given block.
     pub fn get(
         connection: &Connection,
         block: L1TableBlockId,
@@ -202,6 +206,7 @@ impl L1StateTable {
 
 pub struct RefsTable {}
 impl RefsTable {
+    /// Returns the current L1-L2 head. This indicates the latest block for which L1 and L2 agree.
     pub fn get_l1_l2_head(connection: &Connection) -> anyhow::Result<Option<StarknetBlockNumber>> {
         // This table always contains exactly one row.
         let block_number =
@@ -218,6 +223,7 @@ impl RefsTable {
         Ok(block_number)
     }
 
+    /// Sets the current L1-L2 head. This should indicate the latest block for which L1 and L2 agree.
     pub fn set_l1_l2_head(
         connection: &Connection,
         head: Option<StarknetBlockNumber>,
@@ -235,6 +241,7 @@ impl RefsTable {
 /// Stores all knowm [StarknetBlocks][StarknetBlock].
 pub struct StarknetBlocksTable {}
 impl StarknetBlocksTable {
+    /// Insert a new [StarknetBlock]. Fails if the block number is not unique.
     pub fn insert(connection: &Connection, block: &StarknetBlock) -> anyhow::Result<()> {
         let transactions =
             serde_json::ser::to_vec(&block.transactions).context("Serialize transactions")?;
@@ -259,6 +266,7 @@ impl StarknetBlocksTable {
         Ok(())
     }
 
+    /// Returns the [root](GlobalRoot) of the given block.
     pub fn get_root(
         connection: &Connection,
         block: StarknetBlocksBlockId,
@@ -295,6 +303,7 @@ impl StarknetBlocksTable {
         }
     }
 
+    /// Returns the [Starknet block](StarknetBlocksBlockId) of the given block.
     pub fn get_without_tx(
         connection: &Connection,
         block: StarknetBlocksBlockId,
@@ -361,6 +370,7 @@ impl StarknetBlocksTable {
     }
 }
 
+/// Identifies block in some [StarknetBlocksTable] queries.
 pub enum StarknetBlocksBlockId {
     Number(StarknetBlockNumber),
     Hash(StarknetBlockHash),


### PR DESCRIPTION
This PR re-enables `rpc::get_storage_at` functionality. This was previously commented out by #121 due to schema changes.

This required re-adding the missing functionality to storage again.