### PR TITLE
feat: add pathfinder release monitoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1869,6 +1869,7 @@ dependencies = [
  "pretty_assertions",
  "reqwest",
  "rusqlite",
+ "semver",
  "serde",
  "serde_json",
  "serde_with",
@@ -2492,9 +2493,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.4"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
 
 [[package]]
 name = "serde"

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -33,6 +33,7 @@ num-bigint = { version = "0.4.3", features = ["serde"] }
 pedersen = { path = "../pedersen" }
 reqwest = { version = "0.11.4", features = ["json"] }
 rusqlite = { version = "0.27.0", features = ["bundled"] }
+semver = "1.0.7"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = { version = "1.0.68", features = ["arbitrary_precision", "raw_value"] }
 serde_with = "1.9.4"

--- a/crates/pathfinder/src/lib.rs
+++ b/crates/pathfinder/src/lib.rs
@@ -7,3 +7,4 @@ pub mod rpc;
 pub mod sequencer;
 pub mod state;
 pub mod storage;
+pub mod update;

--- a/crates/pathfinder/src/update.rs
+++ b/crates/pathfinder/src/update.rs
@@ -65,10 +65,10 @@ pub async fn poll_github_for_releases() -> anyhow::Result<()> {
 }
 
 /// Creates a [reqwest::Client] for use in querying Github API.
-/// 
+///
 /// Adds a 5 minute request timeout, and sets the required headers:
-/// - [ACCEPT](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#current-version) 
-/// - [USER_AGENT](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#user-agent-required) 
+/// - [ACCEPT](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#current-version)
+/// - [USER_AGENT](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#user-agent-required)
 fn configure_client() -> anyhow::Result<reqwest::Client> {
     use anyhow::Context;
     const USER_AGENT: &str = concat!(

--- a/crates/pathfinder/src/update.rs
+++ b/crates/pathfinder/src/update.rs
@@ -1,0 +1,170 @@
+//! Discover pathfinder releases via github API.
+
+/// Monitors Github for new releases and logs when this occurs.
+///
+/// Will continuously log this with every poll so that the user
+/// has a better chance of spotting it.
+pub async fn poll_github_for_releases() -> anyhow::Result<()> {
+    use anyhow::Context;
+    let current_version = env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT");
+    let current_version = current_version.strip_prefix('v').unwrap_or(current_version);
+    let local_version = semver::Version::parse(current_version)
+        .context("Semver parsing of local version failed")?;
+    let mut latest_gh_version = None;
+
+    let client = reqwest::Client::new();
+    let mut etag = None;
+
+    loop {
+        match fetch_latest_github_release(&client, &etag).await {
+            UpdateResult::Update(release) => {
+                etag = release.etag;
+
+                let release_version = release
+                    .version
+                    .strip_prefix('v')
+                    .unwrap_or(&release.version);
+                match semver::Version::parse(release_version) {
+                    Ok(version) => {
+                        latest_gh_version = Some(version);
+                    }
+                    Err(e) => {
+                        tracing::warn!(error=%e, version=%release.version, "Semver parsing of latest github release failed")
+                    }
+                };
+            }
+            UpdateResult::NotModified => {
+                tracing::trace!(latest=?latest_gh_version, "No new release found on Github");
+            }
+            UpdateResult::RewestError(e) if e.is_decode() || e.is_body() || e.is_builder() => {
+                // More severe errors, probably indicating something is wrong with our setup.
+                // Set to warn and not error because this update checking is a non-critical feature.
+                tracing::warn!(error=%e, "Error checking Github for new releases")
+            }
+            UpdateResult::RewestError(e) => {
+                // Less severe errors, includes transient connection errors and timeouts; does not warrant
+                // a high log level.
+                tracing::trace!(error=%e, "Error checking Github for new releases")
+            }
+            UpdateResult::Other(e) => {
+                // Other, unexpected errors.
+                tracing::warn!(error=%e, "Error checking Github for new releases");
+            }
+        }
+
+        // Display latest release info if it is newer than this application.
+        if let Some(github) = latest_gh_version.as_ref() {
+            if github > &local_version {
+                tracing::warn!(release=%github, "New pathfinder release available! Please consider updating your node!")
+            }
+        }
+
+        // Only poll every 10 minutes.
+        tokio::time::sleep(std::time::Duration::from_secs(60 * 10)).await;
+    }
+}
+
+#[derive(Debug)]
+struct Release {
+    version: String,
+    /// Optional because its possible to have an invalid string ETag header.
+    etag: Option<String>,
+}
+
+#[derive(Debug)]
+enum UpdateResult {
+    /// A new latest release.
+    Update(Release),
+    /// No new releases since last query (status code 304).
+    NotModified,
+    RewestError(reqwest::Error),
+    Other(anyhow::Error),
+}
+
+/// Fetches the latest pathfinder [Release] from Github using their REST API.
+///
+/// The [IF_NONE_MATCH](reqwest::header::IF_NONE_MATCH) header options is set to
+/// the `etag` parameter to prevent Github from sending redundant information. The
+/// resulting 304 status code is mapped to [UpdateResult::NotModified].
+async fn fetch_latest_github_release(
+    client: &reqwest::Client,
+    etag: &Option<String>,
+) -> UpdateResult {
+    use reqwest::StatusCode;
+    use reqwest::Url;
+
+    const USER_AGENT: &str = concat!(
+        env!("CARGO_PKG_NAME"),
+        "/",
+        env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT")
+    );
+    let url = Url::parse("https://api.github.com/repos/eqlabs/pathfinder/releases/latest").unwrap();
+
+    let mut request = client
+        .get(url)
+        .timeout(std::time::Duration::from_secs(300))
+        // https://docs.github.com/en/rest/overview/resources-in-the-rest-api#current-version
+        .header(reqwest::header::ACCEPT, "application/vnd.github.v3+json")
+        // https://docs.github.com/en/rest/overview/resources-in-the-rest-api#user-agent-required
+        .header(reqwest::header::USER_AGENT, USER_AGENT);
+    if let Some(etag) = etag {
+        request = request.header(reqwest::header::IF_NONE_MATCH, etag);
+    }
+
+    let result = match request.send().await {
+        Ok(r) => r,
+        Err(e) => return UpdateResult::RewestError(e),
+    };
+    match result.status() {
+        StatusCode::NOT_MODIFIED => UpdateResult::NotModified,
+        StatusCode::OK => {
+            #[derive(serde::Deserialize)]
+            struct JsonRelease {
+                name: String,
+            }
+
+            let etag = result
+                .headers()
+                .get(reqwest::header::ETAG)
+                // Its technically allowed to have non-valid ascii data in the header,
+                // in which case we can't do anything except set etag=None.
+                .map(|h| h.to_str())
+                .transpose()
+                .unwrap_or_default()
+                .map(|s| s.to_string());
+
+            match result.json::<JsonRelease>().await {
+                Ok(r) => UpdateResult::Update(Release {
+                    version: r.name,
+                    etag,
+                }),
+                Err(e) => UpdateResult::RewestError(e),
+            }
+        }
+        other => UpdateResult::Other(anyhow::anyhow!(
+            "Unexpected response status code: {}",
+            other
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    async fn fetch_latest_github_release() {
+        let client = reqwest::Client::new();
+
+        // First check should result in the latest github release.
+        let release = super::fetch_latest_github_release(&client, &None).await;
+        use super::UpdateResult;
+        let release = match release {
+            UpdateResult::Update(r) => r,
+            other => panic!("Expected an update, but got {:?}", other),
+        };
+
+        // Second check should result in no new update (as etag is set to latest release).
+        let etag = release.etag.expect("etag should be set");
+        let not_modified = super::fetch_latest_github_release(&client, &Some(etag)).await;
+        assert_matches::assert_matches!(not_modified, UpdateResult::NotModified);
+    }
+}


### PR DESCRIPTION
This periodically checks github for updates and logs if a newer release is found.

Does not stop checking for newer releases, even once one is found -- this lets us update the log message to include the release if any. One thing I'm on the fence about my error handling for this. And whether I should be checking for process crash in the main binary (since this is a "minor" feature, maybe it crashing should not end the node?).

Closes #245.