### PR TITLE
fix: work-around L1 bug

### DIFF
--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -382,7 +382,7 @@ async fn l1_update(connection: &mut Connection, updates: &[StateUpdateLog]) -> a
             .context("Create database transaction")?;
 
         for update in updates {
-            L1StateTable::insert(&transaction, update).context("Insert update")?;
+            L1StateTable::upsert(&transaction, update).context("Insert update")?;
         }
 
         // Track combined L1 and L2 state.
@@ -989,7 +989,7 @@ mod tests {
                 .unwrap();
             updates
                 .into_iter()
-                .for_each(|update| L1StateTable::insert(&connection, &update).unwrap());
+                .for_each(|update| L1StateTable::upsert(&connection, &update).unwrap());
 
             // UUT
             let _jh = tokio::spawn(state::sync(
@@ -1033,7 +1033,7 @@ mod tests {
         let connection = storage.connection().unwrap();
 
         // This is what we're asking for
-        L1StateTable::insert(&connection, &*STATE_UPDATE_LOG0).unwrap();
+        L1StateTable::upsert(&connection, &*STATE_UPDATE_LOG0).unwrap();
 
         // A simple L1 sync task which does the request and checks he result
         let l1 = |tx: mpsc::Sender<l1::Event>, _, _, _| async move {
@@ -1150,7 +1150,7 @@ mod tests {
             let connection = storage.connection().unwrap();
 
             if let Some(some_update_log) = update_log {
-                L1StateTable::insert(&connection, &some_update_log).unwrap();
+                L1StateTable::upsert(&connection, &some_update_log).unwrap();
             }
 
             // UUT

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -29,29 +29,10 @@ impl From<StarknetBlockNumber> for L1TableBlockId {
     }
 }
 
-/// An aid to investigate a bug where an L1 reorg followed by an insert
-/// in rare cases results in a primary key violation.
-///
-/// This struct helps audit L1 reorgs when this occurs.
-#[derive(Debug)]
-#[allow(dead_code)]
-struct L1BugAudit {
-    head_pre_reorg: u64,
-    head_post_reorg: u64,
-    reorg_count: u64,
-}
-
-lazy_static::lazy_static!(
-    /// Tracks the latest L1 reorg in an attempt to make sense of a primary key related reorg bug.
-    ///
-    /// Stores the latest reorg's (pre-reorg head, post-reorg head, rows deleted)
-    static ref L1_LATEST_REORG: std::sync::Mutex<Option<L1BugAudit>> = std::sync::Mutex::new(None);
-);
-
 impl L1StateTable {
-    /// Inserts a new [update](StateUpdateLog), fails if it already exists.
+    /// Inserts a new [update](StateUpdateLog), replaces if it already exists.
     pub fn insert(connection: &Connection, update: &StateUpdateLog) -> anyhow::Result<()> {
-        let result = connection.execute(
+        connection.execute(
             r"INSERT INTO l1_state (
                         starknet_block_number,
                         starknet_global_root,
@@ -78,96 +59,18 @@ impl L1StateTable {
                 ":ethereum_transaction_index": update.origin.transaction.index.0,
                 ":ethereum_log_index": update.origin.log_index.0,
             },
-        );
+        )?;
 
-        match result {
-            Ok(_) => Ok(()),
-            Err(err) => {
-                // Log L1 reorg bug audit information.
-                match err {
-                    rusqlite::Error::SqliteFailure(code, _)
-                        if code.code == rusqlite::ErrorCode::ConstraintViolation =>
-                    {
-                        let latest = L1_LATEST_REORG.lock().unwrap_or_else(|e| e.into_inner());
-                        // Attempt to query for conflicting entry.
-                        let existing = Self::get(connection, update.block_number.into())
-                            .context("Read L1 block for PK constraint audit")?;
-
-                        tracing::error!(reorg=?latest, ?existing, ?update, "Additional L1 reorg bug information");
-                    }
-                    _ => {}
-                }
-
-                Err(err.into())
-            }
-        }
+        Ok(())
     }
 
     /// Deletes all rows from __head down-to reorg_tail__
     /// i.e. it deletes all rows where `block number >= reorg_tail`.
     pub fn reorg(connection: &Connection, reorg_tail: StarknetBlockNumber) -> anyhow::Result<()> {
-        // Added to trace a primary key constraint failure bug.
-        let original_head: Option<u64> = connection.query_row(
-            "SELECT MAX(starknet_block_number) FROM l1_state",
-            [],
-            |row| row.get(0),
-        )?;
-
-        let reorg_count = connection.execute(
+        connection.execute(
             "DELETE FROM l1_state WHERE starknet_block_number >= ?",
             params![reorg_tail.0],
-        )? as u64;
-
-        // Added to trace a primary key constraint failure bug.
-        let new_head: Option<u64> = connection.query_row(
-            "SELECT MAX(starknet_block_number) FROM l1_state",
-            [],
-            |row| row.get(0),
         )?;
-
-        // Sanity check the result of reorg.
-        if let Some(new_head) = new_head {
-            anyhow::ensure!(
-                reorg_tail.0 - 1 == new_head,
-                "New L1 head ({}) did not match expectations of reorg tail ({})",
-                new_head,
-                reorg_tail.0
-            );
-        }
-        match (original_head, new_head) {
-            (Some(orig), Some(new_head)) => {
-                anyhow::ensure!(
-                    orig - new_head == reorg_count,
-                    "Deletion count ({}) did not match head change ({} -> {})",
-                    reorg_count,
-                    orig,
-                    new_head
-                );
-
-                let mut latest = L1_LATEST_REORG.lock().unwrap_or_else(|e| e.into_inner());
-
-                let new_info = L1BugAudit {
-                    head_pre_reorg: orig,
-                    head_post_reorg: new_head,
-                    reorg_count,
-                };
-                *latest = Some(new_info);
-            }
-            (Some(orig), None) => {
-                anyhow::ensure!(
-                    orig + 1 == reorg_count,
-                    "Deletion count ({}) did not match head change ({} -> None)",
-                    reorg_count,
-                    orig
-                )
-            }
-            (None, None) => anyhow::bail!("Reorg attempted on an empty database"),
-            (None, Some(new_head)) => anyhow::bail!(
-                "Reorg attempted on an empty database and somehow ended with a new head ({})",
-                new_head
-            ),
-        }
-
         Ok(())
     }
 

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -31,9 +31,9 @@ impl From<StarknetBlockNumber> for L1TableBlockId {
 
 impl L1StateTable {
     /// Inserts a new [update](StateUpdateLog), replaces if it already exists.
-    pub fn insert(connection: &Connection, update: &StateUpdateLog) -> anyhow::Result<()> {
+    pub fn upsert(connection: &Connection, update: &StateUpdateLog) -> anyhow::Result<()> {
         connection.execute(
-            r"INSERT INTO l1_state (
+            r"INSERT OR REPLACE INTO l1_state (
                         starknet_block_number,
                         starknet_global_root,
                         ethereum_block_hash,
@@ -1075,7 +1075,7 @@ mod tests {
 
                 let updates = create_updates();
                 for update in &updates {
-                    L1StateTable::insert(&connection, update).unwrap();
+                    L1StateTable::upsert(&connection, update).unwrap();
                 }
 
                 let non_existent = updates.last().unwrap().block_number + 1;
@@ -1092,7 +1092,7 @@ mod tests {
 
                 let updates = create_updates();
                 for update in &updates {
-                    L1StateTable::insert(&connection, update).unwrap();
+                    L1StateTable::upsert(&connection, update).unwrap();
                 }
 
                 for (idx, update) in updates.iter().enumerate() {
@@ -1128,7 +1128,7 @@ mod tests {
 
                     let updates = create_updates();
                     for update in &updates {
-                        L1StateTable::insert(&connection, update).unwrap();
+                        L1StateTable::upsert(&connection, update).unwrap();
                     }
 
                     assert_eq!(
@@ -1151,7 +1151,7 @@ mod tests {
 
                 let updates = create_updates();
                 for update in &updates {
-                    L1StateTable::insert(&connection, update).unwrap();
+                    L1StateTable::upsert(&connection, update).unwrap();
                 }
 
                 let non_existent = updates.last().unwrap().block_number + 1;
@@ -1168,7 +1168,7 @@ mod tests {
 
                 let updates = create_updates();
                 for update in &updates {
-                    L1StateTable::insert(&connection, update).unwrap();
+                    L1StateTable::upsert(&connection, update).unwrap();
                 }
 
                 for (idx, update) in updates.iter().enumerate() {
@@ -1202,7 +1202,7 @@ mod tests {
 
                     let updates = create_updates();
                     for update in &updates {
-                        L1StateTable::insert(&connection, update).unwrap();
+                        L1StateTable::upsert(&connection, update).unwrap();
                     }
 
                     assert_eq!(
@@ -1223,7 +1223,7 @@ mod tests {
 
                 let updates = create_updates();
                 for update in &updates {
-                    L1StateTable::insert(&connection, update).unwrap();
+                    L1StateTable::upsert(&connection, update).unwrap();
                 }
 
                 L1StateTable::reorg(&connection, StarknetBlockNumber::GENESIS).unwrap();
@@ -1241,7 +1241,7 @@ mod tests {
 
                 let updates = create_updates();
                 for update in &updates {
-                    L1StateTable::insert(&connection, update).unwrap();
+                    L1StateTable::upsert(&connection, update).unwrap();
                 }
 
                 let reorg_tail = updates[1].block_number;


### PR DESCRIPTION
This PR reverts the L1 bug audit added in PR #382.

We can trigger this bug manually now, and appears related to Alchemy endpoint.

The audit and crash logs are quite interruptive for users, and we are not getting more information anymore. So removing this makes sense.

We will continue to investigate manually.