### PR TITLE
Sequencer builder

### DIFF
--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -185,6 +185,15 @@ pub struct EthereumTransactionIndex(pub u64);
 #[derive(Debug, Copy, Clone, PartialEq, Hash, Eq)]
 pub struct EthereumLogIndex(pub u64);
 
+/// A way of identifying a specific block.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum BlockId {
+    Number(StarknetBlockNumber),
+    Hash(StarknetBlockHash),
+    Latest,
+    Pending,
+}
+
 impl StarknetBlockNumber {
     pub const GENESIS: StarknetBlockNumber = StarknetBlockNumber(0);
 }
@@ -274,5 +283,43 @@ impl GasPrice {
 impl From<u64> for GasPrice {
     fn from(src: u64) -> Self {
         Self(u128::from(src))
+    }
+}
+
+impl From<crate::rpc::types::BlockNumberOrTag> for BlockId {
+    fn from(block: crate::rpc::types::BlockNumberOrTag) -> Self {
+        use crate::rpc::types::BlockNumberOrTag::*;
+        use crate::rpc::types::Tag::*;
+
+        match block {
+            Number(number) => Self::Number(number),
+            Tag(Latest) => Self::Latest,
+            Tag(Pending) => Self::Pending,
+        }
+    }
+}
+
+impl From<crate::rpc::types::BlockHashOrTag> for BlockId {
+    fn from(block: crate::rpc::types::BlockHashOrTag) -> Self {
+        use crate::rpc::types::BlockHashOrTag::*;
+        use crate::rpc::types::Tag::*;
+
+        match block {
+            Hash(hash) => Self::Hash(hash),
+            Tag(Latest) => Self::Latest,
+            Tag(Pending) => Self::Pending,
+        }
+    }
+}
+
+impl From<StarknetBlockNumber> for BlockId {
+    fn from(number: StarknetBlockNumber) -> Self {
+        Self::Number(number)
+    }
+}
+
+impl From<StarknetBlockHash> for BlockId {
+    fn from(hash: StarknetBlockHash) -> Self {
+        Self::Hash(hash)
     }
 }

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -99,7 +99,7 @@ impl RpcApi {
             BlockHashOrTag::Tag(Tag::Pending) => {
                 let block = self
                     .sequencer
-                    .block_by_hash(block_hash)
+                    .block(block_hash)
                     .await
                     .map_err(internal_server_error)?;
 
@@ -218,7 +218,7 @@ impl RpcApi {
             BlockNumberOrTag::Tag(Tag::Pending) => {
                 let block = self
                     .sequencer
-                    .block_by_number(block_number)
+                    .block(block_number)
                     .await
                     .context("Fetch block from sequencer")
                     .map_err(internal_server_error)?;
@@ -514,7 +514,7 @@ impl RpcApi {
             BlockHashOrTag::Tag(Tag::Pending) => {
                 let block = self
                     .sequencer
-                    .block_by_hash(block_hash)
+                    .block(block_hash)
                     .await
                     .context("Fetch block from sequencer")
                     .map_err(internal_server_error)?;
@@ -589,7 +589,7 @@ impl RpcApi {
             BlockNumberOrTag::Tag(Tag::Pending) => {
                 let block = self
                     .sequencer
-                    .block_by_number(block_number)
+                    .block(block_number)
                     .await
                     .context("Fetch block from sequencer")
                     .map_err(internal_server_error)?;
@@ -747,7 +747,7 @@ impl RpcApi {
             BlockHashOrTag::Tag(Tag::Pending) => {
                 let block = self
                     .sequencer
-                    .block_by_hash(block_hash)
+                    .block(block_hash)
                     .await
                     .context("Fetch block from sequencer")
                     .map_err(internal_server_error)?;
@@ -814,7 +814,7 @@ impl RpcApi {
             BlockNumberOrTag::Tag(Tag::Pending) => {
                 let block = self
                     .sequencer
-                    .block_by_number(block_number)
+                    .block(block_number)
                     .await
                     .context("Fetch block from sequencer")
                     .map_err(internal_server_error)?;

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -99,7 +99,7 @@ impl RpcApi {
             BlockHashOrTag::Tag(Tag::Pending) => {
                 let block = self
                     .sequencer
-                    .block(block_hash)
+                    .block(block_hash.into())
                     .await
                     .map_err(internal_server_error)?;
 
@@ -218,7 +218,7 @@ impl RpcApi {
             BlockNumberOrTag::Tag(Tag::Pending) => {
                 let block = self
                     .sequencer
-                    .block(block_number)
+                    .block(block_number.into())
                     .await
                     .context("Fetch block from sequencer")
                     .map_err(internal_server_error)?;
@@ -514,7 +514,7 @@ impl RpcApi {
             BlockHashOrTag::Tag(Tag::Pending) => {
                 let block = self
                     .sequencer
-                    .block(block_hash)
+                    .block(block_hash.into())
                     .await
                     .context("Fetch block from sequencer")
                     .map_err(internal_server_error)?;
@@ -589,7 +589,7 @@ impl RpcApi {
             BlockNumberOrTag::Tag(Tag::Pending) => {
                 let block = self
                     .sequencer
-                    .block(block_number)
+                    .block(block_number.into())
                     .await
                     .context("Fetch block from sequencer")
                     .map_err(internal_server_error)?;
@@ -747,7 +747,7 @@ impl RpcApi {
             BlockHashOrTag::Tag(Tag::Pending) => {
                 let block = self
                     .sequencer
-                    .block(block_hash)
+                    .block(block_hash.into())
                     .await
                     .context("Fetch block from sequencer")
                     .map_err(internal_server_error)?;
@@ -814,7 +814,7 @@ impl RpcApi {
             BlockNumberOrTag::Tag(Tag::Pending) => {
                 let block = self
                     .sequencer
-                    .block(block_number)
+                    .block(block_number.into())
                     .await
                     .context("Fetch block from sequencer")
                     .map_err(internal_server_error)?;

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -546,8 +546,12 @@ mod tests {
                 .or_else(|_| async { Ok::<(Option<String>,), std::convert::Infallible>((None,)) });
             let path = warp::any().and(warp::path::full()).and(opt_query_raw).map(
                 move |full_path: warp::path::FullPath, raw_query: Option<String>| {
-                    let actual_full_path_and_query =
-                        format!("{}?{}", full_path.as_str(), raw_query.unwrap_or_default());
+                    let actual_full_path_and_query = match raw_query {
+                        Some(some_raw_query) => {
+                            format!("{}?{}", full_path.as_str(), some_raw_query.as_str())
+                        }
+                        None => full_path.as_str().to_owned(),
+                    };
 
                     match url_paths_queries_and_response_fixtures
                         .iter()
@@ -1482,7 +1486,7 @@ mod tests {
     #[tokio::test]
     async fn eth_contract_addresses() {
         let (_jh, client) = setup([(
-            "/feeder_gateway/get_contract_addresses?",
+            "/feeder_gateway/get_contract_addresses",
             (
                 r#"{"Starknet":"0xde29d060d45901fb19ed6c6e959eb22d8626708e","GpsStatementVerifier":"0xab43ba48c9edf4c2c4bb01237348d1d7b28ef168"}"#,
                 200,
@@ -1507,7 +1511,7 @@ mod tests {
             // test with values dumped from `starknet invoke` for a test contract,
             // except for an invalid entry point value
             let (_jh, client) = setup([(
-                "/gateway/add_transaction?",
+                "/gateway/add_transaction",
                 StarknetErrorCode::UnsupportedSelectorForFee.into_response(),
             )]);
             let  error = client
@@ -1569,7 +1573,7 @@ mod tests {
         #[tokio::test]
         async fn invoke_function() {
             let (_jh, client) = setup([(
-                "/gateway/add_transaction?",
+                "/gateway/add_transaction",
                 (
                     r#"{"code":"TRANSACTION_RECEIVED","transaction_hash":"0x0389DD0629F42176CC8B6C43ACEFC0713D0064ECDFC0470E0FC179F53421A38B"}"#,
                     200,
@@ -1655,7 +1659,7 @@ mod tests {
             let contract_class = get_contract_class_from_fixture();
 
             let (_jh, client) = setup([(
-                "/gateway/add_transaction?",
+                "/gateway/add_transaction",
                 (
                     r#"{"code": "TRANSACTION_RECEIVED",
                         "transaction_hash": "0x77ccba4df42cf0f74a8eb59a96d7880fae371edca5d000ca5f9985652c8a8ed",
@@ -1684,7 +1688,7 @@ mod tests {
             let contract_definition = get_contract_class_from_fixture();
 
             let (_jh, client) = setup([(
-                "/gateway/add_transaction?",
+                "/gateway/add_transaction",
                 (
                     r#"{"code":"TRANSACTION_RECEIVED","transaction_hash":"0x057ED4B4C76A1CA0BA044A654DD3EE2D0D3E550343D739350A22AACDD524110D",
                     "address":"0x03926AEA98213EC34FE9783D803237D221C54C52344422E1F4942A5B340FA6AD"}"#,

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -137,8 +137,8 @@ impl Client {
         })
     }
 
-    fn request(&self) -> builder::Request<builder::WithUrl> {
-        builder::Request::new(&self.inner, self.sequencer_url.clone())
+    fn request(&self) -> builder::Request<builder::stage::Gateway> {
+        builder::Request::builder(&self.inner, self.sequencer_url.clone())
     }
 }
 
@@ -149,7 +149,7 @@ impl ClientApi for Client {
         self.request()
             .feeder_gateway()
             .get_block()
-            .at_block(block)
+            .with_block(block)
             .auto_retry()
             .get()
             .await
@@ -165,7 +165,7 @@ impl ClientApi for Client {
         self.request()
             .feeder_gateway()
             .call_contract()
-            .at_block(block_hash)
+            .with_block(block_hash)
             .auto_retry()
             .post_with_json(&payload)
             .await
@@ -226,7 +226,7 @@ impl ClientApi for Client {
             .get_storage_at()
             .with_contract_address(contract_addr)
             .with_storage_address(key)
-            .at_block(block_hash)
+            .with_block(block_hash)
             .auto_retry()
             .get()
             .await
@@ -267,7 +267,7 @@ impl ClientApi for Client {
         self.request()
             .feeder_gateway()
             .get_state_update()
-            .at_block(block)
+            .with_block(block)
             .auto_retry()
             .get()
             .await

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -16,7 +16,7 @@ use crate::{
     sequencer::error::SequencerError,
 };
 use reqwest::Url;
-use std::{fmt::Debug, future::Future, result::Result, time::Duration};
+use std::{fmt::Debug, result::Result, time::Duration};
 
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
@@ -124,79 +124,6 @@ pub struct Client {
     sequencer_url: Url,
 }
 
-/// Wrapper function to allow retrying sequencer queries in an exponential manner.
-///
-/// Does not retry in tests.
-async fn retry<T, Fut, FutureFactory>(future_factory: FutureFactory) -> Result<T, SequencerError>
-where
-    Fut: Future<Output = Result<T, SequencerError>>,
-    FutureFactory: FnMut() -> Fut,
-{
-    if cfg!(test) {
-        retry0(future_factory, |_| false).await
-    } else {
-        retry0(future_factory, retry_condition).await
-    }
-}
-
-/// Wrapper function to allow retrying sequencer queries in an exponential manner.
-async fn retry0<T, Fut, FutureFactory, Ret>(
-    future_factory: FutureFactory,
-    retry_condition: Ret,
-) -> Result<T, SequencerError>
-where
-    Fut: Future<Output = Result<T, SequencerError>>,
-    FutureFactory: FnMut() -> Fut,
-    Ret: FnMut(&SequencerError) -> bool,
-{
-    use crate::retry::Retry;
-    use std::num::NonZeroU64;
-
-    Retry::exponential(future_factory, NonZeroU64::new(2).unwrap())
-        .factor(NonZeroU64::new(15).unwrap())
-        .max_delay(Duration::from_secs(60 * 60))
-        .when(retry_condition)
-        .await
-}
-
-/// Determines if an error is retryable or not.
-fn retry_condition(e: &SequencerError) -> bool {
-    use reqwest::StatusCode;
-    use tracing::{debug, error, info, warn};
-
-    match e {
-        SequencerError::ReqwestError(e) => {
-            if e.is_body() || e.is_connect() || e.is_timeout() {
-                info!(reason=%e, "Request failed, retrying");
-            } else if e.is_status() {
-                match e.status() {
-                    Some(
-                        StatusCode::NOT_FOUND
-                        | StatusCode::TOO_MANY_REQUESTS
-                        | StatusCode::BAD_GATEWAY
-                        | StatusCode::SERVICE_UNAVAILABLE
-                        | StatusCode::GATEWAY_TIMEOUT,
-                    ) => {
-                        debug!(reason=%e, "Request failed, retrying");
-                    }
-                    Some(StatusCode::INTERNAL_SERVER_ERROR) => {
-                        error!(reason=%e, "Request failed, retrying");
-                    }
-                    Some(_) => warn!(reason=%e, "Request failed, retrying"),
-                    None => unreachable!(),
-                }
-            } else if e.is_decode() {
-                error!(reason=%e, "Request failed, retrying");
-            } else {
-                warn!(reason=%e, "Request failed, retrying");
-            }
-
-            true
-        }
-        SequencerError::StarknetError(_) => false,
-    }
-}
-
 impl Client {
     /// Creates a new Sequencer client for the given chain.
     pub fn new(chain: Chain) -> reqwest::Result<Self> {
@@ -239,15 +166,13 @@ impl ClientApi for Client {
         &self,
         block_number: BlockNumberOrTag,
     ) -> Result<reply::Block, SequencerError> {
-        retry(|| async move {
-            self.request()
-                .feeder_gateway()
-                .get_block()
-                .at_block(block_number)
-                .get()
-                .await
-        })
-        .await
+        self.request()
+            .feeder_gateway()
+            .get_block()
+            .at_block(block_number)
+            .auto_retry()
+            .get()
+            .await
     }
 
     /// Get block by hash.
@@ -256,15 +181,13 @@ impl ClientApi for Client {
         &self,
         block_hash: BlockHashOrTag,
     ) -> Result<reply::Block, SequencerError> {
-        retry(|| async {
-            self.request()
-                .feeder_gateway()
-                .get_block()
-                .at_block(block_hash)
-                .get()
-                .await
-        })
-        .await
+        self.request()
+            .feeder_gateway()
+            .get_block()
+            .at_block(block_hash)
+            .auto_retry()
+            .get()
+            .await
     }
 
     /// Performs a `call` on contract's function. Call result is not stored in L2, as opposed to `invoke`.
@@ -274,15 +197,13 @@ impl ClientApi for Client {
         payload: request::Call,
         block_hash: BlockHashOrTag,
     ) -> Result<reply::Call, SequencerError> {
-        retry(|| async {
-            self.request()
-                .feeder_gateway()
-                .call_contract()
-                .at_block(block_hash)
-                .post_with_json(&payload)
-                .await
-        })
-        .await
+        self.request()
+            .feeder_gateway()
+            .call_contract()
+            .at_block(block_hash)
+            .auto_retry()
+            .post_with_json(&payload)
+            .await
     }
 
     /// Gets full contract definition.
@@ -291,29 +212,25 @@ impl ClientApi for Client {
         &self,
         contract_addr: ContractAddress,
     ) -> Result<bytes::Bytes, SequencerError> {
-        retry(|| async {
-            self.request()
-                .feeder_gateway()
-                .get_full_contract()
-                .with_contract_address(contract_addr)
-                .get_as_bytes()
-                .await
-        })
-        .await
+        self.request()
+            .feeder_gateway()
+            .get_full_contract()
+            .with_contract_address(contract_addr)
+            .auto_retry()
+            .get_as_bytes()
+            .await
     }
 
     /// Gets class for a particular class hash.
     #[tracing::instrument(skip(self))]
     async fn class_by_hash(&self, class_hash: ClassHash) -> Result<bytes::Bytes, SequencerError> {
-        retry(|| async {
-            self.request()
-                .feeder_gateway()
-                .get_class_by_hash()
-                .with_class_hash(class_hash)
-                .get_as_bytes()
-                .await
-        })
-        .await
+        self.request()
+            .feeder_gateway()
+            .get_class_by_hash()
+            .with_class_hash(class_hash)
+            .auto_retry()
+            .get_as_bytes()
+            .await
     }
 
     /// Gets class hash for a particular contract address.
@@ -322,15 +239,13 @@ impl ClientApi for Client {
         &self,
         contract_address: ContractAddress,
     ) -> Result<ClassHash, SequencerError> {
-        retry(|| async {
-            self.request()
-                .feeder_gateway()
-                .get_class_hash_at()
-                .with_contract_address(contract_address)
-                .get()
-                .await
-        })
-        .await
+        self.request()
+            .feeder_gateway()
+            .get_class_hash_at()
+            .with_contract_address(contract_address)
+            .auto_retry()
+            .get()
+            .await
     }
 
     /// Gets storage value associated with a `key` for a prticular contract.
@@ -341,17 +256,15 @@ impl ClientApi for Client {
         key: StorageAddress,
         block_hash: BlockHashOrTag,
     ) -> Result<StorageValue, SequencerError> {
-        retry(|| async {
-            self.request()
-                .feeder_gateway()
-                .get_storage_at()
-                .with_contract_address(contract_addr)
-                .with_storage_address(key)
-                .at_block(block_hash)
-                .get()
-                .await
-        })
-        .await
+        self.request()
+            .feeder_gateway()
+            .get_storage_at()
+            .with_contract_address(contract_addr)
+            .with_storage_address(key)
+            .at_block(block_hash)
+            .auto_retry()
+            .get()
+            .await
     }
 
     /// Gets transaction by hash.
@@ -360,15 +273,13 @@ impl ClientApi for Client {
         &self,
         transaction_hash: StarknetTransactionHash,
     ) -> Result<reply::Transaction, SequencerError> {
-        retry(|| async {
-            self.request()
-                .feeder_gateway()
-                .get_transaction()
-                .with_transaction_hash(transaction_hash)
-                .get()
-                .await
-        })
-        .await
+        self.request()
+            .feeder_gateway()
+            .get_transaction()
+            .with_transaction_hash(transaction_hash)
+            .auto_retry()
+            .get()
+            .await
     }
 
     /// Gets transaction status by transaction hash.
@@ -377,15 +288,13 @@ impl ClientApi for Client {
         &self,
         transaction_hash: StarknetTransactionHash,
     ) -> Result<reply::TransactionStatus, SequencerError> {
-        retry(|| async {
-            self.request()
-                .feeder_gateway()
-                .get_transaction_status()
-                .with_transaction_hash(transaction_hash)
-                .get()
-                .await
-        })
-        .await
+        self.request()
+            .feeder_gateway()
+            .get_transaction_status()
+            .with_transaction_hash(transaction_hash)
+            .auto_retry()
+            .get()
+            .await
     }
 
     /// Gets state update for a particular block hash.
@@ -394,15 +303,13 @@ impl ClientApi for Client {
         &self,
         block_hash: BlockHashOrTag,
     ) -> Result<reply::StateUpdate, SequencerError> {
-        retry(|| async {
-            self.request()
-                .feeder_gateway()
-                .get_state_update()
-                .at_block(block_hash)
-                .get()
-                .await
-        })
-        .await
+        self.request()
+            .feeder_gateway()
+            .get_state_update()
+            .at_block(block_hash)
+            .auto_retry()
+            .get()
+            .await
     }
 
     /// Gets state update for a particular block number.
@@ -411,28 +318,24 @@ impl ClientApi for Client {
         &self,
         block_number: BlockNumberOrTag,
     ) -> Result<reply::StateUpdate, SequencerError> {
-        retry(|| async {
-            self.request()
-                .feeder_gateway()
-                .get_state_update()
-                .at_block(block_number)
-                .get()
-                .await
-        })
-        .await
+        self.request()
+            .feeder_gateway()
+            .get_state_update()
+            .at_block(block_number)
+            .auto_retry()
+            .get()
+            .await
     }
 
     /// Gets addresses of the Ethereum contracts crucial to Starknet operation.
     #[tracing::instrument(skip(self))]
     async fn eth_contract_addresses(&self) -> Result<reply::EthContractAddresses, SequencerError> {
-        retry(|| async {
-            self.request()
-                .feeder_gateway()
-                .get_contract_addresses()
-                .get()
-                .await
-        })
-        .await
+        self.request()
+            .feeder_gateway()
+            .get_contract_addresses()
+            .auto_retry()
+            .get()
+            .await
     }
 
     /// Adds a transaction invoking a contract.
@@ -461,6 +364,7 @@ impl ClientApi for Client {
         self.request()
             .gateway()
             .add_transaction()
+            .without_retry()
             .post_with_json(&req)
             .await
     }
@@ -496,6 +400,7 @@ impl ClientApi for Client {
             .add_transaction()
             // mainnet requires a token (but testnet does not so its optional).
             .with_optional_token(token.as_deref())
+            .without_retry()
             .post_with_json(&req)
             .await
     }
@@ -526,6 +431,7 @@ impl ClientApi for Client {
             .add_transaction()
             // mainnet requires a token (but testnet does not so its optional).
             .with_optional_token(token.as_deref())
+            .without_retry()
             .post_with_json(&req)
             .await
     }
@@ -2058,155 +1964,6 @@ mod tests {
                         assert_eq!(se.message, EXPECTED_ERROR_MESSAGE);
                 });
             }
-        }
-    }
-
-    mod retry {
-        use super::{SequencerError, StarknetErrorCode};
-        use assert_matches::assert_matches;
-        use http::{response::Builder, StatusCode};
-        use pretty_assertions::assert_eq;
-        use std::{
-            collections::VecDeque, convert::Infallible, net::SocketAddr, sync::Arc, time::Duration,
-        };
-        use tokio::{sync::Mutex, task::JoinHandle};
-        use warp::Filter;
-
-        // A test helper
-        fn status_queue_server(
-            statuses: VecDeque<(StatusCode, &'static str)>,
-        ) -> (JoinHandle<()>, SocketAddr) {
-            use std::cell::RefCell;
-
-            let statuses = Arc::new(Mutex::new(RefCell::new(statuses)));
-            let any = warp::any().and_then(move || {
-                let s = statuses.clone();
-                async move {
-                    let s = s.lock().await;
-                    let s = s.borrow_mut().pop_front().unwrap();
-                    Result::<_, Infallible>::Ok(Builder::new().status(s.0).body(s.1))
-                }
-            });
-
-            let (addr, run_srv) = warp::serve(any).bind_ephemeral(([127, 0, 0, 1], 0));
-            let server_handle = tokio::spawn(run_srv);
-            (server_handle, addr)
-        }
-
-        // A test helper
-        fn slow_server() -> (tokio::task::JoinHandle<()>, std::net::SocketAddr) {
-            async fn slow() -> Result<impl warp::Reply, Infallible> {
-                tokio::time::sleep(Duration::from_secs(1)).await;
-                Ok(Builder::new().status(200).body(""))
-            }
-
-            let any = warp::any().and_then(slow);
-            let (addr, run_srv) = warp::serve(any).bind_ephemeral(([127, 0, 0, 1], 0));
-            let server_handle = tokio::spawn(run_srv);
-            (server_handle, addr)
-        }
-
-        #[test_log::test(tokio::test)]
-        async fn stop_on_ok() {
-            use crate::sequencer::builder;
-
-            let statuses = VecDeque::from([
-                (StatusCode::TOO_MANY_REQUESTS, ""),
-                (StatusCode::BAD_GATEWAY, ""),
-                (StatusCode::SERVICE_UNAVAILABLE, ""),
-                (StatusCode::GATEWAY_TIMEOUT, ""),
-                (StatusCode::OK, r#""Finally!""#),
-                (StatusCode::TOO_MANY_REQUESTS, ""),
-                (StatusCode::BAD_GATEWAY, ""),
-                (StatusCode::SERVICE_UNAVAILABLE, ""),
-            ]);
-
-            let (_jh, addr) = status_queue_server(statuses);
-            let result = super::retry0(
-                || async {
-                    let mut url = reqwest::Url::parse("http://localhost/").unwrap();
-                    url.set_port(Some(addr.port())).unwrap();
-                    let response = reqwest::get(url).await?;
-                    builder::parse::<String>(response).await
-                },
-                super::retry_condition,
-            )
-            .await
-            .unwrap();
-            assert_eq!(result, "Finally!");
-        }
-
-        #[test_log::test(tokio::test)]
-        async fn stop_on_fatal() {
-            use crate::sequencer::builder;
-
-            let statuses = VecDeque::from([
-                (StatusCode::TOO_MANY_REQUESTS, ""),
-                (StatusCode::BAD_GATEWAY, ""),
-                (StatusCode::SERVICE_UNAVAILABLE, ""),
-                (StatusCode::GATEWAY_TIMEOUT, ""),
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    r#"{"code":"StarknetErrorCode.BLOCK_NOT_FOUND","message":""}"#,
-                ),
-                (StatusCode::TOO_MANY_REQUESTS, ""),
-                (StatusCode::BAD_GATEWAY, ""),
-                (StatusCode::SERVICE_UNAVAILABLE, ""),
-            ]);
-
-            let (_jh, addr) = status_queue_server(statuses);
-            let error = super::retry0(
-                || async {
-                    let mut url = reqwest::Url::parse("http://localhost/").unwrap();
-                    url.set_port(Some(addr.port())).unwrap();
-                    let response = reqwest::get(url).await?;
-                    builder::parse::<String>(response).await
-                },
-                super::retry_condition,
-            )
-            .await
-            .unwrap_err();
-            assert_matches!(
-                error,
-                SequencerError::StarknetError(se) => assert_eq!(se.code, StarknetErrorCode::BlockNotFound)
-            );
-        }
-
-        #[tokio::test(flavor = "current_thread", start_paused = true)]
-        async fn request_timeout() {
-            use crate::sequencer::builder;
-
-            use std::sync::atomic::{AtomicUsize, Ordering};
-
-            let (_jh, addr) = slow_server();
-            static CNT: AtomicUsize = AtomicUsize::new(0);
-
-            let fut = super::retry0(
-                || async {
-                    let mut url = reqwest::Url::parse("http://localhost/").unwrap();
-                    url.set_port(Some(addr.port())).unwrap();
-
-                    let client = reqwest::Client::builder().build().unwrap();
-
-                    CNT.fetch_add(1, Ordering::Relaxed);
-
-                    // This is the same as using Client::builder().timeout()
-                    let response = client
-                        .get(url)
-                        .timeout(Duration::from_millis(1))
-                        .send()
-                        .await?;
-                    builder::parse::<String>(response).await
-                },
-                super::retry_condition,
-            );
-
-            // The retry loops forever, so wrap it in a timeout and check the counter.
-            tokio::time::timeout(Duration::from_millis(250), fut)
-                .await
-                .unwrap_err();
-            // 4th try should have timedout if this is really exponential backoff
-            assert_eq!(CNT.load(Ordering::Relaxed), 4);
         }
     }
 }

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -1483,7 +1483,7 @@ mod tests {
     #[tokio::test]
     async fn eth_contract_addresses() {
         let (_jh, client) = setup([(
-            "/feeder_gateway/get_contract_addresses",
+            "/feeder_gateway/get_contract_addresses?",
             (
                 r#"{"Starknet":"0xde29d060d45901fb19ed6c6e959eb22d8626708e","GpsStatementVerifier":"0xab43ba48c9edf4c2c4bb01237348d1d7b28ef168"}"#,
                 200,
@@ -1685,7 +1685,7 @@ mod tests {
             let contract_definition = get_contract_class_from_fixture();
 
             let (_jh, client) = setup([(
-                "/gateway/add_transaction",
+                "/gateway/add_transaction?",
                 (
                     r#"{"code":"TRANSACTION_RECEIVED","transaction_hash":"0x057ED4B4C76A1CA0BA044A654DD3EE2D0D3E550343D739350A22AACDD524110D",
                     "address":"0x03926AEA98213EC34FE9783D803237D221C54C52344422E1F4942A5B340FA6AD"}"#,

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -538,7 +538,6 @@ mod tests {
         S2: std::string::ToString + Send + Sync + Clone + 'static,
     {
         if std::env::var_os("SEQUENCER_TESTS_LIVE_API").is_some() {
-            println!("LIVE");
             (None, Client::new(Chain::Goerli).unwrap())
         } else {
             use warp::Filter;

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -109,6 +109,11 @@ pub struct Client {
 }
 
 impl Client {
+    #[cfg(not(test))]
+    const RETRY: builder::Retry = builder::Retry::Enabled;
+    #[cfg(test)]
+    const RETRY: builder::Retry = builder::Retry::Disabled;
+
     /// Creates a new Sequencer client for the given chain.
     pub fn new(chain: Chain) -> reqwest::Result<Self> {
         let url = match chain {
@@ -150,7 +155,7 @@ impl ClientApi for Client {
             .feeder_gateway()
             .get_block()
             .with_block(block)
-            .auto_retry()
+            .with_retry(Self::RETRY)
             .get()
             .await
     }
@@ -166,7 +171,7 @@ impl ClientApi for Client {
             .feeder_gateway()
             .call_contract()
             .with_block(block_hash)
-            .auto_retry()
+            .with_retry(Self::RETRY)
             .post_with_json(&payload)
             .await
     }
@@ -181,7 +186,7 @@ impl ClientApi for Client {
             .feeder_gateway()
             .get_full_contract()
             .with_contract_address(contract_addr)
-            .auto_retry()
+            .with_retry(Self::RETRY)
             .get_as_bytes()
             .await
     }
@@ -193,7 +198,7 @@ impl ClientApi for Client {
             .feeder_gateway()
             .get_class_by_hash()
             .with_class_hash(class_hash)
-            .auto_retry()
+            .with_retry(Self::RETRY)
             .get_as_bytes()
             .await
     }
@@ -208,7 +213,7 @@ impl ClientApi for Client {
             .feeder_gateway()
             .get_class_hash_at()
             .with_contract_address(contract_address)
-            .auto_retry()
+            .with_retry(Self::RETRY)
             .get()
             .await
     }
@@ -227,7 +232,7 @@ impl ClientApi for Client {
             .with_contract_address(contract_addr)
             .with_storage_address(key)
             .with_block(block_hash)
-            .auto_retry()
+            .with_retry(Self::RETRY)
             .get()
             .await
     }
@@ -242,7 +247,7 @@ impl ClientApi for Client {
             .feeder_gateway()
             .get_transaction()
             .with_transaction_hash(transaction_hash)
-            .auto_retry()
+            .with_retry(Self::RETRY)
             .get()
             .await
     }
@@ -257,7 +262,7 @@ impl ClientApi for Client {
             .feeder_gateway()
             .get_transaction_status()
             .with_transaction_hash(transaction_hash)
-            .auto_retry()
+            .with_retry(Self::RETRY)
             .get()
             .await
     }
@@ -268,7 +273,7 @@ impl ClientApi for Client {
             .feeder_gateway()
             .get_state_update()
             .with_block(block)
-            .auto_retry()
+            .with_retry(Self::RETRY)
             .get()
             .await
     }
@@ -279,7 +284,7 @@ impl ClientApi for Client {
         self.request()
             .feeder_gateway()
             .get_contract_addresses()
-            .auto_retry()
+            .with_retry(Self::RETRY)
             .get()
             .await
     }
@@ -310,7 +315,7 @@ impl ClientApi for Client {
         self.request()
             .gateway()
             .add_transaction()
-            .without_retry()
+            .with_retry(builder::Retry::Disabled)
             .post_with_json(&req)
             .await
     }
@@ -346,7 +351,7 @@ impl ClientApi for Client {
             .add_transaction()
             // mainnet requires a token (but testnet does not so its optional).
             .with_optional_token(token.as_deref())
-            .without_retry()
+            .with_retry(builder::Retry::Disabled)
             .post_with_json(&req)
             .await
     }
@@ -377,7 +382,7 @@ impl ClientApi for Client {
             .add_transaction()
             // mainnet requires a token (but testnet does not so its optional).
             .with_optional_token(token.as_deref())
-            .without_retry()
+            .with_retry(builder::Retry::Disabled)
             .post_with_json(&req)
             .await
     }
@@ -1476,7 +1481,7 @@ mod tests {
     #[tokio::test]
     async fn eth_contract_addresses() {
         let (_jh, client) = setup([(
-            "/feeder_gateway/get_contract_addresses?",
+            "/feeder_gateway/get_contract_addresses",
             (
                 r#"{"Starknet":"0xde29d060d45901fb19ed6c6e959eb22d8626708e","GpsStatementVerifier":"0xab43ba48c9edf4c2c4bb01237348d1d7b28ef168"}"#,
                 200,

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -129,27 +129,27 @@ pub struct Client {
 
 /// __Mandatory__ function to parse every sequencer query response and deserialize
 /// to expected output type.
-async fn parse<T>(resp: reqwest::Response) -> Result<T, SequencerError>
+async fn parse<T>(response: reqwest::Response) -> Result<T, SequencerError>
 where
     T: ::serde::de::DeserializeOwned,
 {
-    let resp = parse_raw(resp).await?;
+    let response = parse_raw(response).await?;
     // Attempt to deserialize the actual data we are looking for
-    let resp = resp.json::<T>().await?;
-    Ok(resp)
+    let response = response.json::<T>().await?;
+    Ok(response)
 }
 
 /// Helper function which allows skipping deserialization when required.
-async fn parse_raw(resp: reqwest::Response) -> Result<reqwest::Response, SequencerError> {
+async fn parse_raw(response: reqwest::Response) -> Result<reqwest::Response, SequencerError> {
     // Starknet specific errors end with a 500 status code
     // but the body contains a JSON object with the error description
-    if resp.status() == reqwest::StatusCode::INTERNAL_SERVER_ERROR {
-        let starknet_error = resp.json::<StarknetError>().await?;
+    if response.status() == reqwest::StatusCode::INTERNAL_SERVER_ERROR {
+        let starknet_error = response.json::<StarknetError>().await?;
         return Err(SequencerError::StarknetError(starknet_error));
     }
     // Status codes <400;499> and <501;599> are mapped to SequencerError::TransportError
-    resp.error_for_status_ref().map(|_| ())?;
-    Ok(resp)
+    response.error_for_status_ref().map(|_| ())?;
+    Ok(response)
 }
 
 /// Wrapper function to allow retrying sequencer queries in an exponential manner.
@@ -253,6 +253,10 @@ impl Client {
             sequencer_url: url,
         })
     }
+
+    fn request(&self) -> builder::Request<builder::WithUrl> {
+        builder::Request::new(&self.inner, self.sequencer_url.clone())
+    }
 }
 
 #[async_trait::async_trait]
@@ -264,13 +268,14 @@ impl ClientApi for Client {
         block_number: BlockNumberOrTag,
     ) -> Result<reply::Block, SequencerError> {
         retry(|| async move {
-            let query = builder::Request::with_sequencer_url(self.sequencer_url.clone())
+            let response = self
+                .request()
                 .feeder_gateway()
                 .get_block()
                 .at_block(block_number)
-                .finalize();
-            let resp = self.inner.get(query).send().await?;
-            parse::<reply::Block>(resp).await
+                .get()
+                .await?;
+            parse::<reply::Block>(response).await
         })
         .await
     }
@@ -282,13 +287,14 @@ impl ClientApi for Client {
         block_hash: BlockHashOrTag,
     ) -> Result<reply::Block, SequencerError> {
         retry(|| async {
-            let query = builder::Request::with_sequencer_url(self.sequencer_url.clone())
+            let response = self
+                .request()
                 .feeder_gateway()
                 .get_block()
                 .at_block(block_hash)
-                .finalize();
-            let resp = self.inner.get(query).send().await?;
-            parse::<reply::Block>(resp).await
+                .get()
+                .await?;
+            parse::<reply::Block>(response).await
         })
         .await
     }
@@ -301,14 +307,15 @@ impl ClientApi for Client {
         block_hash: BlockHashOrTag,
     ) -> Result<reply::Call, SequencerError> {
         retry(|| async {
-            let query = builder::Request::with_sequencer_url(self.sequencer_url.clone())
+            let response = self
+                .request()
                 .feeder_gateway()
                 .call_contract()
                 .at_block(block_hash)
                 .finalize();
 
-            let resp = self.inner.post(query).json(&payload).send().await?;
-            parse(resp).await
+            let response = self.inner.post(response).json(&payload).send().await?;
+            parse(response).await
         })
         .await
     }
@@ -320,16 +327,16 @@ impl ClientApi for Client {
         contract_addr: ContractAddress,
     ) -> Result<bytes::Bytes, SequencerError> {
         retry(|| async {
-            let query = builder::Request::with_sequencer_url(self.sequencer_url.clone())
+            let response = self
+                .request()
                 .feeder_gateway()
                 .get_full_contract()
                 .with_contract_address(contract_addr)
-                .finalize();
-
-            let resp = self.inner.get(query).send().await?;
-            let resp = parse_raw(resp).await?;
-            let resp = resp.bytes().await?;
-            Ok(resp)
+                .get()
+                .await?;
+            let response = parse_raw(response).await?;
+            let response = response.bytes().await?;
+            Ok(response)
         })
         .await
     }
@@ -338,16 +345,16 @@ impl ClientApi for Client {
     #[tracing::instrument(skip(self))]
     async fn class_by_hash(&self, class_hash: ClassHash) -> Result<bytes::Bytes, SequencerError> {
         retry(|| async {
-            let query = builder::Request::with_sequencer_url(self.sequencer_url.clone())
+            let response = self
+                .request()
                 .feeder_gateway()
                 .get_class_by_hash()
                 .with_class_hash(class_hash)
-                .finalize();
-
-            let resp = self.inner.get(query).send().await?;
-            let resp = parse_raw(resp).await?;
-            let resp = resp.bytes().await?;
-            Ok(resp)
+                .get()
+                .await?;
+            let response = parse_raw(response).await?;
+            let response = response.bytes().await?;
+            Ok(response)
         })
         .await
     }
@@ -359,14 +366,14 @@ impl ClientApi for Client {
         contract_address: ContractAddress,
     ) -> Result<ClassHash, SequencerError> {
         retry(|| async {
-            let query = builder::Request::with_sequencer_url(self.sequencer_url.clone())
+            let response = self
+                .request()
                 .feeder_gateway()
                 .get_class_hash_at()
                 .with_contract_address(contract_address)
-                .finalize();
-
-            let resp = self.inner.get(query).send().await?;
-            parse(resp).await
+                .get()
+                .await?;
+            parse(response).await
         })
         .await
     }
@@ -380,16 +387,16 @@ impl ClientApi for Client {
         block_hash: BlockHashOrTag,
     ) -> Result<StorageValue, SequencerError> {
         retry(|| async {
-            let query = builder::Request::with_sequencer_url(self.sequencer_url.clone())
+            let response = self
+                .request()
                 .feeder_gateway()
                 .get_storage_at()
                 .with_contract_address(contract_addr)
                 .with_storage_address(key)
                 .at_block(block_hash)
-                .finalize();
-
-            let resp = self.inner.get(query).send().await?;
-            parse::<StorageValue>(resp).await
+                .get()
+                .await?;
+            parse::<StorageValue>(response).await
         })
         .await
     }
@@ -401,14 +408,14 @@ impl ClientApi for Client {
         transaction_hash: StarknetTransactionHash,
     ) -> Result<reply::Transaction, SequencerError> {
         retry(|| async {
-            let query = builder::Request::with_sequencer_url(self.sequencer_url.clone())
+            let response = self
+                .request()
                 .feeder_gateway()
                 .get_transaction()
                 .with_transaction_hash(transaction_hash)
-                .finalize();
-
-            let resp = self.inner.get(query).send().await?;
-            parse(resp).await
+                .get()
+                .await?;
+            parse(response).await
         })
         .await
     }
@@ -420,14 +427,14 @@ impl ClientApi for Client {
         transaction_hash: StarknetTransactionHash,
     ) -> Result<reply::TransactionStatus, SequencerError> {
         retry(|| async {
-            let query = builder::Request::with_sequencer_url(self.sequencer_url.clone())
+            let response = self
+                .request()
                 .feeder_gateway()
                 .get_transaction_status()
                 .with_transaction_hash(transaction_hash)
-                .finalize();
-
-            let resp = self.inner.get(query).send().await?;
-            parse(resp).await
+                .get()
+                .await?;
+            parse(response).await
         })
         .await
     }
@@ -439,14 +446,14 @@ impl ClientApi for Client {
         block_hash: BlockHashOrTag,
     ) -> Result<reply::StateUpdate, SequencerError> {
         retry(|| async {
-            let query = builder::Request::with_sequencer_url(self.sequencer_url.clone())
+            let response = self
+                .request()
                 .feeder_gateway()
                 .get_state_update()
                 .at_block(block_hash)
-                .finalize();
-
-            let resp = self.inner.get(query).send().await?;
-            parse(resp).await
+                .get()
+                .await?;
+            parse(response).await
         })
         .await
     }
@@ -458,14 +465,14 @@ impl ClientApi for Client {
         block_number: BlockNumberOrTag,
     ) -> Result<reply::StateUpdate, SequencerError> {
         retry(|| async {
-            let query = builder::Request::with_sequencer_url(self.sequencer_url.clone())
+            let response = self
+                .request()
                 .feeder_gateway()
                 .get_state_update()
                 .at_block(block_number)
-                .finalize();
-
-            let resp = self.inner.get(query).send().await?;
-            parse(resp).await
+                .get()
+                .await?;
+            parse(response).await
         })
         .await
     }
@@ -474,13 +481,13 @@ impl ClientApi for Client {
     #[tracing::instrument(skip(self))]
     async fn eth_contract_addresses(&self) -> Result<reply::EthContractAddresses, SequencerError> {
         retry(|| async {
-            let query = builder::Request::with_sequencer_url(self.sequencer_url.clone())
+            let response = self
+                .request()
                 .feeder_gateway()
                 .get_contract_addresses()
-                .finalize();
-
-            let resp = self.inner.get(query).send().await?;
-            parse(resp).await
+                .get()
+                .await?;
+            parse(response).await
         })
         .await
     }
@@ -504,17 +511,17 @@ impl ClientApi for Client {
             },
         );
 
-        let query = builder::Request::with_sequencer_url(self.sequencer_url.clone())
-            .gateway()
-            .add_transaction()
-            .finalize();
-
         // Note that we don't do retries here.
         // This method is used to proxy an add transaction operation from the JSON-RPC
         // API to the sequencer. Retries should be implemented in the JSON-RPC
         // client instead.
-        let resp = self.inner.post(query).json(&req).send().await?;
-        parse(resp).await
+        let response = self
+            .request()
+            .gateway()
+            .add_transaction()
+            .post_json(&req)
+            .await?;
+        parse(response).await
     }
 
     /// Adds a transaction declaring a class.
@@ -539,19 +546,20 @@ impl ClientApi for Client {
                 version,
             });
 
-        let query = builder::Request::with_sequencer_url(self.sequencer_url.clone())
-            .gateway()
-            .add_transaction()
-            // mainnet requires a token (but testnet does not so its optional).
-            .with_optional_token(token.as_deref())
-            .finalize();
-
         // Note that we don't do retries here.
         // This method is used to proxy an add transaction operation from the JSON-RPC
         // API to the sequencer. Retries should be implemented in the JSON-RPC
         // client instead.
-        let resp = self.inner.post(query).json(&req).send().await?;
-        parse(resp).await
+        let response = self
+            .request()
+            .gateway()
+            .add_transaction()
+            // mainnet requires a token (but testnet does not so its optional).
+            .with_optional_token(token.as_deref())
+            .post_json(&req)
+            .await?;
+
+        parse(response).await
     }
 
     /// Deploys a contract.
@@ -570,19 +578,21 @@ impl ClientApi for Client {
                 constructor_calldata,
             });
 
-        let query = builder::Request::with_sequencer_url(self.sequencer_url.clone())
-            .gateway()
-            .add_transaction()
-            // mainnet requires a token (but testnet does not so its optional).
-            .with_optional_token(token.as_deref())
-            .finalize();
-
         // Note that we don't do retries here.
         // This method is used to proxy an add transaction operation from the JSON-RPC
         // API to the sequencer. Retries should be implemented in the JSON-RPC
         // client instead.
-        let resp = self.inner.post(query).json(&req).send().await?;
-        parse(resp).await
+
+        let response = self
+            .request()
+            .gateway()
+            .add_transaction()
+            // mainnet requires a token (but testnet does not so its optional).
+            .with_optional_token(token.as_deref())
+            .post_json(&req)
+            .await?;
+
+        parse(response).await
     }
 }
 
@@ -2177,8 +2187,8 @@ mod tests {
                 || async {
                     let mut url = reqwest::Url::parse("http://localhost/").unwrap();
                     url.set_port(Some(addr.port())).unwrap();
-                    let resp = reqwest::get(url).await?;
-                    super::parse::<String>(resp).await
+                    let response = reqwest::get(url).await?;
+                    super::parse::<String>(response).await
                 },
                 super::retry_condition,
             )
@@ -2208,8 +2218,8 @@ mod tests {
                 || async {
                     let mut url = reqwest::Url::parse("http://localhost/").unwrap();
                     url.set_port(Some(addr.port())).unwrap();
-                    let resp = reqwest::get(url).await?;
-                    super::parse::<String>(resp).await
+                    let response = reqwest::get(url).await?;
+                    super::parse::<String>(response).await
                 },
                 super::retry_condition,
             )
@@ -2238,12 +2248,12 @@ mod tests {
                     CNT.fetch_add(1, Ordering::Relaxed);
 
                     // This is the same as using Client::builder().timeout()
-                    let resp = client
+                    let response = client
                         .get(url)
                         .timeout(Duration::from_millis(1))
                         .send()
                         .await?;
-                    super::parse::<String>(resp).await
+                    super::parse::<String>(response).await
                 },
                 super::retry_condition,
             );

--- a/crates/pathfinder/src/sequencer/builder.rs
+++ b/crates/pathfinder/src/sequencer/builder.rs
@@ -20,6 +20,8 @@ pub struct Start;
 pub struct WithUrl;
 pub struct WithGateWay;
 pub struct WithMethod;
+pub struct WithRetry;
+pub struct WithoutRetry;
 
 pub enum BlockId {
     Number(StarknetBlockNumber),
@@ -182,6 +184,24 @@ impl<'a> Request<'a, WithMethod> {
         self
     }
 
+    pub fn auto_retry(self) -> Request<'a, WithRetry> {
+        Request {
+            url: self.url,
+            client: self.client,
+            marker: PhantomData::default(),
+        }
+    }
+
+    pub fn without_retry(self) -> Request<'a, WithoutRetry> {
+        Request {
+            url: self.url,
+            client: self.client,
+            marker: PhantomData::default(),
+        }
+    }
+}
+
+impl<'a> Request<'a, WithoutRetry> {
     pub async fn get<T>(self) -> Result<T, SequencerError>
     where
         T: serde::de::DeserializeOwned,
@@ -203,6 +223,69 @@ impl<'a> Request<'a, WithMethod> {
     {
         let response = self.client.post(self.url).json(json).send().await?;
         parse::<T>(response).await
+    }
+}
+
+impl<'a> Request<'a, WithRetry> {
+    pub async fn get<T>(self) -> Result<T, SequencerError>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        retry0(
+            || {
+                let clone_url = self.url.clone();
+                async move {
+                    let r = Request::<WithoutRetry> {
+                        url: clone_url,
+                        client: self.client,
+                        marker: PhantomData::default(),
+                    };
+                    r.get().await
+                }
+            },
+            retry_condition,
+        )
+        .await
+    }
+
+    pub async fn get_as_bytes(self) -> Result<bytes::Bytes, SequencerError> {
+        retry0(
+            || {
+                let clone_url = self.url.clone();
+                async move {
+                    let r = Request::<WithoutRetry> {
+                        url: clone_url,
+                        client: self.client,
+                        marker: PhantomData::default(),
+                    };
+                    r.get_as_bytes().await
+                }
+            },
+            retry_condition,
+        )
+        .await
+    }
+
+    pub async fn post_with_json<T, J>(self, json: &J) -> Result<T, SequencerError>
+    where
+        T: serde::de::DeserializeOwned,
+        J: serde::Serialize + ?Sized,
+    {
+        retry0(
+            || {
+                let clone_url = self.url.clone();
+                async move {
+                    let r = Request::<WithoutRetry> {
+                        url: clone_url,
+                        client: self.client,
+                        marker: PhantomData::default(),
+                    };
+                    r.post_with_json(json).await
+                }
+            },
+            retry_condition,
+        )
+        .await
     }
 }
 
@@ -235,6 +318,8 @@ impl RequestState for Start {}
 impl RequestState for WithUrl {}
 impl RequestState for WithGateWay {}
 impl RequestState for WithMethod {}
+impl RequestState for WithRetry {}
+impl RequestState for WithoutRetry {}
 
 impl From<crate::rpc::types::BlockNumberOrTag> for BlockId {
     fn from(block: crate::rpc::types::BlockNumberOrTag) -> Self {
@@ -258,6 +343,218 @@ impl From<crate::rpc::types::BlockHashOrTag> for BlockId {
             Hash(hash) => Self::Hash(hash),
             Tag(Latest) => Self::Latest,
             Tag(Pending) => Self::Pending,
+        }
+    }
+}
+
+/// Wrapper function to allow retrying sequencer queries in an exponential manner.
+async fn retry0<T, Fut, FutureFactory, Ret>(
+    future_factory: FutureFactory,
+    retry_condition: Ret,
+) -> Result<T, SequencerError>
+where
+    Fut: futures::Future<Output = Result<T, SequencerError>>,
+    FutureFactory: FnMut() -> Fut,
+    Ret: FnMut(&SequencerError) -> bool,
+{
+    use crate::retry::Retry;
+    use std::num::NonZeroU64;
+
+    Retry::exponential(future_factory, NonZeroU64::new(2).unwrap())
+        .factor(NonZeroU64::new(15).unwrap())
+        .max_delay(std::time::Duration::from_secs(60 * 60))
+        .when(retry_condition)
+        .await
+}
+
+/// Determines if an error is retryable or not.
+fn retry_condition(e: &SequencerError) -> bool {
+    use reqwest::StatusCode;
+    use tracing::{debug, error, info, warn};
+
+    match e {
+        SequencerError::ReqwestError(e) => {
+            if e.is_body() || e.is_connect() || e.is_timeout() {
+                info!(reason=%e, "Request failed, retrying");
+            } else if e.is_status() {
+                match e.status() {
+                    Some(
+                        StatusCode::NOT_FOUND
+                        | StatusCode::TOO_MANY_REQUESTS
+                        | StatusCode::BAD_GATEWAY
+                        | StatusCode::SERVICE_UNAVAILABLE
+                        | StatusCode::GATEWAY_TIMEOUT,
+                    ) => {
+                        debug!(reason=%e, "Request failed, retrying");
+                    }
+                    Some(StatusCode::INTERNAL_SERVER_ERROR) => {
+                        error!(reason=%e, "Request failed, retrying");
+                    }
+                    Some(_) => warn!(reason=%e, "Request failed, retrying"),
+                    None => unreachable!(),
+                }
+            } else if e.is_decode() {
+                error!(reason=%e, "Request failed, retrying");
+            } else {
+                warn!(reason=%e, "Request failed, retrying");
+            }
+
+            true
+        }
+        SequencerError::StarknetError(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod retry {
+        use assert_matches::assert_matches;
+        use http::{response::Builder, StatusCode};
+        use pretty_assertions::assert_eq;
+        use std::{
+            collections::VecDeque, convert::Infallible, net::SocketAddr, sync::Arc, time::Duration,
+        };
+        use tokio::{sync::Mutex, task::JoinHandle};
+        use warp::Filter;
+
+        use crate::sequencer::builder::{retry0, retry_condition};
+
+        // A test helper
+        fn status_queue_server(
+            statuses: VecDeque<(StatusCode, &'static str)>,
+        ) -> (JoinHandle<()>, SocketAddr) {
+            use std::cell::RefCell;
+
+            let statuses = Arc::new(Mutex::new(RefCell::new(statuses)));
+            let any = warp::any().and_then(move || {
+                let s = statuses.clone();
+                async move {
+                    let s = s.lock().await;
+                    let s = s.borrow_mut().pop_front().unwrap();
+                    Result::<_, Infallible>::Ok(Builder::new().status(s.0).body(s.1))
+                }
+            });
+
+            let (addr, run_srv) = warp::serve(any).bind_ephemeral(([127, 0, 0, 1], 0));
+            let server_handle = tokio::spawn(run_srv);
+            (server_handle, addr)
+        }
+
+        // A test helper
+        fn slow_server() -> (tokio::task::JoinHandle<()>, std::net::SocketAddr) {
+            async fn slow() -> Result<impl warp::Reply, Infallible> {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                Ok(Builder::new().status(200).body(""))
+            }
+
+            let any = warp::any().and_then(slow);
+            let (addr, run_srv) = warp::serve(any).bind_ephemeral(([127, 0, 0, 1], 0));
+            let server_handle = tokio::spawn(run_srv);
+            (server_handle, addr)
+        }
+
+        #[test_log::test(tokio::test)]
+        async fn stop_on_ok() {
+            use crate::sequencer::builder;
+
+            let statuses = VecDeque::from([
+                (StatusCode::TOO_MANY_REQUESTS, ""),
+                (StatusCode::BAD_GATEWAY, ""),
+                (StatusCode::SERVICE_UNAVAILABLE, ""),
+                (StatusCode::GATEWAY_TIMEOUT, ""),
+                (StatusCode::OK, r#""Finally!""#),
+                (StatusCode::TOO_MANY_REQUESTS, ""),
+                (StatusCode::BAD_GATEWAY, ""),
+                (StatusCode::SERVICE_UNAVAILABLE, ""),
+            ]);
+
+            let (_jh, addr) = status_queue_server(statuses);
+            let result = retry0(
+                || async {
+                    let mut url = reqwest::Url::parse("http://localhost/").unwrap();
+                    url.set_port(Some(addr.port())).unwrap();
+                    let response = reqwest::get(url).await?;
+                    builder::parse::<String>(response).await
+                },
+                retry_condition,
+            )
+            .await
+            .unwrap();
+            assert_eq!(result, "Finally!");
+        }
+
+        #[test_log::test(tokio::test)]
+        async fn stop_on_fatal() {
+            use crate::sequencer::builder;
+            use crate::sequencer::error::{SequencerError, StarknetErrorCode};
+
+            let statuses = VecDeque::from([
+                (StatusCode::TOO_MANY_REQUESTS, ""),
+                (StatusCode::BAD_GATEWAY, ""),
+                (StatusCode::SERVICE_UNAVAILABLE, ""),
+                (StatusCode::GATEWAY_TIMEOUT, ""),
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    r#"{"code":"StarknetErrorCode.BLOCK_NOT_FOUND","message":""}"#,
+                ),
+                (StatusCode::TOO_MANY_REQUESTS, ""),
+                (StatusCode::BAD_GATEWAY, ""),
+                (StatusCode::SERVICE_UNAVAILABLE, ""),
+            ]);
+
+            let (_jh, addr) = status_queue_server(statuses);
+            let error = retry0(
+                || async {
+                    let mut url = reqwest::Url::parse("http://localhost/").unwrap();
+                    url.set_port(Some(addr.port())).unwrap();
+                    let response = reqwest::get(url).await?;
+                    builder::parse::<String>(response).await
+                },
+                retry_condition,
+            )
+            .await
+            .unwrap_err();
+            assert_matches!(
+                error,
+                SequencerError::StarknetError(se) => assert_eq!(se.code, StarknetErrorCode::BlockNotFound)
+            );
+        }
+
+        #[tokio::test(flavor = "current_thread", start_paused = true)]
+        async fn request_timeout() {
+            use crate::sequencer::builder;
+
+            use std::sync::atomic::{AtomicUsize, Ordering};
+
+            let (_jh, addr) = slow_server();
+            static CNT: AtomicUsize = AtomicUsize::new(0);
+
+            let fut = retry0(
+                || async {
+                    let mut url = reqwest::Url::parse("http://localhost/").unwrap();
+                    url.set_port(Some(addr.port())).unwrap();
+
+                    let client = reqwest::Client::builder().build().unwrap();
+
+                    CNT.fetch_add(1, Ordering::Relaxed);
+
+                    // This is the same as using Client::builder().timeout()
+                    let response = client
+                        .get(url)
+                        .timeout(Duration::from_millis(1))
+                        .send()
+                        .await?;
+                    builder::parse::<String>(response).await
+                },
+                retry_condition,
+            );
+
+            // The retry loops forever, so wrap it in a timeout and check the counter.
+            tokio::time::timeout(Duration::from_millis(250), fut)
+                .await
+                .unwrap_err();
+            // 4th try should have timedout if this is really exponential backoff
+            assert_eq!(CNT.load(Ordering::Relaxed), 4);
         }
     }
 }

--- a/crates/pathfinder/src/sequencer/builder.rs
+++ b/crates/pathfinder/src/sequencer/builder.rs
@@ -1,0 +1,213 @@
+#![allow(dead_code)]
+
+use std::marker::PhantomData;
+
+use crate::core::{
+    ClassHash, ContractAddress, StarknetBlockHash, StarknetBlockNumber, StarknetTransactionHash,
+    StorageAddress,
+};
+
+pub struct Request<S: RequestState> {
+    marker: PhantomData<S>,
+    url: reqwest::Url,
+}
+
+pub struct Start;
+pub struct WithUrl;
+pub struct WithGateWay;
+pub struct WithMethod;
+
+pub enum BlockId {
+    Number(StarknetBlockNumber),
+    Hash(StarknetBlockHash),
+    Latest,
+    Pending,
+}
+
+impl BlockId {
+    fn to_str(&self) -> std::borrow::Cow<'static, str> {
+        use std::borrow::Cow;
+
+        match self {
+            BlockId::Number(number) => Cow::from(number.0.to_string()),
+            BlockId::Hash(hash) => hash.0.to_hex_str(),
+            BlockId::Latest => Cow::from("latest"),
+            BlockId::Pending => Cow::from("pending"),
+        }
+    }
+}
+
+impl Request<Start> {
+    pub fn with_sequencer_url(url: reqwest::Url) -> Request<WithUrl> {
+        Request {
+            url,
+            marker: PhantomData::default(),
+        }
+    }
+}
+
+impl Request<WithUrl> {
+    pub fn gateway(self) -> Request<WithGateWay> {
+        self.with_gateway("gateway")
+    }
+
+    pub fn feeder_gateway(self) -> Request<WithGateWay> {
+        self.with_gateway("feeder_gateway")
+    }
+
+    fn with_gateway(mut self, gateway: &str) -> Request<WithGateWay> {
+        self.url
+            .path_segments_mut()
+            .expect("Base URL is valid")
+            .push(gateway);
+        Request {
+            url: self.url,
+            marker: PhantomData::default(),
+        }
+    }
+}
+
+impl Request<WithGateWay> {
+    pub fn add_transaction(self) -> Request<WithMethod> {
+        self.with_method("add_transaction")
+    }
+
+    pub fn call_contract(self) -> Request<WithMethod> {
+        self.with_method("call_contract")
+    }
+
+    pub fn get_block(self) -> Request<WithMethod> {
+        self.with_method("get_block")
+    }
+
+    pub fn get_full_contract(self) -> Request<WithMethod> {
+        self.with_method("get_full_contract")
+    }
+
+    pub fn get_class_by_hash(self) -> Request<WithMethod> {
+        self.with_method("get_class_by_hash")
+    }
+
+    pub fn get_class_hash_at(self) -> Request<WithMethod> {
+        self.with_method("get_class_hash_at")
+    }
+
+    pub fn get_storage_at(self) -> Request<WithMethod> {
+        self.with_method("get_storage_at")
+    }
+
+    pub fn get_transaction(self) -> Request<WithMethod> {
+        self.with_method("get_transaction")
+    }
+
+    pub fn get_transaction_status(self) -> Request<WithMethod> {
+        self.with_method("get_transaction_status")
+    }
+
+    pub fn get_state_update(self) -> Request<WithMethod> {
+        self.with_method("get_state_update")
+    }
+
+    pub fn get_contract_addresses(self) -> Request<WithMethod> {
+        self.with_method("get_contract_addresses")
+    }
+
+    #[cfg(test)]
+    pub fn custom(self, method: &'static str) -> Request<WithMethod> {
+        self.with_method(method)
+    }
+
+    fn with_method(mut self, method: &str) -> Request<WithMethod> {
+        self.url
+            .path_segments_mut()
+            .expect("Base URL is valid")
+            .push(method);
+
+        Request {
+            url: self.url,
+            marker: PhantomData::default(),
+        }
+    }
+}
+
+impl Request<WithMethod> {
+    pub fn at_block<B: Into<BlockId>>(self, block: B) -> Self {
+        use std::borrow::Cow;
+
+        let block: BlockId = block.into();
+        let (name, value) = match block {
+            BlockId::Number(number) => ("blockNumber", Cow::from(number.0.to_string())),
+            BlockId::Hash(hash) => ("blockHash", hash.0.to_hex_str()),
+            // The name for these two could be either "blockNumber" or "blockHash".
+            BlockId::Latest => ("blockNumber", Cow::from("latest")),
+            BlockId::Pending => ("blockNumber", Cow::from("pending")),
+        };
+
+        self.add_param(name, &value)
+    }
+
+    pub fn with_contract_address(self, address: ContractAddress) -> Self {
+        self.add_param("contractAddress", &address.0.to_hex_str())
+    }
+
+    pub fn with_class_hash(self, class_hash: ClassHash) -> Self {
+        self.add_param("classHash", &class_hash.0.to_hex_str())
+    }
+
+    pub fn with_optional_token(self, token: Option<&str>) -> Self {
+        match token {
+            Some(token) => self.add_param("token", token),
+            None => self,
+        }
+    }
+
+    pub fn with_storage_address(self, address: StorageAddress) -> Self {
+        use crate::rpc::serde::starkhash_to_dec_str;
+        self.add_param("key", &starkhash_to_dec_str(&address.0))
+    }
+
+    pub fn with_transaction_hash(self, hash: StarknetTransactionHash) -> Self {
+        self.add_param("transactionHash", &hash.0.to_hex_str())
+    }
+
+    pub fn add_param(mut self, name: &str, value: &str) -> Self {
+        self.url.query_pairs_mut().append_pair(name, value);
+        self
+    }
+
+    pub fn finalize(self) -> reqwest::Url {
+        self.url
+    }
+}
+
+pub trait RequestState {}
+impl RequestState for Start {}
+impl RequestState for WithUrl {}
+impl RequestState for WithGateWay {}
+impl RequestState for WithMethod {}
+
+impl From<crate::rpc::types::BlockNumberOrTag> for BlockId {
+    fn from(block: crate::rpc::types::BlockNumberOrTag) -> Self {
+        use crate::rpc::types::BlockNumberOrTag::*;
+        use crate::rpc::types::Tag::*;
+
+        match block {
+            Number(number) => Self::Number(number),
+            Tag(Latest) => Self::Latest,
+            Tag(Pending) => Self::Pending,
+        }
+    }
+}
+
+impl From<crate::rpc::types::BlockHashOrTag> for BlockId {
+    fn from(block: crate::rpc::types::BlockHashOrTag) -> Self {
+        use crate::rpc::types::BlockHashOrTag::*;
+        use crate::rpc::types::Tag::*;
+
+        match block {
+            Hash(hash) => Self::Hash(hash),
+            Tag(Latest) => Self::Latest,
+            Tag(Pending) => Self::Pending,
+        }
+    }
+}

--- a/crates/pathfinder/src/sequencer/builder.rs
+++ b/crates/pathfinder/src/sequencer/builder.rs
@@ -239,8 +239,6 @@ impl<'a> Request<'a, stage::Final> {
             url: reqwest::Url,
             client: &reqwest::Client,
         ) -> Result<T, SequencerError> {
-            dbg!(&url);
-
             let response = client.get(url).send().await?;
             parse::<T>(response).await
         }

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -9,8 +9,7 @@ use crate::{
 use serde::Deserialize;
 use serde_with::serde_as;
 
-/// Used to deserialize replies to [ClientApi::block_by_hash](crate::sequencer::ClientApi::block_by_hash) and
-/// [ClientApi::block_by_number](crate::sequencer::ClientApi::block_by_number).
+/// Used to deserialize replies to [ClientApi::block](crate::sequencer::ClientApi::block).
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[cfg_attr(test, derive(serde::Serialize))]

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -303,7 +303,7 @@ pub mod transaction {
 }
 
 /// Used to deserialize a reply from
-/// [ClientApi::state_update_by_hash](crate::sequencer::ClientApi::state_update_by_hash).
+/// [ClientApi::state_update](crate::sequencer::ClientApi::state_update).
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct StateUpdate {

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -629,7 +629,7 @@ mod tests {
             TransactionVersion,
         },
         ethereum,
-        rpc::types::{BlockHashOrTag, BlockNumberOrTag},
+        rpc::types::BlockHashOrTag,
         sequencer::{
             self,
             error::SequencerError,
@@ -688,10 +688,10 @@ mod tests {
 
     #[async_trait::async_trait]
     impl sequencer::ClientApi for FakeSequencer {
-        async fn block<B: 'static + Into<crate::core::BlockId> + Send + core::fmt::Debug>(
-            &self,
-            block: B,
-        ) -> Result<reply::Block, SequencerError> {
+        async fn block<B>(&self, block: B) -> Result<reply::Block, SequencerError>
+        where
+            B: 'static + Into<crate::core::BlockId> + Send + std::fmt::Debug,
+        {
             use crate::core::BlockId;
 
             match block.into() {
@@ -743,17 +743,10 @@ mod tests {
             unimplemented!()
         }
 
-        async fn state_update_by_hash(
-            &self,
-            _: BlockHashOrTag,
-        ) -> Result<reply::StateUpdate, SequencerError> {
-            unimplemented!()
-        }
-
-        async fn state_update_by_number(
-            &self,
-            _: BlockNumberOrTag,
-        ) -> Result<reply::StateUpdate, SequencerError> {
+        async fn state_update<B>(&self, _: B) -> Result<reply::StateUpdate, SequencerError>
+        where
+            B: 'static + Into<crate::core::BlockId> + Send + std::fmt::Debug,
+        {
             unimplemented!()
         }
 

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -688,14 +688,9 @@ mod tests {
 
     #[async_trait::async_trait]
     impl sequencer::ClientApi for FakeSequencer {
-        async fn block<B>(&self, block: B) -> Result<reply::Block, SequencerError>
-        where
-            B: 'static + Into<crate::core::BlockId> + Send + std::fmt::Debug,
-        {
-            use crate::core::BlockId;
-
-            match block.into() {
-                BlockId::Number(_) => Ok(BLOCK0.clone()),
+        async fn block(&self, block: crate::core::BlockId) -> Result<reply::Block, SequencerError> {
+            match block {
+                crate::core::BlockId::Number(_) => Ok(BLOCK0.clone()),
                 _ => unimplemented!(),
             }
         }
@@ -743,10 +738,10 @@ mod tests {
             unimplemented!()
         }
 
-        async fn state_update<B>(&self, _: B) -> Result<reply::StateUpdate, SequencerError>
-        where
-            B: 'static + Into<crate::core::BlockId> + Send + std::fmt::Debug,
-        {
+        async fn state_update(
+            &self,
+            _: crate::core::BlockId,
+        ) -> Result<reply::StateUpdate, SequencerError> {
             unimplemented!()
         }
 

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -96,7 +96,7 @@ pub async fn sync(
         let block_hash = block.block_hash.unwrap();
         let t_update = std::time::Instant::now();
         let state_update = sequencer
-            .state_update(block_hash)
+            .state_update(block_hash.into())
             .await
             .with_context(|| format!("Fetch state diff for block {:?} from sequencer", next))?;
         let state_update_block_hash = state_update.block_hash.unwrap();
@@ -182,7 +182,7 @@ async fn download_block(
     use crate::core::BlockId;
     use sequencer::error::StarknetErrorCode::BlockNotFound;
 
-    let result = sequencer.block(block_number).await;
+    let result = sequencer.block(block_number.into()).await;
 
     match result {
         Ok(block) => Ok(DownloadBlock::Block(Box::new(block))),
@@ -387,12 +387,11 @@ mod tests {
         use super::super::{sync, Event};
         use crate::{
             core::{
-                ClassHash, ContractAddress, GasPrice, GlobalRoot, SequencerAddress,
+                BlockId, ClassHash, ContractAddress, GasPrice, GlobalRoot, SequencerAddress,
                 StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp, StorageAddress,
                 StorageValue,
             },
             ethereum::state_update,
-            rpc::types::BlockHashOrTag,
             sequencer::{
                 error::{SequencerError, StarknetError, StarknetErrorCode},
                 reply, MockClientApi,
@@ -670,29 +669,13 @@ mod tests {
         fn expect_block(
             mock: &mut MockClientApi,
             seq: &mut mockall::Sequence,
-            block_number: StarknetBlockNumber,
+            block: BlockId,
             returned_result: Result<reply::Block, SequencerError>,
         ) {
-            use crate::core::BlockId;
             use mockall::predicate::eq;
 
             mock.expect_block()
-                .with(eq(BlockId::Number(block_number)))
-                .times(1)
-                .in_sequence(seq)
-                .return_once(move |_| returned_result);
-        }
-
-        /// Convenience wrapper
-        fn expect_latest_block(
-            mock: &mut MockClientApi,
-            seq: &mut mockall::Sequence,
-            returned_result: Result<reply::Block, SequencerError>,
-        ) {
-            use crate::core::BlockId;
-
-            mock.expect_block()
-                .withf(move |x: &BlockId| x == &BlockId::Latest)
+                .with(eq(block))
                 .times(1)
                 .in_sequence(seq)
                 .return_once(move |_| returned_result);
@@ -702,11 +685,13 @@ mod tests {
         fn expect_state_update(
             mock: &mut MockClientApi,
             seq: &mut mockall::Sequence,
-            block_hash: StarknetBlockHash,
+            block: BlockId,
             returned_result: Result<reply::StateUpdate, SequencerError>,
         ) {
+            use mockall::predicate::eq;
+
             mock.expect_state_update()
-                .withf(move |x: &BlockHashOrTag| x == &BlockHashOrTag::Hash(block_hash))
+                .with(eq(block))
                 .times(1)
                 .in_sequence(seq)
                 .return_once(|_| returned_result);
@@ -746,8 +731,18 @@ mod tests {
                 let mut seq = mockall::Sequence::new();
 
                 // Downlad the genesis block with respective state update and contracts
-                expect_block(&mut mock, &mut seq, BLOCK0_NUMBER, Ok(BLOCK0.clone()));
-                expect_state_update(&mut mock, &mut seq, *BLOCK0_HASH, Ok(STATE_UPDATE0.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK0_NUMBER.into(),
+                    Ok(BLOCK0.clone()),
+                );
+                expect_state_update(
+                    &mut mock,
+                    &mut seq,
+                    (*BLOCK0_HASH).into(),
+                    Ok(STATE_UPDATE0.clone()),
+                );
                 expect_full_contract(
                     &mut mock,
                     &mut seq,
@@ -755,8 +750,18 @@ mod tests {
                     Ok(CONTRACT0_DEF.clone()),
                 );
                 // Downlad block #1 with respective state update and contracts
-                expect_block(&mut mock, &mut seq, BLOCK1_NUMBER, Ok(BLOCK1.clone()));
-                expect_state_update(&mut mock, &mut seq, *BLOCK1_HASH, Ok(STATE_UPDATE1.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK1_NUMBER.into(),
+                    Ok(BLOCK1.clone()),
+                );
+                expect_state_update(
+                    &mut mock,
+                    &mut seq,
+                    (*BLOCK1_HASH).into(),
+                    Ok(STATE_UPDATE1.clone()),
+                );
                 expect_full_contract(
                     &mut mock,
                     &mut seq,
@@ -764,8 +769,13 @@ mod tests {
                     Ok(CONTRACT1_DEF.clone()),
                 );
                 // Stay at head, no more blocks available
-                expect_block(&mut mock, &mut seq, BLOCK2_NUMBER, Err(block_not_found()));
-                expect_latest_block(&mut mock, &mut seq, Ok(BLOCK1.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK2_NUMBER.into(),
+                    Err(block_not_found()),
+                );
+                expect_block(&mut mock, &mut seq, BlockId::Latest, Ok(BLOCK1.clone()));
 
                 // Let's run the UUT
                 let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Goerli));
@@ -814,8 +824,18 @@ mod tests {
                 let mut seq = mockall::Sequence::new();
 
                 // Start with downloading block #1
-                expect_block(&mut mock, &mut seq, BLOCK1_NUMBER, Ok(BLOCK1.clone()));
-                expect_state_update(&mut mock, &mut seq, *BLOCK1_HASH, Ok(STATE_UPDATE1.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK1_NUMBER.into(),
+                    Ok(BLOCK1.clone()),
+                );
+                expect_state_update(
+                    &mut mock,
+                    &mut seq,
+                    (*BLOCK1_HASH).into(),
+                    Ok(STATE_UPDATE1.clone()),
+                );
                 expect_full_contract(
                     &mut mock,
                     &mut seq,
@@ -824,8 +844,13 @@ mod tests {
                 );
 
                 // Stay at head, no more blocks available
-                expect_block(&mut mock, &mut seq, BLOCK2_NUMBER, Err(block_not_found()));
-                expect_latest_block(&mut mock, &mut seq, Ok(BLOCK1.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK2_NUMBER.into(),
+                    Err(block_not_found()),
+                );
+                expect_block(&mut mock, &mut seq, BlockId::Latest, Ok(BLOCK1.clone()));
 
                 // Let's run the UUT
                 let _jh = tokio::spawn(sync(
@@ -883,8 +908,18 @@ mod tests {
                 let mut seq = mockall::Sequence::new();
 
                 // Fetch the genesis block with respective state update and contracts
-                expect_block(&mut mock, &mut seq, BLOCK0_NUMBER, Ok(BLOCK0.clone()));
-                expect_state_update(&mut mock, &mut seq, *BLOCK0_HASH, Ok(STATE_UPDATE0.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK0_NUMBER.into(),
+                    Ok(BLOCK0.clone()),
+                );
+                expect_state_update(
+                    &mut mock,
+                    &mut seq,
+                    (*BLOCK0_HASH).into(),
+                    Ok(STATE_UPDATE0.clone()),
+                );
                 expect_full_contract(
                     &mut mock,
                     &mut seq,
@@ -893,19 +928,29 @@ mod tests {
                 );
 
                 // Block #1 is not there
-                expect_block(&mut mock, &mut seq, BLOCK1_NUMBER, Err(block_not_found()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK1_NUMBER.into(),
+                    Err(block_not_found()),
+                );
 
                 // L2 sync task is then looking if reorg occured
                 // We indicate that reorg started at genesis
-                expect_latest_block(&mut mock, &mut seq, Ok(BLOCK0_V2.clone()));
+                expect_block(&mut mock, &mut seq, BlockId::Latest, Ok(BLOCK0_V2.clone()));
 
                 // Finally the L2 sync task is downloading the new genesis block
                 // from the fork with respective state update and contracts
-                expect_block(&mut mock, &mut seq, BLOCK0_NUMBER, Ok(BLOCK0_V2.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK0_NUMBER.into(),
+                    Ok(BLOCK0_V2.clone()),
+                );
                 expect_state_update(
                     &mut mock,
                     &mut seq,
-                    *BLOCK0_HASH_V2,
+                    (*BLOCK0_HASH_V2).into(),
                     Ok(STATE_UPDATE0_V2.clone()),
                 );
                 expect_full_contract(
@@ -916,10 +961,15 @@ mod tests {
                 );
 
                 // Indicate that we are still staying at the head - no new blocks
-                expect_block(&mut mock, &mut seq, BLOCK1_NUMBER, Err(block_not_found()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK1_NUMBER.into(),
+                    Err(block_not_found()),
+                );
 
                 // Indicate that we are still staying at the head - the latest block matches our head
-                expect_latest_block(&mut mock, &mut seq, Ok(BLOCK0_V2.clone()));
+                expect_block(&mut mock, &mut seq, BlockId::Latest, Ok(BLOCK0_V2.clone()));
 
                 // Let's run the UUT
                 let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Goerli));
@@ -1000,8 +1050,18 @@ mod tests {
                 };
 
                 // Fetch the genesis block with respective state update and contracts
-                expect_block(&mut mock, &mut seq, BLOCK0_NUMBER, Ok(BLOCK0.clone()));
-                expect_state_update(&mut mock, &mut seq, *BLOCK0_HASH, Ok(STATE_UPDATE0.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK0_NUMBER.into(),
+                    Ok(BLOCK0.clone()),
+                );
+                expect_state_update(
+                    &mut mock,
+                    &mut seq,
+                    (*BLOCK0_HASH).into(),
+                    Ok(STATE_UPDATE0.clone()),
+                );
                 expect_full_contract(
                     &mut mock,
                     &mut seq,
@@ -1009,8 +1069,18 @@ mod tests {
                     Ok(CONTRACT0_DEF.clone()),
                 );
                 // Fetch block #1 with respective state update and contracts
-                expect_block(&mut mock, &mut seq, BLOCK1_NUMBER, Ok(BLOCK1.clone()));
-                expect_state_update(&mut mock, &mut seq, *BLOCK1_HASH, Ok(STATE_UPDATE1.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK1_NUMBER.into(),
+                    Ok(BLOCK1.clone()),
+                );
+                expect_state_update(
+                    &mut mock,
+                    &mut seq,
+                    (*BLOCK1_HASH).into(),
+                    Ok(STATE_UPDATE1.clone()),
+                );
                 expect_full_contract(
                     &mut mock,
                     &mut seq,
@@ -1018,27 +1088,57 @@ mod tests {
                     Ok(CONTRACT1_DEF.clone()),
                 );
                 // Fetch block #2 with respective state update and contracts
-                expect_block(&mut mock, &mut seq, BLOCK2_NUMBER, Ok(BLOCK2.clone()));
-                expect_state_update(&mut mock, &mut seq, *BLOCK2_HASH, Ok(STATE_UPDATE2.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK2_NUMBER.into(),
+                    Ok(BLOCK2.clone()),
+                );
+                expect_state_update(
+                    &mut mock,
+                    &mut seq,
+                    (*BLOCK2_HASH).into(),
+                    Ok(STATE_UPDATE2.clone()),
+                );
 
                 // Block #3 is not there
-                expect_block(&mut mock, &mut seq, BLOCK3_NUMBER, Err(block_not_found()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK3_NUMBER.into(),
+                    Err(block_not_found()),
+                );
 
                 // L2 sync task is then looking if reorg occured
                 // We indicate that reorg started at genesis by setting the latest on the new genesis block
-                expect_latest_block(&mut mock, &mut seq, Ok(BLOCK0_V2.clone()));
+                expect_block(&mut mock, &mut seq, BlockId::Latest, Ok(BLOCK0_V2.clone()));
                 // Then the L2 sync task goes back block by block to find the last block where the block hash matches the DB
-                expect_block(&mut mock, &mut seq, BLOCK1_NUMBER, Ok(block1_v2.clone()));
-                expect_block(&mut mock, &mut seq, BLOCK0_NUMBER, Ok(BLOCK0_V2.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK1_NUMBER.into(),
+                    Ok(block1_v2.clone()),
+                );
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK0_NUMBER.into(),
+                    Ok(BLOCK0_V2.clone()),
+                );
 
                 // Once the L2 sync task has found where reorg occured,
                 // it can get back to downloading the new blocks
                 // Fetch the new genesis block from the fork with respective state update and contracts
-                expect_block(&mut mock, &mut seq, BLOCK0_NUMBER, Ok(BLOCK0_V2.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK0_NUMBER.into(),
+                    Ok(BLOCK0_V2.clone()),
+                );
                 expect_state_update(
                     &mut mock,
                     &mut seq,
-                    *BLOCK0_HASH_V2,
+                    (*BLOCK0_HASH_V2).into(),
                     Ok(STATE_UPDATE0_V2.clone()),
                 );
                 expect_full_contract(
@@ -1048,18 +1148,28 @@ mod tests {
                     Ok(CONTRACT0_DEF_V2.clone()),
                 );
                 // Fetch the new block #1 from the fork with respective state update and contracts
-                expect_block(&mut mock, &mut seq, BLOCK1_NUMBER, Ok(block1_v2.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK1_NUMBER.into(),
+                    Ok(block1_v2.clone()),
+                );
                 expect_state_update(
                     &mut mock,
                     &mut seq,
-                    *BLOCK1_HASH_V2,
+                    (*BLOCK1_HASH_V2).into(),
                     Ok(STATE_UPDATE1_V2.clone()),
                 );
 
                 // Indicate that we are still staying at the head
                 // No new blocks found and the latest block matches our head
-                expect_block(&mut mock, &mut seq, BLOCK2_NUMBER, Err(block_not_found()));
-                expect_latest_block(&mut mock, &mut seq, Ok(block1_v2.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK2_NUMBER.into(),
+                    Err(block_not_found()),
+                );
+                expect_block(&mut mock, &mut seq, BlockId::Latest, Ok(block1_v2.clone()));
 
                 // Run the UUT
                 let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Goerli));
@@ -1210,8 +1320,18 @@ mod tests {
                 };
 
                 // Fetch the genesis block with respective state update and contracts
-                expect_block(&mut mock, &mut seq, BLOCK0_NUMBER, Ok(BLOCK0.clone()));
-                expect_state_update(&mut mock, &mut seq, *BLOCK0_HASH, Ok(STATE_UPDATE0.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK0_NUMBER.into(),
+                    Ok(BLOCK0.clone()),
+                );
+                expect_state_update(
+                    &mut mock,
+                    &mut seq,
+                    (*BLOCK0_HASH).into(),
+                    Ok(STATE_UPDATE0.clone()),
+                );
                 expect_full_contract(
                     &mut mock,
                     &mut seq,
@@ -1219,8 +1339,18 @@ mod tests {
                     Ok(CONTRACT0_DEF.clone()),
                 );
                 // Fetch block #1 with respective state update and contracts
-                expect_block(&mut mock, &mut seq, BLOCK1_NUMBER, Ok(BLOCK1.clone()));
-                expect_state_update(&mut mock, &mut seq, *BLOCK1_HASH, Ok(STATE_UPDATE1.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK1_NUMBER.into(),
+                    Ok(BLOCK1.clone()),
+                );
+                expect_state_update(
+                    &mut mock,
+                    &mut seq,
+                    (*BLOCK1_HASH).into(),
+                    Ok(STATE_UPDATE1.clone()),
+                );
                 expect_full_contract(
                     &mut mock,
                     &mut seq,
@@ -1228,44 +1358,99 @@ mod tests {
                     Ok(CONTRACT1_DEF.clone()),
                 );
                 // Fetch block #2 with respective state update and contracts
-                expect_block(&mut mock, &mut seq, BLOCK2_NUMBER, Ok(BLOCK2.clone()));
-                expect_state_update(&mut mock, &mut seq, *BLOCK2_HASH, Ok(STATE_UPDATE2.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK2_NUMBER.into(),
+                    Ok(BLOCK2.clone()),
+                );
+                expect_state_update(
+                    &mut mock,
+                    &mut seq,
+                    (*BLOCK2_HASH).into(),
+                    Ok(STATE_UPDATE2.clone()),
+                );
                 // Fetch block #3 with respective state update and contracts
-                expect_block(&mut mock, &mut seq, BLOCK3_NUMBER, Ok(block3.clone()));
-                expect_state_update(&mut mock, &mut seq, *BLOCK3_HASH, Ok(STATE_UPDATE3.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK3_NUMBER.into(),
+                    Ok(block3.clone()),
+                );
+                expect_state_update(
+                    &mut mock,
+                    &mut seq,
+                    (*BLOCK3_HASH).into(),
+                    Ok(STATE_UPDATE3.clone()),
+                );
                 // Block #4 is not there
-                expect_block(&mut mock, &mut seq, BLOCK4_NUMBER, Err(block_not_found()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK4_NUMBER.into(),
+                    Err(block_not_found()),
+                );
 
                 // L2 sync task is then looking if reorg occured
                 // We indicate that reorg started at block #1
-                expect_latest_block(&mut mock, &mut seq, Ok(block1_v2.clone()));
+                expect_block(&mut mock, &mut seq, BlockId::Latest, Ok(block1_v2.clone()));
 
                 // L2 sync task goes back block by block to find where the block hash matches the DB
-                expect_block(&mut mock, &mut seq, BLOCK2_NUMBER, Ok(block2_v2.clone()));
-                expect_block(&mut mock, &mut seq, BLOCK1_NUMBER, Ok(block1_v2.clone()));
-                expect_block(&mut mock, &mut seq, BLOCK0_NUMBER, Ok(BLOCK0.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK2_NUMBER.into(),
+                    Ok(block2_v2.clone()),
+                );
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK1_NUMBER.into(),
+                    Ok(block1_v2.clone()),
+                );
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK0_NUMBER.into(),
+                    Ok(BLOCK0.clone()),
+                );
 
                 // Finally the L2 sync task is downloading the new blocks once it knows where to start again
                 // Fetch the new block #1 from the fork with respective state update
-                expect_block(&mut mock, &mut seq, BLOCK1_NUMBER, Ok(block1_v2.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK1_NUMBER.into(),
+                    Ok(block1_v2.clone()),
+                );
                 expect_state_update(
                     &mut mock,
                     &mut seq,
-                    *BLOCK1_HASH_V2,
+                    (*BLOCK1_HASH_V2).into(),
                     Ok(STATE_UPDATE1_V2.clone()),
                 );
                 // Fetch the new block #2 from the fork with respective state update
-                expect_block(&mut mock, &mut seq, BLOCK2_NUMBER, Ok(block2_v2.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK2_NUMBER.into(),
+                    Ok(block2_v2.clone()),
+                );
                 expect_state_update(
                     &mut mock,
                     &mut seq,
-                    *BLOCK2_HASH_V2,
+                    (*BLOCK2_HASH_V2).into(),
                     Ok(STATE_UPDATE2_V2.clone()),
                 );
 
                 // Indicate that we are still staying at the head - no new blocks and the latest block matches our head
-                expect_block(&mut mock, &mut seq, BLOCK3_NUMBER, Err(block_not_found()));
-                expect_latest_block(&mut mock, &mut seq, Ok(block2_v2.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK3_NUMBER.into(),
+                    Err(block_not_found()),
+                );
+                expect_block(&mut mock, &mut seq, BlockId::Latest, Ok(block2_v2.clone()));
 
                 // Run the UUT
                 let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Goerli));
@@ -1380,8 +1565,18 @@ mod tests {
                 };
 
                 // Fetch the genesis block with respective state update and contracts
-                expect_block(&mut mock, &mut seq, BLOCK0_NUMBER, Ok(BLOCK0.clone()));
-                expect_state_update(&mut mock, &mut seq, *BLOCK0_HASH, Ok(STATE_UPDATE0.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK0_NUMBER.into(),
+                    Ok(BLOCK0.clone()),
+                );
+                expect_state_update(
+                    &mut mock,
+                    &mut seq,
+                    (*BLOCK0_HASH).into(),
+                    Ok(STATE_UPDATE0.clone()),
+                );
                 expect_full_contract(
                     &mut mock,
                     &mut seq,
@@ -1389,8 +1584,18 @@ mod tests {
                     Ok(CONTRACT0_DEF.clone()),
                 );
                 // Fetch block #1 with respective state update and contracts
-                expect_block(&mut mock, &mut seq, BLOCK1_NUMBER, Ok(BLOCK1.clone()));
-                expect_state_update(&mut mock, &mut seq, *BLOCK1_HASH, Ok(STATE_UPDATE1.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK1_NUMBER.into(),
+                    Ok(BLOCK1.clone()),
+                );
+                expect_state_update(
+                    &mut mock,
+                    &mut seq,
+                    (*BLOCK1_HASH).into(),
+                    Ok(STATE_UPDATE1.clone()),
+                );
                 expect_full_contract(
                     &mut mock,
                     &mut seq,
@@ -1398,31 +1603,61 @@ mod tests {
                     Ok(CONTRACT1_DEF.clone()),
                 );
                 // Fetch block #2 with respective state update and contracts
-                expect_block(&mut mock, &mut seq, BLOCK2_NUMBER, Ok(BLOCK2.clone()));
-                expect_state_update(&mut mock, &mut seq, *BLOCK2_HASH, Ok(STATE_UPDATE2.clone()));
-                // Block #3 is not there
-                expect_block(&mut mock, &mut seq, BLOCK3_NUMBER, Err(block_not_found()));
-
-                // L2 sync task is then looking if reorg occured
-                // We indicate that reorg started at block #2
-                expect_latest_block(&mut mock, &mut seq, Ok(block2_v2.clone()));
-
-                // L2 sync task goes back block by block to find where the block hash matches the DB
-                expect_block(&mut mock, &mut seq, BLOCK1_NUMBER, Ok(BLOCK1.clone()));
-
-                // Finally the L2 sync task is downloading the new blocks once it knows where to start again
-                // Fetch the new block #2 from the fork with respective state update
-                expect_block(&mut mock, &mut seq, BLOCK2_NUMBER, Ok(block2_v2.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK2_NUMBER.into(),
+                    Ok(BLOCK2.clone()),
+                );
                 expect_state_update(
                     &mut mock,
                     &mut seq,
-                    *BLOCK2_HASH_V2,
+                    (*BLOCK2_HASH).into(),
+                    Ok(STATE_UPDATE2.clone()),
+                );
+                // Block #3 is not there
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK3_NUMBER.into(),
+                    Err(block_not_found()),
+                );
+
+                // L2 sync task is then looking if reorg occured
+                // We indicate that reorg started at block #2
+                expect_block(&mut mock, &mut seq, BlockId::Latest, Ok(block2_v2.clone()));
+
+                // L2 sync task goes back block by block to find where the block hash matches the DB
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK1_NUMBER.into(),
+                    Ok(BLOCK1.clone()),
+                );
+
+                // Finally the L2 sync task is downloading the new blocks once it knows where to start again
+                // Fetch the new block #2 from the fork with respective state update
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK2_NUMBER.into(),
+                    Ok(block2_v2.clone()),
+                );
+                expect_state_update(
+                    &mut mock,
+                    &mut seq,
+                    (*BLOCK2_HASH_V2).into(),
                     Ok(STATE_UPDATE2_V2.clone()),
                 );
 
                 // Indicate that we are still staying at the head - no new blocks and the latest block matches our head
-                expect_block(&mut mock, &mut seq, BLOCK3_NUMBER, Err(block_not_found()));
-                expect_latest_block(&mut mock, &mut seq, Ok(block2_v2.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK3_NUMBER.into(),
+                    Err(block_not_found()),
+                );
+                expect_block(&mut mock, &mut seq, BlockId::Latest, Ok(block2_v2.clone()));
 
                 // Run the UUT
                 let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Goerli));
@@ -1531,8 +1766,18 @@ mod tests {
                 };
 
                 // Fetch the genesis block with respective state update and contracts
-                expect_block(&mut mock, &mut seq, BLOCK0_NUMBER, Ok(BLOCK0.clone()));
-                expect_state_update(&mut mock, &mut seq, *BLOCK0_HASH, Ok(STATE_UPDATE0.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK0_NUMBER.into(),
+                    Ok(BLOCK0.clone()),
+                );
+                expect_state_update(
+                    &mut mock,
+                    &mut seq,
+                    (*BLOCK0_HASH).into(),
+                    Ok(STATE_UPDATE0.clone()),
+                );
                 expect_full_contract(
                     &mut mock,
                     &mut seq,
@@ -1540,8 +1785,18 @@ mod tests {
                     Ok(CONTRACT0_DEF.clone()),
                 );
                 // Fetch block #1 with respective state update and contracts
-                expect_block(&mut mock, &mut seq, BLOCK1_NUMBER, Ok(BLOCK1.clone()));
-                expect_state_update(&mut mock, &mut seq, *BLOCK1_HASH, Ok(STATE_UPDATE1.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK1_NUMBER.into(),
+                    Ok(BLOCK1.clone()),
+                );
+                expect_state_update(
+                    &mut mock,
+                    &mut seq,
+                    (*BLOCK1_HASH).into(),
+                    Ok(STATE_UPDATE1.clone()),
+                );
                 expect_full_contract(
                     &mut mock,
                     &mut seq,
@@ -1549,28 +1804,58 @@ mod tests {
                     Ok(CONTRACT1_DEF.clone()),
                 );
                 // Fetch block #2 whose parent hash does not match block #1 hash
-                expect_block(&mut mock, &mut seq, BLOCK2_NUMBER, Ok(block2.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK2_NUMBER.into(),
+                    Ok(block2.clone()),
+                );
 
                 // L2 sync task goes back block by block to find where the block hash matches the DB
                 // It starts at the previous block to which the mismatch happened
-                expect_block(&mut mock, &mut seq, BLOCK0_NUMBER, Ok(BLOCK0.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK0_NUMBER.into(),
+                    Ok(BLOCK0.clone()),
+                );
 
                 // Finally the L2 sync task is downloading the new blocks once it knows where to start again
                 // Fetch the new block #1 from the fork with respective state update
-                expect_block(&mut mock, &mut seq, BLOCK1_NUMBER, Ok(block1_v2.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK1_NUMBER.into(),
+                    Ok(block1_v2.clone()),
+                );
                 expect_state_update(
                     &mut mock,
                     &mut seq,
-                    *BLOCK1_HASH_V2,
+                    (*BLOCK1_HASH_V2).into(),
                     Ok(STATE_UPDATE1_V2.clone()),
                 );
                 // Fetch the block #2 again, now with respective state update
-                expect_block(&mut mock, &mut seq, BLOCK2_NUMBER, Ok(block2.clone()));
-                expect_state_update(&mut mock, &mut seq, *BLOCK2_HASH, Ok(STATE_UPDATE2.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK2_NUMBER.into(),
+                    Ok(block2.clone()),
+                );
+                expect_state_update(
+                    &mut mock,
+                    &mut seq,
+                    (*BLOCK2_HASH).into(),
+                    Ok(STATE_UPDATE2.clone()),
+                );
 
                 // Indicate that we are still staying at the head - no new blocks and the latest block matches our head
-                expect_block(&mut mock, &mut seq, BLOCK3_NUMBER, Err(block_not_found()));
-                expect_latest_block(&mut mock, &mut seq, Ok(block2.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK3_NUMBER.into(),
+                    Err(block_not_found()),
+                );
+                expect_block(&mut mock, &mut seq, BlockId::Latest, Ok(block2.clone()));
 
                 // Run the UUT
                 let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Goerli));
@@ -1645,8 +1930,18 @@ mod tests {
                 let mut mock = MockClientApi::new();
                 let mut seq = mockall::Sequence::new();
 
-                expect_block(&mut mock, &mut seq, BLOCK0_NUMBER, Ok(BLOCK0.clone()));
-                expect_state_update(&mut mock, &mut seq, *BLOCK0_HASH, Ok(STATE_UPDATE0.clone()));
+                expect_block(
+                    &mut mock,
+                    &mut seq,
+                    BLOCK0_NUMBER.into(),
+                    Ok(BLOCK0.clone()),
+                );
+                expect_state_update(
+                    &mut mock,
+                    &mut seq,
+                    (*BLOCK0_HASH).into(),
+                    Ok(STATE_UPDATE0.clone()),
+                );
 
                 // Run the UUT
                 let jh = tokio::spawn(sync(tx_event, mock, None, Chain::Goerli));

--- a/crates/stark_hash/src/hash.rs
+++ b/crates/stark_hash/src/hash.rs
@@ -369,8 +369,6 @@ mod tests {
         bits.set(3, false);
         bits.set(4, false);
 
-        dbg!(bits.len());
-
         let res = StarkHash::from_bits(&bits).unwrap();
 
         let x = res.view_bits();


### PR DESCRIPTION
PR with my attempt at making a request builder for the sequencer queries. It uses the typestate pattern.

Current usage:
```rust
    let block: Starknetlock = self
        .request()    
        .feeder_gateway()
        .get_block()
        .at_block(block_number)
        .with_retry(Retry::Enabled)
        .get()
        .await
        .unwrap();
```

Still todo:
- [x] docs
- [x] move parsing to builder (?)
- [x] move retry to builder (?)

~~Also somewhat strangely, the tests for the transaction write's fail when executed locally, but pass when using the sequencer. I suspect it has something to do with the test setup; but I haven't figured out what / how to fix it.~~ 

This is due to the warp test server requiring query params be set even when there aren't any. Our previous request implementation always set these params to `[]` whereas this new one never sets them if there aren't any (`None`).

I've also collapsed the `block_by_hash` and `block_by_number` into a single call: `block(block_id)` where `BlockId` can represent `Hash`, `Number`, `Latest` and `Pending`.
