### PR TITLE
Block number in sync status

### DIFF
--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -2126,9 +2126,18 @@ mod tests {
         #[tokio::test]
         async fn syncing() {
             let expected = Syncing::Status(syncing::Status {
-                starting_block: StarknetBlockHash(StarkHash::from_be_slice(b"starting").unwrap()),
-                current_block: StarknetBlockHash(StarkHash::from_be_slice(b"current").unwrap()),
-                highest_block: StarknetBlockHash(StarkHash::from_be_slice(b"highest").unwrap()),
+                starting_block_hash: StarknetBlockHash(
+                    StarkHash::from_be_slice(b"starting").unwrap(),
+                ),
+                starting_block_num: StarknetBlockNumber(1),
+                current_block_hash: StarknetBlockHash(
+                    StarkHash::from_be_slice(b"current").unwrap(),
+                ),
+                current_block_num: StarknetBlockNumber(2),
+                highest_block_hash: StarknetBlockHash(
+                    StarkHash::from_be_slice(b"highest").unwrap(),
+                ),
+                highest_block_num: StarknetBlockNumber(3),
             });
 
             let storage = setup_storage();

--- a/crates/pathfinder/src/rpc/serde.rs
+++ b/crates/pathfinder/src/rpc/serde.rs
@@ -228,6 +228,7 @@ impl<'de> DeserializeAs<'de, StarknetBlockNumber> for StarknetBlockNumberAsHexSt
             where
                 E: serde::de::Error,
             {
+                let stripped = v.strip_prefix("0x").unwrap_or(v);
                 u64::from_str_radix(v, 16)
                     .map_err(serde::de::Error::custom)
                     .map(StarknetBlockNumber)

--- a/crates/pathfinder/src/rpc/serde.rs
+++ b/crates/pathfinder/src/rpc/serde.rs
@@ -215,26 +215,26 @@ impl<'de> DeserializeAs<'de, StarknetBlockNumber> for StarknetBlockNumberAsHexSt
     where
         D: serde::Deserializer<'de>,
     {
+        struct StarknetBlockNumberVisitor;
+
+        impl<'de> Visitor<'de> for StarknetBlockNumberVisitor {
+            type Value = StarknetBlockNumber;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a hex string of up to 16 digits with an optional '0x' prefix")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                u64::from_str_radix(v, 16)
+                    .map_err(serde::de::Error::custom)
+                    .map(StarknetBlockNumber)
+            }
+        }
+
         deserializer.deserialize_str(StarknetBlockNumberVisitor)
-    }
-}
-
-struct StarknetBlockNumberVisitor;
-
-impl<'de> Visitor<'de> for StarknetBlockNumberVisitor {
-    type Value = StarknetBlockNumber;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("a hex string of up to 16 digits with an optional '0x' prefix")
-    }
-
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        u64::from_str_radix(v, 16)
-            .map_err(serde::de::Error::custom)
-            .map(StarknetBlockNumber)
     }
 }
 

