### PR TITLE
Improve l2 errors

### DIFF
--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -122,7 +122,7 @@ async fn parse_raw(resp: reqwest::Response) -> Result<reqwest::Response, Sequenc
 /// Wrapper function to allow retrying sequencer queries in an exponential manner.
 ///
 /// Retry is performed on __all__ types of errors __except for__
-/// [StarkNet specific errors](crate::sequencer::errors::StarknetError).
+/// [StarkNet specific errors](crate::sequencer::error::StarknetError).
 ///
 /// Initial backoff time is 30 seconds and saturates at 1 hour:
 ///

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -135,11 +135,11 @@ where
         // Max number of retries of 7 gives a total accumulated timeout of 4 minutes and 15 seconds (2^8-1)
         .max_num_retries(NonZeroUsize::new(7).unwrap())
         .when(|e| match e {
-            SequencerError::TransportError(te) if te.is_timeout() => {
+            SequencerError::ReqwestError(te) if te.is_timeout() => {
                 tracing::debug!("Retrying due to timeout");
                 true
             }
-            SequencerError::TransportError(te) => match te.status() {
+            SequencerError::ReqwestError(te) => match te.status() {
                 Some(
                     status @ (StatusCode::TOO_MANY_REQUESTS
                     | StatusCode::BAD_GATEWAY

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -137,61 +137,33 @@ where
     use crate::retry::Retry;
     use reqwest::StatusCode;
     use std::num::NonZeroU64;
-    use tracing::{info, trace, warn, Level};
+    use tracing::{error, info, warn};
 
     Retry::exponential(future_factory, NonZeroU64::new(2).unwrap())
         .factor(NonZeroU64::new(15).unwrap())
         .max_delay(Duration::from_secs(60 * 60))
         .when(|e| match e {
             SequencerError::ReqwestError(e) => {
-                match tracing::level_filters::LevelFilter::current().into_level() {
-                    None => {}
-                    Some(level) if level >= Level::TRACE => {
-                        trace!("Retrying due to: {:?}", e);
-                    }
-                    Some(_) => {
-                        if e.is_timeout() {
-                            info!("Retrying due to a timeout.");
-                        } else if e.is_decode() {
-                            warn!("Retrying due to a deserialization error.");
-                        } else if e.is_status() {
-                            match e.status() {
-                                Some(code) if code.is_redirection() => {
-                                    warn!("Retrying due to a redirect error: {code}")
-                                }
-                                Some(code @ StatusCode::NOT_FOUND) => {
-                                    info!("Retrying due to: {code}.")
-                                }
-                                Some(StatusCode::TOO_MANY_REQUESTS) => {
-                                    info!("Retrying due to rate limiting.")
-                                }
-                                Some(code) if code.is_client_error() => {
-                                    warn!("Retrying due to: {code}.")
-                                }
-                                Some(StatusCode::INTERNAL_SERVER_ERROR) => {
-                                    unreachable!("All HTTP 500s should either be converted to StarkNet errors or result in a deserialization error.")
-                                }
-                                Some(
-                                    code @ (StatusCode::BAD_GATEWAY
-                                    | StatusCode::SERVICE_UNAVAILABLE
-                                    | StatusCode::GATEWAY_TIMEOUT),
-                                ) => info!("Retrying due to: {code}."),
-                                Some(code) if code.is_server_error() => warn!("Retrying due to: {code}."),
-                                Some(code) => warn!("Retrying due to unclassified status code: {code}."),
-                                None => unreachable!(),
-                            }
-                        } else if e.is_redirect() {
-                            warn!("Retrying due to a redirect error.")
-                        } else if e.is_connect() {
-                            info!("Retrying due to a connection error.")
-                        } else if e.is_body() {
-                            info!("Retrying due to an error sending the request's or receiving the reply's body.")
-                        } else {
-                            // We should not get here since the only remaining error category
-                            // is a builder error
-                            warn!("Retrying due to an unexpected error.")
+                if e.is_body() || e.is_connect() || e.is_timeout() {
+                    info!(error=%e, "Request failed, retrying:");
+                } else if e.is_status() {
+                    match e.status() {
+                        Some(StatusCode::NOT_FOUND | StatusCode::TOO_MANY_REQUESTS | StatusCode::BAD_GATEWAY
+                            | StatusCode::SERVICE_UNAVAILABLE
+                            | StatusCode::GATEWAY_TIMEOUT) => {
+                            info!(error=%e, "Request failed, retrying:");
                         }
+                        Some(StatusCode::INTERNAL_SERVER_ERROR) => {
+                            unreachable!("All HTTP 500s should either be converted to StarkNet errors or result in a deserialization error.")
+                        }
+                        Some(_) => warn!(error=%e, "Request failed, retrying:"),
+                        None => unreachable!(),
                     }
+
+                } else if e.is_decode() {
+                    error!(error=%e, "Request failed, retrying:");
+                } else {
+                    warn!(error=%e, "Request failed, retrying:");
                 }
 
                 true


### PR DESCRIPTION
This PR implements #246 with some slight deviations (ie. no distinction between other standard and other "non-standard" status codes).

In essence:
- **all** errors except for `StarknetError` cause a retry,
- upon retry each type of error is logged in a short form at the level described in #246 **unless** the `trace` level is enabled, in which case the full details of the error are logged,
- retrying is done **forever**, so the outer sync loop should in practice never have to restart the l2 sync task,
- backoff is still exponential, but the timings have changed: `{30s, 1m, 2m, 4m, ..., 32m, 1hr, 1hr,...}` - eventually saturating at 1hr,
- the `DeserializeError` variant has been removed as it was dead code.