### PR TITLE
Github Docker workflow: add more flexible tagging of images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,15 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
           echo "after freeing up space:"
           df -h
-     # Workaround for https://github.com/rust-lang/cargo/issues/8719
+      - name: Determine Docker image metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: eqlabs/pathfinder
+          tags: |
+            type=semver,pattern={{raw}}
+            type=raw,value=snapshot-{{branch}}-{{sha}}
+      # Workaround for https://github.com/rust-lang/cargo/issues/8719
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@v1.0
         with:
@@ -53,6 +61,6 @@ jobs:
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true
-          tags:  eqlabs/pathfinder:latest, eqlabs/pathfinder:${{github.ref_name}}
+          tags:  ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,7 +52,7 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Build
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           platforms: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,5 +62,6 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           push: true
           tags:  ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
This PR introduces the use of `docker/metadata-action` to determine which tags we should tag the Docker image with.

The action provides a flexible way of defining rules to determine tags, and we're using the following:

* For Git tags that are pushed we're using the name of the Git tag as the Docker tag.
* In all other cases we're tagging with `snapshot-{{branch}}-{{sha}}`.

`latest` is managed automatically by `docker/metadata-action`: builds triggered by Git tags are automatically tagged as `latest`, too.

This change makes possible to do one-off test builds of the Docker image (from test branches), as those snapshot builds won't update the `latest` tag on Docker Hub.

It also adds labels generated by the metadata action to our image. These labels are the standard [Opencontainers annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md), like:
    
```
org.opencontainers.image.title=pathfinder
org.opencontainers.image.description=A Starknet full node written in Rust
org.opencontainers.image.url=https://github.com/eqlabs/pathfinder
org.opencontainers.image.source=https://github.com/eqlabs/pathfinder
org.opencontainers.image.version=snapshot-krisztian-docker-workflow-manual-trigger-35013b8
org.opencontainers.image.created=2022-06-09T06:47:06.363Z
org.opencontainers.image.revision=35013b80b54ffe24efdfe744f3cef5d86ce0f711
org.opencontainers.image.licenses=NOASSERTION
```
