### PR TITLE
upper and lower hex representations

### DIFF
--- a/crates/pathfinder/src/rpc/serde.rs
+++ b/crates/pathfinder/src/rpc/serde.rs
@@ -394,10 +394,12 @@ fn it_to_hex_str<'a>(
     &buf[..len]
 }
 
-/// A convenience function which produces a "0x" prefixed hex str slice in a given buffer `buf`
-/// from an array of bytes.
+/// Produce a "0x" prefixed hex str slice from an array of bytes.
+///
+/// The result is written to `buf` and the conversion is performed
+/// based on a nibble to char lookup table `lut`.
+///
 /// Panics if `bytes.len() * 2 + 2 > buf.len()`
-/// TODO
 fn bytes_as_hex_str<'a>(bytes: &'a [u8], buf: &'a mut [u8], lut: &[u8]) -> &'a str {
     let expected_buf_len = bytes.len() * 2 + 2;
     assert!(
@@ -417,8 +419,8 @@ fn bytes_as_hex_str<'a>(bytes: &'a [u8], buf: &'a mut [u8], lut: &[u8]) -> &'a s
     std::str::from_utf8(res).unwrap()
 }
 
-/// A convenience function which produces a "0x" prefixed hex string from a [StarkHash].
-/// TODO
+/// Produce a "0x" prefixed hex string from an array of bytes
+/// based on a nibble to char lookup table `lut`.
 #[allow(dead_code)]
 fn bytes_to_hex_str(bytes: &[u8], lut: &[u8]) -> Cow<'static, str> {
     if !bytes.iter().any(|b| *b != 0) {
@@ -431,24 +433,24 @@ fn bytes_to_hex_str(bytes: &[u8], lut: &[u8]) -> Cow<'static, str> {
     String::from_utf8(buf).unwrap().into()
 }
 
-/// TODO
+/// Produce a "0x" prefixed lower hex str slice in `buf` from an array of bytes.
 fn bytes_as_lower_hex_str<'a>(bytes: &'a [u8], buf: &'a mut [u8]) -> &'a str {
     bytes_as_hex_str(bytes, buf, &LUT_LOWER)
 }
 
-/// TODO
+/// Produce a "0x" prefixed upper hex str slice in `buf` from an array of bytes.
 #[allow(dead_code)]
 fn bytes_as_upper_hex_str<'a>(bytes: &'a [u8], buf: &'a mut [u8]) -> &'a str {
     bytes_as_hex_str(bytes, buf, &LUT_UPPER)
 }
 
-/// TODO
+/// Produce a "0x" prefixed lower hex string from an array of bytes.
 #[allow(dead_code)]
 fn bytes_to_lower_hex_str(bytes: &[u8]) -> Cow<'static, str> {
     bytes_to_hex_str(bytes, &LUT_LOWER)
 }
 
-/// TODO
+/// Produce a "0x" prefixed upper hex string from an array of bytes.
 #[allow(dead_code)]
 fn bytes_to_upper_hex_str(bytes: &[u8]) -> Cow<'static, str> {
     bytes_to_hex_str(bytes, &LUT_UPPER)

