### PR TITLE
fix(storage): transaction and receipts not dropped

### DIFF
--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -26,7 +26,7 @@ use tracing::info;
 /// Indicates database is non-existant.
 const DB_VERSION_EMPTY: u32 = 0;
 /// Current database version.
-const DB_VERSION_CURRENT: u32 = 5;
+const DB_VERSION_CURRENT: u32 = 6;
 /// Sqlite key used for the PRAGMA user version.
 const VERSION_KEY: &str = "user_version";
 
@@ -142,6 +142,7 @@ fn migrate_database(connection: &mut Connection) -> anyhow::Result<()> {
             2 => schema::revision_0003::migrate(&transaction)?,
             3 => schema::revision_0004::migrate(&transaction)?,
             4 => schema::revision_0005::migrate(&transaction)?,
+            5 => schema::revision_0006::migrate(&transaction)?,
             _ => unreachable!("Database version constraint was already checked!"),
         };
         // If any migration action requires vacuuming, we should vacuum.

--- a/crates/pathfinder/src/storage/schema.rs
+++ b/crates/pathfinder/src/storage/schema.rs
@@ -3,6 +3,7 @@ pub(crate) mod revision_0002;
 pub(crate) mod revision_0003;
 pub(crate) mod revision_0004;
 pub(crate) mod revision_0005;
+pub(crate) mod revision_0006;
 
 /// Used to indicate which action the caller should perform after a schema migration.
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/pathfinder/src/storage/schema/revision_0005.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0005.rs
@@ -6,6 +6,9 @@ use crate::{sequencer::reply::transaction, storage::schema::PostMigrationAction}
 
 /// This schema migration moves the Starknet transactions and transaction receipts into
 /// their own table. These tables are indexed by the origin Starknet block hash.
+///
+/// This migration has a non-fatal bug where it fails to drop the columns if the table is empty.
+/// This bug is fixed in [schema revision 6](super::revision_0006::migrate).
 pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigrationAction> {
     // Create the new transaction and transaction receipt tables.
     transaction

--- a/crates/pathfinder/src/storage/schema/revision_0006.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0006.rs
@@ -1,0 +1,104 @@
+use anyhow::Context;
+use rusqlite::Transaction;
+
+use crate::storage::schema::PostMigrationAction;
+
+/// This schema migration fixes a mistake in the previous migration. It failed to
+/// drop the transactions and transaction_receipts columns if the table was empty due to
+/// to an early exit condition.
+pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigrationAction> {
+    // Check if the columns still exist. Checking just one is enough as either both exist, or neither.
+    //
+    // This is necessary as sqlite will error when dropping a non-existant column. As a benefit
+    // it also lets us skip vacuuming if nothing is done.
+    let count: usize = transaction
+        .query_row(
+            "SELECT COUNT(1) FROM pragma_table_info('starknet_blocks') where name='transactions'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    if count == 0 {
+        return Ok(PostMigrationAction::None);
+    }
+
+    // Remove transaction columns from blocks table.
+    transaction
+        .execute("ALTER TABLE starknet_blocks DROP COLUMN transactions", [])
+        .context("Dropping transactions from starknet_blocks table")?;
+
+    transaction
+        .execute(
+            "ALTER TABLE starknet_blocks DROP COLUMN transaction_receipts",
+            [],
+        )
+        .context("Dropping transaction receipts from starknet_blocks table")?;
+
+    // Database should be vacuum'd to defrag removal of transaction columns.
+    Ok(PostMigrationAction::Vacuum)
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    use crate::storage::schema;
+
+    use super::*;
+
+    #[test]
+    fn columns_are_dropped() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        let transaction = conn.transaction().unwrap();
+
+        schema::revision_0001::migrate(&transaction).unwrap();
+        schema::revision_0002::migrate(&transaction).unwrap();
+        schema::revision_0003::migrate(&transaction).unwrap();
+        schema::revision_0004::migrate(&transaction).unwrap();
+        schema::revision_0005::migrate(&transaction).unwrap();
+        let action = migrate(&transaction).unwrap();
+        assert_eq!(action, PostMigrationAction::Vacuum);
+
+        // Collect all the column names in table `starknet_blocks`.
+        let mut columns = Vec::new();
+        let mut stmt = transaction
+            .prepare("select name from pragma_table_info('starknet_blocks')")
+            .unwrap();
+        let mut rows = stmt.query([]).unwrap();
+        while let Some(row) = rows.next().unwrap() {
+            columns.push(row.get_ref_unwrap("name").as_str().unwrap().to_owned());
+        }
+
+        // The dropped columns should be gone.
+        assert!(!columns.contains(&"transactions".to_string()));
+        assert!(!columns.contains(&"transaction_receipts".to_string()));
+    }
+
+    #[test]
+    fn succeeds_if_columns_are_already_dropped() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        let transaction = conn.transaction().unwrap();
+
+        schema::revision_0001::migrate(&transaction).unwrap();
+        schema::revision_0002::migrate(&transaction).unwrap();
+        schema::revision_0003::migrate(&transaction).unwrap();
+        schema::revision_0004::migrate(&transaction).unwrap();
+        schema::revision_0005::migrate(&transaction).unwrap();
+
+        // Manually drop the columns.
+        transaction
+            .execute("ALTER TABLE starknet_blocks DROP COLUMN transactions", [])
+            .context("Dropping transactions from starknet_blocks table")
+            .unwrap();
+        transaction
+            .execute(
+                "ALTER TABLE starknet_blocks DROP COLUMN transaction_receipts",
+                [],
+            )
+            .context("Dropping transaction receipts from starknet_blocks table")
+            .unwrap();
+
+        let action = migrate(&transaction).unwrap();
+        assert_eq!(action, PostMigrationAction::None);
+    }
+}

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -205,7 +205,7 @@ def check_schema(connection):
     assert cursor is not None, "there has to be an user_version defined in the database"
 
     [version] = next(cursor)
-    return version == 5
+    return version == 6
 
 
 def resolve_block(connection, at_block):

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -37,6 +37,7 @@ end
 """
 
 
+# This only contains the tables required for call.
 def inmemory_with_tables():
     con = sqlite3.connect(":memory:")
     con.isolation_level = None
@@ -88,9 +89,7 @@ def inmemory_with_tables():
             number               INTEGER PRIMARY KEY,
             hash                 BLOB    NOT NULL,
             root                 BLOB    NOT NULL,
-            timestamp            INTEGER NOT NULL,
-            transactions         BLOB,
-            transaction_receipts BLOB
+            timestamp            INTEGER NOT NULL
         );
         """
     )
@@ -98,7 +97,7 @@ def inmemory_with_tables():
     # strangely this cannot be pulled into the script, maybe pragmas have
     # different kind of semantics than what is normally executed, would explain
     # the similar behaviour of sqlite3 .dump and restore.
-    cur.execute("pragma user_version = 5;")
+    cur.execute("pragma user_version = 6")
 
     con.commit()
     return con


### PR DESCRIPTION
This PR adds a new storage migration 6 to fix a non-fatal bug in migration 5.

Migration 5 fails to drop the transaction and receipts columns if the table is empty due to an early exit condition.