### PR TITLE
fix(ext_py): fix busy-loop in task handling Python subprocesses

### DIFF
--- a/crates/pathfinder/src/cairo/ext_py/service.rs
+++ b/crates/pathfinder/src/cairo/ext_py/service.rs
@@ -138,6 +138,9 @@ pub async fn start(
                     _ = &mut wait_before_spawning => {
                         // spawn if needed
                         spawn = count.get() > joinhandles.len();
+                        wait_before_spawning
+                            .as_mut()
+                            .reset(tokio::time::Instant::now() + WAIT_BEFORE_SPAWN);
                     }
                 }
 
@@ -153,10 +156,6 @@ pub async fn start(
                     );
 
                     joinhandles.push(jh);
-                } else if count.get() > joinhandles.len() && wait_before_spawning.is_elapsed() {
-                    wait_before_spawning
-                        .as_mut()
-                        .reset(tokio::time::Instant::now() + WAIT_BEFORE_SPAWN);
                 }
             }
         }


### PR DESCRIPTION
This change fixes a busy loop where the expiration of wait_before_spawning
wakes up the select!() again and again if the number of Python subprocesses
match what we're expecting.

The logic is now: check if the number of subprocesses matches expectations
once per second. Start _one_ new subprocess if that's not the case.