### PR TITLE
ci: require up to date lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,8 @@ jobs:
             PATHFINDER_ETHEREUM_HTTP_MAINNET_PASSWORD=${{ secrets.ALCHEMY_MAINNET_PASSWORD }} \
             timeout 3m cargo test -p pathfinder -- ethereum::
 
-          timeout 3m cargo test -p stark_hash --benches
+          timeout 3m cargo test -p stark_hash --all-targets
+          timeout 1m cargo test -p stark_curve --all-targets
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v1
       - run: |
-          cargo test --no-run --workspace
+          cargo test --no-run --workspace --frozen
           timeout 5m cargo test -p pathfinder -- --skip ethereum::
 
           # Run Ethereum tests using Infura endpoint


### PR DESCRIPTION
Also, start running the stark_curve unit tests just for completness.
Also, use `--all-targets` in favor of `--benches`.