### PR TITLE
feat(storage): remove vacuum option

### DIFF
--- a/crates/pathfinder/src/storage/schema.rs
+++ b/crates/pathfinder/src/storage/schema.rs
@@ -13,12 +13,3 @@ pub(crate) mod revision_0012;
 
 #[cfg(test)]
 pub(crate) mod fixtures;
-
-/// Used to indicate which action the caller should perform after a schema migration.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum PostMigrationAction {
-    /// A database VACUUM should be performed.
-    Vacuum,
-    /// No further action requried.
-    None,
-}

--- a/crates/pathfinder/src/storage/schema/revision_0001.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0001.rs
@@ -1,8 +1,6 @@
 use rusqlite::Transaction;
 
-use crate::storage::schema::PostMigrationAction;
-
-pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigrationAction> {
+pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<()> {
     transaction.execute(
         r"CREATE TABLE contract_code (
             hash       BLOB PRIMARY KEY,
@@ -60,5 +58,5 @@ pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigra
         [],
     )?;
 
-    Ok(PostMigrationAction::None)
+    Ok(())
 }

--- a/crates/pathfinder/src/storage/schema/revision_0002.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0002.rs
@@ -2,9 +2,7 @@ use anyhow::Context;
 use rusqlite::Transaction;
 use sha3::{Digest, Keccak256};
 
-use crate::storage::schema::PostMigrationAction;
-
-pub(crate) fn migrate(tx: &Transaction<'_>) -> anyhow::Result<PostMigrationAction> {
+pub(crate) fn migrate(tx: &Transaction<'_>) -> anyhow::Result<()> {
     // we had a mishap of forking the schema at version 1 so to really support all combinations of
     // schema at version 1 we need to make sure that contracts table still looks like:
     // CREATE TABLE contracts (
@@ -34,7 +32,7 @@ pub(crate) fn migrate(tx: &Transaction<'_>) -> anyhow::Result<PostMigrationActio
         }
 
         if actual == no_need {
-            return Ok(PostMigrationAction::None);
+            return Ok(());
         }
 
         assert_eq!(
@@ -157,5 +155,5 @@ pub(crate) fn migrate(tx: &Transaction<'_>) -> anyhow::Result<PostMigrationActio
 
     println!("table contracts_v1 dropped in {:?}", started_at.elapsed());
 
-    Ok(PostMigrationAction::None)
+    Ok(())
 }

--- a/crates/pathfinder/src/storage/schema/revision_0003.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0003.rs
@@ -1,14 +1,12 @@
 use rusqlite::{params, OptionalExtension, Transaction};
 
-use crate::storage::schema::PostMigrationAction;
-
 /// This schema migration splits the global state table into
 /// separate tables containing L1 and L2 data.
 ///
 /// In addition, it also adds a refs table which only contains a single column.
 /// This columns references the latest Starknet block for which the L1 and L2
 /// states are the same.
-pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigrationAction> {
+pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<()> {
     // Create the new L1 table.
     transaction.execute(
         r"CREATE TABLE l1_state (
@@ -104,7 +102,7 @@ pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigra
     transaction.execute("DROP TABLE ethereum_transactions", [])?;
     transaction.execute("DROP TABLE ethereum_blocks", [])?;
 
-    Ok(PostMigrationAction::None)
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/pathfinder/src/storage/schema/revision_0005.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0005.rs
@@ -1,4 +1,3 @@
-use crate::storage::schema::PostMigrationAction;
 use anyhow::Context;
 use rusqlite::{named_params, Transaction};
 use tracing::info;
@@ -181,7 +180,7 @@ mod transaction {
 ///
 /// This migration has a non-fatal bug where it fails to drop the columns if the table is empty.
 /// This bug is fixed in [schema revision 6](super::revision_0006::migrate).
-pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigrationAction> {
+pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<()> {
     // Create the new transaction and transaction receipt tables.
     transaction
         .execute(
@@ -272,12 +271,7 @@ pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigra
         )
         .context("Dropping transaction receipts from starknet_blocks table")?;
 
-    if todo > 0 {
-        // Database should be vacuum'd to defrag removal of transaction columns.
-        Ok(PostMigrationAction::Vacuum)
-    } else {
-        Ok(PostMigrationAction::None)
-    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/pathfinder/src/storage/schema/revision_0006.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0006.rs
@@ -1,19 +1,16 @@
 use anyhow::Context;
 use rusqlite::Transaction;
 
-use crate::storage::schema::PostMigrationAction;
-
 /// This schema migration fixes a mistake in the previous migration. It failed to
 /// drop the transactions and transaction_receipts columns if the table was empty due to
 /// to an early exit condition.
 ///
 /// This mistake has since been rectified, but we should still fix databases that included
 /// this bug.
-pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigrationAction> {
+pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<()> {
     // Check if the columns still exist. Checking just one is enough as either both exist, or neither.
     //
-    // This is necessary as sqlite will error when dropping a non-existant column. As a benefit
-    // it also lets us skip vacuuming if nothing is done.
+    // This is necessary as sqlite will error when dropping a non-existant column.
     let count: usize = transaction
         .query_row(
             "SELECT COUNT(1) FROM pragma_table_info('starknet_blocks') where name='transactions'",
@@ -21,24 +18,21 @@ pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigra
             |row| row.get(0),
         )
         .unwrap();
-    if count == 0 {
-        return Ok(PostMigrationAction::None);
+    if count > 0 {
+        // Remove transaction columns from blocks table.
+        transaction
+            .execute("ALTER TABLE starknet_blocks DROP COLUMN transactions", [])
+            .context("Dropping transactions from starknet_blocks table")?;
+
+        transaction
+            .execute(
+                "ALTER TABLE starknet_blocks DROP COLUMN transaction_receipts",
+                [],
+            )
+            .context("Dropping transaction receipts from starknet_blocks table")?;
     }
 
-    // Remove transaction columns from blocks table.
-    transaction
-        .execute("ALTER TABLE starknet_blocks DROP COLUMN transactions", [])
-        .context("Dropping transactions from starknet_blocks table")?;
-
-    transaction
-        .execute(
-            "ALTER TABLE starknet_blocks DROP COLUMN transaction_receipts",
-            [],
-        )
-        .context("Dropping transaction receipts from starknet_blocks table")?;
-
-    // Database should be vacuum'd to defrag removal of transaction columns.
-    Ok(PostMigrationAction::Vacuum)
+    Ok(())
 }
 
 #[cfg(test)]
@@ -73,8 +67,7 @@ mod tests {
             .context("Adding transaction receipts from starknet_blocks table")
             .unwrap();
 
-        let action = migrate(&transaction).unwrap();
-        assert_eq!(action, PostMigrationAction::Vacuum);
+        migrate(&transaction).unwrap();
 
         // Collect all the column names in table `starknet_blocks`.
         let mut columns = Vec::new();
@@ -102,7 +95,6 @@ mod tests {
         schema::revision_0004::migrate(&transaction).unwrap();
         schema::revision_0005::migrate(&transaction).unwrap();
 
-        let action = migrate(&transaction).unwrap();
-        assert_eq!(action, PostMigrationAction::None);
+        migrate(&transaction).unwrap();
     }
 }

--- a/crates/pathfinder/src/storage/schema/revision_0008.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0008.rs
@@ -1,17 +1,15 @@
 use rusqlite::Transaction;
 
-use crate::storage::schema::PostMigrationAction;
-
 /// This schema migration creates a missing index that is used to join blocks
 /// and transactions when we're querying for all transactions in a block.
 ///
 /// According to load tests this improves block query performance significantly.
-pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigrationAction> {
+pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<()> {
     // Create the new index.
     transaction.execute(
         "CREATE INDEX starknet_transactions_block_hash ON starknet_transactions(block_hash)",
         [],
     )?;
 
-    Ok(PostMigrationAction::None)
+    Ok(())
 }

--- a/crates/pathfinder/src/storage/schema/revision_0009.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0009.rs
@@ -1,8 +1,7 @@
-use crate::storage::schema::PostMigrationAction;
 use anyhow::Context;
 use rusqlite::Transaction;
 
-pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigrationAction> {
+pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<()> {
     // Add new columns to the blocks table
     transaction
         .execute_batch(
@@ -13,13 +12,11 @@ pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigra
         )
         .context("Add columns gas_price and starknet_address to starknet_blocks table")?;
 
-    Ok(PostMigrationAction::None)
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::PostMigrationAction;
-
     use crate::{
         core::{
             GasPrice, GlobalRoot, SequencerAddress, StarknetBlockHash, StarknetBlockNumber,
@@ -45,8 +42,7 @@ mod tests {
         schema::revision_0007::migrate(&transaction).unwrap();
         schema::revision_0008::migrate(&transaction).unwrap();
 
-        let action = super::migrate(&transaction).unwrap();
-        assert_eq!(action, PostMigrationAction::None);
+        super::migrate(&transaction).unwrap();
     }
 
     #[test]
@@ -81,8 +77,7 @@ mod tests {
             )
             .unwrap();
 
-        let action = super::migrate(&transaction).unwrap();
-        assert_eq!(action, PostMigrationAction::None);
+        super::migrate(&transaction).unwrap();
 
         let block = StarknetBlocksTable::get(&transaction, StarknetBlocksBlockId::Hash(block_hash))
             .unwrap()

--- a/crates/pathfinder/src/storage/schema/revision_0011.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0011.rs
@@ -1,11 +1,9 @@
-use crate::storage::schema::PostMigrationAction;
-
 use anyhow::Context;
 use rusqlite::{named_params, Transaction};
 
 /// This migration fixes event addresses. Events were incorrectly stored using the transaction's
 /// contract address instead of the event's `from_address`.
-pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigrationAction> {
+pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<()> {
     let todo: usize = transaction
         .query_row("SELECT count(1) FROM starknet_transactions", [], |r| {
             r.get(0)
@@ -13,7 +11,7 @@ pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigra
         .context("Count rows in starknet transactions table")?;
 
     if todo == 0 {
-        return Ok(PostMigrationAction::None);
+        return Ok(());
     }
 
     tracing::info!(
@@ -154,7 +152,7 @@ pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<PostMigra
 
     tracing::info!(?recreation_time, "Recreation complete");
 
-    Ok(PostMigrationAction::None)
+    Ok(())
 }
 
 /// Real receipt json has a bunch of fields which we don't need


### PR DESCRIPTION
This PR removes database vacuuming entirely. Performing a full vacuum takes an incredibly long time for testnet database, which makes it unfeasible.

We can consider adding documentation for the user to perform it manually if this becomes desired.

Fixes #352.