### PR TITLE
Serialize on stack

### DIFF
--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -35,7 +35,7 @@ use std::sync::Arc;
 pub struct RpcApi {
     storage: Storage,
     sequencer: sequencer::Client,
-    chain_id: String,
+    chain_id: &'static str,
     call_handle: Option<ext_py::Handle>,
     sync_state: Arc<SyncState>,
 }
@@ -62,11 +62,12 @@ impl RpcApi {
         Self {
             storage,
             sequencer,
-            chain_id: super::serde::bytes_to_hex_str(match chain {
-                Chain::Goerli => b"SN_GOERLI",
-                Chain::Mainnet => b"SN_MAIN",
-            })
-            .into(),
+            chain_id: match chain {
+                // Hex str for b"SN_GOERLI"
+                Chain::Goerli => "0x534e5f474f45524c49",
+                // Hex str for b"SN_MAIN"
+                Chain::Mainnet => "0x534e5f4d41494e",
+            },
             call_handle: None,
             sync_state,
         }
@@ -893,8 +894,8 @@ impl RpcApi {
     }
 
     /// Return the currently configured StarkNet chain id.
-    pub async fn chain_id(&self) -> RpcResult<String> {
-        Ok(self.chain_id.clone())
+    pub async fn chain_id(&self) -> RpcResult<&'static str> {
+        Ok(self.chain_id)
     }
 
     // /// Returns the transactions in the transaction pool, recognized by this sequencer.

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -62,7 +62,7 @@ impl RpcApi {
         Self {
             storage,
             sequencer,
-            chain_id: super::serde::bytes_to_hex_str_owned(match chain {
+            chain_id: super::serde::bytes_to_hex_str(match chain {
                 Chain::Goerli => b"SN_GOERLI",
                 Chain::Mainnet => b"SN_MAIN",
             }),

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -35,7 +35,7 @@ use std::sync::Arc;
 pub struct RpcApi {
     storage: Storage,
     sequencer: sequencer::Client,
-    chain: Chain,
+    chain_id: String,
     call_handle: Option<ext_py::Handle>,
     sync_state: Arc<SyncState>,
 }
@@ -62,7 +62,10 @@ impl RpcApi {
         Self {
             storage,
             sequencer,
-            chain,
+            chain_id: super::serde::bytes_to_hex_str_owned(match chain {
+                Chain::Goerli => b"SN_GOERLI",
+                Chain::Mainnet => b"SN_MAIN",
+            }),
             call_handle: None,
             sync_state,
         }
@@ -890,12 +893,7 @@ impl RpcApi {
 
     /// Return the currently configured StarkNet chain id.
     pub async fn chain_id(&self) -> RpcResult<String> {
-        use super::serde::bytes_to_hex_str;
-
-        Ok(bytes_to_hex_str(match self.chain {
-            Chain::Goerli => b"SN_GOERLI",
-            Chain::Mainnet => b"SN_MAIN",
-        }))
+        Ok(self.chain_id.clone())
     }
 
     // /// Returns the transactions in the transaction pool, recognized by this sequencer.

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -65,7 +65,8 @@ impl RpcApi {
             chain_id: super::serde::bytes_to_hex_str(match chain {
                 Chain::Goerli => b"SN_GOERLI",
                 Chain::Mainnet => b"SN_MAIN",
-            }),
+            })
+            .into(),
             call_handle: None,
             sync_state,
         }

--- a/crates/pathfinder/src/rpc/serde.rs
+++ b/crates/pathfinder/src/rpc/serde.rs
@@ -77,9 +77,8 @@ impl SerializeAs<EthereumAddress> for EthereumAddressAsHexStr {
     {
         // EthereumAddress is "0x" + 40 digits at most
         let mut buf = [0u8; 2 + 40];
-        let s =
-            bytes_as_hex_str(source.0.as_bytes(), &mut buf).map_err(serde::ser::Error::custom)?;
-        serializer.serialize_str(&s)
+        let s = bytes_as_hex_str(source.0.as_bytes(), &mut buf);
+        serializer.serialize_str(s)
     }
 }
 
@@ -88,26 +87,26 @@ impl<'de> DeserializeAs<'de, EthereumAddress> for EthereumAddressAsHexStr {
     where
         D: serde::Deserializer<'de>,
     {
+        struct EthereumAddressVisitor;
+
+        impl<'de> Visitor<'de> for EthereumAddressVisitor {
+            type Value = EthereumAddress;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a hex string of up to 40 digits with an optional '0x' prefix")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                bytes_from_hex_str::<{ H160::len_bytes() }>(v)
+                    .map_err(serde::de::Error::custom)
+                    .map(|b| EthereumAddress(H160::from(b)))
+            }
+        }
+
         deserializer.deserialize_str(EthereumAddressVisitor)
-    }
-}
-
-struct EthereumAddressVisitor;
-
-impl<'de> Visitor<'de> for EthereumAddressVisitor {
-    type Value = EthereumAddress;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("a hex string of up to 40 digits with an optional '0x' prefix")
-    }
-
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        bytes_from_hex_str::<{ H160::len_bytes() }>(v)
-            .map_err(serde::de::Error::custom)
-            .map(|b| EthereumAddress(H160::from(b)))
     }
 }
 
@@ -120,8 +119,8 @@ impl SerializeAs<H256> for H256AsNoLeadingZerosHexStr {
     {
         // H256 is "0x" + 64 digits at most
         let mut buf = [0u8; 2 + 64];
-        let s = bytes_as_hex_str(source.as_bytes(), &mut buf).map_err(serde::ser::Error::custom)?;
-        serializer.serialize_str(&s)
+        let s = bytes_as_hex_str(source.as_bytes(), &mut buf);
+        serializer.serialize_str(s)
     }
 }
 
@@ -130,26 +129,26 @@ impl<'de> DeserializeAs<'de, H256> for H256AsNoLeadingZerosHexStr {
     where
         D: serde::Deserializer<'de>,
     {
+        struct H256Visitor;
+
+        impl<'de> Visitor<'de> for H256Visitor {
+            type Value = H256;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a hex string of up to 64 digits with an optional '0x' prefix")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                bytes_from_hex_str::<{ H256::len_bytes() }>(v)
+                    .map_err(serde::de::Error::custom)
+                    .map(H256::from)
+            }
+        }
+
         deserializer.deserialize_str(H256Visitor)
-    }
-}
-
-struct H256Visitor;
-
-impl<'de> Visitor<'de> for H256Visitor {
-    type Value = H256;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("a hex string of up to 64 digits with an optional '0x' prefix")
-    }
-
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        bytes_from_hex_str::<{ H256::len_bytes() }>(v)
-            .map_err(serde::de::Error::custom)
-            .map(H256::from)
     }
 }
 
