### PR TITLE
fix: state_update_by_number

### DIFF
--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -7,18 +7,18 @@ use serde::{Deserialize, Serialize};
 use web3::types::{H128, H160, H256};
 
 /// The address of a StarkNet contract.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
 pub struct ContractAddress(pub StarkHash);
 
 /// The salt of a StarkNet contract address.
-#[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize, PartialOrd, Ord)]
 pub struct ContractAddressSalt(pub StarkHash);
 
 /// A StarkNet contract's hash. This is a hash over a contract's
 /// deployment properties e.g. code and ABI.
 ///
 /// Not to be confused with [ContractStateHash].
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct ContractHash(pub StarkHash);
 
 /// A StarkNet contract's state hash. This is the value stored
@@ -78,11 +78,11 @@ pub struct CallSignatureElem(pub StarkHash);
 pub struct ByteCodeWord(pub StarkHash);
 
 /// The address of a storage element for a StarkNet contract.
-#[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize, PartialOrd, Ord)]
 pub struct StorageAddress(pub StarkHash);
 
 /// The value of a storage element for a StarkNet contract.
-#[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize, PartialOrd, Ord)]
 pub struct StorageValue(pub StarkHash);
 
 /// A commitment root of the global StarkNet state. This is the entry-point

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -299,7 +299,7 @@ pub mod state_update {
     }
 
     /// L2 storage diff.
-    #[derive(Clone, Debug, Deserialize, PartialEq)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
     #[serde(deny_unknown_fields)]
     pub struct StorageDiff {
         pub key: StorageAddress,
@@ -307,7 +307,7 @@ pub mod state_update {
     }
 
     /// L2 contract data within state diff.
-    #[derive(Clone, Debug, Deserialize, PartialEq)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
     #[serde(deny_unknown_fields)]
     pub struct Contract {
         pub address: ContractAddress,

--- a/crates/pedersen/src/hash.rs
+++ b/crates/pedersen/src/hash.rs
@@ -14,7 +14,7 @@ use ff::PrimeField;
 /// The Starknet elliptic curve Field Element.
 ///
 /// Forms the basic building block of most Starknet interactions.
-#[derive(Clone, Copy, PartialEq, Hash, Eq)]
+#[derive(Clone, Copy, PartialEq, Hash, Eq, PartialOrd, Ord)]
 pub struct StarkHash([u8; 32]);
 
 impl std::fmt::Debug for StarkHash {


### PR DESCRIPTION
It turned out that `state_update_by_number` contained a typo which caused to always return the result for `latest`.