### PR TITLE
Use GitHub Actions cache when building the Docker images on GitHub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,5 +51,5 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           push: true
           tags:  eqlabs/pathfinder:latest, eqlabs/pathfinder:${{github.ref_name}}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Based on the documentation here: https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache