### PR TITLE
update docker base images, less copying more packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 ########################################
 FROM rust:1.61-alpine AS rust-builder
 
+RUN apk upgrade --no-cache
 RUN apk add --no-cache musl-dev gcc openssl-dev
 
 WORKDIR /usr/src/pathfinder
@@ -41,6 +42,7 @@ RUN RUSTFLAGS='-L/usr/lib -Ctarget-feature=-crt-static' cargo build --release -p
 #######################################
 FROM python:3.8-alpine AS python-builder
 
+RUN apk upgrade --no-cache
 RUN apk add --no-cache gcc musl-dev gmp-dev g++
 
 WORKDIR /usr/share/pathfinder
@@ -60,6 +62,7 @@ RUN find ${PY_PATH} -type f -a -name '*.pyo' -exec rm -rf '{}' +
 #######################
 FROM python:3.8-alpine AS runner
 
+RUN apk upgrade --no-cache
 RUN apk add --no-cache tini gmp libstdc++ libgcc
 
 COPY --from=rust-builder /usr/src/pathfinder/target/release/pathfinder /usr/local/bin/pathfinder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,13 @@
+# when developing this file, you might want to start by creating a copy of this
+# file away from the source tree and then editing that, finally committing a
+# changed version of this file. editing this file will render most of the
+# layers unusable.
+#
+# our build process requires that all files are copied for the rust build,
+# which uses `git describe --tags` to determine the build identifier.
+# Dockerfile cannot be .dockerignore'd because of this as it would produce a
+# false dirty flag.
+
 ########################################
 # Stage 1: Build the pathfinder binary #
 ########################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,9 +60,8 @@ RUN find ${PY_PATH} -type f -a -name '*.pyo' -exec rm -rf '{}' +
 #######################
 FROM python:3.8-alpine AS runner
 
-RUN apk add --no-cache tini
+RUN apk add --no-cache tini gmp libstdc++ libgcc
 
-COPY --from=rust-builder ["/usr/lib/libstdc++.so.6", "/usr/lib/libgcc_s.so.1", "/usr/lib/libgmp.so.10", "/usr/lib/" ]
 COPY --from=rust-builder /usr/src/pathfinder/target/release/pathfinder /usr/local/bin/pathfinder
 COPY --from=python-builder /usr/local/lib/python3.8/ /usr/local/lib/python3.8/
 

--- a/crates/pathfinder/rpc_examples.sh
+++ b/crates/pathfinder/rpc_examples.sh
@@ -67,6 +67,21 @@ rpc_call '[{"jsonrpc":"2.0","id":"34","method":"starknet_call","params":[{"calld
 {"jsonrpc":"2.0","id":"35","method":"starknet_call","params":[{"calldata":["0x1234"],"contract_address":"0x6fbd460228d843b7fbef670ff15607bf72e19fa94de21e29811ada167b4ca39",
 "entry_point_selector":"0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320"}, "pending"]}]'
 
+# smoke test call on first block of goerli, should return 0x22b; same as examples/call_against_sequencer.rs example.
+rpc_call '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "starknet_call",
+    "params": {
+        "request": {
+            "calldata": ["0x5"],
+            "contract_address": "0x019245f0f49d23f2379d3e3f20d1f3f46207d1c4a1d09cac8dd50e8d528aabe1",
+            "entry_point_selector": "0x026813d396fdb198e9ead934e4f7a592a8b88a059e45ab0eb6ee53494e8d45b0"
+        },
+        "block_hash": "0x7d328a71faf48c5c3857e99f20a77b18522480956d1cd5bff1ff2df3c8b427b"
+    }
+}'
+
 rpc_call '{"jsonrpc":"2.0","id":"36","method":"starknet_blockNumber"}'
 
 rpc_call '{


### PR DESCRIPTION
And add notes on how to develop the dockerfile without having layers trashed all of the time.

I am not 100% sure if all upgrades are needed, but I can't think of an argument why they shouldn't be there. Caching is of course one.