### PR TITLE
feat(load-test): add a load-test for most of our RPC endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,15 @@ checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "arrayvec"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
+dependencies = [
+ "nodrop",
+]
+
+[[package]]
+name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
@@ -71,6 +80,19 @@ name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
+name = "async-compression"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bf394cfbbe876f0ac67b13b6ca819f9c9f2fb9ec67223cceb1555fbab1c31a"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "async-stream"
@@ -120,6 +142,12 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "base-x"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc19a4937b4fbd3fe3379793130e42060d10627a360f2127802b10b87e7baf74"
 
 [[package]]
 name = "base64"
@@ -222,7 +250,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -239,6 +267,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time 0.1.43",
+ "winapi",
+]
 
 [[package]]
 name = "clap"
@@ -304,10 +345,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fn"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "cookie"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f1c7727e460397e56abc4bddc1d49e07a1ad78fc98eb2e1c8f032a58a2f80d"
+dependencies = [
+ "percent-encoding",
+ "time 0.2.27",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3f7034c0932dc36f5bd8ec37368d971346809435824f277cb3b8299fc56167c"
+dependencies = [
+ "cookie",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_json",
+ "time 0.2.27",
+ "url",
+]
 
 [[package]]
 name = "core-foundation"
@@ -462,6 +536,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19c6cedffdc8c03a3346d723eb20bd85a13362bb96dc2ac000842c6381ec7bf"
+dependencies = [
+ "nix",
+ "winapi",
+]
+
+[[package]]
 name = "darling"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,7 +589,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.0",
  "syn",
 ]
 
@@ -531,10 +615,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "either"
@@ -694,6 +790,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.10.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b279436a715a9de95dcd26b151db590a71961cc06e54918b24fe0dd5b7d3fc4"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "pin-project",
+ "spin 0.9.3",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,8 +957,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -888,6 +999,59 @@ dependencies = [
  "fnv",
  "log",
  "regex",
+]
+
+[[package]]
+name = "goose"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a1b9de95ea08c665f53d16d3ae7dadd590b271c8a4dae1c96ea45a7df0d3b3a"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "ctrlc",
+ "downcast-rs",
+ "flume",
+ "futures",
+ "gumdrop",
+ "http",
+ "itertools",
+ "lazy_static",
+ "log",
+ "num-format",
+ "num_cpus",
+ "rand",
+ "regex",
+ "reqwest",
+ "rustc_version 0.4.0",
+ "serde",
+ "serde_cbor",
+ "serde_json",
+ "simplelog",
+ "tokio",
+ "tokio-tungstenite",
+ "tungstenite 0.15.0",
+ "url",
+]
+
+[[package]]
+name = "gumdrop"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bc700f989d2f6f0248546222d9b4258f5b02a171a431f8285a81c08142629e3"
+dependencies = [
+ "gumdrop_derive",
+]
+
+[[package]]
+name = "gumdrop_derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729f9bd3449d77e7831a18abfb7ba2f99ee813dfd15b8c2167c9a54ba20aa99d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1341,7 +1505,7 @@ dependencies = [
  "futures-util",
  "hyper",
  "jsonrpsee-types",
- "parking_lot 0.11.2",
+ "parking_lot",
  "rand",
  "rustc-hash",
  "serde",
