### PR TITLE
fix: sync status highest block number

### DIFF
--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -679,6 +679,17 @@ pub mod reply {
         Status(syncing::Status),
     }
 
+    impl std::fmt::Display for Syncing {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Syncing::False(_) => f.write_str("false"),
+                Syncing::Status(status) => {
+                    write!(f, "{}", status)
+                }
+            }
+        }
+    }
+
     /// Starknet's syncing status substructures.
     pub mod syncing {
         use crate::{
@@ -702,6 +713,21 @@ pub mod reply {
             pub highest_block_hash: StarknetBlockHash,
             #[serde_as(as = "StarknetBlockNumberAsHexStr")]
             pub highest_block_num: StarknetBlockNumber,
+        }
+
+        impl std::fmt::Display for Status {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(
+                    f,
+                    "starting: ({}, {}), current: ({}, {}), highest: ({}, {})",
+                    self.starting_block_num.0,
+                    self.starting_block_hash.0,
+                    self.current_block_num.0,
+                    self.current_block_hash.0,
+                    self.highest_block_num.0,
+                    self.highest_block_hash.0,
+                )
+            }
         }
     }
 

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -346,12 +346,7 @@ async fn update_sync_status_latest(
                         });
 
                         tracing::debug!(
-                            starting_hash=%starting_block_hash.0,
-                            starting_num=%starting_block_num.0,
-                            current_hash=%starting_block_hash.0,
-                            current_num=%starting_block_num.0,
-                            highest_hash=%latest_hash.0,
-                            highest_num=%latest_num.0,
+                            status=%sync_status,
                             "Updated sync status",
                         );
                     }
@@ -361,8 +356,7 @@ async fn update_sync_status_latest(
                             status.highest_block_num = latest_num;
 
                             tracing::debug!(
-                                highest_hash=%latest_hash.0,
-                                highest_num=%latest_num.0,
+                                %status,
                                 "Updated sync status",
                             );
                         }

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -358,6 +358,8 @@ async fn update_sync_status_latest(
                     SyncStatus::Status(status) => {
                         if status.highest_block_hash != latest_hash {
                             status.highest_block_hash = latest_hash;
+                            status.highest_block_num = latest_num;
+
                             tracing::debug!(
                                 highest_hash=%latest_hash.0,
                                 highest_num=%latest_num.0,


### PR DESCRIPTION
This PR fixes the sync status' highest block number not being updated.

Additionally, it adds `impl Display for SyncStatus`, which the debug trace output. This was an afterthought, and I'm not sure if its an improvement. (open to dropping the commit for this.)