### PR TITLE
fix(storage): add an integer primary key to the starknet_events table

### DIFF
--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -27,7 +27,7 @@ use tracing::info;
 /// Indicates database is non-existant.
 const DB_VERSION_EMPTY: u32 = 0;
 /// Current database version.
-const DB_VERSION_CURRENT: u32 = 11;
+const DB_VERSION_CURRENT: u32 = 12;
 /// Sqlite key used for the PRAGMA user version.
 const VERSION_KEY: &str = "user_version";
 
@@ -149,6 +149,7 @@ fn migrate_database(connection: &mut Connection) -> anyhow::Result<()> {
             8 => schema::revision_0009::migrate(&transaction).context("migrating from 8")?,
             9 => schema::revision_0010::migrate(&transaction).context("migrating from 9")?,
             10 => schema::revision_0011::migrate(&transaction).context("migrating from 10")?,
+            11 => schema::revision_0012::migrate(&transaction).context("migrating from 11")?,
             _ => unreachable!("Database version constraint was already checked!"),
         };
         // If any migration action requires vacuuming, we should vacuum.

--- a/crates/pathfinder/src/storage/schema.rs
+++ b/crates/pathfinder/src/storage/schema.rs
@@ -9,6 +9,7 @@ pub(crate) mod revision_0008;
 pub(crate) mod revision_0009;
 pub(crate) mod revision_0010;
 pub(crate) mod revision_0011;
+pub(crate) mod revision_0012;
 
 /// Used to indicate which action the caller should perform after a schema migration.
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/pathfinder/src/storage/schema.rs
+++ b/crates/pathfinder/src/storage/schema.rs
@@ -11,6 +11,9 @@ pub(crate) mod revision_0010;
 pub(crate) mod revision_0011;
 pub(crate) mod revision_0012;
 
+#[cfg(test)]
+pub(crate) mod fixtures;
+
 /// Used to indicate which action the caller should perform after a schema migration.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PostMigrationAction {

--- a/crates/pathfinder/src/storage/schema/fixtures/mod.rs
+++ b/crates/pathfinder/src/storage/schema/fixtures/mod.rs
@@ -1,0 +1,53 @@
+use crate::storage::StarknetEmittedEvent;
+use rusqlite::Connection;
+
+pub const NUM_BLOCKS: usize = 4;
+pub const TXNS_PER_BLOCK: usize = 10;
+pub const NUM_TXNS: usize = NUM_BLOCKS * TXNS_PER_BLOCK;
+
+pub fn setup_events(connection: &Connection) -> Vec<StarknetEmittedEvent> {
+    let blocks = crate::storage::test_utils::create_blocks::<NUM_BLOCKS>();
+    let transactions_and_receipts =
+        crate::storage::test_utils::create_transactions_and_receipts::<NUM_TXNS>();
+
+    for (i, block) in blocks.iter().enumerate() {
+        connection
+            .execute(
+                r"INSERT INTO starknet_blocks ( number,  hash,  root,  timestamp)
+                                               VALUES (:number, :hash, :root, :timestamp)",
+                rusqlite::named_params! {
+                    ":number": block.number.0,
+                    ":hash": block.hash.0.as_be_bytes(),
+                    ":root": block.root.0.as_be_bytes(),
+                    ":timestamp": block.timestamp.0,
+                },
+            )
+            .unwrap();
+
+        crate::storage::StarknetTransactionsTable::upsert(
+            connection,
+            block.hash,
+            block.number,
+            &transactions_and_receipts[i * TXNS_PER_BLOCK..(i + 1) * TXNS_PER_BLOCK],
+        )
+        .unwrap();
+    }
+
+    transactions_and_receipts
+        .iter()
+        .enumerate()
+        .map(|(i, (txn, receipt))| {
+            let event = &receipt.events[0];
+            let block = &blocks[i / 10];
+
+            StarknetEmittedEvent {
+                data: event.data.clone(),
+                from_address: event.from_address,
+                keys: event.keys.clone(),
+                block_hash: block.hash,
+                block_number: block.number,
+                transaction_hash: txn.transaction_hash,
+            }
+        })
+        .collect()
+}

--- a/crates/pathfinder/src/storage/schema/revision_0010.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0010.rs
@@ -462,57 +462,6 @@ mod tests {
             });
         }
 