--- a/crates/pathfinder/src/rpc/serde.rs
+++ b/crates/pathfinder/src/rpc/serde.rs
@@ -474,49 +474,61 @@ mod tests {
 
         let c: [u8; 1] = bytes_from_hex_str(ZERO_HEX_STR).unwrap();
         assert!(c.iter().all(|x| *x == 0));
-        assert_eq!(bytes_to_hex_str(&c[..]), ZERO_HEX_STR);
+        assert_eq!(bytes_to_lower_hex_str(&c[..]), ZERO_HEX_STR);
+        assert_eq!(bytes_to_upper_hex_str(&c[..]), ZERO_HEX_STR);
         let mut buf = [0u8; 2 + 2];
-        assert_eq!(bytes_as_hex_str(&c[..], &mut buf), ZERO_HEX_STR);
+        assert_eq!(bytes_as_lower_hex_str(&c[..], &mut buf), ZERO_HEX_STR);
+        assert_eq!(bytes_as_upper_hex_str(&c[..], &mut buf), ZERO_HEX_STR);
     }
 
     #[test]
     fn odd() {
-        const ODD_HEX_STR: &str = "0x1234567890abcde";
+        const ODD_HEX_STR_LOWER: &str = "0x1234567890abcde";
+        const ODD_HEX_STR_UPPER: &str = "0x1234567890ABCDE";
         const ODD_DEC_STR: &str = "81985529205931230";
         const ODD_BYTES: [u8; 8] = [1, 0x23, 0x45, 0x67, 0x89, 0x0a, 0xbc, 0xde];
 
         let a = starkhash_from_biguint(BigUint::from_bytes_be(&ODD_BYTES)).unwrap();
         let b = starkhash_from_dec_str(ODD_DEC_STR).unwrap();
-        let expected = StarkHash::from_hex_str(ODD_HEX_STR).unwrap();
+        let expected = StarkHash::from_hex_str(ODD_HEX_STR_LOWER).unwrap();
         assert_eq!(expected, a);
         assert_eq!(expected, b);
         assert_eq!(starkhash_to_dec_str(&expected), ODD_DEC_STR);
 
-        let c: [u8; 8] = bytes_from_hex_str(ODD_HEX_STR).unwrap();
+        let c: [u8; 8] = bytes_from_hex_str(ODD_HEX_STR_LOWER).unwrap();
         assert_eq!(c, ODD_BYTES);
-        assert_eq!(bytes_to_hex_str(&c[..]), ODD_HEX_STR);
+        let d: [u8; 8] = bytes_from_hex_str(ODD_HEX_STR_UPPER).unwrap();
+        assert_eq!(d, ODD_BYTES);
+        assert_eq!(bytes_to_lower_hex_str(&d[..]), ODD_HEX_STR_LOWER);
+        assert_eq!(bytes_to_upper_hex_str(&d[..]), ODD_HEX_STR_UPPER);
         let mut buf = [0u8; 2 + 16];
-        assert_eq!(bytes_as_hex_str(&c[..], &mut buf), ODD_HEX_STR);
+        assert_eq!(bytes_as_lower_hex_str(&d[..], &mut buf), ODD_HEX_STR_LOWER);
+        assert_eq!(bytes_as_upper_hex_str(&d[..], &mut buf), ODD_HEX_STR_UPPER);
     }
 
     #[test]
     fn even() {
-        const EVEN_HEX_STR: &str = "0x1234567890abcdef";
+        const EVEN_HEX_STR_LOWER: &str = "0x1234567890abcdef";
+        const EVEN_HEX_STR_UPPER: &str = "0x1234567890ABCDEF";
         const EVEN_DEC_STR: &str = "1311768467294899695";
         const EVEN_BYTES: [u8; 8] = [0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef];
 
         let a = starkhash_from_biguint(BigUint::from_bytes_be(&EVEN_BYTES)).unwrap();
         let b = starkhash_from_dec_str(EVEN_DEC_STR).unwrap();
-        let expected = StarkHash::from_hex_str(EVEN_HEX_STR).unwrap();
+        let expected = StarkHash::from_hex_str(EVEN_HEX_STR_LOWER).unwrap();
         assert_eq!(expected, a);
         assert_eq!(expected, b);
         assert_eq!(starkhash_to_dec_str(&expected), EVEN_DEC_STR);
 
-        let c: [u8; 8] = bytes_from_hex_str(EVEN_HEX_STR).unwrap();
+        let c: [u8; 8] = bytes_from_hex_str(EVEN_HEX_STR_LOWER).unwrap();
         assert_eq!(c, EVEN_BYTES);
-        assert_eq!(bytes_to_hex_str(&c[..]), EVEN_HEX_STR);
+        let d: [u8; 8] = bytes_from_hex_str(EVEN_HEX_STR_UPPER).unwrap();
+        assert_eq!(d, EVEN_BYTES);
+        assert_eq!(bytes_to_lower_hex_str(&d[..]), EVEN_HEX_STR_LOWER);
+        assert_eq!(bytes_to_upper_hex_str(&d[..]), EVEN_HEX_STR_UPPER);
         let mut buf = [0u8; 2 + 16];
-        assert_eq!(bytes_as_hex_str(&c[..], &mut buf), EVEN_HEX_STR);
+        assert_eq!(bytes_as_lower_hex_str(&d[..], &mut buf), EVEN_HEX_STR_LOWER);
+        assert_eq!(bytes_as_upper_hex_str(&d[..], &mut buf), EVEN_HEX_STR_UPPER);
     }
 
     #[test]