--- a/crates/pathfinder/src/rpc/serde.rs
+++ b/crates/pathfinder/src/rpc/serde.rs
@@ -205,8 +205,8 @@ impl SerializeAs<StarknetBlockNumber> for StarknetBlockNumberAsHexStr {
         let bytes = source.0.to_be_bytes();
         // StarknetBlockNumber is "0x" + 16 digits at most
         let mut buf = [0u8; 2 + 16];
-        let s = bytes_as_hex_str(&bytes, &mut buf).map_err(serde::ser::Error::custom)?;
-        serializer.serialize_str(&s)
+        let s = bytes_as_hex_str(&bytes, &mut buf);
+        serializer.serialize_str(s)
     }
 }
 

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -654,16 +654,27 @@ pub mod reply {
 
     /// Starknet's syncing status substructures.
     pub mod syncing {
-        use crate::core::StarknetBlockHash;
+        use crate::{
+            core::{StarknetBlockHash, StarknetBlockNumber},
+            rpc::serde::StarknetBlockNumberAsHexStr,
+        };
         use serde::{Deserialize, Serialize};
+        use serde_with::serde_as;
 
         /// Represents Starknet node syncing status.
+        #[serde_as]
         #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
         #[serde(deny_unknown_fields)]
         pub struct Status {
-            pub starting_block: StarknetBlockHash,
-            pub current_block: StarknetBlockHash,
-            pub highest_block: StarknetBlockHash,
+            pub starting_block_hash: StarknetBlockHash,
+            #[serde_as(as = "StarknetBlockNumberAsHexStr")]
+            pub starting_block_num: StarknetBlockNumber,
+            pub current_block_hash: StarknetBlockHash,
+            #[serde_as(as = "StarknetBlockNumberAsHexStr")]
+            pub current_block_num: StarknetBlockNumber,
+            pub highest_block_hash: StarknetBlockHash,
+            #[serde_as(as = "StarknetBlockNumberAsHexStr")]
+            pub highest_block_num: StarknetBlockNumber,
         }
     }
 

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -82,7 +82,8 @@ where
 
     // Start update sync-status process.
     let (starting_block_num, starting_block_hash) = l2_head.unwrap_or((
-        StarknetBlockNumber::GENESIS,
+        // Seems a better choice for an invalid block number than 0
+        StarknetBlockNumber(u64::MAX),
         StarknetBlockHash(StarkHash::ZERO),
     ));
     let _status_sync = tokio::spawn(update_sync_status_latest(

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -81,13 +81,15 @@ where
     })?;
 
     // Start update sync-status process.
-    let starting_block = l2_head
-        .map(|(_, hash)| hash)
-        .unwrap_or(StarknetBlockHash(StarkHash::ZERO));
+    let (starting_block_num, starting_block_hash) = l2_head.unwrap_or((
+        StarknetBlockNumber::GENESIS,
+        StarknetBlockHash(StarkHash::ZERO),
+    ));
     let _status_sync = tokio::spawn(update_sync_status_latest(
         Arc::clone(&state),
         sequencer.clone(),
-        starting_block,
+        starting_block_hash,
+        starting_block_num,
         chain,
     ));
 
@@ -199,7 +201,8 @@ where
                     match &mut *state.status.write().await {
                         SyncStatus::False(_) => {}
                         SyncStatus::Status(status) => {
-                            status.current_block = block_hash;
+                            status.current_block_hash = block_hash;
+                            status.current_block_num = StarknetBlockNumber(block_num);
                         }
                     }
 
@@ -311,7 +314,8 @@ where
 async fn update_sync_status_latest(
     state: Arc<State>,
     sequencer: impl sequencer::ClientApi,
-    starting_block: StarknetBlockHash,
+    starting_block_hash: StarknetBlockHash,
+    starting_block_num: StarknetBlockNumber,
     chain: Chain,
 ) -> anyhow::Result<()> {
     use crate::rpc::types::{BlockNumberOrTag, Tag};
@@ -323,28 +327,36 @@ async fn update_sync_status_latest(
             .await
         {
             Ok(block) => {
-                let latest = block.block_hash.unwrap();
+                let latest_hash = block.block_hash.unwrap();
+                let latest_num = block.block_number.unwrap();
                 // Update the sync status.
                 match &mut *state.status.write().await {
                     sync_status @ SyncStatus::False(_) => {
                         *sync_status = SyncStatus::Status(syncing::Status {
-                            starting_block,
-                            current_block: starting_block,
-                            highest_block: latest,
+                            starting_block_hash,
+                            starting_block_num,
+                            current_block_hash: starting_block_hash,
+                            current_block_num: starting_block_num,
+                            highest_block_hash: latest_hash,
+                            highest_block_num: latest_num,
                         });
 
                         tracing::debug!(
-                            starting=%starting_block.0,
-                            current=%starting_block.0,
-                            highest=%latest.0,
+                            starting_hash=%starting_block_hash.0,
+                            starting_num=%starting_block_num.0,
+                            current_hash=%starting_block_hash.0,
+                            current_num=%starting_block_num.0,
+                            highest_hash=%latest_hash.0,
+                            highest_num=%latest_num.0,
                             "Updated sync status",
                         );
                     }
                     SyncStatus::Status(status) => {
-                        if status.highest_block != latest {
-                            status.highest_block = latest;
+                        if status.highest_block_hash != latest_hash {
+                            status.highest_block_hash = latest_hash;
                             tracing::debug!(
-                                highest=%latest.0,
+                                highest_hash=%latest_hash.0,
+                                highest_num=%latest_num.0,
                                 "Updated sync status",
                             );
                         }


### PR DESCRIPTION
This PR adds support for block numbers in `starknet_syncing` and is based on #264 (which splits `to_hex_str` into heap and stack based flavors).