-        const NUM_BLOCKS: usize = 4;
-        const TXNS_PER_BLOCK: usize = 10;
-        const NUM_TXNS: usize = NUM_BLOCKS * TXNS_PER_BLOCK;
-
-        fn setup(connection: &Connection) -> Vec<StarknetEmittedEvent> {
-            let blocks = crate::storage::test_utils::create_blocks::<NUM_BLOCKS>();
-            let transactions_and_receipts =
-                crate::storage::test_utils::create_transactions_and_receipts::<NUM_TXNS>();
-
-            for (i, block) in blocks.iter().enumerate() {
-                connection
-                    .execute(
-                        r"INSERT INTO starknet_blocks ( number,  hash,  root,  timestamp)
-                                               VALUES (:number, :hash, :root, :timestamp)",
-                        rusqlite::named_params! {
-                            ":number": block.number.0,
-                            ":hash": block.hash.0.as_be_bytes(),
-                            ":root": block.root.0.as_be_bytes(),
-                            ":timestamp": block.timestamp.0,
-                        },
-                    )
-                    .unwrap();
-
-                crate::storage::StarknetTransactionsTable::upsert(
-                    connection,
-                    block.hash,
-                    block.number,
-                    &transactions_and_receipts[i * TXNS_PER_BLOCK..(i + 1) * TXNS_PER_BLOCK],
-                )
-                .unwrap();
-            }
-
-            transactions_and_receipts
-                .iter()
-                .enumerate()
-                .map(|(i, (txn, receipt))| {
-                    let event = &receipt.events[0];
-                    let block = &blocks[i / 10];
-
-                    StarknetEmittedEvent {
-                        data: event.data.clone(),
-                        from_address: event.from_address,
-                        keys: event.keys.clone(),
-                        block_hash: block.hash,
-                        block_number: block.number,
-                        transaction_hash: txn.transaction_hash,
-                    }
-                })
-                .collect()
-        }
-
         #[test]
         fn virtual_table_still_references_valid_data() {
             use crate::storage::schema;
@@ -538,12 +487,12 @@ mod tests {
 
             // 2. Simulate rowids of the old `starknet_events` table to be different from
             // the new, migrated `starknet_events` table
-            let emitted_events = setup(&transaction);
+            let emitted_events = schema::fixtures::setup_events(&transaction);
             let changed = transaction
                 .execute(r"UPDATE starknet_events SET rowid = rowid + 1000000", [])
                 .context("Force arbitrary rowids")
                 .unwrap();
-            assert_eq!(changed, NUM_TXNS);
+            assert_eq!(changed, schema::fixtures::NUM_TXNS);
 
             let expected_event = &emitted_events[1];
             let filter = StarknetEventFilter {
@@ -552,7 +501,7 @@ mod tests {
                 contract_address: Some(expected_event.from_address),
                 // we're using a key which is present in _all_ events
                 keys: vec![EventKey(StarkHash::from_hex_str("deadbeef").unwrap())],
-                page_size: NUM_TXNS,
+                page_size: schema::fixtures::NUM_TXNS,
                 page_number: 0,
             };
 

--- a/crates/pathfinder/src/storage/schema/revision_0012.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0012.rs
@@ -1,0 +1,184 @@
+use crate::storage::schema::PostMigrationAction;
+
+use anyhow::Context;
+use rusqlite::Transaction;
+
+pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigrationAction> {
+    let todo: usize = transaction
+        .query_row("SELECT count(1) FROM starknet_events", [], |r| r.get(0))
+        .context("Count rows in starknet events table")?;
+
+    if todo == 0 {
+        return Ok(PostMigrationAction::None);
+    }
+
+    tracing::info!(
+        num_events=%todo,
+        "Upgrading events table schema and re-indexing events, this may take a while.",
+    );
+
+    // When altering a table in a way that requires recreating it through copying and deletion
+    // it is [recommended](https://www.sqlite.org/lang_altertable.html) to:
+    // 1. create the new table with some temporary name
+    // 2. copy the data from the old table
+    // 3. drop the old table
+    // 4. rename the new table
+    // Instead of the opposite:
+    // 1. rename the old table
+    // 2. create the new table with the final name
+    // 3. copy the data from the old table
+    // 4. drop the old table
+    //
+    // Important notes:
+    // 1. Triggers and indexes are dropped with the old `starknet_events` table,
+    //    so they need to be recreated
+    // 2. The virtual table `starknet_events_keys` needs to be recreated so that
+    //    it uses the explicit `id` primary key of starknet_events as the content
+    //    rowid (we're using starknet_events as external content table).
+    transaction
+        .execute_batch(
+            r"
+            -- Create new events table with a schema containing an integer primary key
+            CREATE TABLE starknet_events_v2 (
+                id INTEGER PRIMARY KEY NOT NULL,
+                block_number  INTEGER NOT NULL,
+                idx INTEGER NOT NULL,
+                transaction_hash BLOB NOT NULL,
+                from_address BLOB NOT NULL,
+                -- Keys are represented as base64 encoded strings separated by space
+                keys TEXT,
+                data BLOB,
+                FOREIGN KEY(block_number) REFERENCES starknet_blocks(number)
+                ON DELETE CASCADE
+            );
+            
+            -- Copy event data from the old table
+            INSERT INTO starknet_events_v2 (
+                block_number,
+                idx,
+                transaction_hash,
+                from_address,
+                keys,
+                data)
+            
+                SELECT
+                    starknet_events.block_number,
+                    starknet_events.idx,
+                    starknet_events.transaction_hash,
+                    starknet_events.from_address,
+                    starknet_events.keys,
+                    starknet_events.data
+            
+                FROM starknet_events;
+            
+            -- Drop old table and rename the new one
+            DROP TABLE starknet_events;
+            ALTER TABLE starknet_events_v2 RENAME TO starknet_events;",
+        )
+        .context("Recreating the starknet_events table and copying data")?;
+
+    tracing::info!("Re-created the starknet_events table and copied data");
+
+    transaction
+        .execute_batch(
+            r"
+            -- Event filters can specify ranges of blocks
+            CREATE INDEX starknet_events_block_number ON starknet_events(block_number);
+            
+            -- Event filter can specify a contract address
+            CREATE INDEX starknet_events_from_address ON starknet_events(from_address);",
+        )
+        .context("Recreating indexes for starknet_events")?;
+
+    tracing::info!("Re-created the indexes for starknet_events");
+
+    transaction
+        .execute_batch(r"
+            -- Drop FTS5 virtual table containing key lookup data
+            DROP TABLE starknet_events_keys;
+            
+            -- Re-create FTS5 virtual table as an external content table using `id` as the content rowid
+            CREATE VIRTUAL TABLE starknet_events_keys
+            USING fts5(
+                keys,
+                content='starknet_events',
+                content_rowid='id',
+                tokenize='ascii'
+            );
+            
+            -- Re-populate the full text index with keys
+            INSERT INTO starknet_events_keys (rowid, keys)
+                SELECT starknet_events.id, starknet_events.keys
+                FROM starknet_events;
+            
+            -- Re-create triggers updating the FTS5 table
+            CREATE TRIGGER starknet_events_ai
+            AFTER INSERT ON starknet_events
+            BEGIN
+                INSERT INTO starknet_events_keys(rowid, keys)
+                VALUES (
+                    new.id,
+                    new.keys
+                );
+            END;
+            
+            CREATE TRIGGER starknet_events_ad
+            AFTER DELETE ON starknet_events
+            BEGIN
+                INSERT INTO starknet_events_keys(starknet_events_keys, rowid, keys)
+                VALUES (
+                    'delete',
+                    old.id,
+                    old.keys
+                );
+            END;
+            
+            CREATE TRIGGER starknet_events_au
+            AFTER UPDATE ON starknet_events
+            BEGIN
+                INSERT INTO starknet_events_keys(starknet_events_keys, rowid, keys)
+                VALUES (
+                    'delete',
+                    old.id,
+                    old.keys
+                );
+                INSERT INTO starknet_events_keys(rowid, keys)
+                VALUES (
+                    new.id,
+                    new.keys
+                );
+            END;"
+        )
+        .context("Recreating the starknet_events_key FTS5 table and related triggers")?;
+
+    tracing::info!("Re-created the full-text index for starknet_events");
+
+    Ok(PostMigrationAction::None)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::storage::schema::{self, PostMigrationAction};
+    use rusqlite::Connection;
+
+    #[test]
+    fn empty() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        let transaction = conn.transaction().unwrap();
+
+        schema::revision_0001::migrate(&transaction).unwrap();
+        schema::revision_0002::migrate(&transaction).unwrap();
+        schema::revision_0003::migrate(&transaction).unwrap();
+        schema::revision_0004::migrate(&transaction).unwrap();
+        schema::revision_0005::migrate(&transaction).unwrap();
+        schema::revision_0006::migrate(&transaction).unwrap();
+        schema::revision_0007::migrate(&transaction).unwrap();
+        schema::revision_0008::migrate(&transaction).unwrap();
+        schema::revision_0009::migrate(&transaction).unwrap();
+        schema::revision_0010::migrate(&transaction).unwrap();
+        schema::revision_0011::migrate(&transaction).unwrap();
+
+        let action = super::migrate(&transaction).unwrap();
+        assert_eq!(action, PostMigrationAction::None);
+    }
+}

--- a/crates/pathfinder/src/storage/schema/revision_0012.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0012.rs
@@ -181,4 +181,65 @@ mod tests {
         let action = super::migrate(&transaction).unwrap();
         assert_eq!(action, PostMigrationAction::None);
     }
+
+    #[test]
+    fn stateful() {
+        use crate::core::EventKey;
+        use crate::storage::{
+            schema, state::PageOfEvents, StarknetEventFilter, StarknetEventsTable,
+        };
+        use stark_hash::StarkHash;
+
+        let mut connection = Connection::open_in_memory().unwrap();
+        let transaction = connection.transaction().unwrap();
+
+        // 0. Initial migrations happen
+        schema::revision_0001::migrate(&transaction).unwrap();
+        schema::revision_0002::migrate(&transaction).unwrap();
+        schema::revision_0003::migrate(&transaction).unwrap();
+        schema::revision_0004::migrate(&transaction).unwrap();
+        schema::revision_0005::migrate(&transaction).unwrap();
+        schema::revision_0006::migrate(&transaction).unwrap();
+        schema::revision_0007::migrate(&transaction).unwrap();
+        schema::revision_0008::migrate(&transaction).unwrap();
+        schema::revision_0009::migrate(&transaction).unwrap();
+        schema::revision_0010::migrate(&transaction).unwrap();
+        schema::revision_0011::migrate(&transaction).unwrap();
+
+        // 2. Insert some data
+        let emitted_events = schema::fixtures::setup_events(&transaction);
+
+        let expected_event = &emitted_events[1];
+        let filter = StarknetEventFilter {
+            from_block: Some(expected_event.block_number),
+            to_block: Some(expected_event.block_number),
+            contract_address: Some(expected_event.from_address),
+            // we're using a key which is present in _all_ events
+            keys: vec![EventKey(StarkHash::from_hex_str("deadbeef").unwrap())],
+            page_size: schema::fixtures::NUM_TXNS,
+            page_number: 0,
+        };
+
+        // 3. Getting events works just fine, the result relies on the data in `starknet_events_keys` virtual table
+        let events = StarknetEventsTable::get_events(&transaction, &filter).unwrap();
+        assert_eq!(
+            events,
+            PageOfEvents {
+                events: vec![expected_event.clone()],
+                is_last_page: true
+            }
+        );
+
+        // 4. We're doing the events table migration
+        super::migrate(&transaction).unwrap();
+
+        let events = StarknetEventsTable::get_events(&transaction, &filter).unwrap();
+        assert_eq!(
+            events,
+            PageOfEvents {
+                events: vec![expected_event.clone()],
+                is_last_page: true
+            }
+        );
+    }
 }

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -7,7 +7,7 @@ from starkware.starkware_utils.error_handling import WebFriendlyException
 from starkware.storage.storage import Storage
 
 # used from tests, and the query which asserts that the schema is of expected version.
-EXPECTED_SCHEMA_REVISION = 11
+EXPECTED_SCHEMA_REVISION = 12
 EXPECTED_CAIRO_VERSION = "0.9.0"
 
 


### PR DESCRIPTION
This is required so that we can stop relying on non-stable rowids in
the FTS5 virtual table we're using for indexing keys.

According to https://www.sqlite.org/rowidtable.html:

> If the rowid is not aliased by INTEGER PRIMARY KEY then it is not
> persistent and might change. In particular the VACUUM command will
> change rowids for tables that do not declare an INTEGER PRIMARY KEY.
> Therefore, applications should not normally access the rowid directly,
> but instead use an INTEGER PRIMARY KEY."

This change adds a migration that re-creates the starknet_events table
with an explicit INTEGER PRIMARY KEY and then re-creates all indexes
for the events.

Fixes issue #353.