### PR TITLE
Increase L1 head poll rate

### DIFF
--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -315,7 +315,7 @@ async fn update_sync_status_latest(
     chain: Chain,
 ) -> anyhow::Result<()> {
     use crate::rpc::types::{BlockNumberOrTag, Tag};
-    let poll_interval = l2::head_poll_interval(chain);
+    let poll_interval = head_poll_interval(chain);
 
     loop {
         match sequencer
@@ -577,6 +577,24 @@ fn deploy_contract(
         .context("Insert constract state hash into contracts state table")?;
     ContractsTable::upsert(transaction, contract.address, contract.hash)
         .context("Inserting contract hash into contracts table")
+}
+
+/// Returns the interval to be used when polling the sequencer while at the head of the chain. The
+/// interval is chosen to provide a good balance between spamming the sequencer and getting new
+/// block information as it is available.
+///
+/// The interval is based on the block creation time, which is 2 minutes for Goerlie and 2 hours for
+/// Mainnet.
+pub fn head_poll_interval(chain: crate::ethereum::Chain) -> std::time::Duration {
+    use crate::ethereum::Chain::*;
+    use std::time::Duration;
+
+    match chain {
+        // 15 minute interval for a 2 hour block time.
+        Mainnet => Duration::from_secs(60 * 15),
+        // 30 second interval for a 2 minute block time.
+        Goerli => Duration::from_secs(30),
+    }
 }
 
 #[cfg(test)]

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -579,12 +579,12 @@ fn deploy_contract(
         .context("Inserting contract hash into contracts table")
 }
 
-/// Returns the interval to be used when polling the sequencer while at the head of the chain. The
-/// interval is chosen to provide a good balance between spamming the sequencer and getting new
-/// block information as it is available.
+/// Interval at which poll for new data when at the head of chain.
 ///
-/// The interval is based on the block creation time, which is 2 minutes for Goerlie and 2 hours for
-/// Mainnet.
+/// Returns the interval to be used when polling while at the head of the chain. The
+/// interval is chosen to provide a good balance between spamming and getting new
+/// block information as it is available. The interval is based on the block creation
+/// time, which is 2 minutes for Goerlie and 2 hours for Mainnet.
 pub fn head_poll_interval(chain: crate::ethereum::Chain) -> std::time::Duration {
     use crate::ethereum::Chain::*;
     use std::time::Duration;

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -53,6 +53,8 @@ pub async fn sync(
     mut head: Option<(StarknetBlockNumber, StarknetBlockHash)>,
     chain: crate::ethereum::Chain,
 ) -> anyhow::Result<()> {
+    use crate::state::sync::head_poll_interval;
+
     'outer: loop {
         // Get the next block from L2.
         let (next, head_hash) = match head {
@@ -370,22 +372,6 @@ async fn download_and_compress_contract(
         definition,
         hash,
     })
-}
-
-/// Returns the interval to be used when polling the sequencer while at the head of the chain. The
-/// interval is chosen to provide a good balance between spamming the sequencer and getting new
-/// block information as it is available.
-///
-/// The interval is based on the block creation time, which is 2 minutes for Goerlie and 2 hours for
-/// Mainnet.
-pub fn head_poll_interval(chain: crate::ethereum::Chain) -> Duration {
-    use crate::ethereum::Chain::*;
-    match chain {
-        // 15 minute interval for a 2 hour block time.
-        Mainnet => Duration::from_secs(60 * 15),
-        // 30 second interval for a 2 minute block time.
-        Goerli => Duration::from_secs(30),
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
L1 was polling for updates every 5s. This PR changes this to match the L2 rate, which is based on the StarkNet block time.