### PR TITLE
Upgrade to cairo-lang 0.8.0

### DIFF
--- a/py/requirements-dev.in
+++ b/py/requirements-dev.in
@@ -1,5 +1,5 @@
 # see README.md
-cairo-lang==0.7.1
+cairo-lang==0.8.0
 # We don't use rlp directly, however this needs to be defined for it to help pip-compile
 eth-rlp==0.2.1
 pip-tools==6.4.0

--- a/py/requirements-dev.txt
+++ b/py/requirements-dev.txt
@@ -25,7 +25,7 @@ black==21.12b0
     # via -r requirements-dev.in
 cachetools==5.0.0
     # via cairo-lang
-cairo-lang==0.7.1
+cairo-lang==0.8.0
     # via -r requirements-dev.in
 certifi==2021.10.8
     # via requests

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -1,4 +1,4 @@
-from call import do_loop
+from call import do_loop, loop_inner
 import sqlite3
 import io
 import json
@@ -245,6 +245,27 @@ def test_success():
 
     assert number == expected == block_hash == latest
 
+
+def test_positive_directly():
+    """
+    this is like test_success but does it directly with the do_call, instead of the json wrapping, which hides exceptions which come from upgrading.
+    """
+
+    con = inmemory_with_tables()
+    contract_address = populate_test_contract_with_132_on_3(con)
+
+    command = {
+        "at_block": 1,
+        "contract_address": contract_address,
+        "entry_point_selector": "get_value",
+        "calldata": [132],
+    }
+
+    con.execute("BEGIN")
+
+    output = loop_inner(con, command)
+
+    assert output.retdata == [3]
 
 def test_called_contract_not_found():
     con = inmemory_with_tables()

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -265,7 +265,8 @@ def test_positive_directly():
 
     output = loop_inner(con, command)
 
-    assert output.retdata == [3]
+    assert output == [3]
+
 
 def test_called_contract_not_found():
     con = inmemory_with_tables()


### PR DESCRIPTION
Upgrades to latest with minor refactoring to allow for easier testing in future as the old tests all went through the json per line i/o and as such formatted exceptions.

Sets `max_fee = 0` at least for now, perhaps a better value for this is learned later. The same value is used by the cairo-lang test support as well by default.

This will most likely not support calling post 0.8.0 contracts, which would use the new additions.