### PR TITLE
Combined sync tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,6 +1860,7 @@ dependencies = [
  "hex",
  "home",
  "http",
+ "jsonrpc-core",
  "jsonrpsee",
  "lazy_static",
  "mockall",

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -50,6 +50,7 @@ zstd = "0.10"
 [dev-dependencies]
 assert_matches = "1.5.0"
 http = "0.2.6"
+jsonrpc-core = "18.0.0"
 mockall = "0.11.0"
 pretty_assertions = "1.0.0"
 tempfile = "3"

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -48,6 +48,8 @@ async fn main() -> anyhow::Result<()> {
         network_chain,
         sequencer.clone(),
         sync_state.clone(),
+        state::l1_sync,
+        state::l2_sync,
     ));
 
     // TODO: the error could be recovered, but currently it's required for startup. There should

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -48,8 +48,8 @@ async fn main() -> anyhow::Result<()> {
         network_chain,
         sequencer.clone(),
         sync_state.clone(),
-        state::l1_sync,
-        state::l2_sync,
+        state::l1::sync,
+        state::l2::sync,
     ));
 
     // TODO: the error could be recovered, but currently it's required for startup. There should

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -16,7 +16,7 @@ pub(crate) mod state_tree;
 mod sync;
 
 pub use contract_hash::compute_contract_hash;
-pub use sync::{sync, State as SyncState};
+pub use sync::{l1_sync, l2_sync, sync, State as SyncState};
 
 #[derive(Clone, PartialEq)]
 pub struct CompressedContract {
@@ -467,8 +467,16 @@ mod tests {
         let sequencer = crate::sequencer::Client::new(chain).unwrap();
         let state = std::sync::Arc::new(sync::State::default());
 
-        sync::sync(storage, transport, chain, sequencer, state)
-            .await
-            .unwrap();
+        sync::sync(
+            storage,
+            transport,
+            chain,
+            sequencer,
+            state,
+            sync::l1_sync,
+            sync::l2_sync,
+        )
+        .await
+        .unwrap();
     }
 }

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -16,7 +16,7 @@ pub(crate) mod state_tree;
 mod sync;
 
 pub use contract_hash::compute_contract_hash;
-pub use sync::{l1_sync, l2_sync, sync, State as SyncState};
+pub use sync::{l1, l2, sync, State as SyncState};
 
 #[derive(Clone, PartialEq)]
 pub struct CompressedContract {
@@ -473,8 +473,8 @@ mod tests {
             chain,
             sequencer,
             state,
-            sync::l1_sync,
-            sync::l2_sync,
+            sync::l1::sync,
+            sync::l2::sync,
         )
         .await
         .unwrap();

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -1,5 +1,5 @@
-mod l1;
-mod l2;
+pub mod l1;
+pub mod l2;
 
 use std::{future::Future, sync::Arc, time::Duration};
 
@@ -19,9 +19,6 @@ use crate::{
         StarknetTransactionsTable, Storage,
     },
 };
-
-pub use l1::sync as l1_sync;
-pub use l2::sync as l2_sync;
 
 use anyhow::Context;
 use pedersen::StarkHash;

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -41,9 +41,9 @@ impl Default for State {
     }
 }
 
-pub async fn sync<Web3Transport, SequencerClient, F1, F2, L1Sync, L2Sync>(
+pub async fn sync<Transport, SequencerClient, F1, F2, L1Sync, L2Sync>(
     storage: Storage,
-    transport: Web3<Web3Transport>,
+    transport: Web3<Transport>,
     chain: Chain,
     sequencer: SequencerClient,
     state: Arc<State>,
@@ -51,11 +51,11 @@ pub async fn sync<Web3Transport, SequencerClient, F1, F2, L1Sync, L2Sync>(
     l2_sync: L2Sync,
 ) -> anyhow::Result<()>
 where
-    Web3Transport: web3::Transport,
+    Transport: web3::Transport,
     SequencerClient: sequencer::ClientApi + Clone + Send + Sync + 'static,
     F1: Future<Output = anyhow::Result<()>> + Send + 'static,
     F2: Future<Output = anyhow::Result<()>> + Send + 'static,
-    L1Sync: FnOnce(mpsc::Sender<l1::Event>, Web3<Web3Transport>, Chain, Option<StateUpdateLog>) -> F1
+    L1Sync: FnOnce(mpsc::Sender<l1::Event>, Web3<Transport>, Chain, Option<StateUpdateLog>) -> F1
         + Copy,
     L2Sync: FnOnce(
             mpsc::Sender<l2::Event>,

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -12,7 +12,7 @@ use crate::{
         Chain,
     },
     rpc::types::reply::syncing,
-    sequencer::{self, reply::Block, ClientApi},
+    sequencer::{self, reply::Block},
     state::{calculate_contract_state_hash, state_tree::GlobalStateTree, update_contract_state},
     storage::{
         ContractCodeTable, ContractsStateTable, ContractsTable, L1StateTable, L1TableBlockId,
@@ -45,7 +45,7 @@ pub async fn sync(
     storage: Storage,
     transport: Web3<Http>,
     chain: Chain,
-    sequencer: sequencer::Client,
+    sequencer: impl sequencer::ClientApi + Clone + Send + Sync + 'static,
     state: Arc<State>,
 ) -> anyhow::Result<()> {
     // TODO: should this be owning a Storage, or just take in a Connection?
@@ -294,7 +294,7 @@ pub async fn sync(
 /// Periodically updates sync state with the latest block height.
 async fn update_sync_status_latest(
     state: Arc<State>,
-    sequencer: sequencer::Client,
+    sequencer: impl sequencer::ClientApi,
     starting_block: StarknetBlockHash,
 ) -> anyhow::Result<()> {
     use crate::rpc::types::{BlockNumberOrTag, Tag};
@@ -557,4 +557,10 @@ fn deploy_contract(
         .context("Insert constract state hash into contracts state table")?;
     ContractsTable::upsert(transaction, contract.address, contract.hash)
         .context("Inserting contract hash into contracts table")
+}
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    async fn happy_path() {}
 }

--- a/crates/pathfinder/src/state/sync/l1.rs
+++ b/crates/pathfinder/src/state/sync/l1.rs
@@ -31,7 +31,7 @@ pub enum Event {
 
 /// Syncs L1 state update logs. Emits [sync events](Event) which should be handled
 /// to update storage and respond to queries.
-pub(super) async fn sync(
+pub async fn sync(
     tx_event: mpsc::Sender<Event>,
     transport: Web3<Http>,
     chain: Chain,


### PR DESCRIPTION
This PR adds some basic tests for `state::sync::sync()`, which essentially inject events from either `l1` or `l2` sync tasks and then assert the DB for respective updates.

I had to introduce some dependency injection for `sync()` to decouple from any concrete `l1` & `l2` sync implementations.

At the moment keeping this PR as draft as to get your opinion on these tests.
IMO it's better to have _some_ tests rather then _none_.