@@ -162,9 +161,8 @@ impl SerializeAs<Fee> for FeeAsHexStr {
     {
         // Fee is "0x" + 32 digits at most
         let mut buf = [0u8; 2 + 32];
-        let s =
-            bytes_as_hex_str(source.0.as_bytes(), &mut buf).map_err(serde::ser::Error::custom)?;
-        serializer.serialize_str(&s)
+        let s = bytes_as_hex_str(source.0.as_bytes(), &mut buf);
+        serializer.serialize_str(s)
     }
 }
 
@@ -173,26 +171,26 @@ impl<'de> DeserializeAs<'de, Fee> for FeeAsHexStr {
     where
         D: serde::Deserializer<'de>,
     {
+        struct FeeVisitor;
+
+        impl<'de> Visitor<'de> for FeeVisitor {
+            type Value = Fee;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a hex string of up to 32 digits with an optional '0x' prefix")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                bytes_from_hex_str::<{ H128::len_bytes() }>(v)
+                    .map_err(serde::de::Error::custom)
+                    .map(|b| Fee(H128::from(b)))
+            }
+        }
+
         deserializer.deserialize_str(FeeVisitor)
-    }
-}
-
-struct FeeVisitor;
-
-impl<'de> Visitor<'de> for FeeVisitor {
-    type Value = Fee;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("a hex string of up to 32 digits with an optional '0x' prefix")
-    }
-
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        bytes_from_hex_str::<{ H128::len_bytes() }>(v)
-            .map_err(serde::de::Error::custom)
-            .map(|b| Fee(H128::from(b)))
     }
 }
 
@@ -262,13 +260,6 @@ fn bytes_from_hex_str<const N: usize>(hex_str: &str) -> Result<[u8; N], HexParse
     Ok(buf)
 }
 
-#[derive(Copy, Clone, Debug, thiserror::Error, PartialEq)]
-#[error("Expected buffer size {expected:}, got {actual:}")]
-pub(crate) struct InvalidBufferSizeError {
-    expected: usize,
-    actual: usize,
-}
-
 /// The first stage of conversion - skip leading zeros
 fn skip_zeros(bytes: &[u8]) -> (impl Iterator<Item = &u8>, usize, usize) {
     // Skip all leading zero bytes
@@ -304,38 +295,36 @@ fn it_to_hex_str<'a>(
 
 /// A convenience function which produces a "0x" prefixed hex str slice in a given buffer `buf`
 /// from an array of bytes.
-/// Returns `InvalidBufferLengthError` if `bytes.len() * 2 + 2 > buf.len()`
-pub(crate) fn bytes_as_hex_str<'a>(
-    bytes: &'a [u8],
-    buf: &'a mut [u8],
-) -> Result<Cow<'a, str>, InvalidBufferSizeError> {
-    if bytes.len() * 2 + 2 > buf.len() {
-        return Err(InvalidBufferSizeError {
-            actual: buf.len(),
-            expected: bytes.len() * 2 + 2,
-        });
-    }
+/// Panics if `bytes.len() * 2 + 2 > buf.len()`
+pub(crate) fn bytes_as_hex_str<'a>(bytes: &'a [u8], buf: &'a mut [u8]) -> &'a str {
+    let expected_buf_len = bytes.len() * 2 + 2;
+    assert!(
+        buf.len() >= expected_buf_len,
+        "buffer size is {}, expected at least {}",
+        buf.len(),
+        expected_buf_len
+    );
 
     if !bytes.iter().any(|b| *b != 0) {
-        return Ok(Cow::from("0x0"));
+        return "0x0";
     }
 
     let (it, start, len) = skip_zeros(bytes);
     let res = it_to_hex_str(it, start, len, buf);
-    // No heap allocations
-    Ok(String::from_utf8_lossy(res))
+    // Unwrap is safe because `buf` holds valid UTF8 characters.
+    std::str::from_utf8(res).unwrap()
 }
 
 /// A convenience function which produces a "0x" prefixed hex string from a [StarkHash].
-pub(crate) fn bytes_to_hex_str(bytes: &[u8]) -> String {
+pub(crate) fn bytes_to_hex_str(bytes: &[u8]) -> Cow<'static, str> {
     if !bytes.iter().any(|b| *b != 0) {
-        return "0x0".to_string();
+        return Cow::from("0x0");
     }
     let (it, start, len) = skip_zeros(bytes);
     let mut buf = vec![0u8; len];
     it_to_hex_str(it, start, len, &mut buf);
     // Unwrap is safe as the buffer contains valid utf8
-    String::from_utf8(buf).unwrap()
+    String::from_utf8(buf).unwrap().into()
 }
 
 #[cfg(test)]
@@ -360,7 +349,7 @@ mod tests {
         assert!(c.iter().all(|x| *x == 0));
         assert_eq!(bytes_to_hex_str(&c[..]), ZERO_HEX_STR);
         let mut buf = [0u8; 2 + 2];
-        assert_eq!(bytes_as_hex_str(&c[..], &mut buf).unwrap(), ZERO_HEX_STR);
+        assert_eq!(bytes_as_hex_str(&c[..], &mut buf), ZERO_HEX_STR);
     }
 
     #[test]
