### PR TITLE
Fix L2 reorg related issues

### DIFF
--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -256,7 +256,7 @@ mod tests {
         crate::storage::ContractCodeTable::insert(tx, hash, &abi, &bytecode, &contract_definition)
             .unwrap();
 
-        crate::storage::ContractsTable::insert(tx, crate::core::ContractAddress(address), hash)
+        crate::storage::ContractsTable::upsert(tx, crate::core::ContractAddress(address), hash)
             .unwrap();
 
         // this will create the table, not created by migration

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -479,24 +479,9 @@ mod tests {
         let transaction_data0 = [(txn0, receipt0)];
         let transaction_data1 = [(txn1, receipt1), (txn2, receipt2)];
         let transaction_data2 = [(txn3, receipt3), (txn4, receipt4), (txn5, receipt5)];
-        StarknetTransactionsTable::upsert(
-            &db_txn,
-            genesis_hash,
-            &transaction_data0,
-        )
-        .unwrap();
-        StarknetTransactionsTable::upsert(
-            &db_txn,
-            block1_hash,
-            &transaction_data1,
-        )
-        .unwrap();
-        StarknetTransactionsTable::upsert(
-            &db_txn,
-            latest_hash,
-            &transaction_data2,
-        )
-        .unwrap();
+        StarknetTransactionsTable::upsert(&db_txn, genesis_hash, &transaction_data0).unwrap();
+        StarknetTransactionsTable::upsert(&db_txn, block1_hash, &transaction_data1).unwrap();
+        StarknetTransactionsTable::upsert(&db_txn, latest_hash, &transaction_data2).unwrap();
 
         db_txn.commit().unwrap();
         storage

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -362,8 +362,8 @@ mod tests {
         ContractCodeTable::insert_compressed(&db_txn, &contract0_code).unwrap();
         ContractCodeTable::insert_compressed(&db_txn, &contract1_code).unwrap();
 
-        ContractsTable::insert(&db_txn, contract0_addr, contract0_hash).unwrap();
-        ContractsTable::insert(&db_txn, contract1_addr, contract1_hash).unwrap();
+        ContractsTable::upsert(&db_txn, contract0_addr, contract0_hash).unwrap();
+        ContractsTable::upsert(&db_txn, contract1_addr, contract1_hash).unwrap();
 
         let mut global_tree = GlobalStateTree::load(&db_txn, GlobalRoot(StarkHash::ZERO)).unwrap();
         let contract_state_hash =
@@ -479,19 +479,19 @@ mod tests {
         let transaction_data0 = [(txn0, receipt0)];
         let transaction_data1 = [(txn1, receipt1), (txn2, receipt2)];
         let transaction_data2 = [(txn3, receipt3), (txn4, receipt4), (txn5, receipt5)];
-        StarknetTransactionsTable::insert_block_transactions(
+        StarknetTransactionsTable::upsert(
             &db_txn,
             genesis_hash,
             &transaction_data0,
         )
         .unwrap();
-        StarknetTransactionsTable::insert_block_transactions(
+        StarknetTransactionsTable::upsert(
             &db_txn,
             block1_hash,
             &transaction_data1,
         )
         .unwrap();
-        StarknetTransactionsTable::insert_block_transactions(
+        StarknetTransactionsTable::upsert(
             &db_txn,
             latest_hash,
             &transaction_data2,
@@ -1575,7 +1575,7 @@ mod tests {
                 .context("Deploy testing contract")
                 .unwrap();
 
-                crate::storage::ContractsTable::insert(
+                crate::storage::ContractsTable::upsert(
                     &tx,
                     crate::core::ContractAddress(address),
                     hash,

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -72,7 +72,7 @@ pub(crate) fn update_contract_state(
         .context("Contract hash is missing from contracts table")?;
     let contract_state_hash = calculate_contract_state_hash(contract_hash, new_contract_root);
 
-    ContractsStateTable::insert(db, contract_state_hash, contract_hash, new_contract_root)
+    ContractsStateTable::upsert(db, contract_state_hash, contract_hash, new_contract_root)
         .context("Insert constract state hash into contracts state table")?;
 
     Ok(contract_state_hash)

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -455,7 +455,7 @@ async fn l2_update(
             .into_iter()
             .zip(block.transaction_receipts.into_iter())
             .collect::<Vec<_>>();
-        StarknetTransactionsTable::insert_block_transactions(
+        StarknetTransactionsTable::upsert(
             &transaction,
             starknet_block.hash,
             &transaction_data,
@@ -554,8 +554,8 @@ fn deploy_contract(
     global_tree
         .set(contract.address, state_hash)
         .context("Adding deployed contract to global state tree")?;
-    ContractsStateTable::insert(transaction, state_hash, contract.hash, contract_root)
+    ContractsStateTable::upsert(transaction, state_hash, contract.hash, contract_root)
         .context("Insert constract state hash into contracts state table")?;
-    ContractsTable::insert(transaction, contract.address, contract.hash)
+    ContractsTable::upsert(transaction, contract.address, contract.hash)
         .context("Inserting contract hash into contracts table")
 }

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -455,12 +455,8 @@ async fn l2_update(
             .into_iter()
             .zip(block.transaction_receipts.into_iter())
             .collect::<Vec<_>>();
-        StarknetTransactionsTable::upsert(
-            &transaction,
-            starknet_block.hash,
-            &transaction_data,
-        )
-        .context("Insert transaction data into database")?;
+        StarknetTransactionsTable::upsert(&transaction, starknet_block.hash, &transaction_data)
+            .context("Insert transaction data into database")?;
 
         // Track combined L1 and L2 state.
         let l1_l2_head = RefsTable::get_l1_l2_head(&transaction).context("Query L1-L2 head")?;

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -234,7 +234,7 @@ async fn reorg(
     };
 
     let reorg_tail = new_head
-        .map(|x| x.0)
+        .map(|x| x.0 + 1)
         .unwrap_or(StarknetBlockNumber::GENESIS);
 
     tx_event

--- a/crates/pathfinder/src/storage/ethereum.rs
+++ b/crates/pathfinder/src/storage/ethereum.rs
@@ -15,16 +15,14 @@ pub struct EthereumBlocksTable {}
 impl EthereumBlocksTable {
     /// Inserts a new Ethereum block with the given [hash](EthereumBlockHash) and [number](EthereumBlockNumber).
     ///
-    /// Does nothing if the hash already exists.
+    /// overwrites the data if the hash already exists.
     pub fn insert(
         transaction: &Transaction,
         hash: EthereumBlockHash,
         number: EthereumBlockNumber,
     ) -> anyhow::Result<()> {
         transaction.execute(
-            r"INSERT INTO ethereum_blocks ( hash,  number)
-                                       VALUES (:hash, :number)
-                                       ON CONFLICT DO NOTHING",
+            "INSERT OR REPLACE INTO ethereum_blocks (hash, number) VALUES (:hash, :number)",
             named_params! {
                 ":hash": hash.0.as_bytes(),
                 ":number": number.0,
@@ -46,20 +44,18 @@ pub struct EthereumTransactionsTable {}
 impl EthereumTransactionsTable {
     /// Insert a new Ethereum transaction.
     ///
-    /// Does nothing if the ethereum hash already exists.
+    /// Overwrites the data if the ethereum hash already exists.
     ///
     /// Note that [block_hash](EthereumBlockHash) must reference an
     /// Ethereum block stored in [EthereumBlocksTable].
-    pub fn insert(
+    pub fn upsert(
         transaction: &Transaction,
         block_hash: EthereumBlockHash,
         tx_hash: EthereumTransactionHash,
         tx_index: EthereumTransactionIndex,
     ) -> anyhow::Result<()> {
         transaction.execute(
-            r"INSERT INTO ethereum_transactions ( hash,  idx,  block_hash)
-                                             VALUES (:hash, :idx, :block_hash)
-                                             ON CONFLICT DO NOTHING",
+            "INSERT OR REPLACE INTO ethereum_transactions (hash, idx, block_hash) VALUES (:hash, :idx, :block_hash)",
             named_params! {
                 ":hash": tx_hash.0.as_bytes(),
                 ":idx": tx_index.0,


### PR DESCRIPTION
This PR fixes two separate bugs.

1. The L2 reorg tail was off-by-one block which means afterL2 reorg we would skip a block which would fail due to the state root not matching.
2. After an L2 reorg, we don't clean up transaction data which meant following new blocks could fail due to already existing transactions.