### PR TITLE
feat: make number of Python subprocesses configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ data-directory = "..."
 # have a caching proxy in front of the actual Sequencer gateway. If you're unsure
 # of what this does, then you don't need it.
 sequencer-url = "https://..."
+# Set the number of Python subprocesses pathfinder starts. These processes are used
+# to service the `starknet_call` JSON-RPC method and their number limits the maximal
+# number of call requests that can be processed in parallel. Defaults to 2.
+python-subprocesses = 2
 
 [ethereum]
 # This is required and must be an HTTP(s) URL pointing to your Ethereum node's endpoint.

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -73,7 +73,7 @@ async fn main() -> anyhow::Result<()> {
     // not be other reason for the start to fail than python script not firing up.
     let (call_handle, cairo_handle) = cairo::ext_py::start(
         storage.path().into(),
-        std::num::NonZeroUsize::new(2).unwrap(),
+        config.python_subprocesses,
         futures::future::pending(),
     )
     .await

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -23,6 +23,8 @@ pub enum ConfigOption {
     DataDirectory,
     /// The Sequencer's HTTP URL.
     SequencerHttpUrl,
+    /// Number of Python sub-processes to start.
+    PythonSubprocesses,
 }
 
 impl Display for ConfigOption {
@@ -33,6 +35,7 @@ impl Display for ConfigOption {
             ConfigOption::DataDirectory => f.write_str("Data directory"),
             ConfigOption::HttpRpcAddress => f.write_str("HTTP-RPC socket address"),
             ConfigOption::SequencerHttpUrl => f.write_str("Sequencer HTTP URL"),
+            ConfigOption::PythonSubprocesses => f.write_str("Number of Python subprocesses"),
         }
     }
 }
@@ -57,6 +60,8 @@ pub struct Configuration {
     pub data_directory: PathBuf,
     /// The Sequencer's HTTP URL.
     pub sequencer_url: Option<Url>,
+    /// The number of Python subprocesses to start.
+    pub python_subprocesses: std::num::NonZeroUsize,
 }
 
 impl Configuration {


### PR DESCRIPTION
This PR adds the `python-subprocesses` command line argument, config file key and the corresponding environment variable, PATHFINDER_PYTHON_SUBPROCESSES.

By making the number of subprocesses configurable we provide an option to set up `pathfinder` for better `starknet_call` performance, which is limited by the number of Python subprocesses we use to service those requests.

Fixes issue #354 