### PR TITLE
fix(storage): migration to fix event addresses

### DIFF
--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -27,7 +27,7 @@ use tracing::info;
 /// Indicates database is non-existant.
 const DB_VERSION_EMPTY: u32 = 0;
 /// Current database version.
-const DB_VERSION_CURRENT: u32 = 10;
+const DB_VERSION_CURRENT: u32 = 11;
 /// Sqlite key used for the PRAGMA user version.
 const VERSION_KEY: &str = "user_version";
 
@@ -139,15 +139,16 @@ fn migrate_database(connection: &mut Connection) -> anyhow::Result<()> {
             .context("Create database transaction")?;
         let action = match from_version {
             DB_VERSION_EMPTY => schema::revision_0001::migrate(&transaction)?,
-            1 => schema::revision_0002::migrate(&transaction)?,
-            2 => schema::revision_0003::migrate(&transaction)?,
-            3 => schema::revision_0004::migrate(&transaction)?,
-            4 => schema::revision_0005::migrate(&transaction)?,
-            5 => schema::revision_0006::migrate(&transaction)?,
-            6 => schema::revision_0007::migrate(&transaction)?,
-            7 => schema::revision_0008::migrate(&transaction)?,
-            8 => schema::revision_0009::migrate(&transaction)?,
-            9 => schema::revision_0010::migrate(&transaction)?,
+            1 => schema::revision_0002::migrate(&transaction).context("migrating from 1")?,
+            2 => schema::revision_0003::migrate(&transaction).context("migrating from 2")?,
+            3 => schema::revision_0004::migrate(&transaction).context("migrating from 3")?,
+            4 => schema::revision_0005::migrate(&transaction).context("migrating from 4")?,
+            5 => schema::revision_0006::migrate(&transaction).context("migrating from 5")?,
+            6 => schema::revision_0007::migrate(&transaction).context("migrating from 6")?,
+            7 => schema::revision_0008::migrate(&transaction).context("migrating from 7")?,
+            8 => schema::revision_0009::migrate(&transaction).context("migrating from 8")?,
+            9 => schema::revision_0010::migrate(&transaction).context("migrating from 9")?,
+            10 => schema::revision_0011::migrate(&transaction).context("migrating from 10")?,
             _ => unreachable!("Database version constraint was already checked!"),
         };
         // If any migration action requires vacuuming, we should vacuum.

--- a/crates/pathfinder/src/storage/schema.rs
+++ b/crates/pathfinder/src/storage/schema.rs
@@ -8,6 +8,7 @@ pub(crate) mod revision_0007;
 pub(crate) mod revision_0008;
 pub(crate) mod revision_0009;
 pub(crate) mod revision_0010;
+pub(crate) mod revision_0011;
 
 /// Used to indicate which action the caller should perform after a schema migration.
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/pathfinder/src/storage/schema/revision_0011.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0011.rs
@@ -1,0 +1,57 @@
+use crate::{sequencer::reply::transaction, storage::schema::PostMigrationAction};
+
+use anyhow::Context;
+use rusqlite::{named_params, Transaction};
+
+/// This migration fixes event addresses. Events were incorrectly stored using the transaction's
+/// contract address instead of the event's `from_address`.
+pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigrationAction> {
+    let todo: usize = transaction
+        .query_row("SELECT count(1) FROM starknet_transactions", [], |r| {
+            r.get(0)
+        })
+        .context("Count rows in starknet transactions table")?;
+
+    if todo == 0 {
+        return Ok(PostMigrationAction::None);
+    }
+
+    tracing::info!(
+        num_transactions=%todo,
+        "Decompressing transactions and fixing event addresses, this may take a while.",
+    );
+
+    let mut stmt = transaction
+        .prepare("SELECT hash, receipt FROM starknet_transactions")
+        .context("Prepare transaction query")?;
+    let mut rows = stmt.query([])?;
+
+    while let Some(r) = rows.next()? {
+        let transaction_hash = r.get_ref_unwrap("hash").as_blob()?;
+        let receipt = r.get_ref_unwrap("receipt").as_blob()?;
+        let receipt = zstd::decode_all(receipt).context("Decompress receipt")?;
+        let receipt: transaction::Receipt =
+            serde_json::de::from_slice(&receipt).context("Deserializing transaction receipt")?;
+
+        receipt.events.into_iter().enumerate().try_for_each(
+            |(idx, event)| -> anyhow::Result<_> {
+                transaction
+                    .execute(
+                        r"UPDATE starknet_events 
+                            SET from_address=:from_address
+                            WHERE idx=:idx AND transaction_hash=:transaction_hash",
+                        named_params![
+                            ":idx": idx,
+                            ":transaction_hash": transaction_hash,
+                            ":from_address": &event.from_address.0.as_be_bytes()[..],
+                        ],
+                    )
+                    .context("Insert event data into events table")?;
+
+                Ok(())
+            },
+        )?;
+    }
+
+    Ok(PostMigrationAction::None)
+}

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -7,7 +7,7 @@ from starkware.starkware_utils.error_handling import WebFriendlyException
 from starkware.storage.storage import Storage
 
 # used from tests, and the query which asserts that the schema is of expected version.
-EXPECTED_SCHEMA_REVISION = 10
+EXPECTED_SCHEMA_REVISION = 11
 EXPECTED_CAIRO_VERSION = "0.9.0"
 
 


### PR DESCRIPTION
This fixes the database to match the fix in PR #346, which only fixed new event inserts.

One unknown for me is does this impact the triggers at all? And the indexing (if any)?

Draft PR until tested on actual database.