### PR TITLE
feat: startup permission check

### DIFF
--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -58,7 +58,6 @@ http = "0.2.6"
 jsonrpsee = { version = "0.11.0", features = ["server", "client"] }
 mockall = "0.11.0"
 pretty_assertions = "1.0.0"
-tempfile = "3"
 # log crate should be handled through tracing-subscriber if needed
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
 tokio = { version = "1.11.0", features = ["test-util"] }

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -27,6 +27,8 @@ async fn main() -> anyhow::Result<()> {
         "🏁 Starting node."
     );
 
+    permission_check(&config.data_directory)?;
+
     let eth_transport =
         HttpTransport::from_config(config.ethereum).context("Creating Ethereum transport")?;
 
@@ -191,4 +193,13 @@ fn setup_tracing() {
         .with_target(false)
         .compact()
         .init();
+}
+
+fn permission_check(base: &std::path::Path) -> Result<(), anyhow::Error> {
+    tempfile::tempfile_in(base)
+        .with_context(|| format!("Failed to create a file in {}. Make sure the directory is writable by the user running pathfinder.", base.display()))?;
+
+    // well, don't really know what else to check
+
+    Ok(())
 }


### PR DESCRIPTION
When running with data directory which is not writeable (but still might contain writable database files), this gives:

```
INFO 🏁 Starting node. version="v0.2.3-alpha-38-gf719abe"
Error: Failed to create a file in /.../tmpdir. Make sure the directory is writable by the user running pathfinder.

Caused by:
    Permission denied (os error 13)
```

This check might of course cause issues for some users but helping these out are always confusing, especially if the error comes from sqlite because a journal file couldn't be removed or created or whatever.