### PR TITLE
fix: temporary index used by migration

### DIFF
--- a/crates/pathfinder/examples/migrate_db.rs
+++ b/crates/pathfinder/examples/migrate_db.rs
@@ -33,23 +33,26 @@ fn main() {
         size_after_migration - size_before
     );
 
-    let conn = storage.connection().unwrap();
+    // in general one does not want to do the full vacuum because it's going to take a long time
+    if false {
+        let conn = storage.connection().unwrap();
 
-    let vacuum_started = std::time::Instant::now();
-    let vacuum_ret = conn.execute("VACUUM", []).expect("vacuum failed");
-    drop(conn);
-    drop(storage);
+        let vacuum_started = std::time::Instant::now();
+        let vacuum_ret = conn.execute("VACUUM", []).expect("vacuum failed");
+        drop(conn);
+        drop(storage);
 
-    let vacuumed_at = std::time::Instant::now();
+        let vacuumed_at = std::time::Instant::now();
 
-    let size_after_vacuum = std::fs::metadata(&path)
-        .expect("Vacuuming removed the database?")
-        .len() as i64;
+        let size_after_vacuum = std::fs::metadata(&path)
+            .expect("Vacuuming removed the database?")
+            .len() as i64;
 
-    println!(
-        "vacuumed in {:?}, size change: {}, VACUUM returned {}",
-        vacuumed_at - vacuum_started,
-        size_after_vacuum - size_after_migration,
-        vacuum_ret
-    );
+        println!(
+            "vacuumed in {:?}, size change: {}, VACUUM returned {}",
+            vacuumed_at - vacuum_started,
+            size_after_vacuum - size_after_migration,
+            vacuum_ret
+        );
+    }
 }

--- a/crates/pathfinder/src/storage/schema/revision_0011.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0011.rs
@@ -31,7 +31,7 @@ pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigration
     // index, so there should be an index for that, and it's unique since it can be.
     transaction
         .execute(
-            "CREATE UNIQUE INDEX temp_starknet_events_q ON starknet_events (idx, transaction_hash)",
+            "CREATE UNIQUE INDEX temp_starknet_events_q ON starknet_events (transaction_hash, idx)",
             [],
         )
         .context("create temporary index")?;


### PR DESCRIPTION
Follow-up to #351 to swap the index around, hopefully making this migration faster on ram limited devices. Includes a fix to disable vacuum on `examples/migrate_db` which is just trying to have less mandatory patches running around.