### PR TITLE
Removing arm/v7 from multi-platform build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,6 @@ jobs:
           platforms: |
             linux/amd64
             linux/arm64
-            linux/arm/v7
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true


### PR DESCRIPTION
As mentioned by @odyslam in #210, alpine doesn't support this platform. Eventually we might need to switch back to Debian-based images, but this is a consideration that needs time and discussion.

In the meantime, we should remove this platform to get the Docker builds running again.