### PR TITLE
fix(py): lower logging levels

### DIFF
--- a/py/src/call.py
+++ b/py/src/call.py
@@ -140,8 +140,10 @@ def do_loop(connection, input_gen, output_file):
 
 
 def report_failed(logger, command, e):
-    logger.debug(f"{command}")
-    logger.error(str(e))
+    logger.trace(f"{command}")
+    # we cannot log errors at higher than info, which is the default level, to
+    # allow opting in to these and not forcing them on everyone
+    logger.debug(str(e))
 
 
 def loop_inner(connection, command):


### PR DESCRIPTION
original idea was that calls and fee estimations are rare, we should log them at error. after looking more into filtering with tracing_subscriber, i learned one cannot turn off by span, only to enable them, which is why these messages need to be under the default level of INFO in order to be opted-in.