### PR TITLE
chore: bump to web3 0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,12 +65,6 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
@@ -678,11 +672,10 @@ dependencies = [
 
 [[package]]
 name = "ethabi"
-version = "14.1.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01317735d563b3bad2d5f90d2e1799f414165408251abb762510f40e790e69a"
+checksum = "a4c98847055d934070b90e806e12d3936b787d0a115068981c1d8dfd5dfef5a5"
 dependencies = [
- "anyhow",
  "ethereum-types",
  "hex",
  "serde",
@@ -707,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum-types"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64b5df66a228d85e4b17e5d6c6aa43b0310898ffe8a85988c4c032357aaabfd"
+checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
 dependencies = [
  "ethbloom",
  "fixed-hash",
@@ -1448,7 +1441,7 @@ dependencies = [
  "jsonrpsee-types",
  "pin-project",
  "rustls-native-certs",
- "soketto 0.7.1",
+ "soketto",
  "thiserror",
  "tokio",
  "tokio-rustls",
@@ -1478,7 +1471,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "soketto 0.7.1",
+ "soketto",
  "thiserror",
  "tokio",
  "tracing",
@@ -1558,7 +1551,7 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "serde_json",
- "soketto 0.7.1",
+ "soketto",
  "tokio",
  "tokio-util 0.7.0",
  "tracing",
@@ -2247,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06345ee39fbccfb06ab45f3a1a5798d9dafa04cb8921a76d227040003a234b0e"
+checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -2732,9 +2725,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.20.3"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d03ceae636d0fed5bae6a7f4f664354c5f4fcedf6eef053fef17e49f837d0a"
+checksum = "9c42e6f1735c5f00f51e43e28d6634141f2bcad10931b2609ddd74a86d751260"
 dependencies = [
  "secp256k1-sys",
 ]
@@ -2957,21 +2950,6 @@ checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "soketto"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4919971d141dbadaa0e82b5d369e2d7666c98e4625046140615ca363e50d4daa"
-dependencies = [
- "base64",
- "bytes",
- "futures",
- "httparse",
- "log",
- "rand",
- "sha-1",
 ]
 
 [[package]]
@@ -3888,11 +3866,11 @@ dependencies = [
 
 [[package]]
 name = "web3"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd24abe6f2b68e0677f843059faea87bcbd4892e39f02886f366d8222c3c540d"
+checksum = "44f258e254752d210b84fe117b31f1e3cc9cbf04c0d747eb7f8cf7cf5e370f6d"
 dependencies = [
- "arrayvec 0.5.2",
+ "arrayvec 0.7.2",
  "base64",
  "bytes",
  "derive_more",
@@ -3902,16 +3880,18 @@ dependencies = [
  "futures-timer",
  "headers",
  "hex",
+ "idna",
  "jsonrpc-core",
  "log",
- "parking_lot 0.11.2",
+ "once_cell",
+ "parking_lot 0.12.0",
  "pin-project",
  "reqwest",
  "rlp",
  "secp256k1",
  "serde",
  "serde_json",
- "soketto 0.5.0",
+ "soketto",
  "tiny-keccak",
  "tokio",
  "tokio-stream",

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -48,7 +48,7 @@ tokio-retry = "0.3.0"
 toml = "0.5.8"
 tracing = "0.1.31"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
-web3 = "0.17.0"
+web3 = "0.18.0"
 zstd = "0.10"
 
 [dev-dependencies]

--- a/crates/pathfinder/src/ethereum/transport.rs
+++ b/crates/pathfinder/src/ethereum/transport.rs
@@ -234,16 +234,11 @@ where
 /// A helper function to log Web3 Eth API errors. Always yields __true__.
 fn log_and_always_retry(error: &Error) -> bool {
     match error {
-        Error::Transport(s) => {
-            // this is quite sad but we only have the string to work with
+        Error::Transport(web3::error::TransportError::Code(401)) => {
             // this happens at least on infura with bad urls, also alchemy
-            if s == "response status code is not success: 401 Unauthorized" {
-                return false;
-            }
-
-            debug!(reason=%error, "L1 request failed, retrying")
+            return false;
         }
-        Error::Unreachable | Error::InvalidResponse(_) => {
+        Error::Unreachable | Error::InvalidResponse(_) | Error::Transport(_) => {
             debug!(reason=%error, "L1 request failed, retrying")
         }
         Error::Decoder(_) | Error::Internal | Error::Io(_) | Error::Recovery(_) => {


### PR DESCRIPTION
This will remove at least the soketto older version dependency.