### PR TITLE
fix(sync): changed reorg severity to info

### DIFF
--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -144,9 +144,9 @@ where
 
                     match new_head {
                         Some(head) => {
-                            tracing::warn!("L1 reorg occurred, new L1 head is block {}", head.0)
+                            tracing::info!("L1 reorg occurred, new L1 head is block {}", head.0)
                         }
-                        None => tracing::warn!("L1 reorg occurred, new L1 head is genesis"),
+                        None => tracing::info!("L1 reorg occurred, new L1 head is genesis"),
                     }
                 }
                 Some(l1::Event::QueryUpdate(block, tx)) => {
@@ -247,9 +247,9 @@ where
                     };
                     match new_head {
                         Some(head) => {
-                            tracing::warn!("L2 reorg occurred, new L2 head is block {}", head.0)
+                            tracing::info!("L2 reorg occurred, new L2 head is block {}", head.0)
                         }
-                        None => tracing::warn!("L2 reorg occurred, new L2 head is genesis"),
+                        None => tracing::info!("L2 reorg occurred, new L2 head is genesis"),
                     }
                 }
                 Some(l2::Event::NewContract(contract)) => {


### PR DESCRIPTION
PR changes L1 and L2 reorg events from `tracing::warn` to `tracing::info`.

Since reorgs are expected behaviour, `warn!` did not make sense (and also generated wen-token bug reports).