### PR TITLE
Fix caching layer for third party Rust dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN cargo new --lib --vcs none crates/pedersen
 # Correct: --lib. We'll handle the binary later.
 RUN cargo new --lib --vcs none crates/pathfinder
 COPY Cargo.toml Cargo.toml
+COPY Cargo.lock Cargo.lock
 
 COPY crates/pathfinder/Cargo.toml crates/pathfinder/Cargo.toml
 COPY crates/pathfinder/build.rs crates/pathfinder/build.rs


### PR DESCRIPTION
We need to copy Cargo.lock, too, in addition to Cargo.toml when doing the build step for Rust dependencies.

Otherwise cargo generates a new lock file with incorrect versions of our dependencies, which leads to these being re-downloaded and rebuilt when we're building pathfinder.