### PR TITLE
fix(sync): blocking sleep in async

### DIFF
--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -301,7 +301,7 @@ pub async fn sync(
 
         // Sleep a bit if neither sync process had any events.
         if !l1_did_emit && !l2_did_emit {
-            std::thread::sleep(Duration::from_millis(100));
+            tokio::time::sleep(Duration::from_millis(100)).await;
         }
     }
 }


### PR DESCRIPTION
~Replaces a `std::thread::sleep` with `tokio::time::sleep` in the sync function.~

Replaces separate `try_recv` queries for L1 and L2 sync events with a single `select!` over both. This removes the need for the sleep (which was incorrectly blocking in the first place).