### PR TITLE
Add a configuration / command line option to enable SQLite write-ahead logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ sequencer-url = "https://..."
 # to service the `starknet_call` JSON-RPC method and their number limits the maximal
 # number of call requests that can be processed in parallel. Defaults to 2.
 python-subprocesses = 2
+# Whether to enable SQLite write-ahead logging. Defaults to false but we reserve the
+# right to change this in the future. Will likely default to true soon, but if you
+# **want** a specific behavior you should always set this.
+enable-sqlite-wal = false
 
 [ethereum]
 # This is required and must be an HTTP(s) URL pointing to your Ethereum node's endpoint.

--- a/crates/pathfinder/examples/estimate_past_transactions.rs
+++ b/crates/pathfinder/examples/estimate_past_transactions.rs
@@ -20,6 +20,7 @@ fn main() -> Result<(), anyhow::Error> {
             .nth(1)
             .context("missing DATABASE_FILE argument")?
             .into(),
+        pathfinder_lib::storage::JournalMode::WAL,
     )?;
 
     let rt = tokio::runtime::Builder::new_multi_thread()

--- a/crates/pathfinder/examples/migrate_db.rs
+++ b/crates/pathfinder/examples/migrate_db.rs
@@ -20,7 +20,11 @@ fn main() {
     let size_before = std::fs::metadata(&path).expect("Path does not exist").len() as i64;
 
     let started_at = std::time::Instant::now();
-    let storage = pathfinder_lib::storage::Storage::migrate(path.clone()).unwrap();
+    let storage = pathfinder_lib::storage::Storage::migrate(
+        path.clone(),
+        pathfinder_lib::storage::JournalMode::WAL,
+    )
+    .unwrap();
     let migrated_at = std::time::Instant::now();
 
     let size_after_migration = std::fs::metadata(&path)

--- a/crates/pathfinder/examples/verify_block_hashes.rs
+++ b/crates/pathfinder/examples/verify_block_hashes.rs
@@ -3,7 +3,9 @@ use pathfinder_lib::{
     core::{Chain, StarknetBlockHash, StarknetBlockNumber},
     sequencer::reply::{Block, Status},
     state::block_hash::{verify_block_hash, VerifyResult},
-    storage::{StarknetBlocksBlockId, StarknetBlocksTable, StarknetTransactionsTable, Storage},
+    storage::{
+        JournalMode, StarknetBlocksBlockId, StarknetBlocksTable, StarknetTransactionsTable, Storage,
+    },
 };
 use stark_hash::StarkHash;
 
@@ -24,7 +26,7 @@ fn main() -> anyhow::Result<()> {
     };
 
     let database_path = std::env::args().nth(2).unwrap();
-    let storage = Storage::migrate(database_path.into())?;
+    let storage = Storage::migrate(database_path.into(), JournalMode::WAL)?;
     let db = storage
         .connection()
         .context("Opening database connection")?;

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -5,7 +5,7 @@ use pathfinder_lib::{
     cairo, config, core,
     ethereum::transport::{EthereumTransport, HttpTransport},
     rpc, sequencer, state,
-    storage::Storage,
+    storage::{JournalMode, Storage},
 };
 use std::sync::Arc;
 use tracing::info;
@@ -39,7 +39,7 @@ async fn main() -> anyhow::Result<()> {
         core::Chain::Mainnet => "mainnet.sqlite",
         core::Chain::Goerli => "goerli.sqlite",
     });
-    let storage = Storage::migrate(database_path.clone()).unwrap();
+    let storage = Storage::migrate(database_path.clone(), JournalMode::WAL).unwrap();
     info!(location=?database_path, "Database migrated.");
     verify_database_chain(&storage, ethereum_chain).context("Verifying database")?;
 

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -39,7 +39,11 @@ async fn main() -> anyhow::Result<()> {
         core::Chain::Mainnet => "mainnet.sqlite",
         core::Chain::Goerli => "goerli.sqlite",
     });
-    let storage = Storage::migrate(database_path.clone(), JournalMode::WAL).unwrap();
+    let journal_mode = match config.enable_sqlite_wal {
+        false => JournalMode::Rollback,
+        true => JournalMode::WAL,
+    };
+    let storage = Storage::migrate(database_path.clone(), journal_mode).unwrap();
     info!(location=?database_path, "Database migrated.");
     verify_database_chain(&storage, ethereum_chain).context("Verifying database")?;
 

