### PR TITLE
Add instruction for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ We need access to a full archive Ethereum node operating on the network matching
 ```bash
 sudo apt-get install libgmp-dev
 ```
+- Ensure you have pkg-config installed
+```bash
+sudo apt-get install pkg-config
+```
 
 ### Clone `pathfinder`
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ We need access to a full archive Ethereum node operating on the network matching
 
 - Install Rust by following the [official instructions](https://www.rust-lang.org/tools/install)
 - Ensure you have at least python 3.7 installed
+- Ensure you have libgmp installed
+```bash
+sudo apt-get install libgmp-dev
+```
 
 ### Clone `pathfinder`
 

--- a/README.md
+++ b/README.md
@@ -26,20 +26,35 @@ For help or to submit bug reports or feature requests, please open an issue or a
 ### Prerequisites
 
 Currently only supports Linux. Windows and MacOS support is planned.
-
 We need access to a full archive Ethereum node operating on the network matching the StarkNet network you wish to run. Currently this is either Goerli or Mainnet.
+
+Before you start, make sure your system is up to date with Curl and Git available
+
+```bash
+sudo apt update
+sudo apt upgrade
+sudo apt install curl
+sudo apt install git
+```
 
 `pathfinder` depends on Rust and some Python.
 
 - Install Rust by following the [official instructions](https://www.rust-lang.org/tools/install)
 - Ensure you have at least python 3.7 installed
-- Ensure you have libgmp installed
+
 ```bash
-sudo apt-get install libgmp-dev
+sudo apt install python3
+sudo apt install python3-venv
+sudo apt install python3-dev
 ```
-- Ensure you have pkg-config installed
+
+- `pathfinder` compilation need additional libraries to be installed (C compiler, linker, other deps)
+
 ```bash
-sudo apt-get install pkg-config
+sudo apt install build-essential
+sudo apt install libgmp-dev
+sudo apt install pkg-config
+sudo apt install libssl-dev
 ```
 
 ### Clone `pathfinder`


### PR DESCRIPTION
On new fresh installation, libgmp need to be installed before setup to avoid failed installation on fastecdsa library.

```bash
 building 'fastecdsa.curvemath' extension
      creating build/temp.linux-x86_64-3.9
      creating build/temp.linux-x86_64-3.9/src
      x86_64-linux-gnu-gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -Isrc
/ -I/starknet/pathfinder/py/.venv/include -I/usr/include/python3.9 -c src/curve.c -o build/temp.linux-x86_64-3.9/src/curve.o -O2
      In file included from src/curve.c:1:
      src/curve.h:4:10: fatal error: gmp.h: No such file or directory
          4 | #include "gmp.h"
            |          ^~~~~~~
      compilation terminated.
      error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
```