### PR TITLE
Rename `ContractHash` to `ClassHash`

### DIFF
--- a/crates/load-test/src/main.rs
+++ b/crates/load-test/src/main.rs
@@ -1,7 +1,7 @@
 //! Load test for pathfinder JSON-RPC endpoints.
 //!
 //! This program expects a mainnet pathfinder node synced until block 1800,
-//! since it contains references to transactions and contract hashes on mainnet.
+//! since it contains references to transactions and contract addresses on mainnet.
 //!
 //! Running the load test:
 //! ```

--- a/crates/pathfinder/examples/compute_class_hash.rs
+++ b/crates/pathfinder/examples/compute_class_hash.rs
@@ -2,8 +2,10 @@ use std::io::Read;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     if std::env::args().count() != 1 {
-        println!("compute_contract_hash -- reads from stdin, outputs a contract hash");
-        println!("the input read from stdin is expected to be a contract definition, which is a json blob.");
+        println!("compute_class_hash -- reads from stdin, outputs a class hash");
+        println!(
+            "the input read from stdin is expected to be a class definition, which is a json blob."
+        );
         std::process::exit(1);
     }
     let mut s = Vec::new();

--- a/crates/pathfinder/examples/compute_contract_hash.rs
+++ b/crates/pathfinder/examples/compute_contract_hash.rs
@@ -9,6 +9,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut s = Vec::new();
     std::io::stdin().read_to_end(&mut s).unwrap();
     let s = s;
-    println!("{:x}", pathfinder_lib::state::compute_contract_hash(&s)?.0);
+    println!("{:x}", pathfinder_lib::state::compute_class_hash(&s)?.0);
     Ok(())
 }

