### PR TITLE
Add new methods to the sequencer client api

### DIFF
--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -113,14 +113,6 @@ pub struct StarknetTransactionHash(pub StarkHash);
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct StarknetTransactionIndex(pub u64);
 
-/// StarkNet transaction version.
-#[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
-pub struct StarknetTransactionVersion(pub u64);
-
-/// A StarkNet transaction nonce.
-#[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
-pub struct StarknetTransactionNonce(pub StarkHash);
-
 /// A single element of a signature used to secure a StarkNet transaction.
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct TransactionSignatureElem(pub StarkHash);
@@ -168,6 +160,10 @@ pub struct TransactionNonce(pub StarkHash);
 /// StarkNet transaction version.
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct TransactionVersion(pub H256);
+
+/// A StarkNet transaction nonce.
+#[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
+pub struct TransactionNonce(pub StarkHash);
 
 /// An Ethereum address.
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -113,6 +113,14 @@ pub struct StarknetTransactionHash(pub StarkHash);
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct StarknetTransactionIndex(pub u64);
 
+/// StarkNet transaction version.
+#[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
+pub struct StarknetTransactionVersion(pub u64);
+
+/// A StarkNet transaction nonce.
+#[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
+pub struct StarknetTransactionNonce(pub StarkHash);
+
 /// A single element of a signature used to secure a StarkNet transaction.
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct TransactionSignatureElem(pub StarkHash);

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -161,10 +161,6 @@ pub struct TransactionNonce(pub StarkHash);
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct TransactionVersion(pub H256);
 
