### PR TITLE
Storage: move Starknet transactions to a separate table

### DIFF
--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -326,8 +326,6 @@ async fn l2_update(
             hash: block.block_hash.unwrap(),
             root: block.state_root.unwrap(),
             timestamp: StarknetBlockTimestamp(block.timestamp),
-            // transaction_receipts: block.transaction_receipts,
-            // transactions: block.transactions,
         };
         StarknetBlocksTable::insert(&transaction, &starknet_block)
             .context("Insert block into database")?;

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -14,7 +14,8 @@ use crate::{
     state::{calculate_contract_state_hash, state_tree::GlobalStateTree, update_contract_state},
     storage::{
         ContractCodeTable, ContractsStateTable, ContractsTable, L1StateTable, L1TableBlockId,
-        RefsTable, StarknetBlock, StarknetBlocksBlockId, StarknetBlocksTable, Storage,
+        RefsTable, StarknetBlock, StarknetBlocksBlockId, StarknetBlocksTable,
+        StarknetTransactionsTable, Storage,
     },
 };
 
@@ -41,7 +42,7 @@ pub async fn sync(
     let (l1_head, l2_head) = tokio::task::block_in_place(|| -> anyhow::Result<_> {
         let l1_head = L1StateTable::get(&db_conn, L1TableBlockId::Latest)
             .context("Query L1 head from database")?;
-        let l2_head = StarknetBlocksTable::get_without_tx(&db_conn, StarknetBlocksBlockId::Latest)
+        let l2_head = StarknetBlocksTable::get(&db_conn, StarknetBlocksBlockId::Latest)
             .context("Query L2 head from database")?
             .map(|block| (block.number, block.hash));
 
@@ -174,7 +175,7 @@ pub async fn sync(
             }
             Ok(l2::Event::QueryHash(block, tx)) => {
                 let hash = tokio::task::block_in_place(|| {
-                    StarknetBlocksTable::get_without_tx(&db_conn, block.into())
+                    StarknetBlocksTable::get(&db_conn, block.into())
                 })
                 .with_context(|| format!("Query L2 block hash for block {:?}", block))?
                 .map(|block| block.hash);
@@ -205,7 +206,7 @@ pub async fn sync(
                 }
 
                 let l2_head = tokio::task::block_in_place(|| {
-                    StarknetBlocksTable::get_without_tx(&db_conn, StarknetBlocksBlockId::Latest)
+                    StarknetBlocksTable::get(&db_conn, StarknetBlocksBlockId::Latest)
                 })
                 .context("Query L2 head from database")?
                 .map(|block| (block.number, block.hash));
@@ -248,12 +249,10 @@ async fn l1_update(
             Some(update) if update.block_number == expected_next => {
                 let mut next_head = None;
                 for update in updates {
-                    let l2_root = StarknetBlocksTable::get_without_tx(
-                        &transaction,
-                        update.block_number.into(),
-                    )
-                    .context("Query L2 root")?
-                    .map(|block| block.root);
+                    let l2_root =
+                        StarknetBlocksTable::get(&transaction, update.block_number.into())
+                            .context("Query L2 root")?
+                            .map(|block| block.root);
 
                     match l2_root {
                         Some(l2_root) if l2_root == update.global_root => {
@@ -322,15 +321,35 @@ async fn l2_update(
         // Update L2 database. These types shouldn't be options at this level,
         // but for now the unwraps are "safe" in that these should only ever be
         // None for pending queries to the sequencer, but we aren't using those here.
-        let block = StarknetBlock {
+        let starknet_block = StarknetBlock {
             number: block.block_number.unwrap(),
             hash: block.block_hash.unwrap(),
             root: block.state_root.unwrap(),
             timestamp: StarknetBlockTimestamp(block.timestamp),
-            transaction_receipts: block.transaction_receipts,
-            transactions: block.transactions,
+            // transaction_receipts: block.transaction_receipts,
+            // transactions: block.transactions,
         };
-        StarknetBlocksTable::insert(&transaction, &block).context("Insert update")?;
+        StarknetBlocksTable::insert(&transaction, &starknet_block)
+            .context("Insert block into database")?;
+
+        // Insert the transactions.
+        anyhow::ensure!(
+            block.transactions.len() == block.transaction_receipts.len(),
+            "Transactions and receipts mismatch. There were {} transactions and {} receipts.",
+            block.transactions.len(),
+            block.transaction_receipts.len()
+        );
+        let transaction_data = block
+            .transactions
+            .into_iter()
+            .zip(block.transaction_receipts.into_iter())
+            .collect::<Vec<_>>();
+        StarknetTransactionsTable::insert_block_transactions(
+            &transaction,
+            starknet_block.hash,
+            &transaction_data,
+        )
+        .context("Insert transaction data into database")?;
 
         // Track combined L1 and L2 state.
         let l1_l2_head = RefsTable::get_l1_l2_head(&transaction).context("Query L1-L2 head")?;
@@ -338,11 +357,11 @@ async fn l2_update(
             .map(|head| head + 1)
             .unwrap_or(StarknetBlockNumber::GENESIS);
 
-        if expected_next == block.number {
-            let l1_root = L1StateTable::get_root(&transaction, block.number.into())
+        if expected_next == starknet_block.number {
+            let l1_root = L1StateTable::get_root(&transaction, starknet_block.number.into())
                 .context("Query L1 root")?;
-            if l1_root == Some(block.root) {
-                RefsTable::set_l1_l2_head(&transaction, Some(block.number))
+            if l1_root == Some(starknet_block.root) {
+                RefsTable::set_l1_l2_head(&transaction, Some(starknet_block.number))
                     .context("Update L1-L2 head")?;
             }
         }
@@ -386,11 +405,10 @@ fn update_starknet_state(
     transaction: &Transaction,
     diff: StateUpdate,
 ) -> anyhow::Result<GlobalRoot> {
-    let global_root =
-        StarknetBlocksTable::get_without_tx(transaction, StarknetBlocksBlockId::Latest)
-            .context("Query latest state root")?
-            .map(|block| block.root)
-            .unwrap_or(GlobalRoot(StarkHash::ZERO));
+    let global_root = StarknetBlocksTable::get(transaction, StarknetBlocksBlockId::Latest)
+        .context("Query latest state root")?
+        .map(|block| block.root)
+        .unwrap_or(GlobalRoot(StarkHash::ZERO));
     let mut global_tree =
         GlobalStateTree::load(transaction, global_root).context("Loading global state tree")?;
 

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -26,7 +26,7 @@ use tracing::info;
 /// Indicates database is non-existant.
 const DB_VERSION_EMPTY: u32 = 0;
 /// Current database version.
-const DB_VERSION_CURRENT: u32 = 4;
+const DB_VERSION_CURRENT: u32 = 5;
 /// Sqlite key used for the PRAGMA user version.
 const VERSION_KEY: &str = "user_version";
 
@@ -141,6 +141,7 @@ fn migrate_database(connection: &mut Connection) -> anyhow::Result<()> {
             1 => schema::revision_0002::migrate(&transaction)?,
             2 => schema::revision_0003::migrate(&transaction)?,
             3 => schema::revision_0004::migrate(&transaction)?,
+            4 => schema::revision_0005::migrate(&transaction)?,
             _ => unreachable!("Database version constraint was already checked!"),
         };
         // If any migration action requires vacuuming, we should vacuum.

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -16,7 +16,7 @@ pub use contract::{ContractCodeTable, ContractsTable};
 pub use ethereum::{EthereumBlocksTable, EthereumTransactionsTable};
 pub use state::{
     ContractsStateTable, L1StateTable, L1TableBlockId, RefsTable, StarknetBlock,
-    StarknetBlocksBlockId, StarknetBlocksTable,
+    StarknetBlocksBlockId, StarknetBlocksTable, StarknetTransactionsTable,
 };
 
 use anyhow::Context;

--- a/crates/pathfinder/src/storage/schema.rs
+++ b/crates/pathfinder/src/storage/schema.rs
@@ -2,6 +2,7 @@ pub(crate) mod revision_0001;
 pub(crate) mod revision_0002;
 pub(crate) mod revision_0003;
 pub(crate) mod revision_0004;
+pub(crate) mod revision_0005;
 
 /// Used to indicate which action the caller should perform after a schema migration.
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/pathfinder/src/storage/schema/revision_0005.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0005.rs
@@ -1,0 +1,251 @@
+use anyhow::Context;
+use rusqlite::{named_params, Transaction};
+use tracing::info;
+
+use crate::{sequencer::reply::transaction, storage::schema::PostMigrationAction};
+
+/// This schema migration moves the Starknet transactions and transaction receipts into
+/// their own table. These tables are indexed by the origin Starknet block hash.
+pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigrationAction> {
+    // Create the new transaction and transaction receipt tables.
+    transaction
+        .execute(
+            r"CREATE TABLE starknet_transactions (
+            hash        BLOB PRIMARY KEY,
+            idx         INTEGER NOT NULL,
+            block_hash  BLOB NOT NULL,
+            tx          BLOB,
+            receipt     BLOB
+        )",
+            [],
+        )
+        .context("Create starknet transactions table")?;
+
+    let todo: usize = transaction
+        .query_row("SELECT count(1) FROM starknet_blocks", [], |r| r.get(0))
+        .context("Count rows in starknet blocks table")?;
+    if todo == 0 {
+        return Ok(PostMigrationAction::None);
+    }
+
+    info!(
+        "Decompressing and migrating {} blocks of transaction data, this may take a while.",
+        todo
+    );
+
+    let mut stmt = transaction
+        .prepare("SELECT hash, transactions, transaction_receipts FROM starknet_blocks")
+        .context("Prepare statement")?;
+    let mut rows = stmt.query([])?;
+
+    let mut decompressor = zstd::bulk::Decompressor::new().context("Create zstd decompressor")?;
+    let mut compressor = zstd::bulk::Compressor::new(10).context("Create zstd compressor")?;
+    const CAPACITY_100_MB: usize = 1_000 * 1_000 * 100;
+
+    while let Some(r) = rows.next()? {
+        let block_hash = r.get_ref_unwrap("hash").as_blob()?;
+        let transactions = r.get_ref_unwrap("transactions").as_blob()?;
+        let receipts = r.get_ref_unwrap("transaction_receipts").as_blob()?;
+
+        let transactions = decompressor
+            .decompress(transactions, CAPACITY_100_MB)
+            .context("Decompressing transactions")?;
+        let transactions =
+            serde_json::de::from_slice::<Vec<transaction::Transaction>>(&transactions)
+                .context("Deserializing transactions")?;
+
+        let receipts = decompressor
+            .decompress(receipts, CAPACITY_100_MB)
+            .context("Decompressing transactions")?;
+        let receipts = serde_json::de::from_slice::<Vec<transaction::Receipt>>(&receipts)
+            .context("Deserializing transaction receipts")?;
+
+        anyhow::ensure!(
+            transactions.len() == receipts.len(),
+            "Mismatched number of transactions and receipts"
+        );
+
+        transactions
+            .into_iter()
+            .zip(receipts.into_iter())
+            .enumerate()
+            .try_for_each(|(idx, (tx, rx))| -> anyhow::Result<_> {
+                let transaction_data = serde_json::ser::to_vec(&tx).context("Serializing transaction data")?;
+                let transaction_data = compressor.compress(&transaction_data).context("Compressing transaction data")?;
+
+                let receipt_data = serde_json::ser::to_vec(&rx).context("Serializing transaction receipt data")?;
+                let receipt_data = compressor.compress(&receipt_data).context("Compressing transaction receipt data")?;
+
+                transaction.execute(r"INSERT INTO starknet_transactions ( hash,  idx,  block_hash,  tx,  receipt)
+                                                                     VALUES (:hash, :idx, :block_hash, :tx, :receipt)",
+        named_params![
+                    ":hash": &tx.transaction_hash.0.as_be_bytes()[..],
+                    ":idx": idx,
+                    ":block_hash": block_hash,
+                    ":tx": &transaction_data,
+                    ":receipt": &receipt_data,
+                ]).context("Insert transaction data into transactions table")?;
+
+                Ok(())
+            })?;
+    }
+
+    // Remove transaction columns from blocks table.
+    let rows_altered = transaction
+        .execute("ALTER TABLE starknet_blocks DROP COLUMN transactions", [])
+        .context("Dropping transactions from starknet_blocks table")?;
+    anyhow::ensure!(
+        rows_altered == todo,
+        "Number of altered rows did not match expectation when dropping transactions column"
+    );
+
+    let rows_altered = transaction
+        .execute(
+            "ALTER TABLE starknet_blocks DROP COLUMN transaction_receipts",
+            [],
+        )
+        .context("Dropping transaction receipts from starknet_blocks table")?;
+    anyhow::ensure!(
+        rows_altered == todo,
+        "Number of altered rows did not match expectation when dropping transaction receipts column"
+    );
+
+    // Database should be vacuum'd to defrag removal of transaction columns.
+    Ok(PostMigrationAction::Vacuum)
+}
+
+#[cfg(test)]
+mod tests {
+    use pedersen::StarkHash;
+    use rusqlite::{named_params, Connection};
+
+    use crate::{
+        core::{ContractAddress, StarknetTransactionHash, StarknetTransactionIndex},
+        sequencer::reply::transaction::{
+            self,
+            execution_resources::{BuiltinInstanceCounter, EmptyBuiltinInstanceCounter},
+            ExecutionResources,
+        },
+        storage::schema,
+    };
+
+    #[test]
+    fn empty() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        let transaction = conn.transaction().unwrap();
+
+        schema::revision_0001::migrate(&transaction).unwrap();
+        schema::revision_0002::migrate(&transaction).unwrap();
+        schema::revision_0003::migrate(&transaction).unwrap();
+        schema::revision_0004::migrate(&transaction).unwrap();
+        schema::revision_0005::migrate(&transaction).unwrap();
+    }
+
+    #[test]
+    fn stateful() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        let transaction = conn.transaction().unwrap();
+
+        schema::revision_0001::migrate(&transaction).unwrap();
+        schema::revision_0002::migrate(&transaction).unwrap();
+        schema::revision_0003::migrate(&transaction).unwrap();
+        schema::revision_0004::migrate(&transaction).unwrap();
+
+        // Value doesn't have to be correct as we aren't parsing it.
+        let block_hash = vec![0u8, 13u8, 25u8];
+        // Create some unique transaction and receipt pairs.
+        let tx_original = (0..10)
+            .map(|i| transaction::Transaction {
+                calldata: None,
+                constructor_calldata: None,
+                contract_address: ContractAddress(
+                    StarkHash::from_hex_str(&"23".repeat(i as usize + 3)).unwrap(),
+                ),
+                contract_address_salt: None,
+                entry_point_type: None,
+                entry_point_selector: None,
+                signature: None,
+                transaction_hash: StarknetTransactionHash(
+                    StarkHash::from_hex_str(&"fe".repeat(i as usize + 3)).unwrap(),
+                ),
+                r#type: transaction::Type::InvokeFunction,
+            })
+            .collect::<Vec<_>>();
+
+        let receipts_original = (0..10)
+            .map(|i| transaction::Receipt {
+                events: Vec::new(),
+                execution_resources: ExecutionResources {
+                    builtin_instance_counter: BuiltinInstanceCounter::Empty(
+                        EmptyBuiltinInstanceCounter {},
+                    ),
+                    n_steps: i + 987,
+                    n_memory_holes: i + 1177,
+                },
+                l1_to_l2_consumed_message: None,
+                l2_to_l1_messages: Vec::new(),
+                transaction_hash: StarknetTransactionHash(
+                    StarkHash::from_hex_str(&"ee".repeat(i as usize + 3)).unwrap(),
+                ),
+                transaction_index: StarknetTransactionIndex(i + 2311),
+            })
+            .collect::<Vec<_>>();
+
+        let tx = serde_json::ser::to_vec(&tx_original).unwrap();
+        let receipts = serde_json::ser::to_vec(&receipts_original).unwrap();
+
+        let mut compressor = zstd::bulk::Compressor::new(10).unwrap();
+        let mut decompressor = zstd::bulk::Decompressor::new().unwrap();
+        let tx = compressor.compress(&tx).unwrap();
+        let receipts = compressor.compress(&receipts).unwrap();
+
+        transaction.execute(r"INSERT INTO starknet_blocks ( number,  hash,  root,  timestamp,  transactions,  transaction_receipts)
+                                                   VALUES (:number, :hash, :root, :timestamp, :transactions, :transaction_receipts)",
+        named_params! {
+                ":number": 123, // This doesn't matter
+                ":hash": &block_hash,
+                ":root": &vec![12u8, 33, 55],   // This doesn't matter
+                ":timestamp": 200, // This doesn't matter
+                ":transactions": &tx,
+                ":transaction_receipts": &receipts,
+            }).unwrap();
+
+        // Perform this migration
+        super::migrate(&transaction).unwrap();
+
+        // The transactions table should now contain all the transactions and receipts.
+        let mut stmt = transaction
+            .prepare("SELECT * FROM starknet_transactions")
+            .unwrap();
+        let mut rows = stmt.query([]).unwrap();
+
+        for (i, (tx, rx)) in tx_original.iter().zip(receipts_original.iter()).enumerate() {
+            let row = rows.next().unwrap().unwrap();
+
+            let hash = row.get_ref_unwrap("hash").as_blob().unwrap();
+            let hash = StarkHash::from_be_slice(hash).unwrap();
+            let hash = StarknetTransactionHash(hash);
+
+            let idx = row.get_ref_unwrap("idx").as_i64().unwrap() as usize;
+            let b_hash = row.get_ref_unwrap("block_hash").as_blob().unwrap();
+            let tx_i = row.get_ref_unwrap("tx").as_blob_or_null().unwrap().unwrap();
+            let rx_i = row
+                .get_ref_unwrap("receipt")
+                .as_blob_or_null()
+                .unwrap()
+                .unwrap();
+
+            let tx_i = decompressor.decompress(tx_i, 1000 * 1000).unwrap();
+            let rx_i = decompressor.decompress(rx_i, 1000 * 1000).unwrap();
+
+            let tx_i = serde_json::de::from_slice::<transaction::Transaction>(&tx_i).unwrap();
+            let rx_i = serde_json::de::from_slice::<transaction::Receipt>(&rx_i).unwrap();
+
+            assert_eq!(tx.transaction_hash, hash);
+            assert_eq!(i, idx);
+            assert_eq!(block_hash, b_hash);
+            assert_eq!(tx, &tx_i);
+            assert_eq!(rx, &rx_i);
+        }
+    }
+}

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -205,7 +205,7 @@ def check_schema(connection):
     assert cursor is not None, "there has to be an user_version defined in the database"
 
     [version] = next(cursor)
-    return version == 4
+    return version == 5
 
 
 def resolve_block(connection, at_block):

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -98,7 +98,7 @@ def inmemory_with_tables():
     # strangely this cannot be pulled into the script, maybe pragmas have
     # different kind of semantics than what is normally executed, would explain
     # the similar behaviour of sqlite3 .dump and restore.
-    cur.execute("pragma user_version = 4;")
+    cur.execute("pragma user_version = 5;")
 
     con.commit()
     return con


### PR DESCRIPTION
This enables the various RPC functions that need to query by transaction hash.

Closes #131 