### PR TITLE
Embed version tag

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,8 @@
-Dockerfile
+# Don't ignore this, because it being missing would interfere with -dirty in `git describe`.
+# Dockerfile
+# rust temporary files
+target/
+# database files
+*.sqlite
+# compressed database dump files
+*.zst

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "arrayvec"
@@ -839,6 +839,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "git2"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3826a6e0e2215d7a41c2bfc7c9244123969273f3476b939a226aac0ab56e9e3c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "globset"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,12 +1397,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.13.2+1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a42de9a51a5c12e00fc0e4ca6bc2ea43582fc6418488e8f615e905d886f258b"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb644c388dfaefa18035c12614156d285364769e818893da0dda9030c80ad2ba"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f35facd4a5673cb5a48822be2be1d4236c1c99cb4113cab7061ac720d5bf859"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -1632,6 +1681,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,6 +1861,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
+ "vergen",
  "warp",
  "web3",
  "zstd",
@@ -1973,6 +2032,30 @@ checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
 dependencies = [
  "thiserror",
  "toml",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -2680,6 +2763,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+dependencies = [
+ "itoa 1.0.1",
+ "libc",
+ "num_threads",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3155,6 +3249,22 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "vergen"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4db743914c971db162f35bf46601c5a63ec4452e61461937b4c1ab817a60c12e"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "enum-iterator",
+ "getset",
+ "git2",
+ "rustversion",
+ "thiserror",
+ "time",
+]
 
 [[package]]
 name = "version_check"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ WORKDIR /usr/src/pathfinder
 # Build only the dependencies first. This utilizes
 # container layer caching for Rust builds
 RUN mkdir crates
-RUN cargo new --lib crates/pedersen
+RUN cargo new --lib --vcs none crates/pedersen
 # Correct: --lib. We'll handle the binary later.
-RUN cargo new --lib crates/pathfinder
+RUN cargo new --lib --vcs none crates/pathfinder
 COPY Cargo.toml Cargo.toml
 
 COPY crates/pathfinder/Cargo.toml crates/pathfinder/Cargo.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,17 +16,20 @@ RUN cargo new --lib crates/pathfinder
 COPY Cargo.toml Cargo.toml
 
 COPY crates/pathfinder/Cargo.toml crates/pathfinder/Cargo.toml
+COPY crates/pathfinder/build.rs crates/pathfinder/build.rs
 COPY crates/pedersen/Cargo.toml crates/pedersen/Cargo.toml
 COPY crates/pedersen/benches crates/pedersen/benches
 
-RUN RUSTFLAGS='-L/usr/lib -Ctarget-feature=-crt-static' cargo build --release
-
+# DEPENDENCY_LAYER=1 should disable any vergen interaction, because the .git directory is not yet available
+RUN DEPENDENCY_LAYER=1 RUSTFLAGS='-L/usr/lib -Ctarget-feature=-crt-static' cargo build --release
 
 # Compile the actual libraries and binary now
 COPY . .
+COPY ./.git /usr/src/pathfinder/.git
 
 # Mark these for re-compilation
 RUN touch crates/pathfinder/src/lib.rs
+RUN touch crates/pathfinder/src/build.rs
 RUN touch crates/pedersen/src/lib.rs
 
 RUN RUSTFLAGS='-L/usr/lib -Ctarget-feature=-crt-static' cargo build --release

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.58"
+build = "build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
@@ -56,3 +57,6 @@ tempfile = "3"
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
 tracing-test = "0.2.1"
 warp = "0.3.2"
+
+[build-dependencies]
+vergen = { version = "7", default-features = false, features = ["git"] }

--- a/crates/pathfinder/build.rs
+++ b/crates/pathfinder/build.rs
@@ -1,0 +1,23 @@
+//! Pathfinder build script.
+//!
+//! Just sets up `vergen` to query our git information for the build.
+
+fn main() {
+    // our Dockerfile is set up to a dependency only run, to cache a layer with all of the
+    // dependencies downloaded. during that "DEPENDENCY_LAYER" environment variable is set,
+    // and we shouldn't ask vergen to setup anything on that run to avoid this adding additional
+    // cache-miss reasons.
+
+    if std::env::var_os("DEPENDENCY_LAYER").is_some() {
+        return;
+    }
+
+    {
+        // at 7.0.0 default enables everything compiled in, selected with feature-flags
+        let mut config = vergen::Config::default();
+        *config.git_mut().semver_kind_mut() = vergen::SemverKind::Lightweight;
+        *config.git_mut().semver_dirty_mut() = Some("-dirty");
+        vergen::vergen(config)
+            .expect("vergen failed; this is probably due to missing .git directory");
+    }
+}

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -20,7 +20,11 @@ async fn main() -> anyhow::Result<()> {
     let config =
         config::Configuration::parse_cmd_line_and_cfg_file().context("Parsing configuration")?;
 
-    info!("🏁 Starting node.");
+    info!(
+        // this is expected to be $(last_git_tag)-$(commits_since)-$(commit_hash)
+        version = env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT"),
+        "🏁 Starting node."
+    );
     let eth_transport = ethereum_transport(config.ethereum)
         .await
         .context("Creating Ethereum transport")?;

--- a/crates/pathfinder/src/config/cli.rs
+++ b/crates/pathfinder/src/config/cli.rs
@@ -1,5 +1,5 @@
 //! Command-line argument parsing
-use clap::{crate_version, Arg};
+use clap::Arg;
 use std::ffi::OsString;
 
 use crate::config::builder::ConfigBuilder;
@@ -60,7 +60,7 @@ fn clap_app() -> clap::App<'static, 'static> {
             format!("HTTP-RPC listening address [default: {}]", DEFAULT_HTTP_RPC_ADDR);
     }
 
-    let version = concat!(crate_version!(), "-alpha");
+    let version = env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT");
     clap::App::new("Pathfinder")
         .version(version)
         .about("A StarkNet node implemented by Equilibrium. Submit bug reports and issues at https://github.com/eqlabs/pathfinder.")


### PR DESCRIPTION
Embed it with vergen. Use it on the first tracing message, and `--help`.

The commits after the second one are questionable. I couldn't get the caching work, each time the build.rs execution failed with an libgit2 based error even though the `.git` directory was in place. ~I did the quick edits on start-node.sh as I noticed it didn't work like README.md says, which it again does after the changes.~ `start-node.sh` changes dropped to keep this minimal.