### PR TITLE
Track and expose metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,6 +584,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+dependencies = [
+ "cfg-if",
+ "num_cpus",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1961,6 +1971,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "dashmap",
+ "fnv",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project",
+ "rand",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry-prometheus"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9328977e479cebe12ce0d3fcecdaea4721d234895a9440c5b5dfd113f0594ac6"
+dependencies = [
+ "opentelemetry",
+ "prometheus",
+ "protobuf",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,6 +2117,8 @@ dependencies = [
  "lazy_static",
  "mockall",
  "num-bigint 0.4.3",
+ "opentelemetry",
+ "opentelemetry-prometheus",
  "pretty_assertions",
  "r2d2",
  "r2d2_sqlite",
@@ -2291,6 +2337,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cface98dfa6d645ea4c789839f176e4b072265d085bfcc48eaa8d137f58d3c39"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.12.0",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
 name = "prost"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2342,6 +2403,12 @@ dependencies = [
  "bytes",
  "prost",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
 
 [[package]]
 name = "psl-types"

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -30,6 +30,8 @@ hex = "0.4.3"
 jsonrpsee = { version = "0.11.0", features = ["server"] }
 lazy_static = "1.4.0"
 num-bigint = { version = "0.4.3", features = ["serde"] }
+opentelemetry = { version = "0.17.0", features = ["metrics", "rt-tokio"] }
+opentelemetry-prometheus = { version = "0.10.0", features = ["prometheus-encoding"] }
 r2d2 = "0.8.9"
 r2d2_sqlite = "0.20.0"
 reqwest = { version = "0.11.4", features = ["json"] }
@@ -47,6 +49,7 @@ tokio-retry = "0.3.0"
 toml = "0.5.8"
 tracing = "0.1.31"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
+warp = "0.3.2"
 web3 = "0.18.0"
 zstd = "0.10"
 

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -19,6 +19,8 @@ pub enum ConfigOption {
     EthereumPassword,
     /// The HTTP-RPC listening socket address.
     HttpRpcAddress,
+    /// The metrics listening socket address.
+    MetricsAddress,
     /// Path to the node's data directory.
     DataDirectory,
     /// The Sequencer's HTTP URL.
@@ -41,6 +43,7 @@ impl Display for ConfigOption {
             ConfigOption::EnableSQLiteWriteAheadLogging => {
                 f.write_str("Enable SQLite write-ahead logging")
             }
+            ConfigOption::MetricsAddress => f.write_str("metrics socket address"),
         }
     }
 }
@@ -61,6 +64,8 @@ pub struct Configuration {
     pub ethereum: EthereumConfig,
     /// The HTTP-RPC listening address and port.
     pub http_rpc_addr: SocketAddr,
+    /// The metrics listening address and port.
+    pub metrics_addr: Option<SocketAddr>,
     /// The node's data directory.
     pub data_directory: PathBuf,
     /// The Sequencer's HTTP URL.

--- a/crates/pathfinder/src/config/builder.rs
+++ b/crates/pathfinder/src/config/builder.rs
@@ -129,12 +129,24 @@ Hint: Register your own account or run your own Ethereum node and put the real U
             )
         })?;
 
+        let metrics_addr = self
+            .take(ConfigOption::MetricsAddress)
+            .map(|a| a.parse::<SocketAddr>())
+            .transpose()
+            .map_err(|err| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("Invalid metrics listening interface and port: {}", err),
+                )
+            })?;
+
         Ok(Configuration {
             ethereum: EthereumConfig {
                 url: eth_url,
                 password: eth_password,
             },
             http_rpc_addr,
+            metrics_addr,
             data_directory,
             sequencer_url,
             python_subprocesses,

--- a/crates/pathfinder/src/lib.rs
+++ b/crates/pathfinder/src/lib.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod consts;
 pub mod core;
 pub mod ethereum;
+pub mod observability;
 pub mod retry;
 pub mod rpc;
 pub mod sequencer;

--- a/crates/pathfinder/src/observability.rs
+++ b/crates/pathfinder/src/observability.rs
@@ -1,0 +1,70 @@
+use futures::Future;
+use opentelemetry_prometheus::{Encoder, PrometheusExporter, TextEncoder};
+use std::net::SocketAddr;
+use std::pin::Pin;
+use warp::http::Response as HttpResponse;
+use warp::hyper::StatusCode;
+use warp::Filter;
+
+type ServerFuture = Pin<Box<dyn Future<Output = ()>>>;
+
+pub fn init_prometheus_exporter() -> PrometheusExporter {
+    // Set default histogram boundaries to something more useful.
+    // The opentelemetry_prometheus crate does not allow to set buckets
+    // for each metric individually but in pathfinder's case all
+    // value recorders are used to measure request latencies.
+    //
+    // The buckets where chosen based on real-world measured latencies.
+    opentelemetry_prometheus::exporter()
+        .with_default_histogram_boundaries(vec![10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 3000.0, 5000.0])
+        .init()
+}
+
+/// Run metrics server if `addr` is specified.
+pub fn run_server(
+    addr: Option<SocketAddr>,
+    exporter: PrometheusExporter,
+) -> anyhow::Result<(ServerFuture, Option<SocketAddr>)> {
+    if let Some(addr) = addr {
+        let readyz = warp::path!("readyz").and(warp::get()).map({
+            move || {
+                HttpResponse::builder()
+                    .status(StatusCode::OK)
+                    .body("ok")
+                    .unwrap()
+            }
+        });
+
+        let livez = warp::path!("livez").and(warp::get()).map({
+            move || {
+                HttpResponse::builder()
+                    .status(StatusCode::OK)
+                    .body("ok")
+                    .unwrap()
+            }
+        });
+        let metrics = warp::path!("metrics").and(warp::get()).map({
+            move || {
+                let mut buffer = Vec::new();
+                let encoder = TextEncoder::new();
+                let metric_families = exporter.registry().gather();
+                if let Err(err) = encoder.encode(&metric_families, &mut buffer) {
+                    return HttpResponse::builder()
+                        .status(StatusCode::INTERNAL_SERVER_ERROR)
+                        .body(err.to_string().into_bytes())
+                        .unwrap();
+                }
+                HttpResponse::builder()
+                    .status(StatusCode::OK)
+                    .body(buffer)
+                    .unwrap()
+            }
+        });
+
+        let (bind_addr, server) = warp::serve(livez.or(readyz).or(metrics)).bind_ephemeral(addr);
+        Ok((Box::pin(server), Some(bind_addr)))
+    } else {
+        let do_nothing = Box::pin(std::future::pending::<()>());
+        Ok((do_nothing, None))
+    }
+}

--- a/crates/pathfinder/src/rpc/metrics.rs
+++ b/crates/pathfinder/src/rpc/metrics.rs
@@ -1,0 +1,67 @@
+use std::time::Instant;
+
+use jsonrpsee::core::middleware::Middleware;
+use opentelemetry::{
+    global,
+    metrics::{Counter, ValueRecorder},
+    KeyValue,
+};
+
+#[derive(Clone)]
+/// Track rpc-related metrics
+pub struct RpcMetricsMiddleware {
+    call_count: Counter<u64>,
+    call_error_count: Counter<u64>,
+    call_duration: ValueRecorder<u64>,
+}
+
+impl RpcMetricsMiddleware {
+    pub fn new() -> RpcMetricsMiddleware {
+        let meter = global::meter("rpc");
+        let call_count = meter
+            .u64_counter("rpc.call_count")
+            .with_description("Number of times the RPC method is called")
+            .init();
+        let call_error_count = meter
+            .u64_counter("rpc.call_error_count")
+            .with_description("Number of times the RPC method returns an error")
+            .init();
+        let call_duration = meter
+            .u64_value_recorder("rpc.call_duration")
+            .with_description("Duration (in ms) required to server the RPC call")
+            .init();
+
+        RpcMetricsMiddleware {
+            call_count,
+            call_error_count,
+            call_duration,
+        }
+    }
+}
+
+impl Default for RpcMetricsMiddleware {
+    fn default() -> Self {
+        RpcMetricsMiddleware::new()
+    }
+}
+
+impl Middleware for RpcMetricsMiddleware {
+    type Instant = Instant;
+
+    fn on_request(&self) -> Self::Instant {
+        Instant::now()
+    }
+
+    fn on_result(&self, name: &str, success: bool, started_at: Self::Instant) {
+        let mut attributes = vec![KeyValue::new("method", name.to_string())];
+        self.call_count.add(1, &attributes);
+        if !success {
+            self.call_error_count.add(1, &attributes);
+            attributes.push(KeyValue::new("status", "ERROR"));
+        } else {
+            attributes.push(KeyValue::new("status", "SUCCESS"));
+        }
+        let millis = started_at.elapsed().as_millis();
+        self.call_duration.record(millis as u64, &attributes);
+    }
+}

--- a/crates/pathfinder/src/state/sync/metrics.rs
+++ b/crates/pathfinder/src/state/sync/metrics.rs
@@ -1,0 +1,188 @@
+use super::l2::Timings;
+use opentelemetry::{
+    global,
+    metrics::{Counter, Meter, ValueRecorder},
+};
+use std::time::Duration;
+
+/// Track sync-related metrics.
+pub struct SyncMetrics {
+    pub l1: L1Metrics,
+    pub l2: L2Metrics,
+}
+
+pub struct L1Metrics {
+    updates_count: Counter<u64>,
+    reorgs_count: Counter<u64>,
+    query_updates_count: Counter<u64>,
+    restarts_count: Counter<u64>,
+}
+
+pub struct L2Metrics {
+    updates_count: Counter<u64>,
+    reorgs_count: Counter<u64>,
+    new_contracts_count: Counter<u64>,
+    restarts_count: Counter<u64>,
+    hash_queries_count: Counter<u64>,
+    contract_existance_queries_count: Counter<u64>,
+    block_time_duration: ValueRecorder<f64>,
+    block_download_time_duration: ValueRecorder<f64>,
+    state_diff_time_duration: ValueRecorder<f64>,
+    contract_deployment_time_duration: ValueRecorder<f64>,
+    storage_updates_count: Counter<u64>,
+}
+
+impl SyncMetrics {
+    pub fn new() -> SyncMetrics {
+        let meter = global::meter("sync");
+        let l1 = L1Metrics::new(&meter);
+        let l2 = L2Metrics::new(&meter);
+        SyncMetrics { l1, l2 }
+    }
+}
+
+impl L1Metrics {
+    pub fn new(meter: &Meter) -> L1Metrics {
+        let updates_count = meter
+            .u64_counter("l1.updates_count")
+            .with_description("Number of l1 reorgs")
+            .init();
+        let reorgs_count = meter
+            .u64_counter("l1.reorgs_count")
+            .with_description("Number of L1 reorgs")
+            .init();
+        let query_updates_count = meter
+            .u64_counter("l1.query_updates_count")
+            .with_description("Number of L1 query updates")
+            .init();
+        let restarts_count = meter
+            .u64_counter("l1.restarts_count")
+            .with_description("Number of L1 restarts")
+            .init();
+        L1Metrics {
+            updates_count,
+            reorgs_count,
+            query_updates_count,
+            restarts_count,
+        }
+    }
+
+    pub fn add_updates(&self, count: u64) {
+        self.updates_count.add(count, &[]);
+    }
+
+    pub fn inc_reorgs(&self) {
+        self.reorgs_count.add(1, &[]);
+    }
+
+    pub fn inc_query_updates(&self) {
+        self.query_updates_count.add(1, &[]);
+    }
+
+    pub fn inc_restarts(&self) {
+        self.restarts_count.add(1, &[]);
+    }
+}
+
+impl L2Metrics {
+    pub fn new(meter: &Meter) -> L2Metrics {
+        let updates_count = meter
+            .u64_counter("l2.updates_count")
+            .with_description("Number of StarkNet updates")
+            .init();
+        let reorgs_count = meter
+            .u64_counter("l2.reorgs_count")
+            .with_description("Number of StarkNet reorgs")
+            .init();
+        let new_contracts_count = meter
+            .u64_counter("l2.new_contracts_count")
+            .with_description("Number of new StarkNet contracts")
+            .init();
+        let hash_queries_count = meter
+            .u64_counter("l2.hash_queries_count")
+            .with_description("Number of StarkNet hash queries")
+            .init();
+        let contract_existance_queries_count = meter
+            .u64_counter("l2.contract_existance_queries_count")
+            .with_description("Number of StarkNet contract existance queries")
+            .init();
+        let restarts_count = meter
+            .u64_counter("l2.restarts_count")
+            .with_description("Number of StarkNet restarts")
+            .init();
+        let block_time_duration = meter
+            .f64_value_recorder("l2.block_time_duration")
+            .with_description("Time (in ms) between two StarkNet blocks")
+            .init();
+        let block_download_time_duration = meter
+            .f64_value_recorder("l2.block_download_time_duration")
+            .with_description("Time (in ms) spent downloading StarkNet blocks")
+            .init();
+        let contract_deployment_time_duration = meter
+            .f64_value_recorder("l2.contract_deployment_time_duration")
+            .with_description("Time (in ms) spent deploying StarkNet contracts")
+            .init();
+        let state_diff_time_duration = meter
+            .f64_value_recorder("l2.state_diff_time_duration")
+            .with_description("Time (in ms) spent computing StarkNet state diff")
+            .init();
+        let storage_updates_count = meter
+            .u64_counter("l2.storage_updates_duration")
+            .with_description("Number (in ms) of StarkNet storage updates")
+            .init();
+        L2Metrics {
+            updates_count,
+            reorgs_count,
+            new_contracts_count,
+            hash_queries_count,
+            contract_existance_queries_count,
+            restarts_count,
+            block_time_duration,
+            block_download_time_duration,
+            state_diff_time_duration,
+            contract_deployment_time_duration,
+            storage_updates_count,
+        }
+    }
+
+    pub fn inc_updates(&self) {
+        self.updates_count.add(1, &[]);
+    }
+
+    pub fn inc_reorgs(&self) {
+        self.reorgs_count.add(1, &[]);
+    }
+
+    pub fn inc_new_contracts(&self) {
+        self.new_contracts_count.add(1, &[]);
+    }
+
+    pub fn inc_hash_queries(&self) {
+        self.hash_queries_count.add(1, &[]);
+    }
+
+    pub fn inc_contract_existance_queries(&self) {
+        self.contract_existance_queries_count.add(1, &[]);
+    }
+
+    pub fn inc_restarts(&self) {
+        self.restarts_count.add(1, &[]);
+    }
+
+    pub fn record_block_time(&self, time: &Duration) {
+        self.block_time_duration.record(time.as_secs_f64(), &[]);
+    }
+
+    pub fn record_timings(&self, timings: &Timings) {
+        self.block_download_time_duration
+            .record(timings.block_download.as_secs_f64(), &[]);
+        self.state_diff_time_duration
+            .record(timings.state_diff_download.as_secs_f64(), &[]);
+        self.contract_deployment_time_duration
+            .record(timings.contract_deployment.as_secs_f64(), &[]);
+    }
+
+    pub fn record_storage_updates(&self, count: usize) {
+        self.storage_updates_count.add(count as u64, &[]);
+    }
+}


### PR DESCRIPTION
I added a way to track and expose metrics. Users can decide to run the service by specifying the metrics socket address (e.g. `--metrics=0.0.0.0:7060`).
The metrics server exposes 3 pages:

 - `/readyz` which is the ready check page. At the moment it doesn't do much but in a future PR I will add proper startup checks.
 - `/livez` which is the liveness check page. Like the other page, in the future it will check on other modules to see if they're working correctly.
 - `/metrics` which is the prometheus metrics page.﻿

At the moment the metrics tracked are related tothe sync service and the rpc api.
