### PR TITLE
Bump pathfinder crate version to 0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pathfinder"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.58"


### PR DESCRIPTION
Looks like I've missed this last week when releasing 0.1.8.