### PR TITLE
fix(storage/schema): cascade delete events when blocks are deleted

### DIFF
--- a/crates/pathfinder/src/storage/schema/revision_0007.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0007.rs
@@ -193,7 +193,7 @@ pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigration
                 -- Keys are represented as base64 encoded strings separated by space
                 keys TEXT,
                 data BLOB,
-                FOREIGN KEY(block_number) REFERENCES starknet_blocks(number)
+                FOREIGN KEY(block_number) REFERENCES starknet_blocks(number) ON DELETE CASCADE
             );
 
             -- Event filters can specify ranges of blocks


### PR DESCRIPTION
When a reorg occurs and Starknet blocks are deleted from the DB we
should be deleting events for transactions in those blocks, too.