### PR TITLE
Fix L2 reorg

### DIFF
--- a/crates/pathfinder/resources/contracts/core_impl.json
+++ b/crates/pathfinder/resources/contracts/core_impl.json
@@ -5,13 +5,13 @@
             {
                 "indexed": true,
                 "internalType": "uint256",
-                "name": "from_address",
+                "name": "fromAddress",
                 "type": "uint256"
             },
             {
                 "indexed": true,
                 "internalType": "address",
-                "name": "to_address",
+                "name": "toAddress",
                 "type": "address"
             },
             {
@@ -30,13 +30,13 @@
             {
                 "indexed": true,
                 "internalType": "address",
-                "name": "from_address",
+                "name": "fromAddress",
                 "type": "address"
             },
             {
                 "indexed": true,
                 "internalType": "uint256",
-                "name": "to_address",
+                "name": "toAddress",
                 "type": "uint256"
             },
             {
@@ -67,13 +67,13 @@
             {
                 "indexed": true,
                 "internalType": "uint256",
-                "name": "from_address",
+                "name": "fromAddress",
                 "type": "uint256"
             },
             {
                 "indexed": true,
                 "internalType": "address",
-                "name": "to_address",
+                "name": "toAddress",
                 "type": "address"
             },
             {
@@ -92,13 +92,13 @@
             {
                 "indexed": true,
                 "internalType": "address",
-                "name": "from_address",
+                "name": "fromAddress",
                 "type": "address"
             },
             {
                 "indexed": true,
                 "internalType": "uint256",
-                "name": "to_address",
+                "name": "toAddress",
                 "type": "uint256"
             },
             {
@@ -227,10 +227,125 @@
         "type": "event"
     },
     {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "fromAddress",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "toAddress",
+                "type": "uint256"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "selector",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256[]",
+                "name": "payload",
+                "type": "uint256[]"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "nonce",
+                "type": "uint256"
+            }
+        ],
+        "name": "MessageToL2Canceled",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "fromAddress",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "toAddress",
+                "type": "uint256"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "selector",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256[]",
+                "name": "payload",
+                "type": "uint256[]"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "nonce",
+                "type": "uint256"
+            }
+        ],
+        "name": "MessageToL2CancellationStarted",
+        "type": "event"
+    },
+    {
         "inputs": [
             {
                 "internalType": "uint256",
-                "name": "from_address",
+                "name": "toAddress",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "selector",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "payload",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "nonce",
+                "type": "uint256"
+            }
+        ],
+        "name": "cancelL1ToL2Message",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "configHash",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "fromAddress",
                 "type": "uint256"
             },
             {
@@ -329,6 +444,25 @@
         "type": "function"
     },
     {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "msgHash",
+                "type": "bytes32"
+            }
+        ],
+        "name": "l1ToL2MessageCancellations",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
         "inputs": [],
         "name": "l1ToL2MessageNonce",
         "outputs": [
@@ -381,6 +515,19 @@
     },
     {
         "inputs": [],
+        "name": "messageCancellationDelay",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
         "name": "programHash",
         "outputs": [
             {
@@ -409,7 +556,7 @@
         "inputs": [
             {
                 "internalType": "uint256",
-                "name": "to_address",
+                "name": "toAddress",
                 "type": "uint256"
             },
             {
@@ -431,6 +578,32 @@
                 "type": "bytes32"
             }
         ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "newConfigHash",
+                "type": "uint256"
+            }
+        ],
+        "name": "setConfigHash",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "delayInSeconds",
+                "type": "uint256"
+            }
+        ],
+        "name": "setMessageCancellationDelay",
+        "outputs": [],
         "stateMutability": "nonpayable",
         "type": "function"
     },
@@ -502,6 +675,34 @@
             }
         ],
         "name": "starknetRemoveGovernor",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "toAddress",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "selector",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "payload",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "nonce",
+                "type": "uint256"
+            }
+        ],
+        "name": "startL1ToL2MessageCancellation",
         "outputs": [],
         "stateMutability": "nonpayable",
         "type": "function"

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -71,7 +71,7 @@ pub async fn sync(
                 DownloadBlock::AtHead => tokio::time::sleep(Duration::from_secs(5)).await,
                 DownloadBlock::Reorg => {
                     let some_head = head.unwrap();
-                    reorg(some_head, &tx_event, &sequencer)
+                    head = reorg(some_head, &tx_event, &sequencer)
                         .await
                         .context("L2 reorg")?;
 
@@ -83,7 +83,7 @@ pub async fn sync(
 
         if let Some(some_head) = head {
             if some_head.1 != block.parent_block_hash {
-                reorg(some_head, &tx_event, &sequencer)
+                head = reorg(some_head, &tx_event, &sequencer)
                     .await
                     .context("L2 reorg")?;
 

--- a/crates/pathfinder/src/storage/contract.rs
+++ b/crates/pathfinder/src/storage/contract.rs
@@ -135,9 +135,7 @@ impl ContractCodeTable {
 pub struct ContractsTable {}
 
 impl ContractsTable {
-    /// Insert a contract into the table.
-    ///
-    /// Fails if the contract address is already populated.
+    /// Insert a contract into the table, does nothing if the contract already exists.
     ///
     /// Note that [hash](ContractHash) must reference a contract stored in [ContractCodeTable].
     pub fn insert(
@@ -146,7 +144,7 @@ impl ContractsTable {
         hash: ContractHash,
     ) -> anyhow::Result<()> {
         transaction.execute(
-            r"INSERT INTO contracts (address, hash) VALUES (:address, :hash)",
+            r"INSERT OR IGNORE INTO contracts (address, hash) VALUES (:address, :hash)",
             named_params! {
                 ":address": &address.0.to_be_bytes()[..],
                 ":hash": &hash.0.to_be_bytes()[..],

--- a/crates/pathfinder/src/storage/contract.rs
+++ b/crates/pathfinder/src/storage/contract.rs
@@ -143,6 +143,7 @@ impl ContractsTable {
         address: ContractAddress,
         hash: ContractHash,
     ) -> anyhow::Result<()> {
+        // A contract may be deployed multiple times due to L2 reorgs, so we ignore all after the first.
         transaction.execute(
             r"INSERT OR IGNORE INTO contracts (address, hash) VALUES (:address, :hash)",
             named_params! {


### PR DESCRIPTION
This PR fixes two bugs in the L2 sync process:

1. After an L2 reorg, the sync process would continue from the old local block head, instead of taking into account the reorg'd blocks.
2. The sync process would crash due to inserting a duplicate contract. This can occur when after a reorg as we never delete the old contracts (this prevents us downloading them again), and the "new blocks" will contain the same contract again.

As an aside this really should have been caught by tests -- which I didn't write due to time crunch.