### PR TITLE
refactor(docker): use Debian base images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,8 @@
 # Dockerfile
 # rust temporary files
 target/
+# Python virtualenv
+.venv
 # database files
 *.sqlite
 # compressed database dump files

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ COPY crates/stark_hash/Cargo.toml crates/stark_hash/Cargo.toml
 COPY crates/stark_hash/benches crates/stark_hash/benches
 
 # DEPENDENCY_LAYER=1 should disable any vergen interaction, because the .git directory is not yet available
-RUN DEPENDENCY_LAYER=1 cargo build --release -p pathfinder
+RUN CARGO_INCREMENTAL=0 DEPENDENCY_LAYER=1 cargo build --release -p pathfinder
 
 # Compile the actual libraries and binary now
 COPY . .
@@ -50,7 +50,7 @@ RUN touch crates/pathfinder/src/build.rs
 RUN touch crates/stark_curve/src/lib.rs
 RUN touch crates/stark_hash/src/lib.rs
 
-RUN cargo build --release -p pathfinder
+RUN CARGO_INCREMENTAL=0 cargo build --release -p pathfinder
 
 #######################################
 # Stage 2: Build the Python libraries #

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,13 +78,13 @@ RUN find ${PY_PATH} -type f -a -name '*.pyo' -exec rm -rf '{}' +
 FROM python:3.8-slim-bullseye AS runner
 
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y libgmp10 tini && rm -rf /var/lib/apt/lists/*
+RUN groupadd --gid 1000 pathfinder && useradd --no-log-init --uid 1000 --gid pathfinder --no-create-home pathfinder
 
 COPY --from=rust-builder /usr/src/pathfinder/target/release/pathfinder /usr/local/bin/pathfinder
 COPY --from=python-builder /usr/local/lib/python3.8/site-packages /usr/local/lib/python3.8/site-packages
 
 # Create directory and volume for persistent data
-RUN mkdir -p /usr/share/pathfinder/data
-RUN chown 1000:1000 /usr/share/pathfinder/data
+RUN install --owner 1000 --group 1000 --mode 0755 -d /usr/share/pathfinder/data
 VOLUME /usr/share/pathfinder/data
 
 USER 1000:1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y libgmp-dev gcc &
 
 WORKDIR /usr/share/pathfinder
 COPY py py
-RUN python3 -m pip install -r py/requirements-dev.txt
+RUN python3 -m pip --disable-pip-version-check install -r py/requirements-dev.txt
 
 # This reduces the size of the python libs by about 50%
 ENV PY_PATH=/usr/local/lib/python3.8/


### PR DESCRIPTION
This PR changes our Dockerfile to use Debian-based base images.

Using a glibc-based distribution makes it possible to install wheels when we're setting up our Python dependencies. This helps a lot because on Alpine `numpy` compiles a lot of C++ code.

The resulting image sizes are significantly larger than what we had with Alpine, but not an order of magnitude worse (for `linux/amd64`, but `linux/arm64` is similar):

| | Debian-based  | Alpine-based |
| --- | --- | --- |
| Uncompressed size | 269 MiB | 160 MiB |
| Compressed size | 84 MiB | 48 MiB |

I've also tried to look into what makes the Debian-based image significantly larger. It seems there are two major factors:

- The base image is larger: 118 MiB vs 44.6 MiB
- The Python packages we're installing as wheels are larger: they contain a different set of shared libraries, like OpenBLAS for `numpy`, which we don't have on the Alpine image.

Build times when building for `linux/arm64` are significantly better, around 1600s for the Debian-based, and around 3600s for the Alpine-based images (with qemu emulation).
