### PR TITLE
Storage: compress transaction data

### DIFF
--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -11,6 +11,7 @@ mod state;
 use schema::revision_0001::migrate_to_1;
 use schema::revision_0002::migrate_to_2;
 use schema::revision_0003::migrate_to_3;
+use schema::revision_0004::migrate_to_4;
 
 use std::path::{Path, PathBuf};
 #[cfg(test)]
@@ -29,7 +30,7 @@ use rusqlite::{Connection, Transaction};
 /// Indicates database is non-existant.
 const DB_VERSION_EMPTY: u32 = 0;
 /// Current database version.
-const DB_VERSION_CURRENT: u32 = 3;
+const DB_VERSION_CURRENT: u32 = 4;
 /// Sqlite key used for the PRAGMA user version.
 const VERSION_KEY: &str = "user_version";
 
@@ -138,6 +139,7 @@ fn migrate_database(transaction: &Transaction) -> anyhow::Result<()> {
             DB_VERSION_EMPTY => migrate_to_1(transaction)?,
             1 => migrate_to_2(transaction)?,
             2 => migrate_to_3(transaction)?,
+            3 => migrate_to_4(transaction)?,
             _ => unreachable!("Database version constraint was already checked!"),
         }
     }

--- a/crates/pathfinder/src/storage/contract.rs
+++ b/crates/pathfinder/src/storage/contract.rs
@@ -195,10 +195,9 @@ mod tests {
 
     #[test]
     fn fails_if_contract_hash_missing() {
-        let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+        let storage = Storage::in_memory().unwrap();
+        let mut conn = storage.connection().unwrap();
         let transaction = conn.transaction().unwrap();
-
-        crate::storage::migrate_to_1(&transaction).unwrap();
 
         let address = ContractAddress(StarkHash::from_hex_str("abc").unwrap());
         let hash = ContractHash(StarkHash::from_hex_str("123").unwrap());
@@ -208,10 +207,9 @@ mod tests {
 
     #[test]
     fn get_hash() {
-        let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+        let storage = Storage::in_memory().unwrap();
+        let mut conn = storage.connection().unwrap();
         let transaction = conn.transaction().unwrap();
-
-        crate::storage::migrate_to_1(&transaction).unwrap();
 
         let address = ContractAddress(StarkHash::from_hex_str("abc").unwrap());
         let hash = ContractHash(StarkHash::from_hex_str("123").unwrap());
@@ -227,10 +225,9 @@ mod tests {
 
     #[test]
     fn get_code() {
-        let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+        let storage = Storage::in_memory().unwrap();
+        let mut conn = storage.connection().unwrap();
         let transaction = conn.transaction().unwrap();
-
-        crate::storage::migrate_to_1(&transaction).unwrap();
 
         let address = ContractAddress(StarkHash::from_hex_str("abc").unwrap());
         let hash = ContractHash(StarkHash::from_hex_str("123").unwrap());

--- a/crates/pathfinder/src/storage/schema.rs
+++ b/crates/pathfinder/src/storage/schema.rs
@@ -2,3 +2,12 @@ pub(crate) mod revision_0001;
 pub(crate) mod revision_0002;
 pub(crate) mod revision_0003;
 pub(crate) mod revision_0004;
+
+/// Used to indicate which action the caller should perform after a schema migration.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PostMigrationAction {
+    /// A database VACUUM should be performed.
+    Vacuum,
+    /// No further action requried.
+    None,
+}

--- a/crates/pathfinder/src/storage/schema.rs
+++ b/crates/pathfinder/src/storage/schema.rs
@@ -1,3 +1,4 @@
 pub(crate) mod revision_0001;
 pub(crate) mod revision_0002;
 pub(crate) mod revision_0003;
+pub(crate) mod revision_0004;

--- a/crates/pathfinder/src/storage/schema/revision_0001.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0001.rs
@@ -1,6 +1,8 @@
 use rusqlite::Transaction;
 
-pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<()> {
+use crate::storage::schema::PostMigrationAction;
+
+pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigrationAction> {
     transaction.execute(
         r"CREATE TABLE contract_code (
             hash       BLOB PRIMARY KEY,
@@ -58,5 +60,5 @@ pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<()> {
         [],
     )?;
 
-    Ok(())
+    Ok(PostMigrationAction::None)
 }

--- a/crates/pathfinder/src/storage/schema/revision_0001.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0001.rs
@@ -1,6 +1,6 @@
 use rusqlite::Transaction;
 
-pub(crate) fn migrate_to_1(transaction: &Transaction) -> anyhow::Result<()> {
+pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<()> {
     transaction.execute(
         r"CREATE TABLE contract_code (
             hash       BLOB PRIMARY KEY,

--- a/crates/pathfinder/src/storage/schema/revision_0002.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0002.rs
@@ -2,7 +2,9 @@ use anyhow::Context;
 use rusqlite::Transaction;
 use sha3::{Digest, Keccak256};
 
-pub(crate) fn migrate(tx: &Transaction) -> anyhow::Result<()> {
+use crate::storage::schema::PostMigrationAction;
+
+pub(crate) fn migrate(tx: &Transaction) -> anyhow::Result<PostMigrationAction> {
     // we had a mishap of forking the schema at version 1 so to really support all combinations of
     // schema at version 1 we need to make sure that contracts table still looks like:
     // CREATE TABLE contracts (
@@ -32,7 +34,7 @@ pub(crate) fn migrate(tx: &Transaction) -> anyhow::Result<()> {
         }
 
         if actual == no_need {
-            return Ok(());
+            return Ok(PostMigrationAction::None);
         }
 
         assert_eq!(
@@ -155,5 +157,5 @@ pub(crate) fn migrate(tx: &Transaction) -> anyhow::Result<()> {
 
     println!("table contracts_v1 dropped in {:?}", started_at.elapsed());
 
-    Ok(())
+    Ok(PostMigrationAction::None)
 }

--- a/crates/pathfinder/src/storage/schema/revision_0002.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0002.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use rusqlite::Transaction;
 use sha3::{Digest, Keccak256};
 
-pub(crate) fn migrate_to_2(tx: &Transaction) -> anyhow::Result<()> {
+pub(crate) fn migrate(tx: &Transaction) -> anyhow::Result<()> {
     // we had a mishap of forking the schema at version 1 so to really support all combinations of
     // schema at version 1 we need to make sure that contracts table still looks like:
     // CREATE TABLE contracts (

--- a/crates/pathfinder/src/storage/schema/revision_0003.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0003.rs
@@ -1,12 +1,14 @@
 use rusqlite::{params, OptionalExtension, Transaction};
 
+use crate::storage::schema::PostMigrationAction;
+
 /// This schema migration splits the global state table into
 /// separate tables containing L1 and L2 data.
 ///
 /// In addition, it also adds a refs table which only contains a single column.
 /// This columns references the latest Starknet block for which the L1 and L2
 /// states are the same.
-pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<()> {
+pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigrationAction> {
     // Create the new L1 table.
     transaction.execute(
         r"CREATE TABLE l1_state (
@@ -102,13 +104,13 @@ pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<()> {
     transaction.execute("DROP TABLE ethereum_transactions", [])?;
     transaction.execute("DROP TABLE ethereum_blocks", [])?;
 
-    Ok(())
+    Ok(PostMigrationAction::None)
 }
 
 #[cfg(test)]
 mod tests {
-    use rusqlite::{named_params, params, Connection};
     use crate::storage::schema;
+    use rusqlite::{named_params, params, Connection};
 
     use super::*;
 

--- a/crates/pathfinder/src/storage/schema/revision_0004.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0004.rs
@@ -1,0 +1,41 @@
+use anyhow::Context;
+use rusqlite::{params, Transaction};
+use tracing::info;
+
+/// This schema migration adds ZTSD compression to the Starknet transaction and transaction receipts.
+/// There are no physical changes to the actual schema, but simply the data in these two columns.
+pub(crate) fn migrate_to_4(transaction: &Transaction) -> anyhow::Result<()> {
+    let todo: u32 = transaction
+        .query_row("SELECT count(1) FROM starknet_blocks", [], |r| r.get(0))
+        .unwrap();
+    if todo == 0 {
+        return Ok(());
+    }
+
+    info!("Compressing {} rows of transaction data", todo);
+
+    let mut stmt = transaction
+        .prepare("SELECT number, transactions, transaction_receipts FROM starknet_blocks")?;
+    let mut rows = stmt.query([])?;
+
+    let mut compressor = zstd::bulk::Compressor::new(10).context("Create zstd compressor")?;
+
+    while let Some(r) = rows.next()? {
+        let number = r.get_ref_unwrap("number").as_i64()?;
+        let transactions = r.get_ref_unwrap("transactions").as_blob()?;
+        let transaction_receipts = r.get_ref_unwrap("transaction_receipts").as_blob()?;
+
+        let transactions = compressor
+            .compress(transactions)
+            .context("Compress transactions")?;
+        let transaction_receipts = compressor
+            .compress(transaction_receipts)
+            .context("Compress transaction receipts")?;
+
+        let diff_count = transaction.execute("UPDATE starknet_blocks SET transactions = ?1, transaction_receipts = ?2 WHERE number = ?3",
+            params![&transactions, &transaction_receipts, number]).context("Update transaction data")?;
+        assert_eq!(diff_count, 1);
+    }
+
+    Ok(())
+}

--- a/crates/pathfinder/src/storage/schema/revision_0004.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0004.rs
@@ -4,7 +4,7 @@ use tracing::info;
 
 /// This schema migration adds ZTSD compression to the Starknet transaction and transaction receipts.
 /// There are no physical changes to the actual schema, but simply the data in these two columns.
-pub(crate) fn migrate_to_4(transaction: &Transaction) -> anyhow::Result<()> {
+pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<()> {
     let todo: u32 = transaction
         .query_row("SELECT count(1) FROM starknet_blocks", [], |r| r.get(0))
         .unwrap();

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -489,10 +489,9 @@ mod tests {
 
         #[test]
         fn get_root() {
-            let mut conn = rusqlite::Connection::open_in_memory().unwrap();
-            let transaction = conn.transaction().unwrap();
-
-            crate::storage::migrate_to_1(&transaction).unwrap();
+            let storage = Storage::in_memory().unwrap();
+            let mut connection = storage.connection().unwrap();
+            let transaction = connection.transaction().unwrap();
 
             let state_hash = ContractStateHash(StarkHash::from_hex_str("abc").unwrap());
             let hash = ContractHash(StarkHash::from_hex_str("123").unwrap());

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -248,7 +248,13 @@ impl StarknetBlocksTable {
         let receipts = serde_json::ser::to_vec(&block.transaction_receipts)
             .context("Serialize transaction receipts")?;
 
-        // TODO: compress transactions...
+        let mut compressor = zstd::bulk::Compressor::new(10).context("Create zstd compressor")?;
+        let transactions = compressor
+            .compress(&transactions)
+            .context("Compress transactions")?;
+        let receipts = compressor
+            .compress(&receipts)
+            .context("Compress transaction receipts")?;
 
         connection.execute(
         r"INSERT INTO starknet_blocks ( number,  hash,  root,  timestamp,  transactions,  transaction_receipts)

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -206,7 +206,7 @@ def check_schema(connection):
     assert cursor is not None, "there has to be an user_version defined in the database"
 
     [version] = next(cursor)
-    return version == 3
+    return version == 4
 
 
 def resolve_block(connection, at_block):

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -98,7 +98,7 @@ def inmemory_with_tables():
     # strangely this cannot be pulled into the script, maybe pragmas have
     # different kind of semantics than what is normally executed, would explain
     # the similar behaviour of sqlite3 .dump and restore.
-    cur.execute("pragma user_version = 3;")
+    cur.execute("pragma user_version = 4;")
 
     con.commit()
     return con


### PR DESCRIPTION
This PR adds compression to the Starknet transaction data in our storage.

As an overview of the changes:

- add a migration which compresses existing database data
  - add post-migration action to enable selective database vacuuming - to take advantage of the compression space saving
- add compression to database insertion
- fix-up some tests which relied on old versions instead of the full migration
- migrations are now committed independently instead of one bulk transaction
- refactor migration naming 

The compression saves me around 300MB on a 2GB database file after 40k blocks.