--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -255,7 +255,11 @@ mod tests {
     async fn start_with_wrong_database_schema_fails() {
         let db_file = tempfile::NamedTempFile::new().unwrap();
 
-        let s = crate::storage::Storage::migrate(PathBuf::from(db_file.path())).unwrap();
+        let s = crate::storage::Storage::migrate(
+            PathBuf::from(db_file.path()),
+            crate::storage::JournalMode::WAL,
+        )
+        .unwrap();
 
         {
             let conn = s.connection().unwrap();
@@ -285,7 +289,11 @@ mod tests {
 
         let db_file = tempfile::NamedTempFile::new().unwrap();
 
-        let s = crate::storage::Storage::migrate(PathBuf::from(db_file.path())).unwrap();
+        let s = crate::storage::Storage::migrate(
+            PathBuf::from(db_file.path()),
+            crate::storage::JournalMode::WAL,
+        )
+        .unwrap();
 
         let mut conn = s.connection().unwrap();
         conn.execute("PRAGMA foreign_keys = off", []).unwrap();
@@ -356,7 +364,11 @@ mod tests {
         // TODO: refactor the outer parts to a with_test_env or similar?
         let db_file = tempfile::NamedTempFile::new().unwrap();
 
-        let s = crate::storage::Storage::migrate(PathBuf::from(db_file.path())).unwrap();
+        let s = crate::storage::Storage::migrate(
+            PathBuf::from(db_file.path()),
+            crate::storage::JournalMode::WAL,
+        )
+        .unwrap();
 
         let mut conn = s.connection().unwrap();
         conn.execute("PRAGMA foreign_keys = off", []).unwrap();
@@ -449,7 +461,11 @@ mod tests {
     async fn call_with_unknown_contract() {
         let db_file = tempfile::NamedTempFile::new().unwrap();
 
-        let s = crate::storage::Storage::migrate(PathBuf::from(db_file.path())).unwrap();
+        let s = crate::storage::Storage::migrate(
+            PathBuf::from(db_file.path()),
+            crate::storage::JournalMode::WAL,
+        )
+        .unwrap();
 
         let mut conn = s.connection().unwrap();
         conn.execute("PRAGMA foreign_keys = off", []).unwrap();

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -25,6 +25,8 @@ pub enum ConfigOption {
     SequencerHttpUrl,
     /// Number of Python sub-processes to start.
     PythonSubprocesses,
+    /// Enable SQLite write-ahead logging.
+    EnableSQLiteWriteAheadLogging,
 }
 
 impl Display for ConfigOption {
@@ -36,6 +38,9 @@ impl Display for ConfigOption {
             ConfigOption::HttpRpcAddress => f.write_str("HTTP-RPC socket address"),
             ConfigOption::SequencerHttpUrl => f.write_str("Sequencer HTTP URL"),
             ConfigOption::PythonSubprocesses => f.write_str("Number of Python subprocesses"),
+            ConfigOption::EnableSQLiteWriteAheadLogging => {
+                f.write_str("Enable SQLite write-ahead logging")
+            }
         }
     }
 }
@@ -62,6 +67,8 @@ pub struct Configuration {
     pub sequencer_url: Option<Url>,
     /// The number of Python subprocesses to start.
     pub python_subprocesses: std::num::NonZeroUsize,
+    /// Enable SQLite write-ahead logging.
+    pub enable_sqlite_wal: bool,
 }
 
 impl Configuration {

--- a/crates/pathfinder/src/config/file.rs
+++ b/crates/pathfinder/src/config/file.rs
@@ -20,6 +20,8 @@ struct FileConfig {
     sequencer_url: Option<String>,
     #[serde(rename = "python-subprocesses")]
     python_subprocesses: Option<String>,
+    #[serde(rename = "enable-sqlite-wal")]
+    enable_sqlite_wal: Option<String>,
 }
 
 impl FileConfig {
@@ -35,6 +37,10 @@ impl FileConfig {
         .with(ConfigOption::HttpRpcAddress, self.http_rpc)
         .with(ConfigOption::SequencerHttpUrl, self.sequencer_url)
         .with(ConfigOption::PythonSubprocesses, self.python_subprocesses)
+        .with(
+            ConfigOption::EnableSQLiteWriteAheadLogging,
+            self.enable_sqlite_wal,
+        )
     }
 }
 
@@ -118,6 +124,17 @@ password = "{}""#,
         let toml = format!(r#"python-subprocesses = "{}""#, value);
         let mut cfg = config_from_str(&toml).unwrap();
         assert_eq!(cfg.take(ConfigOption::PythonSubprocesses), Some(value));
+    }
+
+    #[test]
+    fn enable_sqlite_wal() {
+        let value = "true".to_owned();
+        let toml = format!(r#"enable-sqlite-wal = "{}""#, value);
+        let mut cfg = config_from_str(&toml).unwrap();
+        assert_eq!(
+            cfg.take(ConfigOption::EnableSQLiteWriteAheadLogging),
+            Some(value)
+        );
     }
 
     #[test]

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -461,8 +461,11 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[ignore = "this is manual testing only, but we should really use the binary for this"]
     async fn go_sync() {
-        let storage =
-            crate::storage::Storage::migrate(std::path::PathBuf::from("testing.sqlite")).unwrap();
+        let storage = crate::storage::Storage::migrate(
+            std::path::PathBuf::from("testing.sqlite"),
+            crate::storage::JournalMode::WAL,
+        )
+        .unwrap();
         let chain = crate::core::Chain::Goerli;
         let transport = crate::ethereum::transport::HttpTransport::test_transport(chain);
         let sequencer = crate::sequencer::Client::new(chain).unwrap();


### PR DESCRIPTION
Using SQLite write-ahead logging would make parallel readers (like JSON-RPC reads or reads from the Python subprocess) work much better, since a write to the database doesn't stop readers.

Fixes #384 