### PR TITLE
feat: accounting for L1 reorg bug tracking

### DIFF
--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -72,15 +72,12 @@ impl L1StateTable {
             Ok(_) => Ok(()),
             Err(err) => {
                 if err.to_string().contains("A PRIMARY KEY constraint failed") {
-                    let latest = L1_LATEST_REORG
-                        .lock()
-                        .map_err(|_| anyhow::anyhow!("L1 accounting lock is poisoned"))
-                        .context("Aquire L1 accounting lock")?;
+                    let latest = L1_LATEST_REORG.lock().unwrap_or_else(|e| e.into_inner());
 
                     tracing::error!(pre_reorg=%latest.0, post_reorg=%latest.1, count=%latest.2, "Additional L1 reorg bug information");
                 }
 
-                Err(anyhow::anyhow!(err))
+                Err(err.into())
             }
         }
     }
@@ -130,10 +127,7 @@ impl L1StateTable {
                     new_head
                 );
 
-                let mut latest = L1_LATEST_REORG
-                    .lock()
-                    .map_err(|_| anyhow::anyhow!("L1 accounting lock is poisoned"))
-                    .context("Aquire L1 accounting lock")?;
+                let mut latest = L1_LATEST_REORG.lock().unwrap_or_else(|e| e.into_inner());
 
                 latest.0 = orig;
                 latest.1 = new_head;

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -107,13 +107,11 @@ impl L1StateTable {
     /// i.e. it deletes all rows where `block number >= reorg_tail`.
     pub fn reorg(connection: &Connection, reorg_tail: StarknetBlockNumber) -> anyhow::Result<()> {
         // Added to trace a primary key constraint failure bug.
-        let original_head: Option<u64> = connection
-            .query_row(
-                "SELECT MAX(starknet_block_number) FROM l1_state",
-                [],
-                |row| row.get(0),
-            )
-            .optional()?;
+        let original_head: Option<u64> = connection.query_row(
+            "SELECT MAX(starknet_block_number) FROM l1_state",
+            [],
+            |row| row.get(0),
+        )?;
 
         let reorg_count = connection.execute(
             "DELETE FROM l1_state WHERE starknet_block_number >= ?",
@@ -121,13 +119,11 @@ impl L1StateTable {
         )? as u64;
 
         // Added to trace a primary key constraint failure bug.
-        let new_head: Option<u64> = connection
-            .query_row(
-                "SELECT MAX(starknet_block_number) FROM l1_state",
-                [],
-                |row| row.get(0),
-            )
-            .optional()?;
+        let new_head: Option<u64> = connection.query_row(
+            "SELECT MAX(starknet_block_number) FROM l1_state",
+            [],
+            |row| row.get(0),
+        )?;
 
         // Sanity check the result of reorg.
         if let Some(new_head) = new_head {
@@ -159,7 +155,7 @@ impl L1StateTable {
             }
             (Some(orig), None) => {
                 anyhow::ensure!(
-                    orig == reorg_count,
+                    orig + 1 == reorg_count,
                     "Deletion count ({}) did not match head change ({} -> None)",
                     reorg_count,
                     orig


### PR DESCRIPTION
An attempt at gathering extra information for #381. This bug has been reported several times, but the code looks fool-proof i.e. no route for this to occur has been identified.

This PR adds additional checks to both the reorg and insert functions in order to shed some light on the matter.