### PR TITLE
ci: enable clippy 2018 idiom check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v1
-      - run: cargo clippy --workspace --all-targets -- -D warnings
+      - run: cargo clippy --workspace --all-targets -- -D warnings -D rust_2018_idioms
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/crates/load-test/src/main.rs
+++ b/crates/load-test/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 //! Load test for pathfinder JSON-RPC endpoints.
 //!
 //! This program expects a mainnet pathfinder node synced until block 1800,

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 use anyhow::Context;
 use pathfinder_lib::{
     cairo, config,

--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -233,7 +233,7 @@ mod tests {
         jh.await.unwrap();
     }
 
-    fn fill_example_state(tx: &rusqlite::Transaction) {
+    fn fill_example_state(tx: &rusqlite::Transaction<'_>) {
         let contract_definition = zstd::decode_all(std::io::Cursor::new(include_bytes!(
             "../../fixtures/contract_definition.json.zst"
         )))

--- a/crates/pathfinder/src/cairo/ext_py/sub_process.rs
+++ b/crates/pathfinder/src/cairo/ext_py/sub_process.rs
@@ -372,7 +372,7 @@ async fn rpc_round<'a>(
     }
 
     let resp =
-        serde_json::from_str::<ChildResponse>(buffer).map_err(SubprocessError::InvalidJson)?;
+        serde_json::from_str::<ChildResponse<'_>>(buffer).map_err(SubprocessError::InvalidJson)?;
 
     resp.refine()
 }

--- a/crates/pathfinder/src/lib.rs
+++ b/crates/pathfinder/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 pub mod cairo;
 pub mod config;
 pub(crate) mod consts;

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -42,7 +42,10 @@ impl<Context: Send + Sync + 'static> RpcModuleWrapper<Context> {
         &mut self,
         method_name: &'static str,
         callback: Fun,
-    ) -> Result<jsonrpsee::core::server::rpc_module::MethodResourcesBuilder, jsonrpsee::core::Error>
+    ) -> Result<
+        jsonrpsee::core::server::rpc_module::MethodResourcesBuilder<'_>,
+        jsonrpsee::core::Error,
+    >
     where
         R: ::serde::Serialize + Send + Sync + 'static,
         Fut: std::future::Future<Output = Result<R, Error>> + Send,

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -142,7 +142,7 @@ impl RpcApi {
 
     /// This function assumes that the block ID is valid i.e. it won't check if the block hash or number exist.
     pub fn get_block_transactions(
-        db_tx: &rusqlite::Transaction,
+        db_tx: &rusqlite::Transaction<'_>,
         block_number: StarknetBlockNumber,
         scope: BlockResponseScope,
     ) -> RpcResult<super::types::reply::Transactions> {
@@ -263,7 +263,7 @@ impl RpcApi {
     /// Returns [`jsonrpsee::core::Error::Call`] with code [`ErrorCode::InvalidBlockHash`]
     /// when called with [`StarknetBlocksBlockId::Latest`] on an empty storage.
     fn get_raw_block_by_hash(
-        tx: &rusqlite::Transaction,
+        tx: &rusqlite::Transaction<'_>,
         block_id: StarknetBlocksBlockId,
     ) -> RpcResult<RawBlock> {
         Self::get_raw_block(tx, block_id, ErrorCode::InvalidBlockHash)
@@ -274,7 +274,7 @@ impl RpcApi {
     /// Returns [`jsonrpsee::core::Error::Call`] with code [`ErrorCode::InvalidBlockNumber`]
     /// when called with [`StarknetBlocksBlockId::Latest`] on an empty storage.
     fn get_raw_block_by_number(
-        tx: &rusqlite::Transaction,
+        tx: &rusqlite::Transaction<'_>,
         block_id: StarknetBlocksBlockId,
     ) -> RpcResult<RawBlock> {
         Self::get_raw_block(tx, block_id, ErrorCode::InvalidBlockNumber)
@@ -285,7 +285,7 @@ impl RpcApi {
     /// `error_code_for_latest` is the error code when the `latest` block is missing,
     /// ie. when the storage is empty.
     fn get_raw_block(
-        transaction: &rusqlite::Transaction,
+        transaction: &rusqlite::Transaction<'_>,
         block_id: StarknetBlocksBlockId,
         error_code_for_latest: ErrorCode,
     ) -> RpcResult<RawBlock> {

--- a/crates/pathfinder/src/rpc/serde.rs
+++ b/crates/pathfinder/src/rpc/serde.rs
@@ -93,7 +93,7 @@ impl<'de> DeserializeAs<'de, EthereumAddress> for EthereumAddressAsHexStr {
         impl<'de> Visitor<'de> for EthereumAddressVisitor {
             type Value = EthereumAddress;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 formatter.write_str("a hex string of up to 40 digits with an optional '0x' prefix")
             }
 
@@ -135,7 +135,7 @@ impl<'de> DeserializeAs<'de, H256> for H256AsNoLeadingZerosHexStr {
         impl<'de> Visitor<'de> for H256Visitor {
             type Value = H256;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 formatter.write_str("a hex string of up to 64 digits with an optional '0x' prefix")
             }
 
@@ -177,7 +177,7 @@ impl<'de> DeserializeAs<'de, Fee> for FeeAsHexStr {
         impl<'de> Visitor<'de> for FeeVisitor {
             type Value = Fee;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 formatter.write_str("a hex string of up to 32 digits with an optional '0x' prefix")
             }
 
@@ -220,7 +220,7 @@ impl<'de> DeserializeAs<'de, GasPrice> for GasPriceAsHexStr {
         impl<'de> Visitor<'de> for GasPriceVisitor {
             type Value = GasPrice;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 formatter.write_str("a hex string of up to 32 digits with an optional '0x' prefix")
             }
 
@@ -263,7 +263,7 @@ impl<'de> DeserializeAs<'de, StarknetBlockNumber> for StarknetBlockNumberAsHexSt
         impl<'de> Visitor<'de> for StarknetBlockNumberVisitor {
             type Value = StarknetBlockNumber;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 formatter.write_str("a hex string of up to 16 digits with an optional '0x' prefix")
             }
 

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -142,7 +142,7 @@ impl Client {
         })
     }
 
-    fn request(&self) -> builder::Request<builder::stage::Gateway> {
+    fn request(&self) -> builder::Request<'_, builder::stage::Gateway> {
         builder::Request::builder(&self.inner, self.sequencer_url.clone())
     }
 }

--- a/crates/pathfinder/src/state/class_hash.rs
+++ b/crates/pathfinder/src/state/class_hash.rs
@@ -30,7 +30,7 @@ use crate::sequencer::request::contract::EntryPointType;
 /// [py-sortkeys]: https://github.com/starkware-libs/cairo-lang/blob/64a7f6aed9757d3d8d6c28bd972df73272b0cb0a/src/starkware/starknet/core/os/contract_hash.py#L58-L71
 pub fn compute_class_hash(contract_definition_dump: &[u8]) -> Result<ClassHash> {
     let contract_definition =
-        serde_json::from_slice::<json::ContractDefinition>(contract_definition_dump)
+        serde_json::from_slice::<json::ContractDefinition<'_>>(contract_definition_dump)
             .context("Failed to parse contract_definition")?;
 
     compute_class_hash0(contract_definition).context("Compute class hash")
@@ -42,7 +42,7 @@ pub(crate) fn extract_abi_code_hash(
     contract_definition_dump: &[u8],
 ) -> Result<(Vec<u8>, Vec<u8>, ClassHash)> {
     let contract_definition =
-        serde_json::from_slice::<json::ContractDefinition>(contract_definition_dump)
+        serde_json::from_slice::<json::ContractDefinition<'_>>(contract_definition_dump)
             .context("Failed to parse contract_definition")?;
 
     // just in case we'd accidentially modify these in the compute_class_hash0
@@ -519,7 +519,7 @@ mod json {
                 debug_info: Option<&'a serde_json::value::RawValue>,
             }
 
-            let mut input = serde_json::from_str::<Program>(
+            let mut input = serde_json::from_str::<Program<'_>>(
                 r#"{"debug_info": {"long": {"tree": { "which": ["we dont", "care", "about", 0] }}}}"#,
             ).unwrap();
 

--- a/crates/pathfinder/src/state/merkle_tree.rs
+++ b/crates/pathfinder/src/state/merkle_tree.rs
@@ -108,7 +108,7 @@ impl<'a> MerkleTree<RcNodeStorage<'a>> {
     /// is encountered, the transaction should be rolled back to prevent database corruption.
     pub fn load(
         table: String,
-        transaction: &'a Transaction,
+        transaction: &'a Transaction<'_>,
         root: StarkHash,
     ) -> anyhow::Result<Self> {
         let storage = RcNodeStorage::open(table, transaction)?;

--- a/crates/pathfinder/src/state/state_tree.rs
+++ b/crates/pathfinder/src/state/state_tree.rs
@@ -20,7 +20,7 @@ pub struct ContractsStateTree<'a> {
 }
 
 impl<'a> ContractsStateTree<'a> {
-    pub fn load(transaction: &'a Transaction, root: ContractRoot) -> anyhow::Result<Self> {
+    pub fn load(transaction: &'a Transaction<'_>, root: ContractRoot) -> anyhow::Result<Self> {
         // TODO: move the string into storage.
         let tree = MerkleTree::load("tree_contracts".to_string(), transaction, root.0)?;
 
@@ -51,7 +51,7 @@ pub struct GlobalStateTree<'a> {
 }
 
 impl<'a> GlobalStateTree<'a> {
-    pub fn load(transaction: &'a Transaction, root: GlobalRoot) -> anyhow::Result<Self> {
+    pub fn load(transaction: &'a Transaction<'_>, root: GlobalRoot) -> anyhow::Result<Self> {
         // TODO: move the string into storage.
         let tree = MerkleTree::load("tree_global".to_string(), transaction, root.0)?;
 

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -551,7 +551,7 @@ async fn l2_reorg(
 }
 
 fn update_starknet_state(
-    transaction: &Transaction,
+    transaction: &Transaction<'_>,
     diff: StateUpdate,
 ) -> anyhow::Result<GlobalRoot> {
     let global_root = StarknetBlocksTable::get(transaction, StarknetBlocksBlockId::Latest)
@@ -582,8 +582,8 @@ fn update_starknet_state(
 }
 
 fn deploy_contract(
-    transaction: &Transaction,
-    global_tree: &mut GlobalStateTree,
+    transaction: &Transaction<'_>,
+    global_tree: &mut GlobalStateTree<'_>,
     contract: DeployedContract,
 ) -> anyhow::Result<()> {
     // Add a new contract to global tree, the contract root is initialized to ZERO.

--- a/crates/pathfinder/src/storage/contract.rs
+++ b/crates/pathfinder/src/storage/contract.rs
@@ -20,7 +20,7 @@ impl ContractCodeTable {
     ///
     /// Does nothing if the class [hash](ClassHash) is already populated.
     pub fn insert(
-        transaction: &Transaction,
+        transaction: &Transaction<'_>,
         hash: ClassHash,
         abi: &[u8],
         bytecode: &[u8],
@@ -71,7 +71,7 @@ impl ContractCodeTable {
 
     /// Gets the specified contract's [code](ContractCode).
     pub fn get_code(
-        transaction: &Transaction,
+        transaction: &Transaction<'_>,
         address: ContractAddress,
     ) -> anyhow::Result<Option<ContractCode>> {
         let row = transaction
@@ -136,7 +136,7 @@ impl ContractsTable {
     ///
     /// Note that [hash](ClassHash) must reference a class stored in [ContractCodeTable].
     pub fn upsert(
-        transaction: &Transaction,
+        transaction: &Transaction<'_>,
         address: ContractAddress,
         hash: ClassHash,
     ) -> anyhow::Result<()> {
@@ -153,7 +153,7 @@ impl ContractsTable {
 
     /// Gets the specified contract's class hash.
     pub fn get_hash(
-        transaction: &Transaction,
+        transaction: &Transaction<'_>,
         address: ContractAddress,
     ) -> anyhow::Result<Option<ClassHash>> {
         let bytes: Option<Vec<u8>> = transaction

--- a/crates/pathfinder/src/storage/ethereum.rs
+++ b/crates/pathfinder/src/storage/ethereum.rs
@@ -17,7 +17,7 @@ impl EthereumBlocksTable {
     ///
     /// overwrites the data if the hash already exists.
     pub fn insert(
-        transaction: &Transaction,
+        transaction: &Transaction<'_>,
         hash: EthereumBlockHash,
         number: EthereumBlockNumber,
     ) -> anyhow::Result<()> {
@@ -49,7 +49,7 @@ impl EthereumTransactionsTable {
     /// Note that [block_hash](EthereumBlockHash) must reference an
     /// Ethereum block stored in [EthereumBlocksTable].
     pub fn upsert(
-        transaction: &Transaction,
+        transaction: &Transaction<'_>,
         block_hash: EthereumBlockHash,
         tx_hash: EthereumTransactionHash,
         tx_index: EthereumTransactionIndex,

--- a/crates/pathfinder/src/storage/merkle_tree.rs
+++ b/crates/pathfinder/src/storage/merkle_tree.rs
@@ -184,7 +184,7 @@ impl<'a> RcNodeStorage<'a> {
     ///
     /// None of the [RcNodeStorage] functions rollback on failure. This means that if any error
     /// is encountered, the transaction should be rolled back to prevent database corruption.
-    pub fn open(table: String, transaction: &'a Transaction) -> anyhow::Result<Self> {
+    pub fn open(table: String, transaction: &'a Transaction<'_>) -> anyhow::Result<Self> {
         transaction.execute(
             &format!(
                 r"CREATE TABLE IF NOT EXISTS {}(
@@ -373,7 +373,7 @@ mod tests {
     use bitvec::bitvec;
 
     /// Test helper function to query a node's current reference count from the database.
-    fn get_ref_count(storage: &RcNodeStorage, key: StarkHash) -> u16 {
+    fn get_ref_count(storage: &RcNodeStorage<'_>, key: StarkHash) -> u16 {
         let hash = key.to_be_bytes();
         storage
             .transaction

--- a/crates/pathfinder/src/storage/schema/revision_0001.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0001.rs
@@ -2,7 +2,7 @@ use rusqlite::Transaction;
 
 use crate::storage::schema::PostMigrationAction;
 
-pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigrationAction> {
+pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigrationAction> {
     transaction.execute(
         r"CREATE TABLE contract_code (
             hash       BLOB PRIMARY KEY,

--- a/crates/pathfinder/src/storage/schema/revision_0002.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0002.rs
@@ -4,7 +4,7 @@ use sha3::{Digest, Keccak256};
 
 use crate::storage::schema::PostMigrationAction;
 
-pub(crate) fn migrate(tx: &Transaction) -> anyhow::Result<PostMigrationAction> {
+pub(crate) fn migrate(tx: &Transaction<'_>) -> anyhow::Result<PostMigrationAction> {
     // we had a mishap of forking the schema at version 1 so to really support all combinations of
     // schema at version 1 we need to make sure that contracts table still looks like:
     // CREATE TABLE contracts (

--- a/crates/pathfinder/src/storage/schema/revision_0003.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0003.rs
@@ -8,7 +8,7 @@ use crate::storage::schema::PostMigrationAction;
 /// In addition, it also adds a refs table which only contains a single column.
 /// This columns references the latest Starknet block for which the L1 and L2
 /// states are the same.
-pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigrationAction> {
+pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigrationAction> {
     // Create the new L1 table.
     transaction.execute(
         r"CREATE TABLE l1_state (

--- a/crates/pathfinder/src/storage/schema/revision_0004.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0004.rs
@@ -6,7 +6,7 @@ use crate::storage::schema::PostMigrationAction;
 
 /// This schema migration adds ZTSD compression to the Starknet transaction and transaction receipts.
 /// There are no physical changes to the actual schema, but simply the data in these two columns.
-pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigrationAction> {
+pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigrationAction> {
     let todo: u32 = transaction
         .query_row("SELECT count(1) FROM starknet_blocks", [], |r| r.get(0))
         .unwrap();

--- a/crates/pathfinder/src/storage/schema/revision_0005.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0005.rs
@@ -181,7 +181,7 @@ mod transaction {
 ///
 /// This migration has a non-fatal bug where it fails to drop the columns if the table is empty.
 /// This bug is fixed in [schema revision 6](super::revision_0006::migrate).
-pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigrationAction> {
+pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigrationAction> {
     // Create the new transaction and transaction receipt tables.
     transaction
         .execute(

--- a/crates/pathfinder/src/storage/schema/revision_0006.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0006.rs
@@ -9,7 +9,7 @@ use crate::storage::schema::PostMigrationAction;
 ///
 /// This mistake has since been rectified, but we should still fix databases that included
 /// this bug.
-pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigrationAction> {
+pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigrationAction> {
     // Check if the columns still exist. Checking just one is enough as either both exist, or neither.
     //
     // This is necessary as sqlite will error when dropping a non-existant column. As a benefit

--- a/crates/pathfinder/src/storage/schema/revision_0007.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0007.rs
@@ -242,12 +242,12 @@ const STARKNET_EVENTS_CREATE_STMT: &str = r"CREATE TABLE starknet_events (
         );
     END;";
 
-pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigrationAction> {
+pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigrationAction> {
     migrate_with(transaction, STARKNET_EVENTS_CREATE_STMT)
 }
 
 pub(crate) fn migrate_with(
-    transaction: &Transaction,
+    transaction: &Transaction<'_>,
     starknet_events_create_stmt: &'static str,
 ) -> anyhow::Result<PostMigrationAction> {
     // Create the new events table.

--- a/crates/pathfinder/src/storage/schema/revision_0008.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0008.rs
@@ -6,7 +6,7 @@ use crate::storage::schema::PostMigrationAction;
 /// and transactions when we're querying for all transactions in a block.
 ///
 /// According to load tests this improves block query performance significantly.
-pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigrationAction> {
+pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigrationAction> {
     // Create the new index.
     transaction.execute(
         "CREATE INDEX starknet_transactions_block_hash ON starknet_transactions(block_hash)",

--- a/crates/pathfinder/src/storage/schema/revision_0009.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0009.rs
@@ -2,7 +2,7 @@ use crate::storage::schema::PostMigrationAction;
 use anyhow::Context;
 use rusqlite::Transaction;
 
-pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigrationAction> {
+pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigrationAction> {
     // Add new columns to the blocks table
     transaction
         .execute_batch(

--- a/crates/pathfinder/src/storage/schema/revision_0010.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0010.rs
@@ -3,7 +3,7 @@ use crate::storage::schema::PostMigrationAction;
 use anyhow::Context;
 use rusqlite::Transaction;
 
-pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigrationAction> {
+pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigrationAction> {
     // We need to check if this db needs fixing at all
     let update_is_not_required = {
         let mut stmt = transaction
@@ -307,7 +307,9 @@ mod tests {
 
         /// This is a test helper function which runs a stateful scenario of the migration
         /// with the revision 7 migration being customisable via a closure provided by the caller
-        fn run_stateful_scenario<Fn: FnOnce(&rusqlite::Transaction)>(revision_0007_migrate_fn: Fn) {
+        fn run_stateful_scenario<Fn: for<'a> FnOnce(&rusqlite::Transaction<'a>)>(
+            revision_0007_migrate_fn: Fn,
+        ) {
             let mut connection = Connection::open_in_memory().unwrap();
             let transaction = connection.transaction().unwrap();
 

--- a/crates/pathfinder/src/storage/schema/revision_0011.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0011.rs
@@ -5,7 +5,7 @@ use rusqlite::{named_params, Transaction};
 
 /// This migration fixes event addresses. Events were incorrectly stored using the transaction's
 /// contract address instead of the event's `from_address`.
-pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigrationAction> {
+pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigrationAction> {
     let todo: usize = transaction
         .query_row("SELECT count(1) FROM starknet_transactions", [], |r| {
             r.get(0)

--- a/crates/pathfinder/src/storage/schema/revision_0012.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0012.rs
@@ -3,7 +3,7 @@ use crate::storage::schema::PostMigrationAction;
 use anyhow::Context;
 use rusqlite::Transaction;
 
-pub(crate) fn migrate(transaction: &Transaction) -> anyhow::Result<PostMigrationAction> {
+pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigrationAction> {
     let todo: usize = transaction
         .query_row("SELECT count(1) FROM starknet_events", [], |r| r.get(0))
         .context("Count rows in starknet events table")?;

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -929,7 +929,7 @@ pub struct ContractsStateTable {}
 impl ContractsStateTable {
     /// Insert a state hash into the table, overwrites the data if the hash already exists.
     pub fn upsert(
-        transaction: &Transaction,
+        transaction: &Transaction<'_>,
         state_hash: ContractStateHash,
         hash: ClassHash,
         root: ContractRoot,
@@ -948,7 +948,7 @@ impl ContractsStateTable {
     /// Gets the root associated with the given state hash, or [None]
     /// if it does not exist.
     pub fn get_root(
-        transaction: &Transaction,
+        transaction: &Transaction<'_>,
         state_hash: ContractStateHash,
     ) -> anyhow::Result<Option<ContractRoot>> {
         let bytes: Option<Vec<u8>> = transaction

--- a/crates/stark_curve/src/lib.rs
+++ b/crates/stark_curve/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 mod curve;
 mod field;
 

--- a/crates/stark_hash/src/lib.rs
+++ b/crates/stark_hash/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 mod hash;
 mod serde;
 

--- a/crates/stark_hash/src/serde.rs
+++ b/crates/stark_hash/src/serde.rs
@@ -23,7 +23,7 @@ impl<'de> Deserialize<'de> for StarkHash {
         impl<'de> Visitor<'de> for StarkHashVisitor {
             type Value = StarkHash;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 formatter.write_str("a hex string of up to 64 digits with an optional '0x' prefix")
             }
 


### PR DESCRIPTION
Adds `--deny rust_2018_idioms` to CI and fixes the existing code issues.