### PR TITLE
Sequencer retry

### DIFF
--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -41,8 +41,10 @@ zstd = "0.10"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
+http = "0.2.6"
 mockall = "0.11.0"
 pretty_assertions = "1.0.0"
 tempfile = "3"
 # log crate should be handled through tracing-subscriber if needed
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
+warp = "0.3.2"

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -47,4 +47,5 @@ pretty_assertions = "1.0.0"
 tempfile = "3"
 # log crate should be handled through tracing-subscriber if needed
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
+tracing-test = "0.2.1"
 warp = "0.3.2"

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -93,7 +93,7 @@ where
                     | StatusCode::SERVICE_UNAVAILABLE
                     | StatusCode::GATEWAY_TIMEOUT),
                 ) => {
-                    tracing::debug!("Retrying due to: {status}");
+                    tracing::debug!("Retrying due to {status}");
                     true
                 }
                 Some(_) | None => false,
@@ -1168,6 +1168,7 @@ mod tests {
         use assert_matches::assert_matches;
         use http::StatusCode;
         use pretty_assertions::assert_eq;
+        use tracing_test::traced_test;
 
         async fn run_retry(
             statuses: Vec<(StatusCode, &'static str)>,
@@ -1202,6 +1203,7 @@ mod tests {
         }
 
         #[tokio::test]
+        #[traced_test]
         async fn stop_on_ok() {
             let ends_with_ok = vec![
                 (StatusCode::OK, r#""Finally!""#),
@@ -1217,6 +1219,7 @@ mod tests {
         }
 
         #[tokio::test]
+        #[traced_test]
         async fn stop_on_fatal() {
             let ends_with_ok = vec![
                 (
@@ -1238,6 +1241,7 @@ mod tests {
         }
 
         #[tokio::test]
+        #[traced_test]
         async fn stop_on_max_retry_count() {
             let ends_with_ok = vec![
                 (StatusCode::SERVICE_UNAVAILABLE, ""),

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -170,15 +170,9 @@ async fn download_block(
 ) -> anyhow::Result<DownloadBlock> {
     use sequencer::error::StarknetErrorCode::BlockNotFound;
 
-    let result = loop {
-        match sequencer
-            .block_by_number_with_timeout(block.into(), Duration::from_secs(3))
-            .await
-        {
-            Err(SequencerError::TransportError(err)) if err.is_timeout() => continue,
-            non_timeout => break non_timeout,
-        }
-    };
+    let result = sequencer
+        .block_by_number_with_timeout(block.into(), Duration::from_secs(3))
+        .await;
 
     match result {
         Ok(block) => Ok(DownloadBlock::Block(block)),


### PR DESCRIPTION
Adds a universal retry behavior behind each `sequencer::Client` method. At the moment backoff params are hard coded.