### PR TITLE
Support data directory config item

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,12 +237,13 @@ docker run \
 
 The following environment variables can be passed to the container:
 
-| Name                               | Description                                                  | Default value | Required |
-| ---------------------------------- | ------------------------------------------------------------ | ------------- | -------- |
-| PATHFINDER_ETHEREUM_API_URL        | Ethereum (archive) node JSON-RPC endpoint URL                |               | yes      |
-| PATHFINDER_ETHEREUM_API_USER_AGENT | User-Agent header value to use with Ethereum node API        |               | no       |
-| PATHFINDER_ETHEREUM_API_PASSWORD   | Password to use during authentication with Ethereum node API |               | no       |
-| PATHFINDER_HTTP_RPC_ADDRESS        | Address to bind the `pathfinder` RPC server to               | 0.0.0.0:9545  | no       |
+| Name                               | Description                                                  | Default value     | Required |
+| ---------------------------------- | ------------------------------------------------------------ | ----------------- | -------- |
+| PATHFINDER_ETHEREUM_API_URL        | Ethereum (archive) node JSON-RPC endpoint URL                |                   | yes      |
+| PATHFINDER_ETHEREUM_API_USER_AGENT | User-Agent header value to use with Ethereum node API        |                   | no       |
+| PATHFINDER_ETHEREUM_API_PASSWORD   | Password to use during authentication with Ethereum node API |                   | no       |
+| PATHFINDER_HTTP_RPC_ADDRESS        | Address to bind the `pathfinder` RPC server to               | 0.0.0.0:9545      | no       |
+| PATHFINDER_DATA_DIRECTORY          | Directory used to store `pathfinder` data                    | Current directory | no       |
 
 ### Building the container image yourself
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ The configuration file uses the `toml` format:
 ```toml
 # The address we will host the RPC API at. Defaults to "127.0.0.1:9545"
 http-rpc = "127.0.0.1:1235"
+# The directory the node will use to store its data. Defaults to the current directory.
+data-directory = "..."
 
 [ethereum]
 # This is required and must be an HTTP(s) URL pointing to your Ethereum node's endpoint.

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -35,12 +35,13 @@ async fn main() -> anyhow::Result<()> {
         .await
         .context("Determining Ethereum chain")?;
 
-    let database_path = match network_chain {
+    let database_path = config.data_directory.join(match network_chain {
         ethereum::Chain::Mainnet => "mainnet.sqlite",
         ethereum::Chain::Goerli => "goerli.sqlite",
-    };
+    });
+    let storage = Storage::migrate(database_path.clone()).unwrap();
+    info!(location=?database_path, "Database loaded.");
 
-    let storage = Storage::migrate(database_path.into()).unwrap();
     let sequencer = sequencer::Client::new(network_chain).unwrap();
     let sync_state = Arc::new(state::SyncState::default());
 

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -40,7 +40,7 @@ async fn main() -> anyhow::Result<()> {
         ethereum::Chain::Goerli => "goerli.sqlite",
     });
     let storage = Storage::migrate(database_path.clone()).unwrap();
-    info!(location=?database_path, "Database loaded.");
+    info!(location=?database_path, "Database migrated.");
 
     let sequencer = sequencer::Client::new(network_chain).unwrap();
     let sync_state = Arc::new(state::SyncState::default());

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -21,6 +21,8 @@ pub enum ConfigOption {
     EthereumPassword,
     /// The HTTP-RPC listening socket address.
     HttpRpcAddress,
+    /// Path to the node's data directory.
+    DataDirectory,
 }
 
 impl Display for ConfigOption {
@@ -29,6 +31,7 @@ impl Display for ConfigOption {
             ConfigOption::EthereumHttpUrl => f.write_str("Ethereum HTTP URL"),
             ConfigOption::EthereumUserAgent => f.write_str("Ethereum user agent"),
             ConfigOption::EthereumPassword => f.write_str("Ethereum password"),
+            ConfigOption::DataDirectory => f.write_str("Data directory"),
             ConfigOption::HttpRpcAddress => f.write_str("HTTP-RPC socket address"),
         }
     }
@@ -52,6 +55,8 @@ pub struct Configuration {
     pub ethereum: EthereumConfig,
     /// The HTTP-RPC listening address and port.
     pub http_rpc_addr: SocketAddr,
+    /// The node's data directory.
+    pub data_directory: PathBuf,
 }
 
 impl Configuration {

--- a/crates/pathfinder/src/config/builder.rs
+++ b/crates/pathfinder/src/config/builder.rs
@@ -40,26 +40,12 @@ impl ConfigBuilder {
 
         // Required parameters.
         let eth_url = self.take_required(ConfigOption::EthereumHttpUrl)?;
-        let http_rpc_addr = self
-            .take_required(ConfigOption::HttpRpcAddress)
-            .unwrap_or_else(|_| DEFAULT_HTTP_RPC_ADDR.to_owned());
 
         // Parse the Ethereum URL.
         let eth_url = eth_url.parse::<Url>().map_err(|err| {
             std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 format!("Invalid Ethereum URL ({}): {}", eth_url, err),
-            )
-        })?;
-
-        // Parse the HTTP-RPC listening address and port.
-        let http_rpc_addr = http_rpc_addr.parse::<SocketAddr>().map_err(|err| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!(
-                    "Invalid HTTP-RPC listening interface and port ({}): {}",
-                    http_rpc_addr, err
-                ),
             )
         })?;
 
@@ -72,6 +58,20 @@ impl ConfigBuilder {
             .take(ConfigOption::DataDirectory)
             .map(|s| Ok(PathBuf::from_str(&s).unwrap()))
             .unwrap_or_else(|| std::env::current_dir())?;
+        let http_rpc_addr = self
+            .take(ConfigOption::HttpRpcAddress)
+            .unwrap_or_else(|| DEFAULT_HTTP_RPC_ADDR.to_owned());
+
+        // Parse the HTTP-RPC listening address and port.
+        let http_rpc_addr = http_rpc_addr.parse::<SocketAddr>().map_err(|err| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "Invalid HTTP-RPC listening interface and port ({}): {}",
+                    http_rpc_addr, err
+                ),
+            )
+        })?;
 
         Ok(Configuration {
             ethereum: EthereumConfig {

--- a/crates/pathfinder/src/config/builder.rs
+++ b/crates/pathfinder/src/config/builder.rs
@@ -3,7 +3,7 @@
 
 use crate::config::{ConfigOption, Configuration, EthereumConfig};
 use reqwest::Url;
-use std::{collections::HashMap, net::SocketAddr};
+use std::{collections::HashMap, net::SocketAddr, path::PathBuf, str::FromStr};
 
 /// A convenient way of collecting and merging configuration options.
 ///
@@ -67,6 +67,12 @@ impl ConfigBuilder {
         let eth_user_agent = self.take(ConfigOption::EthereumUserAgent);
         let eth_password = self.take(ConfigOption::EthereumPassword);
 
+        // Optional parameters with defaults.
+        let data_directory = self
+            .take(ConfigOption::DataDirectory)
+            .map(|s| Ok(PathBuf::from_str(&s).unwrap()))
+            .unwrap_or_else(|| std::env::current_dir())?;
+
         Ok(Configuration {
             ethereum: EthereumConfig {
                 url: eth_url,
@@ -74,6 +80,7 @@ impl ConfigBuilder {
                 password: eth_password,
             },
             http_rpc_addr,
+            data_directory,
         })
     }
 

--- a/crates/pathfinder/src/config/builder.rs
+++ b/crates/pathfinder/src/config/builder.rs
@@ -57,7 +57,7 @@ impl ConfigBuilder {
         let data_directory = self
             .take(ConfigOption::DataDirectory)
             .map(|s| Ok(PathBuf::from_str(&s).unwrap()))
-            .unwrap_or_else(|| std::env::current_dir())?;
+            .unwrap_or_else(std::env::current_dir)?;
         let http_rpc_addr = self
             .take(ConfigOption::HttpRpcAddress)
             .unwrap_or_else(|| DEFAULT_HTTP_RPC_ADDR.to_owned());

--- a/crates/pathfinder/src/config/builder.rs
+++ b/crates/pathfinder/src/config/builder.rs
@@ -238,5 +238,29 @@ mod tests {
                 assert!(builder.try_build().is_err());
             }
         }
+
+        mod defaults {
+            //! Tests that the correct default values are applied during `try_build`.
+
+            use super::builder_with_all_required;
+
+            #[test]
+            fn data_directory() {
+                let expected = std::env::current_dir().unwrap();
+                let config = builder_with_all_required().try_build().unwrap();
+                assert_eq!(config.data_directory, expected);
+            }
+
+            #[test]
+            fn http_rpc_addr() {
+                use crate::config::DEFAULT_HTTP_RPC_ADDR;
+                use std::net::SocketAddr;
+
+                let expected = DEFAULT_HTTP_RPC_ADDR.parse::<SocketAddr>().unwrap();
+
+                let config = builder_with_all_required().try_build().unwrap();
+                assert_eq!(config.http_rpc_addr, expected);
+            }
+        }
     }
 }

--- a/crates/pathfinder/src/config/builder.rs
+++ b/crates/pathfinder/src/config/builder.rs
@@ -235,7 +235,7 @@ mod tests {
             for option in REQUIRED {
                 let mut builder = builder_with_all_required();
                 builder.take(*option);
-                assert!(builder.try_build().is_err());
+                assert!(builder.try_build().is_err(), "{option} failed");
             }
         }
 

--- a/crates/pathfinder/src/config/file.rs
+++ b/crates/pathfinder/src/config/file.rs
@@ -16,19 +16,22 @@ struct FileConfig {
     ethereum: Option<EthereumConfig>,
     #[serde(rename = "http-rpc")]
     http_rpc: Option<String>,
+    #[serde(rename = "data-directory")]
+    data_directory: Option<String>,
 }
 
 impl FileConfig {
     fn into_config_options(self) -> ConfigBuilder {
         use crate::config::ConfigOption;
-        let builder = match self.ethereum {
+        match self.ethereum {
             Some(eth) => ConfigBuilder::default()
                 .with(ConfigOption::EthereumHttpUrl, eth.url)
                 .with(ConfigOption::EthereumUserAgent, eth.user_agent)
                 .with(ConfigOption::EthereumPassword, eth.password),
             None => ConfigBuilder::default(),
-        };
-        builder.with(ConfigOption::HttpRpcAddress, self.http_rpc)
+        }
+        .with(ConfigOption::DataDirectory, self.data_directory)
+        .with(ConfigOption::HttpRpcAddress, self.http_rpc)
     }
 }
 
@@ -99,6 +102,14 @@ password = "{}""#,
         let toml = format!(r#"http-rpc = "{}""#, value);
         let mut cfg = config_from_str(&toml).unwrap();
         assert_eq!(cfg.take(ConfigOption::HttpRpcAddress), Some(value));
+    }
+
+    #[test]
+    fn data_directory() {
+        let value = "value".to_owned();
+        let toml = format!(r#"data-directory = "{}""#, value);
+        let mut cfg = config_from_str(&toml).unwrap();
+        assert_eq!(cfg.take(ConfigOption::DataDirectory), Some(value));
     }
 
     #[test]


### PR DESCRIPTION
This PR adds support for specifying the data directory the pathfinder node should use.

`--data-directory` can now be specified via cli or toml file, or alternatively `PATHFINDER_DATA_DIRECTORY` env variable.