### PR TITLE
ci: revert environment change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    environment: CI
     env:
       # An Ethereum access point is required for some L1 StarkNet contract tests.
       # This sets it to secret values stored in the repository, which prevents


### PR DESCRIPTION
This PR reverts the change in #169 whose change did not help with sharing secrets to fork CI runs.

This appears not to be possible with github due to security concerns.