### PR TITLE
fix: rev7 l2_reorg failure

### DIFF
--- a/crates/pathfinder/src/storage/schema/revision_0007.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0007.rs
@@ -194,6 +194,7 @@ pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigration
                 keys TEXT,
                 data BLOB,
                 FOREIGN KEY(block_number) REFERENCES starknet_blocks(number)
+                ON DELETE CASCADE
             );
 
             -- Event filters can specify ranges of blocks


### PR DESCRIPTION
Just like @kkovaacs said: When a reorg occurs and Starknet blocks are deleted from the DB we
should be deleting events for transactions in those blocks, too.

This PR also adds a regression test.