### PR TITLE
feat(pathfinder): add sync

### DIFF
--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -13,9 +13,10 @@ pub(crate) mod contract_hash;
 mod merkle_node;
 pub(crate) mod merkle_tree;
 pub(crate) mod state_tree;
-pub mod sync;
+mod sync;
 
 pub use contract_hash::compute_contract_hash;
+pub use sync::sync;
 
 pub struct CompressedContract {
     pub abi: Vec<u8>,

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -193,7 +193,6 @@ pub async fn sync(
                 let _ = tx.send(exists);
             }
             Err(TryRecvError::Empty) => {
-                println!("nothing from L2");
                 l2_did_emit = false;
             }
             Err(TryRecvError::Disconnected) => {


### PR DESCRIPTION
This PR adds the sync process to the `pathfinder` binary.

Also removed a spammy `println!` (these will get reworked into tracing soon).

Closes #138.