### PR TITLE
fix(sequencer/transcation): remove redundant type field from tx structs

### DIFF
--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -364,7 +364,6 @@ mod tests {
             reply::transaction::{
                 execution_resources::{BuiltinInstanceCounter, EmptyBuiltinInstanceCounter},
                 EntryPointType, Event, ExecutionResources, InvokeTransaction, Receipt, Transaction,
-                Type,
             },
             test_utils::*,
             Client as SeqClient,
@@ -536,7 +535,6 @@ mod tests {
             max_fee: Fee(H128::zero()),
             signature: vec![],
             transaction_hash: txn0_hash,
-            r#type: Type::Deploy,
         };
         let mut receipt0 = Receipt {
             actual_fee: None,

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -227,22 +227,16 @@ pub mod transaction {
         pub keys: Vec<EventKey>,
     }
 
-    /// Represents deserialized object containing L2 contract address and transaction type.
-    #[serde_as]
-    #[derive(Copy, Clone, Debug, Deserialize, PartialEq)]
-    #[serde(deny_unknown_fields)]
-    pub struct Source {
-        pub contract_address: ContractAddress,
-        pub r#type: Type,
-    }
-
     /// Represents deserialized L2 transaction data.
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-    #[serde(untagged)]
+    #[serde(tag = "type")]
     #[serde(deny_unknown_fields)]
     pub enum Transaction {
+        #[serde(rename = "DECLARE")]
         Declare(DeclareTransaction),
+        #[serde(rename = "DEPLOY")]
         Deploy(DeployTransaction),
+        #[serde(rename = "INVOKE_FUNCTION")]
         Invoke(InvokeTransaction),
     }
 
@@ -271,7 +265,6 @@ pub mod transaction {
         #[serde(default)]
         pub signature: Vec<TransactionSignatureElem>,
         pub transaction_hash: StarknetTransactionHash,
-        pub r#type: Type,
         #[serde_as(as = "TransactionVersionAsHexStr")]
         pub version: TransactionVersion,
     }
@@ -287,7 +280,6 @@ pub mod transaction {
         #[serde_as(as = "Vec<ConstructorParamAsDecimalStr>")]
         pub constructor_calldata: Vec<ConstructorParam>,
         pub transaction_hash: StarknetTransactionHash,
-        pub r#type: Type,
     }
 
     /// Represents deserialized L2 invoke transaction data.
@@ -305,19 +297,6 @@ pub mod transaction {
         #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
         pub signature: Vec<TransactionSignatureElem>,
         pub transaction_hash: StarknetTransactionHash,
-        pub r#type: Type,
-    }
-
-    /// Describes L2 transaction types.
-    #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
-    #[serde(deny_unknown_fields)]
-    pub enum Type {
-        #[serde(rename = "DEPLOY")]
-        Deploy,
-        #[serde(rename = "INVOKE_FUNCTION")]
-        InvokeFunction,
-        #[serde(rename = "DECLARE")]
-        Declare,
     }
 
     /// Describes L2 transaction failure details.

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -245,7 +245,6 @@ pub(crate) mod test_utils {
                     transaction_hash: StarknetTransactionHash(
                         StarkHash::from_hex_str(&"4".repeat(i + 3)).unwrap(),
                     ),
-                    r#type: transaction::Type::InvokeFunction,
                 })
             }
             x if (INVOKE_TRANSACTIONS_PER_BLOCK
@@ -266,7 +265,6 @@ pub(crate) mod test_utils {
                     transaction_hash: StarknetTransactionHash(
                         StarkHash::from_hex_str(&"9".repeat(i + 3)).unwrap(),
                     ),
-                    r#type: transaction::Type::Deploy,
                 })
             }
             _ => transaction::Transaction::Declare(DeclareTransaction {
@@ -282,7 +280,6 @@ pub(crate) mod test_utils {
                 transaction_hash: StarknetTransactionHash(
                     StarkHash::from_hex_str(&"e".repeat(i + 3)).unwrap(),
                 ),
-                r#type: transaction::Type::Deploy,
                 version: TransactionVersion(H256::zero()),
             }),
         });

--- a/crates/pathfinder/src/storage/schema/revision_0010.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0010.rs
@@ -273,7 +273,7 @@ mod tests {
                     CallParam, ClassHash, ConstructorParam, ContractAddressSalt, EntryPoint, Fee,
                     TransactionNonce, TransactionSignatureElem, TransactionVersion,
                 },
-                sequencer::reply::transaction::{EntryPointType, Type},
+                sequencer::reply::transaction::EntryPointType,
             };
 
             use super::*;
@@ -326,6 +326,15 @@ mod tests {
                 pub transaction_hash: StarknetTransactionHash,
                 pub r#type: Type,
                 pub version: Option<TransactionVersion>,
+            }
+
+            /// Describes L2 transaction types.
+            #[derive(Copy, Clone, Debug, PartialEq)]
+            #[allow(dead_code)]
+            pub enum Type {
+                Deploy,
+                InvokeFunction,
+                Declare,
             }
 
             pub struct StarknetEventsTable {}
@@ -433,7 +442,7 @@ mod tests {
                 sender_address: None,
                 signature: None,
                 transaction_hash: transaction0_hash,
-                r#type: transaction::Type::Deploy,
+                r#type: revision7::Type::Deploy,
                 version: None,
             };
             let mut transaction1 = transaction0.clone();


### PR DESCRIPTION
The `Transaction` enum already has the type, so there's no need to
have a type field in the structs for the individual transaction types.

This also changes the serde serialization of the enum from untagged
to [internally tagged](https://serde.rs/enum-representations.html#internally-tagged).