### PR TITLE
fix(rpc): fix return type of `starknet_getClass` and `starknet_getClassAt`

### DIFF
--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -24,6 +24,7 @@ bytes = "1.1.0"
 clap = { version = "3.1.6", features = ["env"] }
 console-subscriber = { version = "0.1.3", optional = true }
 enum-iterator = "0.7.0"
+flate2 = "1.0.23"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 hex = "0.4.3"
 home = "0.5.3"

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -40,7 +40,8 @@ pub struct ContractCode {
 // Bytecode and entry point list of a class
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ContractClass {
-    pub program: Vec<ByteCodeWord>,
+    // A base64 encoding of the gzip-compressed JSON representation of program.
+    pub program: String,
     // A JSON representation of the entry points
     // We don't actually process this value, just serialize/deserialize
     // from an already validated JSON.

--- a/crates/pathfinder/src/state/class_hash.rs
+++ b/crates/pathfinder/src/state/class_hash.rs
@@ -56,12 +56,13 @@ pub(crate) fn extract_abi_code_hash(
     Ok((abi, code, hash))
 }
 
-/// Extract JSON representation of entry points from the contract definition
-pub(crate) fn extract_entry_points_by_type(
+/// Extract JSON representation of program and entry points from the contract definition.
+pub(crate) fn extract_program_and_entry_points_by_type(
     contract_definition_dump: &[u8],
-) -> Result<serde_json::Value> {
+) -> Result<(serde_json::Value, serde_json::Value)> {
     #[derive(serde::Deserialize)]
     struct ContractDefinition {
+        pub program: serde_json::Value,
         pub entry_points_by_type: serde_json::Value,
     }
 
@@ -69,7 +70,10 @@ pub(crate) fn extract_entry_points_by_type(
         serde_json::from_slice::<ContractDefinition>(contract_definition_dump)
             .context("Failed to parse contract_definition")?;
 
-    Ok(contract_definition.entry_points_by_type)
+    Ok((
+        contract_definition.program,
+        contract_definition.entry_points_by_type,
+    ))
 }
 
 fn compute_class_hash0(mut contract_definition: json::ContractDefinition<'_>) -> Result<ClassHash> {


### PR DESCRIPTION
According to the OpenRPC specification the Base64 encoded, gzip
compressed JSON representation of the class should be returned. (The
same representation that is used by the write API.)

Just like the entry points, we don't store this in the database
directly, so we have to decompress our full JSON, extract the relevant
part, and then compress and encode it as expected by the specification.

Fixes #406 