### PR TITLE
fix(contract_hash/test): fix 0.8.2 API breakage causing test to fail

### DIFF
--- a/crates/pathfinder/src/state/contract_hash.rs
+++ b/crates/pathfinder/src/state/contract_hash.rs
@@ -439,7 +439,7 @@ mod json {
             .unwrap();
 
             // this is quite big payload, ~500kB
-            let resp = reqwest::get("https://external.integration.starknet.io/feeder_gateway/get_full_contract?contractAddress=0x4ae0618c330c59559a59a27d143dd1c07cd74cf4e5e5a7cd85d53c6bf0e89dc")
+            let resp = reqwest::get("https://external.integration.starknet.io/feeder_gateway/get_full_contract?blockNumber=latest&contractAddress=0x4ae0618c330c59559a59a27d143dd1c07cd74cf4e5e5a7cd85d53c6bf0e89dc")
                 .await
                 .unwrap();
 


### PR DESCRIPTION
The recent 0.8.2 rollout to the Starknet integration environment had
some incompatible API changes: we have to specify blockNumber explicitly
on the get_full_contract endpoint.