### PR TITLE
feat(ext_py): logging via stderr

### DIFF
--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot, Mutex};
 
 mod de;
-use de::{ErrorKind, Status, Timings};
+use de::ErrorKind;
 
 mod ser;
 use ser::UsedChain;
@@ -214,13 +214,11 @@ impl Command {
 #[derive(Debug)]
 enum SubProcessEvent {
     ProcessLaunched(u32),
-    CommandHandled(u32, Option<Timings>, Status),
 }
 
 /// The reason the [`sub_process::launch_python`] exited.
 #[derive(Debug)]
 enum SubprocessExitReason {
-    ClosedChannel,
     UnrecoverableIO,
     Shutdown,
     Death,

--- a/crates/pathfinder/src/cairo/ext_py/de.rs
+++ b/crates/pathfinder/src/cairo/ext_py/de.rs
@@ -8,7 +8,6 @@ use crate::{core::CallResultValue, rpc::types::reply::FeeEstimate};
 ///
 /// This is [`ChildResponse::refine`]'d into [`RefinedChildResponse`]
 #[derive(serde::Deserialize, Debug)]
-#[allow(unused)]
 pub(crate) struct ChildResponse<'a> {
     /// Describes the outcome with three alternatives (good, known error, unknown error)
     status: Status,

--- a/crates/pathfinder/src/cairo/ext_py/de.rs
+++ b/crates/pathfinder/src/cairo/ext_py/de.rs
@@ -18,9 +18,6 @@ pub(crate) struct ChildResponse<'a> {
     exception: Option<std::borrow::Cow<'a, str>>,
     /// Enumeration of "known errors", present when `status` is [`Status::Error`].
     kind: Option<ErrorKind>,
-    /// Timing information, possibly available.
-    #[serde(default)]
-    timings: Timings,
     /// The real output from the contract when `status` is [`Status::Ok`].
     #[serde(default)]
     output: Option<OutputValue>,
@@ -39,15 +36,12 @@ impl<'a> ChildResponse<'a> {
         match (&self.status, &mut self.kind, &mut self.exception) {
             (Status::Ok, None, None) => Ok(RefinedChildResponse {
                 status: RefinedStatus::Ok(self.output.ok_or(SubprocessError::InvalidResponse)?),
-                timings: self.timings,
             }),
             (Status::Error, x @ Some(_), None) => Ok(RefinedChildResponse {
                 status: RefinedStatus::Error(x.take().unwrap()),
-                timings: self.timings,
             }),
             (Status::Failed, None, s @ &mut Some(_)) => Ok(RefinedChildResponse {
                 status: RefinedStatus::Failed(s.take().unwrap()),
-                timings: self.timings,
             }),
             // these should not happen, so turn them into similar as serde_json errors
             _ => Err(SubprocessError::InvalidResponse),
@@ -56,23 +50,17 @@ impl<'a> ChildResponse<'a> {
 }
 
 impl RefinedChildResponse<'_> {
-    pub(super) fn into_messages(
-        self,
-    ) -> (Option<Timings>, Status, Result<OutputValue, CallFailure>) {
+    pub(super) fn into_messages(self) -> (Status, Result<OutputValue, CallFailure>) {
         match self {
             RefinedChildResponse {
-                timings,
                 status: RefinedStatus::Ok(x),
-            } => (Some(timings), Status::Ok, Ok(x)),
+            } => (Status::Ok, Ok(x)),
             RefinedChildResponse {
-                timings,
                 status: RefinedStatus::Error(e),
-            } => (Some(timings), Status::Error, Err(CallFailure::from(e))),
+            } => (Status::Error, Err(CallFailure::from(e))),
             RefinedChildResponse {
-                timings,
                 status: RefinedStatus::Failed(s),
             } => (
-                Some(timings),
                 Status::Failed,
                 Err(CallFailure::ExecutionFailed(s.to_string())),
             ),
@@ -108,21 +96,9 @@ pub enum Status {
     Failed,
 }
 
-/// Just something python internally recorded, so we'd know at least something.
-/// No plans aside from logging for now for the data.
-#[derive(serde::Deserialize, Debug, Default)]
-#[allow(unused)]
-pub(super) struct Timings {
-    /// Time it took to parse, before opening the transaction.
-    parsing: Option<f64>,
-    /// Time it took to find the tree root, and execute.
-    execution: Option<f64>,
-}
-
 /// The format we'd prefer to process instead of [`ChildResponse`].
 pub(super) struct RefinedChildResponse<'a> {
     status: RefinedStatus<'a>,
-    timings: Timings,
 }
 
 /// More sensible alternative to [`Status`].

--- a/crates/pathfinder/src/cairo/ext_py/service.rs
+++ b/crates/pathfinder/src/cairo/ext_py/service.rs
@@ -59,9 +59,6 @@ pub async fn start(
                 SubProcessEvent::ProcessLaunched(_pid) => {
                     // good, now we can launch the other processes requested later
                 },
-                SubProcessEvent::CommandHandled(..) => {
-                    unreachable!("First message must not be CommandHandled");
-                },
             }
         },
         Some(res) = &mut joinhandles.next() => {
@@ -115,9 +112,6 @@ pub async fn start(
                     Some(evt) = status_rx.recv() => {
                         match evt {
                             SubProcessEvent::ProcessLaunched(_) => {},
-                            SubProcessEvent::CommandHandled(pid, timings, status) => {
-                                trace!(%pid, ?status, ?timings, "Command handled");
-                            },
                         }
                     },
                     Some(res) = joinhandles.next() => {

--- a/crates/pathfinder/src/cairo/ext_py/sub_process.rs
+++ b/crates/pathfinder/src/cairo/ext_py/sub_process.rs
@@ -217,7 +217,7 @@ async fn spawn(
     // spawn the stderr out, just forget it it will die down once the process has been torn down
     let _forget = tokio::task::spawn({
         let stderr = child.stderr.take().expect("stderr was piped");
-        let default_span = tracing::trace_span!("stderr");
+        let default_span = tracing::info_span!("stderr");
         async move {
             let mut buffer = String::new();
             let mut reader = BufReader::new(stderr);
@@ -314,7 +314,7 @@ async fn process(
         let mut g = current_span.lock().unwrap_or_else(|e| e.into_inner());
         // this takes becomes child span of the current span, hopefully, and will get the pid as
         // well.
-        *g = tracing::warn_span!("stderr");
+        *g = tracing::info_span!("stderr");
     }
 
     command_buffer.clear();

--- a/crates/pathfinder/src/cairo/ext_py/sub_process.rs
+++ b/crates/pathfinder/src/cairo/ext_py/sub_process.rs
@@ -437,10 +437,6 @@ async fn process(
         }
     };
 
-    // This will demo that the span is correctly combined to the callers span, but unnecessary
-    // let result = response.send(sent_response).map_err(|_| ());
-    // trace!(?result, "Call result sent");
-
     // TODO: this could be pushed to Command but ...
     match (command, output) {
         (Command::Call { response, .. }, Ok(OutputValue::Call(x))) => {

--- a/crates/pathfinder/src/cairo/ext_py/sub_process.rs
+++ b/crates/pathfinder/src/cairo/ext_py/sub_process.rs
@@ -249,8 +249,7 @@ async fn spawn(
 
                 let (level, displayed) = if let Ok(level) = level {
                     let rem = chars.as_str();
-                    // if we treat the thing as json, we can easily get multiline messages, which most
-                    // are
+                    // if we treat the thing as json, we can easily get multiline messages
                     let displayed = if rem.starts_with('"') {
                         serde_json::from_str::<String>(rem)
                             .ok()

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import json
 import time
@@ -11,8 +10,6 @@ from starkware.storage.storage import Storage
 EXPECTED_SCHEMA_REVISION = 12
 EXPECTED_CAIRO_VERSION = "0.9.0"
 SUPPORTED_COMMANDS = frozenset(["call", "estimate_fee"])
-
-DUMP_COMMANDS = os.environ.get("PATHFINDER_DUMP_FAILING_COMMANDS", None) is not None
 
 
 def main():
@@ -136,16 +133,23 @@ def do_loop(connection, input_gen, output_file):
             if parsed_at is not None and parsed_at < completed_at:
                 timings["execution"] = completed_at - parsed_at
 
-            out["timings"] = timings
+            # ERROR = 0
+            # WARN = 1
+            # INFO = 2
+            # DEBUG = 3
+            # TRACE = 4
+
+            payload = json.dumps(timings)
+            print(f"4{json.dumps(payload)}", file=sys.stderr, flush=True)
 
             print(json.dumps(out), file=output_file, flush=True)
 
 
 def report_failed(command, e):
-    if DUMP_COMMANDS:
-        print(json.dumps(f"{command} => {e}"), file=sys.stderr, flush=True)
-    else:
-        print(json.dumps(str(e)), file=sys.stderr, flush=True)
+    # use debug level for the command
+    print(f"3{json.dumps(command)}", file=sys.stderr)
+    # error level for the message
+    print(f"0{json.dumps(str(e))}", file=sys.stderr, flush=True)
 
 
 def loop_inner(connection, command):

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -291,7 +291,7 @@ def test_positive_directly():
 
     con.execute("BEGIN")
 
-    (verb, output) = loop_inner(con, command)
+    (verb, output, _timings) = loop_inner(con, command)
 
     assert output == [3]
 
@@ -424,7 +424,7 @@ def test_fee_estimate_on_positive_directly():
         "chain": StarknetChainId.TESTNET,
     }
 
-    (verb, output) = loop_inner(con, command)
+    (verb, output, _timings) = loop_inner(con, command)
 
     assert output == {
         "gas_consumed": 0,
@@ -504,7 +504,9 @@ def test_failing_mainnet_tx2():
         "chain": StarknetChainId.MAINNET,
     }
 
-    (verb, output) = loop_inner(con, command)
+    (verb, output, _timings) = loop_inner(con, command)
+
+    print(_timings)
 
     # this is wrong answer, but good enough for now
     # assert output == {

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -235,15 +235,7 @@ def default_132_on_3_scenario(con, input_jsons):
 
     print(output)
 
-    def strip_timings(loaded_json):
-        """
-        Remove the timings because that's not really interesting for our tests here,
-        cannot be compared for equality.
-        """
-        del loaded_json["timings"]
-        return loaded_json
-
-    output = [strip_timings(json.loads(line)) for line in output.splitlines()]
+    output = [json.loads(line) for line in output.splitlines()]
 
     if len(output) == 1:
         output = output[0]


### PR DESCRIPTION
This PR will start logging full exceptions from the python side over as ERROR level messages, reproductions of failed inputs at DEBUG, timing information at TRACE via a simple `<level><message>` line protocol.

For the new "hoist" (not really sure if the word means what I hope it means), the ext_py::Handle level span is propagated to the stderr printing task via a mutex which is believed to be uncontented. This way any stderr output will be correlated to the ext_py request, and further to the context of the ext_py request.

This PR was developed and can easiest be seen in action with up to date snapshot and #418.

- [x] check span levels, mix of warn with error messages -- unified at INFO
- [x] consider if the error level will create too much spam for public nodes => they can silence it, need to mention on the release notes
