### PR TITLE
Add ignore files(*.sqlite)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 # Added by cargo
 
 /target
+
+# database files
+*.sqlite


### PR DESCRIPTION
I'm using google translate so I'm sorry if it's strange English.

I am running `pathfinder` with the following settings(systemctl).
I think there is no problem if I change the `PATHFINDER_DATA_DIRECTORY `.
However, depending on the environment, anyone may accidentally commit the entire sqlite file.
Therefore, I added a description to ignore the sqlite file in the ignore file.

```
[Unit]
Description=Pathfinder

[Service]
Type=simple
WorkingDirectory=/home/<username>/pathfinder
ExecStart=/home/<username>/pathfinder/target/release/pathfinder --ethereum.url <https://goerli.infura.io/v3/...> --http-rpc 0.0.0.0:9545
Restart=on-failure
RestartSec=60
User=<username>

[Install]
WantedBy=multi-user.target
```