### PR TITLE
refactor: non-stringifying anyhow wrapping

### DIFF
--- a/crates/pathfinder/src/ethereum/log.rs
+++ b/crates/pathfinder/src/ethereum/log.rs
@@ -115,10 +115,9 @@ pub async fn get_logs<T: Transport>(
                 continue;
             }
             Err(other) => {
-                return Err(GetLogsError::Other(anyhow::anyhow!(
-                    "Error getting logs: {:?}",
-                    other
-                )));
+                return Err(GetLogsError::Other(
+                    anyhow::Error::new(other).context("Error getting logs"),
+                ));
             }
         };
     }


### PR DESCRIPTION
Per earlier discussion: replace the stringifying use of `anyhow::anyhow!` when wrapping another error. This ended up being the only one instance, no other similar was found. There is a single instance of `anyhow::anyhow!(err)` which seems to be `anyhow::Error::new(err)`.