### PR TITLE
Omit nulls in the RPC api replies

### DIFF
--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -82,7 +82,7 @@ pub mod request {
         rpc::serde::H256AsNoLeadingZerosHexStr,
     };
     use serde::{Deserialize, Serialize};
-    use serde_with::serde_as;
+    use serde_with::{serde_as, skip_serializing_none};
     use web3::types::H256;
 
     /// The address of a storage element for a StarkNet contract.
@@ -121,6 +121,7 @@ pub mod request {
     }
 
     /// Contains event filter parameters passed to `starknet_getEvents`.
+    #[skip_serializing_none]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     #[serde(deny_unknown_fields)]
     pub struct EventFilter {
@@ -154,7 +155,7 @@ pub mod reply {
         sequencer,
     };
     use serde::{Deserialize, Serialize};
-    use serde_with::serde_as;
+    use serde_with::{serde_as, skip_serializing_none};
     use stark_hash::StarkHash;
     use std::convert::From;
 
@@ -210,6 +211,7 @@ pub mod reply {
 
     /// L2 Block as returned by the RPC API.
     #[serde_as]
+    #[skip_serializing_none]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     #[serde(deny_unknown_fields)]
     pub struct Block {
@@ -483,6 +485,7 @@ pub mod reply {
     /// `contract_address` field is available for Deploy and Invoke transactions.
     /// `entry_point_selector` and `calldata` fields are available only
     /// for Invoke transactions.
+    #[skip_serializing_none]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     pub struct Transaction {
         pub txn_hash: StarknetTransactionHash,
@@ -519,6 +522,7 @@ pub mod reply {
     }
 
     /// L2 transaction receipt as returned by the RPC API.
+    #[skip_serializing_none]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     pub struct TransactionReceipt {
         pub txn_hash: StarknetTransactionHash,
@@ -634,7 +638,7 @@ pub mod reply {
     /// `contract_address` field is available for Deploy and Invoke transactions.
     /// `entry_point_selector` and `calldata` fields are available only
     /// for Invoke transactions.
-    #[serde_as]
+    #[skip_serializing_none]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     pub struct TransactionAndReceipt {
         pub txn_hash: StarknetTransactionHash,


### PR DESCRIPTION
- As agreed with SW.
- Fixed some comments.
- Removed `#[serde_as]` annotations where they were unused.