--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -249,7 +249,7 @@ mod tests {
         .unwrap();
 
         let (abi, bytecode, hash) =
-            crate::state::contract_hash::extract_abi_code_hash(&*contract_definition).unwrap();
+            crate::state::class_hash::extract_abi_code_hash(&*contract_definition).unwrap();
 
         assert_eq!(hash.0, expected_hash);
 

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -47,7 +47,7 @@ impl EntryPoint {
     /// See: <https://starknet.io/documentation/contracts/#function_selector>
     pub fn hashed(input: &[u8]) -> Self {
         use sha3::Digest;
-        EntryPoint(crate::state::contract_hash::truncated_keccak(
+        EntryPoint(crate::state::class_hash::truncated_keccak(
             <[u8; 32]>::from(sha3::Keccak256::digest(input)),
         ))
     }

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -10,25 +10,17 @@ use web3::types::{H128, H160, H256};
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
 pub struct ContractAddress(pub StarkHash);
 
-/// The hash of a StarkNet class.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
-pub struct ClassHash(pub StarkHash);
-
 /// The salt of a StarkNet contract address.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize, PartialOrd, Ord)]
 pub struct ContractAddressSalt(pub StarkHash);
 
-/// A StarkNet contract's hash. This is a hash over a contract's
+/// The hash of a StarkNet contract. This is a hash over a class'
 /// deployment properties e.g. code and ABI.
-///
-/// Not to be confused with [ContractStateHash].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
-pub struct ContractHash(pub StarkHash);
+pub struct ClassHash(pub StarkHash);
 
 /// A StarkNet contract's state hash. This is the value stored
 /// in the global state tree.
-///
-/// Not to be confused with [ContractHash].
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ContractStateHash(pub StarkHash);
 
@@ -64,7 +56,7 @@ impl EntryPoint {
 /// Offset of an entry point into the bytecode of a StarkNet contract.
 ///
 /// This is a StarkHash because we use it directly for computing the
-/// contract hashes.
+/// class hashes.
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ByteCodeOffset(pub StarkHash);
 

--- a/crates/pathfinder/src/ethereum/state_update.rs
+++ b/crates/pathfinder/src/ethereum/state_update.rs
@@ -6,7 +6,7 @@ use retrieve::*;
 use stark_hash::StarkHash;
 
 use crate::{
-    core::{ContractAddress, ContractHash, StorageAddress, StorageValue},
+    core::{ClassHash, ContractAddress, StorageAddress, StorageValue},
     ethereum::{
         log::StateUpdateLog,
         state_update::{parse::StateUpdateParser, retrieve::retrieve_transition_fact},
@@ -19,7 +19,7 @@ use crate::{
 #[derive(Debug, Clone, PartialEq)]
 pub struct DeployedContract {
     pub address: ContractAddress,
-    pub hash: ContractHash,
+    pub hash: ClassHash,
     pub call_data: Vec<StarkHash>,
 }
 
@@ -150,7 +150,7 @@ mod tests {
         let expected = StateUpdate {
             deployed_contracts: vec![DeployedContract {
                 address: ContractAddress(StarkHash::from_hex_str("6CF1C6DCA6DE4CE15DB3EB7AEE1C6191537C82E2F2DE22FE4426199EE50E9A").unwrap()),
-                hash: ContractHash(StarkHash::from_hex_str("484DE75F165C844F9D8C5B07A7D1A650A476815DC7A061126FD41BB998C043D").unwrap()),
+                hash: ClassHash(StarkHash::from_hex_str("484DE75F165C844F9D8C5B07A7D1A650A476815DC7A061126FD41BB998C043D").unwrap()),
                 call_data: vec![StarkHash::from_hex_str("5D7C088BB051DB0A4C5A9C435A2009E2A82EE896080DDF4E6E953770F313EAF").unwrap()],
             }],
             contract_updates: vec![

--- a/crates/pathfinder/src/ethereum/state_update/parse.rs
+++ b/crates/pathfinder/src/ethereum/state_update/parse.rs
@@ -5,7 +5,7 @@ use stark_hash::StarkHash;
 use web3::types::U256;
 
 use crate::{
-    core::{ContractAddress, ContractHash, StorageAddress, StorageValue},
+    core::{ClassHash, ContractAddress, StorageAddress, StorageValue},
     ethereum::state_update::{ContractUpdate, DeployedContract, StateUpdate, StorageUpdate},
 };
 
@@ -64,9 +64,9 @@ impl StateUpdateParser {
 
             let hash = deployment_data
                 .next()
-                .context("Deployed contract hash missing")?;
-            let hash = parse_starkhash(hash).context("Parsing contract hash")?;
-            let hash = ContractHash(hash);
+                .context("Deployed class hash missing")?;
+            let hash = parse_starkhash(hash).context("Parsing class hash")?;
+            let hash = ClassHash(hash);
 
             let num_constructor_args = deployment_data
                 .next()
@@ -270,7 +270,7 @@ mod tests {
     fn deployed_contract() -> DeployedContract {
         DeployedContract {
             address: ContractAddress(StarkHash::from_hex_str("45691").unwrap()),
-            hash: ContractHash(StarkHash::from_hex_str("22513").unwrap()),
+            hash: ClassHash(StarkHash::from_hex_str("22513").unwrap()),
             call_data: vec![
                 StarkHash::from_hex_str("1").unwrap(),
                 StarkHash::from_hex_str("2").unwrap(),

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -322,7 +322,7 @@ mod tests {
     use super::*;
     use crate::{
         core::{
-            ContractAddress, ContractHash, EventData, EventKey, GasPrice, GlobalRoot,
+            ClassHash, ContractAddress, EventData, EventKey, GasPrice, GlobalRoot,
             SequencerAddress, StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp,
             StarknetProtocolVersion, StorageAddress,
         },
@@ -392,8 +392,8 @@ mod tests {
         let contract0_addr = ContractAddress(StarkHash::from_be_slice(b"contract 0").unwrap());
         let contract1_addr = ContractAddress(StarkHash::from_be_slice(b"contract 1").unwrap());
 
-        let contract0_hash = ContractHash(StarkHash::from_be_slice(b"contract 0 hash").unwrap());
-        let contract1_hash = ContractHash(StarkHash::from_be_slice(b"contract 1 hash").unwrap());
+        let class0_hash = ClassHash(StarkHash::from_be_slice(b"class 0 hash").unwrap());
+        let class1_hash = ClassHash(StarkHash::from_be_slice(b"class 1 hash").unwrap());
 
         let contract0_update = ContractUpdate {
             address: contract0_addr,
@@ -422,16 +422,16 @@ mod tests {
             abi: zstd_magic.clone(),
             bytecode: zstd_magic.clone(),
             definition: zstd_magic,
-            hash: contract0_hash,
+            hash: class0_hash,
         };
         let mut contract1_code = contract0_code.clone();
-        contract1_code.hash = contract1_hash;
+        contract1_code.hash = class1_hash;
 
         ContractCodeTable::insert_compressed(&db_txn, &contract0_code).unwrap();
         ContractCodeTable::insert_compressed(&db_txn, &contract1_code).unwrap();
 
-        ContractsTable::upsert(&db_txn, contract0_addr, contract0_hash).unwrap();
-        ContractsTable::upsert(&db_txn, contract1_addr, contract1_hash).unwrap();
+        ContractsTable::upsert(&db_txn, contract0_addr, class0_hash).unwrap();
+        ContractsTable::upsert(&db_txn, contract1_addr, class1_hash).unwrap();
 
         let mut global_tree = GlobalStateTree::load(&db_txn, GlobalRoot(StarkHash::ZERO)).unwrap();
         let contract_state_hash =

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -1631,8 +1631,7 @@ mod tests {
                 .unwrap();
 
                 let (abi, bytecode, hash) =
-                    crate::state::contract_hash::extract_abi_code_hash(&*contract_definition)
-                        .unwrap();
+                    crate::state::class_hash::extract_abi_code_hash(&*contract_definition).unwrap();
 
                 assert_eq!(hash.0, expected_hash);
 

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -447,7 +447,7 @@ pub mod reply {
 
     /// State update related substructures.
     pub mod state_update {
-        use crate::core::{ContractAddress, ContractHash, StorageAddress, StorageValue};
+        use crate::core::{ClassHash, ContractAddress, StorageAddress, StorageValue};
         use serde::{Deserialize, Serialize};
 
         /// L2 state diff.
@@ -472,7 +472,7 @@ pub mod reply {
         #[serde(deny_unknown_fields)]
         pub struct Contract {
             address: ContractAddress,
-            contract_hash: ContractHash,
+            contract_hash: ClassHash,
         }
     }
 

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -308,7 +308,7 @@ pub struct StateUpdate {
 
 /// Types used when deserializing state update related data.
 pub mod state_update {
-    use crate::core::{ContractAddress, ContractHash, StorageAddress, StorageValue};
+    use crate::core::{ClassHash, ContractAddress, StorageAddress, StorageValue};
     use serde::Deserialize;
     use serde_with::serde_as;
     use std::collections::HashMap;
@@ -336,7 +336,7 @@ pub mod state_update {
     #[serde(deny_unknown_fields)]
     pub struct Contract {
         pub address: ContractAddress,
-        pub contract_hash: ContractHash,
+        pub contract_hash: ClassHash,
     }
 }
 

--- a/crates/pathfinder/src/sequencer/request.rs
+++ b/crates/pathfinder/src/sequencer/request.rs
@@ -88,7 +88,7 @@ pub mod add_transaction {
     /// Definition of a contract.
     ///
     /// This is somewhat different compared to the contract definition we're using
-    /// for contract hash calculation. The actual program contents are not relevant
+    /// for class hash calculation. The actual program contents are not relevant
     /// for us, and they are sent as a gzip + base64 encoded string via the API.
     #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
     pub struct ContractDefinition {

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -9,13 +9,13 @@ use crate::{
     storage::{ContractsStateTable, ContractsTable},
 };
 
-pub(crate) mod contract_hash;
+pub(crate) mod class_hash;
 mod merkle_node;
 pub(crate) mod merkle_tree;
 pub(crate) mod state_tree;
 mod sync;
 
-pub use contract_hash::compute_class_hash;
+pub use class_hash::compute_class_hash;
 pub use sync::{l1, l2, sync, State as SyncState};
 
 #[derive(Clone, PartialEq)]

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -3,7 +3,7 @@ use rusqlite::Transaction;
 use stark_hash::{stark_hash, StarkHash};
 
 use crate::{
-    core::{ContractHash, ContractRoot, ContractStateHash},
+    core::{ClassHash, ContractRoot, ContractStateHash},
     ethereum::state_update::ContractUpdate,
     state::state_tree::{ContractsStateTree, GlobalStateTree},
     storage::{ContractsStateTable, ContractsTable},
@@ -15,7 +15,7 @@ pub(crate) mod merkle_tree;
 pub(crate) mod state_tree;
 mod sync;
 
-pub use contract_hash::compute_contract_hash;
+pub use contract_hash::compute_class_hash;
 pub use sync::{l1, l2, sync, State as SyncState};
 
 #[derive(Clone, PartialEq)]
@@ -23,7 +23,7 @@ pub struct CompressedContract {
     pub abi: Vec<u8>,
     pub bytecode: Vec<u8>,
     pub definition: Vec<u8>,
-    pub hash: ContractHash,
+    pub hash: ClassHash,
 }
 
 impl std::fmt::Debug for CompressedContract {
@@ -67,19 +67,19 @@ pub(crate) fn update_contract_state(
         .context("Apply contract storage tree changes")?;
 
     // Calculate contract state hash, update global state tree and persist pre-image.
-    let contract_hash = ContractsTable::get_hash(db, update.address)
-        .context("Read contract hash from contracts table")?
-        .context("Contract hash is missing from contracts table")?;
-    let contract_state_hash = calculate_contract_state_hash(contract_hash, new_contract_root);
+    let class_hash = ContractsTable::get_hash(db, update.address)
+        .context("Read class hash from contracts table")?
+        .context("Class hash is missing from contracts table")?;
+    let contract_state_hash = calculate_contract_state_hash(class_hash, new_contract_root);
 
-    ContractsStateTable::upsert(db, contract_state_hash, contract_hash, new_contract_root)
+    ContractsStateTable::upsert(db, contract_state_hash, class_hash, new_contract_root)
         .context("Insert constract state hash into contracts state table")?;
 
     Ok(contract_state_hash)
 }
 
 /// Calculates the contract state hash from its preimage.
-fn calculate_contract_state_hash(hash: ContractHash, root: ContractRoot) -> ContractStateHash {
+fn calculate_contract_state_hash(hash: ClassHash, root: ContractRoot) -> ContractStateHash {
     const RESERVED: StarkHash = StarkHash::ZERO;
     const CONTRACT_VERSION: StarkHash = StarkHash::ZERO;
 
@@ -96,7 +96,7 @@ fn calculate_contract_state_hash(hash: ContractHash, root: ContractRoot) -> Cont
 #[cfg(test)]
 mod tests {
     use super::{calculate_contract_state_hash, sync};
-    use crate::core::{ContractHash, ContractRoot, ContractStateHash};
+    use crate::core::{ClassHash, ContractRoot, ContractStateHash};
     use stark_hash::StarkHash;
 
     #[test]
@@ -111,7 +111,7 @@ mod tests {
             "02ff4903e17f87b298ded00c44bfeb22874c5f73be2ced8f1d9d9556fb509779",
         )
         .unwrap();
-        let hash = ContractHash(hash);
+        let hash = ClassHash(hash);
 
         let expected = StarkHash::from_hex_str(
             "07161b591c893836263a64f2a7e0d829c92f6956148a60ce5e99a3f55c7973f3",
@@ -135,7 +135,7 @@ mod tests {
 
         // let s = crate::storage::Storage::in_memory().unwrap();
 
-        // let contract_hash = ContractHash(StarkHash::from_hex_str("0x11").unwrap());
+        // let contract_hash = ClassHash(StarkHash::from_hex_str("0x11").unwrap());
         // let contract_addr = ContractAddress(StarkHash::from_hex_str("1").unwrap());
         // let contract_deploy = DeployedContract {
         //     address: contract_addr,
@@ -263,9 +263,9 @@ mod tests {
         // let s = crate::storage::Storage::in_memory().unwrap();
 
         // let shared_hash =
-        //     ContractHash(StarkHash::from_be_slice(&b"this is shared by multiple"[..]).unwrap());
+        //     ClassHash(StarkHash::from_be_slice(&b"this is shared by multiple"[..]).unwrap());
         // let unique_hash =
-        //     ContractHash(StarkHash::from_be_slice(&b"this is unique contract"[..]).unwrap());
+        //     ClassHash(StarkHash::from_be_slice(&b"this is unique contract"[..]).unwrap());
 
         // let one = ContractAddress(StarkHash::from_hex_str("1").unwrap());
         // let two = ContractAddress(StarkHash::from_hex_str("2").unwrap());

--- a/crates/pathfinder/src/state/class_hash.rs
+++ b/crates/pathfinder/src/state/class_hash.rs
@@ -438,7 +438,7 @@ mod json {
                 .await
                 .expect("Download contract from sequencer");
 
-            let _ = crate::state::contract_hash::compute_class_hash(&contract_definition)
+            let _ = super::super::compute_class_hash(&contract_definition)
                 .expect("Extract and compute  hash");
         }
 

--- a/crates/pathfinder/src/state/contract_hash.rs
+++ b/crates/pathfinder/src/state/contract_hash.rs
@@ -3,22 +3,22 @@ use serde::Serialize;
 use sha3::Digest;
 use stark_hash::{stark_hash, StarkHash};
 
-use crate::core::ContractHash;
+use crate::core::ClassHash;
 use crate::sequencer::request::contract::EntryPointType;
 
-/// Computes the starknet contract hash for given contract definition json blob.
+/// Computes the starknet class hash for given class definition json blob.
 ///
 /// The structure of the blob is not strictly defined, so it lives in privacy under `json` module
-/// of this module. The contract hash has [official documentation][starknet-doc] and [cairo-lang
+/// of this module. The class hash has [official documentation][starknet-doc] and [cairo-lang
 /// has an implementation][cairo-compute] which is half-python and half-[cairo][cairo-contract].
 ///
 /// Outline of the hashing is:
 ///
-/// 1. contract definition is serialized with python's [`sort_keys=True` option][py-sortkeys], then
+/// 1. class definition is serialized with python's [`sort_keys=True` option][py-sortkeys], then
 ///    a truncated Keccak256 hash is calculated of the serialized json
 /// 2. a hash chain construction out of [`stark_hash()`] is used to process in order the contract
 ///    entry points, builtins, the truncated keccak hash and bytecodes
-/// 3. each of the hashchains is hash chained together to produce a final contract hash
+/// 3. each of the hashchains is hash chained together to produce a final class hash
 ///
 /// Hash chain construction is explained at the [official documentation][starknet-doc], but it's
 /// text explanations are much more complex than the actual implementation in `HashChain`, which
@@ -28,37 +28,35 @@ use crate::sequencer::request::contract::EntryPointType;
 /// [cairo-compute]: https://github.com/starkware-libs/cairo-lang/blob/64a7f6aed9757d3d8d6c28bd972df73272b0cb0a/src/starkware/starknet/core/os/contract_hash.py
 /// [cairo-contract]: https://github.com/starkware-libs/cairo-lang/blob/64a7f6aed9757d3d8d6c28bd972df73272b0cb0a/src/starkware/starknet/core/os/contracts.cairo#L76-L118
 /// [py-sortkeys]: https://github.com/starkware-libs/cairo-lang/blob/64a7f6aed9757d3d8d6c28bd972df73272b0cb0a/src/starkware/starknet/core/os/contract_hash.py#L58-L71
-pub fn compute_contract_hash(contract_definition_dump: &[u8]) -> Result<ContractHash> {
+pub fn compute_class_hash(contract_definition_dump: &[u8]) -> Result<ClassHash> {
     let contract_definition =
         serde_json::from_slice::<json::ContractDefinition>(contract_definition_dump)
             .context("Failed to parse contract_definition")?;
 
-    compute_contract_hash0(contract_definition).context("Compute contract hash")
+    compute_class_hash0(contract_definition).context("Compute class hash")
 }
 
-/// Sibling functionality to only [`compute_contract_hash`], returning also the ABI, and bytecode
+/// Sibling functionality to only [`compute_class_hash`], returning also the ABI, and bytecode
 /// parts as json bytes.
 pub(crate) fn extract_abi_code_hash(
     contract_definition_dump: &[u8],
-) -> Result<(Vec<u8>, Vec<u8>, ContractHash)> {
+) -> Result<(Vec<u8>, Vec<u8>, ClassHash)> {
     let contract_definition =
         serde_json::from_slice::<json::ContractDefinition>(contract_definition_dump)
             .context("Failed to parse contract_definition")?;
 
-    // just in case we'd accidentially modify these in the compute_contract_hash0
+    // just in case we'd accidentially modify these in the compute_class_hash0
     let abi = serde_json::to_vec(&contract_definition.abi)
         .context("Serialize contract_definition.abi")?;
     let code = serde_json::to_vec(&contract_definition.program.data)
         .context("Serialize contract_definition.program.data")?;
 
-    let hash = compute_contract_hash0(contract_definition).context("Compute contract hash")?;
+    let hash = compute_class_hash0(contract_definition).context("Compute class hash")?;
 
     Ok((abi, code, hash))
 }
 
-fn compute_contract_hash0(
-    mut contract_definition: json::ContractDefinition<'_>,
-) -> Result<ContractHash> {
+fn compute_class_hash0(mut contract_definition: json::ContractDefinition<'_>) -> Result<ClassHash> {
     use EntryPointType::*;
 
     // the other modification is handled by skipping if the attributes vec is empty
@@ -119,7 +117,7 @@ fn compute_contract_hash0(
 
     // This wasn't in the docs, but similarly to contract_state hash, we start with this 0, so this
     // will yield outer == H(0, 0); However, dissimilarly to contract_state hash, we do include the
-    // number of items in this contract_hash.
+    // number of items in this class_hash.
     outer.update(API_VERSION);
 
     // It is important process the different entrypoint hashchains in correct order.
@@ -180,11 +178,11 @@ fn compute_contract_hash0(
 
     outer.update(bytecodes.finalize());
 
-    Ok(ContractHash(outer.finalize()))
+    Ok(ClassHash(outer.finalize()))
 }
 
 /// HashChain is the structure used over at cairo side to represent the hash construction needed
-/// for computing the contract hash.
+/// for computing the class hash.
 ///
 /// Empty hash chained value equals `H(0, 0)` where `H` is the [`stark_hash()`] function, and the
 /// second value is the number of values hashed together in this chain. For other values, the
@@ -230,7 +228,7 @@ pub(crate) fn truncated_keccak(mut plain: [u8; 32]) -> StarkHash {
 }
 
 /// `std::io::Write` adapter for Keccak256; we don't need the serialized version in
-/// compute_contract_hash, but we need the truncated_keccak hash.
+/// compute_class_hash, but we need the truncated_keccak hash.
 ///
 /// When debugging mismatching hashes, it might be useful to check the length of each before trying
 /// to find the wrongly serialized spot. Example length > 500kB.
@@ -398,7 +396,7 @@ mod json {
             // 500
             // {"code": "StarknetErrorCode.UNINITIALIZED_CONTRACT", "message": "Contract with address 2116724861677265616176388745625154424116334641142188761834194304782006389228 is not deployed."}
 
-            let hash = super::super::compute_contract_hash(payload.as_bytes()).unwrap();
+            let hash = super::super::compute_class_hash(payload.as_bytes()).unwrap();
 
             assert_eq!(hash.0, expected);
         }
@@ -411,7 +409,7 @@ mod json {
             )
             .unwrap();
 
-            let hash = super::super::compute_contract_hash(&contract_definition).unwrap();
+            let hash = super::super::compute_class_hash(&contract_definition).unwrap();
 
             assert_eq!(
                 hash.0,
@@ -440,16 +438,16 @@ mod json {
                 .await
                 .expect("Download contract from sequencer");
 
-            let _ = crate::state::contract_hash::compute_contract_hash(&contract_definition)
+            let _ = crate::state::contract_hash::compute_class_hash(&contract_definition)
                 .expect("Extract and compute  hash");
         }
 
         #[tokio::test]
         async fn cairo_0_8() {
-            // Cairo 0.8 update broke our contract hash calculation by adding new attribute fields (which
+            // Cairo 0.8 update broke our class hash calculation by adding new attribute fields (which
             // we now need to ignore if empty).
             use super::super::extract_abi_code_hash;
-            use crate::core::{ContractAddress, ContractHash};
+            use crate::core::{ClassHash, ContractAddress};
             use crate::sequencer::{self, ClientApi};
             use stark_hash::StarkHash;
 
@@ -461,7 +459,7 @@ mod json {
                 .unwrap(),
             );
 
-            let expected = ContractHash(
+            let expected = ClassHash(
                 StarkHash::from_hex_str(
                     "0x056b96c1d1bbfa01af44b465763d1b71150fa00c6c9d54c3947f57e979ff68c3",
                 )
@@ -486,7 +484,7 @@ mod json {
         fn serde_json_value_sorts_maps() {
             // this property is leaned on and the default implementation of serde_json works like
             // this. serde_json has a feature called "preserve_order" which could get enabled by
-            // accident, and it would destroy the ability to compute_contract_hash.
+            // accident, and it would destroy the ability to compute_class_hash.
 
             let input = r#"{"foo": 1, "bar": 2}"#;
             let parsed = serde_json::from_str::<serde_json::Value>(input).unwrap();

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -597,7 +597,7 @@ fn deploy_contract(
     ContractsStateTable::upsert(transaction, state_hash, contract.hash, contract_root)
         .context("Insert constract state hash into contracts state table")?;
     ContractsTable::upsert(transaction, contract.address, contract.hash)
-        .context("Inserting contract hash into contracts table")
+        .context("Inserting class hash into contracts table")
 }
 
 /// Interval at which poll for new data when at the head of chain.
@@ -623,10 +623,10 @@ mod tests {
     use super::{l1, l2};
     use crate::{
         core::{
-            CallSignatureElem, ConstructorParam, ContractAddress, ContractAddressSalt,
-            ContractHash, EthereumBlockHash, EthereumBlockNumber, EthereumLogIndex,
-            EthereumTransactionHash, EthereumTransactionIndex, Fee, GasPrice, GlobalRoot,
-            SequencerAddress, StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp,
+            CallSignatureElem, ClassHash, ConstructorParam, ContractAddress, ContractAddressSalt,
+            EthereumBlockHash, EthereumBlockNumber, EthereumLogIndex, EthereumTransactionHash,
+            EthereumTransactionIndex, Fee, GasPrice, GlobalRoot, SequencerAddress,
+            StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp,
             StarknetTransactionHash, StorageAddress, StorageValue, TransactionNonce,
             TransactionVersion,
         },
@@ -1245,7 +1245,7 @@ mod tests {
                 abi: zstd_magic.clone(),
                 bytecode: zstd_magic.clone(),
                 definition: zstd_magic,
-                hash: ContractHash(*A),
+                hash: ClassHash(*A),
             }))
             .await
             .unwrap();
@@ -1269,7 +1269,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(10)).await;
 
         assert_eq!(
-            storage::ContractCodeTable::exists(&connection, &[ContractHash(*A)]).unwrap(),
+            storage::ContractCodeTable::exists(&connection, &[ClassHash(*A)]).unwrap(),
             vec![true]
         );
     }
@@ -1322,7 +1322,7 @@ mod tests {
                 abi: zstd_magic.clone(),
                 bytecode: zstd_magic.clone(),
                 definition: zstd_magic,
-                hash: ContractHash(*A),
+                hash: ClassHash(*A),
             },
         )
         .unwrap();
@@ -1331,12 +1331,9 @@ mod tests {
         let l2 = |tx: mpsc::Sender<l2::Event>, _, _, _| async move {
             let (tx1, rx1) = tokio::sync::oneshot::channel::<Vec<bool>>();
 
-            tx.send(l2::Event::QueryContractExistance(
-                vec![ContractHash(*A)],
-                tx1,
-            ))
-            .await
-            .unwrap();
+            tx.send(l2::Event::QueryContractExistance(vec![ClassHash(*A)], tx1))
+                .await
+                .unwrap();
 
             // Check the result straight away ¯\_(ツ)_/¯
             assert_eq!(rx1.await.unwrap(), vec![true]);

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -11,7 +11,7 @@ use crate::sequencer::error::SequencerError;
 use crate::sequencer::reply::state_update::{Contract, StateDiff};
 use crate::sequencer::reply::Block;
 use crate::sequencer::{self};
-use crate::state::contract_hash::extract_abi_code_hash;
+use crate::state::class_hash::extract_abi_code_hash;
 use crate::state::CompressedContract;
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/pathfinder/src/storage/schema/revision_0002.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0002.rs
@@ -87,7 +87,7 @@ pub(crate) fn migrate(tx: &Transaction) -> anyhow::Result<PostMigrationAction> {
             let definition = r.get_ref_unwrap(0).as_blob()?;
             let raw_definition = zstd::decode_all(definition)?;
             let (abi, code, hash) =
-                crate::state::contract_hash::extract_abi_code_hash(&raw_definition).with_context(
+                crate::state::class_hash::extract_abi_code_hash(&raw_definition).with_context(
                     || format!("Failed to process {} bytes of definition", definition.len()),
                 )?;
 

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -5,7 +5,7 @@ use web3::types::H256;
 
 use crate::{
     core::{
-        ContractAddress, ContractHash, ContractRoot, ContractStateHash, EthereumBlockHash,
+        ClassHash, ContractAddress, ContractRoot, ContractStateHash, EthereumBlockHash,
         EthereumBlockNumber, EthereumLogIndex, EthereumTransactionHash, EthereumTransactionIndex,
         EventData, EventKey, GasPrice, GlobalRoot, SequencerAddress, StarknetBlockHash,
         StarknetBlockNumber, StarknetBlockTimestamp, StarknetTransactionHash,
@@ -918,7 +918,7 @@ pub struct StarknetBlock {
 /// Specifically it stores
 ///
 /// - [contract state hash](ContractStateHash)
-/// - [contract hash](ContractHash)
+/// - [class hash](ClassHash)
 /// - [contract root](ContractRoot)
 pub struct ContractsStateTable {}
 
@@ -927,7 +927,7 @@ impl ContractsStateTable {
     pub fn upsert(
         transaction: &Transaction,
         state_hash: ContractStateHash,
-        hash: ContractHash,
+        hash: ClassHash,
         root: ContractRoot,
     ) -> anyhow::Result<()> {
         transaction.execute(
@@ -989,7 +989,7 @@ mod tests {
             let transaction = connection.transaction().unwrap();
 
             let state_hash = ContractStateHash(StarkHash::from_hex_str("abc").unwrap());
-            let hash = ContractHash(StarkHash::from_hex_str("123").unwrap());
+            let hash = ClassHash(StarkHash::from_hex_str("123").unwrap());
             let root = ContractRoot(StarkHash::from_hex_str("def").unwrap());
 
             ContractsStateTable::upsert(&transaction, state_hash, hash, root).unwrap();

--- a/py/src/compute_class_hash.py
+++ b/py/src/compute_class_hash.py
@@ -1,5 +1,5 @@
-# reads stdin for a contract_definition json blob, writes a contract hash to stdout
-# example: python py/src/compute_contract_hash.py < contract_definition.json
+# reads stdin for a contract_definition json blob, writes a class hash to stdout
+# example: python py/src/compute_class_hash.py < class_definition.json
 
 from starkware.starknet.business_logic.state_objects import ContractDefinitionFact
 from starkware.starknet.services.api.contract_definition import ContractDefinition


### PR DESCRIPTION
`cairo-lang` 0.9.0 seems to have made this naming change. This PR renames ContractHash to ClassHash (and in general all references to contract hashes) so that we're consistent with the naming convention used by Starkware.