### PR TITLE
fix(storage): event address is using tx address

### DIFF
--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -741,7 +741,7 @@ impl StarknetEventsTable {
                         ":block_number": block_number.0,
                         ":idx": idx,
                         ":transaction_hash": &transaction.transaction_hash.0.as_be_bytes()[..],
-                        ":from_address": &transaction.contract_address.expect("contract_address should exist for non-declare transactions").0.as_be_bytes()[..],
+                        ":from_address": &event.from_address.0.as_be_bytes()[..],
                         ":keys": Self::event_keys_to_base64_strings(&event.keys),
                         ":data": Self::event_data_to_bytes(&event.data),
                     ],


### PR DESCRIPTION
This does not include any migration or fixing the database since I am unsure if that's event possible without redownloading it all..

Fixes #331.