### PR TITLE
ci: use github env to enable external contribs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    environment: CI
     env:
       # An Ethereum access point is required for some L1 StarkNet contract tests.
       # This sets it to secret values stored in the repository, which prevents


### PR DESCRIPTION
Github secrets are not available to actions run on PRs from forks. This means our CI tests fail for PRs from forks as these secrets are missing.

This PR sets the tests to use `CI` github environment instead, which now contains the same keys.