### PR TITLE
fix(rpc): get_block_* used two transactions

### DIFF
--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -133,6 +133,7 @@ impl RpcApi {
             Ok(Block::from_raw(block, transactions))
         })
         .await
+        .context("Database read panic or shutting down")
         .map_err(internal_server_error)
         .and_then(|x| x)
     }
@@ -248,6 +249,7 @@ impl RpcApi {
             Ok(Block::from_raw(block, transactions))
         })
         .await
+        .context("Database read panic or shutting down")
         .map_err(internal_server_error)
         .and_then(|x| x)
     }


### PR DESCRIPTION
A perf and correctness fix while looking if some of the methods could be made just blocking, and seems that they can. But separated this fix as it's independent.