### PR TITLE
ci: lower worker.oci.max-parallelism

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           config-inline: |
             [worker.oci]
-              max-parallelism = 1
+              max-parallelism = 0
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
unclear if this is even allowed, but worth a shot. this is done
following rust processes getting killed once more during a build.