### PR TITLE
fix(rpc): Less async rpc methods

### DIFF
--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -196,14 +196,12 @@ pub async fn run_server(
                 .await
         },
     )?;
-    module.register_async_method("starknet_getCode", |params, context| async move {
+    module.register_blocking_method("starknet_getCode", |params, context| {
         #[derive(Debug, Deserialize)]
         pub struct NamedArgs {
             pub contract_address: ContractAddress,
         }
-        context
-            .get_code(params.parse::<NamedArgs>()?.contract_address)
-            .await
+        context.get_code(params.parse::<NamedArgs>()?.contract_address)
     })?;
     module.register_async_method(
         "starknet_getBlockTransactionCountByHash",
@@ -238,9 +236,7 @@ pub async fn run_server(
         let params = params.parse::<NamedArgs>()?;
         context.call(params.request, params.block_hash).await
     })?;
-    module.register_async_method("starknet_blockNumber", |_, context| async move {
-        context.block_number().await
-    })?;
+    module.register_blocking_method("starknet_blockNumber", |_, context| context.block_number())?;
     module.register_async_method("starknet_chainId", |_, context| async move {
         context.chain_id().await
     })?;
@@ -253,13 +249,13 @@ pub async fn run_server(
     module.register_async_method("starknet_syncing", |_, context| async move {
         context.syncing().await
     })?;
-    module.register_async_method("starknet_getEvents", |params, context| async move {
+    module.register_blocking_method("starknet_getEvents", |params, context| {
         #[derive(Debug, Deserialize)]
         struct NamedArgs {
             pub filter: EventFilter,
         }
         let request = params.parse::<NamedArgs>()?.filter;
-        context.get_events(request).await
+        context.get_events(request)
     })?;
     module.register_async_method(
         "starknet_addInvokeTransaction",


### PR DESCRIPTION
Continuation or the original idea behind #359, use `RpcModule::register_blocking_method` when applicable (when the only async thing to do is to use spawn_blocking).

Additionally carry/hoist the span from async context to spawn_blocking context -- in case more async stuff is added in future it will continue to be in use because of the instrumentation at `RpcModule::register_async_method`....

While testing noticed that this cannot be done because jsonrpsee 0.11 doesn't turn joinerrors into internal errors, instead it just closes the connection and doesn't even send headers. Leaving as a draft.