### PR TITLE
feat: reduce mainnet poll rate to 5 minutes

### DIFF
--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -616,8 +616,8 @@ pub fn head_poll_interval(chain: crate::core::Chain) -> std::time::Duration {
     use std::time::Duration;
 
     match chain {
-        // 15 minute interval for a 2 hour block time.
-        Mainnet => Duration::from_secs(60 * 15),
+        // 5 minute interval for a 30 hour block time.
+        Mainnet => Duration::from_secs(60 * 5),
         // 30 second interval for a 2 minute block time.
         Goerli => Duration::from_secs(30),
     }


### PR DESCRIPTION
As requested by StarkWare to match the new 30 minute block time.