### PR TITLE
fix(py): find more correct gas_consumed

### DIFF
--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -423,7 +423,7 @@ mod tests {
         assert_eq!(
             at_block_fee,
             crate::rpc::types::reply::FeeEstimate {
-                consumed: H256::from_low_u64_be(0),
+                consumed: H256::from_low_u64_be(3),
                 gas_price: H256::from_low_u64_be(1),
                 fee: H256::from_low_u64_be(4)
             }
@@ -443,7 +443,7 @@ mod tests {
         assert_eq!(
             current_fee,
             crate::rpc::types::reply::FeeEstimate {
-                consumed: H256::from_low_u64_be(0),
+                consumed: H256::from_low_u64_be(3),
                 gas_price: H256::from_low_u64_be(10),
                 fee: H256::from_low_u64_be(35)
             }

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -419,7 +419,7 @@ def test_fee_estimate_on_positive_directly():
     (verb, output, _timings) = loop_inner(con, command)
 
     assert output == {
-        "gas_consumed": 0,
+        "gas_consumed": 3,
         "gas_price": 0,
         "overall_fee": 0,
     }
@@ -441,7 +441,7 @@ def test_fee_estimate_on_positive():
     assert first == {
         "status": "ok",
         "output": {
-            "gas_consumed": "0x" + (0).to_bytes(32, "big").hex(),
+            "gas_consumed": "0x" + (3).to_bytes(32, "big").hex(),
             "gas_price": "0x" + (0).to_bytes(32, "big").hex(),
             "overall_fee": "0x" + (0).to_bytes(32, "big").hex(),
         },
@@ -450,7 +450,7 @@ def test_fee_estimate_on_positive():
     assert second == {
         "status": "ok",
         "output": {
-            "gas_consumed": "0x" + (0).to_bytes(32, "big").hex(),
+            "gas_consumed": "0x" + (3).to_bytes(32, "big").hex(),
             "gas_price": "0x" + (10).to_bytes(32, "big").hex(),
             "overall_fee": "0x" + (35).to_bytes(32, "big").hex(),
         },
@@ -509,7 +509,7 @@ def test_failing_mainnet_tx2():
 
     # this is correct
     assert output == {
-        "gas_consumed": 8568,
+        "gas_consumed": 8732,
         "gas_price": 21367239423,
         "overall_fee": 186590486623319,
     }


### PR DESCRIPTION
this should be fixed in cairo-lang 0.9.1, there should be a triple returning api.

Unable to reproduce the original in #412, but I would assume this now the correct version, and overall fee doesn't change.

Fixes but maybe not: #412