### PR TITLE
feat(storage): use a connection pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,6 +2091,8 @@ dependencies = [
  "mockall",
  "num-bigint 0.4.3",
  "pretty_assertions",
+ "r2d2",
+ "r2d2_sqlite",
  "reqwest",
  "rusqlite",
  "semver 1.0.7",
@@ -2392,6 +2394,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "r2d2"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
+dependencies = [
+ "log",
+ "parking_lot 0.11.2",
+ "scheduled-thread-pool",
+]
+
+[[package]]
+name = "r2d2_sqlite"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fdc8e4da70586127893be32b7adf21326a4c6b1aba907611edf467d13ffe895"
+dependencies = [
+ "r2d2",
+ "rusqlite",
+]
+
+[[package]]
 name = "radium"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2674,6 +2697,15 @@ checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
  "winapi",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
+dependencies = [
+ "parking_lot 0.11.2",
 ]
 
 [[package]]

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -30,6 +30,8 @@ home = "0.5.3"
 jsonrpsee = { version = "0.11.0", features = ["server"] }
 lazy_static = "1.4.0"
 num-bigint = { version = "0.4.3", features = ["serde"] }
+r2d2 = "0.8.9"
+r2d2_sqlite = "0.20.0"
 reqwest = { version = "0.11.4", features = ["json"] }
 rusqlite = { version = "0.27.0", features = ["bundled"] }
 semver = "1.0.7"


### PR DESCRIPTION
Instead of re-opening the Sqlite database for each request Storage now contains a connection pool.

We're using `r2d2` with a blocking API because this was the smallest change (the `rusqlite` API is blocking, too, and these calls are already called from `spawn_blocking()` tasks). This also means that when we've reached the maximum number of connections ([10 by default](https://docs.rs/r2d2/0.8.9/r2d2/struct.Builder.html#method.max_size)) getting a connection from the pool will block. This is probably better behavior than running an arbitrary number of SQL queries in parallel (which we were doing) but it still means that we're using one thread from tokio's blocking thread pool for waiting for a new connection to be available.

The `load-test` tool shows significantly improved performance.
* Before: 
![image](https://user-images.githubusercontent.com/629536/172349388-1c74698c-b4ba-4a38-9d89-c05d4bcc558e.png)

* After: 
![image](https://user-images.githubusercontent.com/629536/172349253-7cc2c4df-4f9d-47cd-9a7d-a5cde5c10d63.png)