@@ -380,7 +369,7 @@ mod tests {
         assert_eq!(c, ODD_BYTES);
         assert_eq!(bytes_to_hex_str(&c[..]), ODD_HEX_STR);
         let mut buf = [0u8; 2 + 16];
-        assert_eq!(bytes_as_hex_str(&c[..], &mut buf).unwrap(), ODD_HEX_STR);
+        assert_eq!(bytes_as_hex_str(&c[..], &mut buf), ODD_HEX_STR);
     }
 
     #[test]
@@ -400,7 +389,7 @@ mod tests {
         assert_eq!(c, EVEN_BYTES);
         assert_eq!(bytes_to_hex_str(&c[..]), EVEN_HEX_STR);
         let mut buf = [0u8; 2 + 16];
-        assert_eq!(bytes_as_hex_str(&c[..], &mut buf).unwrap(), EVEN_HEX_STR);
+        assert_eq!(bytes_as_hex_str(&c[..], &mut buf), EVEN_HEX_STR);
     }
 
     #[test]
@@ -425,19 +414,14 @@ mod tests {
         assert_eq!(c, MAX_BYTES);
         assert_eq!(bytes_to_hex_str(&c[..]), MAX_HEX_STR);
         let mut buf = [0u8; 2 + 64];
-        assert_eq!(bytes_as_hex_str(&c[..], &mut buf).unwrap(), MAX_HEX_STR);
+        assert_eq!(bytes_as_hex_str(&c[..], &mut buf), MAX_HEX_STR);
     }
 
     #[test]
+    #[should_panic]
     fn buffer_too_small() {
         let mut buf = [0u8; 2 + 1];
-        assert_eq!(
-            bytes_as_hex_str(&[0u8], &mut buf).unwrap_err(),
-            InvalidBufferSizeError {
-                actual: 3,
-                expected: 4
-            }
-        );
+        bytes_as_hex_str(&[0u8], &mut buf);
     }
 
     #[test]

--- a/crates/pathfinder/src/rpc/serde.rs
+++ b/crates/pathfinder/src/rpc/serde.rs
@@ -248,9 +248,11 @@ mod tests {
         assert_eq!(expected, b);
         assert_eq!(starkhash_to_dec_str(&expected), ZERO_DEC_STR);
 
-        let c: [u8; 32] = bytes_from_hex_str(ZERO_HEX_STR).unwrap();
+        let c: [u8; 1] = bytes_from_hex_str(ZERO_HEX_STR).unwrap();
         assert!(c.iter().all(|x| *x == 0));
         assert_eq!(bytes_to_hex_str_owned(&c[..]), ZERO_HEX_STR);
+        let mut buf = [0u8; 2 + 2];
+        assert_eq!(bytes_to_hex_str(&c[..], &mut buf).unwrap(), ZERO_HEX_STR);
     }
 
     #[test]
@@ -269,6 +271,8 @@ mod tests {
         let c: [u8; 8] = bytes_from_hex_str(ODD_HEX_STR).unwrap();
         assert_eq!(c, ODD_BYTES);
         assert_eq!(bytes_to_hex_str_owned(&c[..]), ODD_HEX_STR);
+        let mut buf = [0u8; 2 + 16];
+        assert_eq!(bytes_to_hex_str(&c[..], &mut buf).unwrap(), ODD_HEX_STR);
     }
 
     #[test]
@@ -287,6 +291,8 @@ mod tests {
         let c: [u8; 8] = bytes_from_hex_str(EVEN_HEX_STR).unwrap();
         assert_eq!(c, EVEN_BYTES);
         assert_eq!(bytes_to_hex_str_owned(&c[..]), EVEN_HEX_STR);
+        let mut buf = [0u8; 2 + 16];
+        assert_eq!(bytes_to_hex_str(&c[..], &mut buf).unwrap(), EVEN_HEX_STR);
     }
 
     #[test]
@@ -310,6 +316,20 @@ mod tests {
         let c: [u8; 32] = bytes_from_hex_str(MAX_HEX_STR).unwrap();
         assert_eq!(c, MAX_BYTES);
         assert_eq!(bytes_to_hex_str_owned(&c[..]), MAX_HEX_STR);
+        let mut buf = [0u8; 2 + 64];
+        assert_eq!(bytes_to_hex_str(&c[..], &mut buf).unwrap(), MAX_HEX_STR);
+    }
+
+    #[test]
+    fn buffer_too_small() {
+        let mut buf = [0u8; 2 + 1];
+        assert_eq!(
+            bytes_to_hex_str(&[0u8], &mut buf).unwrap_err(),
+            InvalidBufferSizeError {
+                actual: 3,
+                expected: 4
+            }
+        );
     }
 
     #[test]

--- a/crates/pathfinder/src/rpc/serde.rs
+++ b/crates/pathfinder/src/rpc/serde.rs
@@ -296,7 +296,7 @@ fn it_to_hex_str<'a>(
 /// A convenience function which produces a "0x" prefixed hex str slice in a given buffer `buf`
 /// from an array of bytes.
 /// Panics if `bytes.len() * 2 + 2 > buf.len()`
