### PR TITLE
doc(README): add docker updating note

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,12 @@ The following environment variables can be passed to the container:
 | PATHFINDER_ETHEREUM_API_PASSWORD   | Password to use during authentication with Ethereum node API |               | no       |
 | PATHFINDER_HTTP_RPC_ADDRESS        | Address to bind the `pathfinder` RPC server to               | 0.0.0.0:9545  | no       |
 
+### Updating the docker image
+
+```bash
+docker pull eqlabs/pathfinder
+```
+
 ### Building the container image yourself
 
 Building the container image from source code is necessary only in special cases or development.


### PR DESCRIPTION
Adds a note on how to update the image.

I think this should be kept as draft until we are ready to do a new release, then add a snapshot of what the release notification looks like then, and include it in the doc section.