### PR TITLE
feat(rpc): add optional token for starknet_addDeployTransaction

### DIFF
--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -273,6 +273,10 @@ pub fn run_server(addr: SocketAddr, api: RpcApi) -> Result<(HttpServerHandle, So
                 pub contract_address_salt: ContractAddressSalt,
                 pub constructor_calldata: Vec<ConstructorParam>,
                 pub contract_definition: ContractDefinition,
+                // An undocumented parameter that we forward to the sequencer API
+                // A deploy token is required to deploy contracts on Starknet mainnet only.
+                #[serde(default)]
+                pub token: Option<String>,
             }
             let params = params.parse::<NamedArgs>()?;
             context
@@ -280,6 +284,7 @@ pub fn run_server(addr: SocketAddr, api: RpcApi) -> Result<(HttpServerHandle, So
                     params.contract_address_salt,
                     params.constructor_calldata,
                     params.contract_definition,
+                    params.token,
                 )
                 .await
         },

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -990,6 +990,7 @@ impl RpcApi {
         contract_address_salt: ContractAddressSalt,
         constructor_calldata: Vec<ConstructorParam>,
         contract_definition: ContractDefinition,
+        token: Option<String>,
     ) -> RpcResult<DeployTransactionResult> {
         let result = self
             .sequencer
@@ -997,6 +998,7 @@ impl RpcApi {
                 contract_address_salt,
                 constructor_calldata,
                 contract_definition,
+                token,
             )
             .await?;
         Ok(DeployTransactionResult {

--- a/crates/pathfinder/src/sequencer/error.rs
+++ b/crates/pathfinder/src/sequencer/error.rs
@@ -44,7 +44,8 @@ impl From<SequencerError> for rpc::Error {
                 | StarknetErrorCode::SchemaValidationError
                 | StarknetErrorCode::MalformedRequest
                 | StarknetErrorCode::UnsupportedSelectorForFee
-                | StarknetErrorCode::OutOfRangeBlockHash => {
+                | StarknetErrorCode::OutOfRangeBlockHash
+                | StarknetErrorCode::NotPermittedContract => {
                     rpc::Error::Call(rpc::CallError::Failed(e.into()))
                 }
             },
@@ -97,4 +98,6 @@ pub enum StarknetErrorCode {
     UnsupportedSelectorForFee,
     #[serde(rename = "StarknetErrorCode.INVALID_CONTRACT_DEFINITION")]
     InvalidContractDefinition,
+    #[serde(rename = "StarknetErrorCode.NON_PERMITTED_CONTRACT")]
+    NotPermittedContract,
 }

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -769,6 +769,7 @@ mod tests {
             _: ContractAddressSalt,
             _: Vec<ConstructorParam>,
             _: ContractDefinition,
+            _: Option<String>,
         ) -> Result<reply::add_transaction::DeployResponse, SequencerError> {
             unimplemented!()
         }


### PR DESCRIPTION
This is currently required for mainnet deployment operations. The
token gets passed on to the sequencer API as a query parameter.