### PR TITLE
Update Python code for cairo-lang 0.8.1 release

### DIFF
--- a/py/requirements-dev.in
+++ b/py/requirements-dev.in
@@ -1,5 +1,5 @@
 # see README.md
-cairo-lang==0.8.0
+cairo-lang==0.8.1
 # We don't use rlp directly, however this needs to be defined for it to help pip-compile
 eth-rlp==0.2.1
 pip-tools==6.4.0

--- a/py/requirements-dev.txt
+++ b/py/requirements-dev.txt
@@ -25,7 +25,7 @@ black==21.12b0
     # via -r requirements-dev.in
 cachetools==5.0.0
     # via cairo-lang
-cairo-lang==0.8.0
+cairo-lang==0.8.1
     # via -r requirements-dev.in
 certifi==2021.10.8
     # via requests

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -230,6 +230,7 @@ def check_schema(connection):
 
 def resolve_block(connection, at_block):
     from starkware.starknet.business_logic.state.state import BlockInfo
+    from starkware.starknet.definitions.general_config import DEFAULT_GAS_PRICE
 
     if at_block == "latest":
         # latest is questionable, but the rust side cannot use it at the moment at least,
@@ -258,7 +259,7 @@ def resolve_block(connection, at_block):
         # NOTE: this assumes the rust side to serialize starknet_blocks::timestamp as compatible
         # for blocks before 0.7.0
         return (
-            BlockInfo(block_number, block_time),
+            BlockInfo(block_number, block_time, DEFAULT_GAS_PRICE),
             global_root,
         )
     except Exception:

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -46,7 +46,7 @@ def check_cairolang_version():
     import pkg_resources
 
     version = pkg_resources.get_distribution("cairo-lang").version
-    return version == "0.8.0"
+    return version == "0.8.1"
 
 
 def do_loop(connection, input_gen, output_file):

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -229,7 +229,7 @@ def check_schema(connection):
 
 
 def resolve_block(connection, at_block):
-    from starkware.starknet.business_logic.state import BlockInfo
+    from starkware.starknet.business_logic.state.state import BlockInfo
 
     if at_block == "latest":
         # latest is questionable, but the rust side cannot use it at the moment at least,
@@ -420,7 +420,7 @@ async def do_call(
 
     Returns the retdata from the call, which is the only property needed by the RPC api.
     """
-    from starkware.starknet.business_logic.state import (
+    from starkware.starknet.business_logic.state.state import (
         SharedState,
         StateSelector,
     )

--- a/py/src/generate_test_global_tree.py
+++ b/py/src/generate_test_global_tree.py
@@ -33,7 +33,7 @@ async def generate_root_and_nodes(input):
     from starkware.starkware_utils.commitment_tree.patricia_tree.patricia_tree import (
         PatriciaTree,
     )
-    from starkware.starknet.business_logic.state_objects import ContractState
+    from starkware.starknet.business_logic.state.objects import ContractState
     from copy import deepcopy
 
     # still create this for the ffc it creates.


### PR DESCRIPTION
This PR fixes up some imports and the `BlockInfo` constructor so that our code works with `cairo-lang==0.8.1`.

It also has some extra commits that fix some pylint warnings or just make our code conform to PEP8 better (like importing at the module level).