### PR TITLE
refactor: retry converting Transaction into an enum

### DIFF
--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -393,7 +393,8 @@ mod tests {
         sequencer::{
             reply::transaction::{
                 execution_resources::{BuiltinInstanceCounter, EmptyBuiltinInstanceCounter},
-                Event, ExecutionResources, Receipt, Transaction, Type,
+                EntryPointType, Event, ExecutionResources, InvokeTransaction, Receipt, Transaction,
+                Type,
             },
             test_utils::*,
             Client,
@@ -542,21 +543,16 @@ mod tests {
         StarknetBlocksTable::insert(&db_txn, &block2, None).unwrap();
 
         let txn0_hash = StarknetTransactionHash(StarkHash::from_be_slice(b"txn 0").unwrap());
-        let txn0 = Transaction {
-            calldata: None,
-            class_hash: None,
-            constructor_calldata: None,
-            contract_address: Some(contract0_addr),
-            contract_address_salt: None,
-            entry_point_type: None,
-            entry_point_selector: None,
-            max_fee: Some(Fee(H128::zero())),
-            nonce: None,
-            sender_address: None,
-            signature: None,
+        // TODO introduce other types of transactions too
+        let txn0 = InvokeTransaction {
+            calldata: vec![],
+            contract_address: contract0_addr,
+            entry_point_type: EntryPointType::External,
+            entry_point_selector: EntryPoint(StarkHash::ZERO),
+            max_fee: Fee(H128::zero()),
+            signature: vec![],
             transaction_hash: txn0_hash,
             r#type: Type::Deploy,
-            version: None,
         };
         let mut receipt0 = Receipt {
             actual_fee: None,
@@ -583,16 +579,22 @@ mod tests {
         let mut txn3 = txn0.clone();
         let mut txn4 = txn0.clone();
         txn1.transaction_hash = txn1_hash;
-        txn1.contract_address = Some(contract1_addr);
+        txn1.contract_address = contract1_addr;
         txn2.transaction_hash = txn2_hash;
-        txn2.contract_address = Some(contract1_addr);
+        txn2.contract_address = contract1_addr;
         txn3.transaction_hash = txn3_hash;
-        txn3.contract_address = Some(contract1_addr);
+        txn3.contract_address = contract1_addr;
         txn4.transaction_hash = txn4_hash;
 
-        txn4.contract_address = Some(ContractAddress(StarkHash::ZERO));
+        txn4.contract_address = ContractAddress(StarkHash::ZERO);
         let mut txn5 = txn4.clone();
         txn5.transaction_hash = txn5_hash;
+        let txn0 = Transaction::Invoke(txn0);
+        let txn1 = Transaction::Invoke(txn1);
+        let txn2 = Transaction::Invoke(txn2);
+        let txn3 = Transaction::Invoke(txn3);
+        let txn4 = Transaction::Invoke(txn4);
+        let txn5 = Transaction::Invoke(txn5);
         let mut receipt1 = receipt0.clone();
         let mut receipt2 = receipt0.clone();
         let mut receipt3 = receipt0.clone();
@@ -2506,114 +2508,11 @@ mod tests {
         use super::*;
 
         use super::types::reply::{EmittedEvent, GetEventsResult};
-        use crate::sequencer::reply::transaction;
-
-        const NUM_BLOCKS: usize = 4;
-        const TRANSACTIONS_PER_BLOCK: usize = 10;
-        const EVENTS_PER_BLOCK: usize = TRANSACTIONS_PER_BLOCK;
-        const NUM_TRANSACTIONS: usize = NUM_BLOCKS * TRANSACTIONS_PER_BLOCK;
-        const NUM_EVENTS: usize = NUM_BLOCKS * EVENTS_PER_BLOCK;
-
-        fn create_transactions_and_receipts(
-        ) -> [(transaction::Transaction, transaction::Receipt); NUM_TRANSACTIONS] {
-            let transactions = (0..NUM_TRANSACTIONS).map(|i| transaction::Transaction {
-                calldata: None,
-                class_hash: None,
-                constructor_calldata: None,
-                contract_address: Some(ContractAddress(
-                    StarkHash::from_hex_str(&"2".repeat(i + 3)).unwrap(),
-                )),
-                contract_address_salt: None,
-                entry_point_type: None,
-                entry_point_selector: None,
-                max_fee: None,
-                nonce: None,
-                sender_address: None,
-                signature: None,
-                transaction_hash: StarknetTransactionHash(
-                    StarkHash::from_hex_str(&"f".repeat(i + 3)).unwrap(),
-                ),
-                r#type: transaction::Type::InvokeFunction,
-                version: None,
-            });
-            let receipts = (0..NUM_TRANSACTIONS).map(|i| transaction::Receipt {
-                actual_fee: None,
-                events: vec![transaction::Event {
-                    from_address: ContractAddress(
-                        StarkHash::from_hex_str(&"2".repeat(i + 3)).unwrap(),
-                    ),
-                    data: vec![EventData(
-                        StarkHash::from_hex_str(&"c".repeat(i + 3)).unwrap(),
-                    )],
-                    keys: vec![
-                        EventKey(StarkHash::from_hex_str(&"d".repeat(i + 3)).unwrap()),
-                        EventKey(StarkHash::from_hex_str("deadbeef").unwrap()),
-                    ],
-                }],
-                execution_resources: transaction::ExecutionResources {
-                    builtin_instance_counter:
-                        transaction::execution_resources::BuiltinInstanceCounter::Empty(
-                            transaction::execution_resources::EmptyBuiltinInstanceCounter {},
-                        ),
-                    n_steps: i as u64 + 987,
-                    n_memory_holes: i as u64 + 1177,
-                },
-                l1_to_l2_consumed_message: None,
-                l2_to_l1_messages: Vec::new(),
-                transaction_hash: StarknetTransactionHash(
-                    StarkHash::from_hex_str(&"e".repeat(i + 3)).unwrap(),
-                ),
-                transaction_index: StarknetTransactionIndex(i as u64 + 2311),
-            });
-
-            transactions
-                .into_iter()
-                .zip(receipts)
-                .collect::<Vec<_>>()
-                .try_into()
-                .unwrap()
-        }
+        use crate::storage::test_utils;
 
         fn setup() -> (Storage, Vec<EmittedEvent>) {
-            let storage = Storage::in_memory().unwrap();
-            let mut connection = storage.connection().unwrap();
-            let tx = connection.transaction().unwrap();
-
-            let blocks = crate::storage::test_utils::create_blocks::<NUM_BLOCKS>();
-            let transactions_and_receipts = create_transactions_and_receipts();
-
-            for (i, block) in blocks.iter().enumerate() {
-                StarknetBlocksTable::insert(&tx, block, None).unwrap();
-                StarknetTransactionsTable::upsert(
-                    &tx,
-                    block.hash,
-                    block.number,
-                    &transactions_and_receipts
-                        [i * TRANSACTIONS_PER_BLOCK..(i + 1) * TRANSACTIONS_PER_BLOCK],
-                )
-                .unwrap();
-            }
-
-            let events = transactions_and_receipts
-                .iter()
-                .enumerate()
-                .map(|(i, (txn, receipt))| {
-                    let event = &receipt.events[0];
-                    let block = &blocks[i / TRANSACTIONS_PER_BLOCK];
-
-                    EmittedEvent {
-                        data: event.data.clone(),
-                        from_address: event.from_address,
-                        keys: event.keys.clone(),
-                        block_hash: block.hash,
-                        block_number: block.number,
-                        transaction_hash: txn.transaction_hash,
-                    }
-                })
-                .collect();
-
-            tx.commit().unwrap();
-
+            let (storage, events) = test_utils::setup_test_storage();
+            let events = events.into_iter().map(EmittedEvent::from).collect();
             (storage, events)
         }
 
@@ -2635,7 +2534,7 @@ mod tests {
                     to_block: None,
                     address: None,
                     keys: vec![],
-                    page_size: NUM_EVENTS,
+                    page_size: test_utils::NUM_EVENTS,
                     page_number: 0,
                 });
                 let rpc_result = client(addr)
@@ -2668,7 +2567,7 @@ mod tests {
                     address: Some(expected_event.from_address),
                     // we're using a key which is present in _all_ events
                     keys: vec![EventKey(StarkHash::from_hex_str("deadbeef").unwrap())],
-                    page_size: NUM_EVENTS,
+                    page_size: test_utils::NUM_EVENTS,
                     page_number: 0,
                 });
                 let rpc_result = client(addr)
@@ -2700,7 +2599,7 @@ mod tests {
                     to_block: Some(StarknetBlockNumber(BLOCK_NUMBER as u64)),
                     address: None,
                     keys: vec![],
-                    page_size: NUM_EVENTS,
+                    page_size: test_utils::NUM_EVENTS,
                     page_number: 0,
                 });
                 let rpc_result = client(addr)
@@ -2708,8 +2607,8 @@ mod tests {
                     .await
                     .unwrap();
 
-                let expected_events =
-                    &events[EVENTS_PER_BLOCK * BLOCK_NUMBER..EVENTS_PER_BLOCK * (BLOCK_NUMBER + 1)];
+                let expected_events = &events[test_utils::EVENTS_PER_BLOCK * BLOCK_NUMBER
+                    ..test_utils::EVENTS_PER_BLOCK * (BLOCK_NUMBER + 1)];
                 assert_eq!(
                     rpc_result,
                     GetEventsResult {
@@ -2856,8 +2755,10 @@ mod tests {
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
-                let params =
-                    by_name([("filter", json!({"page_size": NUM_EVENTS, "page_number": 0}))]);
+                let params = by_name([(
+                    "filter",
+                    json!({"page_size": test_utils::NUM_EVENTS, "page_number": 0}),
+                )]);
                 let rpc_result = client(addr)
                     .request::<GetEventsResult>("starknet_getEvents", params)
                     .await
@@ -2889,7 +2790,7 @@ mod tests {
                         "toBlock": expected_event.block_number.0,
                         "address": expected_event.from_address,
                         "keys": [expected_event.keys[0]],
-                        "page_size": NUM_EVENTS,
+                        "page_size": super::test_utils::NUM_EVENTS,
                         "page_number": 0,
                     }),
                 )]);

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -385,9 +385,9 @@ mod tests {
     use super::{test_client::client, *};
     use crate::{
         core::{
-            Chain, ClassHash, ContractAddress, EventData, EventKey, GasPrice, GlobalRoot,
-            SequencerAddress, StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp,
-            StarknetProtocolVersion, StorageAddress,
+            Chain, ClassHash, ContractAddress, EntryPoint, EventData, EventKey, GasPrice,
+            GlobalRoot, SequencerAddress, StarknetBlockHash, StarknetBlockNumber,
+            StarknetBlockTimestamp, StarknetProtocolVersion, StorageAddress,
         },
         rpc::run_server,
         sequencer::{

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -394,7 +394,6 @@ mod tests {
             reply::transaction::{
                 execution_resources::{BuiltinInstanceCounter, EmptyBuiltinInstanceCounter},
                 EntryPointType, Event, ExecutionResources, InvokeTransaction, Receipt, Transaction,
-                Type,
             },
             test_utils::*,
             Client,
@@ -552,7 +551,6 @@ mod tests {
             max_fee: Fee(H128::zero()),
             signature: vec![],
             transaction_hash: txn0_hash,
-            r#type: Type::Deploy,
         };
         let mut receipt0 = Receipt {
             actual_fee: None,

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -1058,13 +1058,13 @@ impl RpcApi {
                 .map_err(internal_server_error)?;
 
             let filter = request.into();
-            // We don't add context here, because [StarknetEventsTable::get_events] adds its
-            // own context to the errors. This way we get meaningful error information
-            // for errors related to query parameters.
             let tx = connection
                 .transaction()
                 .context("Opening database transaction")
                 .map_err(internal_server_error)?;
+            // We don't add context here, because [StarknetEventsTable::get_events] adds its
+            // own context to the errors. This way we get meaningful error information
+            // for errors related to query parameters.
             let page = StarknetEventsTable::get_events(&tx, &filter).map_err(|e| {
                 if let Some(e) = e.downcast_ref::<EventFilterError>() {
                     Error::from(*e)

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -177,7 +177,7 @@ impl RpcApi {
             BlockResponseScope::TransactionHashes => reply::Transactions::HashesOnly(
                 transactions_receipts
                     .into_iter()
-                    .map(|(t, _)| t.transaction_hash)
+                    .map(|(t, _)| t.hash())
                     .collect(),
             ),
             BlockResponseScope::FullTransactions => reply::Transactions::Full(

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -649,24 +649,7 @@ pub mod reply {
                 .transaction
                 .ok_or_else(|| anyhow::anyhow!("Transaction not found."))?;
 
-            Ok(match txn {
-                sequencer::reply::transaction::Transaction::Invoke(txn) => Self {
-                    txn_hash: txn.transaction_hash,
-                    contract_address: Some(txn.contract_address),
-                    entry_point_selector: Some(txn.entry_point_selector),
-                    calldata: Some(txn.calldata),
-                    max_fee: Some(txn.max_fee),
-                },
-                _ => Self {
-                    // TODO this is probably the best we can do until the RPC spec introduces
-                    // 3 variants for all the transaction types
-                    txn_hash: txn.hash(),
-                    contract_address: None,
-                    entry_point_selector: None,
-                    calldata: None,
-                    max_fee: None,
-                },
-            })
+            Ok(txn.into())
         }
     }
 

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -365,11 +365,7 @@ pub mod reply {
         ) -> Self {
             let transactions = match scope {
                 BlockResponseScope::TransactionHashes => {
-                    let hashes = block
-                        .transactions()
-                        .iter()
-                        .map(|t| t.transaction_hash)
-                        .collect();
+                    let hashes = block.transactions().iter().map(|t| t.hash()).collect();
 
                     Transactions::HashesOnly(hashes)
                 }
@@ -652,12 +648,24 @@ pub mod reply {
             let txn = txn
                 .transaction
                 .ok_or_else(|| anyhow::anyhow!("Transaction not found."))?;
-            Ok(Self {
-                txn_hash: txn.transaction_hash,
-                contract_address: txn.contract_address,
-                entry_point_selector: txn.entry_point_selector,
-                calldata: txn.calldata,
-                max_fee: txn.max_fee,
+
+            Ok(match txn {
+                sequencer::reply::transaction::Transaction::Invoke(txn) => Self {
+                    txn_hash: txn.transaction_hash,
+                    contract_address: Some(txn.contract_address),
+                    entry_point_selector: Some(txn.entry_point_selector),
+                    calldata: Some(txn.calldata),
+                    max_fee: Some(txn.max_fee),
+                },
+                _ => Self {
+                    // TODO this is probably the best we can do until the RPC spec introduces
+                    // 3 variants for all the transaction types
+                    txn_hash: txn.hash(),
+                    contract_address: None,
+                    entry_point_selector: None,
+                    calldata: None,
+                    max_fee: None,
+                },
             })
         }
     }
@@ -670,12 +678,23 @@ pub mod reply {
 
     impl From<&sequencer::reply::transaction::Transaction> for Transaction {
         fn from(txn: &sequencer::reply::transaction::Transaction) -> Self {
-            Self {
-                txn_hash: txn.transaction_hash,
-                contract_address: txn.contract_address,
-                entry_point_selector: txn.entry_point_selector,
-                calldata: txn.calldata.clone(),
-                max_fee: txn.max_fee,
+            match txn {
+                sequencer::reply::transaction::Transaction::Invoke(txn) => Self {
+                    txn_hash: txn.transaction_hash,
+                    contract_address: Some(txn.contract_address),
+                    entry_point_selector: Some(txn.entry_point_selector),
+                    calldata: Some(txn.calldata.clone()),
+                    max_fee: Some(txn.max_fee),
+                },
+                _ => Self {
+                    // TODO this is probably the best we can do until the RPC spec introduces
+                    // 3 variants for all the transaction types
+                    txn_hash: txn.hash(),
+                    contract_address: None,
+                    entry_point_selector: None,
+                    calldata: None,
+                    max_fee: None,
+                },
             }
         }
     }

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -299,46 +299,75 @@ pub mod transaction {
     }
 
     /// Represents deserialized L2 transaction data.
-    ///
-    /// TODO refactor into a 3-variant enum (Declare, Deploy, Invoke)
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+    #[serde(untagged)]
+    #[serde(deny_unknown_fields)]
+    pub enum Transaction {
+        Declare(DeclareTransaction),
+        Deploy(DeployTransaction),
+        Invoke(InvokeTransaction),
+    }
+
+    impl Transaction {
+        /// Returns hash of the transaction
+        pub fn hash(&self) -> StarknetTransactionHash {
+            match self {
+                Transaction::Declare(t) => t.transaction_hash,
+                Transaction::Deploy(t) => t.transaction_hash,
+                Transaction::Invoke(t) => t.transaction_hash,
+            }
+        }
+    }
+
+    /// Represents deserialized L2 declare transaction data.
     #[serde_as]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     #[serde(deny_unknown_fields)]
-    pub struct Transaction {
-        #[serde_as(as = "Option<Vec<CallParamAsDecimalStr>>")]
+    pub struct DeclareTransaction {
+        pub class_hash: ClassHash,
+        #[serde_as(as = "FeeAsHexStr")]
+        pub max_fee: Fee,
+        pub nonce: TransactionNonce,
+        pub sender_address: ContractAddress,
+        #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
         #[serde(default)]
-        pub calldata: Option<Vec<CallParam>>,
-        /// None for Invoke, Some() for Deploy and Declare
-        #[serde(default)]
-        pub class_hash: Option<ClassHash>,
-        #[serde_as(as = "Option<Vec<ConstructorParamAsDecimalStr>>")]
-        #[serde(default)]
-        pub constructor_calldata: Option<Vec<ConstructorParam>>,
-        /// None for Declare
-        #[serde(default)]
-        pub contract_address: Option<ContractAddress>,
-        #[serde(default)]
-        pub contract_address_salt: Option<ContractAddressSalt>,
-        #[serde(default)]
-        pub entry_point_type: Option<EntryPointType>,
-        #[serde(default)]
-        pub entry_point_selector: Option<EntryPoint>,
-        #[serde_as(as = "Option<FeeAsHexStr>")]
-        #[serde(default)]
-        pub max_fee: Option<Fee>,
-        #[serde(default)]
-        pub nonce: Option<TransactionNonce>,
-        /// Some() for Declare
-        #[serde(default)]
-        pub sender_address: Option<ContractAddress>,
-        #[serde_as(as = "Option<Vec<TransactionSignatureElemAsDecimalStr>>")]
-        #[serde(default)]
-        pub signature: Option<Vec<TransactionSignatureElem>>,
+        pub signature: Vec<TransactionSignatureElem>,
         pub transaction_hash: StarknetTransactionHash,
         pub r#type: Type,
-        #[serde_as(as = "Option<TransactionVersionAsHexStr>")]
-        #[serde(default)]
-        pub version: Option<TransactionVersion>,
+        #[serde_as(as = "TransactionVersionAsHexStr")]
+        pub version: TransactionVersion,
+    }
+
+    /// Represents deserialized L2 deploy transaction data.
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+    #[serde(deny_unknown_fields)]
+    pub struct DeployTransaction {
+        pub contract_address: ContractAddress,
+        pub contract_address_salt: ContractAddressSalt,
+        pub class_hash: ClassHash,
+        #[serde_as(as = "Vec<ConstructorParamAsDecimalStr>")]
+        pub constructor_calldata: Vec<ConstructorParam>,
+        pub transaction_hash: StarknetTransactionHash,
+        pub r#type: Type,
+    }
+
+    /// Represents deserialized L2 invoke transaction data.
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+    #[serde(deny_unknown_fields)]
+    pub struct InvokeTransaction {
+        #[serde_as(as = "Vec<CallParamAsDecimalStr>")]
+        pub calldata: Vec<CallParam>,
+        pub contract_address: ContractAddress,
+        pub entry_point_selector: EntryPoint,
+        pub entry_point_type: EntryPointType,
+        #[serde_as(as = "FeeAsHexStr")]
+        pub max_fee: Fee,
+        #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
+        pub signature: Vec<TransactionSignatureElem>,
+        pub transaction_hash: StarknetTransactionHash,
+        pub r#type: Type,
     }
 
     /// Describes L2 transaction types.

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -289,22 +289,16 @@ pub mod transaction {
         pub keys: Vec<EventKey>,
     }
 
-    /// Represents deserialized object containing L2 contract address and transaction type.
-    #[serde_as]
-    #[derive(Copy, Clone, Debug, Deserialize, PartialEq)]
-    #[serde(deny_unknown_fields)]
-    pub struct Source {
-        pub contract_address: ContractAddress,
-        pub r#type: Type,
-    }
-
     /// Represents deserialized L2 transaction data.
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-    #[serde(untagged)]
+    #[serde(tag = "type")]
     #[serde(deny_unknown_fields)]
     pub enum Transaction {
+        #[serde(rename = "DECLARE")]
         Declare(DeclareTransaction),
+        #[serde(rename = "DEPLOY")]
         Deploy(DeployTransaction),
+        #[serde(rename = "INVOKE_FUNCTION")]
         Invoke(InvokeTransaction),
     }
 
@@ -333,7 +327,6 @@ pub mod transaction {
         #[serde(default)]
         pub signature: Vec<TransactionSignatureElem>,
         pub transaction_hash: StarknetTransactionHash,
-        pub r#type: Type,
         #[serde_as(as = "TransactionVersionAsHexStr")]
         pub version: TransactionVersion,
     }
@@ -349,7 +342,6 @@ pub mod transaction {
         #[serde_as(as = "Vec<ConstructorParamAsDecimalStr>")]
         pub constructor_calldata: Vec<ConstructorParam>,
         pub transaction_hash: StarknetTransactionHash,
-        pub r#type: Type,
     }
 
     /// Represents deserialized L2 invoke transaction data.
@@ -367,19 +359,6 @@ pub mod transaction {
         #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
         pub signature: Vec<TransactionSignatureElem>,
         pub transaction_hash: StarknetTransactionHash,
-        pub r#type: Type,
-    }
-
-    /// Describes L2 transaction types.
-    #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
-    #[serde(deny_unknown_fields)]
-    pub enum Type {
-        #[serde(rename = "DEPLOY")]
-        Deploy,
-        #[serde(rename = "INVOKE_FUNCTION")]
-        InvokeFunction,
-        #[serde(rename = "DECLARE")]
-        Declare,
     }
 
     /// Describes L2 transaction failure details.

--- a/crates/pathfinder/src/state/block_hash.rs
+++ b/crates/pathfinder/src/state/block_hash.rs
@@ -401,7 +401,7 @@ fn number_of_events_in_block(block: &Block) -> usize {
 mod tests {
     use crate::{
         core::{EntryPoint, Fee},
-        sequencer::reply::transaction::{EntryPointType, InvokeTransaction, Type},
+        sequencer::reply::transaction::{EntryPointType, InvokeTransaction},
     };
 
     use super::*;
@@ -452,7 +452,6 @@ mod tests {
                 TransactionSignatureElem(StarkHash::from_hex_str("0x3").unwrap()),
             ],
             transaction_hash: StarknetTransactionHash(StarkHash::from_hex_str("0x1").unwrap()),
-            r#type: Type::InvokeFunction,
         });
 
         // produced by the cairo-lang Python implementation:

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -188,15 +188,13 @@ async fn declare_classes(
     sequencer: &impl sequencer::ClientApi,
     tx_event: &mpsc::Sender<Event>,
 ) -> Result<(), anyhow::Error> {
+    use crate::sequencer::reply::transaction::Transaction;
     let declared_classes = block
         .transactions
         .iter()
-        .filter_map(|t| match t {
-            sequencer::reply::transaction::Transaction::Declare(declare) => {
-                Some(declare.class_hash)
-            }
-            sequencer::reply::transaction::Transaction::Deploy(_)
-            | sequencer::reply::transaction::Transaction::Invoke(_) => None,
+        .filter_map(|tx| match tx {
+            Transaction::Declare(declare) => Some(declare.class_hash),
+            Transaction::Invoke(_) | Transaction::Deploy(_) => None,
         })
         // Get unique class hashes only. Its unlikely they would have dupes here, but rather safe than sorry.
         .collect::<HashSet<_>>()

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -188,14 +188,15 @@ async fn declare_classes(
     sequencer: &impl sequencer::ClientApi,
     tx_event: &mpsc::Sender<Event>,
 ) -> Result<(), anyhow::Error> {
-    use crate::sequencer::reply::transaction::Type as TransactionType;
     let declared_classes = block
         .transactions
         .iter()
-        .filter(|b| b.r#type == TransactionType::Declare)
-        .map(|b| {
-            b.class_hash
-                .expect("Class hash is present for declare transaction")
+        .filter_map(|t| match t {
+            sequencer::reply::transaction::Transaction::Declare(declare) => {
+                Some(declare.class_hash)
+            }
+            sequencer::reply::transaction::Transaction::Deploy(_)
+            | sequencer::reply::transaction::Transaction::Invoke(_) => None,
         })
         // Get unique class hashes only. Its unlikely they would have dupes here, but rather safe than sorry.
         .collect::<HashSet<_>>()

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -275,7 +275,7 @@ async fn download_block(
             let verify_hash = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
                 let block_number = block.block_number;
                 let verify_result = verify_block_hash(&block, chain, expected_block_hash)
-                    .with_context(move || format!("Verify block {}", block_number.0))?;
+                    .with_context(move || format!("Verify block {block_number}"))?;
                 Ok((block, verify_result))
             });
             let (block, verify_result) = verify_hash.await.context("Verify block hash")??;

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -270,7 +270,6 @@ pub(crate) mod test_utils {
                     transaction_hash: StarknetTransactionHash(
                         StarkHash::from_hex_str(&"4".repeat(i + 3)).unwrap(),
                     ),
-                    r#type: transaction::Type::InvokeFunction,
                 })
             }
             x if (INVOKE_TRANSACTIONS_PER_BLOCK
@@ -291,7 +290,6 @@ pub(crate) mod test_utils {
                     transaction_hash: StarknetTransactionHash(
                         StarkHash::from_hex_str(&"9".repeat(i + 3)).unwrap(),
                     ),
-                    r#type: transaction::Type::Deploy,
                 })
             }
             _ => transaction::Transaction::Declare(DeclareTransaction {
@@ -307,7 +305,6 @@ pub(crate) mod test_utils {
                 transaction_hash: StarknetTransactionHash(
                     StarkHash::from_hex_str(&"e".repeat(i + 3)).unwrap(),
                 ),
-                r#type: transaction::Type::Deploy,
                 version: TransactionVersion(H256::zero()),
             }),
         });

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -28,7 +28,9 @@ use rusqlite::Connection;
 /// Indicates database is non-existant.
 const DB_VERSION_EMPTY: u32 = 0;
 /// Current database version.
-const DB_VERSION_CURRENT: u32 = 14;
+///
+/// **Make sure** `EXPECTED_SCHEMA_REVISION` in `call.py` is also updated every time the value is incremented.
+const DB_VERSION_CURRENT: u32 = 15;
 /// Sqlite key used for the PRAGMA user version.
 const VERSION_KEY: &str = "user_version";
 
@@ -163,6 +165,7 @@ fn migrate_database(connection: &mut Connection) -> anyhow::Result<()> {
             11 => schema::revision_0012::migrate(&transaction).context("migrating from 11")?,
             12 => schema::revision_0013::migrate(&transaction).context("migrating from 12")?,
             13 => schema::revision_0014::migrate(&transaction).context("migrating from 13")?,
+            14 => schema::revision_0015::migrate(&transaction).context("migrating from 14")?,
             _ => unreachable!("Database version constraint was already checked!"),
         };
         transaction

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -198,23 +198,42 @@ fn enable_foreign_keys(connection: &Connection) -> anyhow::Result<()> {
 
 #[cfg(test)]
 pub(crate) mod test_utils {
-    use super::StarknetBlock;
+    use super::{
+        StarknetBlock, StarknetBlocksTable, StarknetEmittedEvent, StarknetTransactionsTable,
+        Storage,
+    };
 
     use crate::{
         core::{
-            ContractAddress, EventData, EventKey, GasPrice, GlobalRoot, SequencerAddress,
+            CallParam, ClassHash, ConstructorParam, ContractAddress, ContractAddressSalt,
+            EntryPoint, EventData, EventKey, Fee, GasPrice, GlobalRoot, SequencerAddress,
             StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp,
-            StarknetTransactionHash, StarknetTransactionIndex,
+            StarknetTransactionHash, StarknetTransactionIndex, TransactionNonce,
+            TransactionSignatureElem, TransactionVersion,
         },
-        sequencer::reply::transaction,
+        sequencer::reply::transaction::{
+            self, DeclareTransaction, DeployTransaction, EntryPointType, InvokeTransaction,
+        },
     };
 
     use stark_hash::StarkHash;
+    use web3::types::{H128, H256};
+
+    pub(crate) const NUM_BLOCKS: usize = 4;
+    pub(crate) const TRANSACTIONS_PER_BLOCK: usize = 15;
+    const INVOKE_TRANSACTIONS_PER_BLOCK: usize = 5;
+    const DEPLOY_TRANSACTIONS_PER_BLOCK: usize = 5;
+    const DECLARE_TRANSACTIONS_PER_BLOCK: usize =
+        TRANSACTIONS_PER_BLOCK - (INVOKE_TRANSACTIONS_PER_BLOCK + DEPLOY_TRANSACTIONS_PER_BLOCK);
+    pub(crate) const EVENTS_PER_BLOCK: usize =
+        INVOKE_TRANSACTIONS_PER_BLOCK + DECLARE_TRANSACTIONS_PER_BLOCK;
+    pub(crate) const NUM_TRANSACTIONS: usize = NUM_BLOCKS * TRANSACTIONS_PER_BLOCK;
+    pub(crate) const NUM_EVENTS: usize = NUM_BLOCKS * EVENTS_PER_BLOCK;
 
     /// Creates a set of consecutive [StarknetBlock]s starting from L2 genesis,
     /// with arbitrary other values.
-    pub(crate) fn create_blocks<const N: usize>() -> [StarknetBlock; N] {
-        (0..N)
+    pub(crate) fn create_blocks() -> [StarknetBlock; NUM_BLOCKS] {
+        (0..NUM_BLOCKS)
             .map(|i| StarknetBlock {
                 number: StarknetBlockNumber::GENESIS + i as u64,
                 hash: StarknetBlockHash(StarkHash::from_hex_str(&"a".repeat(i + 3)).unwrap()),
@@ -229,40 +248,87 @@ pub(crate) mod test_utils {
     }
 
     /// Creates a set of test transactions and receipts.
-    pub(crate) fn create_transactions_and_receipts<const N: usize>(
-    ) -> [(transaction::Transaction, transaction::Receipt); N] {
-        let transactions = (0..N).map(|i| transaction::Transaction {
-            calldata: None,
-            class_hash: None,
-            constructor_calldata: None,
-            contract_address: Some(ContractAddress(
-                StarkHash::from_hex_str(&"2".repeat(i + 3)).unwrap(),
-            )),
-            contract_address_salt: None,
-            entry_point_type: None,
-            entry_point_selector: None,
-            signature: None,
-            transaction_hash: StarknetTransactionHash(
-                StarkHash::from_hex_str(&"f".repeat(i + 3)).unwrap(),
-            ),
-            max_fee: None,
-            nonce: None,
-            r#type: transaction::Type::InvokeFunction,
-            sender_address: None,
-            version: None,
-        });
-        let receipts = (0..N).map(|i| transaction::Receipt {
-            actual_fee: None,
-            events: vec![transaction::Event {
-                from_address: ContractAddress(StarkHash::from_hex_str(&"2".repeat(i + 3)).unwrap()),
-                data: vec![EventData(
+    pub(crate) fn create_transactions_and_receipts(
+    ) -> [(transaction::Transaction, transaction::Receipt); NUM_TRANSACTIONS] {
+        let transactions = (0..NUM_TRANSACTIONS).map(|i| match i % TRANSACTIONS_PER_BLOCK {
+            x if x < INVOKE_TRANSACTIONS_PER_BLOCK => {
+                transaction::Transaction::Invoke(InvokeTransaction {
+                    calldata: vec![CallParam::from_hex_str(&"0".repeat(i + 3)).unwrap()],
+                    contract_address: ContractAddress(
+                        StarkHash::from_hex_str(&"1".repeat(i + 3)).unwrap(),
+                    ),
+                    entry_point_selector: EntryPoint::from_hex_str(&"2".repeat(i + 3)).unwrap(),
+                    entry_point_type: if i & 1 == 0 {
+                        EntryPointType::External
+                    } else {
+                        EntryPointType::L1Handler
+                    },
+                    max_fee: Fee(H128::zero()),
+                    signature: vec![TransactionSignatureElem(
+                        StarkHash::from_hex_str(&"3".repeat(i + 3)).unwrap(),
+                    )],
+                    transaction_hash: StarknetTransactionHash(
+                        StarkHash::from_hex_str(&"4".repeat(i + 3)).unwrap(),
+                    ),
+                    r#type: transaction::Type::InvokeFunction,
+                })
+            }
+            x if (INVOKE_TRANSACTIONS_PER_BLOCK
+                ..INVOKE_TRANSACTIONS_PER_BLOCK + DEPLOY_TRANSACTIONS_PER_BLOCK)
+                .contains(&x) =>
+            {
+                transaction::Transaction::Deploy(DeployTransaction {
+                    contract_address: ContractAddress(
+                        StarkHash::from_hex_str(&"5".repeat(i + 3)).unwrap(),
+                    ),
+                    contract_address_salt: ContractAddressSalt(
+                        StarkHash::from_hex_str(&"6".repeat(i + 3)).unwrap(),
+                    ),
+                    class_hash: ClassHash(StarkHash::from_hex_str(&"7".repeat(i + 3)).unwrap()),
+                    constructor_calldata: vec![ConstructorParam(
+                        StarkHash::from_hex_str(&"8".repeat(i + 3)).unwrap(),
+                    )],
+                    transaction_hash: StarknetTransactionHash(
+                        StarkHash::from_hex_str(&"9".repeat(i + 3)).unwrap(),
+                    ),
+                    r#type: transaction::Type::Deploy,
+                })
+            }
+            _ => transaction::Transaction::Declare(DeclareTransaction {
+                class_hash: ClassHash(StarkHash::from_hex_str(&"a".repeat(i + 3)).unwrap()),
+                max_fee: Fee(H128::zero()),
+                nonce: TransactionNonce(StarkHash::from_hex_str(&"b".repeat(i + 3)).unwrap()),
+                sender_address: ContractAddress(
                     StarkHash::from_hex_str(&"c".repeat(i + 3)).unwrap(),
+                ),
+                signature: vec![TransactionSignatureElem(
+                    StarkHash::from_hex_str(&"d".repeat(i + 3)).unwrap(),
                 )],
-                keys: vec![
-                    EventKey(StarkHash::from_hex_str(&"d".repeat(i + 3)).unwrap()),
-                    EventKey(StarkHash::from_hex_str("deadbeef").unwrap()),
-                ],
-            }],
+                transaction_hash: StarknetTransactionHash(
+                    StarkHash::from_hex_str(&"e".repeat(i + 3)).unwrap(),
+                ),
+                r#type: transaction::Type::Deploy,
+                version: TransactionVersion(H256::zero()),
+            }),
+        });
+        let receipts = (0..NUM_TRANSACTIONS).map(|i| transaction::Receipt {
+            actual_fee: None,
+            events: if i % TRANSACTIONS_PER_BLOCK < EVENTS_PER_BLOCK {
+                vec![transaction::Event {
+                    from_address: ContractAddress(
+                        StarkHash::from_hex_str(&"2".repeat(i + 3)).unwrap(),
+                    ),
+                    data: vec![EventData(
+                        StarkHash::from_hex_str(&"c".repeat(i + 3)).unwrap(),
+                    )],
+                    keys: vec![
+                        EventKey(StarkHash::from_hex_str(&"d".repeat(i + 3)).unwrap()),
+                        EventKey(StarkHash::from_hex_str("deadbeef").unwrap()),
+                    ],
+                }]
+            } else {
+                vec![]
+            },
             execution_resources: transaction::ExecutionResources {
                 builtin_instance_counter:
                     transaction::execution_resources::BuiltinInstanceCounter::Empty(
@@ -285,6 +351,62 @@ pub(crate) mod test_utils {
             .collect::<Vec<_>>()
             .try_into()
             .unwrap()
+    }
+
+    /// Creates a set of emitted events from given blocks and transactions.
+    pub(crate) fn extract_events(
+        blocks: &[StarknetBlock],
+        transactions_and_receipts: &[(transaction::Transaction, transaction::Receipt)],
+    ) -> Vec<StarknetEmittedEvent> {
+        transactions_and_receipts
+            .iter()
+            .enumerate()
+            .filter_map(|(i, (txn, receipt))| {
+                if i % TRANSACTIONS_PER_BLOCK < EVENTS_PER_BLOCK {
+                    let event = &receipt.events[0];
+                    let block = &blocks[i / TRANSACTIONS_PER_BLOCK];
+
+                    Some(StarknetEmittedEvent {
+                        data: event.data.clone(),
+                        from_address: event.from_address,
+                        keys: event.keys.clone(),
+                        block_hash: block.hash,
+                        block_number: block.number,
+                        transaction_hash: txn.hash(),
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Creates a storage instance in memory with a set of expected emitted events
+    pub(crate) fn setup_test_storage() -> (Storage, Vec<StarknetEmittedEvent>) {
+        let storage = Storage::in_memory().unwrap();
+        let mut connection = storage.connection().unwrap();
+        let tx = connection.transaction().unwrap();
+
+        let blocks = create_blocks();
+        let transactions_and_receipts = create_transactions_and_receipts();
+
+        for (i, block) in blocks.iter().enumerate() {
+            StarknetBlocksTable::insert(&tx, block, None).unwrap();
+            StarknetTransactionsTable::upsert(
+                &tx,
+                block.hash,
+                block.number,
+                &transactions_and_receipts
+                    [i * TRANSACTIONS_PER_BLOCK..(i + 1) * TRANSACTIONS_PER_BLOCK],
+            )
+            .unwrap();
+        }
+
+        tx.commit().unwrap();
+
+        let events = extract_events(&blocks, &transactions_and_receipts);
+
+        (storage, events)
     }
 }
 

--- a/crates/pathfinder/src/storage/schema.rs
+++ b/crates/pathfinder/src/storage/schema.rs
@@ -12,3 +12,4 @@ pub(crate) mod revision_0011;
 pub(crate) mod revision_0012;
 pub(crate) mod revision_0013;
 pub(crate) mod revision_0014;
+pub(crate) mod revision_0015;

--- a/crates/pathfinder/src/storage/schema/revision_0005.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0005.rs
@@ -221,11 +221,11 @@ pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<()> {
             let transactions =
                 zstd::decode_all(transactions).context("Decompressing transactions")?;
             let transactions =
-                serde_json::de::from_slice::<Vec<transaction::Transaction>>(&transactions)
+                serde_json::from_slice::<Vec<transaction::Transaction>>(&transactions)
                     .context("Deserializing transactions")?;
 
             let receipts = zstd::decode_all(receipts).context("Decompressing transactions")?;
-            let receipts = serde_json::de::from_slice::<Vec<transaction::Receipt>>(&receipts)
+            let receipts = serde_json::from_slice::<Vec<transaction::Receipt>>(&receipts)
                 .context("Deserializing transaction receipts")?;
 
             anyhow::ensure!(

--- a/crates/pathfinder/src/storage/schema/revision_0007.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0007.rs
@@ -291,10 +291,10 @@ pub(crate) fn migrate_with(
 
         let tx = zstd::decode_all(tx).context("Decompress transaction")?;
         let tx: transaction::Transaction =
-            serde_json::de::from_slice(&tx).context("Deserializing transaction")?;
+            serde_json::from_slice(&tx).context("Deserializing transaction")?;
         let receipt = zstd::decode_all(receipt).context("Decompress receipt")?;
         let receipt: transaction::Receipt =
-            serde_json::de::from_slice(&receipt).context("Deserializing transaction receipt")?;
+            serde_json::from_slice(&receipt).context("Deserializing transaction receipt")?;
 
         receipt.events.into_iter().enumerate().try_for_each(
             |(idx, event)| -> anyhow::Result<_> {

--- a/crates/pathfinder/src/storage/schema/revision_0011.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0011.rs
@@ -69,7 +69,7 @@ pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<()> {
 
         let parsing_started = std::time::Instant::now();
         let receipt: LightReceipt =
-            serde_json::de::from_slice(&receipt).context("Deserializing transaction receipt")?;
+            serde_json::from_slice(&receipt).context("Deserializing transaction receipt")?;
         parsing_time += parsing_started.elapsed();
 
         receipt.events.into_iter().enumerate().try_for_each(

--- a/crates/pathfinder/src/storage/schema/revision_0013.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0013.rs
@@ -1,4 +1,3 @@
-use crate::sequencer::reply::transaction::Type as TransactionType;
 use crate::{core::ClassHash, state::CompressedContract};
 #[allow(unused)]
 use anyhow::Context;
@@ -150,6 +149,17 @@ pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<()> {
     extract_compress.join().unwrap();
 
     Ok(())
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub enum TransactionType {
+    #[serde(rename = "DEPLOY")]
+    Deploy,
+    #[serde(rename = "INVOKE_FUNCTION")]
+    InvokeFunction,
+    #[serde(rename = "DECLARE")]
+    Declare,
 }
 
 #[derive(serde::Deserialize)]

--- a/crates/pathfinder/src/storage/schema/revision_0015.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0015.rs
@@ -1,0 +1,404 @@
+use anyhow::Context;
+use rusqlite::{named_params, Transaction as RusqliteTransaction};
+use stark_hash::StarkHash;
+
+use crate::core::ClassHash;
+
+// This is a copy of the sequencer reply types _without_ deny_unknown_fields
+// The point is that with the old `struct Transaction` we had some optional
+// null-valued fields that are now missing from the enum-based serialization
+// format. The point of this migration is getting rid of those `null` values.
+mod transaction {
+    use crate::{
+        core::{
+            CallParam, ClassHash, ConstructorParam, ContractAddress, ContractAddressSalt,
+            EntryPoint, Fee, StarknetTransactionHash, TransactionNonce, TransactionSignatureElem,
+            TransactionVersion,
+        },
+        rpc::serde::{
+            CallParamAsDecimalStr, ConstructorParamAsDecimalStr, FeeAsHexStr,
+            TransactionSignatureElemAsDecimalStr, TransactionVersionAsHexStr,
+        },
+        sequencer::reply::transaction::EntryPointType,
+    };
+    use serde::{Deserialize, Serialize};
+    use serde_with::serde_as;
+
+    /// Represents deserialized L2 transaction data.
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+    #[serde(tag = "type")]
+    pub enum Transaction {
+        #[serde(rename = "DECLARE")]
+        Declare(DeclareTransaction),
+        #[serde(rename = "DEPLOY")]
+        Deploy(DeployTransaction),
+        #[serde(rename = "INVOKE_FUNCTION")]
+        Invoke(InvokeTransaction),
+    }
+
+    impl Transaction {
+        /// Returns hash of the transaction
+        #[cfg(test)]
+        pub fn hash(&self) -> StarknetTransactionHash {
+            match self {
+                Transaction::Declare(t) => t.transaction_hash,
+                Transaction::Deploy(t) => t.transaction_hash,
+                Transaction::Invoke(t) => t.transaction_hash,
+            }
+        }
+    }
+
+    /// Represents deserialized L2 declare transaction data.
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+    pub struct DeclareTransaction {
+        pub class_hash: ClassHash,
+        #[serde_as(as = "FeeAsHexStr")]
+        pub max_fee: Fee,
+        pub nonce: TransactionNonce,
+        pub sender_address: ContractAddress,
+        #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
+        #[serde(default)]
+        pub signature: Vec<TransactionSignatureElem>,
+        pub transaction_hash: StarknetTransactionHash,
+        #[serde_as(as = "TransactionVersionAsHexStr")]
+        pub version: TransactionVersion,
+    }
+
+    /// Represents deserialized L2 deploy transaction data.
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+    pub struct DeployTransaction {
+        pub contract_address: ContractAddress,
+        pub contract_address_salt: ContractAddressSalt,
+        // FIXME: why this has to be optional
+        pub class_hash: Option<ClassHash>,
+        #[serde_as(as = "Vec<ConstructorParamAsDecimalStr>")]
+        pub constructor_calldata: Vec<ConstructorParam>,
+        pub transaction_hash: StarknetTransactionHash,
+    }
+
+    /// Represents deserialized L2 invoke transaction data.
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+    pub struct InvokeTransaction {
+        #[serde_as(as = "Vec<CallParamAsDecimalStr>")]
+        pub calldata: Vec<CallParam>,
+        pub contract_address: ContractAddress,
+        pub entry_point_selector: EntryPoint,
+        pub entry_point_type: EntryPointType,
+        #[serde_as(as = "FeeAsHexStr")]
+        pub max_fee: Fee,
+        #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
+        pub signature: Vec<TransactionSignatureElem>,
+        pub transaction_hash: StarknetTransactionHash,
+    }
+}
+
+/// This migration reserializes transactions to match the change from a single variant to three
+/// variants  (deploy, declare and invoke). It also adds the `class_hash` field for historic `Deploy`
+/// transactions which did not have this field explicitly.
+///
+/// The reserialisation essentially removes null values from the old variant's optional fields. These
+/// fields are no longer optional in the newer variants as they are now specialized.
+pub(crate) fn migrate(transaction: &RusqliteTransaction<'_>) -> anyhow::Result<()> {
+    let todo: usize = transaction
+        .query_row("SELECT count(1) FROM starknet_transactions", [], |r| {
+            r.get(0)
+        })
+        .context("Count rows in starknet transactions table")?;
+
+    if todo == 0 {
+        return Ok(());
+    }
+
+    tracing::info!(
+        num_transactions=%todo,
+        "Decompressing and migrating transactions, this may take a while.",
+    );
+
+    let mut compressor = zstd::bulk::Compressor::new(1).context("Create zstd compressor")?;
+
+    let mut stmt = transaction
+        .prepare("SELECT hash, tx FROM starknet_transactions")
+        .context("Prepare transaction query")?;
+    let mut update_stmt = transaction
+        .prepare("UPDATE starknet_transactions SET tx = :tx WHERE hash = :hash")
+        .context("Prepare transaction update statement")?;
+    let mut query_class_hash_stmt = transaction
+        .prepare("SELECT hash FROM contracts WHERE address = :contract_address")
+        .context("Prepare class hash lookup statement")?;
+
+    let mut old_uncompressed_size = 0usize;
+    let mut old_compressed_size = 0usize;
+    let mut new_uncompressed_size = 0usize;
+    let mut new_compressed_size = 0usize;
+
+    let mut processed_rows = 0;
+    let batch_size = (todo / 11).max(100000);
+    let start_of_run = std::time::Instant::now();
+    let mut start_of_batch = start_of_run;
+
+    let mut rows = stmt.query([])?;
+    while let Some(r) = rows.next()? {
+        let transaction_hash = r.get_ref_unwrap("hash").as_blob()?;
+        let tx = r.get_ref_unwrap("tx").as_blob()?;
+
+        old_compressed_size += tx.len();
+        let tx = zstd::decode_all(tx).context("Decompressing transaction")?;
+        old_uncompressed_size += tx.len();
+        let tx: transaction::Transaction = serde_json::from_slice(&tx).context(format!(
+            "Deserializing transaction '{}'",
+            String::from_utf8_lossy(&tx)
+        ))?;
+
+        // Fix missing class_hash in deploy transactions
+        let tx = match tx {
+            transaction::Transaction::Deploy(mut deploy) => {
+                if deploy.class_hash.is_none() {
+                    let class_hash = query_class_hash_stmt.query_row(
+                        named_params![":contract_address": deploy.contract_address.0.as_be_bytes()],
+                        |r| {
+                            let class_hash = r.get_ref_unwrap("hash").as_blob().unwrap();
+                            let class_hash = StarkHash::from_be_slice(class_hash).unwrap();
+                            Ok(ClassHash(class_hash))
+                        },
+                    ).context("Query class hash for contract")?;
+                    deploy.class_hash = Some(class_hash);
+                    tracing::trace!(transaction_hash = ?deploy.transaction_hash, "Fixed missing class_hash for deploy transaction");
+                }
+                transaction::Transaction::Deploy(deploy)
+            }
+            transaction::Transaction::Declare(declare) => {
+                transaction::Transaction::Declare(declare)
+            }
+            transaction::Transaction::Invoke(invoke) => transaction::Transaction::Invoke(invoke),
+        };
+
+        let tx = serde_json::to_vec(&tx).context("Serializing transaction")?;
+        new_uncompressed_size += tx.len();
+        let tx = compressor
+            .compress(&tx)
+            .context("Compressing transaction")?;
+        new_compressed_size += tx.len();
+        update_stmt
+            .execute(named_params![":hash": &transaction_hash, ":tx": &tx])
+            .context("Updating transaction JSON")?;
+
+        processed_rows += 1;
+
+        if processed_rows % batch_size == 0 {
+            let now = std::time::Instant::now();
+            let total_elapsed = now - start_of_run;
+            let batch_elapsed = now - start_of_batch;
+
+            let total_per_row = total_elapsed.div_f64(processed_rows as f64);
+            let batch_per_row = batch_elapsed.div_f64(batch_size as f64);
+
+            // this is non-scientific, but perhaps the latest helps? seems to be very much off until 75% when divided by 2, 50% when divided by 1.5
+            let est_per_row = (total_per_row + batch_per_row).div_f64(1.5);
+            let remaining = est_per_row * ((todo - processed_rows) as u32);
+
+            tracing::info!(
+                "Fixing {:.1}% complete, estimated remaining {remaining:?}",
+                (100.0 * processed_rows as f64 / todo as f64)
+            );
+            start_of_batch = now;
+        }
+    }
+
+    tracing::info!(
+        %old_compressed_size,
+        %old_uncompressed_size,
+        %new_uncompressed_size,
+        %new_compressed_size,
+        total_time=?start_of_run.elapsed(),
+        "Finished transaction migration"
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        core::StarknetTransactionHash,
+        storage::schema::{self},
+    };
+    use rusqlite::{named_params, Connection};
+    use stark_hash::StarkHash;
+
+    use super::transaction;
+
+    #[test]
+    fn empty() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        let transaction = conn.transaction().unwrap();
+
+        migrate_to_previous_version(&transaction);
+
+        super::migrate(&transaction).unwrap();
+    }
+
+    fn migrate_to_previous_version(transaction: &rusqlite::Transaction<'_>) {
+        schema::revision_0001::migrate(transaction).unwrap();
+        schema::revision_0002::migrate(transaction).unwrap();
+        schema::revision_0003::migrate(transaction).unwrap();
+        schema::revision_0004::migrate(transaction).unwrap();
+        schema::revision_0005::migrate(transaction).unwrap();
+        schema::revision_0006::migrate(transaction).unwrap();
+        schema::revision_0007::migrate(transaction).unwrap();
+        schema::revision_0008::migrate(transaction).unwrap();
+        schema::revision_0009::migrate(transaction).unwrap();
+        schema::revision_0010::migrate(transaction).unwrap();
+        schema::revision_0011::migrate(transaction).unwrap();
+        schema::revision_0012::migrate(transaction).unwrap();
+        schema::revision_0013::migrate(transaction).unwrap();
+        schema::revision_0014::migrate(transaction).unwrap();
+    }
+
+    const OLD_DEPLOY_TX: &str = r#"{
+        "calldata":null,
+        "class_hash":"0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+        "constructor_calldata":["1758287985645384642592689047925649198321392050007099540447534039060479296296","215307247182100370520050591091822763712463273430149262739280891880522753123","2","898900680805551884939731794595262211795827363801567949161288957386233341890","0"],
+        "contract_address":"0x1f2d42032cce9c8497527653ebc9cfd6b67569895562899ab947a2d1cc110da",
+        "contract_address_salt":"0x1fcc27f574c791760dd7b99919e11379f0a5ad3b345596d2a76ba3d05ade7c2",
+        "entry_point_type":null,
+        "entry_point_selector":null,
+        "max_fee":null,
+        "nonce":null,
+        "sender_address":null,
+        "signature":null,
+        "transaction_hash":"0x350a394b1f74c5e71d9d1a787da91033e877a106ca965c65ad691d7725ade67",
+        "type":"DEPLOY",
+        "version":null
+    }"#;
+    const OLD_INVOKE_TX: &str = r#"{
+        "calldata":["1","2087021424722619777119509474943472645767659996348769578120564519014510906823","232670485425082704932579856502088130646006032362877466777181098476241604910","0","3","3","490809789286600582400843108881568438665982864055734060730291220939795284993","7700000000000000","0","0"],
+        "class_hash":null,
+        "constructor_calldata":null,
+        "contract_address":"0x4f9e9d3f9d8138a97efda56b33bc5d2065043d015ff089e5a26360573ae8759",
+        "contract_address_salt":null,
+        "entry_point_type":"EXTERNAL",
+        "entry_point_selector":"0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+        "max_fee":"0xb6bad3ab5367",
+        "nonce":null,
+        "sender_address":null,
+        "signature":["1315154516032005373376104412744922964590083352995277496702591367622675229681","2722865577796457381979632752916119040497485378397880545907561256288316181904"],
+        "transaction_hash":"0x5d08e1d6a87d87feaa97307e6746c1946fdcc21345f88cdee545efdda273a42",
+        "type":"INVOKE_FUNCTION",
+        "version":null
+    }"#;
+    const OLD_DECLARE_TX: &str = r#"{
+        "calldata":null,
+        "class_hash":"0x2759db6e3df9433b04c05e1dd1e634dd960fab8ea9b821bea4204e96ae68c9e",
+        "constructor_calldata":null,
+        "contract_address":null,
+        "contract_address_salt":null,
+        "entry_point_type":null,
+        "entry_point_selector":null,
+        "max_fee":"0x0",
+        "nonce":"0x0",
+        "sender_address":"0x1",
+        "signature":[],
+        "transaction_hash":"0x2304618d8803f7e46960352c8125f5c2316975c0ee29d5924fca956f7630f2b",
+        "type":"DECLARE",
+        "version":"0x0"
+    }"#;
+
+    #[test]
+    fn old_schema_with_optional_nulls() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        let transaction = conn.transaction().unwrap();
+
+        migrate_to_previous_version(&transaction);
+
+        insert_transaction(&transaction, OLD_DEPLOY_TX, 0);
+        insert_transaction(&transaction, OLD_INVOKE_TX, 1);
+        insert_transaction(&transaction, OLD_DECLARE_TX, 2);
+
+        super::migrate(&transaction).unwrap();
+    }
+
+    fn insert_transaction(transaction: &rusqlite::Transaction<'_>, json: &str, idx: u64) {
+        let tx: transaction::Transaction = serde_json::from_str(json).unwrap();
+        let compressed_tx = zstd::bulk::compress(json.as_bytes(), 1).unwrap();
+        transaction.execute("INSERT INTO starknet_transactions (hash, idx, block_hash, tx, receipt) VALUES (:hash, :idx, :block_hash, :tx, :receipt)",
+            named_params![
+                ":hash": tx.hash().0.as_be_bytes(),
+                ":idx": idx,
+                ":block_hash": StarkHash::from_hex_str("0x1").unwrap().as_be_bytes(),
+                ":tx": &compressed_tx,
+                ":receipt": &[],
+            ]
+        ).unwrap();
+    }
+
+    const OLD_DEPLOY_TX_WITHOUT_CLASS_HASH: &str = r#"{
+        "calldata":null,
+        "constructor_calldata":["3080361095405506737150169455874612808064922679726640693390570786953208555504","3468681769215879069828264006873144040317368534778938657407160341645658370624"],
+        "contract_address":"0x20cfa74ee3564b4cd5435cdace0f9c4d43b939620e4a0bb5076105df0a626c6",
+        "contract_address_salt":"0x546c86dc6e40a5e5492b782d8964e9a4274ff6ecb16d31eb09cee45a3564015",
+        "entry_point_type":null,
+        "entry_point_selector":null,
+        "max_fee":null,
+        "signature":null,
+        "transaction_hash":"0xe0a2e45a80bb827967e096bcf58874f6c01c191e0a0530624cba66a508ae75",
+        "type":"DEPLOY"}"#;
+    const OLD_DEPLOY_TX_WITHOUT_CLASS_HASH_TX_HASH: &str =
+        "0xe0a2e45a80bb827967e096bcf58874f6c01c191e0a0530624cba66a508ae75";
+    const OLD_DEPLOY_TX_WITHOUT_CLASS_HASH_CONTRACT_ADDRESS: &str =
+        "0x20cfa74ee3564b4cd5435cdace0f9c4d43b939620e4a0bb5076105df0a626c6";
+
+    #[test]
+    fn old_declare_transaction_with_missing_class_hash() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        let transaction = conn.transaction().unwrap();
+
+        migrate_to_previous_version(&transaction);
+
+        let fake_class_hash = StarkHash::from_hex_str("0xdeadadd").unwrap();
+        let contract_address =
+            StarkHash::from_hex_str(OLD_DEPLOY_TX_WITHOUT_CLASS_HASH_CONTRACT_ADDRESS).unwrap();
+
+        // insert fake class
+        transaction
+            .execute(
+                "INSERT INTO contract_code (hash) VALUES (:hash)",
+                named_params![
+                    ":hash": fake_class_hash.as_be_bytes(),
+                ],
+            )
+            .unwrap();
+
+        // insert contract pointing to fake class
+        transaction
+            .execute(
+                "INSERT INTO contracts (address, hash) VALUES(:address, :hash)",
+                named_params![
+                    ":address": contract_address.as_be_bytes(),
+                    ":hash": fake_class_hash.as_be_bytes(),
+                ],
+            )
+            .unwrap();
+
+        // insert transaction deploying the contract
+        insert_transaction(&transaction, OLD_DEPLOY_TX_WITHOUT_CLASS_HASH, 0);
+
+        super::migrate(&transaction).unwrap();
+
+        let transaction_hash =
+            StarkHash::from_hex_str(OLD_DEPLOY_TX_WITHOUT_CLASS_HASH_TX_HASH).unwrap();
+
+        let migrated_tx = crate::storage::state::StarknetTransactionsTable::get_transaction(
+            &transaction,
+            StarknetTransactionHash(transaction_hash),
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_matches::assert_matches!(migrated_tx, crate::sequencer::reply::transaction::Transaction::Deploy(deploy) => {
+            assert_eq!(deploy.class_hash.0, fake_class_hash);
+        });
+    }
+}

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -1735,7 +1735,6 @@ mod tests {
                     transaction_hash: StarknetTransactionHash(
                         StarkHash::from_hex_str("0xF").unwrap(),
                     ),
-                    r#type: crate::sequencer::reply::transaction::Type::InvokeFunction,
                 }),
                 transaction::Transaction::Invoke(transaction::InvokeTransaction {
                     calldata: vec![],
@@ -1748,7 +1747,6 @@ mod tests {
                     transaction_hash: StarknetTransactionHash(
                         StarkHash::from_hex_str("0x1").unwrap(),
                     ),
-                    r#type: crate::sequencer::reply::transaction::Type::InvokeFunction,
                 }),
             ];
 

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -450,7 +450,7 @@ impl StarknetTransactionsTable {
 
             tx.execute(r"INSERT OR REPLACE INTO starknet_transactions (hash, idx, block_hash, tx, receipt) VALUES (:hash, :idx, :block_hash, :tx, :receipt)",
         named_params![
-                    ":hash": transaction.transaction_hash.0.as_be_bytes(),
+                    ":hash": transaction.hash().0.as_be_bytes(),
                     ":idx": i,
                     ":block_hash": block_hash.0.as_be_bytes(),
                     ":tx": &tx_data,
@@ -729,27 +729,43 @@ impl StarknetEventsTable {
         transaction: &transaction::Transaction,
         events: &[transaction::Event],
     ) -> anyhow::Result<()> {
-        if transaction.contract_address.is_none() && !events.is_empty() {
-            anyhow::bail!("Declare transactions cannot emit events");
+        match transaction {
+            transaction::Transaction::Declare(_) => {
+                anyhow::ensure!(
+                    events.is_empty(),
+                    "Declare transactions cannot emit events: block {}, transaction {}",
+                    block_number,
+                    transaction.hash().0
+                );
+                Ok(())
+            }
+            transaction::Transaction::Deploy(transaction::DeployTransaction {
+                transaction_hash,
+                ..
+            })
+            | transaction::Transaction::Invoke(transaction::InvokeTransaction {
+                transaction_hash,
+                ..
+            }) => {
+                for (idx, event) in events.iter().enumerate() {
+                    tx
+                        .execute(
+                            r"INSERT INTO starknet_events ( block_number,  idx,  transaction_hash,  from_address,  keys,  data)
+                                                   VALUES (:block_number, :idx, :transaction_hash, :from_address, :keys, :data)",
+                            named_params![
+                                ":block_number": block_number.0,
+                                ":idx": idx,
+                                ":transaction_hash": &transaction_hash.0.as_be_bytes()[..],
+                                ":from_address": &event.from_address.0.as_be_bytes()[..],
+                                ":keys": Self::event_keys_to_base64_strings(&event.keys),
+                                ":data": Self::event_data_to_bytes(&event.data),
+                            ],
+                        )
+                        .context("Insert events into events table")?;
+                }
+                Ok(())
+            }
         }
-
-        for (idx, event) in events.iter().enumerate() {
-            tx
-                .execute(
-                    r"INSERT INTO starknet_events ( block_number,  idx,  transaction_hash,  from_address,  keys,  data)
-                                           VALUES (:block_number, :idx, :transaction_hash, :from_address, :keys, :data)",
-                    named_params![
-                        ":block_number": block_number.0,
-                        ":idx": idx,
-                        ":transaction_hash": &transaction.transaction_hash.0.as_be_bytes()[..],
-                        ":from_address": &event.from_address.0.as_be_bytes()[..],
-                        ":keys": Self::event_keys_to_base64_strings(&event.keys),
-                        ":data": Self::event_data_to_bytes(&event.data),
-                    ],
-                )
-                .context("Insert events into events table")?;
-        }
-        Ok(())
     }
 
     pub(crate) const PAGE_SIZE_LIMIT: usize = 1024;
@@ -1323,14 +1339,15 @@ mod tests {
 
     mod starknet_blocks {
         use super::*;
+        use crate::storage::test_utils;
 
-        fn create_blocks() -> [StarknetBlock; 3] {
-            crate::storage::test_utils::create_blocks::<3>()
+        fn create_blocks() -> [StarknetBlock; test_utils::NUM_BLOCKS] {
+            test_utils::create_blocks()
         }
 
         fn with_default_blocks<F>(f: F)
         where
-            F: FnOnce(&Transaction<'_>, [StarknetBlock; 3]),
+            F: FnOnce(&Transaction<'_>, [StarknetBlock; test_utils::NUM_BLOCKS]),
         {
             let storage = Storage::in_memory().unwrap();
             let mut connection = storage.connection().unwrap();
@@ -1603,10 +1620,13 @@ mod tests {
     }
 
     mod starknet_events {
+        use web3::types::H128;
+
         use super::*;
 
-        use crate::core::EventData;
+        use crate::core::{EntryPoint, EventData, Fee};
         use crate::sequencer::reply::transaction;
+        use crate::storage::test_utils;
 
         #[test]
         fn event_data_serialization() {
@@ -1646,64 +1666,11 @@ mod tests {
             );
         }
 
-        const NUM_BLOCKS: usize = 4;
-
-        fn create_blocks() -> [StarknetBlock; NUM_BLOCKS] {
-            crate::storage::test_utils::create_blocks::<NUM_BLOCKS>()
-        }
-
-        const TRANSACTIONS_PER_BLOCK: usize = 10;
-        const EVENTS_PER_BLOCK: usize = TRANSACTIONS_PER_BLOCK;
-        const NUM_TRANSACTIONS: usize = NUM_BLOCKS * TRANSACTIONS_PER_BLOCK;
-        const NUM_EVENTS: usize = NUM_BLOCKS * EVENTS_PER_BLOCK;
-
-        fn create_transactions_and_receipts(
-        ) -> [(transaction::Transaction, transaction::Receipt); NUM_TRANSACTIONS] {
-            crate::storage::test_utils::create_transactions_and_receipts::<NUM_TRANSACTIONS>()
-        }
-
-        fn setup(tx: &Transaction<'_>) -> Vec<StarknetEmittedEvent> {
-            let blocks = create_blocks();
-            let transactions_and_receipts = create_transactions_and_receipts();
-
-            for (i, block) in blocks.iter().enumerate() {
-                StarknetBlocksTable::insert(tx, block, None).unwrap();
-                StarknetTransactionsTable::upsert(
-                    tx,
-                    block.hash,
-                    block.number,
-                    &transactions_and_receipts
-                        [i * TRANSACTIONS_PER_BLOCK..(i + 1) * TRANSACTIONS_PER_BLOCK],
-                )
-                .unwrap();
-            }
-
-            transactions_and_receipts
-                .iter()
-                .enumerate()
-                .map(|(i, (txn, receipt))| {
-                    let event = &receipt.events[0];
-                    let block = &blocks[i / TRANSACTIONS_PER_BLOCK];
-
-                    StarknetEmittedEvent {
-                        data: event.data.clone(),
-                        from_address: event.from_address,
-                        keys: event.keys.clone(),
-                        block_hash: block.hash,
-                        block_number: block.number,
-                        transaction_hash: txn.transaction_hash,
-                    }
-                })
-                .collect()
-        }
-
         #[test]
         fn get_events_with_fully_specified_filter() {
-            let storage = Storage::in_memory().unwrap();
+            let (storage, emitted_events) = test_utils::setup_test_storage();
             let mut connection = storage.connection().unwrap();
             let tx = connection.transaction().unwrap();
-
-            let emitted_events = setup(&tx);
 
             let expected_event = &emitted_events[1];
             let filter = StarknetEventFilter {
@@ -1712,7 +1679,7 @@ mod tests {
                 contract_address: Some(expected_event.from_address),
                 // we're using a key which is present in _all_ events
                 keys: vec![EventKey(StarkHash::from_hex_str("deadbeef").unwrap())],
-                page_size: NUM_EVENTS,
+                page_size: test_utils::NUM_EVENTS,
                 page_number: 0,
             };
 
@@ -1757,44 +1724,32 @@ mod tests {
 
             // Note: hashes are reverse ordered to trigger the sorting bug.
             let transactions = vec![
-                transaction::Transaction {
-                    calldata: None,
-                    class_hash: None,
-                    constructor_calldata: None,
+                transaction::Transaction::Invoke(transaction::InvokeTransaction {
+                    calldata: vec![],
                     // Only required because event insert rejects if this is None
-                    contract_address: Some(ContractAddress(StarkHash::ZERO)),
-                    contract_address_salt: None,
-                    entry_point_type: None,
-                    entry_point_selector: None,
-                    max_fee: None,
-                    nonce: None,
-                    sender_address: None,
-                    signature: None,
+                    contract_address: ContractAddress(StarkHash::ZERO),
+                    entry_point_type: transaction::EntryPointType::External,
+                    entry_point_selector: EntryPoint(StarkHash::ZERO),
+                    max_fee: Fee(H128::zero()),
+                    signature: vec![],
                     transaction_hash: StarknetTransactionHash(
                         StarkHash::from_hex_str("0xF").unwrap(),
                     ),
                     r#type: crate::sequencer::reply::transaction::Type::InvokeFunction,
-                    version: None,
-                },
-                transaction::Transaction {
-                    calldata: None,
-                    class_hash: None,
-                    constructor_calldata: None,
+                }),
+                transaction::Transaction::Invoke(transaction::InvokeTransaction {
+                    calldata: vec![],
                     // Only required because event insert rejects if this is None
-                    contract_address: Some(ContractAddress(StarkHash::ZERO)),
-                    contract_address_salt: None,
-                    entry_point_type: None,
-                    entry_point_selector: None,
-                    max_fee: None,
-                    nonce: None,
-                    sender_address: None,
-                    signature: None,
+                    contract_address: ContractAddress(StarkHash::ZERO),
+                    entry_point_type: transaction::EntryPointType::External,
+                    entry_point_selector: EntryPoint(StarkHash::ZERO),
+                    max_fee: Fee(H128::zero()),
+                    signature: vec![],
                     transaction_hash: StarknetTransactionHash(
                         StarkHash::from_hex_str("0x1").unwrap(),
                     ),
                     r#type: crate::sequencer::reply::transaction::Type::InvokeFunction,
-                    version: None,
-                },
+                }),
             ];
 
             let receipts = vec![
@@ -1811,7 +1766,7 @@ mod tests {
                     },
                     l1_to_l2_consumed_message: None,
                     l2_to_l1_messages: Vec::new(),
-                    transaction_hash: transactions[0].transaction_hash,
+                    transaction_hash: transactions[0].hash(),
                     transaction_index: crate::core::StarknetTransactionIndex(0),
                 },
                 transaction::Receipt {
@@ -1827,7 +1782,7 @@ mod tests {
                     },
                     l1_to_l2_consumed_message: None,
                     l2_to_l1_messages: Vec::new(),
-                    transaction_hash: transactions[1].transaction_hash,
+                    transaction_hash: transactions[1].hash(),
                     transaction_index: crate::core::StarknetTransactionIndex(1),
                 },
             ];
@@ -1875,11 +1830,9 @@ mod tests {
 
         #[test]
         fn get_events_by_block() {
-            let storage = Storage::in_memory().unwrap();
+            let (storage, emitted_events) = test_utils::setup_test_storage();
             let mut connection = storage.connection().unwrap();
             let tx = connection.transaction().unwrap();
-
-            let emitted_events = setup(&tx);
 
             const BLOCK_NUMBER: usize = 2;
             let filter = StarknetEventFilter {
@@ -1887,12 +1840,12 @@ mod tests {
                 to_block: Some(StarknetBlockNumber(BLOCK_NUMBER as u64)),
                 contract_address: None,
                 keys: vec![],
-                page_size: NUM_EVENTS,
+                page_size: test_utils::NUM_EVENTS,
                 page_number: 0,
             };
 
-            let expected_events = &emitted_events
-                [EVENTS_PER_BLOCK * BLOCK_NUMBER..EVENTS_PER_BLOCK * (BLOCK_NUMBER + 1)];
+            let expected_events = &emitted_events[test_utils::EVENTS_PER_BLOCK * BLOCK_NUMBER
+                ..test_utils::EVENTS_PER_BLOCK * (BLOCK_NUMBER + 1)];
             let events = StarknetEventsTable::get_events(&tx, &filter).unwrap();
             assert_eq!(
                 events,
@@ -1905,11 +1858,9 @@ mod tests {
 
         #[test]
         fn get_events_up_to_block() {
-            let storage = Storage::in_memory().unwrap();
+            let (storage, emitted_events) = test_utils::setup_test_storage();
             let mut connection = storage.connection().unwrap();
             let tx = connection.transaction().unwrap();
-
-            let emitted_events = setup(&tx);
 
             const UNTIL_BLOCK_NUMBER: usize = 2;
             let filter = StarknetEventFilter {
@@ -1917,12 +1868,12 @@ mod tests {
                 to_block: Some(StarknetBlockNumber(UNTIL_BLOCK_NUMBER as u64)),
                 contract_address: None,
                 keys: vec![],
-                page_size: NUM_EVENTS,
+                page_size: test_utils::NUM_EVENTS,
                 page_number: 0,
             };
 
             let expected_events =
-                &emitted_events[..TRANSACTIONS_PER_BLOCK * (UNTIL_BLOCK_NUMBER + 1)];
+                &emitted_events[..test_utils::EVENTS_PER_BLOCK * (UNTIL_BLOCK_NUMBER + 1)];
             let events = StarknetEventsTable::get_events(&tx, &filter).unwrap();
             assert_eq!(
                 events,
@@ -1935,11 +1886,9 @@ mod tests {
 
         #[test]
         fn get_events_from_block_onwards() {
-            let storage = Storage::in_memory().unwrap();
+            let (storage, emitted_events) = test_utils::setup_test_storage();
             let mut connection = storage.connection().unwrap();
             let tx = connection.transaction().unwrap();
-
-            let emitted_events = setup(&tx);
 
             const FROM_BLOCK_NUMBER: usize = 2;
             let filter = StarknetEventFilter {
@@ -1947,11 +1896,12 @@ mod tests {
                 to_block: None,
                 contract_address: None,
                 keys: vec![],
-                page_size: NUM_EVENTS,
+                page_size: test_utils::NUM_EVENTS,
                 page_number: 0,
             };
 
-            let expected_events = &emitted_events[TRANSACTIONS_PER_BLOCK * FROM_BLOCK_NUMBER..];
+            let expected_events =
+                &emitted_events[test_utils::EVENTS_PER_BLOCK * FROM_BLOCK_NUMBER..];
             let events = StarknetEventsTable::get_events(&tx, &filter).unwrap();
             assert_eq!(
                 events,
@@ -1964,11 +1914,9 @@ mod tests {
 
         #[test]
         fn get_events_from_contract() {
-            let storage = Storage::in_memory().unwrap();
+            let (storage, emitted_events) = test_utils::setup_test_storage();
             let mut connection = storage.connection().unwrap();
             let tx = connection.transaction().unwrap();
-
-            let emitted_events = setup(&tx);
 
             let expected_event = &emitted_events[33];
 
@@ -1977,7 +1925,7 @@ mod tests {
                 to_block: None,
                 contract_address: Some(expected_event.from_address),
                 keys: vec![],
-                page_size: NUM_EVENTS,
+                page_size: test_utils::NUM_EVENTS,
                 page_number: 0,
             };
 
@@ -1993,11 +1941,9 @@ mod tests {
 
         #[test]
         fn get_events_by_key() {
-            let storage = Storage::in_memory().unwrap();
+            let (storage, emitted_events) = test_utils::setup_test_storage();
             let mut connection = storage.connection().unwrap();
             let tx = connection.transaction().unwrap();
-
-            let emitted_events = setup(&tx);
 
             let expected_event = &emitted_events[27];
             let filter = StarknetEventFilter {
@@ -2005,7 +1951,7 @@ mod tests {
                 to_block: None,
                 contract_address: None,
                 keys: vec![expected_event.keys[0]],
-                page_size: NUM_EVENTS,
+                page_size: test_utils::NUM_EVENTS,
                 page_number: 0,
             };
 
@@ -2021,18 +1967,16 @@ mod tests {
 
         #[test]
         fn get_events_with_no_filter() {
-            let storage = Storage::in_memory().unwrap();
+            let (storage, emitted_events) = test_utils::setup_test_storage();
             let mut connection = storage.connection().unwrap();
             let tx = connection.transaction().unwrap();
-
-            let emitted_events = setup(&tx);
 
             let filter = StarknetEventFilter {
                 from_block: None,
                 to_block: None,
                 contract_address: None,
                 keys: vec![],
-                page_size: NUM_EVENTS,
+                page_size: test_utils::NUM_EVENTS,
                 page_number: 0,
             };
 
@@ -2048,11 +1992,9 @@ mod tests {
 
         #[test]
         fn get_events_with_no_filter_and_paging() {
-            let storage = Storage::in_memory().unwrap();
+            let (storage, emitted_events) = test_utils::setup_test_storage();
             let mut connection = storage.connection().unwrap();
             let tx = connection.transaction().unwrap();
-
-            let emitted_events = setup(&tx);
 
             let filter = StarknetEventFilter {
                 from_block: None,
@@ -2108,11 +2050,9 @@ mod tests {
 
         #[test]
         fn get_events_with_no_filter_and_nonexistent_page() {
-            let storage = Storage::in_memory().unwrap();
+            let (storage, _) = test_utils::setup_test_storage();
             let mut connection = storage.connection().unwrap();
             let tx = connection.transaction().unwrap();
-
-            let _emitted_events = setup(&tx);
 
             const PAGE_SIZE: usize = 10;
             let filter = StarknetEventFilter {
@@ -2122,7 +2062,7 @@ mod tests {
                 keys: vec![],
                 page_size: PAGE_SIZE,
                 // one page _after_ the last one
-                page_number: NUM_BLOCKS * EVENTS_PER_BLOCK / PAGE_SIZE,
+                page_number: test_utils::NUM_BLOCKS * test_utils::EVENTS_PER_BLOCK / PAGE_SIZE,
             };
             let events = StarknetEventsTable::get_events(&tx, &filter).unwrap();
             assert_eq!(
@@ -2136,11 +2076,9 @@ mod tests {
 
         #[test]
         fn get_events_with_invalid_page_size() {
-            let storage = Storage::in_memory().unwrap();
+            let (storage, _) = test_utils::setup_test_storage();
             let mut connection = storage.connection().unwrap();
             let tx = connection.transaction().unwrap();
-
-            let _emitted_events = setup(&tx);
 
             let filter = StarknetEventFilter {
                 from_block: None,
@@ -2172,11 +2110,9 @@ mod tests {
 
         #[test]
         fn get_events_by_key_with_paging() {
-            let storage = Storage::in_memory().unwrap();
+            let (storage, emitted_events) = test_utils::setup_test_storage();
             let mut connection = storage.connection().unwrap();
             let tx = connection.transaction().unwrap();
-
-            let emitted_events = setup(&tx);
 
             let expected_events = &emitted_events[27..32];
             let keys_for_expected_events: Vec<_> =

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -502,8 +502,8 @@ impl StarknetTransactionsTable {
                 .as_blob_or_null()?
                 .context("Receipt data missing")?;
             let receipt = zstd::decode_all(receipt).context("Decompressing transaction receipt")?;
-            let receipt = serde_json::de::from_slice(&receipt)
-                .context("Deserializing transaction receipt")?;
+            let receipt =
+                serde_json::from_slice(&receipt).context("Deserializing transaction receipt")?;
 
             let transaction = row
                 .get_ref_unwrap("tx")
@@ -511,7 +511,7 @@ impl StarknetTransactionsTable {
                 .context("Transaction data missing")?;
             let transaction = zstd::decode_all(transaction).context("Decompressing transaction")?;
             let transaction =
-                serde_json::de::from_slice(&transaction).context("Deserializing transaction")?;
+                serde_json::from_slice(&transaction).context("Deserializing transaction")?;
 
             data.push((transaction, receipt));
         }
@@ -561,7 +561,7 @@ impl StarknetTransactionsTable {
 
         let transaction = zstd::decode_all(transaction).context("Decompressing transaction")?;
         let transaction =
-            serde_json::de::from_slice(&transaction).context("Deserializing transaction")?;
+            serde_json::from_slice(&transaction).context("Deserializing transaction")?;
 
         Ok(Some(transaction))
     }
@@ -588,7 +588,7 @@ impl StarknetTransactionsTable {
             None => return Ok(None),
         };
         let receipt = zstd::decode_all(receipt).context("Decompressing transaction")?;
-        let receipt = serde_json::de::from_slice(&receipt).context("Deserializing transaction")?;
+        let receipt = serde_json::from_slice(&receipt).context("Deserializing transaction")?;
 
         let block_hash = row.get_ref_unwrap("block_hash").as_blob()?;
         let block_hash =
@@ -622,7 +622,7 @@ impl StarknetTransactionsTable {
 
         let transaction = zstd::decode_all(transaction).context("Decompressing transaction")?;
         let transaction =
-            serde_json::de::from_slice(&transaction).context("Deserializing transaction")?;
+            serde_json::from_slice(&transaction).context("Deserializing transaction")?;
 
         Ok(Some(transaction))
     }

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -7,7 +7,7 @@ from starkware.starkware_utils.error_handling import WebFriendlyException
 from starkware.storage.storage import Storage
 
 # used from tests, and the query which asserts that the schema is of expected version.
-EXPECTED_SCHEMA_REVISION = 14
+EXPECTED_SCHEMA_REVISION = 15
 EXPECTED_CAIRO_VERSION = "0.9.1"
 SUPPORTED_COMMANDS = frozenset(["call", "estimate_fee"])
 


### PR DESCRIPTION
This PR is a revert of the revert for PR #380 with the small optimization in PR #392 applied, plus a migration step that makes sure that the compressed transaction JSONs are compatible with the new `enum Transaction`.

This migration is necessary because serializing the old `struct Transaction` lead to fields irrelevant for the given transaction type being serialized into the JSON with `null` value, and this breaks de-serialization with the enum type with our standard `deny_unknown_fields` serde option.

During testing I've also discovered an edge case: very old versions of deploy transactions did not have the `class_hash` in the serialized JSON. `class_hash` is now a non-optional field of `DeployTransaction`, so this migration looks up the class hash corresponding to the contract address in the transaction.