-pub(crate) fn bytes_as_hex_str<'a>(bytes: &'a [u8], buf: &'a mut [u8]) -> &'a str {
+fn bytes_as_hex_str<'a>(bytes: &'a [u8], buf: &'a mut [u8]) -> &'a str {
     let expected_buf_len = bytes.len() * 2 + 2;
     assert!(
         buf.len() >= expected_buf_len,
@@ -316,7 +316,8 @@ pub(crate) fn bytes_as_hex_str<'a>(bytes: &'a [u8], buf: &'a mut [u8]) -> &'a st
 }
 
 /// A convenience function which produces a "0x" prefixed hex string from a [StarkHash].
-pub(crate) fn bytes_to_hex_str(bytes: &[u8]) -> Cow<'static, str> {
+#[allow(dead_code)]
+fn bytes_to_hex_str(bytes: &[u8]) -> Cow<'static, str> {
     if !bytes.iter().any(|b| *b != 0) {
         return Cow::from("0x0");
     }

--- a/crates/pathfinder/src/rpc/serde.rs
+++ b/crates/pathfinder/src/rpc/serde.rs
@@ -69,21 +69,21 @@ serde_conv!(
 serde_with::serde_conv!(
     pub EthereumAddressAsHexStr,
     EthereumAddress,
-    |serialize_me: &EthereumAddress| bytes_to_hex_str(serialize_me.0.as_bytes()),
+    |serialize_me: &EthereumAddress| bytes_to_hex_str_owned(serialize_me.0.as_bytes()),
     |s: &str| bytes_from_hex_str::<{ H160::len_bytes() }>(s).map(|b| EthereumAddress(H160::from(b)))
 );
 
 serde_with::serde_conv!(
     pub H256AsNoLeadingZerosHexStr,
     H256,
-    |serialize_me: &H256| bytes_to_hex_str(serialize_me.as_bytes()),
+    |serialize_me: &H256| bytes_to_hex_str_owned(serialize_me.as_bytes()),
     |s: &str| bytes_from_hex_str::<{ H256::len_bytes() }>(s).map(H256::from)
 );
 
 serde_with::serde_conv!(
     pub FeeAsHexStr,
     Fee,
-    |serialize_me: &Fee| bytes_to_hex_str(serialize_me.0.as_bytes()),
+    |serialize_me: &Fee| bytes_to_hex_str_owned(serialize_me.0.as_bytes()),
     |s: &str| bytes_from_hex_str::<{ H128::len_bytes() }>(s).map(|b| Fee(H128::from(b)))
 );
 
@@ -154,7 +154,7 @@ fn bytes_from_hex_str<const N: usize>(hex_str: &str) -> Result<[u8; N], HexParse
 }
 
 /// A convenience function which produces a "0x" prefixed hex string from a byte slice.
-pub(crate) fn bytes_to_hex_str(bytes: &[u8]) -> String {
+pub(crate) fn bytes_to_hex_str_owned(bytes: &[u8]) -> String {
     if !bytes.iter().any(|b| *b != 0) {
         return "0x0".to_string();
     }
@@ -203,7 +203,7 @@ mod tests {
 
         let c: [u8; 32] = bytes_from_hex_str(ZERO_HEX_STR).unwrap();
         assert!(c.iter().all(|x| *x == 0));
-        assert_eq!(bytes_to_hex_str(&c[..]), ZERO_HEX_STR);
+        assert_eq!(bytes_to_hex_str_owned(&c[..]), ZERO_HEX_STR);
     }
 
     #[test]
@@ -221,7 +221,7 @@ mod tests {
 
         let c: [u8; 8] = bytes_from_hex_str(ODD_HEX_STR).unwrap();
         assert_eq!(c, ODD_BYTES);
-        assert_eq!(bytes_to_hex_str(&c[..]), ODD_HEX_STR);
+        assert_eq!(bytes_to_hex_str_owned(&c[..]), ODD_HEX_STR);
     }
 
     #[test]
@@ -239,7 +239,7 @@ mod tests {
 
         let c: [u8; 8] = bytes_from_hex_str(EVEN_HEX_STR).unwrap();
         assert_eq!(c, EVEN_BYTES);
-        assert_eq!(bytes_to_hex_str(&c[..]), EVEN_HEX_STR);
+        assert_eq!(bytes_to_hex_str_owned(&c[..]), EVEN_HEX_STR);
     }
 
     #[test]
@@ -262,7 +262,7 @@ mod tests {
 
         let c: [u8; 32] = bytes_from_hex_str(MAX_HEX_STR).unwrap();
         assert_eq!(c, MAX_BYTES);
-        assert_eq!(bytes_to_hex_str(&c[..]), MAX_HEX_STR);
+        assert_eq!(bytes_to_hex_str_owned(&c[..]), MAX_HEX_STR);
     }
 
     #[test]

--- a/crates/pathfinder/src/rpc/serde.rs
+++ b/crates/pathfinder/src/rpc/serde.rs
@@ -78,7 +78,7 @@ impl SerializeAs<EthereumAddress> for EthereumAddressAsHexStr {
         // EthereumAddress is "0x" + 40 digits at most
         let mut buf = [0u8; 2 + 40];
         let s =
-            bytes_to_hex_str(source.0.as_bytes(), &mut buf).map_err(serde::ser::Error::custom)?;
+            bytes_as_hex_str(source.0.as_bytes(), &mut buf).map_err(serde::ser::Error::custom)?;
         serializer.serialize_str(&s)
     }
 }
@@ -120,7 +120,7 @@ impl SerializeAs<H256> for H256AsNoLeadingZerosHexStr {
     {
         // H256 is "0x" + 64 digits at most
         let mut buf = [0u8; 2 + 64];
-        let s = bytes_to_hex_str(source.as_bytes(), &mut buf).map_err(serde::ser::Error::custom)?;
+        let s = bytes_as_hex_str(source.as_bytes(), &mut buf).map_err(serde::ser::Error::custom)?;
         serializer.serialize_str(&s)
     }
 }
@@ -163,7 +163,7 @@ impl SerializeAs<Fee> for FeeAsHexStr {
         // Fee is "0x" + 32 digits at most
         let mut buf = [0u8; 2 + 32];
         let s =
-            bytes_to_hex_str(source.0.as_bytes(), &mut buf).map_err(serde::ser::Error::custom)?;
+            bytes_as_hex_str(source.0.as_bytes(), &mut buf).map_err(serde::ser::Error::custom)?;
         serializer.serialize_str(&s)
     }
 }
@@ -305,7 +305,7 @@ fn it_to_hex_str<'a>(
 /// A convenience function which produces a "0x" prefixed hex str slice in a given buffer `buf`
 /// from an array of bytes.
 /// Returns `InvalidBufferLengthError` if `bytes.len() * 2 + 2 > buf.len()`
-pub(crate) fn bytes_to_hex_str<'a>(
+pub(crate) fn bytes_as_hex_str<'a>(
     bytes: &'a [u8],
     buf: &'a mut [u8],
 ) -> Result<Cow<'a, str>, InvalidBufferSizeError> {
@@ -327,7 +327,7 @@ pub(crate) fn bytes_to_hex_str<'a>(
 }
 
 /// A convenience function which produces a "0x" prefixed hex string from a [StarkHash].
