### PR TITLE
test: make the request_timeout test faster

### DIFF
--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -57,6 +57,7 @@ pretty_assertions = "1.0.0"
 tempfile = "3"
 # log crate should be handled through tracing-subscriber if needed
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
+tokio = { version = "1.11.0", features = ["test-util"] }
 warp = "0.3.2"
 
 [build-dependencies]

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -1603,7 +1603,7 @@ mod tests {
             );
         }
 
-        #[test_log::test(tokio::test)]
+        #[tokio::test(flavor = "current_thread", start_paused = true)]
         async fn request_timeout() {
             use std::sync::atomic::{AtomicUsize, Ordering};
 


### PR DESCRIPTION
Use auto advancing time in tokio to speed up a test.
Duplicated dependency for prod and test albeit with a different feature set is possible due to [using resolver 2](https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2).