### PR TITLE
feat: add docker GH workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,35 @@
+name: Docker
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  update-docker-images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Docker build latest version
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: eqlabs/pathfinder:latest
+
+      - name: Build tagged pathfinder image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: eqlabs/pathfinder:${{github.ref_name}}

--- a/README.md
+++ b/README.md
@@ -182,7 +182,21 @@ The StarkNet network is based on the provided Ethereum endpoint. If the Ethereum
 
 ## Running with Docker
 
-The `pathfinder` node can be run in the provided Docker image. You can build the image by running:
+The `pathfinder` node can be run in the provided Docker image.
+
+```bash
+docker run \
+  -e RUST_LOG=info \
+  -p 9545:9545 \
+  eqlabs/pathfinder \
+    --http-rpc "0.0.0.0:9545" \
+    --ethereum.url https://goerli.infura.io/v3/<project-id>
+    --ethereum.password <password>
+```
+
+### Building the container image yourself
+
+You can build the image by running:
 
 ```bash
 docker build -t pathfinder .


### PR DESCRIPTION
This PR adds the `docker.yml` workflow which will:
- automatically push to `latest` on merges to main
- automatically push to a versioned tag on new git tag publication

This will also require two GitHub secrets: `DOCKER_HUB_USERNAME` and `DOCKER_HUB_ACCESS_TOKEN`