### PR TITLE
refactor transaction type into 3 variants

### DIFF
--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -2452,29 +2452,8 @@ mod tests {
         use crate::storage::test_utils;
 
         fn setup() -> (Storage, Vec<EmittedEvent>) {
-            let storage = Storage::in_memory().unwrap();
-            let connection = storage.connection().unwrap();
-
-            let blocks = test_utils::create_blocks();
-            let transactions_and_receipts = test_utils::create_transactions_and_receipts();
-
-            for (i, block) in blocks.iter().enumerate() {
-                StarknetBlocksTable::insert(&connection, block).unwrap();
-                StarknetTransactionsTable::upsert(
-                    &connection,
-                    block.hash,
-                    block.number,
-                    &transactions_and_receipts[i * test_utils::TRANSACTIONS_PER_BLOCK
-                        ..(i + 1) * test_utils::TRANSACTIONS_PER_BLOCK],
-                )
-                .unwrap();
-            }
-
-            let events = test_utils::create_emitted_events(&blocks, &transactions_and_receipts)
-                .into_iter()
-                .map(EmittedEvent::from)
-                .collect();
-
+            let (storage, events) = test_utils::setup_storage();
+            let events = events.into_iter().map(EmittedEvent::from).collect();
             (storage, events)
         }
 

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -2546,7 +2546,7 @@ mod tests {
                         keys: event.keys.clone(),
                         block_hash: block.hash,
                         block_number: block.number,
-                        transaction_hash: txn.transaction_hash,
+                        transaction_hash: txn.hash(),
                     }
                 })
                 .collect();

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -166,7 +166,7 @@ impl RpcApi {
             BlockResponseScope::TransactionHashes => reply::Transactions::HashesOnly(
                 transactions_receipts
                     .into_iter()
-                    .map(|(t, _)| t.transaction_hash)
+                    .map(|(t, _)| t.hash())
                     .collect(),
             ),
             BlockResponseScope::FullTransactions => reply::Transactions::Full(

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -329,8 +329,8 @@ pub mod reply {
                     BlockResponseScope::TransactionHashes => Transactions::HashesOnly(
                         block
                             .transactions
-                            .into_iter()
-                            .map(|t| t.transaction_hash)
+                            .iter()
+                            .map(sequencer::reply::transaction::Transaction::hash)
                             .collect(),
                     ),
                     BlockResponseScope::FullTransactions => Transactions::Full(
@@ -571,24 +571,47 @@ pub mod reply {
             let txn = txn
                 .transaction
                 .ok_or_else(|| anyhow::anyhow!("Transaction not found."))?;
-            Ok(Self {
-                txn_hash: txn.transaction_hash,
-                contract_address: txn.contract_address,
-                entry_point_selector: txn.entry_point_selector,
-                calldata: txn.calldata,
-                max_fee: txn.max_fee,
+
+            Ok(match txn {
+                sequencer::reply::transaction::Transaction::Invoke(txn) => Self {
+                    // TODO
+                    txn_hash: txn.transaction_hash,
+                    contract_address: Some(txn.contract_address),
+                    entry_point_selector: Some(txn.entry_point_selector),
+                    calldata: Some(txn.calldata),
+                    max_fee: Some(txn.max_fee),
+                },
+                _ => Self {
+                    // TODO
+                    txn_hash: txn.hash(),
+                    contract_address: None,
+                    entry_point_selector: None,
+                    calldata: None,
+                    max_fee: None,
+                },
             })
         }
     }
 
     impl From<sequencer::reply::transaction::Transaction> for Transaction {
         fn from(txn: sequencer::reply::transaction::Transaction) -> Self {
-            Self {
-                txn_hash: txn.transaction_hash,
-                contract_address: txn.contract_address,
-                entry_point_selector: txn.entry_point_selector,
-                calldata: txn.calldata,
-                max_fee: txn.max_fee,
+            match txn {
+                sequencer::reply::transaction::Transaction::Invoke(txn) => Self {
+                    // TODO
+                    txn_hash: txn.transaction_hash,
+                    contract_address: Some(txn.contract_address),
+                    entry_point_selector: Some(txn.entry_point_selector),
+                    calldata: Some(txn.calldata),
+                    max_fee: Some(txn.max_fee),
+                },
+                _ => Self {
+                    // TODO
+                    txn_hash: txn.hash(),
+                    contract_address: None,
+                    entry_point_selector: None,
+                    calldata: None,
+                    max_fee: None,
+                },
             }
         }
     }

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -272,6 +272,7 @@ pub mod transaction {
         pub signature: Vec<TransactionSignatureElem>,
         pub transaction_hash: StarknetTransactionHash,
         pub r#type: Type,
+        #[serde_as(as = "TransactionVersionAsHexStr")]
         pub version: TransactionVersion,
     }
 

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -301,7 +301,6 @@ pub mod transaction {
         pub contract_address: ContractAddress,
         pub entry_point_selector: EntryPoint,
         pub entry_point_type: EntryPointType,
-        // TODO check if should be Optional for old data ?
         #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
         #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -180,23 +180,39 @@ fn enable_foreign_keys(connection: &Connection) -> anyhow::Result<()> {
 
 #[cfg(test)]
 pub(crate) mod test_utils {
-    use super::StarknetBlock;
+    use super::{StarknetBlock, StarknetEmittedEvent};
 
     use crate::{
         core::{
-            ContractAddress, EventData, EventKey, GasPrice, GlobalRoot, SequencerAddress,
+            CallParam, ClassHash, ConstructorParam, ContractAddress, ContractAddressSalt,
+            EntryPoint, EventData, EventKey, Fee, GasPrice, GlobalRoot, SequencerAddress,
             StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp,
-            StarknetTransactionHash, StarknetTransactionIndex,
+            StarknetTransactionHash, StarknetTransactionIndex, TransactionNonce,
+            TransactionSignatureElem, TransactionVersion,
         },
-        sequencer::reply::transaction,
+        sequencer::reply::transaction::{
+            self, DeclareTransaction, DeployTransaction, EntryPointType, InvokeTransaction,
+        },
     };
 
     use stark_hash::StarkHash;
+    use web3::types::{H128, H256};
+
+    pub(crate) const NUM_BLOCKS: usize = 4;
+    pub(crate) const TRANSACTIONS_PER_BLOCK: usize = 15;
+    const INVOKE_TRANSACTIONS_PER_BLOCK: usize = 5;
+    const DEPLOY_TRANSACTIONS_PER_BLOCK: usize = 5;
+    const DECLARE_TRANSACTIONS_PER_BLOCK: usize =
+        TRANSACTIONS_PER_BLOCK - (INVOKE_TRANSACTIONS_PER_BLOCK + DEPLOY_TRANSACTIONS_PER_BLOCK);
+    pub(crate) const EVENTS_PER_BLOCK: usize =
+        INVOKE_TRANSACTIONS_PER_BLOCK + DECLARE_TRANSACTIONS_PER_BLOCK;
+    pub(crate) const NUM_TRANSACTIONS: usize = NUM_BLOCKS * TRANSACTIONS_PER_BLOCK;
+    pub(crate) const NUM_EVENTS: usize = NUM_BLOCKS * EVENTS_PER_BLOCK;
 
     /// Creates a set of consecutive [StarknetBlock]s starting from L2 genesis,
     /// with arbitrary other values.
-    pub(crate) fn create_blocks<const N: usize>() -> [StarknetBlock; N] {
-        (0..N)
+    pub(crate) fn create_blocks() -> [StarknetBlock; NUM_BLOCKS] {
+        (0..NUM_BLOCKS)
             .map(|i| StarknetBlock {
                 number: StarknetBlockNumber::GENESIS + i as u64,
                 hash: StarknetBlockHash(StarkHash::from_hex_str(&"a".repeat(i + 3)).unwrap()),
@@ -211,40 +227,89 @@ pub(crate) mod test_utils {
     }
 
     /// Creates a set of test transactions and receipts.
-    pub(crate) fn create_transactions_and_receipts<const N: usize>(
-    ) -> [(transaction::Transaction, transaction::Receipt); N] {
-        let transactions = (0..N).map(|i| transaction::Transaction {
-            calldata: None,
-            class_hash: None,
-            constructor_calldata: None,
-            contract_address: Some(ContractAddress(
-                StarkHash::from_hex_str(&"2".repeat(i + 3)).unwrap(),
-            )),
-            contract_address_salt: None,
-            entry_point_type: None,
-            entry_point_selector: None,
-            signature: None,
-            transaction_hash: StarknetTransactionHash(
-                StarkHash::from_hex_str(&"f".repeat(i + 3)).unwrap(),
-            ),
-            max_fee: None,
-            nonce: None,
-            r#type: transaction::Type::InvokeFunction,
-            sender_address: None,
-            version: None,
-        });
-        let receipts = (0..N).map(|i| transaction::Receipt {
-            actual_fee: None,
-            events: vec![transaction::Event {
-                from_address: ContractAddress(StarkHash::from_hex_str(&"2".repeat(i + 3)).unwrap()),
-                data: vec![EventData(
+    pub(crate) fn create_transactions_and_receipts(
+    ) -> [(transaction::Transaction, transaction::Receipt); NUM_TRANSACTIONS] {
+        let transactions = (0..NUM_TRANSACTIONS).map(|i| match i % TRANSACTIONS_PER_BLOCK {
+            x if x < INVOKE_TRANSACTIONS_PER_BLOCK => {
+                transaction::Transaction::Invoke(InvokeTransaction {
+                    calldata: vec![CallParam::from_hex_str(&"0".repeat(i + 3)).unwrap()],
+                    contract_address: ContractAddress(
+                        StarkHash::from_hex_str(&"1".repeat(i + 3)).unwrap(),
+                    ),
+                    entry_point_selector: EntryPoint::from_hex_str(&"2".repeat(i + 3)).unwrap(),
+                    entry_point_type: if i & 1 == 0 {
+                        EntryPointType::External
+                    } else {
+                        EntryPointType::L1Handler
+                    },
+                    max_fee: Fee(H128::zero()),
+                    signature: vec![TransactionSignatureElem(
+                        StarkHash::from_hex_str(&"3".repeat(i + 3)).unwrap(),
+                    )],
+                    transaction_hash: StarknetTransactionHash(
+                        StarkHash::from_hex_str(&"4".repeat(i + 3)).unwrap(),
+                    ),
+                    r#type: transaction::Type::InvokeFunction,
+                    version: Some(TransactionVersion(H256::zero())),
+                })
+            }
+            x if x >= INVOKE_TRANSACTIONS_PER_BLOCK
+                && x < INVOKE_TRANSACTIONS_PER_BLOCK + DEPLOY_TRANSACTIONS_PER_BLOCK =>
+            {
+                transaction::Transaction::Deploy(DeployTransaction {
+                    contract_address: ContractAddress(
+                        StarkHash::from_hex_str(&"5".repeat(i + 3)).unwrap(),
+                    ),
+                    contract_address_salt: ContractAddressSalt(
+                        StarkHash::from_hex_str(&"6".repeat(i + 3)).unwrap(),
+                    ),
+                    class_hash: Some(ClassHash(
+                        StarkHash::from_hex_str(&"7".repeat(i + 3)).unwrap(),
+                    )),
+                    constructor_calldata: vec![ConstructorParam(
+                        StarkHash::from_hex_str(&"8".repeat(i + 3)).unwrap(),
+                    )],
+                    transaction_hash: StarknetTransactionHash(
+                        StarkHash::from_hex_str(&"9".repeat(i + 3)).unwrap(),
+                    ),
+                    r#type: transaction::Type::Deploy,
+                })
+            }
+            _ => transaction::Transaction::Declare(DeclareTransaction {
+                class_hash: ClassHash(StarkHash::from_hex_str(&"a".repeat(i + 3)).unwrap()),
+                max_fee: Fee(H128::zero()),
+                nonce: TransactionNonce(StarkHash::from_hex_str(&"b".repeat(i + 3)).unwrap()),
+                sender_address: ContractAddress(
                     StarkHash::from_hex_str(&"c".repeat(i + 3)).unwrap(),
+                ),
+                signature: vec![TransactionSignatureElem(
+                    StarkHash::from_hex_str(&"d".repeat(i + 3)).unwrap(),
                 )],
-                keys: vec![
-                    EventKey(StarkHash::from_hex_str(&"d".repeat(i + 3)).unwrap()),
-                    EventKey(StarkHash::from_hex_str("deadbeef").unwrap()),
-                ],
-            }],
+                transaction_hash: StarknetTransactionHash(
+                    StarkHash::from_hex_str(&"e".repeat(i + 3)).unwrap(),
+                ),
+                r#type: transaction::Type::Deploy,
+                version: TransactionVersion(H256::zero()),
+            }),
+        });
+        let receipts = (0..NUM_TRANSACTIONS).map(|i| transaction::Receipt {
+            actual_fee: None,
+            events: if i % TRANSACTIONS_PER_BLOCK < EVENTS_PER_BLOCK {
+                vec![transaction::Event {
+                    from_address: ContractAddress(
+                        StarkHash::from_hex_str(&"2".repeat(i + 3)).unwrap(),
+                    ),
+                    data: vec![EventData(
+                        StarkHash::from_hex_str(&"c".repeat(i + 3)).unwrap(),
+                    )],
+                    keys: vec![
+                        EventKey(StarkHash::from_hex_str(&"d".repeat(i + 3)).unwrap()),
+                        EventKey(StarkHash::from_hex_str("deadbeef").unwrap()),
+                    ],
+                }]
+            } else {
+                vec![]
+            },
             execution_resources: transaction::ExecutionResources {
                 builtin_instance_counter:
                     transaction::execution_resources::BuiltinInstanceCounter::Empty(
@@ -267,6 +332,34 @@ pub(crate) mod test_utils {
             .collect::<Vec<_>>()
             .try_into()
             .unwrap()
+    }
+
+    /// Creates a set of emitted events from given blocks and transactions.
+    pub(crate) fn create_emitted_events(
+        blocks: &[StarknetBlock],
+        transactions_and_receipts: &[(transaction::Transaction, transaction::Receipt)],
+    ) -> Vec<StarknetEmittedEvent> {
+        transactions_and_receipts
+            .iter()
+            .enumerate()
+            .filter_map(|(i, (txn, receipt))| {
+                if i % TRANSACTIONS_PER_BLOCK < EVENTS_PER_BLOCK {
+                    let event = &receipt.events[0];
+                    let block = &blocks[i / TRANSACTIONS_PER_BLOCK];
+
+                    Some(StarknetEmittedEvent {
+                        data: event.data.clone(),
+                        from_address: event.from_address,
+                        keys: event.keys.clone(),
+                        block_hash: block.hash,
+                        block_number: block.number,
+                        transaction_hash: txn.hash(),
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 }
 

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -180,7 +180,10 @@ fn enable_foreign_keys(connection: &Connection) -> anyhow::Result<()> {
 
 #[cfg(test)]
 pub(crate) mod test_utils {
-    use super::{StarknetBlock, StarknetEmittedEvent};
+    use super::{
+        StarknetBlock, StarknetBlocksTable, StarknetEmittedEvent, StarknetTransactionsTable,
+        Storage,
+    };
 
     use crate::{
         core::{
@@ -361,6 +364,31 @@ pub(crate) mod test_utils {
                 }
             })
             .collect()
+    }
+
+    /// Creates a storage instance in memory with a set of expected emitted events
+    pub(crate) fn setup_storage() -> (Storage, Vec<StarknetEmittedEvent>) {
+        let storage = Storage::in_memory().unwrap();
+        let connection = storage.connection().unwrap();
+
+        let blocks = create_blocks();
+        let transactions_and_receipts = create_transactions_and_receipts();
+
+        for (i, block) in blocks.iter().enumerate() {
+            StarknetBlocksTable::insert(&connection, block).unwrap();
+            StarknetTransactionsTable::upsert(
+                &connection,
+                block.hash,
+                block.number,
+                &transactions_and_receipts
+                    [i * TRANSACTIONS_PER_BLOCK..(i + 1) * TRANSACTIONS_PER_BLOCK],
+            )
+            .unwrap();
+        }
+
+        let events = create_emitted_events(&blocks, &transactions_and_receipts);
+
+        (storage, events)
     }
 }
 

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -253,8 +253,9 @@ pub(crate) mod test_utils {
                     version: Some(TransactionVersion(H256::zero())),
                 })
             }
-            x if x >= INVOKE_TRANSACTIONS_PER_BLOCK
-                && x < INVOKE_TRANSACTIONS_PER_BLOCK + DEPLOY_TRANSACTIONS_PER_BLOCK =>
+            x if (INVOKE_TRANSACTIONS_PER_BLOCK
+                ..INVOKE_TRANSACTIONS_PER_BLOCK + DEPLOY_TRANSACTIONS_PER_BLOCK)
+                .contains(&x) =>
             {
                 transaction::Transaction::Deploy(DeployTransaction {
                     contract_address: ContractAddress(

--- a/crates/pathfinder/src/storage/schema/fixtures/mod.rs
+++ b/crates/pathfinder/src/storage/schema/fixtures/mod.rs
@@ -1,14 +1,11 @@
 use crate::storage::StarknetEmittedEvent;
 use rusqlite::Connection;
 
-pub const NUM_BLOCKS: usize = 4;
-pub const TXNS_PER_BLOCK: usize = 10;
-pub const NUM_TXNS: usize = NUM_BLOCKS * TXNS_PER_BLOCK;
-
 pub fn setup_events(connection: &Connection) -> Vec<StarknetEmittedEvent> {
-    let blocks = crate::storage::test_utils::create_blocks::<NUM_BLOCKS>();
-    let transactions_and_receipts =
-        crate::storage::test_utils::create_transactions_and_receipts::<NUM_TXNS>();
+    use crate::storage::test_utils;
+
+    let blocks = test_utils::create_blocks();
+    let transactions_and_receipts = test_utils::create_transactions_and_receipts();
 
     for (i, block) in blocks.iter().enumerate() {
         connection
@@ -28,26 +25,11 @@ pub fn setup_events(connection: &Connection) -> Vec<StarknetEmittedEvent> {
             connection,
             block.hash,
             block.number,
-            &transactions_and_receipts[i * TXNS_PER_BLOCK..(i + 1) * TXNS_PER_BLOCK],
+            &transactions_and_receipts[i * test_utils::TRANSACTIONS_PER_BLOCK
+                ..(i + 1) * test_utils::TRANSACTIONS_PER_BLOCK],
         )
         .unwrap();
     }
 
-    transactions_and_receipts
-        .iter()
-        .enumerate()
-        .map(|(i, (txn, receipt))| {
-            let event = &receipt.events[0];
-            let block = &blocks[i / 10];
-
-            StarknetEmittedEvent {
-                data: event.data.clone(),
-                from_address: event.from_address,
-                keys: event.keys.clone(),
-                block_hash: block.hash,
-                block_number: block.number,
-                transaction_hash: txn.transaction_hash,
-            }
-        })
-        .collect()
+    test_utils::create_emitted_events(&blocks, &transactions_and_receipts)
 }

--- a/crates/pathfinder/src/storage/schema/revision_0010.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0010.rs
@@ -254,10 +254,11 @@ mod tests {
                 ContractAddress, EventData, EventKey, GlobalRoot, StarknetBlockHash,
                 StarknetBlockNumber, StarknetBlockTimestamp, StarknetTransactionHash,
             },
-            sequencer::reply::transaction::{self, Event, Transaction},
+            sequencer::reply::transaction::{self, Event},
             storage::{
                 schema::{self},
                 state::PageOfEvents,
+                test_utils::NUM_EVENTS,
                 StarknetBlocksTable, StarknetEmittedEvent, StarknetEventFilter,
                 StarknetEventsTable,
             },
@@ -266,8 +267,17 @@ mod tests {
         // This is a copy of the structures and functions as of revision 7,
         // which allows us to simulate the conditions in which the bug
         // used to occur.
-        mod storage_rev7 {
+        mod revision7 {
+            use crate::{
+                core::{
+                    CallParam, ClassHash, ConstructorParam, ContractAddressSalt, EntryPoint, Fee,
+                    TransactionNonce, TransactionSignatureElem, TransactionVersion,
+                },
+                sequencer::reply::transaction::{EntryPointType, Type},
+            };
+
             use super::*;
+            use anyhow::Context;
             use rusqlite::named_params;
 
             #[derive(Debug, Clone, PartialEq)]
@@ -299,6 +309,73 @@ mod tests {
                     Ok(())
                 }
             }
+
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct Transaction {
+                pub calldata: Option<Vec<CallParam>>,
+                pub class_hash: Option<ClassHash>,
+                pub constructor_calldata: Option<Vec<ConstructorParam>>,
+                pub contract_address: Option<ContractAddress>,
+                pub contract_address_salt: Option<ContractAddressSalt>,
+                pub entry_point_type: Option<EntryPointType>,
+                pub entry_point_selector: Option<EntryPoint>,
+                pub max_fee: Option<Fee>,
+                pub nonce: Option<TransactionNonce>,
+                pub sender_address: Option<ContractAddress>,
+                pub signature: Option<Vec<TransactionSignatureElem>>,
+                pub transaction_hash: StarknetTransactionHash,
+                pub r#type: Type,
+                pub version: Option<TransactionVersion>,
+            }
+
+            pub struct StarknetEventsTable {}
+            impl StarknetEventsTable {
+                pub fn insert_events(
+                    connection: &Connection,
+                    block_number: StarknetBlockNumber,
+                    transaction: &Transaction,
+                    events: &[transaction::Event],
+                ) -> anyhow::Result<()> {
+                    if transaction.contract_address.is_none() && !events.is_empty() {
+                        anyhow::bail!("Declare transactions cannot emit events");
+                    }
+
+                    for (idx, event) in events.iter().enumerate() {
+                        connection
+                        .execute(
+                            r"INSERT INTO starknet_events ( block_number,  idx,  transaction_hash,  from_address,  keys,  data)
+                                                   VALUES (:block_number, :idx, :transaction_hash, :from_address, :keys, :data)",
+                            named_params![
+                                ":block_number": block_number.0,
+                                ":idx": idx,
+                                ":transaction_hash": &transaction.transaction_hash.0.as_be_bytes()[..],
+                                ":from_address": &event.from_address.0.as_be_bytes()[..],
+                                ":keys": Self::event_keys_to_base64_strings(&event.keys),
+                                ":data": Self::event_data_to_bytes(&event.data),
+                            ],
+                        )
+                        .context("Insert events into events table")?;
+                    }
+                    Ok(())
+                }
+
+                pub fn event_data_to_bytes(data: &[EventData]) -> Vec<u8> {
+                    data.iter()
+                        .flat_map(|e| (*e.0.as_be_bytes()).into_iter())
+                        .collect()
+                }
+
+                fn event_key_to_base64_string(key: &EventKey) -> String {
+                    base64::encode(key.0.as_be_bytes())
+                }
+
+                pub fn event_keys_to_base64_strings(keys: &[EventKey]) -> String {
+                    // TODO: we really should be using Iterator::intersperse() here once it's stabilized.
+                    let keys: Vec<String> =
+                        keys.iter().map(Self::event_key_to_base64_string).collect();
+                    keys.join(" ")
+                }
+            }
         }
 
         /// This is a test helper function which runs a stateful scenario of the migration
@@ -322,13 +399,13 @@ mod tests {
             let block0_number = StarknetBlockNumber(0);
             let block1_number = StarknetBlockNumber(1);
             let block0_hash = StarknetBlockHash(StarkHash::from_be_slice(b"block 1 hash").unwrap());
-            let block0 = storage_rev7::StarknetBlock {
+            let block0 = revision7::StarknetBlock {
                 hash: block0_hash,
                 number: block0_number,
                 root: GlobalRoot(StarkHash::from_be_slice(b"root 0").unwrap()),
                 timestamp: StarknetBlockTimestamp(0),
             };
-            let block1 = storage_rev7::StarknetBlock {
+            let block1 = revision7::StarknetBlock {
                 hash: StarknetBlockHash(StarkHash::from_be_slice(b"block 1 hash").unwrap()),
                 number: block1_number,
                 root: GlobalRoot(StarkHash::from_be_slice(b"root 1").unwrap()),
@@ -340,7 +417,7 @@ mod tests {
                 ContractAddress(StarkHash::from_be_slice(b"contract 1 address").unwrap());
             let transaction0_hash =
                 StarknetTransactionHash(StarkHash::from_be_slice(b"transaction 0 hash").unwrap());
-            let transaction0 = Transaction {
+            let transaction0 = revision7::Transaction {
                 calldata: None,
                 class_hash: None,
                 constructor_calldata: None,
@@ -375,16 +452,16 @@ mod tests {
                 keys: vec![event1_key],
             };
 
-            storage_rev7::StarknetBlocksTable::insert(&transaction, &block0).unwrap();
-            StarknetEventsTable::insert_events(
+            revision7::StarknetBlocksTable::insert(&transaction, &block0).unwrap();
+            revision7::StarknetEventsTable::insert_events(
                 &transaction,
                 block0_number,
                 &transaction0,
                 &[event0],
             )
             .unwrap();
-            storage_rev7::StarknetBlocksTable::insert(&transaction, &block1).unwrap();
-            StarknetEventsTable::insert_events(
+            revision7::StarknetBlocksTable::insert(&transaction, &block1).unwrap();
+            revision7::StarknetEventsTable::insert_events(
                 &transaction,
                 block1_number,
                 &transaction1,
@@ -489,7 +566,7 @@ mod tests {
                 .execute(r"UPDATE starknet_events SET rowid = rowid + 1000000", [])
                 .context("Force arbitrary rowids")
                 .unwrap();
-            assert_eq!(changed, schema::fixtures::NUM_TXNS);
+            assert_eq!(changed, NUM_EVENTS);
 
             let expected_event = &emitted_events[1];
             let filter = StarknetEventFilter {
@@ -498,7 +575,7 @@ mod tests {
                 contract_address: Some(expected_event.from_address),
                 // we're using a key which is present in _all_ events
                 keys: vec![EventKey(StarkHash::from_hex_str("deadbeef").unwrap())],
-                page_size: schema::fixtures::NUM_TXNS,
+                page_size: NUM_EVENTS,
                 page_number: 0,
             };
 

--- a/crates/pathfinder/src/storage/schema/revision_0012.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0012.rs
@@ -213,7 +213,7 @@ mod tests {
             contract_address: Some(expected_event.from_address),
             // we're using a key which is present in _all_ events
             keys: vec![EventKey(StarkHash::from_hex_str("deadbeef").unwrap())],
-            page_size: schema::fixtures::NUM_TXNS,
+            page_size: crate::storage::test_utils::NUM_TRANSACTIONS,
             page_number: 0,
         };
 

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -730,7 +730,8 @@ impl StarknetEventsTable {
     ) -> anyhow::Result<()> {
         match transaction {
             transaction::Transaction::Declare(_) => {
-                anyhow::bail!("Declare transactions cannot emit events")
+                anyhow::ensure!(events.is_empty(), "Declare transactions cannot emit events");
+                Ok(())
             }
             transaction::Transaction::Deploy(transaction::DeployTransaction {
                 transaction_hash,
@@ -1272,22 +1273,19 @@ mod tests {
     mod starknet_blocks {
         use super::*;
 
-        fn create_blocks() -> [StarknetBlock; 3] {
-            crate::storage::test_utils::create_blocks::<3>()
-        }
-
         mod get {
             use super::*;
 
             mod by_number {
                 use super::*;
+                use crate::storage::test_utils;
 
                 #[test]
                 fn some() {
                     let storage = Storage::in_memory().unwrap();
                     let connection = storage.connection().unwrap();
 
-                    let blocks = create_blocks();
+                    let blocks = test_utils::create_blocks();
                     for block in &blocks {
                         StarknetBlocksTable::insert(&connection, block).unwrap();
                     }
@@ -1306,7 +1304,7 @@ mod tests {
                     let storage = Storage::in_memory().unwrap();
                     let connection = storage.connection().unwrap();
 
-                    let blocks = create_blocks();
+                    let blocks = test_utils::create_blocks();
                     for block in &blocks {
                         StarknetBlocksTable::insert(&connection, block).unwrap();
                     }
@@ -1321,13 +1319,14 @@ mod tests {
 
             mod by_hash {
                 use super::*;
+                use crate::storage::test_utils;
 
                 #[test]
                 fn some() {
                     let storage = Storage::in_memory().unwrap();
                     let connection = storage.connection().unwrap();
 
-                    let blocks = create_blocks();
+                    let blocks = test_utils::create_blocks();
                     for block in &blocks {
                         StarknetBlocksTable::insert(&connection, block).unwrap();
                     }
@@ -1346,7 +1345,7 @@ mod tests {
                     let storage = Storage::in_memory().unwrap();
                     let connection = storage.connection().unwrap();
 
-                    let blocks = create_blocks();
+                    let blocks = test_utils::create_blocks();
                     for block in &blocks {
                         StarknetBlocksTable::insert(&connection, block).unwrap();
                     }
@@ -1362,13 +1361,14 @@ mod tests {
 
             mod latest {
                 use super::*;
+                use crate::storage::test_utils;
 
                 #[test]
                 fn some() {
                     let storage = Storage::in_memory().unwrap();
                     let connection = storage.connection().unwrap();
 
-                    let blocks = create_blocks();
+                    let blocks = test_utils::create_blocks();
                     for block in &blocks {
                         StarknetBlocksTable::insert(&connection, block).unwrap();
                     }
@@ -1400,13 +1400,14 @@ mod tests {
 
             mod by_number {
                 use super::*;
+                use crate::storage::test_utils;
 
                 #[test]
                 fn some() {
                     let storage = Storage::in_memory().unwrap();
                     let connection = storage.connection().unwrap();
 
-                    let blocks = create_blocks();
+                    let blocks = test_utils::create_blocks();
                     for block in &blocks {
                         StarknetBlocksTable::insert(&connection, block).unwrap();
                     }
@@ -1425,7 +1426,7 @@ mod tests {
                     let storage = Storage::in_memory().unwrap();
                     let connection = storage.connection().unwrap();
 
-                    let blocks = create_blocks();
+                    let blocks = test_utils::create_blocks();
                     for block in &blocks {
                         StarknetBlocksTable::insert(&connection, block).unwrap();
                     }
@@ -1440,13 +1441,14 @@ mod tests {
 
             mod by_hash {
                 use super::*;
+                use crate::storage::test_utils;
 
                 #[test]
                 fn some() {
                     let storage = Storage::in_memory().unwrap();
                     let connection = storage.connection().unwrap();
 
-                    let blocks = create_blocks();
+                    let blocks = test_utils::create_blocks();
                     for block in &blocks {
                         StarknetBlocksTable::insert(&connection, block).unwrap();
                     }
@@ -1465,7 +1467,7 @@ mod tests {
                     let storage = Storage::in_memory().unwrap();
                     let connection = storage.connection().unwrap();
 
-                    let blocks = create_blocks();
+                    let blocks = test_utils::create_blocks();
                     for block in &blocks {
                         StarknetBlocksTable::insert(&connection, block).unwrap();
                     }
@@ -1481,13 +1483,14 @@ mod tests {
 
             mod latest {
                 use super::*;
+                use crate::storage::test_utils;
 
                 #[test]
                 fn some() {
                     let storage = Storage::in_memory().unwrap();
                     let connection = storage.connection().unwrap();
 
-                    let blocks = create_blocks();
+                    let blocks = test_utils::create_blocks();
                     for block in &blocks {
                         StarknetBlocksTable::insert(&connection, block).unwrap();
                     }
@@ -1516,13 +1519,14 @@ mod tests {
 
         mod reorg {
             use super::*;
+            use crate::storage::test_utils;
 
             #[test]
             fn full() {
                 let storage = Storage::in_memory().unwrap();
                 let connection = storage.connection().unwrap();
 
-                let blocks = create_blocks();
+                let blocks = test_utils::create_blocks();
                 for block in &blocks {
                     StarknetBlocksTable::insert(&connection, block).unwrap();
                 }
@@ -1540,7 +1544,7 @@ mod tests {
                 let storage = Storage::in_memory().unwrap();
                 let connection = storage.connection().unwrap();
 
-                let blocks = create_blocks();
+                let blocks = test_utils::create_blocks();
                 for block in &blocks {
                     StarknetBlocksTable::insert(&connection, block).unwrap();
                 }
@@ -1570,6 +1574,7 @@ mod tests {
 
         use crate::core::EventData;
         use crate::sequencer::reply::transaction;
+        use crate::storage::test_utils;
 
         #[test]
         fn event_data_serialization() {
@@ -1609,25 +1614,9 @@ mod tests {
             );
         }
 
-        const NUM_BLOCKS: usize = 4;
-
-        fn create_blocks() -> [StarknetBlock; NUM_BLOCKS] {
-            crate::storage::test_utils::create_blocks::<NUM_BLOCKS>()
-        }
-
-        const TRANSACTIONS_PER_BLOCK: usize = 10;
-        const EVENTS_PER_BLOCK: usize = TRANSACTIONS_PER_BLOCK;
-        const NUM_TRANSACTIONS: usize = NUM_BLOCKS * TRANSACTIONS_PER_BLOCK;
-        const NUM_EVENTS: usize = NUM_BLOCKS * EVENTS_PER_BLOCK;
-
-        fn create_transactions_and_receipts(
-        ) -> [(transaction::Transaction, transaction::Receipt); NUM_TRANSACTIONS] {
-            crate::storage::test_utils::create_transactions_and_receipts::<NUM_TRANSACTIONS>()
-        }
-
         fn setup(connection: &Connection) -> Vec<StarknetEmittedEvent> {
-            let blocks = create_blocks();
-            let transactions_and_receipts = create_transactions_and_receipts();
+            let blocks = test_utils::create_blocks();
+            let transactions_and_receipts = test_utils::create_transactions_and_receipts();
 
             for (i, block) in blocks.iter().enumerate() {
                 StarknetBlocksTable::insert(connection, block).unwrap();
@@ -1635,29 +1624,13 @@ mod tests {
                     connection,
                     block.hash,
                     block.number,
-                    &transactions_and_receipts
-                        [i * TRANSACTIONS_PER_BLOCK..(i + 1) * TRANSACTIONS_PER_BLOCK],
+                    &transactions_and_receipts[i * test_utils::TRANSACTIONS_PER_BLOCK
+                        ..(i + 1) * test_utils::TRANSACTIONS_PER_BLOCK],
                 )
                 .unwrap();
             }
 
-            transactions_and_receipts
-                .iter()
-                .enumerate()
-                .map(|(i, (txn, receipt))| {
-                    let event = &receipt.events[0];
-                    let block = &blocks[i / TRANSACTIONS_PER_BLOCK];
-
-                    StarknetEmittedEvent {
-                        data: event.data.clone(),
-                        from_address: event.from_address,
-                        keys: event.keys.clone(),
-                        block_hash: block.hash,
-                        block_number: block.number,
-                        transaction_hash: txn.hash(),
-                    }
-                })
-                .collect()
+            test_utils::create_emitted_events(&blocks, &transactions_and_receipts)
         }
 
         #[test]
@@ -1674,7 +1647,7 @@ mod tests {
                 contract_address: Some(expected_event.from_address),
                 // we're using a key which is present in _all_ events
                 keys: vec![EventKey(StarkHash::from_hex_str("deadbeef").unwrap())],
-                page_size: NUM_EVENTS,
+                page_size: test_utils::NUM_EVENTS,
                 page_number: 0,
             };
 
@@ -1701,12 +1674,12 @@ mod tests {
                 to_block: Some(StarknetBlockNumber(BLOCK_NUMBER as u64)),
                 contract_address: None,
                 keys: vec![],
-                page_size: NUM_EVENTS,
+                page_size: test_utils::NUM_EVENTS,
                 page_number: 0,
             };
 
-            let expected_events = &emitted_events
-                [EVENTS_PER_BLOCK * BLOCK_NUMBER..EVENTS_PER_BLOCK * (BLOCK_NUMBER + 1)];
+            let expected_events = &emitted_events[test_utils::EVENTS_PER_BLOCK * BLOCK_NUMBER
+                ..test_utils::EVENTS_PER_BLOCK * (BLOCK_NUMBER + 1)];
             let events = StarknetEventsTable::get_events(&connection, &filter).unwrap();
             assert_eq!(
                 events,
@@ -1730,12 +1703,12 @@ mod tests {
                 to_block: Some(StarknetBlockNumber(UNTIL_BLOCK_NUMBER as u64)),
                 contract_address: None,
                 keys: vec![],
-                page_size: NUM_EVENTS,
+                page_size: test_utils::NUM_EVENTS,
                 page_number: 0,
             };
 
             let expected_events =
-                &emitted_events[..TRANSACTIONS_PER_BLOCK * (UNTIL_BLOCK_NUMBER + 1)];
+                &emitted_events[..test_utils::EVENTS_PER_BLOCK * (UNTIL_BLOCK_NUMBER + 1)];
             let events = StarknetEventsTable::get_events(&connection, &filter).unwrap();
             assert_eq!(
                 events,
@@ -1759,11 +1732,12 @@ mod tests {
                 to_block: None,
                 contract_address: None,
                 keys: vec![],
-                page_size: NUM_EVENTS,
+                page_size: test_utils::NUM_EVENTS,
                 page_number: 0,
             };
 
-            let expected_events = &emitted_events[TRANSACTIONS_PER_BLOCK * FROM_BLOCK_NUMBER..];
+            let expected_events =
+                &emitted_events[test_utils::EVENTS_PER_BLOCK * FROM_BLOCK_NUMBER..];
             let events = StarknetEventsTable::get_events(&connection, &filter).unwrap();
             assert_eq!(
                 events,
@@ -1788,7 +1762,7 @@ mod tests {
                 to_block: None,
                 contract_address: Some(expected_event.from_address),
                 keys: vec![],
-                page_size: NUM_EVENTS,
+                page_size: test_utils::NUM_EVENTS,
                 page_number: 0,
             };
 
@@ -1815,7 +1789,7 @@ mod tests {
                 to_block: None,
                 contract_address: None,
                 keys: vec![expected_event.keys[0]],
-                page_size: NUM_EVENTS,
+                page_size: test_utils::NUM_EVENTS,
                 page_number: 0,
             };
 
@@ -1841,7 +1815,7 @@ mod tests {
                 to_block: None,
                 contract_address: None,
                 keys: vec![],
-                page_size: NUM_EVENTS,
+                page_size: test_utils::NUM_EVENTS,
                 page_number: 0,
             };
 
@@ -1929,7 +1903,7 @@ mod tests {
                 keys: vec![],
                 page_size: PAGE_SIZE,
                 // one page _after_ the last one
-                page_number: NUM_BLOCKS * EVENTS_PER_BLOCK / PAGE_SIZE,
+                page_number: test_utils::NUM_BLOCKS * test_utils::EVENTS_PER_BLOCK / PAGE_SIZE,
             };
             let events = StarknetEventsTable::get_events(&connection, &filter).unwrap();
             assert_eq!(

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -1614,31 +1614,10 @@ mod tests {
             );
         }
 
-        fn setup(connection: &Connection) -> Vec<StarknetEmittedEvent> {
-            let blocks = test_utils::create_blocks();
-            let transactions_and_receipts = test_utils::create_transactions_and_receipts();
-
-            for (i, block) in blocks.iter().enumerate() {
-                StarknetBlocksTable::insert(connection, block).unwrap();
-                StarknetTransactionsTable::upsert(
-                    connection,
-                    block.hash,
-                    block.number,
-                    &transactions_and_receipts[i * test_utils::TRANSACTIONS_PER_BLOCK
-                        ..(i + 1) * test_utils::TRANSACTIONS_PER_BLOCK],
-                )
-                .unwrap();
-            }
-
-            test_utils::create_emitted_events(&blocks, &transactions_and_receipts)
-        }
-
         #[test]
         fn get_events_with_fully_specified_filter() {
-            let storage = Storage::in_memory().unwrap();
+            let (storage, emitted_events) = test_utils::setup_storage();
             let connection = storage.connection().unwrap();
-
-            let emitted_events = setup(&connection);
 
             let expected_event = &emitted_events[1];
             let filter = StarknetEventFilter {
@@ -1663,10 +1642,8 @@ mod tests {
 
         #[test]
         fn get_events_by_block() {
-            let storage = Storage::in_memory().unwrap();
+            let (storage, emitted_events) = test_utils::setup_storage();
             let connection = storage.connection().unwrap();
-
-            let emitted_events = setup(&connection);
 
             const BLOCK_NUMBER: usize = 2;
             let filter = StarknetEventFilter {
@@ -1692,10 +1669,8 @@ mod tests {
 
         #[test]
         fn get_events_up_to_block() {
-            let storage = Storage::in_memory().unwrap();
+            let (storage, emitted_events) = test_utils::setup_storage();
             let connection = storage.connection().unwrap();
-
-            let emitted_events = setup(&connection);
 
             const UNTIL_BLOCK_NUMBER: usize = 2;
             let filter = StarknetEventFilter {
@@ -1721,10 +1696,8 @@ mod tests {
 
         #[test]
         fn get_events_from_block_onwards() {
-            let storage = Storage::in_memory().unwrap();
+            let (storage, emitted_events) = test_utils::setup_storage();
             let connection = storage.connection().unwrap();
-
-            let emitted_events = setup(&connection);
 
             const FROM_BLOCK_NUMBER: usize = 2;
             let filter = StarknetEventFilter {
@@ -1750,10 +1723,8 @@ mod tests {
 
         #[test]
         fn get_events_from_contract() {
-            let storage = Storage::in_memory().unwrap();
+            let (storage, emitted_events) = test_utils::setup_storage();
             let connection = storage.connection().unwrap();
-
-            let emitted_events = setup(&connection);
 
             let expected_event = &emitted_events[33];
 
@@ -1778,10 +1749,8 @@ mod tests {
 
         #[test]
         fn get_events_by_key() {
-            let storage = Storage::in_memory().unwrap();
+            let (storage, emitted_events) = test_utils::setup_storage();
             let connection = storage.connection().unwrap();
-
-            let emitted_events = setup(&connection);
 
             let expected_event = &emitted_events[27];
             let filter = StarknetEventFilter {
@@ -1805,10 +1774,8 @@ mod tests {
 
         #[test]
         fn get_events_with_no_filter() {
-            let storage = Storage::in_memory().unwrap();
+            let (storage, emitted_events) = test_utils::setup_storage();
             let connection = storage.connection().unwrap();
-
-            let emitted_events = setup(&connection);
 
             let filter = StarknetEventFilter {
                 from_block: None,
@@ -1831,10 +1798,8 @@ mod tests {
 
         #[test]
         fn get_events_with_no_filter_and_paging() {
-            let storage = Storage::in_memory().unwrap();
+            let (storage, emitted_events) = test_utils::setup_storage();
             let connection = storage.connection().unwrap();
-
-            let emitted_events = setup(&connection);
 
             let filter = StarknetEventFilter {
                 from_block: None,
@@ -1890,10 +1855,8 @@ mod tests {
 
         #[test]
         fn get_events_with_no_filter_and_nonexistent_page() {
-            let storage = Storage::in_memory().unwrap();
+            let (storage, _) = test_utils::setup_storage();
             let connection = storage.connection().unwrap();
-
-            let _emitted_events = setup(&connection);
 
             const PAGE_SIZE: usize = 10;
             let filter = StarknetEventFilter {
@@ -1917,10 +1880,8 @@ mod tests {
 
         #[test]
         fn get_events_with_invalid_page_size() {
-            let storage = Storage::in_memory().unwrap();
+            let (storage, _) = test_utils::setup_storage();
             let connection = storage.connection().unwrap();
-
-            let _emitted_events = setup(&connection);
 
             let filter = StarknetEventFilter {
                 from_block: None,
@@ -1952,10 +1913,8 @@ mod tests {
 
         #[test]
         fn get_events_by_key_with_paging() {
-            let storage = Storage::in_memory().unwrap();
+            let (storage, emitted_events) = test_utils::setup_storage();
             let connection = storage.connection().unwrap();
-
-            let emitted_events = setup(&connection);
 
             let expected_events = &emitted_events[27..32];
             let keys_for_expected_events: Vec<_> =


### PR DESCRIPTION
`sequencer::transaction::Transaction` contains so many `Option`s that it is really difficult to remember which of the fields is `None` and which is `Some` for each type of transaction, namely: declare, deploy, invoke.

This PR introduces a `Transaction` as a 3-variant where optional fields are limited to the fields which the api could still not be sending for older blocks/transactions.

This change is also introduced in anticipation of a similar change in the RPC spec, which would lead to a 1:1 translation between input (ie. sequencer) and output (ie. RPC) variants.