### PR TITLE
Remove sleeps

### DIFF
--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -95,7 +95,7 @@ fn calculate_contract_state_hash(hash: ContractHash, root: ContractRoot) -> Cont
 
 #[cfg(test)]
 mod tests {
-    use super::{calculate_contract_state_hash, sync};
+    use super::calculate_contract_state_hash;
     use crate::core::{ContractHash, ContractRoot, ContractStateHash};
     use pedersen::StarkHash;
 

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -456,27 +456,4 @@ mod tests {
         // assert_eq!(state.eth_tx_index, genesis.origin.transaction.index);
         // assert_eq!(state.eth_log_index, genesis.origin.log_index);
     }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    #[ignore = "this is manual testing only, but we should really use the binary for this"]
-    async fn go_sync() {
-        let storage =
-            crate::storage::Storage::migrate(std::path::PathBuf::from("testing.sqlite")).unwrap();
-        let chain = crate::ethereum::Chain::Goerli;
-        let transport = crate::ethereum::test_transport(chain);
-        let sequencer = crate::sequencer::Client::new(chain).unwrap();
-        let state = std::sync::Arc::new(sync::State::default());
-
-        // sync::sync(
-        //     storage,
-        //     transport,
-        //     chain,
-        //     sequencer,
-        //     state,
-        //     sync::l1::sync,
-        //     sync::l2::sync,
-        // )
-        // .await
-        // .unwrap();
-    }
 }

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -467,16 +467,16 @@ mod tests {
         let sequencer = crate::sequencer::Client::new(chain).unwrap();
         let state = std::sync::Arc::new(sync::State::default());
 
-        sync::sync(
-            storage,
-            transport,
-            chain,
-            sequencer,
-            state,
-            sync::l1::sync,
-            sync::l2::sync,
-        )
-        .await
-        .unwrap();
+        // sync::sync(
+        //     storage,
+        //     transport,
+        //     chain,
+        //     sequencer,
+        //     state,
+        //     sync::l1::sync,
+        //     sync::l2::sync,
+        // )
+        // .await
+        // .unwrap();
     }
 }

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -77,6 +77,7 @@ impl From<mpsc::Sender<BlockingTaskDone>> for BlockingTaskDoneSender {
     }
 }
 
+#[cfg_attr(test, allow(clippy::too_many_arguments))]
 pub async fn sync<Transport, SequencerClient, F1, F2, L1Sync, L2Sync>(
     storage: Storage,
     transport: Web3<Transport>,
@@ -1051,7 +1052,6 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn l1_restart() {
-        use std::sync::atomic::AtomicUsize;
         let storage = Storage::in_memory().unwrap();
 
         // A simple L1 sync task
@@ -1361,7 +1361,6 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn l2_restart() {
-        use std::sync::atomic::AtomicUsize;
         let storage = Storage::in_memory().unwrap();
 
         // A simple L2 sync task


### PR DESCRIPTION
This is a quick and naive fix to using sleeps in `sync::tests` albeit at the cost of using manual notifications which are hidden in the public API (ie. in the non-test signature of `sync::sync()`).
Test execution time is now negligible.
Keeping it as draft as I'm not sure if you think is is acceptable before a real refactor is done.
 