-pub(crate) fn bytes_to_hex_str_owned(bytes: &[u8]) -> String {
+pub(crate) fn bytes_to_hex_str(bytes: &[u8]) -> String {
     if !bytes.iter().any(|b| *b != 0) {
         return "0x0".to_string();
     }
@@ -358,9 +358,9 @@ mod tests {
 
         let c: [u8; 1] = bytes_from_hex_str(ZERO_HEX_STR).unwrap();
         assert!(c.iter().all(|x| *x == 0));
-        assert_eq!(bytes_to_hex_str_owned(&c[..]), ZERO_HEX_STR);
+        assert_eq!(bytes_to_hex_str(&c[..]), ZERO_HEX_STR);
         let mut buf = [0u8; 2 + 2];
-        assert_eq!(bytes_to_hex_str(&c[..], &mut buf).unwrap(), ZERO_HEX_STR);
+        assert_eq!(bytes_as_hex_str(&c[..], &mut buf).unwrap(), ZERO_HEX_STR);
     }
 
     #[test]
@@ -378,9 +378,9 @@ mod tests {
 
         let c: [u8; 8] = bytes_from_hex_str(ODD_HEX_STR).unwrap();
         assert_eq!(c, ODD_BYTES);
-        assert_eq!(bytes_to_hex_str_owned(&c[..]), ODD_HEX_STR);
+        assert_eq!(bytes_to_hex_str(&c[..]), ODD_HEX_STR);
         let mut buf = [0u8; 2 + 16];
-        assert_eq!(bytes_to_hex_str(&c[..], &mut buf).unwrap(), ODD_HEX_STR);
+        assert_eq!(bytes_as_hex_str(&c[..], &mut buf).unwrap(), ODD_HEX_STR);
     }
 
     #[test]
@@ -398,9 +398,9 @@ mod tests {
 
         let c: [u8; 8] = bytes_from_hex_str(EVEN_HEX_STR).unwrap();
         assert_eq!(c, EVEN_BYTES);
-        assert_eq!(bytes_to_hex_str_owned(&c[..]), EVEN_HEX_STR);
+        assert_eq!(bytes_to_hex_str(&c[..]), EVEN_HEX_STR);
         let mut buf = [0u8; 2 + 16];
-        assert_eq!(bytes_to_hex_str(&c[..], &mut buf).unwrap(), EVEN_HEX_STR);
+        assert_eq!(bytes_as_hex_str(&c[..], &mut buf).unwrap(), EVEN_HEX_STR);
     }
 
     #[test]
@@ -423,16 +423,16 @@ mod tests {
 
         let c: [u8; 32] = bytes_from_hex_str(MAX_HEX_STR).unwrap();
         assert_eq!(c, MAX_BYTES);
-        assert_eq!(bytes_to_hex_str_owned(&c[..]), MAX_HEX_STR);
+        assert_eq!(bytes_to_hex_str(&c[..]), MAX_HEX_STR);
         let mut buf = [0u8; 2 + 64];
-        assert_eq!(bytes_to_hex_str(&c[..], &mut buf).unwrap(), MAX_HEX_STR);
+        assert_eq!(bytes_as_hex_str(&c[..], &mut buf).unwrap(), MAX_HEX_STR);
     }
 
     #[test]
     fn buffer_too_small() {
         let mut buf = [0u8; 2 + 1];
         assert_eq!(
-            bytes_to_hex_str(&[0u8], &mut buf).unwrap_err(),
+            bytes_as_hex_str(&[0u8], &mut buf).unwrap_err(),
             InvalidBufferSizeError {
                 actual: 3,
                 expected: 4

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -88,7 +88,7 @@ pub struct Client {
 /// Helper function which simplifies the handling of optional block hashes in queries.
 fn block_hash_str(hash: BlockHashOrTag) -> (&'static str, Cow<'static, str>) {
     match hash {
-        BlockHashOrTag::Hash(h) => ("blockHash", Cow::from(h.0.to_hex_str())),
+        BlockHashOrTag::Hash(h) => ("blockHash", Cow::from(h.0.to_hex_str_owned())),
         BlockHashOrTag::Tag(Tag::Latest) => ("blockNumber", Cow::from("null")),
         BlockHashOrTag::Tag(Tag::Pending) => ("blockNumber", Cow::from("pending")),
     }
@@ -287,7 +287,7 @@ impl ClientApi for Client {
                 .inner
                 .get(self.build_query(
                     "get_full_contract",
-                    &[("contractAddress", &contract_addr.0.to_hex_str())],
+                    &[("contractAddress", &contract_addr.0.to_hex_str_owned())],
                 ))
                 .send()
                 .await?;
@@ -315,7 +315,7 @@ impl ClientApi for Client {
                 .get(self.build_query(
                     "get_storage_at",
                     &[
-                        ("contractAddress", &contract_addr.0.to_hex_str()),
+                        ("contractAddress", &contract_addr.0.to_hex_str_owned()),
                         ("key", &starkhash_to_dec_str(&key.0)),
                         (tag, &hash),
                     ],
@@ -338,7 +338,7 @@ impl ClientApi for Client {
                 .inner
                 .get(self.build_query(
                     "get_transaction",
-                    &[("transactionHash", &transaction_hash.0.to_hex_str())],
+                    &[("transactionHash", &transaction_hash.0.to_hex_str_owned())],
                 ))
                 .send()
                 .await?;
@@ -358,7 +358,7 @@ impl ClientApi for Client {
                 .inner
                 .get(self.build_query(
                     "get_transaction_status",
-                    &[("transactionHash", &transaction_hash.0.to_hex_str())],
+                    &[("transactionHash", &transaction_hash.0.to_hex_str_owned())],
                 ))
                 .send()
                 .await?;

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -88,7 +88,7 @@ pub struct Client {
 /// Helper function which simplifies the handling of optional block hashes in queries.
 fn block_hash_str(hash: BlockHashOrTag) -> (&'static str, Cow<'static, str>) {
     match hash {
-        BlockHashOrTag::Hash(h) => ("blockHash", Cow::from(h.0.to_hex_str())),
+        BlockHashOrTag::Hash(h) => ("blockHash", h.0.to_hex_str()),
         BlockHashOrTag::Tag(Tag::Latest) => ("blockNumber", Cow::from("null")),
         BlockHashOrTag::Tag(Tag::Pending) => ("blockNumber", Cow::from("pending")),
     }

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -88,7 +88,7 @@ pub struct Client {
 /// Helper function which simplifies the handling of optional block hashes in queries.
 fn block_hash_str(hash: BlockHashOrTag) -> (&'static str, Cow<'static, str>) {
     match hash {
-        BlockHashOrTag::Hash(h) => ("blockHash", Cow::from(h.0.to_hex_str_owned())),
+        BlockHashOrTag::Hash(h) => ("blockHash", Cow::from(h.0.to_hex_str())),
         BlockHashOrTag::Tag(Tag::Latest) => ("blockNumber", Cow::from("null")),
         BlockHashOrTag::Tag(Tag::Pending) => ("blockNumber", Cow::from("pending")),
     }
@@ -287,7 +287,7 @@ impl ClientApi for Client {
                 .inner
                 .get(self.build_query(
                     "get_full_contract",
-                    &[("contractAddress", &contract_addr.0.to_hex_str_owned())],
+                    &[("contractAddress", &contract_addr.0.to_hex_str())],
                 ))
                 .send()
                 .await?;
@@ -315,7 +315,7 @@ impl ClientApi for Client {
                 .get(self.build_query(
                     "get_storage_at",
                     &[
-                        ("contractAddress", &contract_addr.0.to_hex_str_owned()),
+                        ("contractAddress", &contract_addr.0.to_hex_str()),
                         ("key", &starkhash_to_dec_str(&key.0)),
                         (tag, &hash),
                     ],
@@ -338,7 +338,7 @@ impl ClientApi for Client {
                 .inner
                 .get(self.build_query(
                     "get_transaction",
-                    &[("transactionHash", &transaction_hash.0.to_hex_str_owned())],
+                    &[("transactionHash", &transaction_hash.0.to_hex_str())],
                 ))
                 .send()
                 .await?;
@@ -358,7 +358,7 @@ impl ClientApi for Client {
                 .inner
                 .get(self.build_query(
                     "get_transaction_status",
-                    &[("transactionHash", &transaction_hash.0.to_hex_str_owned())],
+                    &[("transactionHash", &transaction_hash.0.to_hex_str())],
                 ))
                 .send()
                 .await?;

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -253,7 +253,7 @@ where
                         format!("Insert contract definition with hash: {:?}", contract.hash)
                     })?;
 
-                    tracing::trace!("Inserted new contract {}", contract.hash.0.to_hex_str_owned());
+                    tracing::trace!("Inserted new contract {}", contract.hash.0.to_hex_str());
                 }
                 Some(l2::Event::QueryHash(block, tx)) => {
                     let hash = tokio::task::block_in_place(|| {

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -253,7 +253,7 @@ where
                         format!("Insert contract definition with hash: {:?}", contract.hash)
                     })?;
 
-                    tracing::trace!("Inserted new contract {}", contract.hash.0.to_hex_str());
+                    tracing::trace!("Inserted new contract {}", contract.hash.0.to_hex_str_owned());
                 }
                 Some(l2::Event::QueryHash(block, tx)) => {
                     let hash = tokio::task::block_in_place(|| {

--- a/crates/pedersen/src/hash.rs
+++ b/crates/pedersen/src/hash.rs
@@ -303,9 +303,9 @@ impl StarkHash {
         &buf[..len]
     }
 
-    /// A convenience function which produces a "0x" prefixed hex str slice in a given
-    /// buffer `buf` from slice of `bytes`.
-    /// Returns `InvalidBufferLengthError` if `bytes.len() * 2 + 2 > buf.len()`
+    /// A convenience function which produces a "0x" prefixed hex str slice in a given buffer `buf`
+    /// from a [StarkHash].
+    /// Returns `InvalidBufferLengthError` if `self.0.len() * 2 + 2 > buf.len()`
     pub(crate) fn to_hex_str_cow<'a>(
         &'a self,
         buf: &'a mut [u8],

--- a/crates/pedersen/src/hash.rs
+++ b/crates/pedersen/src/hash.rs
@@ -306,7 +306,7 @@ impl StarkHash {
     /// A convenience function which produces a "0x" prefixed hex str slice in a given buffer `buf`
     /// from a [StarkHash].
     /// Returns `InvalidBufferLengthError` if `self.0.len() * 2 + 2 > buf.len()`
-    pub(crate) fn to_hex_str<'a>(
+    pub(crate) fn as_hex_str<'a>(
         &'a self,
         buf: &'a mut [u8],
     ) -> Result<Cow<'a, str>, InvalidBufferSizeError> {
@@ -655,7 +655,7 @@ mod tests {
         fn zero() {
             assert_eq!(StarkHash::ZERO.to_hex_str_owned(), "0x0");
             let mut buf = [0u8; 66];
-            assert_eq!(StarkHash::ZERO.to_hex_str(&mut buf).unwrap(), "0x0");
+            assert_eq!(StarkHash::ZERO.as_hex_str(&mut buf).unwrap(), "0x0");
         }
 
         #[test]
@@ -663,7 +663,7 @@ mod tests {
             let hash = StarkHash::from_hex_str(ODD).unwrap();
             assert_eq!(hash.to_hex_str_owned(), ODD);
             let mut buf = [0u8; 66];
-            assert_eq!(hash.to_hex_str(&mut buf).unwrap(), ODD);
+            assert_eq!(hash.as_hex_str(&mut buf).unwrap(), ODD);
         }
 
         #[test]
@@ -671,7 +671,7 @@ mod tests {
             let hash = StarkHash::from_hex_str(EVEN).unwrap();
             assert_eq!(hash.to_hex_str_owned(), EVEN);
             let mut buf = [0u8; 66];
-            assert_eq!(hash.to_hex_str(&mut buf).unwrap(), EVEN);
+            assert_eq!(hash.as_hex_str(&mut buf).unwrap(), EVEN);
         }
 
         #[test]
@@ -679,14 +679,14 @@ mod tests {
             let hash = StarkHash::from_hex_str(MAX).unwrap();
             assert_eq!(hash.to_hex_str_owned(), MAX);
             let mut buf = [0u8; 66];
-            assert_eq!(hash.to_hex_str(&mut buf).unwrap(), MAX);
+            assert_eq!(hash.as_hex_str(&mut buf).unwrap(), MAX);
         }
 
         #[test]
         fn buffer_too_small() {
             let mut buf = [0u8; 65];
             assert_eq!(
-                StarkHash::ZERO.to_hex_str(&mut buf).unwrap_err(),
+                StarkHash::ZERO.as_hex_str(&mut buf).unwrap_err(),
                 InvalidBufferSizeError {
                     actual: 65,
                     expected: 66

--- a/crates/pedersen/src/hash.rs
+++ b/crates/pedersen/src/hash.rs
@@ -328,7 +328,7 @@ impl StarkHash {
     }
 
     /// A convenience function which produces a "0x" prefixed hex string from a [StarkHash].
-    pub fn to_hex_str_owned(&self) -> String {
+    pub fn to_hex_str(&self) -> String {
         if !self.0.iter().any(|b| *b != 0) {
             return "0x0".to_string();
         }
@@ -653,7 +653,7 @@ mod tests {
 
         #[test]
         fn zero() {
-            assert_eq!(StarkHash::ZERO.to_hex_str_owned(), "0x0");
+            assert_eq!(StarkHash::ZERO.to_hex_str(), "0x0");
             let mut buf = [0u8; 66];
             assert_eq!(StarkHash::ZERO.as_hex_str(&mut buf).unwrap(), "0x0");
         }
@@ -661,7 +661,7 @@ mod tests {
         #[test]
         fn odd() {
             let hash = StarkHash::from_hex_str(ODD).unwrap();
-            assert_eq!(hash.to_hex_str_owned(), ODD);
+            assert_eq!(hash.to_hex_str(), ODD);
             let mut buf = [0u8; 66];
             assert_eq!(hash.as_hex_str(&mut buf).unwrap(), ODD);
         }
@@ -669,7 +669,7 @@ mod tests {
         #[test]
         fn even() {
             let hash = StarkHash::from_hex_str(EVEN).unwrap();
-            assert_eq!(hash.to_hex_str_owned(), EVEN);
+            assert_eq!(hash.to_hex_str(), EVEN);
             let mut buf = [0u8; 66];
             assert_eq!(hash.as_hex_str(&mut buf).unwrap(), EVEN);
         }
@@ -677,7 +677,7 @@ mod tests {
         #[test]
         fn max() {
             let hash = StarkHash::from_hex_str(MAX).unwrap();
-            assert_eq!(hash.to_hex_str_owned(), MAX);
+            assert_eq!(hash.to_hex_str(), MAX);
             let mut buf = [0u8; 66];
             assert_eq!(hash.as_hex_str(&mut buf).unwrap(), MAX);
         }

--- a/crates/pedersen/src/hash.rs
+++ b/crates/pedersen/src/hash.rs
@@ -306,7 +306,7 @@ impl StarkHash {
     /// A convenience function which produces a "0x" prefixed hex str slice in a given buffer `buf`
     /// from a [StarkHash].
     /// Returns `InvalidBufferLengthError` if `self.0.len() * 2 + 2 > buf.len()`
-    pub(crate) fn to_hex_str_cow<'a>(
+    pub(crate) fn to_hex_str<'a>(
         &'a self,
         buf: &'a mut [u8],
     ) -> Result<Cow<'a, str>, InvalidBufferSizeError> {
@@ -328,7 +328,7 @@ impl StarkHash {
     }
 
     /// A convenience function which produces a "0x" prefixed hex string from a [StarkHash].
-    pub fn to_hex_str(&self) -> String {
+    pub fn to_hex_str_owned(&self) -> String {
         if !self.0.iter().any(|b| *b != 0) {
             return "0x0".to_string();
         }
@@ -653,40 +653,40 @@ mod tests {
 
         #[test]
         fn zero() {
-            assert_eq!(StarkHash::ZERO.to_hex_str(), "0x0");
+            assert_eq!(StarkHash::ZERO.to_hex_str_owned(), "0x0");
             let mut buf = [0u8; 66];
-            assert_eq!(StarkHash::ZERO.to_hex_str_cow(&mut buf).unwrap(), "0x0");
+            assert_eq!(StarkHash::ZERO.to_hex_str(&mut buf).unwrap(), "0x0");
         }
 
         #[test]
         fn odd() {
             let hash = StarkHash::from_hex_str(ODD).unwrap();
-            assert_eq!(hash.to_hex_str(), ODD);
+            assert_eq!(hash.to_hex_str_owned(), ODD);
             let mut buf = [0u8; 66];
-            assert_eq!(hash.to_hex_str_cow(&mut buf).unwrap(), ODD);
+            assert_eq!(hash.to_hex_str(&mut buf).unwrap(), ODD);
         }
 
         #[test]
         fn even() {
             let hash = StarkHash::from_hex_str(EVEN).unwrap();
-            assert_eq!(hash.to_hex_str(), EVEN);
+            assert_eq!(hash.to_hex_str_owned(), EVEN);
             let mut buf = [0u8; 66];
-            assert_eq!(hash.to_hex_str_cow(&mut buf).unwrap(), EVEN);
+            assert_eq!(hash.to_hex_str(&mut buf).unwrap(), EVEN);
         }
 
         #[test]
         fn max() {
             let hash = StarkHash::from_hex_str(MAX).unwrap();
-            assert_eq!(hash.to_hex_str(), MAX);
+            assert_eq!(hash.to_hex_str_owned(), MAX);
             let mut buf = [0u8; 66];
-            assert_eq!(hash.to_hex_str_cow(&mut buf).unwrap(), MAX);
+            assert_eq!(hash.to_hex_str(&mut buf).unwrap(), MAX);
         }
 
         #[test]
         fn buffer_too_small() {
             let mut buf = [0u8; 65];
             assert_eq!(
-                StarkHash::ZERO.to_hex_str_cow(&mut buf).unwrap_err(),
+                StarkHash::ZERO.to_hex_str(&mut buf).unwrap_err(),
                 InvalidBufferSizeError {
                     actual: 65,
                     expected: 66

--- a/crates/pedersen/src/hash.rs
+++ b/crates/pedersen/src/hash.rs
@@ -654,24 +654,44 @@ mod tests {
         #[test]
         fn zero() {
             assert_eq!(StarkHash::ZERO.to_hex_str(), "0x0");
+            let mut buf = [0u8; 66];
+            assert_eq!(StarkHash::ZERO.to_hex_str_cow(&mut buf).unwrap(), "0x0");
         }
 
         #[test]
         fn odd() {
             let hash = StarkHash::from_hex_str(ODD).unwrap();
             assert_eq!(hash.to_hex_str(), ODD);
+            let mut buf = [0u8; 66];
+            assert_eq!(hash.to_hex_str_cow(&mut buf).unwrap(), ODD);
         }
 
         #[test]
         fn even() {
             let hash = StarkHash::from_hex_str(EVEN).unwrap();
             assert_eq!(hash.to_hex_str(), EVEN);
+            let mut buf = [0u8; 66];
+            assert_eq!(hash.to_hex_str_cow(&mut buf).unwrap(), EVEN);
         }
 
         #[test]
         fn max() {
             let hash = StarkHash::from_hex_str(MAX).unwrap();
             assert_eq!(hash.to_hex_str(), MAX);
+            let mut buf = [0u8; 66];
+            assert_eq!(hash.to_hex_str_cow(&mut buf).unwrap(), MAX);
+        }
+
+        #[test]
+        fn buffer_too_small() {
+            let mut buf = [0u8; 65];
+            assert_eq!(
+                StarkHash::ZERO.to_hex_str_cow(&mut buf).unwrap_err(),
+                InvalidBufferSizeError {
+                    actual: 65,
+                    expected: 66
+                }
+            );
         }
     }
 

--- a/crates/pedersen/src/serde.rs
+++ b/crates/pedersen/src/serde.rs
@@ -8,10 +8,8 @@ impl Serialize for StarkHash {
     {
         // StarkHash has a leading "0x" and at most 64 digits
         let mut buf = [0u8; 2 + 64];
-        let s = self
-            .as_hex_str(&mut buf)
-            .map_err(serde::ser::Error::custom)?;
-        serializer.serialize_str(&s)
+        let s = self.as_hex_str(&mut buf);
+        serializer.serialize_str(s)
     }
 }
 
@@ -20,24 +18,24 @@ impl<'de> Deserialize<'de> for StarkHash {
     where
         D: serde::Deserializer<'de>,
     {
+        struct StarkHashVisitor;
+
+        impl<'de> Visitor<'de> for StarkHashVisitor {
+            type Value = StarkHash;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a hex string of up to 64 digits with an optional '0x' prefix")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                StarkHash::from_hex_str(v).map_err(|e| serde::de::Error::custom(e))
+            }
+        }
+
         deserializer.deserialize_str(StarkHashVisitor)
-    }
-}
-
-struct StarkHashVisitor;
-
-impl<'de> Visitor<'de> for StarkHashVisitor {
-    type Value = StarkHash;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("a hex string of up to 64 digits with an optional '0x' prefix")
-    }
-
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        StarkHash::from_hex_str(v).map_err(|e| serde::de::Error::custom(e))
     }
 }
 

--- a/crates/pedersen/src/serde.rs
+++ b/crates/pedersen/src/serde.rs
@@ -6,7 +6,12 @@ impl Serialize for StarkHash {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&self.to_hex_str())
+        // StarkHash has a leading "0x" and at most 64 digits
+        let mut buf = [0u8; 2 + 64];
+        let s = self
+            .to_hex_str_cow(&mut buf)
+            .map_err(serde::ser::Error::custom)?;
+        serializer.serialize_str(&s)
     }
 }
 

--- a/crates/pedersen/src/serde.rs
+++ b/crates/pedersen/src/serde.rs
@@ -9,7 +9,7 @@ impl Serialize for StarkHash {
         // StarkHash has a leading "0x" and at most 64 digits
         let mut buf = [0u8; 2 + 64];
         let s = self
-            .to_hex_str_cow(&mut buf)
+            .to_hex_str(&mut buf)
             .map_err(serde::ser::Error::custom)?;
         serializer.serialize_str(&s)
     }

--- a/crates/pedersen/src/serde.rs
+++ b/crates/pedersen/src/serde.rs
@@ -9,7 +9,7 @@ impl Serialize for StarkHash {
         // StarkHash has a leading "0x" and at most 64 digits
         let mut buf = [0u8; 2 + 64];
         let s = self
-            .to_hex_str(&mut buf)
+            .as_hex_str(&mut buf)
             .map_err(serde::ser::Error::custom)?;
         serializer.serialize_str(&s)
     }


### PR DESCRIPTION
I was about to _just_ add the block numbers into `starknet_syncing` but couldn't stop thinking about the unnecessary `String`s in serialization.
So now there are two conversion fns:
- the `as_hex_str` flavor, which takes a `&mut [u8]` and allows to get rid of the heap allocation,
- the old flavor, still named `to_hex_str`.

The `as_` naming is correct from [`clippy`'s perspective](https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention) and I guess is consistent with the general _rust_ way of doing things.
