### PR TITLE
fix: sync status current running ahead of highest

### DIFF
--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -207,6 +207,11 @@ where
                         SyncStatus::Status(status) => {
                             status.current_block_hash = block_hash;
                             status.current_block_num = StarknetBlockNumber(block_num);
+
+                            if status.highest_block_num.0 <= block_num {
+                                status.highest_block_num = StarknetBlockNumber(block_num);
+                                status.highest_block_hash = block_hash;
+                            }
                         }
                     }
 


### PR DESCRIPTION
This PR fixes an issue with sync status updates. 

The issue is caused because we have a poll to update latest. However because current is updated for every block we sync, its possible that current would exceed latest if latest was only polled after.

Unfortunately, this doesn't fix this issue perfectly. There is still this possibility:
1. L2 reorg
2. latest poll catches this
3. latest (highest) is now moved to before current

Fixing this would require some more substantial re-design of how this works.