-/// A StarkNet transaction nonce.
-#[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
-pub struct TransactionNonce(pub StarkHash);
-
 /// An Ethereum address.
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct EthereumAddress(pub H160);

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -498,16 +498,17 @@ mod tests {
             calldata: None,
             class_hash: None,
             constructor_calldata: None,
-            contract_address: contract0_addr,
+            contract_address: Some(contract0_addr),
             contract_address_salt: None,
             entry_point_type: None,
             entry_point_selector: None,
             max_fee: Some(Fee(H128::zero())),
+            nonce: None,
+            sender_address: None,
             signature: None,
             transaction_hash: txn0_hash,
-            sender_address: None,
-            nonce: None,
             r#type: Type::Deploy,
+            version: None,
         };
         let mut receipt0 = Receipt {
             actual_fee: None,
@@ -534,14 +535,14 @@ mod tests {
         let mut txn3 = txn0.clone();
         let mut txn4 = txn0.clone();
         txn1.transaction_hash = txn1_hash;
-        txn1.contract_address = contract1_addr;
+        txn1.contract_address = Some(contract1_addr);
         txn2.transaction_hash = txn2_hash;
-        txn2.contract_address = contract1_addr;
+        txn2.contract_address = Some(contract1_addr);
         txn3.transaction_hash = txn3_hash;
-        txn3.contract_address = contract1_addr;
+        txn3.contract_address = Some(contract1_addr);
         txn4.transaction_hash = txn4_hash;
 
-        txn4.contract_address = ContractAddress(StarkHash::ZERO);
+        txn4.contract_address = Some(ContractAddress(StarkHash::ZERO));
         let mut txn5 = txn4.clone();
         txn5.transaction_hash = txn5_hash;
         let mut receipt1 = receipt0.clone();
@@ -2217,20 +2218,21 @@ mod tests {
                 calldata: None,
                 class_hash: None,
                 constructor_calldata: None,
-                contract_address: ContractAddress(
+                contract_address: Some(ContractAddress(
                     StarkHash::from_hex_str(&"2".repeat(i + 3)).unwrap(),
-                ),
+                )),
                 contract_address_salt: None,
                 entry_point_type: None,
                 entry_point_selector: None,
+                max_fee: None,
+                nonce: None,
+                sender_address: None,
                 signature: None,
                 transaction_hash: StarknetTransactionHash(
                     StarkHash::from_hex_str(&"f".repeat(i + 3)).unwrap(),
                 ),
-                max_fee: None,
-                sender_address: None,
-                nonce: None,
                 r#type: transaction::Type::InvokeFunction,
+                version: None,
             });
             let receipts = (0..NUM_TRANSACTIONS).map(|i| transaction::Receipt {
                 actual_fee: None,

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -82,7 +82,7 @@ pub mod request {
         rpc::serde::H256AsNoLeadingZerosHexStr,
     };
     use serde::{Deserialize, Serialize};
-    use serde_with::{serde_as, skip_serializing_none};
+    use serde_with::serde_as;
     use web3::types::H256;
 
     /// The address of a storage element for a StarkNet contract.
@@ -121,7 +121,6 @@ pub mod request {
     }
 
     /// Contains event filter parameters passed to `starknet_getEvents`.
-    #[skip_serializing_none]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     #[serde(deny_unknown_fields)]
     pub struct EventFilter {
@@ -155,7 +154,7 @@ pub mod reply {
         sequencer,
     };
     use serde::{Deserialize, Serialize};
-    use serde_with::{serde_as, skip_serializing_none};
+    use serde_with::serde_as;
     use stark_hash::StarkHash;
     use std::convert::From;
 
@@ -211,7 +210,6 @@ pub mod reply {
 
     /// L2 Block as returned by the RPC API.
     #[serde_as]
-    #[skip_serializing_none]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     #[serde(deny_unknown_fields)]
     pub struct Block {
@@ -484,7 +482,6 @@ pub mod reply {
     ///
     /// `entry_point_selector` and `calldata` fields are available only
     /// for Invoke transactions.
-    #[skip_serializing_none]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     pub struct Transaction {
         pub txn_hash: StarknetTransactionHash,
@@ -521,7 +518,6 @@ pub mod reply {
     }
 
     /// L2 transaction receipt as returned by the RPC API.
-    #[skip_serializing_none]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     pub struct TransactionReceipt {
         pub txn_hash: StarknetTransactionHash,
@@ -633,7 +629,7 @@ pub mod reply {
 
     /// Used in [Block](crate::rpc::types::reply::Block) when the requested scope of
     /// reply is [BlockResponseScope::FullTransactionsAndReceipts](crate::rpc::types::request::BlockResponseScope).
-    #[skip_serializing_none]
+    #[serde_as]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     pub struct TransactionAndReceipt {
         pub txn_hash: StarknetTransactionHash,

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -481,16 +481,15 @@ pub mod reply {
     }
 
     /// L2 transaction as returned by the RPC API.
+    ///
+    /// `entry_point_selector` and `calldata` fields are available only
+    /// for Invoke transactions.
     #[skip_serializing_none]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     pub struct Transaction {
         pub txn_hash: StarknetTransactionHash,
         pub contract_address: ContractAddress,
-        /// Absent for [Deploy](crate::sequencer::reply::transaction::DeployTransaction) and
-        /// [Declare](crate::sequencer::reply::transaction::DeclareTransaction) transactions
         pub entry_point_selector: Option<EntryPoint>,
-        /// Absent for [Deploy](crate::sequencer::reply::transaction::DeployTransaction) and
-        /// [Declare](crate::sequencer::reply::transaction::DeclareTransaction) transactions
         pub calldata: Option<Vec<CallParam>>,
     }
 
@@ -503,7 +502,7 @@ pub mod reply {
                 .ok_or_else(|| anyhow::anyhow!("Transaction not found."))?;
             Ok(Self {
                 txn_hash: txn.transaction_hash,
-                contract_address: txn.contract_address,
+                contract_address: txn.source_address(),
                 entry_point_selector: txn.entry_point_selector,
                 calldata: txn.calldata,
             })
@@ -514,7 +513,7 @@ pub mod reply {
         fn from(txn: sequencer::reply::transaction::Transaction) -> Self {
             Self {
                 txn_hash: txn.transaction_hash,
-                contract_address: txn.contract_address,
+                contract_address: txn.source_address(),
                 entry_point_selector: txn.entry_point_selector,
                 calldata: txn.calldata,
             }

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -151,8 +151,7 @@ pub mod reply {
             StarknetBlockTimestamp, StarknetTransactionHash,
         },
         rpc::{api::RawBlock, serde::GasPriceAsHexStr},
-        sequencer::reply as seq,
-        sequencer::reply::Status as SeqStatus,
+        sequencer,
     };
     use serde::{Deserialize, Serialize};
     use serde_with::serde_as;
@@ -175,18 +174,18 @@ pub mod reply {
         Rejected,
     }
 
-    impl From<SeqStatus> for BlockStatus {
-        fn from(status: SeqStatus) -> Self {
+    impl From<sequencer::reply::Status> for BlockStatus {
+        fn from(status: sequencer::reply::Status) -> Self {
             match status {
                 // TODO verify this mapping with Starkware
-                SeqStatus::AcceptedOnL1 => BlockStatus::AcceptedOnL1,
-                SeqStatus::AcceptedOnL2 => BlockStatus::AcceptedOnL2,
-                SeqStatus::NotReceived => BlockStatus::Rejected,
-                SeqStatus::Pending => BlockStatus::Pending,
-                SeqStatus::Received => BlockStatus::Pending,
-                SeqStatus::Rejected => BlockStatus::Rejected,
-                SeqStatus::Reverted => BlockStatus::Rejected,
-                SeqStatus::Aborted => BlockStatus::Rejected,
+                sequencer::reply::Status::AcceptedOnL1 => BlockStatus::AcceptedOnL1,
+                sequencer::reply::Status::AcceptedOnL2 => BlockStatus::AcceptedOnL2,
+                sequencer::reply::Status::NotReceived => BlockStatus::Rejected,
+                sequencer::reply::Status::Pending => BlockStatus::Pending,
+                sequencer::reply::Status::Received => BlockStatus::Pending,
+                sequencer::reply::Status::Rejected => BlockStatus::Rejected,
+                sequencer::reply::Status::Reverted => BlockStatus::Rejected,
+                sequencer::reply::Status::Aborted => BlockStatus::Rejected,
             }
         }
     }
@@ -245,7 +244,10 @@ pub mod reply {
         }
 
         /// Constructs [Block] from [sequencer's block representation](crate::sequencer::reply::Block)
-        pub fn from_sequencer_scoped(block: seq::Block, scope: BlockResponseScope) -> Self {
+        pub fn from_sequencer_scoped(
+            block: sequencer::reply::Block,
+            scope: BlockResponseScope,
+        ) -> Self {
             Self {
                 block_hash: block.block_hash,
                 parent_hash: block.parent_block_hash,
@@ -487,10 +489,10 @@ pub mod reply {
         pub calldata: Option<Vec<CallParam>>,
     }
 
-    impl TryFrom<seq::Transaction> for Transaction {
+    impl TryFrom<sequencer::reply::Transaction> for Transaction {
         type Error = anyhow::Error;
 
-        fn try_from(txn: seq::Transaction) -> Result<Self, Self::Error> {
+        fn try_from(txn: sequencer::reply::Transaction) -> Result<Self, Self::Error> {
             let txn = txn
                 .transaction
                 .ok_or_else(|| anyhow::anyhow!("Transaction not found."))?;
@@ -503,8 +505,8 @@ pub mod reply {
         }
     }
 
-    impl From<seq::transaction::Transaction> for Transaction {
-        fn from(txn: seq::transaction::Transaction) -> Self {
+    impl From<sequencer::reply::transaction::Transaction> for Transaction {
+        fn from(txn: sequencer::reply::transaction::Transaction) -> Self {
             Self {
                 txn_hash: txn.transaction_hash,
                 contract_address: txn.contract_address,
@@ -526,7 +528,10 @@ pub mod reply {
     }
 
     impl TransactionReceipt {
-        pub fn with_status(receipt: seq::transaction::Receipt, status: BlockStatus) -> Self {
+        pub fn with_status(
+            receipt: sequencer::reply::transaction::Receipt,
+            status: BlockStatus,
+        ) -> Self {
             Self {
                 txn_hash: receipt.transaction_hash,
                 status: status.into(),
@@ -657,18 +662,18 @@ pub mod reply {
         Rejected,
     }
 
-    impl From<seq::Status> for TransactionStatus {
-        fn from(status: SeqStatus) -> Self {
+    impl From<sequencer::reply::Status> for TransactionStatus {
+        fn from(status: sequencer::reply::Status) -> Self {
             match status {
                 // TODO verify this mapping with Starkware
-                SeqStatus::AcceptedOnL1 => TransactionStatus::AcceptedOnL1,
-                SeqStatus::AcceptedOnL2 => TransactionStatus::AcceptedOnL2,
-                SeqStatus::NotReceived => TransactionStatus::Unknown,
-                SeqStatus::Pending => TransactionStatus::Pending,
-                SeqStatus::Received => TransactionStatus::Received,
-                SeqStatus::Rejected => TransactionStatus::Rejected,
-                SeqStatus::Reverted => TransactionStatus::Unknown,
-                SeqStatus::Aborted => TransactionStatus::Unknown,
+                sequencer::reply::Status::AcceptedOnL1 => TransactionStatus::AcceptedOnL1,
+                sequencer::reply::Status::AcceptedOnL2 => TransactionStatus::AcceptedOnL2,
+                sequencer::reply::Status::NotReceived => TransactionStatus::Unknown,
+                sequencer::reply::Status::Pending => TransactionStatus::Pending,
+                sequencer::reply::Status::Received => TransactionStatus::Received,
+                sequencer::reply::Status::Rejected => TransactionStatus::Rejected,
+                sequencer::reply::Status::Reverted => TransactionStatus::Unknown,
+                sequencer::reply::Status::Aborted => TransactionStatus::Unknown,
             }
         }
     }

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -82,7 +82,7 @@ pub mod request {
         rpc::serde::H256AsNoLeadingZerosHexStr,
     };
     use serde::{Deserialize, Serialize};
-    use serde_with::serde_as;
+    use serde_with::{serde_as, skip_serializing_none};
     use web3::types::H256;
 
     /// The address of a storage element for a StarkNet contract.
@@ -121,6 +121,7 @@ pub mod request {
     }
 
     /// Contains event filter parameters passed to `starknet_getEvents`.
+    #[skip_serializing_none]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     #[serde(deny_unknown_fields)]
     pub struct EventFilter {
@@ -154,7 +155,7 @@ pub mod reply {
         sequencer,
     };
     use serde::{Deserialize, Serialize};
-    use serde_with::serde_as;
+    use serde_with::{serde_as, skip_serializing_none};
     use stark_hash::StarkHash;
     use std::convert::From;
 
@@ -210,6 +211,7 @@ pub mod reply {
 
     /// L2 Block as returned by the RPC API.
     #[serde_as]
+    #[skip_serializing_none]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     #[serde(deny_unknown_fields)]
     pub struct Block {
@@ -479,13 +481,16 @@ pub mod reply {
     }
 
     /// L2 transaction as returned by the RPC API.
+    #[skip_serializing_none]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     pub struct Transaction {
         pub txn_hash: StarknetTransactionHash,
         pub contract_address: ContractAddress,
-        /// Absent for "deploy" transactions
+        /// Absent for [Deploy](crate::sequencer::reply::transaction::DeployTransaction) and
+        /// [Declare](crate::sequencer::reply::transaction::DeclareTransaction) transactions
         pub entry_point_selector: Option<EntryPoint>,
-        /// Absent for "deploy" transactions
+        /// Absent for [Deploy](crate::sequencer::reply::transaction::DeployTransaction) and
+        /// [Declare](crate::sequencer::reply::transaction::DeclareTransaction) transactions
         pub calldata: Option<Vec<CallParam>>,
     }
 
@@ -517,6 +522,7 @@ pub mod reply {
     }
 
     /// L2 transaction receipt as returned by the RPC API.
+    #[skip_serializing_none]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     pub struct TransactionReceipt {
         pub txn_hash: StarknetTransactionHash,
@@ -628,7 +634,7 @@ pub mod reply {
 
     /// Used in [Block](crate::rpc::types::reply::Block) when the requested scope of
     /// reply is [BlockResponseScope::FullTransactionsAndReceipts](crate::rpc::types::request::BlockResponseScope).
-    #[serde_as]
+    #[skip_serializing_none]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     pub struct TransactionAndReceipt {
         pub txn_hash: StarknetTransactionHash,

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -480,12 +480,13 @@ pub mod reply {
 
     /// L2 transaction as returned by the RPC API.
     ///
+    /// `contract_address` field is available for Deploy and Invoke transactions.
     /// `entry_point_selector` and `calldata` fields are available only
     /// for Invoke transactions.
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     pub struct Transaction {
         pub txn_hash: StarknetTransactionHash,
-        pub contract_address: ContractAddress,
+        pub contract_address: Option<ContractAddress>,
         pub entry_point_selector: Option<EntryPoint>,
         pub calldata: Option<Vec<CallParam>>,
     }
@@ -499,7 +500,7 @@ pub mod reply {
                 .ok_or_else(|| anyhow::anyhow!("Transaction not found."))?;
             Ok(Self {
                 txn_hash: txn.transaction_hash,
-                contract_address: txn.source_address(),
+                contract_address: txn.contract_address,
                 entry_point_selector: txn.entry_point_selector,
                 calldata: txn.calldata,
             })
@@ -510,7 +511,7 @@ pub mod reply {
         fn from(txn: sequencer::reply::transaction::Transaction) -> Self {
             Self {
                 txn_hash: txn.transaction_hash,
-                contract_address: txn.source_address(),
+                contract_address: txn.contract_address,
                 entry_point_selector: txn.entry_point_selector,
                 calldata: txn.calldata,
             }
@@ -629,14 +630,16 @@ pub mod reply {
 
     /// Used in [Block](crate::rpc::types::reply::Block) when the requested scope of
     /// reply is [BlockResponseScope::FullTransactionsAndReceipts](crate::rpc::types::request::BlockResponseScope).
+    ///
+    /// `contract_address` field is available for Deploy and Invoke transactions.
+    /// `entry_point_selector` and `calldata` fields are available only
+    /// for Invoke transactions.
     #[serde_as]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     pub struct TransactionAndReceipt {
         pub txn_hash: StarknetTransactionHash,
-        pub contract_address: ContractAddress,
-        /// Absent in "deploy" transaction
+        pub contract_address: Option<ContractAddress>,
         pub entry_point_selector: Option<EntryPoint>,
-        /// Absent in "deploy" transaction
         pub calldata: Option<Vec<CallParam>>,
         pub status: TransactionStatus,
         pub status_data: String,

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -46,7 +46,7 @@ pub trait ClientApi {
 
     async fn class_by_hash(&self, class_hash: ClassHash) -> Result<bytes::Bytes, SequencerError>;
 
-    async fn class_hash(
+    async fn class_hash_at(
         &self,
         contract_address: ContractAddress,
     ) -> Result<ClassHash, SequencerError>;
@@ -388,7 +388,7 @@ impl ClientApi for Client {
 
     /// Gets class hash for a particular contract address.
     #[tracing::instrument(skip(self))]
-    async fn class_hash(
+    async fn class_hash_at(
         &self,
         contract_address: ContractAddress,
     ) -> Result<ClassHash, SequencerError> {
@@ -1289,7 +1289,10 @@ mod tests {
                 ),
                 StarknetErrorCode::UninitializedContract.into_response(),
             )]);
-            let error = client.class_hash(*INVALID_CONTRACT_ADDR).await.unwrap_err();
+            let error = client
+                .class_hash_at(*INVALID_CONTRACT_ADDR)
+                .await
+                .unwrap_err();
             assert_matches!(
                 error,
                 SequencerError::StarknetError(e) => assert_eq!(e.code, StarknetErrorCode::UninitializedContract)
@@ -1305,7 +1308,7 @@ mod tests {
                 ),
                 (r#""0x01""#, 200),
             )]);
-            client.class_hash(*VALID_CONTRACT_ADDR).await.unwrap();
+            client.class_hash_at(*VALID_CONTRACT_ADDR).await.unwrap();
         }
     }
 

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -670,9 +670,9 @@ pub mod test_utils {
         pub static ref VALID_KEY: StorageAddress = StorageAddress::from_hex_str("0x0206F38F7E4F15E87567361213C28F235CCCDAA1D7FD34C9DB1DFE9489C6A091").unwrap();
         pub static ref VALID_KEY_DEC: String = crate::rpc::serde::starkhash_to_dec_str(&VALID_KEY.0);
         pub static ref VALID_CALL_DATA: Vec<CallParam> = vec![CallParam::from_hex_str("0x4d2").unwrap()];
-        // TODO these values are for external.integration.starknet.io and should be fixed when goerli gets to 0.9.0
-        pub static ref VALID_CLASS_HASH: ClassHash = ClassHash::from_hex_str("0x187f3d2b5c92198003975ba4d07a4664dac3690fab3a461ac8b136816b95c2c").unwrap();
-        pub static ref INVALID_CLASS_HASH: ClassHash = ClassHash::from_hex_str("0x087f3d2b5c92198003975ba4d07a4664dac3690fab3a461ac8b136816b95c2c").unwrap();
+        /// Class hash for VALID_CONTRACT_ADDR
+        pub static ref VALID_CLASS_HASH: ClassHash = ClassHash::from_hex_str("0x021a7f43387573b68666669a0ed764252ce5367708e696e31967764a90b429c2").unwrap();
+        pub static ref INVALID_CLASS_HASH: ClassHash = ClassHash::from_hex_str("0x031a7f43387573b68666669a0ed764252ce5367708e696e31967764a90b429c2").unwrap();
     }
 }
 

--- a/crates/pathfinder/src/sequencer/error.rs
+++ b/crates/pathfinder/src/sequencer/error.rs
@@ -48,6 +48,7 @@ impl From<SequencerError> for Error {
                 | StarknetErrorCode::NotPermittedContract => {
                     Error::Call(CallError::Failed(e.into()))
                 }
+                StarknetErrorCode::UndeclaredClass => RpcErrorCode::InvalidContractClassHash.into(),
             },
         }
     }
@@ -100,4 +101,6 @@ pub enum StarknetErrorCode {
     InvalidContractDefinition,
     #[serde(rename = "StarknetErrorCode.NON_PERMITTED_CONTRACT")]
     NotPermittedContract,
+    #[serde(rename = "StarknetErrorCode.UNDECLARED_CLASS")]
+    UndeclaredClass,
 }

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -279,19 +279,6 @@ pub mod transaction {
         pub version: Option<TransactionVersion>,
     }
 
-    impl Transaction {
-        /// Retruns either the `contract_address` or `sender_address` depending on the
-        /// transaction type.
-        ///
-        /// This function is a temporary measure until [Transaction] is refactored
-        /// into a 3-variant enum.
-        pub fn source_address(&self) -> ContractAddress {
-            // Unwrap is safe because either `contract_address` or `sender_address` is always present
-            self.contract_address
-                .unwrap_or_else(|| self.sender_address.unwrap())
-        }
-    }
-
     /// Describes L2 transaction types.
     #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
     #[serde(deny_unknown_fields)]

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -787,6 +787,10 @@ mod tests {
         ) -> Result<reply::add_transaction::DeployResponse, SequencerError> {
             unimplemented!()
         }
+
+        async fn class_hash(&self, _: ContractAddress) -> Result<ClassHash, SequencerError> {
+            unimplemented!()
+        }
     }
 
     async fn l1_noop(

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -717,7 +717,7 @@ mod tests {
             unimplemented!()
         }
 
-        async fn class_hash(&self, _: ContractAddress) -> Result<ClassHash, SequencerError> {
+        async fn class_hash_at(&self, _: ContractAddress) -> Result<ClassHash, SequencerError> {
             unimplemented!()
         }
 

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -713,6 +713,14 @@ mod tests {
             unimplemented!()
         }
 
+        async fn class_by_hash(&self, _: ClassHash) -> Result<bytes::Bytes, SequencerError> {
+            unimplemented!()
+        }
+
+        async fn class_hash(&self, _: ContractAddress) -> Result<ClassHash, SequencerError> {
+            unimplemented!()
+        }
+
         async fn storage(
             &self,
             _: ContractAddress,
@@ -785,10 +793,6 @@ mod tests {
             _: ContractDefinition,
             _: Option<String>,
         ) -> Result<reply::add_transaction::DeployResponse, SequencerError> {
-            unimplemented!()
-        }
-
-        async fn class_hash(&self, _: ContractAddress) -> Result<ClassHash, SequencerError> {
             unimplemented!()
         }
     }

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -234,7 +234,9 @@ pub(crate) mod test_utils {
             calldata: None,
             class_hash: None,
             constructor_calldata: None,
-            contract_address: ContractAddress(StarkHash::from_hex_str(&"2".repeat(i + 3)).unwrap()),
+            contract_address: Some(ContractAddress(
+                StarkHash::from_hex_str(&"2".repeat(i + 3)).unwrap(),
+            )),
             contract_address_salt: None,
             entry_point_type: None,
             entry_point_selector: None,
@@ -243,9 +245,10 @@ pub(crate) mod test_utils {
                 StarkHash::from_hex_str(&"f".repeat(i + 3)).unwrap(),
             ),
             max_fee: None,
-            sender_address: None,
             nonce: None,
             r#type: transaction::Type::InvokeFunction,
+            sender_address: None,
+            version: None,
         });
         let receipts = (0..N).map(|i| transaction::Receipt {
             actual_fee: None,

--- a/crates/pathfinder/src/storage/schema/revision_0010.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0010.rs
@@ -346,16 +346,17 @@ mod tests {
                 calldata: None,
                 class_hash: None,
                 constructor_calldata: None,
-                contract_address: contract0_address,
+                contract_address: Some(contract0_address),
                 contract_address_salt: None,
                 entry_point_selector: None,
                 entry_point_type: None,
                 max_fee: None,
+                nonce: None,
+                sender_address: None,
                 signature: None,
                 transaction_hash: transaction0_hash,
-                sender_address: None,
-                nonce: None,
                 r#type: transaction::Type::Deploy,
+                version: None,
             };
             let mut transaction1 = transaction0.clone();
             transaction1.transaction_hash =

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -737,7 +737,7 @@ impl StarknetEventsTable {
                         ":block_number": block_number.0,
                         ":idx": idx,
                         ":transaction_hash": &transaction.transaction_hash.0.as_be_bytes()[..],
-                        ":from_address": &transaction.contract_address.0.as_be_bytes()[..],
+                        ":from_address": &transaction.source_address().0.as_be_bytes()[..],
                         ":keys": Self::event_keys_to_base64_strings(&event.keys),
                         ":data": Self::event_data_to_bytes(&event.data),
                     ],

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -728,6 +728,10 @@ impl StarknetEventsTable {
         transaction: &transaction::Transaction,
         events: &[transaction::Event],
     ) -> anyhow::Result<()> {
+        if transaction.contract_address.is_none() && !events.is_empty() {
+            anyhow::bail!("Declare transactions cannot emit events");
+        }
+
         for (idx, event) in events.iter().enumerate() {
             connection
                 .execute(
@@ -737,7 +741,7 @@ impl StarknetEventsTable {
                         ":block_number": block_number.0,
                         ":idx": idx,
                         ":transaction_hash": &transaction.transaction_hash.0.as_be_bytes()[..],
-                        ":from_address": &transaction.source_address().0.as_be_bytes()[..],
+                        ":from_address": &transaction.contract_address.expect("contract_address exists for non-declare transactions").0.as_be_bytes()[..],
                         ":keys": Self::event_keys_to_base64_strings(&event.keys),
                         ":data": Self::event_data_to_bytes(&event.data),
                     ],

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -741,7 +741,7 @@ impl StarknetEventsTable {
                         ":block_number": block_number.0,
                         ":idx": idx,
                         ":transaction_hash": &transaction.transaction_hash.0.as_be_bytes()[..],
-                        ":from_address": &transaction.contract_address.expect("contract_address exists for non-declare transactions").0.as_be_bytes()[..],
+                        ":from_address": &transaction.contract_address.expect("contract_address should exist for non-declare transactions").0.as_be_bytes()[..],
                         ":keys": Self::event_keys_to_base64_strings(&event.keys),
                         ":data": Self::event_data_to_bytes(&event.data),
                     ],


### PR DESCRIPTION
- Not required for the incoming release.
- Caused by 0.9.0.
- I plan to refactor `Transaction` on the sequencer side into a 3-variant enum to get rid of the majority of `Option`-al fields but at the same time I'd like to keep that change separate from just aligning the client to 0.9.0.
