### PR TITLE
feat: separate type for pending blocks

### DIFF
--- a/crates/pathfinder/examples/verify_block_hashes.rs
+++ b/crates/pathfinder/examples/verify_block_hashes.rs
@@ -46,12 +46,12 @@ fn main() -> anyhow::Result<()> {
             transactions_and_receipts.into_iter().unzip();
 
         let block = Block {
-            block_hash: Some(block.hash),
-            block_number: Some(block.number),
+            block_hash: block.hash,
+            block_number: block.number,
             gas_price: Some(block.gas_price),
             parent_block_hash,
             sequencer_address: Some(block.sequencer_address),
-            state_root: Some(block.root),
+            state_root: block.root,
             status: Status::AcceptedOnL1,
             timestamp: block.timestamp,
             transaction_receipts: receipts,

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -506,10 +506,10 @@ impl RpcApi {
 
                 return block
                     .transactions()
-                    .into_iter()
+                    .iter()
                     .nth(index)
                     .map_or(Err(ErrorCode::InvalidTransactionIndex.into()), |txn| {
-                        Ok(txn.clone().into())
+                        Ok(txn.into())
                     });
             }
         };
@@ -579,7 +579,7 @@ impl RpcApi {
 
                 return block
                     .transactions()
-                    .into_iter()
+                    .iter()
                     .nth(index)
                     .map_or(Err(ErrorCode::InvalidTransactionIndex.into()), |txn| {
                         Ok(txn.clone().into())

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -505,11 +505,11 @@ impl RpcApi {
                     .map_err(internal_server_error)?;
 
                 return block
-                    .transactions
+                    .transactions()
                     .into_iter()
                     .nth(index)
                     .map_or(Err(ErrorCode::InvalidTransactionIndex.into()), |txn| {
-                        Ok(txn.into())
+                        Ok(txn.clone().into())
                     });
             }
         };
@@ -578,11 +578,11 @@ impl RpcApi {
                     .map_err(internal_server_error)?;
 
                 return block
-                    .transactions
+                    .transactions()
                     .into_iter()
                     .nth(index)
                     .map_or(Err(ErrorCode::InvalidTransactionIndex.into()), |txn| {
-                        Ok(txn.into())
+                        Ok(txn.clone().into())
                     });
             }
         };
@@ -854,7 +854,7 @@ impl RpcApi {
                     .map_err(internal_server_error)?;
 
                 let len: u64 =
-                    block.transactions.len().try_into().map_err(|e| {
+                    block.transactions().len().try_into().map_err(|e| {
                         Error::Call(CallError::InvalidParams(anyhow::Error::new(e)))
                     })?;
 
@@ -919,7 +919,7 @@ impl RpcApi {
                     .map_err(internal_server_error)?;
 
                 let len: u64 =
-                    block.transactions.len().try_into().map_err(|e| {
+                    block.transactions().len().try_into().map_err(|e| {
                         Error::Call(CallError::InvalidParams(anyhow::Error::new(e)))
                     })?;
 

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -359,21 +359,21 @@ pub mod reply {
                 BlockResponseScope::TransactionHashes => {
                     let hashes = block
                         .transactions()
-                        .into_iter()
+                        .iter()
                         .map(|t| t.transaction_hash)
                         .collect();
 
                     Transactions::HashesOnly(hashes)
                 }
                 BlockResponseScope::FullTransactions => {
-                    let transactions = block.transactions().into_iter().map(|t| t.into()).collect();
+                    let transactions = block.transactions().iter().map(|t| t.into()).collect();
                     Transactions::Full(transactions)
                 }
                 BlockResponseScope::FullTransactionsAndReceipts => {
                     let with_receipts = block
                         .transactions()
-                        .into_iter()
-                        .zip(block.receipts().into_iter())
+                        .iter()
+                        .zip(block.receipts().iter())
                         .map(|(t, r)| {
                             let t: Transaction = t.into();
                             let r =

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -325,6 +325,7 @@ pub mod reply {
         pub status: BlockStatus,
         pub sequencer: SequencerAddress,
         pub new_root: Option<GlobalRoot>,
+        // FIXME: remove this field
         pub old_root: GlobalRoot,
         pub accepted_time: StarknetBlockTimestamp,
         #[serde_as(as = "GasPriceAsHexStr")]
@@ -351,65 +352,121 @@ pub mod reply {
 
         /// Constructs [Block] from [sequencer's block representation](crate::sequencer::reply::Block)
         pub fn from_sequencer_scoped(
-            block: sequencer::reply::Block,
+            block: sequencer::reply::MaybePendingBlock,
             scope: BlockResponseScope,
         ) -> Self {
-            Self {
-                block_hash: block.block_hash,
-                parent_hash: block.parent_block_hash,
-                block_number: block.block_number,
-                status: block.status.into(),
-                sequencer: block
-                    .sequencer_address
-                    // Default value for cairo <0.8.0 is 0
-                    .unwrap_or(SequencerAddress(StarkHash::ZERO)),
-                new_root: block.state_root,
-                // TODO where to get it from
-                old_root: GlobalRoot(StarkHash::ZERO),
-                accepted_time: block.timestamp,
-                gas_price: block
-                    .gas_price
-                    // Default value for cairo <0.8.2 is 0
-                    .unwrap_or(GasPrice::ZERO),
+            use sequencer::reply::MaybePendingBlock;
+            match block {
+                MaybePendingBlock::Block(block) => Self {
+                    block_hash: block.block_hash,
+                    parent_hash: block.parent_block_hash,
+                    block_number: block.block_number,
+                    status: block.status.into(),
+                    sequencer: block
+                        .sequencer_address
+                        // Default value for cairo <0.8.0 is 0
+                        .unwrap_or(SequencerAddress(StarkHash::ZERO)),
+                    new_root: block.state_root,
+                    old_root: GlobalRoot(StarkHash::ZERO),
+                    accepted_time: block.timestamp,
+                    gas_price: block
+                        .gas_price
+                        // Default value for cairo <0.8.2 is 0
+                        .unwrap_or(GasPrice::ZERO),
 
-                transactions: match scope {
-                    BlockResponseScope::TransactionHashes => Transactions::HashesOnly(
-                        block
-                            .transactions
-                            .into_iter()
-                            .map(|t| t.transaction_hash)
-                            .collect(),
-                    ),
-                    BlockResponseScope::FullTransactions => Transactions::Full(
-                        block.transactions.into_iter().map(|t| t.into()).collect(),
-                    ),
-                    BlockResponseScope::FullTransactionsAndReceipts => {
-                        Transactions::FullWithReceipts(
+                    transactions: match scope {
+                        BlockResponseScope::TransactionHashes => Transactions::HashesOnly(
                             block
                                 .transactions
                                 .into_iter()
-                                .zip(block.transaction_receipts.into_iter())
-                                .map(|(t, r)| {
-                                    let t: Transaction = t.into();
-                                    let r = TransactionReceipt::with_status(r, block.status.into());
-
-                                    TransactionAndReceipt {
-                                        txn_hash: t.txn_hash,
-                                        contract_address: t.contract_address,
-                                        entry_point_selector: t.entry_point_selector,
-                                        calldata: t.calldata,
-                                        max_fee: t.max_fee,
-                                        actual_fee: r.actual_fee,
-                                        status: r.status,
-                                        status_data: r.status_data,
-                                        messages_sent: r.messages_sent,
-                                        l1_origin_message: r.l1_origin_message,
-                                        events: r.events,
-                                    }
-                                })
+                                .map(|t| t.transaction_hash)
                                 .collect(),
-                        )
-                    }
+                        ),
+                        BlockResponseScope::FullTransactions => Transactions::Full(
+                            block.transactions.into_iter().map(|t| t.into()).collect(),
+                        ),
+                        BlockResponseScope::FullTransactionsAndReceipts => {
+                            Transactions::FullWithReceipts(
+                                block
+                                    .transactions
+                                    .into_iter()
+                                    .zip(block.transaction_receipts.into_iter())
+                                    .map(|(t, r)| {
+                                        let t: Transaction = t.into();
+                                        let r =
+                                            TransactionReceipt::with_status(r, block.status.into());
+
+                                        TransactionAndReceipt {
+                                            txn_hash: t.txn_hash,
+                                            contract_address: t.contract_address,
+                                            entry_point_selector: t.entry_point_selector,
+                                            calldata: t.calldata,
+                                            max_fee: t.max_fee,
+                                            actual_fee: r.actual_fee,
+                                            status: r.status,
+                                            status_data: r.status_data,
+                                            messages_sent: r.messages_sent,
+                                            l1_origin_message: r.l1_origin_message,
+                                            events: r.events,
+                                        }
+                                    })
+                                    .collect(),
+                            )
+                        }
+                    },
+                },
+                MaybePendingBlock::Pending(pending) => Self {
+                    block_hash: None,
+                    parent_hash: pending.parent_hash,
+                    block_number: None,
+                    status: pending.status.into(),
+                    sequencer: pending.sequencer_address,
+                    new_root: None,
+                    old_root: GlobalRoot(StarkHash::ZERO),
+                    accepted_time: pending.timestamp,
+                    gas_price: pending.gas_price,
+                    transactions: match scope {
+                        BlockResponseScope::TransactionHashes => Transactions::HashesOnly(
+                            pending
+                                .transactions
+                                .into_iter()
+                                .map(|t| t.transaction_hash)
+                                .collect(),
+                        ),
+                        BlockResponseScope::FullTransactions => Transactions::Full(
+                            pending.transactions.into_iter().map(|t| t.into()).collect(),
+                        ),
+                        BlockResponseScope::FullTransactionsAndReceipts => {
+                            Transactions::FullWithReceipts(
+                                pending
+                                    .transactions
+                                    .into_iter()
+                                    .zip(pending.transaction_receipts.into_iter())
+                                    .map(|(t, r)| {
+                                        let t: Transaction = t.into();
+                                        let r = TransactionReceipt::with_status(
+                                            r,
+                                            pending.status.into(),
+                                        );
+
+                                        TransactionAndReceipt {
+                                            txn_hash: t.txn_hash,
+                                            contract_address: t.contract_address,
+                                            entry_point_selector: t.entry_point_selector,
+                                            calldata: t.calldata,
+                                            max_fee: t.max_fee,
+                                            actual_fee: r.actual_fee,
+                                            status: r.status,
+                                            status_data: r.status_data,
+                                            messages_sent: r.messages_sent,
+                                            l1_origin_message: r.l1_origin_message,
+                                            events: r.events,
+                                        }
+                                    })
+                                    .collect(),
+                            )
+                        }
+                    },
                 },
             }
         }

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -20,7 +20,7 @@ use std::{fmt::Debug, result::Result, time::Duration};
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
 pub trait ClientApi {
-    async fn block(&self, block: BlockId) -> Result<reply::Block, SequencerError>;
+    async fn block(&self, block: BlockId) -> Result<reply::MaybePendingBlock, SequencerError>;
 
     async fn call(
         &self,
@@ -154,8 +154,9 @@ impl Client {
         let genesis_hash = self
             .block(StarknetBlockNumber::GENESIS.into())
             .await?
-            .block_hash
-            .unwrap();
+            .as_block()
+            .expect("Genesis block should not be pending")
+            .block_hash;
 
         match genesis_hash {
             goerli if goerli == *GOERLI_GENESIS_HASH => Ok(Chain::Goerli),
@@ -168,7 +169,7 @@ impl Client {
 #[async_trait::async_trait]
 impl ClientApi for Client {
     #[tracing::instrument(skip(self))]
-    async fn block(&self, block: BlockId) -> Result<reply::Block, SequencerError> {
+    async fn block(&self, block: BlockId) -> Result<reply::MaybePendingBlock, SequencerError> {
         self.request()
             .feeder_gateway()
             .get_block()

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -616,12 +616,12 @@ mod tests {
                 assert_eq!(version, env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT"));
 
                 Ok::<_, Infallible>(warp::reply::json(&Block {
-                    block_hash: None,
-                    block_number: None,
+                    block_hash: StarknetBlockHash(StarkHash::ZERO),
+                    block_number: StarknetBlockNumber::GENESIS,
                     gas_price: None,
                     parent_block_hash: StarknetBlockHash(StarkHash::ZERO),
                     sequencer_address: None,
-                    state_root: None,
+                    state_root: crate::core::GlobalRoot(StarkHash::ZERO),
                     status: Status::NotReceived,
                     timestamp: StarknetBlockTimestamp(0),
                     transaction_receipts: vec![],


### PR DESCRIPTION
This PR creates a separate type for pending blocks. The current block type contains many `Option<T>` fields to cater for the pending variant for which these don't exist. This PR therefore also simplifies the non-pending block variant by removing the `Option` for these fields.

The Sequencer's block query now returns a `MaybePendingBlock` which is an enum with `Pending` and `Block` variants. An alternative solution is to separate the query for `pending` blocks from the rest, but I deemed too disruptive for now. To make it easier I added `as_block() -> Option<Block>` to the enum which means in cases where you are certain you didn't request a `pending` block you can `.unwrap()`.

This is an internal only change, so this does not need to be part of the current release.