### PR TITLE
fix: starknet_getTransactionReceipt does not contain events

### DIFF
--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -251,7 +251,7 @@ mod tests {
         sequencer::{
             reply::transaction::{
                 execution_resources::{BuiltinInstanceCounter, EmptyBuiltinInstanceCounter},
-                ExecutionResources, Receipt, Transaction, Type,
+                Event, ExecutionResources, Receipt, Transaction, Type,
             },
             test_utils::*,
             Client as SeqClient,
@@ -441,7 +441,7 @@ mod tests {
             transaction_hash: txn0_hash,
             r#type: Type::Deploy,
         };
-        let receipt0 = Receipt {
+        let mut receipt0 = Receipt {
             actual_fee: None,
             events: vec![],
             execution_resources: ExecutionResources {
@@ -481,6 +481,13 @@ mod tests {
         let mut receipt3 = receipt0.clone();
         let mut receipt4 = receipt0.clone();
         let mut receipt5 = receipt0.clone();
+        receipt0.events = vec![Event {
+            data: vec![EventData(
+                StarkHash::from_be_slice(b"event 0 data").unwrap(),
+            )],
+            from_address: ContractAddress(StarkHash::from_be_slice(b"event 0 from addr").unwrap()),
+            keys: vec![EventKey(StarkHash::from_be_slice(b"event 0 key").unwrap())],
+        }];
         receipt1.transaction_hash = txn1_hash;
         receipt2.transaction_hash = txn2_hash;
         receipt3.transaction_hash = txn3_hash;
@@ -1454,6 +1461,10 @@ mod tests {
                     .await
                     .unwrap();
                 assert_eq!(receipt.txn_hash, txn_hash);
+                assert_eq!(
+                    receipt.events[0].keys[0],
+                    EventKey(StarkHash::from_be_slice(b"event 0 key").unwrap())
+                );
             }
 
             #[tokio::test]
@@ -1470,6 +1481,10 @@ mod tests {
                     .await
                     .unwrap();
                 assert_eq!(receipt.txn_hash, txn_hash);
+                assert_eq!(
+                    receipt.events[0].keys[0],
+                    EventKey(StarkHash::from_be_slice(b"event 0 key").unwrap())
+                );
             }
         }
 

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -511,8 +511,11 @@ pub mod reply {
                 l1_origin_message: receipt
                     .l1_to_l2_consumed_message
                     .map(transaction_receipt::MessageToL2::from),
-                // TODO at the moment not available in sequencer replies
-                events: vec![],
+                events: receipt
+                    .events
+                    .into_iter()
+                    .map(transaction_receipt::Event::from)
+                    .collect(),
             }
         }
     }
@@ -573,9 +576,19 @@ pub mod reply {
         #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
         #[serde(deny_unknown_fields)]
         pub struct Event {
-            from_address: ContractAddress,
-            keys: Vec<EventKey>,
-            data: Vec<EventData>,
+            pub from_address: ContractAddress,
+            pub keys: Vec<EventKey>,
+            pub data: Vec<EventData>,
+        }
+
+        impl From<crate::sequencer::reply::transaction::Event> for Event {
+            fn from(e: crate::sequencer::reply::transaction::Event) -> Self {
+                Self {
+                    from_address: e.from_address,
+                    keys: e.keys,
+                    data: e.data,
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This is a fix to #269.

`starknet_getTransactionReceipt` did not contain `events` as per spec ([1](https://github.com/starkware-libs/starknet-specs/blob/79ce68d55f4c5bc4796305bf8ed9b5b2f432653e/api/starknet_api_openrpc.json#L275) [2](https://github.com/starkware-libs/starknet-specs/blob/79ce68d55f4c5bc4796305bf8ed9b5b2f432653e/api/starknet_api_openrpc.json#L984)) but always emitted an empty JSON array.

I've also tested the fix manually on `mainnet`.
