### PR TITLE
feat(sequencer): remove get block with timeout

### DIFF
--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -135,26 +135,6 @@ impl Client {
         .await
     }
 
-    /// Gets block by number with the specified timeout.
-    #[tracing::instrument(skip(self))]
-    pub async fn block_by_number_with_timeout(
-        &self,
-        block_number: BlockNumberOrTag,
-        timeout: Duration,
-    ) -> Result<reply::Block, SequencerError> {
-        let number = block_number_str(block_number);
-        retry(|| async {
-            let resp = self
-                .inner
-                .get(self.build_query("get_block", &[("blockNumber", &number)]))
-                .timeout(timeout)
-                .send()
-                .await?;
-            parse::<reply::Block>(resp).await
-        })
-        .await
-    }
-
     /// Get block by hash.
     #[tracing::instrument(skip(self))]
     pub async fn block_by_hash(
@@ -626,63 +606,6 @@ mod tests {
             retry_on_rate_limiting!(
                 client()
                     .block_by_number(BlockNumberOrTag::Number(StarknetBlockNumber(1716)))
-                    .await
-            )
-            .unwrap();
-        }
-    }
-
-    mod block_by_number_with_timeout {
-        use super::*;
-
-        #[tokio::test]
-        async fn latest() {
-            retry_on_rate_limiting!(
-                client()
-                    .block_by_number_with_timeout(
-                        BlockNumberOrTag::Tag(Tag::Latest),
-                        Duration::from_secs(120)
-                    )
-                    .await
-            )
-            .unwrap();
-        }
-
-        #[tokio::test]
-        async fn pending() {
-            retry_on_rate_limiting!(
-                client()
-                    .block_by_number_with_timeout(
-                        BlockNumberOrTag::Tag(Tag::Pending),
-                        Duration::from_secs(120)
-                    )
-                    .await
-            )
-            .unwrap();
-        }
-
-        #[tokio::test]
-        async fn invalid() {
-            let error = retry_on_rate_limiting!(
-                client()
-                    .block_by_number_with_timeout(*INVALID_BLOCK_NUMBER, Duration::from_secs(120))
-                    .await
-            )
-            .unwrap_err();
-            assert_matches!(
-                error,
-                SequencerError::StarknetError(e) => assert_eq!(e.code, StarknetErrorCode::BlockNotFound)
-            );
-        }
-
-        #[tokio::test]
-        async fn contains_receipts_without_status_field() {
-            retry_on_rate_limiting!(
-                client()
-                    .block_by_number_with_timeout(
-                        BlockNumberOrTag::Number(StarknetBlockNumber(1716)),
-                        Duration::from_secs(120)
-                    )
                     .await
             )
             .unwrap();

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -304,10 +304,7 @@ async fn update_sync_status_latest(
         // Work-around the sequencer block fetch being flakey.
         let latest = loop {
             if let Ok(block) = sequencer
-                .block_by_number_with_timeout(
-                    BlockNumberOrTag::Tag(Tag::Latest),
-                    Duration::from_secs(3),
-                )
+                .block_by_number(BlockNumberOrTag::Tag(Tag::Latest))
                 .await
             {
                 // Unwrap is safe as only pending blocks have None.

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -170,9 +170,7 @@ async fn download_block(
 ) -> anyhow::Result<DownloadBlock> {
     use sequencer::error::StarknetErrorCode::BlockNotFound;
 
-    let result = sequencer
-        .block_by_number_with_timeout(block.into(), Duration::from_secs(3))
-        .await;
+    let result = sequencer.block_by_number(block.into()).await;
 
     match result {
         Ok(block) => Ok(DownloadBlock::Block(block)),


### PR DESCRIPTION
This PR removes `sequencer::block_by_number_with_timeout`. This was a work-around for the sequencer's poor performance on old blocks. This has since been fixed and is hopefully no longer necessary.