### PR TITLE
feat: multi arch Dockerfile

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,27 +9,43 @@ jobs:
   update-docker-images:
     runs-on: ubuntu-latest
     steps:
+     # Workaround for https://github.com/rust-lang/cargo/issues/8719
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@v1.0
+        with:
+          swap-size-gb: 10
+      - run: |
+          sudo mkdir -p /var/lib/docker
+          sudo mount -t tmpfs -o size=10G none /var/lib/docker
+          sudo systemctl restart docker
       - name: Checkout sources
         uses: actions/checkout@v2
-
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
-      - name: Docker build latest version
+      - name: Build
+        id: docker_build
         uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: |
+            linux/amd64
+            linux/arm64
+            linux/arm/v7
           file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
           push: true
-          tags: eqlabs/pathfinder:latest
-
-      - name: Build tagged pathfinder image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: eqlabs/pathfinder:${{github.ref_name}}
+          tags:  eqlabs/pathfinder:latest, eqlabs/pathfinder:${{github.ref_name}}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,7 @@
 name: Docker
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*'

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,17 +19,17 @@ COPY crates/pathfinder/Cargo.toml crates/pathfinder/Cargo.toml
 COPY crates/pedersen/Cargo.toml crates/pedersen/Cargo.toml
 COPY crates/pedersen/benches crates/pedersen/benches
 
-RUN RUSTFLAGS='-L/usr/lib -Ctarget-feature=-crt-static' cargo build --release --target=x86_64-unknown-linux-musl
+RUN RUSTFLAGS='-L/usr/lib -Ctarget-feature=-crt-static' cargo build --release
 
 
 # Compile the actual libraries and binary now
 COPY . .
 
-# Mark these for re-compilation 
+# Mark these for re-compilation
 RUN touch crates/pathfinder/src/lib.rs
 RUN touch crates/pedersen/src/lib.rs
 
-RUN RUSTFLAGS='-L/usr/lib -Ctarget-feature=-crt-static' cargo build --release --target=x86_64-unknown-linux-musl --bin pathfinder
+RUN RUSTFLAGS='-L/usr/lib -Ctarget-feature=-crt-static' cargo build --release
 
 #######################################
 # Stage 2: Build the Python libraries #
@@ -58,7 +58,7 @@ FROM python:3.8-alpine AS runner
 RUN apk add --no-cache tini
 
 COPY --from=rust-builder ["/usr/lib/libstdc++.so.6", "/usr/lib/libgcc_s.so.1", "/usr/lib/libgmp.so.10", "/usr/lib/" ]
-COPY --from=rust-builder /usr/src/pathfinder/target/x86_64-unknown-linux-musl/release/pathfinder /usr/local/bin/pathfinder
+COPY --from=rust-builder /usr/src/pathfinder/target/release/pathfinder /usr/local/bin/pathfinder
 COPY --from=python-builder /usr/local/lib/python3.8/ /usr/local/lib/python3.8/
 
 # Create directory and volume for persistent data
@@ -66,8 +66,13 @@ RUN mkdir -p /usr/share/pathfinder/data
 RUN chown 1000:1000 /usr/share/pathfinder/data
 VOLUME /usr/share/pathfinder/data
 
+# Move the start script in the Dockerfile
+COPY start-node.sh /tmp/start-node.sh
+RUN chmod +x /tmp/start-node.sh && mv /tmp/start-node.sh /usr/local/bin/start-node.sh && chmod 755 /usr/local/bin/start-node.sh
+
 USER 1000:1000
 EXPOSE 9545
 WORKDIR /usr/share/pathfinder/data
 
-ENTRYPOINT ["tini", "--", "/usr/local/bin/pathfinder"]
+ENTRYPOINT ["sh", "/usr/local/bin/start-node.sh"]
+

--- a/start-node.sh
+++ b/start-node.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+if [[ -z "$HTTP_RPC" ]]; then
+  ARG1=""
+else
+  ARG1="--http-rpc="
+fi
+if [[ -z "$ETH_RPC_URL" ]]; then
+  ARG2=""
+else
+  ARG2="--ethereum.url="
+fi
+if [[ -z "$ETH_PASSWORD" ]]; then
+  ARG3=""
+else
+  ARG3="--ethereum.password="
+fi
+if [ "$IDLE" == "1" ]; then
+    echo "Detected \$IDLE=1 env variable"
+    echo "Starknet Pathfinder will now idle"
+    echo "To restart normally, remove the env variable and the container will restart"
+    tail -f /dev/null
+else
+  tini -s -- /usr/local/bin/pathfinder $ARG1$HTTP_RPC $ARG2$ETH_RPC_URL $ARG3$ETH_PASSWORD
+fi


### PR DESCRIPTION
Hey everyone!

I made some modifications to the Docker image to better support odyslam/starknet-node and a multi-arch environment

- Dockerfile downloads the repo  as part of the build process (so that it can run without needing the rest of the repo)
- pathfinder binary is copied to hardcoded paths after they are built so we can copy them to the final destination no matter the arch (target/<arch>/pathfinder)
- start-script replaced pathfinder in entry point to easily support env variables and provide flexibility with the start process (it's easy to change a bash script to add any arbitrary step, env variable, etc.)
- start-script supports IDLING. This is super helpful in case we want to start the container, but not the binary inside it. That way we can ssh (in reality attach a pseudo-tty) and inspect it, run anything we want, etc.