### PR TITLE
fix: add max-parallelism to docker file

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,10 @@ jobs:
           platforms: all
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
+        config-inline: |
+            [worker.oci]
+              max-parallelism = 1
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
This PR is an attempt to fix the issue with `buildx` being a massive resource hog.

It adds a `config-inline` directive to the buildx action which adds a `max-parallelism` value of `1`.

Note that we may want to consider upgrading to the v2 version of the action when either time allows or necessity demands.