### PR TITLE
fix(call): latest is the highest local block number

### DIFF
--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -865,11 +865,9 @@ impl RpcApi {
         use futures::future::TryFutureExt;
 
         match (self.call_handle.as_ref(), &block_hash) {
-            (Some(h), &BlockHashOrTag::Hash(_)) => {
-                // only forward calls to specific blocks to our local impl, because we currently
-                // don't do an on-demand poll and flush for the pending block.
-                //
-                // unsure about the expected Tag::Latest semantics either.
+            (Some(h), &BlockHashOrTag::Hash(_) | &BlockHashOrTag::Tag(Tag::Latest)) => {
+                // we don't yet handle pending at all, and latest has been decided to be whatever
+                // block we have, which is exactly how the py/src/call.py handles it.
                 h.call(request, block_hash).map_err(Error::from).await
             }
             (Some(_), _) | (None, _) => {

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -239,8 +239,8 @@ def resolve_block(connection, at_block):
     from starkware.starknet.business_logic.state.state import BlockInfo
 
     if at_block == "latest":
-        # latest is questionable, but the rust side cannot use it at the moment at least,
-        # should probably be removed.
+        # it has been decided that the latest is whatever pathfinder knows to be latest synced block
+        # regardless of it being the highest known (not yet synced)
         cursor = connection.execute(
             "select number, timestamp, root, gas_price, sequencer_address from starknet_blocks order by number desc limit 1"
         )


### PR DESCRIPTION
it might not be the globally highest, but it has been decided to be the highest locally available.