### PR TITLE
chore: docker preparation for next release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           config-inline: |
             [worker.oci]
-              max-parallelism = 0
+              max-parallelism = 1
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           config-inline: |
             [worker.oci]
-              max-parallelism = 1
+              max-parallelism = 4
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,17 +22,15 @@ WORKDIR /usr/src/pathfinder
 
 # Build only the dependencies first. This utilizes
 # container layer caching for Rust builds
-RUN mkdir crates
-RUN cargo new --lib --vcs none crates/stark_curve
-RUN cargo new --lib --vcs none crates/stark_hash
-# Correct: --lib. We'll handle the binary later.
-RUN cargo new --lib --vcs none crates/pathfinder
-RUN cargo new --lib --vcs none crates/load-test
-COPY Cargo.toml Cargo.toml
-COPY Cargo.lock Cargo.lock
+RUN mkdir crates \
+    && cargo new --lib --vcs none crates/stark_curve \
+    && cargo new --lib --vcs none crates/stark_hash \
+    && cargo new --lib --vcs none crates/pathfinder \
+    && cargo new --lib --vcs none crates/load-test
 
-COPY crates/pathfinder/Cargo.toml crates/pathfinder/Cargo.toml
-COPY crates/pathfinder/build.rs crates/pathfinder/build.rs
+COPY Cargo.toml Cargo.lock .
+
+COPY crates/pathfinder/Cargo.toml crates/pathfinder/build.rs crates/pathfinder/
 COPY crates/stark_curve/Cargo.toml crates/stark_curve/Cargo.toml
 COPY crates/stark_hash/Cargo.toml crates/stark_hash/Cargo.toml
 COPY crates/stark_hash/benches crates/stark_hash/benches
@@ -45,10 +43,7 @@ COPY . .
 COPY ./.git /usr/src/pathfinder/.git
 
 # Mark these for re-compilation
-RUN touch crates/pathfinder/src/lib.rs
-RUN touch crates/pathfinder/src/build.rs
-RUN touch crates/stark_curve/src/lib.rs
-RUN touch crates/stark_hash/src/lib.rs
+RUN touch crates/pathfinder/src/lib.rs crates/pathfinder/src/build.rs crates/stark_curve/src/lib.rs crates/stark_hash/src/lib.rs
 
 RUN CARGO_INCREMENTAL=0 cargo build --release -p pathfinder --bin pathfinder
 
@@ -65,10 +60,10 @@ RUN python3 -m pip --disable-pip-version-check install -r py/requirements-dev.tx
 
 # This reduces the size of the python libs by about 50%
 ENV PY_PATH=/usr/local/lib/python3.8/
-RUN find ${PY_PATH} -type d -a -name test -exec rm -rf '{}' +
-RUN find ${PY_PATH} -type d -a -name tests  -exec rm -rf '{}' +
-RUN find ${PY_PATH} -type f -a -name '*.pyc' -exec rm -rf '{}' +
-RUN find ${PY_PATH} -type f -a -name '*.pyo' -exec rm -rf '{}' +
+RUN find ${PY_PATH} -type d -a -name test -exec rm -rf '{}' + \
+    && find ${PY_PATH} -type d -a -name tests  -exec rm -rf '{}' + \
+    && find ${PY_PATH} -type f -a -name '*.pyc' -exec rm -rf '{}' + \
+    && find ${PY_PATH} -type f -a -name '*.pyo' -exec rm -rf '{}' +
 
 #######################
 # Final Stage: Runner #

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # Note that we're explicitly using the Debian bullseye image to make sure we're
 # compatible with the Python container we'll be copying the pathfinder
 # executable to.
-FROM rust:1.61-bullseye AS rust-builder
+FROM rust:1.62-bullseye AS rust-builder
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libssl-dev && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ COPY crates/stark_curve/Cargo.toml crates/stark_curve/Cargo.toml
 COPY crates/stark_hash/Cargo.toml crates/stark_hash/Cargo.toml
 COPY crates/stark_hash/benches crates/stark_hash/benches
 
+# refresh indices, do it with cli git for much better ram usage
+RUN CARGO_NET_GIT_FETCH_WITH_CLI=true cargo search --limit 0
+
 # DEPENDENCY_LAYER=1 should disable any vergen interaction, because the .git directory is not yet available
 RUN CARGO_INCREMENTAL=0 DEPENDENCY_LAYER=1 cargo build --release -p pathfinder
 


### PR DESCRIPTION
Turns out cargo index refresh is very memory hungry. Using cli `git` seems to be the solution.

Upgrades the rust base image to 1.62.

Compresses a few commands for less layers.