### PR TITLE
fix: wrong default bind address in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ The following environment variables can be passed to the container:
 | ---------------------------------- | ------------------------------------------------------------ | ----------------- | -------- |
 | PATHFINDER_ETHEREUM_API_URL        | Ethereum full node JSON-RPC endpoint URL                     |                   | yes      |
 | PATHFINDER_ETHEREUM_API_PASSWORD   | Password to use during authentication with Ethereum node API |                   | no       |
-| PATHFINDER_HTTP_RPC_ADDRESS        | Address to bind the `pathfinder` RPC server to               | 0.0.0.0:9545      | no       |
+| PATHFINDER_HTTP_RPC_ADDRESS        | Address to bind the `pathfinder` RPC server to               | 127.0.0.1.9545    | no       |
 | PATHFINDER_DATA_DIRECTORY          | Directory used to store `pathfinder` data                    | Current directory | no       |
 
 ### Updating the docker image


### PR DESCRIPTION
Real default is at https://github.com/eqlabs/pathfinder/blob/c04d0a6b6af204164ba6971b528890c633a58244/crates/pathfinder/src/config.rs#L11