### PR TITLE
fix(eth): stop retrying on 401

### DIFF
--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -30,10 +30,13 @@ async fn main() -> anyhow::Result<()> {
     let eth_transport =
         HttpTransport::from_config(config.ethereum).context("Creating Ethereum transport")?;
 
-    let ethereum_chain = eth_transport
-        .chain()
-        .await
-        .context("Determining Ethereum chain")?;
+    // have a special long form hint here because there should be a lot of questions coming up
+    // about this one.
+    let ethereum_chain = eth_transport.chain().await.context(
+        "Determine Ethereum chain.
+
+Hint: Make sure the provided ethereum.url and ethereum.password are good.",
+    )?;
 
     let database_path = config.data_directory.join(match ethereum_chain {
         core::Chain::Mainnet => "mainnet.sqlite",

--- a/crates/pathfinder/src/config/builder.rs
+++ b/crates/pathfinder/src/config/builder.rs
@@ -41,6 +41,16 @@ impl ConfigBuilder {
         // Required parameters.
         let eth_url = self.take_required(ConfigOption::EthereumHttpUrl)?;
 
+        // this used to be the url in docker run example
+        if eth_url == "https://goerli.infura.io/v3/<project-id>" {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("Invalid Ethereum URL ({eth_url}): Cannot use the URL from examples!
+
+Hint: Register your own account or run your own Ethereum node and put the real URL as the configuration value.")
+            ));
+        }
+
         // Parse the Ethereum URL.
         let eth_url = eth_url.parse::<Url>().map_err(|err| {
             std::io::Error::new(

--- a/crates/pathfinder/src/ethereum/transport.rs
+++ b/crates/pathfinder/src/ethereum/transport.rs
@@ -234,7 +234,16 @@ where
 /// A helper function to log Web3 Eth API errors. Always yields __true__.
 fn log_and_always_retry(error: &Error) -> bool {
     match error {
-        Error::Unreachable | Error::InvalidResponse(_) | Error::Transport(_) => {
+        Error::Transport(s) => {
+            // this is quite sad but we only have the string to work with
+            // this happens at least on infura with bad urls, also alchemy
+            if s == "response status code is not success: 401 Unauthorized" {
+                return false;
+            }
+
+            debug!(reason=%error, "L1 request failed, retrying")
+        }
+        Error::Unreachable | Error::InvalidResponse(_) => {
             debug!(reason=%error, "L1 request failed, retrying")
         }
         Error::Decoder(_) | Error::Internal | Error::Io(_) | Error::Recovery(_) => {


### PR DESCRIPTION
we really should not retry 4xx but ... unsure how all cases happen. this helps so that the copypasted url with placeholder will exit fast. I cannot see how 401 could be used for anything else than this. It really shouldn't :)

```
2022-06-30T07:07:59.862256Z  INFO 🏁 Starting node. version="v0.2.3-alpha-37-g6e43229-dirty"
Error: Determine Ethereum chain.

Hint: Make sure the provided ethereum.url and ethereum.password are good.

Caused by:
    Transport error: response status code is not success: 401 Unauthorized
```

and:

```
Error: Parsing configuration

Caused by:
    Invalid Ethereum URL (https://goerli.infura.io/v3/<project-id>): Cannot use the URL from examples!
    
Hint: Register your own account or run your own Ethereum node and put the real URL as the configuration value.
```