### PR TITLE
align with cairo 0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,7 +1884,6 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
- "tracing-test",
  "vergen",
  "warp",
  "web3",
@@ -3122,29 +3121,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "tracing-test"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb7bda2e93bbc9c5b247034acc6a4b3d04f033a3d4b8fc1cb87d4d1c7c7ebd7"
-dependencies = [
- "lazy_static",
- "tracing-core",
- "tracing-subscriber",
- "tracing-test-macro",
-]
-
-[[package]]
-name = "tracing-test-macro"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4801dca35e4e2cee957c469bd4a1c370fadb7894c0d50721a40eba3523e6e91c"
-dependencies = [
- "lazy_static",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -57,7 +57,6 @@ pretty_assertions = "1.0.0"
 tempfile = "3"
 # log crate should be handled through tracing-subscriber if needed
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
-tracing-test = "0.2.1"
 warp = "0.3.2"
 
 [build-dependencies]

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -141,6 +141,10 @@ pub struct EventData(pub StarkHash);
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct EventKey(pub StarkHash);
 
+/// StarkNet sequencer address.
+#[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
+pub struct SequencerAddress(pub StarkHash);
+
 /// StarkNet protocol version.
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct StarknetProtocolVersion(pub H256);

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -113,7 +113,7 @@ pub struct StarknetBlockTimestamp(pub u64);
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct StarknetTransactionHash(pub StarkHash);
 
-/// A StarkNet transaction hash.
+/// A StarkNet transaction index.
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct StarknetTransactionIndex(pub u64);
 

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -149,6 +149,10 @@ pub struct StarknetProtocolVersion(pub H256);
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct Fee(pub H128);
 
+/// StarkNet gas price.
+#[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
+pub struct GasPrice(pub H128);
+
 /// StarkNet transaction version.
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct TransactionVersion(pub H256);

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -242,7 +242,7 @@ impl From<StarknetBlockHash> for crate::rpc::types::BlockHashOrTag {
 }
 
 #[derive(Debug, thiserror::Error)]
-#[error("expected slice lenght of 16 or less, got {0}")]
+#[error("expected slice length of 16 or less, got {0}")]
 pub struct FromSliceError(usize);
 
 impl GasPrice {

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -294,8 +294,8 @@ mod tests {
     use super::*;
     use crate::{
         core::{
-            ContractAddress, ContractHash, EthereumAddress, EventData, EventKey, GasPrice,
-            GlobalRoot, StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp,
+            ContractAddress, ContractHash, EventData, EventKey, GasPrice, GlobalRoot,
+            SequencerAddress, StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp,
             StarknetProtocolVersion, StorageAddress,
         },
         ethereum::Chain,
@@ -329,7 +329,6 @@ mod tests {
         sync::Arc,
         time::Duration,
     };
-    use web3::types::H160;
 
     /// Helper function: produces named rpc method args map.
     fn by_name<const N: usize>(params: [(&'_ str, serde_json::Value); N]) -> Option<ParamsSer<'_>> {
@@ -462,7 +461,7 @@ mod tests {
             root: global_root0,
             timestamp: StarknetBlockTimestamp(0),
             gas_price: GasPrice(H128::zero()),
-            sequencer_address: EthereumAddress(H160::zero()),
+            sequencer_address: SequencerAddress(StarkHash::ZERO),
         };
         let block1_hash = StarknetBlockHash(StarkHash::from_be_slice(b"block 1").unwrap());
         let block1 = StarknetBlock {
@@ -471,7 +470,7 @@ mod tests {
             root: global_root1,
             timestamp: StarknetBlockTimestamp(1),
             gas_price: GasPrice(H128::from([1u8; 16])),
-            sequencer_address: EthereumAddress(H160::from([1u8; 20])),
+            sequencer_address: SequencerAddress(StarkHash::from_be_slice(&[1u8]).unwrap()),
         };
         let latest_hash = StarknetBlockHash(StarkHash::from_be_slice(b"latest").unwrap());
         let block2 = StarknetBlock {
@@ -480,7 +479,7 @@ mod tests {
             root: global_root2,
             timestamp: StarknetBlockTimestamp(2),
             gas_price: GasPrice(H128::from([2u8; 16])),
-            sequencer_address: EthereumAddress(H160::from([2u8; 20])),
+            sequencer_address: SequencerAddress(StarkHash::from_be_slice(&[2u8]).unwrap()),
         };
         StarknetBlocksTable::insert(&db_txn, &block0).unwrap();
         StarknetBlocksTable::insert(&db_txn, &block1).unwrap();
@@ -737,7 +736,7 @@ mod tests {
                         root: latest_root,
                         timestamp: StarknetBlockTimestamp(0),
                         gas_price: GasPrice(H128::zero()),
-                        sequencer_address: EthereumAddress(H160::zero()),
+                        sequencer_address: SequencerAddress(StarkHash::ZERO),
                     }),
                     latest_root,
                 ),
@@ -944,7 +943,7 @@ mod tests {
                         root: latest_root,
                         timestamp: StarknetBlockTimestamp(0),
                         gas_price: GasPrice(H128::zero()),
-                        sequencer_address: EthereumAddress(H160::zero()),
+                        sequencer_address: SequencerAddress(StarkHash::ZERO),
                     }),
                     latest_root,
                 ),
@@ -2309,7 +2308,7 @@ mod tests {
                     root: GlobalRoot(StarkHash::from_hex_str(&"f".repeat(i as usize + 3)).unwrap()),
                     timestamp: StarknetBlockTimestamp(i + 500),
                     gas_price: GasPrice(H128::zero()),
-                    sequencer_address: EthereumAddress(H160::zero()),
+                    sequencer_address: SequencerAddress(StarkHash::ZERO),
                 })
                 .collect::<Vec<_>>()
                 .try_into()

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -2289,8 +2289,6 @@ mod tests {
     }
 
     mod events {
-        use web3::types::H128;
-
         use super::*;
 
         use super::types::reply::{EmittedEvent, GetEventsResult};

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -2297,24 +2297,6 @@ mod tests {
         use crate::sequencer::reply::transaction;
 
         const NUM_BLOCKS: usize = 4;
-
-        fn create_blocks() -> [StarknetBlock; NUM_BLOCKS] {
-            (0..NUM_BLOCKS as u64)
-                .map(|i| StarknetBlock {
-                    number: StarknetBlockNumber::GENESIS + i,
-                    hash: StarknetBlockHash(
-                        StarkHash::from_hex_str(&"a".repeat(i as usize + 3)).unwrap(),
-                    ),
-                    root: GlobalRoot(StarkHash::from_hex_str(&"f".repeat(i as usize + 3)).unwrap()),
-                    timestamp: StarknetBlockTimestamp(i + 500),
-                    gas_price: GasPrice(H128::zero()),
-                    sequencer_address: SequencerAddress(StarkHash::ZERO),
-                })
-                .collect::<Vec<_>>()
-                .try_into()
-                .unwrap()
-        }
-
         const TRANSACTIONS_PER_BLOCK: usize = 10;
         const EVENTS_PER_BLOCK: usize = TRANSACTIONS_PER_BLOCK;
         const NUM_TRANSACTIONS: usize = NUM_BLOCKS * TRANSACTIONS_PER_BLOCK;
@@ -2381,7 +2363,7 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let connection = storage.connection().unwrap();
 
-            let blocks = create_blocks();
+            let blocks = crate::storage::test_utils::create_blocks::<NUM_BLOCKS>();
             let transactions_and_receipts = create_transactions_and_receipts();
 
             for (i, block) in blocks.iter().enumerate() {

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -460,7 +460,7 @@ mod tests {
             hash: genesis_hash,
             root: global_root0,
             timestamp: StarknetBlockTimestamp(0),
-            gas_price: GasPrice(H128::zero()),
+            gas_price: GasPrice::ZERO,
             sequencer_address: SequencerAddress(StarkHash::ZERO),
         };
         let block1_hash = StarknetBlockHash(StarkHash::from_be_slice(b"block 1").unwrap());
@@ -469,7 +469,7 @@ mod tests {
             hash: block1_hash,
             root: global_root1,
             timestamp: StarknetBlockTimestamp(1),
-            gas_price: GasPrice(H128::from([1u8; 16])),
+            gas_price: GasPrice::from(1),
             sequencer_address: SequencerAddress(StarkHash::from_be_slice(&[1u8]).unwrap()),
         };
         let latest_hash = StarknetBlockHash(StarkHash::from_be_slice(b"latest").unwrap());
@@ -478,7 +478,7 @@ mod tests {
             hash: latest_hash,
             root: global_root2,
             timestamp: StarknetBlockTimestamp(2),
-            gas_price: GasPrice(H128::from([2u8; 16])),
+            gas_price: GasPrice::from(2),
             sequencer_address: SequencerAddress(StarkHash::from_be_slice(&[2u8]).unwrap()),
         };
         StarknetBlocksTable::insert(&db_txn, &block0).unwrap();

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -3,7 +3,7 @@ use crate::{
     cairo::ext_py,
     core::{
         CallResultValue, CallSignatureElem, ConstructorParam, ContractAddress, ContractAddressSalt,
-        ContractCode, EthereumAddress, Fee, GasPrice, GlobalRoot, StarknetBlockHash,
+        ContractCode, Fee, GasPrice, GlobalRoot, SequencerAddress, StarknetBlockHash,
         StarknetBlockNumber, StarknetBlockTimestamp, StarknetTransactionHash,
         StarknetTransactionIndex, StorageValue, TransactionVersion,
     },
@@ -52,7 +52,7 @@ pub struct RawBlock {
     pub parent_root: GlobalRoot,
     pub timestamp: StarknetBlockTimestamp,
     pub status: BlockStatus,
-    pub sequencer: EthereumAddress,
+    pub sequencer: SequencerAddress,
     pub gas_price: GasPrice,
 }
 

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -318,8 +318,8 @@ impl RpcApi {
                 parent_root,
                 timestamp: block.timestamp,
                 status: block_status,
-                sequencer: EthereumAddress(web3::types::H160::zero()), // TODO FIXME
-                gas_price: GasPrice(web3::types::H128::zero()),        // TODO FIXME
+                gas_price: block.gas_price,
+                sequencer: block.sequencer_address,
             };
 
             Ok(block)

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -101,9 +101,10 @@ impl RpcApi {
                     .await
                     .map_err(internal_server_error)?;
 
+                let old_root = self.get_latest_block_root().await?;
                 let scope = requested_scope.unwrap_or_default();
 
-                return Ok(Block::from_sequencer_scoped(block, scope));
+                return Ok(Block::from_sequencer_scoped(block, old_root, scope));
             }
             BlockHashOrTag::Hash(hash) => hash.into(),
             BlockHashOrTag::Tag(Tag::Latest) => StarknetBlocksBlockId::Latest,
@@ -221,9 +222,10 @@ impl RpcApi {
                     .context("Fetch block from sequencer")
                     .map_err(internal_server_error)?;
 
+                let old_root = self.get_latest_block_root().await?;
                 let scope = requested_scope.unwrap_or_default();
 
-                return Ok(Block::from_sequencer_scoped(block, scope));
+                return Ok(Block::from_sequencer_scoped(block, old_root, scope));
             }
         };
 
@@ -321,6 +323,38 @@ impl RpcApi {
             };
 
             Ok(block)
+        });
+
+        handle
+            .await
+            .context("Database read panic or shutting down")
+            .map_err(internal_server_error)
+            // flatten is unstable
+            .and_then(|x| x)
+    }
+
+    /// Fetches the global root of the latest block from storage.
+    async fn get_latest_block_root(&self) -> Result<GlobalRoot, Error> {
+        let storage = self.storage.clone();
+
+        let handle = tokio::task::spawn_blocking(move || {
+            let mut connection = storage
+                .connection()
+                .context("Opening database connection")
+                .map_err(internal_server_error)?;
+
+            let transaction = connection
+                .transaction()
+                .context("Creating database transaction")
+                .map_err(internal_server_error)?;
+
+            let root = StarknetBlocksTable::get_root(&transaction, StarknetBlocksBlockId::Latest)
+                .context("Read root from database")
+                .map_err(internal_server_error)?
+                // Latest missing in storage means that pending is genesis and there is no parent block
+                .unwrap_or(GlobalRoot(StarkHash::ZERO));
+
+            Ok(root)
         });
 
         handle

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -3,9 +3,9 @@ use crate::{
     cairo::ext_py,
     core::{
         CallResultValue, CallSignatureElem, ConstructorParam, ContractAddress, ContractAddressSalt,
-        ContractCode, Fee, GlobalRoot, StarknetBlockHash, StarknetBlockNumber,
-        StarknetBlockTimestamp, StarknetTransactionHash, StarknetTransactionIndex, StorageValue,
-        TransactionVersion,
+        ContractCode, EthereumAddress, Fee, GasPrice, GlobalRoot, StarknetBlockHash,
+        StarknetBlockNumber, StarknetBlockTimestamp, StarknetTransactionHash,
+        StarknetTransactionIndex, StorageValue, TransactionVersion,
     },
     ethereum::Chain,
     rpc::types::{
@@ -52,6 +52,8 @@ pub struct RawBlock {
     pub parent_root: GlobalRoot,
     pub timestamp: StarknetBlockTimestamp,
     pub status: BlockStatus,
+    pub sequencer: EthereumAddress,
+    pub gas_price: GasPrice,
 }
 
 /// Based on [the Starknet operator API spec](https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json).
@@ -314,6 +316,8 @@ impl RpcApi {
                 parent_root,
                 timestamp: block.timestamp,
                 status: block_status,
+                sequencer: EthereumAddress(web3::types::H160::zero()), // TODO FIXME
+                gas_price: GasPrice(web3::types::H128::zero()),        // TODO FIXME
             };
 
             Ok(block)

--- a/crates/pathfinder/src/rpc/serde.rs
+++ b/crates/pathfinder/src/rpc/serde.rs
@@ -204,7 +204,8 @@ impl SerializeAs<GasPrice> for GasPriceAsHexStr {
     {
         // GasPrice is "0x" + 32 digits at most
         let mut buf = [0u8; 2 + 32];
-        let s = bytes_as_hex_str(source.0.as_bytes(), &mut buf);
+        let bytes = source.0.to_be_bytes();
+        let s = bytes_as_hex_str(&bytes, &mut buf);
         serializer.serialize_str(s)
     }
 }
@@ -227,9 +228,9 @@ impl<'de> DeserializeAs<'de, GasPrice> for GasPriceAsHexStr {
             where
                 E: serde::de::Error,
             {
-                bytes_from_hex_str::<{ H128::len_bytes() }>(v)
+                bytes_from_hex_str::<16>(v)
                     .map_err(serde::de::Error::custom)
-                    .map(|b| GasPrice(H128::from(b)))
+                    .map(GasPrice::from_be_bytes)
             }
         }
 

--- a/crates/pathfinder/src/rpc/serde.rs
+++ b/crates/pathfinder/src/rpc/serde.rs
@@ -202,7 +202,7 @@ impl SerializeAs<GasPrice> for GasPriceAsHexStr {
     where
         S: serde::Serializer,
     {
-        // Fee is "0x" + 32 digits at most
+        // GasPrice is "0x" + 32 digits at most
         let mut buf = [0u8; 2 + 32];
         let s = bytes_as_hex_str(source.0.as_bytes(), &mut buf);
         serializer.serialize_str(s)

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -229,14 +229,14 @@ pub mod reply {
                 status: block.status.into(),
                 sequencer: block
                     .sequencer_address
-                    // TODO
+                    // Default value for cairo <0.8.0 is 0
                     .unwrap_or(SequencerAddress(StarkHash::ZERO)),
                 new_root: block.state_root,
                 old_root,
                 accepted_time: block.timestamp,
                 gas_price: block
                     .gas_price
-                    // TODO
+                    // Default value for cairo <0.8.2 is 0
                     .unwrap_or(crate::core::GasPrice(web3::types::H128::zero())),
                 transactions: match scope {
                     BlockResponseScope::TransactionHashes => Transactions::HashesOnly(

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -128,7 +128,6 @@ pub mod reply {
         sequencer::reply::Status as SeqStatus,
     };
     use jsonrpsee::types::{CallError, Error};
-    use pedersen::StarkHash;
     use serde::{Deserialize, Serialize};
     use serde_with::serde_as;
     use std::convert::From;
@@ -217,7 +216,11 @@ pub mod reply {
         }
 
         /// Constructs [Block] from [sequencer's block representation](crate::sequencer::reply::Block)
-        pub fn from_sequencer_scoped(block: seq::Block, scope: BlockResponseScope) -> Self {
+        pub fn from_sequencer_scoped(
+            block: seq::Block,
+            old_root: GlobalRoot,
+            scope: BlockResponseScope,
+        ) -> Self {
             Self {
                 block_hash: block.block_hash,
                 parent_hash: block.parent_block_hash,
@@ -228,14 +231,12 @@ pub mod reply {
                     // TODO FIXME
                     .unwrap_or(EthereumAddress(web3::types::H160::zero())),
                 new_root: block.state_root,
-                // TODO where to get it from
-                old_root: GlobalRoot(StarkHash::ZERO),
+                old_root,
                 accepted_time: block.timestamp,
                 gas_price: block
                     .gas_price
                     // TODO FIXME
                     .unwrap_or(crate::core::GasPrice(web3::types::H128::zero())),
-
                 transactions: match scope {
                     BlockResponseScope::TransactionHashes => Transactions::HashesOnly(
                         block

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -119,8 +119,8 @@ pub mod reply {
     use super::request::BlockResponseScope;
     use crate::{
         core::{
-            CallParam, ContractAddress, EntryPoint, EthereumAddress, EventData, EventKey, GasPrice,
-            GlobalRoot, StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp,
+            CallParam, ContractAddress, EntryPoint, EventData, EventKey, GasPrice, GlobalRoot,
+            SequencerAddress, StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp,
             StarknetTransactionHash,
         },
         rpc::api::RawBlock,
@@ -128,6 +128,7 @@ pub mod reply {
         sequencer::reply::Status as SeqStatus,
     };
     use jsonrpsee::types::{CallError, Error};
+    use pedersen::StarkHash;
     use serde::{Deserialize, Serialize};
     use serde_with::serde_as;
     use std::convert::From;
@@ -190,7 +191,7 @@ pub mod reply {
         pub parent_hash: StarknetBlockHash,
         pub block_number: Option<StarknetBlockNumber>,
         pub status: BlockStatus,
-        pub sequencer: EthereumAddress,
+        pub sequencer: SequencerAddress,
         pub new_root: Option<GlobalRoot>,
         pub old_root: GlobalRoot,
         pub accepted_time: StarknetBlockTimestamp,
@@ -229,7 +230,7 @@ pub mod reply {
                 sequencer: block
                     .sequencer_address
                     // TODO
-                    .unwrap_or(EthereumAddress(web3::types::H160::zero())),
+                    .unwrap_or(SequencerAddress(StarkHash::ZERO)),
                 new_root: block.state_root,
                 old_root,
                 accepted_time: block.timestamp,

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -236,7 +236,7 @@ pub mod reply {
                 gas_price: block
                     .gas_price
                     // Default value for cairo <0.8.2 is 0
-                    .unwrap_or(crate::core::GasPrice(web3::types::H128::zero())),
+                    .unwrap_or(GasPrice::ZERO),
 
                 transactions: match scope {
                     BlockResponseScope::TransactionHashes => Transactions::HashesOnly(

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -217,11 +217,7 @@ pub mod reply {
         }
 
         /// Constructs [Block] from [sequencer's block representation](crate::sequencer::reply::Block)
-        pub fn from_sequencer_scoped(
-            block: seq::Block,
-            old_root: GlobalRoot,
-            scope: BlockResponseScope,
-        ) -> Self {
+        pub fn from_sequencer_scoped(block: seq::Block, scope: BlockResponseScope) -> Self {
             Self {
                 block_hash: block.block_hash,
                 parent_hash: block.parent_block_hash,
@@ -232,12 +228,14 @@ pub mod reply {
                     // Default value for cairo <0.8.0 is 0
                     .unwrap_or(SequencerAddress(StarkHash::ZERO)),
                 new_root: block.state_root,
-                old_root,
+                // TODO where to get it from
+                old_root: GlobalRoot(StarkHash::ZERO),
                 accepted_time: block.timestamp,
                 gas_price: block
                     .gas_price
                     // Default value for cairo <0.8.2 is 0
                     .unwrap_or(crate::core::GasPrice(web3::types::H128::zero())),
+
                 transactions: match scope {
                     BlockResponseScope::TransactionHashes => Transactions::HashesOnly(
                         block

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -228,14 +228,14 @@ pub mod reply {
                 status: block.status.into(),
                 sequencer: block
                     .sequencer_address
-                    // TODO FIXME
+                    // TODO
                     .unwrap_or(EthereumAddress(web3::types::H160::zero())),
                 new_root: block.state_root,
                 old_root,
                 accepted_time: block.timestamp,
                 gas_price: block
                     .gas_price
-                    // TODO FIXME
+                    // TODO
                     .unwrap_or(crate::core::GasPrice(web3::types::H128::zero())),
                 transactions: match scope {
                     BlockResponseScope::TransactionHashes => Transactions::HashesOnly(

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -123,7 +123,7 @@ pub mod reply {
             SequencerAddress, StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp,
             StarknetTransactionHash,
         },
-        rpc::api::RawBlock,
+        rpc::{api::RawBlock, serde::GasPriceAsHexStr},
         sequencer::reply as seq,
         sequencer::reply::Status as SeqStatus,
     };
@@ -184,6 +184,7 @@ pub mod reply {
     }
 
     /// L2 Block as returned by the RPC API.
+    #[serde_as]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     #[serde(deny_unknown_fields)]
     pub struct Block {
@@ -195,6 +196,7 @@ pub mod reply {
         pub new_root: Option<GlobalRoot>,
         pub old_root: GlobalRoot,
         pub accepted_time: StarknetBlockTimestamp,
+        #[serde_as(as = "GasPriceAsHexStr")]
         pub gas_price: GasPrice,
         pub transactions: Transactions,
     }

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -454,8 +454,6 @@ impl ClientApi for Client {
             },
         );
 
-        eprintln!("WTF!");
-
         // Note that we don't do retries here.
         // This method is used to proxy an add transaction operation from the JSON-RPC
         // API to the sequencer. Retries should be implemented in the JSON-RPC

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -559,10 +559,11 @@ mod tests {
         Client::new(Chain::Goerli).unwrap()
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn client_user_agent() {
+        use crate::core::StarknetBlockTimestamp;
+        use crate::sequencer::reply::{Block, Status};
         use std::convert::Infallible;
-
         use warp::Filter;
 
         let filter = warp::header::optional("user-agent").and_then(
@@ -570,10 +571,21 @@ mod tests {
                 let user_agent = user_agent.expect("user-agent set");
                 let (name, version) = user_agent.split_once('/').unwrap();
 
-                assert_eq!(name, "pathfinder");
+                assert_eq!(name, "starknet-pathfinder");
                 assert_eq!(version, env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT"));
 
-                Result::<_, Infallible>::Ok("")
+                Ok::<_, Infallible>(warp::reply::json(&Block {
+                    block_hash: None,
+                    block_number: None,
+                    gas_price: None,
+                    parent_block_hash: StarknetBlockHash(StarkHash::ZERO),
+                    sequencer_address: None,
+                    state_root: None,
+                    status: Status::NotReceived,
+                    timestamp: StarknetBlockTimestamp(0),
+                    transaction_receipts: vec![],
+                    transactions: vec![],
+                }))
             },
         );
 

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -1426,7 +1426,6 @@ mod tests {
             collections::VecDeque, convert::Infallible, net::SocketAddr, sync::Arc, time::Duration,
         };
         use tokio::{sync::Mutex, task::JoinHandle};
-        use tracing_test::traced_test;
         use warp::Filter;
 
         // A test helper
@@ -1463,8 +1462,7 @@ mod tests {
             (server_handle, addr)
         }
 
-        #[tokio::test]
-        #[traced_test]
+        #[test_log::test(tokio::test)]
         async fn stop_on_ok() {
             let statuses = VecDeque::from([
                 (StatusCode::TOO_MANY_REQUESTS, ""),
@@ -1489,8 +1487,7 @@ mod tests {
             assert_eq!(result, "Finally!");
         }
 
-        #[tokio::test]
-        #[traced_test]
+        #[test_log::test(tokio::test)]
         async fn stop_on_fatal() {
             let statuses = VecDeque::from([
                 (StatusCode::TOO_MANY_REQUESTS, ""),
@@ -1521,8 +1518,7 @@ mod tests {
             );
         }
 
-        #[tokio::test]
-        #[traced_test]
+        #[test_log::test(tokio::test)]
         async fn request_timeout() {
             use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -453,6 +453,9 @@ impl ClientApi for Client {
                 signature: call.signature,
             },
         );
+
+        eprintln!("WTF!");
+
         // Note that we don't do retries here.
         // This method is used to proxy an add transaction operation from the JSON-RPC
         // API to the sequencer. Retries should be implemented in the JSON-RPC

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -1,8 +1,8 @@
 //! Structures used for deserializing replies from Starkware's sequencer REST API.
 use crate::{
     core::{
-        CallResultValue, EthereumAddress, GlobalRoot, StarknetBlockHash, StarknetBlockNumber,
-        StarknetBlockTimestamp,
+        CallResultValue, EthereumAddress, GasPrice, GlobalRoot, StarknetBlockHash,
+        StarknetBlockNumber, StarknetBlockTimestamp,
     },
     rpc::serde::EthereumAddressAsHexStr,
 };
@@ -18,7 +18,11 @@ pub struct Block {
     pub block_hash: Option<StarknetBlockHash>,
     #[serde(default)]
     pub block_number: Option<StarknetBlockNumber>,
+    #[serde(default)]
+    pub gas_price: Option<GasPrice>,
     pub parent_block_hash: StarknetBlockHash,
+    #[serde(default)]
+    pub sequencer_address: Option<EthereumAddress>,
     #[serde(default)]
     pub state_root: Option<GlobalRoot>,
     pub status: Status,

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -13,6 +13,7 @@ use serde_with::serde_as;
 /// [ClientApi::block_by_number](crate::sequencer::ClientApi::block_by_number).
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, PartialEq)]
+#[cfg_attr(test, derive(serde::Serialize))]
 #[serde(deny_unknown_fields)]
 pub struct Block {
     #[serde(default)]
@@ -35,6 +36,7 @@ pub struct Block {
 
 /// Block and transaction status values.
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq)]
+#[cfg_attr(test, derive(serde::Serialize))]
 #[serde(deny_unknown_fields)]
 pub enum Status {
     #[serde(rename = "NOT_RECEIVED")]

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -4,13 +4,14 @@ use crate::{
         CallResultValue, EthereumAddress, GasPrice, GlobalRoot, SequencerAddress,
         StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp,
     },
-    rpc::serde::EthereumAddressAsHexStr,
+    rpc::serde::{EthereumAddressAsHexStr, GasPriceAsHexStr},
 };
 use serde::Deserialize;
 use serde_with::serde_as;
 
 /// Used to deserialize replies to [ClientApi::block_by_hash](crate::sequencer::ClientApi::block_by_hash) and
 /// [ClientApi::block_by_number](crate::sequencer::ClientApi::block_by_number).
+#[serde_as]
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct Block {
@@ -18,6 +19,7 @@ pub struct Block {
     pub block_hash: Option<StarknetBlockHash>,
     #[serde(default)]
     pub block_number: Option<StarknetBlockNumber>,
+    #[serde_as(as = "Option<GasPriceAsHexStr>")]
     #[serde(default)]
     pub gas_price: Option<GasPrice>,
     pub parent_block_hash: StarknetBlockHash,

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -1,8 +1,8 @@
 //! Structures used for deserializing replies from Starkware's sequencer REST API.
 use crate::{
     core::{
-        CallResultValue, EthereumAddress, GasPrice, GlobalRoot, StarknetBlockHash,
-        StarknetBlockNumber, StarknetBlockTimestamp,
+        CallResultValue, EthereumAddress, GasPrice, GlobalRoot, SequencerAddress,
+        StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp,
     },
     rpc::serde::EthereumAddressAsHexStr,
 };
@@ -22,7 +22,7 @@ pub struct Block {
     pub gas_price: Option<GasPrice>,
     pub parent_block_hash: StarknetBlockHash,
     #[serde(default)]
-    pub sequencer_address: Option<EthereumAddress>,
+    pub sequencer_address: Option<SequencerAddress>,
     #[serde(default)]
     pub state_root: Option<GlobalRoot>,
     pub status: Status,

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -474,7 +474,7 @@ async fn l2_update(
             hash: block.block_hash.unwrap(),
             root: block.state_root.unwrap(),
             timestamp: block.timestamp,
-            // TODO
+            // Default value for cairo <0.8.2 is 0
             gas_price: block.gas_price.unwrap_or(GasPrice(H128::zero())),
             sequencer_address: block
                 .sequencer_address

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -615,11 +615,11 @@ mod tests {
     use super::{l1, l2};
     use crate::{
         core::{
-            ConstructorParam, ContractAddress, ContractAddressSalt, ContractHash,
+            ConstructorParam, ContractAddress, ContractAddressSalt, ContractHash, EthereumAddress,
             EthereumBlockHash, EthereumBlockNumber, EthereumLogIndex, EthereumTransactionHash,
-            EthereumTransactionIndex, Fee, GlobalRoot, StarknetBlockHash, StarknetBlockNumber,
-            StarknetBlockTimestamp, StarknetTransactionHash, StorageAddress, StorageValue,
-            TransactionVersion,
+            EthereumTransactionIndex, Fee, GasPrice, GlobalRoot, StarknetBlockHash,
+            StarknetBlockNumber, StarknetBlockTimestamp, StarknetTransactionHash, StorageAddress,
+            StorageValue, TransactionVersion,
         },
         ethereum,
         rpc::types::{BlockHashOrTag, BlockNumberOrTag},
@@ -636,7 +636,7 @@ mod tests {
     use pedersen::StarkHash;
     use std::{sync::Arc, time::Duration};
     use tokio::sync::mpsc;
-    use web3::types::H256;
+    use web3::types::{H128, H160, H256};
 
     #[derive(Debug, Clone)]
     struct FakeTransport;
@@ -816,7 +816,9 @@ mod tests {
         pub static ref BLOCK0: reply::Block = reply::Block {
             block_hash: Some(StarknetBlockHash(*A)),
             block_number: Some(StarknetBlockNumber(0)),
+            gas_price: Some(GasPrice(H128::zero())),
             parent_block_hash: StarknetBlockHash(StarkHash::ZERO),
+            sequencer_address: Some(EthereumAddress(H160::zero())),
             state_root: Some(GlobalRoot(StarkHash::ZERO)),
             status: reply::Status::AcceptedOnL1,
             timestamp: crate::core::StarknetBlockTimestamp(0),
@@ -826,7 +828,9 @@ mod tests {
         pub static ref BLOCK1: reply::Block = reply::Block {
             block_hash: Some(StarknetBlockHash(*B)),
             block_number: Some(StarknetBlockNumber(1)),
+            gas_price: Some(GasPrice(H128::from_slice(b"1"))),
             parent_block_hash: StarknetBlockHash(*A),
+            sequencer_address: Some(EthereumAddress(H160::from_slice(b"1"))),
             state_root: Some(GlobalRoot(*B)),
             status: reply::Status::AcceptedOnL2,
             timestamp: crate::core::StarknetBlockTimestamp(1),

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -29,7 +29,6 @@ use anyhow::Context;
 use pedersen::StarkHash;
 use rusqlite::{Connection, Transaction};
 use tokio::sync::{mpsc, RwLock};
-use web3::types::H128;
 
 pub struct State {
     pub status: RwLock<SyncStatus>,
@@ -475,7 +474,7 @@ async fn l2_update(
             root: block.state_root.unwrap(),
             timestamp: block.timestamp,
             // Default value for cairo <0.8.2 is 0
-            gas_price: block.gas_price.unwrap_or(GasPrice(H128::zero())),
+            gas_price: block.gas_price.unwrap_or(GasPrice::ZERO),
             sequencer_address: block
                 .sequencer_address
                 .unwrap_or(SequencerAddress(StarkHash::ZERO)),
@@ -645,7 +644,7 @@ mod tests {
     use pedersen::StarkHash;
     use std::{sync::Arc, time::Duration};
     use tokio::sync::mpsc;
-    use web3::types::{H128, H256};
+    use web3::types::H256;
 
     #[derive(Debug, Clone)]
     struct FakeTransport;
@@ -825,7 +824,7 @@ mod tests {
         pub static ref BLOCK0: reply::Block = reply::Block {
             block_hash: Some(StarknetBlockHash(*A)),
             block_number: Some(StarknetBlockNumber(0)),
-            gas_price: Some(GasPrice(H128::zero())),
+            gas_price: Some(GasPrice::ZERO),
             parent_block_hash: StarknetBlockHash(StarkHash::ZERO),
             sequencer_address: Some(SequencerAddress(StarkHash::ZERO)),
             state_root: Some(GlobalRoot(StarkHash::ZERO)),
@@ -837,7 +836,7 @@ mod tests {
         pub static ref BLOCK1: reply::Block = reply::Block {
             block_hash: Some(StarknetBlockHash(*B)),
             block_number: Some(StarknetBlockNumber(1)),
-            gas_price: Some(GasPrice(H128::from([1u8; 16]))),
+            gas_price: Some(GasPrice::from(1)),
             parent_block_hash: StarknetBlockHash(*A),
             sequencer_address: Some(SequencerAddress(StarkHash::from_be_bytes([1u8; 32]).unwrap())),
             state_root: Some(GlobalRoot(*B)),
@@ -851,7 +850,7 @@ mod tests {
             hash: StarknetBlockHash(*A),
             root: GlobalRoot(StarkHash::ZERO),
             timestamp: StarknetBlockTimestamp(0),
-            gas_price: GasPrice(H128::zero()),
+            gas_price: GasPrice::ZERO,
             sequencer_address: SequencerAddress(StarkHash::ZERO),
         };
         pub static ref STORAGE_BLOCK1: storage::StarknetBlock = storage::StarknetBlock {
@@ -859,7 +858,7 @@ mod tests {
             hash: StarknetBlockHash(*B),
             root: GlobalRoot(*B),
             timestamp: StarknetBlockTimestamp(1),
-            gas_price: GasPrice(H128::from([1u8; 16])),
+            gas_price: GasPrice::from(1),
             sequencer_address: SequencerAddress(StarkHash::from_be_bytes([1u8; 32]).unwrap()),
         };
         // Causes root to remain 0

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -192,7 +192,7 @@ where
                         .map(|u| u.storage_updates.len())
                         .sum();
                     let update_t = std::time::Instant::now();
-                    l2_update(&mut db_conn, block, diff)
+                    l2_update(&mut db_conn, *block, diff)
                         .await
                         .with_context(|| format!("Update L2 state to {}", block_num))?;
                     let block_time = last_block_start.elapsed();
@@ -1097,9 +1097,13 @@ mod tests {
 
         // A simple L2 sync task
         let l2 = move |tx: mpsc::Sender<l2::Event>, _, _, _| async move {
-            tx.send(l2::Event::Update(block(), state_update(), timings))
-                .await
-                .unwrap();
+            tx.send(l2::Event::Update(
+                Box::new(block()),
+                state_update(),
+                timings,
+            ))
+            .await
+            .unwrap();
             tokio::time::sleep(Duration::from_secs(1)).await;
             Ok(())
         };

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -380,8 +380,9 @@ mod tests {
         use super::super::{sync, Event};
         use crate::{
             core::{
-                ContractAddress, ContractHash, GlobalRoot, StarknetBlockHash, StarknetBlockNumber,
-                StarknetBlockTimestamp, StorageAddress, StorageValue,
+                ContractAddress, ContractHash, EthereumAddress, GasPrice, GlobalRoot,
+                StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp, StorageAddress,
+                StorageValue,
             },
             ethereum::state_update,
             rpc::types::{BlockHashOrTag, BlockNumberOrTag, Tag},
@@ -394,6 +395,7 @@ mod tests {
         use assert_matches::assert_matches;
         use pedersen::StarkHash;
         use std::collections::HashMap;
+        use web3::types::{H128, H160};
 
         const DEF0: &str = r#"{
             "abi": [],
@@ -471,7 +473,9 @@ mod tests {
             static ref BLOCK0: reply::Block = reply::Block {
                 block_hash: Some(*BLOCK0_HASH),
                 block_number: Some(BLOCK0_NUMBER),
+                gas_price: Some(GasPrice(H128::from_slice(b"0               "))),
                 parent_block_hash: StarknetBlockHash(StarkHash::ZERO),
+                sequencer_address: Some(EthereumAddress(H160::from_slice(b"0                   "))),
                 state_root: Some(*GLOBAL_ROOT0),
                 status: reply::Status::AcceptedOnL1,
                 timestamp: StarknetBlockTimestamp(0),
@@ -481,7 +485,9 @@ mod tests {
             static ref BLOCK0_V2: reply::Block = reply::Block {
                 block_hash: Some(*BLOCK0_HASH_V2),
                 block_number: Some(BLOCK0_NUMBER),
+                gas_price: Some(GasPrice(H128::from_slice(b"0 v2            "))),
                 parent_block_hash: StarknetBlockHash(StarkHash::ZERO),
+                sequencer_address: Some(EthereumAddress(H160::from_slice(b"0 v2                "))),
                 state_root: Some(*GLOBAL_ROOT0_V2),
                 status: reply::Status::AcceptedOnL2,
                 timestamp: StarknetBlockTimestamp(10),
@@ -491,7 +497,9 @@ mod tests {
             static ref BLOCK1: reply::Block = reply::Block {
                 block_hash: Some(*BLOCK1_HASH),
                 block_number: Some(BLOCK1_NUMBER),
+                gas_price: Some(GasPrice(H128::from_slice(b"1               "))),
                 parent_block_hash: *BLOCK0_HASH,
+                sequencer_address: Some(EthereumAddress(H160::from_slice(b"1                   "))),
                 state_root: Some(*GLOBAL_ROOT1),
                 status: reply::Status::AcceptedOnL1,
                 timestamp: StarknetBlockTimestamp(1),
@@ -501,7 +509,9 @@ mod tests {
             static ref BLOCK2: reply::Block = reply::Block {
                 block_hash: Some(*BLOCK2_HASH),
                 block_number: Some(BLOCK2_NUMBER),
+                gas_price: Some(GasPrice(H128::from_slice(b"2               "))),
                 parent_block_hash: *BLOCK1_HASH,
+                sequencer_address: Some(EthereumAddress(H160::from_slice(b"2                   "))),
                 state_root: Some(*GLOBAL_ROOT2),
                 status: reply::Status::AcceptedOnL1,
                 timestamp: StarknetBlockTimestamp(2),
@@ -959,7 +969,11 @@ mod tests {
                 let block1_v2 = reply::Block {
                     block_hash: Some(*BLOCK1_HASH_V2),
                     block_number: Some(BLOCK1_NUMBER),
+                    gas_price: Some(GasPrice(H128::from_slice(b"1 v2            "))),
                     parent_block_hash: *BLOCK0_HASH_V2,
+                    sequencer_address: Some(EthereumAddress(H160::from_slice(
+                        b"1 v2                ",
+                    ))),
                     state_root: Some(*GLOBAL_ROOT1_V2),
                     status: reply::Status::AcceptedOnL2,
                     timestamp: StarknetBlockTimestamp(4),
@@ -1137,7 +1151,11 @@ mod tests {
                 let block1_v2 = reply::Block {
                     block_hash: Some(*BLOCK1_HASH_V2),
                     block_number: Some(BLOCK1_NUMBER),
+                    gas_price: Some(GasPrice(H128::from_slice(b"1 v2            "))),
                     parent_block_hash: *BLOCK0_HASH,
+                    sequencer_address: Some(EthereumAddress(H160::from_slice(
+                        b"1 v2                ",
+                    ))),
                     state_root: Some(*GLOBAL_ROOT1_V2),
                     status: reply::Status::AcceptedOnL2,
                     timestamp: StarknetBlockTimestamp(4),
@@ -1147,7 +1165,11 @@ mod tests {
                 let block2_v2 = reply::Block {
                     block_hash: Some(*BLOCK2_HASH_V2),
                     block_number: Some(BLOCK2_NUMBER),
+                    gas_price: Some(GasPrice(H128::from_slice(b"2 v2            "))),
                     parent_block_hash: *BLOCK1_HASH_V2,
+                    sequencer_address: Some(EthereumAddress(H160::from_slice(
+                        b"2 v2                ",
+                    ))),
                     state_root: Some(*GLOBAL_ROOT2_V2),
                     status: reply::Status::AcceptedOnL2,
                     timestamp: StarknetBlockTimestamp(5),
@@ -1157,7 +1179,11 @@ mod tests {
                 let block3 = reply::Block {
                     block_hash: Some(*BLOCK3_HASH),
                     block_number: Some(BLOCK3_NUMBER),
+                    gas_price: Some(GasPrice(H128::from_slice(b"3               "))),
                     parent_block_hash: *BLOCK2_HASH,
+                    sequencer_address: Some(EthereumAddress(H160::from_slice(
+                        b"3                   ",
+                    ))),
                     state_root: Some(*GLOBAL_ROOT3),
                     status: reply::Status::AcceptedOnL1,
                     timestamp: StarknetBlockTimestamp(3),
@@ -1323,7 +1349,11 @@ mod tests {
                 let block2_v2 = reply::Block {
                     block_hash: Some(*BLOCK2_HASH_V2),
                     block_number: Some(BLOCK2_NUMBER),
+                    gas_price: Some(GasPrice(H128::from_slice(b"2 v2            "))),
                     parent_block_hash: *BLOCK1_HASH,
+                    sequencer_address: Some(EthereumAddress(H160::from_slice(
+                        b"2 v2                ",
+                    ))),
                     state_root: Some(*GLOBAL_ROOT2_V2),
                     status: reply::Status::AcceptedOnL2,
                     timestamp: StarknetBlockTimestamp(5),
@@ -1456,7 +1486,11 @@ mod tests {
                 let block1_v2 = reply::Block {
                     block_hash: Some(*BLOCK1_HASH_V2),
                     block_number: Some(BLOCK1_NUMBER),
+                    gas_price: Some(GasPrice(H128::from_slice(b"1 v2            "))),
                     parent_block_hash: *BLOCK0_HASH,
+                    sequencer_address: Some(EthereumAddress(H160::from_slice(
+                        b"1 v2                ",
+                    ))),
                     state_root: Some(*GLOBAL_ROOT1_V2),
                     status: reply::Status::AcceptedOnL2,
                     timestamp: StarknetBlockTimestamp(4),
@@ -1466,7 +1500,11 @@ mod tests {
                 let block2 = reply::Block {
                     block_hash: Some(*BLOCK2_HASH),
                     block_number: Some(BLOCK2_NUMBER),
+                    gas_price: Some(GasPrice(H128::from_slice(b"2               "))),
                     parent_block_hash: *BLOCK1_HASH_V2,
+                    sequencer_address: Some(EthereumAddress(H160::from_slice(
+                        b"2                   ",
+                    ))),
                     state_root: Some(*GLOBAL_ROOT2),
                     status: reply::Status::AcceptedOnL1,
                     timestamp: StarknetBlockTimestamp(5),

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -395,7 +395,6 @@ mod tests {
         use assert_matches::assert_matches;
         use pedersen::StarkHash;
         use std::collections::HashMap;
-        use web3::types::H128;
 
         const DEF0: &str = r#"{
             "abi": [],
@@ -473,7 +472,7 @@ mod tests {
             static ref BLOCK0: reply::Block = reply::Block {
                 block_hash: Some(*BLOCK0_HASH),
                 block_number: Some(BLOCK0_NUMBER),
-                gas_price: Some(GasPrice(H128::zero())),
+                gas_price: Some(GasPrice::ZERO),
                 parent_block_hash: StarknetBlockHash(StarkHash::ZERO),
                 sequencer_address: Some(SequencerAddress(StarkHash::ZERO)),
                 state_root: Some(*GLOBAL_ROOT0),
@@ -485,7 +484,7 @@ mod tests {
             static ref BLOCK0_V2: reply::Block = reply::Block {
                 block_hash: Some(*BLOCK0_HASH_V2),
                 block_number: Some(BLOCK0_NUMBER),
-                gas_price: Some(GasPrice(H128::from(b"gas price 0 v2--"))),
+                gas_price: Some(GasPrice::from_be_slice(b"gas price 0 v2").unwrap()),
                 parent_block_hash: StarknetBlockHash(StarkHash::ZERO),
                 sequencer_address: Some(SequencerAddress(StarkHash::from_be_slice(b"sequencer addr. 0 v2").unwrap())),
                 state_root: Some(*GLOBAL_ROOT0_V2),
@@ -497,7 +496,7 @@ mod tests {
             static ref BLOCK1: reply::Block = reply::Block {
                 block_hash: Some(*BLOCK1_HASH),
                 block_number: Some(BLOCK1_NUMBER),
-                gas_price: Some(GasPrice(H128::from(b"gas price 1-----"))),
+                gas_price: Some(GasPrice::from(1)),
                 parent_block_hash: *BLOCK0_HASH,
                 sequencer_address: Some(SequencerAddress(StarkHash::from_be_slice(b"sequencer address 1").unwrap())),
                 state_root: Some(*GLOBAL_ROOT1),
@@ -509,7 +508,7 @@ mod tests {
             static ref BLOCK2: reply::Block = reply::Block {
                 block_hash: Some(*BLOCK2_HASH),
                 block_number: Some(BLOCK2_NUMBER),
-                gas_price: Some(GasPrice(H128::from(b"gas price 2-----"))),
+                gas_price: Some(GasPrice::from(2)),
                 parent_block_hash: *BLOCK1_HASH,
                 sequencer_address: Some(SequencerAddress(StarkHash::from_be_slice(b"sequencer address 2").unwrap())),
                 state_root: Some(*GLOBAL_ROOT2),
@@ -969,7 +968,7 @@ mod tests {
                 let block1_v2 = reply::Block {
                     block_hash: Some(*BLOCK1_HASH_V2),
                     block_number: Some(BLOCK1_NUMBER),
-                    gas_price: Some(GasPrice(H128::from(b"gas price 1 v2--"))),
+                    gas_price: Some(GasPrice::from_be_slice(b"gas price 1 v2").unwrap()),
                     parent_block_hash: *BLOCK0_HASH_V2,
                     sequencer_address: Some(SequencerAddress(
                         StarkHash::from_be_slice(b"sequencer addr. 1 v2").unwrap(),
@@ -1151,7 +1150,7 @@ mod tests {
                 let block1_v2 = reply::Block {
                     block_hash: Some(*BLOCK1_HASH_V2),
                     block_number: Some(BLOCK1_NUMBER),
-                    gas_price: Some(GasPrice(H128::from(b"gas price 1 v2--"))),
+                    gas_price: Some(GasPrice::from_be_slice(b"gas price 1 v2").unwrap()),
                     parent_block_hash: *BLOCK0_HASH,
                     sequencer_address: Some(SequencerAddress(
                         StarkHash::from_be_slice(b"sequencer addr. 1 v2").unwrap(),
@@ -1165,7 +1164,7 @@ mod tests {
                 let block2_v2 = reply::Block {
                     block_hash: Some(*BLOCK2_HASH_V2),
                     block_number: Some(BLOCK2_NUMBER),
-                    gas_price: Some(GasPrice(H128::from(b"gas price 2 v2--"))),
+                    gas_price: Some(GasPrice::from_be_slice(b"gas price 2 v2").unwrap()),
                     parent_block_hash: *BLOCK1_HASH_V2,
                     sequencer_address: Some(SequencerAddress(
                         StarkHash::from_be_slice(b"sequencer addr. 2 v2").unwrap(),
@@ -1179,7 +1178,7 @@ mod tests {
                 let block3 = reply::Block {
                     block_hash: Some(*BLOCK3_HASH),
                     block_number: Some(BLOCK3_NUMBER),
-                    gas_price: Some(GasPrice(H128::from(b"gas price 2-----"))),
+                    gas_price: Some(GasPrice::from(3)),
                     parent_block_hash: *BLOCK2_HASH,
                     sequencer_address: Some(SequencerAddress(
                         StarkHash::from_be_slice(b"sequencer address 3").unwrap(),
@@ -1349,7 +1348,7 @@ mod tests {
                 let block2_v2 = reply::Block {
                     block_hash: Some(*BLOCK2_HASH_V2),
                     block_number: Some(BLOCK2_NUMBER),
-                    gas_price: Some(GasPrice(H128::from(b"gas price 2 v2--"))),
+                    gas_price: Some(GasPrice::from_be_slice(b"gas price 2 v2").unwrap()),
                     parent_block_hash: *BLOCK1_HASH,
                     sequencer_address: Some(SequencerAddress(
                         StarkHash::from_be_slice(b"sequencer addr. 2 v2").unwrap(),
@@ -1486,7 +1485,7 @@ mod tests {
                 let block1_v2 = reply::Block {
                     block_hash: Some(*BLOCK1_HASH_V2),
                     block_number: Some(BLOCK1_NUMBER),
-                    gas_price: Some(GasPrice(H128::from(b"gas price 1 v2--"))),
+                    gas_price: Some(GasPrice::from_be_slice(b"gas price 1 v2").unwrap()),
                     parent_block_hash: *BLOCK0_HASH,
                     sequencer_address: Some(SequencerAddress(
                         StarkHash::from_be_slice(b"sequencer addr. 1 v2").unwrap(),
@@ -1500,7 +1499,7 @@ mod tests {
                 let block2 = reply::Block {
                     block_hash: Some(*BLOCK2_HASH),
                     block_number: Some(BLOCK2_NUMBER),
-                    gas_price: Some(GasPrice(H128::from(b"gas price 2-----"))),
+                    gas_price: Some(GasPrice::from_be_slice(b"gas price 2").unwrap()),
                     parent_block_hash: *BLOCK1_HASH_V2,
                     sequencer_address: Some(SequencerAddress(
                         StarkHash::from_be_slice(b"sequencer address 2").unwrap(),

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -380,7 +380,7 @@ mod tests {
         use super::super::{sync, Event};
         use crate::{
             core::{
-                ContractAddress, ContractHash, EthereumAddress, GasPrice, GlobalRoot,
+                ContractAddress, ContractHash, GasPrice, GlobalRoot, SequencerAddress,
                 StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp, StorageAddress,
                 StorageValue,
             },
@@ -395,7 +395,7 @@ mod tests {
         use assert_matches::assert_matches;
         use pedersen::StarkHash;
         use std::collections::HashMap;
-        use web3::types::{H128, H160};
+        use web3::types::H128;
 
         const DEF0: &str = r#"{
             "abi": [],
@@ -475,7 +475,7 @@ mod tests {
                 block_number: Some(BLOCK0_NUMBER),
                 gas_price: Some(GasPrice(H128::zero())),
                 parent_block_hash: StarknetBlockHash(StarkHash::ZERO),
-                sequencer_address: Some(EthereumAddress(H160::zero())),
+                sequencer_address: Some(SequencerAddress(StarkHash::ZERO)),
                 state_root: Some(*GLOBAL_ROOT0),
                 status: reply::Status::AcceptedOnL1,
                 timestamp: StarknetBlockTimestamp(0),
@@ -487,7 +487,7 @@ mod tests {
                 block_number: Some(BLOCK0_NUMBER),
                 gas_price: Some(GasPrice(H128::from(b"gas price 0 v2--"))),
                 parent_block_hash: StarknetBlockHash(StarkHash::ZERO),
-                sequencer_address: Some(EthereumAddress(H160::from(b"sequencer addr. 0 v2"))),
+                sequencer_address: Some(SequencerAddress(StarkHash::from_be_slice(b"sequencer addr. 0 v2").unwrap())),
                 state_root: Some(*GLOBAL_ROOT0_V2),
                 status: reply::Status::AcceptedOnL2,
                 timestamp: StarknetBlockTimestamp(10),
@@ -499,7 +499,7 @@ mod tests {
                 block_number: Some(BLOCK1_NUMBER),
                 gas_price: Some(GasPrice(H128::from(b"gas price 1-----"))),
                 parent_block_hash: *BLOCK0_HASH,
-                sequencer_address: Some(EthereumAddress(H160::from(b"sequencer address 1-"))),
+                sequencer_address: Some(SequencerAddress(StarkHash::from_be_slice(b"sequencer address 1").unwrap())),
                 state_root: Some(*GLOBAL_ROOT1),
                 status: reply::Status::AcceptedOnL1,
                 timestamp: StarknetBlockTimestamp(1),
@@ -511,7 +511,7 @@ mod tests {
                 block_number: Some(BLOCK2_NUMBER),
                 gas_price: Some(GasPrice(H128::from(b"gas price 2-----"))),
                 parent_block_hash: *BLOCK1_HASH,
-                sequencer_address: Some(EthereumAddress(H160::from(b"sequencer address 2-"))),
+                sequencer_address: Some(SequencerAddress(StarkHash::from_be_slice(b"sequencer address 2").unwrap())),
                 state_root: Some(*GLOBAL_ROOT2),
                 status: reply::Status::AcceptedOnL1,
                 timestamp: StarknetBlockTimestamp(2),
@@ -971,7 +971,9 @@ mod tests {
                     block_number: Some(BLOCK1_NUMBER),
                     gas_price: Some(GasPrice(H128::from(b"gas price 1 v2--"))),
                     parent_block_hash: *BLOCK0_HASH_V2,
-                    sequencer_address: Some(EthereumAddress(H160::from(b"sequencer addr. 1 v2"))),
+                    sequencer_address: Some(SequencerAddress(
+                        StarkHash::from_be_slice(b"sequencer addr. 1 v2").unwrap(),
+                    )),
                     state_root: Some(*GLOBAL_ROOT1_V2),
                     status: reply::Status::AcceptedOnL2,
                     timestamp: StarknetBlockTimestamp(4),
@@ -1151,7 +1153,9 @@ mod tests {
                     block_number: Some(BLOCK1_NUMBER),
                     gas_price: Some(GasPrice(H128::from(b"gas price 1 v2--"))),
                     parent_block_hash: *BLOCK0_HASH,
-                    sequencer_address: Some(EthereumAddress(H160::from(b"sequencer addr. 1 v2"))),
+                    sequencer_address: Some(SequencerAddress(
+                        StarkHash::from_be_slice(b"sequencer addr. 1 v2").unwrap(),
+                    )),
                     state_root: Some(*GLOBAL_ROOT1_V2),
                     status: reply::Status::AcceptedOnL2,
                     timestamp: StarknetBlockTimestamp(4),
@@ -1163,7 +1167,9 @@ mod tests {
                     block_number: Some(BLOCK2_NUMBER),
                     gas_price: Some(GasPrice(H128::from(b"gas price 2 v2--"))),
                     parent_block_hash: *BLOCK1_HASH_V2,
-                    sequencer_address: Some(EthereumAddress(H160::from(b"sequencer addr. 2 v2"))),
+                    sequencer_address: Some(SequencerAddress(
+                        StarkHash::from_be_slice(b"sequencer addr. 2 v2").unwrap(),
+                    )),
                     state_root: Some(*GLOBAL_ROOT2_V2),
                     status: reply::Status::AcceptedOnL2,
                     timestamp: StarknetBlockTimestamp(5),
@@ -1175,7 +1181,9 @@ mod tests {
                     block_number: Some(BLOCK3_NUMBER),
                     gas_price: Some(GasPrice(H128::from(b"gas price 2-----"))),
                     parent_block_hash: *BLOCK2_HASH,
-                    sequencer_address: Some(EthereumAddress(H160::from(b"sequencer address 3-"))),
+                    sequencer_address: Some(SequencerAddress(
+                        StarkHash::from_be_slice(b"sequencer address 3").unwrap(),
+                    )),
                     state_root: Some(*GLOBAL_ROOT3),
                     status: reply::Status::AcceptedOnL1,
                     timestamp: StarknetBlockTimestamp(3),
@@ -1343,7 +1351,9 @@ mod tests {
                     block_number: Some(BLOCK2_NUMBER),
                     gas_price: Some(GasPrice(H128::from(b"gas price 2 v2--"))),
                     parent_block_hash: *BLOCK1_HASH,
-                    sequencer_address: Some(EthereumAddress(H160::from(b"sequencer addr. 2 v2"))),
+                    sequencer_address: Some(SequencerAddress(
+                        StarkHash::from_be_slice(b"sequencer addr. 2 v2").unwrap(),
+                    )),
                     state_root: Some(*GLOBAL_ROOT2_V2),
                     status: reply::Status::AcceptedOnL2,
                     timestamp: StarknetBlockTimestamp(5),
@@ -1478,7 +1488,9 @@ mod tests {
                     block_number: Some(BLOCK1_NUMBER),
                     gas_price: Some(GasPrice(H128::from(b"gas price 1 v2--"))),
                     parent_block_hash: *BLOCK0_HASH,
-                    sequencer_address: Some(EthereumAddress(H160::from(b"sequencer addr. 1 v2"))),
+                    sequencer_address: Some(SequencerAddress(
+                        StarkHash::from_be_slice(b"sequencer addr. 1 v2").unwrap(),
+                    )),
                     state_root: Some(*GLOBAL_ROOT1_V2),
                     status: reply::Status::AcceptedOnL2,
                     timestamp: StarknetBlockTimestamp(4),
@@ -1490,7 +1502,9 @@ mod tests {
                     block_number: Some(BLOCK2_NUMBER),
                     gas_price: Some(GasPrice(H128::from(b"gas price 2-----"))),
                     parent_block_hash: *BLOCK1_HASH_V2,
-                    sequencer_address: Some(EthereumAddress(H160::from(b"sequencer address 2-"))),
+                    sequencer_address: Some(SequencerAddress(
+                        StarkHash::from_be_slice(b"sequencer address 2").unwrap(),
+                    )),
                     state_root: Some(*GLOBAL_ROOT2),
                     status: reply::Status::AcceptedOnL1,
                     timestamp: StarknetBlockTimestamp(5),

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -473,9 +473,9 @@ mod tests {
             static ref BLOCK0: reply::Block = reply::Block {
                 block_hash: Some(*BLOCK0_HASH),
                 block_number: Some(BLOCK0_NUMBER),
-                gas_price: Some(GasPrice(H128::from_slice(b"0               "))),
+                gas_price: Some(GasPrice(H128::zero())),
                 parent_block_hash: StarknetBlockHash(StarkHash::ZERO),
-                sequencer_address: Some(EthereumAddress(H160::from_slice(b"0                   "))),
+                sequencer_address: Some(EthereumAddress(H160::zero())),
                 state_root: Some(*GLOBAL_ROOT0),
                 status: reply::Status::AcceptedOnL1,
                 timestamp: StarknetBlockTimestamp(0),
@@ -485,9 +485,9 @@ mod tests {
             static ref BLOCK0_V2: reply::Block = reply::Block {
                 block_hash: Some(*BLOCK0_HASH_V2),
                 block_number: Some(BLOCK0_NUMBER),
-                gas_price: Some(GasPrice(H128::from_slice(b"0 v2            "))),
+                gas_price: Some(GasPrice(H128::from(b"gas price 0 v2--"))),
                 parent_block_hash: StarknetBlockHash(StarkHash::ZERO),
-                sequencer_address: Some(EthereumAddress(H160::from_slice(b"0 v2                "))),
+                sequencer_address: Some(EthereumAddress(H160::from(b"sequencer addr. 0 v2"))),
                 state_root: Some(*GLOBAL_ROOT0_V2),
                 status: reply::Status::AcceptedOnL2,
                 timestamp: StarknetBlockTimestamp(10),
@@ -497,9 +497,9 @@ mod tests {
             static ref BLOCK1: reply::Block = reply::Block {
                 block_hash: Some(*BLOCK1_HASH),
                 block_number: Some(BLOCK1_NUMBER),
-                gas_price: Some(GasPrice(H128::from_slice(b"1               "))),
+                gas_price: Some(GasPrice(H128::from(b"gas price 1-----"))),
                 parent_block_hash: *BLOCK0_HASH,
-                sequencer_address: Some(EthereumAddress(H160::from_slice(b"1                   "))),
+                sequencer_address: Some(EthereumAddress(H160::from(b"sequencer address 1-"))),
                 state_root: Some(*GLOBAL_ROOT1),
                 status: reply::Status::AcceptedOnL1,
                 timestamp: StarknetBlockTimestamp(1),
@@ -509,9 +509,9 @@ mod tests {
             static ref BLOCK2: reply::Block = reply::Block {
                 block_hash: Some(*BLOCK2_HASH),
                 block_number: Some(BLOCK2_NUMBER),
-                gas_price: Some(GasPrice(H128::from_slice(b"2               "))),
+                gas_price: Some(GasPrice(H128::from(b"gas price 2-----"))),
                 parent_block_hash: *BLOCK1_HASH,
-                sequencer_address: Some(EthereumAddress(H160::from_slice(b"2                   "))),
+                sequencer_address: Some(EthereumAddress(H160::from(b"sequencer address 2-"))),
                 state_root: Some(*GLOBAL_ROOT2),
                 status: reply::Status::AcceptedOnL1,
                 timestamp: StarknetBlockTimestamp(2),
@@ -969,11 +969,9 @@ mod tests {
                 let block1_v2 = reply::Block {
                     block_hash: Some(*BLOCK1_HASH_V2),
                     block_number: Some(BLOCK1_NUMBER),
-                    gas_price: Some(GasPrice(H128::from_slice(b"1 v2            "))),
+                    gas_price: Some(GasPrice(H128::from(b"gas price 1 v2--"))),
                     parent_block_hash: *BLOCK0_HASH_V2,
-                    sequencer_address: Some(EthereumAddress(H160::from_slice(
-                        b"1 v2                ",
-                    ))),
+                    sequencer_address: Some(EthereumAddress(H160::from(b"sequencer addr. 1 v2"))),
                     state_root: Some(*GLOBAL_ROOT1_V2),
                     status: reply::Status::AcceptedOnL2,
                     timestamp: StarknetBlockTimestamp(4),
@@ -1151,11 +1149,9 @@ mod tests {
                 let block1_v2 = reply::Block {
                     block_hash: Some(*BLOCK1_HASH_V2),
                     block_number: Some(BLOCK1_NUMBER),
-                    gas_price: Some(GasPrice(H128::from_slice(b"1 v2            "))),
+                    gas_price: Some(GasPrice(H128::from(b"gas price 1 v2--"))),
                     parent_block_hash: *BLOCK0_HASH,
-                    sequencer_address: Some(EthereumAddress(H160::from_slice(
-                        b"1 v2                ",
-                    ))),
+                    sequencer_address: Some(EthereumAddress(H160::from(b"sequencer addr. 1 v2"))),
                     state_root: Some(*GLOBAL_ROOT1_V2),
                     status: reply::Status::AcceptedOnL2,
                     timestamp: StarknetBlockTimestamp(4),
@@ -1165,11 +1161,9 @@ mod tests {
                 let block2_v2 = reply::Block {
                     block_hash: Some(*BLOCK2_HASH_V2),
                     block_number: Some(BLOCK2_NUMBER),
-                    gas_price: Some(GasPrice(H128::from_slice(b"2 v2            "))),
+                    gas_price: Some(GasPrice(H128::from(b"gas price 2 v2--"))),
                     parent_block_hash: *BLOCK1_HASH_V2,
-                    sequencer_address: Some(EthereumAddress(H160::from_slice(
-                        b"2 v2                ",
-                    ))),
+                    sequencer_address: Some(EthereumAddress(H160::from(b"sequencer addr. 2 v2"))),
                     state_root: Some(*GLOBAL_ROOT2_V2),
                     status: reply::Status::AcceptedOnL2,
                     timestamp: StarknetBlockTimestamp(5),
@@ -1179,11 +1173,9 @@ mod tests {
                 let block3 = reply::Block {
                     block_hash: Some(*BLOCK3_HASH),
                     block_number: Some(BLOCK3_NUMBER),
-                    gas_price: Some(GasPrice(H128::from_slice(b"3               "))),
+                    gas_price: Some(GasPrice(H128::from(b"gas price 2-----"))),
                     parent_block_hash: *BLOCK2_HASH,
-                    sequencer_address: Some(EthereumAddress(H160::from_slice(
-                        b"3                   ",
-                    ))),
+                    sequencer_address: Some(EthereumAddress(H160::from(b"sequencer address 3-"))),
                     state_root: Some(*GLOBAL_ROOT3),
                     status: reply::Status::AcceptedOnL1,
                     timestamp: StarknetBlockTimestamp(3),
@@ -1349,11 +1341,9 @@ mod tests {
                 let block2_v2 = reply::Block {
                     block_hash: Some(*BLOCK2_HASH_V2),
                     block_number: Some(BLOCK2_NUMBER),
-                    gas_price: Some(GasPrice(H128::from_slice(b"2 v2            "))),
+                    gas_price: Some(GasPrice(H128::from(b"gas price 2 v2--"))),
                     parent_block_hash: *BLOCK1_HASH,
-                    sequencer_address: Some(EthereumAddress(H160::from_slice(
-                        b"2 v2                ",
-                    ))),
+                    sequencer_address: Some(EthereumAddress(H160::from(b"sequencer addr. 2 v2"))),
                     state_root: Some(*GLOBAL_ROOT2_V2),
                     status: reply::Status::AcceptedOnL2,
                     timestamp: StarknetBlockTimestamp(5),
@@ -1486,11 +1476,9 @@ mod tests {
                 let block1_v2 = reply::Block {
                     block_hash: Some(*BLOCK1_HASH_V2),
                     block_number: Some(BLOCK1_NUMBER),
-                    gas_price: Some(GasPrice(H128::from_slice(b"1 v2            "))),
+                    gas_price: Some(GasPrice(H128::from(b"gas price 1 v2--"))),
                     parent_block_hash: *BLOCK0_HASH,
-                    sequencer_address: Some(EthereumAddress(H160::from_slice(
-                        b"1 v2                ",
-                    ))),
+                    sequencer_address: Some(EthereumAddress(H160::from(b"sequencer addr. 1 v2"))),
                     state_root: Some(*GLOBAL_ROOT1_V2),
                     status: reply::Status::AcceptedOnL2,
                     timestamp: StarknetBlockTimestamp(4),
@@ -1500,11 +1488,9 @@ mod tests {
                 let block2 = reply::Block {
                     block_hash: Some(*BLOCK2_HASH),
                     block_number: Some(BLOCK2_NUMBER),
-                    gas_price: Some(GasPrice(H128::from_slice(b"2               "))),
+                    gas_price: Some(GasPrice(H128::from(b"gas price 2-----"))),
                     parent_block_hash: *BLOCK1_HASH_V2,
-                    sequencer_address: Some(EthereumAddress(H160::from_slice(
-                        b"2                   ",
-                    ))),
+                    sequencer_address: Some(EthereumAddress(H160::from(b"sequencer address 2-"))),
                     state_root: Some(*GLOBAL_ROOT2),
                     status: reply::Status::AcceptedOnL1,
                     timestamp: StarknetBlockTimestamp(5),

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -195,6 +195,36 @@ fn enable_foreign_keys(connection: &Connection) -> anyhow::Result<()> {
 }
 
 #[cfg(test)]
+pub(crate) mod test_utils {
+    use super::StarknetBlock;
+
+    use crate::core::{
+        GasPrice, GlobalRoot, SequencerAddress, StarknetBlockHash, StarknetBlockNumber,
+        StarknetBlockTimestamp,
+    };
+
+    use pedersen::StarkHash;
+    use web3::types::H128;
+
+    /// Creates a set of consecutive [StarknetBlock]s starting from L2 genesis,
+    /// with arbitrary other values.
+    pub(crate) fn create_blocks<const N: usize>() -> [StarknetBlock; N] {
+        (0..N)
+            .map(|i| StarknetBlock {
+                number: StarknetBlockNumber::GENESIS + i as u64,
+                hash: StarknetBlockHash(StarkHash::from_hex_str(&"a".repeat(i + 3)).unwrap()),
+                root: GlobalRoot(StarkHash::from_hex_str(&"f".repeat(i + 3)).unwrap()),
+                timestamp: StarknetBlockTimestamp(i as u64 + 500),
+                gas_price: GasPrice(H128::zero()),
+                sequencer_address: SequencerAddress(StarkHash::ZERO),
+            })
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap()
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -27,7 +27,7 @@ use tracing::info;
 /// Indicates database is non-existant.
 const DB_VERSION_EMPTY: u32 = 0;
 /// Current database version.
-const DB_VERSION_CURRENT: u32 = 8;
+const DB_VERSION_CURRENT: u32 = 9;
 /// Sqlite key used for the PRAGMA user version.
 const VERSION_KEY: &str = "user_version";
 
@@ -146,6 +146,7 @@ fn migrate_database(connection: &mut Connection) -> anyhow::Result<()> {
             5 => schema::revision_0006::migrate(&transaction)?,
             6 => schema::revision_0007::migrate(&transaction)?,
             7 => schema::revision_0008::migrate(&transaction)?,
+            8 => schema::revision_0009::migrate(&transaction)?,
             _ => unreachable!("Database version constraint was already checked!"),
         };
         // If any migration action requires vacuuming, we should vacuum.

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -204,7 +204,6 @@ pub(crate) mod test_utils {
     };
 
     use pedersen::StarkHash;
-    use web3::types::H128;
 
     /// Creates a set of consecutive [StarknetBlock]s starting from L2 genesis,
     /// with arbitrary other values.
@@ -215,8 +214,8 @@ pub(crate) mod test_utils {
                 hash: StarknetBlockHash(StarkHash::from_hex_str(&"a".repeat(i + 3)).unwrap()),
                 root: GlobalRoot(StarkHash::from_hex_str(&"f".repeat(i + 3)).unwrap()),
                 timestamp: StarknetBlockTimestamp(i as u64 + 500),
-                gas_price: GasPrice(H128::zero()),
-                sequencer_address: SequencerAddress(StarkHash::ZERO),
+                gas_price: GasPrice::from(i as u64),
+                sequencer_address: SequencerAddress(StarkHash::from_be_slice(&[i as u8]).unwrap()),
             })
             .collect::<Vec<_>>()
             .try_into()

--- a/crates/pathfinder/src/storage/schema.rs
+++ b/crates/pathfinder/src/storage/schema.rs
@@ -6,6 +6,7 @@ pub(crate) mod revision_0005;
 pub(crate) mod revision_0006;
 pub(crate) mod revision_0007;
 pub(crate) mod revision_0008;
+pub(crate) mod revision_0009;
 
 /// Used to indicate which action the caller should perform after a schema migration.
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/pathfinder/src/storage/schema/revision_0009.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0009.rs
@@ -1,0 +1,104 @@
+use crate::storage::schema::PostMigrationAction;
+use anyhow::Context;
+use rusqlite::Transaction;
+
+pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigrationAction> {
+    // Add new columns to the blocks table
+    transaction
+        .execute_batch(
+            r"ALTER TABLE starknet_blocks ADD COLUMN gas_price INTEGER NOT NULL
+            DEFAULT X'00000000000000000000000000000000';
+            ALTER TABLE starknet_blocks ADD COLUMN sequencer_address BLOB NOT NULL
+            DEFAULT X'0000000000000000000000000000000000000000';",
+        )
+        .context("Add columns gas_price and starknet_address to starknet_blocks table")?;
+
+    Ok(PostMigrationAction::None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PostMigrationAction;
+
+    use crate::{
+        core::{
+            EthereumAddress, GasPrice, GlobalRoot, StarknetBlockHash, StarknetBlockNumber,
+            StarknetBlockTimestamp,
+        },
+        storage::{schema, StarknetBlock, StarknetBlocksBlockId, StarknetBlocksTable},
+    };
+
+    use pedersen::StarkHash;
+    use rusqlite::{named_params, Connection};
+    use web3::types::{H128, H160};
+
+    #[test]
+    fn empty() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        let transaction = conn.transaction().unwrap();
+
+        schema::revision_0001::migrate(&transaction).unwrap();
+        schema::revision_0002::migrate(&transaction).unwrap();
+        schema::revision_0003::migrate(&transaction).unwrap();
+        schema::revision_0004::migrate(&transaction).unwrap();
+        schema::revision_0005::migrate(&transaction).unwrap();
+        schema::revision_0006::migrate(&transaction).unwrap();
+        schema::revision_0007::migrate(&transaction).unwrap();
+        schema::revision_0008::migrate(&transaction).unwrap();
+
+        let action = super::migrate(&transaction).unwrap();
+        assert_eq!(action, PostMigrationAction::None);
+    }
+
+    #[test]
+    fn stateful() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        let transaction = conn.transaction().unwrap();
+
+        schema::revision_0001::migrate(&transaction).unwrap();
+        schema::revision_0002::migrate(&transaction).unwrap();
+        schema::revision_0003::migrate(&transaction).unwrap();
+        schema::revision_0004::migrate(&transaction).unwrap();
+        schema::revision_0005::migrate(&transaction).unwrap();
+        schema::revision_0006::migrate(&transaction).unwrap();
+        schema::revision_0007::migrate(&transaction).unwrap();
+        schema::revision_0008::migrate(&transaction).unwrap();
+
+        let block_number = StarknetBlockNumber(1234);
+        let block_hash = StarknetBlockHash(StarkHash::from_be_slice(b"a block hash").unwrap());
+        let root = GlobalRoot(StarkHash::from_be_slice(b"some global root").unwrap());
+        let timestamp = StarknetBlockTimestamp(5678);
+
+        transaction
+            .execute(
+                r"INSERT INTO starknet_blocks ( number,  hash,  root,  timestamp)
+                                       VALUES (:number, :hash, :root, :timestamp)",
+                named_params![
+                    ":number": block_number.0,
+                    ":hash": &block_hash.0.as_be_bytes(),
+                    ":root": &root.0.as_be_bytes(),
+                    ":timestamp": timestamp.0,
+                ],
+            )
+            .unwrap();
+
+        let action = super::migrate(&transaction).unwrap();
+        assert_eq!(action, PostMigrationAction::None);
+
+        let block = StarknetBlocksTable::get(&transaction, StarknetBlocksBlockId::Hash(block_hash))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            block,
+            StarknetBlock {
+                number: block_number,
+                hash: block_hash,
+                root,
+                timestamp,
+                gas_price: GasPrice(H128::zero()),
+                sequencer_address: EthereumAddress(H160::zero())
+            }
+        )
+    }
+}

--- a/crates/pathfinder/src/storage/schema/revision_0009.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0009.rs
@@ -30,7 +30,6 @@ mod tests {
 
     use pedersen::StarkHash;
     use rusqlite::{named_params, Connection};
-    use web3::types::H128;
 
     #[test]
     fn empty() {
@@ -96,7 +95,7 @@ mod tests {
                 hash: block_hash,
                 root,
                 timestamp,
-                gas_price: GasPrice(H128::zero()),
+                gas_price: GasPrice::ZERO,
                 sequencer_address: SequencerAddress(StarkHash::ZERO)
             }
         )

--- a/crates/pathfinder/src/storage/schema/revision_0009.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0009.rs
@@ -6,7 +6,7 @@ pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigration
     // Add new columns to the blocks table
     transaction
         .execute_batch(
-            r"ALTER TABLE starknet_blocks ADD COLUMN gas_price INTEGER NOT NULL
+            r"ALTER TABLE starknet_blocks ADD COLUMN gas_price BLOB NOT NULL
             DEFAULT X'00000000000000000000000000000000';
             ALTER TABLE starknet_blocks ADD COLUMN sequencer_address BLOB NOT NULL
             DEFAULT X'0000000000000000000000000000000000000000000000000000000000000000';",

--- a/crates/pathfinder/src/storage/schema/revision_0009.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0009.rs
@@ -9,7 +9,7 @@ pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigration
             r"ALTER TABLE starknet_blocks ADD COLUMN gas_price INTEGER NOT NULL
             DEFAULT X'00000000000000000000000000000000';
             ALTER TABLE starknet_blocks ADD COLUMN sequencer_address BLOB NOT NULL
-            DEFAULT X'0000000000000000000000000000000000000000';",
+            DEFAULT X'0000000000000000000000000000000000000000000000000000000000000000';",
         )
         .context("Add columns gas_price and starknet_address to starknet_blocks table")?;
 
@@ -22,7 +22,7 @@ mod tests {
 
     use crate::{
         core::{
-            EthereumAddress, GasPrice, GlobalRoot, StarknetBlockHash, StarknetBlockNumber,
+            GasPrice, GlobalRoot, SequencerAddress, StarknetBlockHash, StarknetBlockNumber,
             StarknetBlockTimestamp,
         },
         storage::{schema, StarknetBlock, StarknetBlocksBlockId, StarknetBlocksTable},
@@ -30,7 +30,7 @@ mod tests {
 
     use pedersen::StarkHash;
     use rusqlite::{named_params, Connection};
-    use web3::types::{H128, H160};
+    use web3::types::H128;
 
     #[test]
     fn empty() {
@@ -97,7 +97,7 @@ mod tests {
                 root,
                 timestamp,
                 gas_price: GasPrice(H128::zero()),
-                sequencer_address: EthereumAddress(H160::zero())
+                sequencer_address: SequencerAddress(StarkHash::ZERO)
             }
         )
     }

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -245,7 +245,7 @@ impl StarknetBlocksTable {
     /// Insert a new [StarknetBlock]. Fails if the block number is not unique.
     pub fn insert(connection: &Connection, block: &StarknetBlock) -> anyhow::Result<()> {
         connection.execute(
-            r"INSERT INTO starknet_blocks ( number,  hash,  root,  timestamp, gas_price, sequencer_address)
+            r"INSERT INTO starknet_blocks ( number,  hash,  root,  timestamp,  gas_price,  sequencer_address)
                                    VALUES (:number, :hash, :root, :timestamp, :gas_price, :sequencer_address)",
             named_params! {
                 ":number": block.number.0,

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use pedersen::StarkHash;
 use rusqlite::{named_params, params, Connection, OptionalExtension, Transaction};
-use web3::types::{H128, H256};
+use web3::types::H256;
 
 use crate::{
     core::{
@@ -252,7 +252,7 @@ impl StarknetBlocksTable {
                 ":hash": block.hash.0.as_be_bytes(),
                 ":root": block.root.0.as_be_bytes(),
                 ":timestamp": block.timestamp.0,
-                ":gas_price": &block.gas_price.0[..],
+                ":gas_price": &block.gas_price.to_be_bytes(),
                 ":sequencer_address": block.sequencer_address.0.as_be_bytes(),
             },
         )?;
@@ -305,7 +305,7 @@ impl StarknetBlocksTable {
                 let timestamp = StarknetBlockTimestamp(timestamp);
 
                 let gas_price = row.get_ref_unwrap("gas_price").as_blob().unwrap();
-                let gas_price = GasPrice(H128(gas_price.try_into().unwrap()));
+                let gas_price = GasPrice::from_be_slice(gas_price).unwrap();
 
                 let sequencer_address = row.get_ref_unwrap("sequencer_address").as_blob().unwrap();
                 let sequencer_address = StarkHash::from_be_slice(sequencer_address).unwrap();
@@ -2094,7 +2094,7 @@ mod tests {
             number: block0_number,
             root: GlobalRoot(StarkHash::from_be_slice(b"root 0").unwrap()),
             timestamp: StarknetBlockTimestamp(0),
-            gas_price: GasPrice(H128::from(b"gas_price 0 ----")),
+            gas_price: GasPrice::from(0),
             sequencer_address: SequencerAddress(
                 StarkHash::from_be_slice(b"sequencer_address 0").unwrap(),
             ),
@@ -2104,7 +2104,7 @@ mod tests {
             number: block1_number,
             root: GlobalRoot(StarkHash::from_be_slice(b"root 1").unwrap()),
             timestamp: StarknetBlockTimestamp(1),
-            gas_price: GasPrice(H128::from(b"gas_price 1 ----")),
+            gas_price: GasPrice::from(1),
             sequencer_address: SequencerAddress(
                 StarkHash::from_be_slice(b"sequencer_address 1").unwrap(),
             ),

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -1261,23 +1261,8 @@ mod tests {
     mod starknet_blocks {
         use super::*;
 
-        /// Creates a set of consecutive [StarknetBlock]s starting from L2 genesis,
-        /// with arbitrary other values.
         fn create_blocks() -> [StarknetBlock; 3] {
-            (0..3)
-                .map(|i| StarknetBlock {
-                    number: StarknetBlockNumber::GENESIS + i,
-                    hash: StarknetBlockHash(
-                        StarkHash::from_hex_str(&"a".repeat(i as usize + 3)).unwrap(),
-                    ),
-                    root: GlobalRoot(StarkHash::from_hex_str(&"f".repeat(i as usize + 3)).unwrap()),
-                    timestamp: StarknetBlockTimestamp(i + 500),
-                    gas_price: GasPrice(H128::zero()),
-                    sequencer_address: SequencerAddress(StarkHash::ZERO),
-                })
-                .collect::<Vec<_>>()
-                .try_into()
-                .unwrap()
+            crate::storage::test_utils::create_blocks::<3>()
         }
 
         mod get {
@@ -1616,20 +1601,7 @@ mod tests {
         const NUM_BLOCKS: usize = 4;
 
         fn create_blocks() -> [StarknetBlock; NUM_BLOCKS] {
-            (0..NUM_BLOCKS as u64)
-                .map(|i| StarknetBlock {
-                    number: StarknetBlockNumber::GENESIS + i,
-                    hash: StarknetBlockHash(
-                        StarkHash::from_hex_str(&"a".repeat(i as usize + 3)).unwrap(),
-                    ),
-                    root: GlobalRoot(StarkHash::from_hex_str(&"f".repeat(i as usize + 3)).unwrap()),
-                    timestamp: StarknetBlockTimestamp(i + 500),
-                    gas_price: GasPrice(H128::zero()),
-                    sequencer_address: SequencerAddress(StarkHash::ZERO),
-                })
-                .collect::<Vec<_>>()
-                .try_into()
-                .unwrap()
+            crate::storage::test_utils::create_blocks::<NUM_BLOCKS>()
         }
 
         const TRANSACTIONS_PER_BLOCK: usize = 10;

--- a/py/requirements-dev.in
+++ b/py/requirements-dev.in
@@ -1,8 +1,8 @@
 # see README.md
-cairo-lang==0.8.1
+cairo-lang==0.8.2
 # We don't use rlp directly, however this needs to be defined for it to help pip-compile
 eth-rlp==0.2.1
-pip-tools==6.4.0
+pip-tools==6.6.0
 pytest==6.2.5
 flake8==4.0.1
 black==21.12b0

--- a/py/requirements-dev.in
+++ b/py/requirements-dev.in
@@ -1,5 +1,5 @@
 # see README.md
-cairo-lang==0.8.2
+cairo-lang==0.8.2.1
 # We don't use rlp directly, however this needs to be defined for it to help pip-compile
 eth-rlp==0.2.1
 pip-tools==6.6.0

--- a/py/requirements-dev.txt
+++ b/py/requirements-dev.txt
@@ -25,7 +25,7 @@ black==21.12b0
     # via -r requirements-dev.in
 cachetools==5.0.0
     # via cairo-lang
-cairo-lang==0.8.1
+cairo-lang==0.8.2
     # via -r requirements-dev.in
 certifi==2021.10.8
     # via requests
@@ -148,7 +148,7 @@ pathspec==0.9.0
     # via black
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.6.0
     # via -r requirements-dev.in
 pipdeptree==2.2.1
     # via cairo-lang

--- a/py/requirements-dev.txt
+++ b/py/requirements-dev.txt
@@ -25,7 +25,7 @@ black==21.12b0
     # via -r requirements-dev.in
 cachetools==5.0.0
     # via cairo-lang
-cairo-lang==0.8.2
+cairo-lang==0.8.2.1
     # via -r requirements-dev.in
 certifi==2021.10.8
     # via requests

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -225,7 +225,7 @@ def check_schema(connection):
     assert cursor is not None, "there has to be an user_version defined in the database"
 
     [version] = next(cursor)
-    return version == 8
+    return version == 9
 
 
 def resolve_block(connection, at_block):

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -9,6 +9,7 @@ from starkware.storage.storage import Storage
 # used from tests, and the query which asserts that the schema is of expected version.
 EXPECTED_SCHEMA_REVISION = 9
 
+
 def main():
     """
     Loops on stdin, reads json commands from lines, outputs single json as a response.

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -8,7 +8,7 @@ from starkware.storage.storage import Storage
 
 # used from tests, and the query which asserts that the schema is of expected version.
 EXPECTED_SCHEMA_REVISION = 9
-
+EXPECTED_CAIRO_VERSION = "0.8.2"
 
 def main():
     """
@@ -49,7 +49,7 @@ def check_cairolang_version():
     import pkg_resources
 
     version = pkg_resources.get_distribution("cairo-lang").version
-    return version == "0.8.1"
+    return version == EXPECTED_CAIRO_VERSION
 
 
 def do_loop(connection, input_gen, output_file):

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -8,7 +8,7 @@ from starkware.storage.storage import Storage
 
 # used from tests, and the query which asserts that the schema is of expected version.
 EXPECTED_SCHEMA_REVISION = 9
-EXPECTED_CAIRO_VERSION = "0.8.2"
+EXPECTED_CAIRO_VERSION = "0.8.2.1"
 
 
 def main():

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -266,7 +266,7 @@ def resolve_block(connection, at_block):
     sequencer_address = int.from_bytes(sequencer_address, "big")
 
     return (
-        BlockInfo(block_number, block_time, gas_price),
+        BlockInfo(block_number, block_time, gas_price, sequencer_address),
         global_root,
     )
 

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -10,6 +10,7 @@ from starkware.storage.storage import Storage
 EXPECTED_SCHEMA_REVISION = 9
 EXPECTED_CAIRO_VERSION = "0.8.2"
 
+
 def main():
     """
     Loops on stdin, reads json commands from lines, outputs single json as a response.

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -6,6 +6,8 @@ import asyncio
 from starkware.starkware_utils.error_handling import WebFriendlyException
 from starkware.storage.storage import Storage
 
+# used from tests, and the query which asserts that the schema is of expected version.
+EXPECTED_SCHEMA_REVISION = 9
 
 def main():
     """
@@ -225,7 +227,7 @@ def check_schema(connection):
     assert cursor is not None, "there has to be an user_version defined in the database"
 
     [version] = next(cursor)
-    return version == 9
+    return version == EXPECTED_SCHEMA_REVISION
 
 
 def resolve_block(connection, at_block):

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -89,7 +89,9 @@ def inmemory_with_tables():
             number               INTEGER PRIMARY KEY,
             hash                 BLOB    NOT NULL,
             root                 BLOB    NOT NULL,
-            timestamp            INTEGER NOT NULL
+            timestamp            INTEGER NOT NULL,
+            gas_price            BLOB    NOT NULL,
+            sequencer_address    BLOB    NOT NULL
         );
         """
     )
@@ -125,9 +127,9 @@ def populate_test_contract_with_132_on_3(con):
     )
     cur = con.execute("BEGIN")
 
-    def pad(b):
-        assert len(b) <= 32
-        return b"\x00" * (32 - len(b)) + b
+    def left_pad(b, to_length):
+        assert len(b) <= to_length
+        return b"\x00" * (to_length - len(b)) + b
 
     cur.execute(
         "insert into contract_code (hash, definition) values (?, ?)",
@@ -187,13 +189,16 @@ def populate_test_contract_with_132_on_3(con):
         ],
     )
 
+    # interestingly python sqlite does not accept X'0' here:
     cur.execute(
-        """insert into starknet_blocks (hash, number, timestamp, root) values (?, 1, 1, ?)""",
+        """insert into starknet_blocks (hash, number, timestamp, root, gas_price, sequencer_address) values (?, 1, 1, ?, ?, ?)""",
         [
-            pad(b"some blockhash somewhere"),
+            left_pad(b"some blockhash somewhere", 32),
             bytes.fromhex(
                 "0704dfcbc470377c68e6f5ffb83970ebd0d7c48d5b8d2f4ed61a24e795e034bd"
             ),
+            left_pad(b"0", 16),
+            left_pad(b"0", 32),
         ],
     )
 

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -1,4 +1,4 @@
-from call import do_loop, loop_inner, EXPECTED_SCHEMA_REVISION
+from call import do_loop, loop_inner, EXPECTED_SCHEMA_REVISION, check_cairolang_version
 import sqlite3
 import io
 import json
@@ -363,3 +363,8 @@ def test_no_such_block():
     assert number == expected
     assert block_hash == expected
     assert latest == expected
+
+def test_check_cairolang_version():
+    # run this here as well so that we get earlier than CI feedback
+    # of another constant that needs to be upgraded
+    assert check_cairolang_version()

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -100,8 +100,12 @@ def inmemory_with_tables():
     #
     # apparently python sqlite does not support pragmas with parameters
     # (questionmark or named).
-    assert type(EXPECTED_SCHEMA_REVISION) is int, f"expected schema revision must be just int, not: {type(EXPECTED_SCHEMA_REVISION)}"
-    assert 0 <= EXPECTED_SCHEMA_REVISION < 2**16, f"schema revision out of range: {EXPECTED_SCHEMA_REVISION}"
+    assert (
+        type(EXPECTED_SCHEMA_REVISION) is int
+    ), f"expected schema revision must be just int, not: {type(EXPECTED_SCHEMA_REVISION)}"
+    assert (
+        0 <= EXPECTED_SCHEMA_REVISION < 2 ** 16
+    ), f"schema revision out of range: {EXPECTED_SCHEMA_REVISION}"
     cur.execute("pragma user_version = %d" % EXPECTED_SCHEMA_REVISION)
 
     con.commit()

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -1,4 +1,4 @@
-from call import do_loop, loop_inner
+from call import do_loop, loop_inner, EXPECTED_SCHEMA_REVISION
 import sqlite3
 import io
 import json
@@ -97,7 +97,12 @@ def inmemory_with_tables():
     # strangely this cannot be pulled into the script, maybe pragmas have
     # different kind of semantics than what is normally executed, would explain
     # the similar behaviour of sqlite3 .dump and restore.
-    cur.execute("pragma user_version = 9")
+    #
+    # apparently python sqlite does not support pragmas with parameters
+    # (questionmark or named).
+    assert type(EXPECTED_SCHEMA_REVISION) is int, f"expected schema revision must be just int, not: {type(EXPECTED_SCHEMA_REVISION)}"
+    assert 0 <= EXPECTED_SCHEMA_REVISION < 2**16, f"schema revision out of range: {EXPECTED_SCHEMA_REVISION}"
+    cur.execute("pragma user_version = %d" % EXPECTED_SCHEMA_REVISION)
 
     con.commit()
     return con

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -97,7 +97,7 @@ def inmemory_with_tables():
     # strangely this cannot be pulled into the script, maybe pragmas have
     # different kind of semantics than what is normally executed, would explain
     # the similar behaviour of sqlite3 .dump and restore.
-    cur.execute("pragma user_version = 8")
+    cur.execute("pragma user_version = 9")
 
     con.commit()
     return con

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -364,6 +364,7 @@ def test_no_such_block():
     assert block_hash == expected
     assert latest == expected
 
+
 def test_check_cairolang_version():
     # run this here as well so that we get earlier than CI feedback
     # of another constant that needs to be upgraded


### PR DESCRIPTION
Changes:
- add `gas_price`, `sequencer_address`
- fix missing `old_root` in `pending` block
- minor test code deduplication

Important notes:
- required cairo lang version in py still 0.8.1 as it hasn't been released yet
- no db changes for `max_fee` and `actual_fee` as those fields are `Optional` so (de)serialization of `sequencer::reply::transaction::{Receipt, Transaction}` will not break upon 0.8.2
