### PR TITLE
chore: upgrade regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2477,9 +2477,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2497,9 +2497,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "remove_dir_all"


### PR DESCRIPTION
After a quick peek, it would appear that `jsonrpsee` uses `regex` only through `globset` and doesn't compile `globset` matchers from user input, but through access control configuration, which are compiled out of developer input. `tracing-subscriber` only uses it to parse the initial env variable configuration with static regexs.