### PR TITLE
feat(cli): upgrade clap, add support for environment variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,13 +246,24 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term",
+ "bitflags",
+ "textwrap 0.11.0",
+ "unicode-width",
+]
+
+[[package]]
+name = "clap"
+version = "3.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
+dependencies = [
  "atty",
  "bitflags",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "indexmap",
+ "os_str_bytes",
+ "strsim",
+ "termcolor",
+ "textwrap 0.15.0",
 ]
 
 [[package]]
@@ -340,7 +351,7 @@ checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.34.0",
  "criterion-plot",
  "csv",
  "itertools",
@@ -470,7 +481,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn",
 ]
 
@@ -1741,6 +1752,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "output_vt100"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,7 +1853,7 @@ dependencies = [
  "base64",
  "bitvec",
  "bytes",
- "clap",
+ "clap 3.1.6",
  "console-subscriber",
  "enum-iterator",
  "futures",
@@ -2660,12 +2680,6 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -2708,6 +2722,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "termtree"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2732,6 +2755,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -3243,12 +3272,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -21,7 +21,7 @@ base64 = "0.13.0"
 # paritys scale codec locks us here
 bitvec = "0.20.4"
 bytes = "1.1.0"
-clap = "2.33.3"
+clap = "3.1.6"
 console-subscriber = { version = "0.1.3", optional = true }
 enum-iterator = "0.7.0"
 futures = { version = "0.3", default-features = false, features = ["std"] }

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -21,7 +21,7 @@ base64 = "0.13.0"
 # paritys scale codec locks us here
 bitvec = "0.20.4"
 bytes = "1.1.0"
-clap = "3.1.6"
+clap = { version = "3.1.6", features = ["env"] }
 console-subscriber = { version = "0.1.3", optional = true }
 enum-iterator = "0.7.0"
 futures = { version = "0.3", default-features = false, features = ["std"] }

--- a/crates/pathfinder/examples/fact_retrieval.rs
+++ b/crates/pathfinder/examples/fact_retrieval.rs
@@ -66,29 +66,29 @@ async fn main() {
 
 /// Creates the CLI and parses the resulting arguments.
 fn parse_cli_args() -> (Web3<Http>, EthereumBlockHash, StarknetBlockNumber) {
-    let cli = clap::App::new("fact-retrieval")
+    let cli = clap::Command::new("fact-retrieval")
         .about("Retrieves and displays a StarkNet state update fact")
         .after_help("You can use Etherscan to identify a fact hash to retrieve. The fact hash for a state update is emitted as a `LogStateTransitionFact` log.")
         .arg(
-            Arg::with_name("seq-no")
+            Arg::new("seq-no")
                 .long("sequence-number")
-                .short("s")
+                .short('s')
                 .takes_value(true)
                 .help("The state update's sequence number.")
                 .value_name("INT")
         )
         .arg(
-             Arg::with_name("block")
+             Arg::new("block")
                 .long("block-hash")
-                .short("b")
+                .short('b')
                 .takes_value(true)
                 .value_name("HASH")
                 .help("The L1 block hash at which the state update occurred.")
         )
         .arg(
-            Arg::with_name("url")
+            Arg::new("url")
                 .long("url")
-                .short("u")
+                .short('u')
                 .takes_value(true)
                 .value_name("HTTP(S) URL")
                 .long_help(r#"This should point to the HTTP RPC endpoint of your Ethereum entry-point, typically a local Ethereum client or a hosted gateway service such as Infura or Cloudflare.

--- a/crates/pathfinder/src/config/cli.rs
+++ b/crates/pathfinder/src/config/cli.rs
@@ -77,6 +77,7 @@ fn clap_app() -> clap::Command<'static> {
                 .long(ETH_USER_KEY)
                 .help("Ethereum API user")
                 .takes_value(true)
+                .env("PATHFINDER_ETHEREUM_API_USERNAME")
                 .long_help("The optional user to use for the Ethereum API"),
         )
         .arg(
@@ -84,6 +85,7 @@ fn clap_app() -> clap::Command<'static> {
                 .long(ETH_PASS_KEY)
                 .help("Ethereum API password")
                 .takes_value(true)
+                .env("PATHFINDER_ETHEREUM_API_PASSWORD")
                 .long_help("The optional password to use for the Ethereum API"),
         )
         .arg(
@@ -92,6 +94,7 @@ fn clap_app() -> clap::Command<'static> {
                 .help("Ethereum API endpoint")
                 .takes_value(true)
                 .value_name("HTTP(s) URL")
+                .env("PATHFINDER_ETHEREUM_API_URL")
                 .long_help(r"This should point to the HTTP RPC endpoint of your Ethereum entry-point, typically a local Ethereum client or a hosted gateway service such as Infura or Cloudflare.
 Examples:
     infura: https://goerli.infura.io/v3/<PROJECT_ID>
@@ -102,36 +105,97 @@ Examples:
                 .help(HTTP_RPC_HELP.as_ref())
                 .takes_value(true)
                 .value_name("IP:PORT")
+                .env("PATHFINDER_HTTP_RPC_ADDRESS")
         )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::env;
+    use std::sync::Mutex;
+
+    lazy_static::lazy_static! {
+        // prevents running tests in parallel, since these depend on
+        // process-global environment variables
+        static ref ENV_VAR_MUTEX: Mutex<()> = Mutex::new(());
+    }
+
+    fn clear_environment() {
+        env::remove_var("PATHFINDER_ETHEREUM_API_USERNAME");
+        env::remove_var("PATHFINDER_ETHEREUM_API_PASSWORD");
+        env::remove_var("PATHFINDER_ETHEREUM_API_URL");
+        env::remove_var("PATHFINDER_HTTP_RPC_ADDRESS");
+    }
 
     #[test]
     fn ethereum_url_long() {
+        let _env_guard = ENV_VAR_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        clear_environment();
+
         let value = "value".to_owned();
         let (_, mut cfg) = parse_args(vec!["bin name", "--ethereum.url", &value]).unwrap();
         assert_eq!(cfg.take(ConfigOption::EthereumHttpUrl), Some(value));
     }
 
     #[test]
+    fn ethereum_url_environment_variable() {
+        let _env_guard = ENV_VAR_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        clear_environment();
+
+        let value = "value".to_owned();
+        env::set_var("PATHFINDER_ETHEREUM_API_URL", &value);
+        let (_, mut cfg) = parse_args(vec!["bin name"]).unwrap();
+        assert_eq!(cfg.take(ConfigOption::EthereumHttpUrl), Some(value));
+    }
+
+    #[test]
     fn ethereum_user_long() {
+        let _env_guard = ENV_VAR_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        clear_environment();
+
         let value = "value".to_owned();
         let (_, mut cfg) = parse_args(vec!["bin name", "--ethereum.user", &value]).unwrap();
         assert_eq!(cfg.take(ConfigOption::EthereumUser), Some(value));
     }
 
     #[test]
+    fn ethereum_user_environment_variable() {
+        let _env_guard = ENV_VAR_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        clear_environment();
+
+        let value = "value".to_owned();
+        env::set_var("PATHFINDER_ETHEREUM_API_USERNAME", &value);
+        let (_, mut cfg) = parse_args(vec!["bin name"]).unwrap();
+        assert_eq!(cfg.take(ConfigOption::EthereumUser), Some(value));
+    }
+
+    #[test]
     fn ethereum_password_long() {
+        let _env_guard = ENV_VAR_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        clear_environment();
+
         let value = "value".to_owned();
         let (_, mut cfg) = parse_args(vec!["bin name", "--ethereum.password", &value]).unwrap();
         assert_eq!(cfg.take(ConfigOption::EthereumPassword), Some(value));
     }
 
     #[test]
+    fn ethereum_password_environment_variable() {
+        let _env_guard = ENV_VAR_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        clear_environment();
+
+        let value = "value".to_owned();
+        env::set_var("PATHFINDER_ETHEREUM_API_PASSWORD", &value);
+        let (_, mut cfg) = parse_args(vec!["bin name"]).unwrap();
+        assert_eq!(cfg.take(ConfigOption::EthereumPassword), Some(value));
+    }
+
+    #[test]
     fn config_filepath_short() {
+        let _env_guard = ENV_VAR_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        clear_environment();
+
         let value = "value".to_owned();
         let (filepath, _) = parse_args(vec!["bin name", "-c", &value]).unwrap();
         assert_eq!(filepath, Some(value));
@@ -139,6 +203,9 @@ mod tests {
 
     #[test]
     fn config_filepath_long() {
+        let _env_guard = ENV_VAR_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        clear_environment();
+
         let value = "value".to_owned();
         let (filepath, _) = parse_args(vec!["bin name", "--config", &value]).unwrap();
         assert_eq!(filepath, Some(value));
@@ -146,13 +213,30 @@ mod tests {
 
     #[test]
     fn http_rpc_address_long() {
+        let _env_guard = ENV_VAR_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        clear_environment();
+
         let value = "value".to_owned();
         let (_, mut cfg) = parse_args(vec!["bin name", "--http-rpc", &value]).unwrap();
         assert_eq!(cfg.take(ConfigOption::HttpRpcAddress), Some(value));
     }
 
     #[test]
+    fn http_rpc_address_environment_variable() {
+        let _env_guard = ENV_VAR_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        clear_environment();
+
+        let value = "value".to_owned();
+        env::set_var("PATHFINDER_HTTP_RPC_ADDRESS", &value);
+        let (_, mut cfg) = parse_args(vec!["bin name"]).unwrap();
+        assert_eq!(cfg.take(ConfigOption::HttpRpcAddress), Some(value));
+    }
+
+    #[test]
     fn empty_config() {
+        let _env_guard = ENV_VAR_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        clear_environment();
+
         let (filepath, cfg) = parse_args(vec!["bin name"]).unwrap();
         assert_eq!(filepath, None);
         assert_eq!(cfg, ConfigBuilder::default());

--- a/crates/pathfinder/src/config/cli.rs
+++ b/crates/pathfinder/src/config/cli.rs
@@ -26,14 +26,14 @@ pub fn parse_cmd_line() -> (Option<String>, ConfigBuilder) {
     }
 }
 
-/// A wrapper around [clap::App]'s `get_matches_from_safe()` which returns
+/// A wrapper around [clap::Command]'s `get_matches_from_safe()` which returns
 /// a [ConfigOption].
 fn parse_args<I, T>(args: I) -> clap::Result<(Option<String>, ConfigBuilder)>
 where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone,
 {
-    let args = clap_app().get_matches_from_safe(args)?;
+    let args = clap_app().try_get_matches_from(args)?;
 
     let config_filepath = args.value_of(CONFIG_KEY).map(|s| s.to_owned());
     let ethereum_url = args.value_of(ETH_URL_KEY).map(|s| s.to_owned());
@@ -50,10 +50,10 @@ where
     Ok((config_filepath, cfg))
 }
 
-/// Defines our command-line interface using [clap::App].
+/// Defines our command-line interface using [clap::Command].
 ///
 /// Sets the argument names, help strings etc.
-fn clap_app() -> clap::App<'static, 'static> {
+fn clap_app() -> clap::Command<'static> {
     use super::DEFAULT_HTTP_RPC_ADDR;
     lazy_static::lazy_static! {
         static ref HTTP_RPC_HELP: String =
@@ -61,33 +61,33 @@ fn clap_app() -> clap::App<'static, 'static> {
     }
 
     let version = env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT");
-    clap::App::new("Pathfinder")
+    clap::Command::new("Pathfinder")
         .version(version)
         .about("A StarkNet node implemented by Equilibrium. Submit bug reports and issues at https://github.com/eqlabs/pathfinder.")
         .arg(
-            Arg::with_name(CONFIG_KEY)
-                .short("c")
+            Arg::new(CONFIG_KEY)
+                .short('c')
                 .long(CONFIG_KEY)
                 .help("Path to the configuration file.")
                 .value_name("FILE")
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name(ETH_USER_KEY)
+            Arg::new(ETH_USER_KEY)
                 .long(ETH_USER_KEY)
                 .help("Ethereum API user")
                 .takes_value(true)
                 .long_help("The optional user to use for the Ethereum API"),
         )
         .arg(
-            Arg::with_name(ETH_PASS_KEY)
+            Arg::new(ETH_PASS_KEY)
                 .long(ETH_PASS_KEY)
                 .help("Ethereum API password")
                 .takes_value(true)
                 .long_help("The optional password to use for the Ethereum API"),
         )
         .arg(
-            Arg::with_name(ETH_URL_KEY)
+            Arg::new(ETH_URL_KEY)
                 .long(ETH_URL_KEY)
                 .help("Ethereum API endpoint")
                 .takes_value(true)
@@ -97,9 +97,9 @@ Examples:
     infura: https://goerli.infura.io/v3/<PROJECT_ID>
     geth:   https://localhost:8545"))
         .arg(
-            Arg::with_name(HTTP_RPC_ADDR_KEY)
+            Arg::new(HTTP_RPC_ADDR_KEY)
                 .long(HTTP_RPC_ADDR_KEY)
-                .help(&HTTP_RPC_HELP)
+                .help(HTTP_RPC_HELP.as_ref())
                 .takes_value(true)
                 .value_name("IP:PORT")
         )


### PR DESCRIPTION
PATHFINDER_ETHEREUM_API_URL, PATHFINDER_ETHEREUM_API_USERNAME, PATHFINDER_ETHEREUM_API_PASSWORD and PATHFINDER_HTTP_RPC_ADDRESS environment variables can now be used instead of command line arguments.

This will make it possible to get rid of the Docker entrypoint script which is currently used to map environment variables to command line arguments.

The PR also updates `clap` to 3.1.6 -- which being a major version upgrade required some changes in our code.