### PR TITLE
fix(cli): rename `ethereum.user` argument to `ethereum.user-agent`

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ url      = "https://goerli.infura.io/v3/..." #
 # The optional password for your Ethereum endpoint.
 password = "..."
 # The optional user-agent for your Ethereum endpoint.
-user     = "..."
+user-agent     = "..."
 ```
 
 ### Logging

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -100,7 +100,7 @@ async fn main() -> anyhow::Result<()> {
 /// - the password (if provided)
 async fn ethereum_transport(config: EthereumConfig) -> anyhow::Result<Web3<Http>> {
     let client = reqwest::Client::builder();
-    let client = match config.user {
+    let client = match config.user_agent {
         Some(user_agent) => client.user_agent(user_agent),
         None => client,
     }

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -15,8 +15,8 @@ const DEFAULT_HTTP_RPC_ADDR: &str = "127.0.0.1:9545";
 pub enum ConfigOption {
     /// The Ethereum URL.
     EthereumHttpUrl,
-    /// The Ethereum user.
-    EthereumUser,
+    /// The User Agent header value to use for the Ethereum URL.
+    EthereumUserAgent,
     /// The Ethereum password.
     EthereumPassword,
     /// The HTTP-RPC listening socket address.
@@ -27,7 +27,7 @@ impl Display for ConfigOption {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ConfigOption::EthereumHttpUrl => f.write_str("Ethereum HTTP URL"),
-            ConfigOption::EthereumUser => f.write_str("Ethereum user"),
+            ConfigOption::EthereumUserAgent => f.write_str("Ethereum user agent"),
             ConfigOption::EthereumPassword => f.write_str("Ethereum password"),
             ConfigOption::HttpRpcAddress => f.write_str("HTTP-RPC socket address"),
         }
@@ -39,8 +39,8 @@ impl Display for ConfigOption {
 pub struct EthereumConfig {
     /// The Ethereum URL.
     pub url: Url,
-    /// The optional Ethereum user.
-    pub user: Option<String>,
+    /// The optional HTTP User-Agent header value to use for Ethereum.
+    pub user_agent: Option<String>,
     /// The optional Ethereum password.
     pub password: Option<String>,
 }

--- a/crates/pathfinder/src/config/builder.rs
+++ b/crates/pathfinder/src/config/builder.rs
@@ -64,13 +64,13 @@ impl ConfigBuilder {
         })?;
 
         // Optional parameters.
-        let eth_user = self.take(ConfigOption::EthereumUser);
+        let eth_user_agent = self.take(ConfigOption::EthereumUserAgent);
         let eth_password = self.take(ConfigOption::EthereumPassword);
 
         Ok(Configuration {
             ethereum: EthereumConfig {
                 url: eth_url,
-                user: eth_user,
+                user_agent: eth_user_agent,
                 password: eth_password,
             },
             http_rpc_addr,

--- a/crates/pathfinder/src/config/cli.rs
+++ b/crates/pathfinder/src/config/cli.rs
@@ -8,7 +8,7 @@ use super::ConfigOption;
 
 const CONFIG_KEY: &str = "config";
 const ETH_URL_KEY: &str = "ethereum.url";
-const ETH_USER_KEY: &str = "ethereum.user";
+const ETH_USER_AGENT_KEY: &str = "ethereum.user-agent";
 const ETH_PASS_KEY: &str = "ethereum.password";
 const HTTP_RPC_ADDR_KEY: &str = "http-rpc";
 
@@ -37,13 +37,13 @@ where
 
     let config_filepath = args.value_of(CONFIG_KEY).map(|s| s.to_owned());
     let ethereum_url = args.value_of(ETH_URL_KEY).map(|s| s.to_owned());
-    let ethereum_user = args.value_of(ETH_USER_KEY).map(|s| s.to_owned());
+    let ethereum_user_agent = args.value_of(ETH_USER_AGENT_KEY).map(|s| s.to_owned());
     let ethereum_password = args.value_of(ETH_PASS_KEY).map(|s| s.to_owned());
     let http_rpc_addr = args.value_of(HTTP_RPC_ADDR_KEY).map(|s| s.to_owned());
 
     let cfg = ConfigBuilder::default()
         .with(ConfigOption::EthereumHttpUrl, ethereum_url)
-        .with(ConfigOption::EthereumUser, ethereum_user)
+        .with(ConfigOption::EthereumUserAgent, ethereum_user_agent)
         .with(ConfigOption::EthereumPassword, ethereum_password)
         .with(ConfigOption::HttpRpcAddress, http_rpc_addr);
 
@@ -73,11 +73,11 @@ fn clap_app() -> clap::Command<'static> {
                 .takes_value(true),
         )
         .arg(
-            Arg::new(ETH_USER_KEY)
-                .long(ETH_USER_KEY)
+            Arg::new(ETH_USER_AGENT_KEY)
+                .long(ETH_USER_AGENT_KEY)
                 .help("Ethereum API user")
                 .takes_value(true)
-                .env("PATHFINDER_ETHEREUM_API_USERNAME")
+                .env("PATHFINDER_ETHEREUM_API_USER_AGENT")
                 .long_help("The optional user to use for the Ethereum API"),
         )
         .arg(
@@ -122,7 +122,7 @@ mod tests {
     }
 
     fn clear_environment() {
-        env::remove_var("PATHFINDER_ETHEREUM_API_USERNAME");
+        env::remove_var("PATHFINDER_ETHEREUM_API_USER_AGENT");
         env::remove_var("PATHFINDER_ETHEREUM_API_PASSWORD");
         env::remove_var("PATHFINDER_ETHEREUM_API_URL");
         env::remove_var("PATHFINDER_HTTP_RPC_ADDRESS");
@@ -150,24 +150,24 @@ mod tests {
     }
 
     #[test]
-    fn ethereum_user_long() {
+    fn ethereum_user_agent_long() {
         let _env_guard = ENV_VAR_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
         clear_environment();
 
         let value = "value".to_owned();
-        let (_, mut cfg) = parse_args(vec!["bin name", "--ethereum.user", &value]).unwrap();
-        assert_eq!(cfg.take(ConfigOption::EthereumUser), Some(value));
+        let (_, mut cfg) = parse_args(vec!["bin name", "--ethereum.user-agent", &value]).unwrap();
+        assert_eq!(cfg.take(ConfigOption::EthereumUserAgent), Some(value));
     }
 
     #[test]
-    fn ethereum_user_environment_variable() {
+    fn ethereum_user_agent_environment_variable() {
         let _env_guard = ENV_VAR_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
         clear_environment();
 
         let value = "value".to_owned();
-        env::set_var("PATHFINDER_ETHEREUM_API_USERNAME", &value);
+        env::set_var("PATHFINDER_ETHEREUM_API_USER_AGENT", &value);
         let (_, mut cfg) = parse_args(vec!["bin name"]).unwrap();
-        assert_eq!(cfg.take(ConfigOption::EthereumUser), Some(value));
+        assert_eq!(cfg.take(ConfigOption::EthereumUserAgent), Some(value));
     }
 
     #[test]

--- a/crates/pathfinder/src/config/file.rs
+++ b/crates/pathfinder/src/config/file.rs
@@ -6,7 +6,8 @@ use crate::config::builder::ConfigBuilder;
 #[derive(Deserialize, Debug, PartialEq)]
 struct EthereumConfig {
     url: Option<String>,
-    user: Option<String>,
+    #[serde(rename = "user-agent")]
+    user_agent: Option<String>,
     password: Option<String>,
 }
 
@@ -23,7 +24,7 @@ impl FileConfig {
         let builder = match self.ethereum {
             Some(eth) => ConfigBuilder::default()
                 .with(ConfigOption::EthereumHttpUrl, eth.url)
-                .with(ConfigOption::EthereumUser, eth.user)
+                .with(ConfigOption::EthereumUserAgent, eth.user_agent)
                 .with(ConfigOption::EthereumPassword, eth.password),
             None => ConfigBuilder::default(),
         };
@@ -59,9 +60,9 @@ mod tests {
     #[test]
     fn ethereum_user() {
         let value = "value".to_owned();
-        let toml = format!(r#"ethereum.user = "{}""#, value);
+        let toml = format!(r#"ethereum.user-agent = "{}""#, value);
         let mut cfg = config_from_str(&toml).unwrap();
-        assert_eq!(cfg.take(ConfigOption::EthereumUser), Some(value));
+        assert_eq!(cfg.take(ConfigOption::EthereumUserAgent), Some(value));
     }
 
     #[test]
@@ -74,20 +75,20 @@ mod tests {
 
     #[test]
     fn ethereum_section() {
-        let user = "user".to_owned();
+        let user_agent = "user_agent".to_owned();
         let url = "url".to_owned();
         let password = "password".to_owned();
 
         let toml = format!(
             r#"[ethereum]
-user = "{}"
+user-agent = "{}"
 url = "{}"
 password = "{}""#,
-            user, url, password
+            user_agent, url, password
         );
 
         let mut cfg = config_from_str(&toml).unwrap();
-        assert_eq!(cfg.take(ConfigOption::EthereumUser), Some(user));
+        assert_eq!(cfg.take(ConfigOption::EthereumUserAgent), Some(user_agent));
         assert_eq!(cfg.take(ConfigOption::EthereumHttpUrl), Some(url));
         assert_eq!(cfg.take(ConfigOption::EthereumPassword), Some(password));
     }


### PR DESCRIPTION
This command line argument can be used to set the value of the
User-Agent header, and _not_ the username for HTTP basic authentication.

This also changes fixes the name of the environment variable we have
been using for this argument.