@@ -1446,6 +1610,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "load-test"
+version = "0.1.0"
+dependencies = [
+ "goose",
+ "pathfinder",
+ "pedersen",
+ "rand",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,9 +1703,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.0"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
 dependencies = [
  "libc",
  "log",
@@ -1598,6 +1775,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanorand"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729eb334247daa1803e0a094d0a5c55711b85571179f5ec6e53eccfdf7008958"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,6 +1800,25 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "nix"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
@@ -1662,6 +1867,16 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
+dependencies = [
+ "arrayvec 0.4.12",
+ "itoa 0.4.8",
 ]
 
 [[package]]
@@ -1805,17 +2020,7 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
-dependencies = [
- "lock_api",
- "parking_lot_core 0.9.1",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1830,19 +2035,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-sys",
 ]
 
 [[package]]
@@ -1871,7 +2063,7 @@ dependencies = [
  "pretty_assertions",
  "reqwest",
  "rusqlite",
- "semver",
+ "semver 1.0.7",
  "serde",
  "serde_json",
  "serde_with",
@@ -2082,6 +2274,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2141,6 +2339,24 @@ checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes",
  "prost",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8eda7c62d9ecaafdf8b62374c006de0adf61666ae96a96ba74a37134aa4e470"
+
+[[package]]
+name = "publicsuffix"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "292972edad6bbecc137ab84c5e36421a4a6c979ea31d3cc73540dd04315b33e1"
+dependencies = [
+ "byteorder",
+ "hashbrown",
+ "idna",
+ "psl-types",
 ]
 
 [[package]]
@@ -2269,8 +2485,11 @@ version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bea77bc708afa10e59905c3d4af7c8fd43c9214251673095ff8b14345fcbc5"
 dependencies = [
+ "async-compression",
  "base64",
  "bytes",
+ "cookie",
+ "cookie_store",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -2286,11 +2505,13 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "proc-macro-hack",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-util 0.6.9",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2307,7 +2528,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi",
@@ -2352,11 +2573,20 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.7",
 ]
 
 [[package]]
@@ -2494,9 +2724,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -2588,6 +2833,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+dependencies = [
+ "sha1_smol",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
+
+[[package]]
 name = "sha3"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2615,6 +2875,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "simplelog"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85d04ae642154220ef00ee82c36fb07853c10a4f2a0ca6719f9991211d2eb959"
+dependencies = [
+ "chrono",
+ "log",
+ "termcolor",
 ]
 
 [[package]]
@@ -2676,10 +2947,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c530c2b0d0bf8b69304b39fe2001993e267461948b890cd037d8ad4293fa1a0d"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "standback"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version 0.2.3",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strsim"
@@ -2796,6 +3134,31 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
+dependencies = [
+ "const_fn",
+ "libc",
+ "standback",
+ "stdweb",
+ "time-macros",
+ "version_check",
+ "winapi",
+]
+
+[[package]]
+name = "time"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
@@ -2803,6 +3166,29 @@ dependencies = [
  "itoa 1.0.1",
  "libc",
  "num_threads",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "standback",
+ "syn",
 ]
 
 [[package]]
@@ -2841,9 +3227,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.17.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
+checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
 dependencies = [
  "bytes",
  "libc",
@@ -2851,10 +3237,9 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.0",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
  "tokio-macros",
  "tracing",
  "winapi",
@@ -2934,7 +3319,7 @@ dependencies = [
  "log",
  "pin-project",
  "tokio",
- "tungstenite",
+ "tungstenite 0.14.0",
 ]
 
 [[package]]
@@ -3149,6 +3534,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "983d40747bce878d2fb67d910dcb8bd3eca2b2358540c3cc1b98c027407a3ae3"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha-1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "twoway"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3266,7 +3670,7 @@ dependencies = [
  "git2",
  "rustversion",
  "thiserror",
- "time",
+ "time 0.3.9",
 ]
 
 [[package]]
@@ -3426,7 +3830,7 @@ dependencies = [
  "hex",
  "jsonrpc-core",
  "log",
- "parking_lot 0.11.2",
+ "parking_lot",
  "pin-project",
  "reqwest",
  "rlp",
@@ -3514,49 +3918,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
-dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/load-test",
     "crates/pathfinder",
     "crates/pedersen",
 ]

--- a/crates/load-test/Cargo.toml
+++ b/crates/load-test/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "load-test"
+version = "0.1.0"
+edition = "2021"
+description = "Load test for pathfinder JSON-RPC endpoints"
+license = "MIT OR Apache-2.0"
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+goose = "0.16.0"
+pathfinder = { path = "../pathfinder" }
+pedersen = { path = "../pedersen" }
+rand = "0.8.5"
+serde = { version = "1.0.130", features = ["derive"] }
+serde_json = { version = "1.0.68", features = ["arbitrary_precision", "raw_value"] }
+tokio = "1.11.0"

--- a/crates/load-test/src/main.rs
+++ b/crates/load-test/src/main.rs
@@ -1,0 +1,460 @@
+//! Load test for pathfinder JSON-RPC endpoints.
+//!
+//! This program expects a mainnet pathfinder node synced until block 1800,
+//! since it contains references to transactions and contract hashes on mainnet.
+//!
+//! Running the load test:
+//! ```
+//! cargo run --release --bin load-test -- -H http://127.0.0.1:9545 --report-file /tmp/report.html -u 30 -r 5 -t 60 --no-gzip
+//! ```
+use goose::prelude::*;
+use pedersen::StarkHash;
+use rand::{Rng, SeedableRng};
+use serde::{de::DeserializeOwned, Deserialize};
+use serde_json::json;
+
+use pathfinder_lib::{
+    core::{
+        ContractAddress, StarknetBlockHash, StarknetBlockNumber, StarknetTransactionHash,
+        StarknetTransactionIndex,
+    },
+    rpc::types::{
+        reply::{
+            Block, GetEventsResult, Syncing, Transaction as StarknetTransaction,
+            TransactionReceipt as StarknetTransactionReceipt, Transactions as StarknetTransactions,
+        },
+        request::EventFilter,
+        BlockHashOrTag, BlockNumberOrTag,
+    },
+};
+
+//
+// Tasks
+//
+
+/// Fetch a random block, then fetch all individual transactions and receipts in the block.
+async fn block_explorer(user: &mut GooseUser) -> TransactionResult {
+    let mut rng = rand::rngs::StdRng::from_entropy();
+    let block_number: u64 = rng.gen_range(1..1800);
+
+    let block = get_block_by_number(user, StarknetBlockNumber(block_number)).await?;
+    let block_by_hash = get_block_by_hash(user, block.block_hash.unwrap()).await?;
+    assert_eq!(block, block_by_hash);
+
+    if let StarknetTransactions::HashesOnly(hashes) = block.transactions {
+        for (idx, hash) in hashes.iter().enumerate() {
+            let transaction = get_transaction_by_hash(user, *hash).await?;
+
+            let transaction_by_hash_and_index = get_transaction_by_block_hash_and_index(
+                user,
+                block.block_hash.unwrap(),
+                StarknetTransactionIndex(idx as u64),
+            )
+            .await?;
+            assert_eq!(transaction, transaction_by_hash_and_index);
+
+            let transaction_by_number_and_index = get_transaction_by_block_number_and_index(
+                user,
+                block.block_number.unwrap(),
+                StarknetTransactionIndex(idx as u64),
+            )
+            .await?;
+            assert_eq!(transaction, transaction_by_number_and_index);
+
+            let _receipt = get_transaction_receipt_by_hash(user, *hash).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn task_block_by_number(user: &mut GooseUser) -> TransactionResult {
+    get_block_by_number(user, StarknetBlockNumber(1000)).await?;
+    Ok(())
+}
+
+async fn task_block_by_hash(user: &mut GooseUser) -> TransactionResult {
+    get_block_by_hash(
+        user,
+        StarknetBlockHash(
+            StarkHash::from_hex_str(
+                "0x58d8604f22510af5b120d1204ebf25292a79bfb09c4882c2e456abc2763d4a",
+            )
+            .unwrap(),
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn task_block_transaction_count_by_hash(user: &mut GooseUser) -> TransactionResult {
+    get_block_transaction_count_by_hash(
+        user,
+        BlockHashOrTag::Hash(StarknetBlockHash(
+            StarkHash::from_hex_str(
+                "0x58d8604f22510af5b120d1204ebf25292a79bfb09c4882c2e456abc2763d4a",
+            )
+            .unwrap(),
+        )),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn task_block_transaction_count_by_number(user: &mut GooseUser) -> TransactionResult {
+    get_block_transaction_count_by_number(
+        user,
+        BlockNumberOrTag::Number(StarknetBlockNumber(1000)),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn task_transaction_by_hash(user: &mut GooseUser) -> TransactionResult {
+    get_transaction_by_hash(
+        user,
+        StarknetTransactionHash(
+            StarkHash::from_hex_str(
+                "0x39ee26a0251338f1ef96b66c0ffacbc7a41f36bd465055e39621673ff10fb60",
+            )
+            .unwrap(),
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn task_transaction_by_block_number_and_index(user: &mut GooseUser) -> TransactionResult {
+    get_transaction_by_block_number_and_index(
+        user,
+        StarknetBlockNumber(1000),
+        StarknetTransactionIndex(3),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn task_transaction_by_block_hash_and_index(user: &mut GooseUser) -> TransactionResult {
+    get_transaction_by_block_hash_and_index(
+        user,
+        StarknetBlockHash(
+            StarkHash::from_hex_str(
+                "0x58d8604f22510af5b120d1204ebf25292a79bfb09c4882c2e456abc2763d4a",
+            )
+            .unwrap(),
+        ),
+        StarknetTransactionIndex(3),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn task_transaction_receipt_by_hash(user: &mut GooseUser) -> TransactionResult {
+    get_transaction_receipt_by_hash(
+        user,
+        StarknetTransactionHash(
+            StarkHash::from_hex_str(
+                "0x39ee26a0251338f1ef96b66c0ffacbc7a41f36bd465055e39621673ff10fb60",
+            )
+            .unwrap(),
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn task_block_number(user: &mut GooseUser) -> TransactionResult {
+    block_number(user).await?;
+    Ok(())
+}
+
+async fn task_syncing(user: &mut GooseUser) -> TransactionResult {
+    syncing(user).await?;
+    Ok(())
+}
+
+async fn task_call(user: &mut GooseUser) -> TransactionResult {
+    // call a test contract deployed in block 0
+    // https://voyager.online/contract/0x06ee3440b08a9c805305449ec7f7003f27e9f7e287b83610952ec36bdc5a6bae
+    call(
+        user,
+        ContractAddress(
+            StarkHash::from_hex_str(
+                "0x06ee3440b08a9c805305449ec7f7003f27e9f7e287b83610952ec36bdc5a6bae",
+            )
+            .unwrap(),
+        ),
+        &[
+            // address
+            "0x01e2cd4b3588e8f6f9c4e89fb0e293bf92018c96d7a93ee367d29a284223b6ff",
+            // value
+            "0x071d1e9d188c784a0bde95c1d508877a0d93e9102b37213d1e13f3ebc54a7751",
+        ],
+        // "set_value" entry point
+        "0x3d7905601c217734671143d457f0db37f7f8883112abd34b92c4abfeafde0c3",
+        // hash of mainnet block 0
+        BlockHashOrTag::Hash(StarknetBlockHash(
+            StarkHash::from_hex_str(
+                "0x47c3637b57c2b079b93c61539950c17e868a28f46cdef28f88521067f21e943",
+            )
+            .unwrap(),
+        )),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn task_chain_id(user: &mut GooseUser) -> TransactionResult {
+    chain_id(user).await?;
+    Ok(())
+}
+
+async fn task_get_events(user: &mut GooseUser) -> TransactionResult {
+    // This returns a single event.
+    let events = get_events(
+        user,
+        EventFilter {
+            from_block: Some(StarknetBlockNumber(1000)),
+            to_block: Some(StarknetBlockNumber(1100)),
+            address: Some(ContractAddress(
+                StarkHash::from_hex_str(
+                    "0x103114c4c5ac233a360d39a9217b9067be6979f3d08e1cf971fd22baf8f8713",
+                )
+                .unwrap(),
+            )),
+            keys: vec![],
+            page_size: 1024,
+            page_number: 0,
+        },
+    )
+    .await?;
+
+    assert_eq!(events.events.len(), 1);
+
+    Ok(())
+}
+
+//
+// Requests
+//
+type GooseTransactionError = goose::goose::TransactionError;
+type MethodResult<T> = Result<T, GooseTransactionError>;
+
+async fn get_block_by_number(
+    user: &mut GooseUser,
+    block_number: StarknetBlockNumber,
+) -> MethodResult<Block> {
+    post_jsonrpc_request(
+        user,
+        "starknet_getBlockByNumber",
+        json!({ "block_number": block_number }),
+    )
+    .await
+}
+
+async fn get_block_by_hash(
+    user: &mut GooseUser,
+    block_hash: StarknetBlockHash,
+) -> MethodResult<Block> {
+    post_jsonrpc_request(
+        user,
+        "starknet_getBlockByHash",
+        json!({ "block_hash": block_hash }),
+    )
+    .await
+}
+
+async fn get_transaction_by_hash(
+    user: &mut GooseUser,
+    hash: StarknetTransactionHash,
+) -> MethodResult<StarknetTransaction> {
+    post_jsonrpc_request(
+        user,
+        "starknet_getTransactionByHash",
+        json!({ "transaction_hash": hash }),
+    )
+    .await
+}
+
+async fn get_transaction_by_block_hash_and_index(
+    user: &mut GooseUser,
+    block_hash: StarknetBlockHash,
+    index: StarknetTransactionIndex,
+) -> MethodResult<StarknetTransaction> {
+    post_jsonrpc_request(
+        user,
+        "starknet_getTransactionByBlockHashAndIndex",
+        json!({ "block_hash": block_hash, "index": index }),
+    )
+    .await
+}
+
+async fn get_transaction_by_block_number_and_index(
+    user: &mut GooseUser,
+    block_number: StarknetBlockNumber,
+    index: StarknetTransactionIndex,
+) -> MethodResult<StarknetTransaction> {
+    post_jsonrpc_request(
+        user,
+        "starknet_getTransactionByBlockNumberAndIndex",
+        json!({ "block_number": block_number, "index": index }),
+    )
+    .await
+}
+
+async fn get_transaction_receipt_by_hash(
+    user: &mut GooseUser,
+    hash: StarknetTransactionHash,
+) -> MethodResult<StarknetTransactionReceipt> {
+    post_jsonrpc_request(
+        user,
+        "starknet_getTransactionReceipt",
+        json!({ "transaction_hash": hash }),
+    )
+    .await
+}
+
+async fn get_block_transaction_count_by_hash(
+    user: &mut GooseUser,
+    hash: BlockHashOrTag,
+) -> MethodResult<u64> {
+    post_jsonrpc_request(
+        user,
+        "starknet_getBlockTransactionCountByHash",
+        json!({ "block_hash": hash }),
+    )
+    .await
+}
+
+async fn get_block_transaction_count_by_number(
+    user: &mut GooseUser,
+    number: BlockNumberOrTag,
+) -> MethodResult<u64> {
+    post_jsonrpc_request(
+        user,
+        "starknet_getBlockTransactionCountByNumber",
+        json!({ "block_number": number }),
+    )
+    .await
+}
+
+async fn block_number(user: &mut GooseUser) -> MethodResult<u64> {
+    post_jsonrpc_request(user, "starknet_blockNumber", json!({})).await
+}
+
+async fn syncing(user: &mut GooseUser) -> MethodResult<Syncing> {
+    post_jsonrpc_request(user, "starknet_syncing", json!({})).await
+}
+
+async fn chain_id(user: &mut GooseUser) -> MethodResult<String> {
+    post_jsonrpc_request(user, "starknet_chainId", json!({})).await
+}
+
+async fn get_events(user: &mut GooseUser, filter: EventFilter) -> MethodResult<GetEventsResult> {
+    post_jsonrpc_request(user, "starknet_getEvents", json!({ "filter": filter })).await
+}
+
+async fn call(
+    user: &mut GooseUser,
+    contract_address: ContractAddress,
+    call_data: &[&str],
+    entry_point_selector: &str,
+    at_block: BlockHashOrTag,
+) -> MethodResult<Vec<String>> {
+    post_jsonrpc_request(
+        user,
+        "starknet_call",
+        json!({
+            "request": {
+                "contract_address": contract_address,
+                "calldata": call_data,
+                "entry_point_selector": entry_point_selector,
+            },
+            "block_hash": at_block,
+        }),
+    )
+    .await
+}
+
+async fn post_jsonrpc_request<T: DeserializeOwned>(
+    user: &mut GooseUser,
+    method: &str,
+    params: serde_json::Value,
+) -> MethodResult<T> {
+    let request = jsonrpc_request(method, params);
+    let response = user.post_json("", &request).await?.response?;
+    #[derive(Deserialize)]
+    struct TransactionReceiptResponse<T> {
+        result: T,
+    }
+    let response: TransactionReceiptResponse<T> = response.json().await?;
+
+    Ok(response.result)
+}
+
+fn jsonrpc_request(method: &str, params: serde_json::Value) -> serde_json::Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": "0",
+        "method": method,
+        "params": params,
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<(), GooseError> {
+    use pathfinder_lib::core::EntryPoint;
+    dbg!(EntryPoint::hashed("set_value".as_bytes()));
+
+    GooseAttack::initialize()?
+        // primitive operations using the database
+        .register_scenario(
+            scenario!("block_by_number").register_transaction(transaction!(task_block_by_number)),
+        )
+        .register_scenario(
+            scenario!("block_by_hash").register_transaction(transaction!(task_block_by_hash)),
+        )
+        .register_scenario(
+            scenario!("block_transaction_count_by_hash")
+                .register_transaction(transaction!(task_block_transaction_count_by_hash)),
+        )
+        .register_scenario(
+            scenario!("block_transaction_count_by_number")
+                .register_transaction(transaction!(task_block_transaction_count_by_number)),
+        )
+        .register_scenario(
+            scenario!("transaction_by_hash")
+                .register_transaction(transaction!(task_transaction_by_hash)),
+        )
+        .register_scenario(
+            scenario!("transaction_by_block_number_and_index")
+                .register_transaction(transaction!(task_transaction_by_block_number_and_index)),
+        )
+        .register_scenario(
+            scenario!("transaction_by_block_hash_and_index")
+                .register_transaction(transaction!(task_transaction_by_block_hash_and_index)),
+        )
+        .register_scenario(
+            scenario!("transaction_receipt_by_hash")
+                .register_transaction(transaction!(task_transaction_receipt_by_hash)),
+        )
+        .register_scenario(
+            scenario!("block_number").register_transaction(transaction!(task_block_number)),
+        )
+        .register_scenario(
+            scenario!("get_events").register_transaction(transaction!(task_get_events)),
+        )
+        // primitive operations that don't use the database
+        .register_scenario(scenario!("syncing").register_transaction(transaction!(task_syncing)))
+        .register_scenario(scenario!("chain_id").register_transaction(transaction!(task_chain_id)))
+        // primitive operation utilizing the Cairo Python subprocesses
+        .register_scenario(scenario!("call").register_transaction(transaction!(task_call)))
+        // composite scenario
+        .register_scenario(
+            scenario!("block_explorer").register_transaction(transaction!(block_explorer)),
+        )
+        .execute()
+        .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
These are meant to be running with a reasonably up-to-date mainnet state.

Unfortunately `goose` doesn't provide a way for just running _some_ scenarios, so I think right now the only option is commenting out the ones we don't want to run... :(

Fixes issue #250.