### PR TITLE
feat(py): assert cairo-lang version

### DIFF
--- a/py/README.md
+++ b/py/README.md
@@ -33,6 +33,10 @@ $ PIP_REQUIRE_VIRTUALENV=true pip install -r requirements-dev.txt
 
 That is currently the only list we have, and it doesn't have too large extras.
 
+### Upgrading dependencies
+
+Re-use the `PIP_REQUIRE_VIRTUALENV=true pip install -r requirements-dev.txt` to upgrade the virtual environment.
+
 ## Testing
 
 Inside the virtual environment, in the same directory as this README, after installing all of the dependencies:

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -31,6 +31,7 @@ def main():
 
         connection.execute("BEGIN")
         if not check_schema(connection):
+            print("unexpected database schema version at start.", flush=True)
             sys.exit(1)
         connection.rollback()
 

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -19,6 +19,13 @@ def main():
     sys.stdout.reconfigure(encoding="utf-8")
     # stderr should not be used
 
+    if not check_cairolang_version():
+        print(
+            "unexpected cairo-lang version: please reinstall dependencies to upgrade.",
+            flush=True,
+        )
+        sys.exit(1)
+
     with sqlite3.connect(db) as connection:
         connection.isolation_level = None
 
@@ -32,6 +39,13 @@ def main():
         # if it didn't add the newline to the written out string.
         print("ready", flush=True)
         do_loop(connection, sys.stdin, sys.stdout)
+
+
+def check_cairolang_version():
+    import pkg_resources
+
+    version = pkg_resources.get_distribution("cairo-lang").version
+    return version == "0.8.0"
 
 
 def do_loop(connection, input_gen, output_file):


### PR DESCRIPTION
Assert it like schema version. Forbids running with outdated python dependencies. Also adds:

- error message on schema version mismatch (most likely development time)
- error message on cairo-lang version (most likely end-user forgot upgrade venv)
- README note on how to upgrade dependencies