### PR TITLE
chore(pathfinder): bump crate version to 0.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1847,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pathfinder"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.58"


### PR DESCRIPTION
Looks like we forgot to do this (once again) when releasing 0.1.10.