### PR TITLE
feat(pathfinder): work without a Python virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ sudo apt install git
 
 ### Install Rust
 
-`pathfinder` requires Rust version `3.58` or later. The easiest way to install Rust is by following the [official instructions](https://www.rust-lang.org/tools/install).
+`pathfinder` requires Rust version `1.58` or later. The easiest way to install Rust is by following the [official instructions](https://www.rust-lang.org/tools/install).
 
 
 If you already have Rust installed, verify the version:
 ```bash
-cargo --version # must be 3.58 or higher
+cargo --version # must be 1.58 or higher
 ```
 To update your Rust version, use the `rustup` tool that came with the official instructions:
 ```bash
@@ -53,7 +53,7 @@ rustup update
 
 ### Install Python
 
-`pathfinder` requires Python version `3.7` or later.
+`pathfinder` requires Python version `3.7` or `3.8`. (In particular, `cairo-lang` 0.7.1 seems incompatible with Python 3.10.)
 
 ```bash
 sudo apt install python3
@@ -62,7 +62,7 @@ sudo apt install python3-dev
 ```
 Verify the python version. Some Linux distributions only supply an outdated python version, in which case you will need to lookup a guide for your distribution.
 ```bash
-python3 --version # must be 3.7 or later
+python3 --version # must be 3.7 or 3.8
 ```
 
 ### Install build dependencies
@@ -81,7 +81,7 @@ Checkout the latest `pathfinder` release by cloning this repo and checking out t
 
 ### Python setup
 
-Create a python virtual environment in the `py` folder. This is important as the node relies on this relative pathing.
+Create a python virtual environment in the `py` folder.
 
 ```bash
 # Enter the `<repo>/py` directory

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -35,6 +35,7 @@ serde = { version = "1.0.130", features = ["derive"] }
 serde_json = { version = "1.0.68", features = ["arbitrary_precision", "raw_value"] }
 serde_with = "1.9.4"
 sha3 = "0.9"
+tempfile = "3"
 thiserror = "1.0.30"
 tokio = "1.11.0"
 tokio-retry = "0.3.0"

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -54,7 +54,9 @@ async fn main() -> anyhow::Result<()> {
         futures::future::pending(),
     )
     .await
-    .context("Creating python process for call handling. Have you setup and activate the python `VIRTUAL_ENV` in the `py` directory?")?;
+    .context(
+        "Creating python process for call handling. Have you setup our Python dependencies?",
+    )?;
 
     let api = rpc::api::RpcApi::new(storage, sequencer, network_chain, sync_state)
         .with_call_handling(call_handle);

--- a/crates/pathfinder/src/cairo/ext_py/service.rs
+++ b/crates/pathfinder/src/cairo/ext_py/service.rs
@@ -10,12 +10,14 @@ use tracing::{info, trace, warn};
 
 /// Starts to maintain a pool of `count` sub-processes which execute the calls.
 ///
-/// In general, the launching currently assumes:
+/// In general, the launching currently assumes `python3` is a compatible Python
+/// interpreter in an environment where our Python dependencies are set up properly.
 ///
-/// - user has entered the python virtual environment created for this project per instructions
-/// under `$REPO_ROOT/py/README.md`
-/// - `call.py` can be found from the `$VIRTUAL_ENV/../src/call.py`
-/// - user has compatible python, 3.7+ should work just fine
+/// This can usually be done in two ways:
+/// - Creating a virtualenv, installing dependencies in that and activating it (as described
+/// in `$REPO_ROOT/py/README.md`)
+/// - By installing Python dependencies in a way that the _global_ `python3` interpreter can
+/// import them.
 ///
 /// Returns an error if executing calls in a sub-process is not supported.
 #[tracing::instrument(name = "ext_py", skip_all, fields(%count))]


### PR DESCRIPTION
`call.py` is now included in the `pathfinder` executable and we're creating
temporary script files to execute the included source with a Python
interpreter.

This way we're not using the VIRTUAL_ENV environment variable anymore
and only depend on the PATH being set up properly so that running
`python3` results in a Python interpreter set up with our `cairo`
dependencies.

This makes it possible to just install those Python dependencies globally
in a Docker image and run `pathfinder` without a virtualenv.