### PR TITLE
old root for pending block

### DIFF
--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -373,7 +373,7 @@ impl RpcApi {
                 .sequencer
                 .block_by_hash(BlockHashOrTag::Hash(block_hash))
                 .await
-                .context("Fetch block from sequencer")
+                .context("Fetch pending - 1 block from sequencer")
                 .map_err(internal_server_error)?
                 .state_root
                 .expect("State root is always present for non pending block")),

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -219,7 +219,11 @@ pub mod reply {
         }
 
         /// Constructs [Block] from [sequencer's block representation](crate::sequencer::reply::Block)
-        pub fn from_sequencer_scoped(block: seq::Block, scope: BlockResponseScope) -> Self {
+        pub fn from_sequencer_scoped(
+            block: seq::Block,
+            old_root: GlobalRoot,
+            scope: BlockResponseScope,
+        ) -> Self {
             Self {
                 block_hash: block.block_hash,
                 parent_hash: block.parent_block_hash,
@@ -230,8 +234,7 @@ pub mod reply {
                     // Default value for cairo <0.8.0 is 0
                     .unwrap_or(SequencerAddress(StarkHash::ZERO)),
                 new_root: block.state_root,
-                // TODO where to get it from
-                old_root: GlobalRoot(StarkHash::ZERO),
+                old_root,
                 accepted_time: block.timestamp,
                 gas_price: block
                     .gas_price


### PR DESCRIPTION
This change fills the `old_root` field in a `pending` block reply with a valid value as opposed to a zero hash used previously.