@@ -539,16 +551,27 @@ mod tests {
 
         let c: [u8; 32] = bytes_from_hex_str(MAX_HEX_STR).unwrap();
         assert_eq!(c, MAX_BYTES);
-        assert_eq!(bytes_to_hex_str(&c[..]), MAX_HEX_STR);
+        assert_eq!(bytes_to_lower_hex_str(&c[..]), MAX_HEX_STR);
+        assert_eq!(bytes_to_upper_hex_str(&c[..]), MAX_HEX_STR);
         let mut buf = [0u8; 2 + 64];
-        assert_eq!(bytes_as_hex_str(&c[..], &mut buf), MAX_HEX_STR);
+        assert_eq!(bytes_as_lower_hex_str(&c[..], &mut buf), MAX_HEX_STR);
+        assert_eq!(bytes_as_upper_hex_str(&c[..], &mut buf), MAX_HEX_STR);
     }
 
-    #[test]
-    #[should_panic]
-    fn buffer_too_small() {
-        let mut buf = [0u8; 2 + 1];
-        bytes_as_hex_str(&[0u8], &mut buf);
+    mod buffer_too_small {
+        #[test]
+        #[should_panic]
+        fn lower() {
+            let mut buf = [0u8; 2 + 1];
+            super::bytes_as_lower_hex_str(&[0u8], &mut buf);
+        }
+
+        #[test]
+        #[should_panic]
+        fn upper() {
+            let mut buf = [0u8; 2 + 1];
+            super::bytes_as_upper_hex_str(&[0u8], &mut buf);
+        }
     }
 
     #[test]

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -49,7 +49,7 @@ pub enum BlockHashOrTag {
 impl std::fmt::Display for BlockHashOrTag {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            BlockHashOrTag::Hash(StarknetBlockHash(h)) => f.write_str(&h.to_hex_str()),
+            BlockHashOrTag::Hash(StarknetBlockHash(h)) => f.write_str(&h.to_lower_hex_str()),
             BlockHashOrTag::Tag(t) => std::fmt::Display::fmt(t, f),
         }
     }

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -491,7 +491,7 @@ mod tests {
     impl std::fmt::Display for crate::core::ContractAddress {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut buf = [0u8; 2 + 64];
-            let s = self.0.as_hex_str(&mut buf);
+            let s = self.0.as_lower_hex_str(&mut buf);
             f.write_str(s)
         }
     }
@@ -499,7 +499,7 @@ mod tests {
     impl std::fmt::Display for crate::core::StarknetTransactionHash {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut buf = [0u8; 2 + 64];
-            let s = self.0.as_hex_str(&mut buf);
+            let s = self.0.as_lower_hex_str(&mut buf);
             f.write_str(s)
         }
     }
@@ -507,7 +507,7 @@ mod tests {
     impl std::fmt::Display for crate::core::ClassHash {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut buf = [0u8; 2 + 64];
-            let s = self.0.as_hex_str(&mut buf);
+            let s = self.0.as_lower_hex_str(&mut buf);
             f.write_str(s)
         }
     }

--- a/crates/pathfinder/src/sequencer/builder.rs
+++ b/crates/pathfinder/src/sequencer/builder.rs
@@ -181,7 +181,7 @@ impl<'a> Request<'a, stage::Params> {
         let block: BlockId = block.into();
         let (name, value) = match block {
             BlockId::Number(number) => ("blockNumber", Cow::from(number.0.to_string())),
-            BlockId::Hash(hash) => ("blockHash", hash.0.to_hex_str()),
+            BlockId::Hash(hash) => ("blockHash", hash.0.to_lower_hex_str()),
             // These have to use "blockNumber", "blockHash" does not accept tags.
             BlockId::Latest => ("blockNumber", Cow::from("latest")),
             BlockId::Pending => ("blockNumber", Cow::from("pending")),
@@ -191,11 +191,11 @@ impl<'a> Request<'a, stage::Params> {
     }
 
     pub fn with_contract_address(self, address: ContractAddress) -> Self {
-        self.add_param("contractAddress", &address.0.to_hex_str())
+        self.add_param("contractAddress", &address.0.to_lower_hex_str())
     }
 
     pub fn with_class_hash(self, class_hash: ClassHash) -> Self {
-        self.add_param("classHash", &class_hash.0.to_hex_str())
+        self.add_param("classHash", &class_hash.0.to_lower_hex_str())
     }
 
     pub fn with_optional_token(self, token: Option<&str>) -> Self {
@@ -211,7 +211,7 @@ impl<'a> Request<'a, stage::Params> {
     }
 
     pub fn with_transaction_hash(self, hash: StarknetTransactionHash) -> Self {
-        self.add_param("transactionHash", &hash.0.to_hex_str())
+        self.add_param("transactionHash", &hash.0.to_lower_hex_str())
     }
 
     pub fn add_param(mut self, name: &str, value: &str) -> Self {

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -263,7 +263,7 @@ where
                         format!("Insert contract definition with hash: {:?}", contract.hash)
                     })?;
 
-                    tracing::trace!("Inserted new contract {}", contract.hash.0.to_hex_str());
+                    tracing::trace!("Inserted new contract {}", contract.hash.0.to_lower_hex_str());
                 }
                 Some(l2::Event::QueryHash(block, tx)) => {
                     let hash = tokio::task::block_in_place(|| {

--- a/crates/stark_hash/src/hash.rs
+++ b/crates/stark_hash/src/hash.rs
@@ -311,7 +311,7 @@ impl StarkHash {
 
     /// A convenience function which produces a "0x" prefixed hex string from a [StarkHash].
     /// TODO
-    fn to_hex_str(&self, lut: &[u8]) -> Cow<'static, str> {
+    fn to_hex_str(self, lut: &[u8]) -> Cow<'static, str> {
         if !self.0.iter().any(|b| *b != 0) {
             return Cow::from("0x0");
         }

--- a/crates/stark_hash/src/hash.rs
+++ b/crates/stark_hash/src/hash.rs
@@ -207,10 +207,9 @@ impl Display for InvalidBufferSizeError {
 }
 
 impl StarkHash {
-    /// A convenience function which parses a hex string into a [StarkHash].
+    /// Parse a hex string into a [StarkHash].
     ///
-    /// Supports both upper and lower case hex strings, as well as an
-    /// optional "0x" prefix.
+    /// Upper or lower case hex strings, and an optional "0x" prefix are allowed.
     pub fn from_hex_str(hex_str: &str) -> Result<Self, HexParseError> {
         fn parse_hex_digit(digit: u8) -> Result<u8, HexParseError> {
             match digit {
@@ -286,10 +285,12 @@ impl StarkHash {
         &buf[..len]
     }
 
-    /// A convenience function which produces a "0x" prefixed hex str slice in a given buffer `buf`
-    /// from a [StarkHash].
-    /// Panics if `self.0.len() * 2 + 2 > buf.len()`
-    /// TODO
+    /// Produce a "0x" prefixed hex str slice from this [StarkHash].
+    ///
+    /// The result is written to `buf` and the conversion is performed
+    /// based on a nibble to char lookup table `lut`.
+    ///
+    /// Panics if `bytes.len() * 2 + 2 > buf.len()`
     fn as_hex_str<'a>(&'a self, buf: &'a mut [u8], lut: &[u8]) -> &'a str {
         let expected_buf_len = self.0.len() * 2 + 2;
         assert!(
@@ -309,8 +310,8 @@ impl StarkHash {
         std::str::from_utf8(res).unwrap()
     }
 
-    /// A convenience function which produces a "0x" prefixed hex string from a [StarkHash].
-    /// TODO
+    /// Produce a "0x" prefixed hex string from this [StarkHash]
+    /// based on a nibble to char lookup table `lut`.
     fn to_hex_str(self, lut: &[u8]) -> Cow<'static, str> {
         if !self.0.iter().any(|b| *b != 0) {
             return Cow::from("0x0");
@@ -322,30 +323,26 @@ impl StarkHash {
         String::from_utf8(buf).unwrap().into()
     }
 
-    /// A convenience function which produces a "0x" prefixed hex str slice in a given buffer `buf`
-    /// from a [StarkHash].
+    /// Produce a "0x" prefixed lower hex str slice in `buf` from this [StarkHash].
+    ///
     /// Panics if `self.0.len() * 2 + 2 > buf.len()`
-    /// TODO
     pub fn as_lower_hex_str<'a>(&'a self, buf: &'a mut [u8]) -> &'a str {
         self.as_hex_str(buf, &Self::LUT_LOWER)
     }
 
-    /// A convenience function which produces a "0x" prefixed hex str slice in a given buffer `buf`
-    /// from a [StarkHash].
+    /// Produce a "0x" prefixed upper hex str slice in `buf` from this [StarkHash].
+    ///
     /// Panics if `self.0.len() * 2 + 2 > buf.len()`
-    /// TODO
     pub fn as_upper_hex_str<'a>(&'a self, buf: &'a mut [u8]) -> &'a str {
         self.as_hex_str(buf, &Self::LUT_UPPER)
     }
 
-    /// A convenience function which produces a "0x" prefixed hex string from a [StarkHash].
-    /// TODO
+    /// Produce a "0x" prefixed lower hex string from this [StarkHash].
     pub fn to_lower_hex_str(&self) -> Cow<'static, str> {
         self.to_hex_str(&Self::LUT_LOWER)
     }
 
-    /// A convenience function which produces a "0x" prefixed hex string from a [StarkHash].
-    /// TODO
+    /// Produce a "0x" prefixed upper hex string from this [StarkHash].
     pub fn to_upper_hex_str(&self) -> Cow<'static, str> {
         self.to_hex_str(&Self::LUT_UPPER)
     }

--- a/crates/stark_hash/src/hash.rs
+++ b/crates/stark_hash/src/hash.rs
@@ -284,7 +284,7 @@ impl StarkHash {
     /// A convenience function which produces a "0x" prefixed hex str slice in a given buffer `buf`
     /// from a [StarkHash].
     /// Panics if `self.0.len() * 2 + 2 > buf.len()`
-    pub fn as_hex_str<'a>(&'a self, buf: &'a mut [u8]) -> &'a str {
+    pub fn as_lower_hex_str<'a>(&'a self, buf: &'a mut [u8]) -> &'a str {
         let expected_buf_len = self.0.len() * 2 + 2;
         assert!(
             buf.len() >= expected_buf_len,
@@ -304,7 +304,7 @@ impl StarkHash {
     }
 
     /// A convenience function which produces a "0x" prefixed hex string from a [StarkHash].
-    pub fn to_hex_str(&self) -> Cow<'static, str> {
+    pub fn to_lower_hex_str(&self) -> Cow<'static, str> {
         if !self.0.iter().any(|b| *b != 0) {
             return Cow::from("0x0");
         }
@@ -627,40 +627,40 @@ mod tests {
 
         #[test]
         fn zero() {
-            assert_eq!(StarkHash::ZERO.to_hex_str(), "0x0");
+            assert_eq!(StarkHash::ZERO.to_lower_hex_str(), "0x0");
             let mut buf = [0u8; 66];
-            assert_eq!(StarkHash::ZERO.as_hex_str(&mut buf), "0x0");
+            assert_eq!(StarkHash::ZERO.as_lower_hex_str(&mut buf), "0x0");
         }
 
         #[test]
         fn odd() {
             let hash = StarkHash::from_hex_str(ODD).unwrap();
-            assert_eq!(hash.to_hex_str(), ODD);
+            assert_eq!(hash.to_lower_hex_str(), ODD);
             let mut buf = [0u8; 66];
-            assert_eq!(hash.as_hex_str(&mut buf), ODD);
+            assert_eq!(hash.as_lower_hex_str(&mut buf), ODD);
         }
 
         #[test]
         fn even() {
             let hash = StarkHash::from_hex_str(EVEN).unwrap();
-            assert_eq!(hash.to_hex_str(), EVEN);
+            assert_eq!(hash.to_lower_hex_str(), EVEN);
             let mut buf = [0u8; 66];
-            assert_eq!(hash.as_hex_str(&mut buf), EVEN);
+            assert_eq!(hash.as_lower_hex_str(&mut buf), EVEN);
         }
 
         #[test]
         fn max() {
             let hash = StarkHash::from_hex_str(MAX).unwrap();
-            assert_eq!(hash.to_hex_str(), MAX);
+            assert_eq!(hash.to_lower_hex_str(), MAX);
             let mut buf = [0u8; 66];
-            assert_eq!(hash.as_hex_str(&mut buf), MAX);
+            assert_eq!(hash.as_lower_hex_str(&mut buf), MAX);
         }
 
         #[test]
         #[should_panic]
         fn buffer_too_small() {
             let mut buf = [0u8; 65];
-            StarkHash::ZERO.as_hex_str(&mut buf);
+            StarkHash::ZERO.as_lower_hex_str(&mut buf);
         }
     }
 

--- a/crates/stark_hash/src/hash.rs
+++ b/crates/stark_hash/src/hash.rs
@@ -654,46 +654,72 @@ mod tests {
     mod to_hex_str {
         use super::*;
         use pretty_assertions::assert_eq;
-        const ODD: &str = "0x1234567890abcde";
-        const EVEN: &str = "0x1234567890abcdef";
+        const ODD_LOWER: &str = "0x1234567890abcde";
+        const ODD_UPPER: &str = "0x1234567890ABCDE";
+        const EVEN_LOWER: &str = "0x1234567890abcdef";
+        const EVEN_UPPER: &str = "0x1234567890ABCDEF";
         const MAX: &str = "0x800000000000011000000000000000000000000000000000000000000000000";
 
         #[test]
         fn zero() {
+            assert_eq!(StarkHash::from_hex_str("0x0").unwrap(), StarkHash::ZERO);
             assert_eq!(StarkHash::ZERO.to_lower_hex_str(), "0x0");
+            assert_eq!(StarkHash::ZERO.to_upper_hex_str(), "0x0");
             let mut buf = [0u8; 66];
             assert_eq!(StarkHash::ZERO.as_lower_hex_str(&mut buf), "0x0");
+            assert_eq!(StarkHash::ZERO.as_upper_hex_str(&mut buf), "0x0");
         }
 
         #[test]
         fn odd() {
-            let hash = StarkHash::from_hex_str(ODD).unwrap();
-            assert_eq!(hash.to_lower_hex_str(), ODD);
+            let hash0 = StarkHash::from_hex_str(ODD_LOWER).unwrap();
+            let hash = StarkHash::from_hex_str(ODD_UPPER).unwrap();
+            assert_eq!(hash0, hash);
+            assert_eq!(hash.to_lower_hex_str(), ODD_LOWER);
+            assert_eq!(hash.to_upper_hex_str(), ODD_UPPER);
             let mut buf = [0u8; 66];
-            assert_eq!(hash.as_lower_hex_str(&mut buf), ODD);
+            assert_eq!(hash.as_lower_hex_str(&mut buf), ODD_LOWER);
+            assert_eq!(hash.as_upper_hex_str(&mut buf), ODD_UPPER);
         }
 
         #[test]
         fn even() {
-            let hash = StarkHash::from_hex_str(EVEN).unwrap();
-            assert_eq!(hash.to_lower_hex_str(), EVEN);
+            let hash0 = StarkHash::from_hex_str(EVEN_LOWER).unwrap();
+            let hash = StarkHash::from_hex_str(EVEN_UPPER).unwrap();
+            assert_eq!(hash0, hash);
+            assert_eq!(hash.to_lower_hex_str(), EVEN_LOWER);
+            assert_eq!(hash.to_upper_hex_str(), EVEN_UPPER);
             let mut buf = [0u8; 66];
-            assert_eq!(hash.as_lower_hex_str(&mut buf), EVEN);
+            assert_eq!(hash.as_lower_hex_str(&mut buf), EVEN_LOWER);
+            assert_eq!(hash.as_upper_hex_str(&mut buf), EVEN_UPPER);
         }
 
         #[test]
         fn max() {
             let hash = StarkHash::from_hex_str(MAX).unwrap();
             assert_eq!(hash.to_lower_hex_str(), MAX);
+            assert_eq!(hash.to_upper_hex_str(), MAX);
             let mut buf = [0u8; 66];
             assert_eq!(hash.as_lower_hex_str(&mut buf), MAX);
+            assert_eq!(hash.as_upper_hex_str(&mut buf), MAX);
         }
 
-        #[test]
-        #[should_panic]
-        fn buffer_too_small() {
-            let mut buf = [0u8; 65];
-            StarkHash::ZERO.as_lower_hex_str(&mut buf);
+        mod buffer_too_small {
+            use super::StarkHash;
+
+            #[test]
+            #[should_panic]
+            fn lower() {
+                let mut buf = [0u8; 65];
+                StarkHash::ZERO.as_lower_hex_str(&mut buf);
+            }
+
+            #[test]
+            #[should_panic]
+            fn upper() {
+                let mut buf = [0u8; 65];
+                StarkHash::ZERO.as_upper_hex_str(&mut buf);
+            }
         }
     }
 

--- a/crates/stark_hash/src/hash.rs
+++ b/crates/stark_hash/src/hash.rs
@@ -24,19 +24,21 @@ impl std::fmt::Debug for StarkHash {
 impl std::fmt::Display for StarkHash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // 0xABCDEF1234567890
-        write!(f, "0x{:X}", self)
+        self.0.iter().try_for_each(|&b| write!(f, "{:02X}", b))
     }
 }
 
 impl std::fmt::LowerHex for StarkHash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.iter().try_for_each(|&b| write!(f, "{:02x}", b))
+        let mut buf = [0u8; 66];
+        f.write_str(self.as_lower_hex_str(&mut buf))
     }
 }
 
 impl std::fmt::UpperHex for StarkHash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.iter().try_for_each(|&b| write!(f, "{:02X}", b))
+        let mut buf = [0u8; 66];
+        f.write_str(self.as_upper_hex_str(&mut buf))
     }
 }
 
@@ -536,16 +538,15 @@ mod tests {
         }
 
         #[test]
-        fn fmt() {
+        fn display() {
             let hex_str = "1234567890abcdef000edcba0987654321";
             let starkhash = StarkHash::from_hex_str(hex_str).unwrap();
-            let result = format!("{:x}", starkhash);
+            let result = format!("{starkhash}");
 
             let mut expected = "0".repeat(64 - hex_str.len());
             expected.push_str(hex_str);
 
-            // We don't really care which casing is used by fmt.
-            assert_eq!(result.to_lowercase(), expected.to_lowercase());
+            assert_eq!(result, expected.to_uppercase());
         }
 
         #[test]
@@ -554,10 +555,9 @@ mod tests {
             let starkhash = StarkHash::from_hex_str(hex_str).unwrap();
             let result = format!("{:x}", starkhash);
 
-            let mut expected = "0".repeat(64 - hex_str.len());
-            expected.push_str(hex_str);
+            let expected = format!("0x{hex_str}");
 
-            assert_eq!(result, expected.to_lowercase());
+            assert_eq!(result, expected);
         }
 
         #[test]
@@ -566,10 +566,9 @@ mod tests {
             let starkhash = StarkHash::from_hex_str(hex_str).unwrap();
             let result = format!("{:X}", starkhash);
 
-            let mut expected = "0".repeat(64 - hex_str.len());
-            expected.push_str(hex_str);
+            let expected = format!("0x{}", hex_str.to_uppercase());
 
-            assert_eq!(result, expected.to_uppercase());
+            assert_eq!(result, expected);
         }
     }
 

--- a/crates/stark_hash/src/serde.rs
+++ b/crates/stark_hash/src/serde.rs
@@ -8,7 +8,7 @@ impl Serialize for StarkHash {
     {
         // StarkHash has a leading "0x" and at most 64 digits
         let mut buf = [0u8; 2 + 64];
-        let s = self.as_hex_str(&mut buf);
+        let s = self.as_lower_hex_str(&mut buf);
         serializer.serialize_str(s)
     }
 }


### PR DESCRIPTION
Split `*_[to|as]_hex_str` into upper and lower variants. This will be useful when we add an `impl` macro to add respective methods and other utilities to stark hash based newtypes.
`[Upper|Lower]Hex` now produce a 0 prefix stripped representations.