### PR TITLE
feat: local pending

### DIFF
--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -86,7 +86,7 @@ Hint: Make sure the provided ethereum.url and ethereum.password are good.",
         sync_state.clone(),
         state::l1::sync,
         state::l2::sync,
-        pending_state,
+        pending_state.clone(),
         pending_interval,
     ));
 
@@ -105,9 +105,15 @@ Hint: Make sure the provided ethereum.url and ethereum.password are good.",
 
     let shared = rpc::api::Cached::new(Arc::new(eth_transport));
 
-    let api = rpc::api::RpcApi::new(storage, sequencer, ethereum_chain, sync_state)
-        .with_call_handling(call_handle)
-        .with_eth_gas_price(shared);
+    let api = rpc::api::RpcApi::new(
+        storage,
+        sequencer,
+        ethereum_chain,
+        sync_state,
+        pending_state,
+    )
+    .with_call_handling(call_handle)
+    .with_eth_gas_price(shared);
 
     let (rpc_handle, local_addr) = rpc::run_server(config.http_rpc_addr, api)
         .await

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -8,7 +8,6 @@ use pathfinder_lib::{
     storage::{JournalMode, Storage},
 };
 use std::sync::Arc;
-use tokio::sync::RwLock;
 use tracing::info;
 
 #[tokio::main]
@@ -73,7 +72,7 @@ Hint: Make sure the provided ethereum.url and ethereum.password are good.",
         None => sequencer::Client::new(ethereum_chain).unwrap(),
     };
     let sync_state = Arc::new(state::SyncState::default());
-    let pending_state = Arc::new(RwLock::new(None));
+    let pending_state = Arc::new(state::PendingData::default());
     let pending_interval = match config.poll_pending {
         true => Some(std::time::Duration::from_secs(5)),
         false => None,

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -72,7 +72,7 @@ Hint: Make sure the provided ethereum.url and ethereum.password are good.",
         None => sequencer::Client::new(ethereum_chain).unwrap(),
     };
     let sync_state = Arc::new(state::SyncState::default());
-    let pending_state = Arc::new(state::PendingData::default());
+    let pending_state = state::PendingData::default();
     let pending_interval = match config.poll_pending {
         true => Some(std::time::Duration::from_secs(5)),
         false => None,

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -40,7 +40,7 @@ async fn main() -> anyhow::Result<()> {
 Hint: Make sure the provided ethereum.url and ethereum.password are good.",
     )?;
 
-    // Pending is only supported on mainnet.
+    // Pending is only for use on mainnet as it is meant as a work-around for slow block times.
     anyhow::ensure!(
         !(config.poll_pending && ethereum_chain != core::Chain::Mainnet),
         "Poll pending option may only be enabled on Mainnet"

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -105,15 +105,14 @@ Hint: Make sure the provided ethereum.url and ethereum.password are good.",
 
     let shared = rpc::api::Cached::new(Arc::new(eth_transport));
 
-    let api = rpc::api::RpcApi::new(
-        storage,
-        sequencer,
-        ethereum_chain,
-        sync_state,
-        pending_state,
-    )
-    .with_call_handling(call_handle)
-    .with_eth_gas_price(shared);
+    let api = rpc::api::RpcApi::new(storage, sequencer, ethereum_chain, sync_state)
+        .with_call_handling(call_handle)
+        .with_eth_gas_price(shared);
+
+    let api = match config.poll_pending {
+        true => api.with_pending_data(pending_state),
+        false => api,
+    };
 
     let (rpc_handle, local_addr) = rpc::run_server(config.http_rpc_addr, api)
         .await

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -8,6 +8,7 @@ use pathfinder_lib::{
     storage::{JournalMode, Storage},
 };
 use std::sync::Arc;
+use tokio::sync::RwLock;
 use tracing::info;
 
 #[tokio::main]
@@ -66,6 +67,7 @@ Hint: Make sure the provided ethereum.url and ethereum.password are good.",
         None => sequencer::Client::new(ethereum_chain).unwrap(),
     };
     let sync_state = Arc::new(state::SyncState::default());
+    let pending_state = Arc::new(RwLock::new(None));
 
     let sync_handle = tokio::spawn(state::sync(
         storage.clone(),
@@ -75,6 +77,8 @@ Hint: Make sure the provided ethereum.url and ethereum.password are good.",
         sync_state.clone(),
         state::l1::sync,
         state::l2::sync,
+        pending_state,
+        None,
     ));
 
     // TODO: the error could be recovered, but currently it's required for startup. There should

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -27,6 +27,8 @@ pub enum ConfigOption {
     PythonSubprocesses,
     /// Enable SQLite write-ahead logging.
     EnableSQLiteWriteAheadLogging,
+    /// Enable pending polling.
+    PollPending,
 }
 
 impl Display for ConfigOption {
@@ -41,6 +43,7 @@ impl Display for ConfigOption {
             ConfigOption::EnableSQLiteWriteAheadLogging => {
                 f.write_str("Enable SQLite write-ahead logging")
             }
+            ConfigOption::PollPending => f.write_str("Enable pending block polling"),
         }
     }
 }
@@ -69,6 +72,8 @@ pub struct Configuration {
     pub python_subprocesses: std::num::NonZeroUsize,
     /// Enable SQLite write-ahead logging.
     pub sqlite_wal: bool,
+    /// Enable pending polling.
+    pub poll_pending: bool,
 }
 
 impl Configuration {

--- a/crates/pathfinder/src/config/builder.rs
+++ b/crates/pathfinder/src/config/builder.rs
@@ -129,6 +129,24 @@ Hint: Register your own account or run your own Ethereum node and put the real U
             )
         })?;
 
+        let poll_pending = match self.take(ConfigOption::PollPending) {
+            Some(enable) => {
+                let enable = enable.to_lowercase();
+                match enable.as_str() {
+                    "true" => Ok(true),
+                    "false" => Ok(false),
+                    _ => Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        format!(
+                            "Invalid value '{}' for enable poll pending option, must be true|false",
+                            enable
+                        ),
+                    )),
+                }
+            }
+            None => Ok(false),
+        }?;
+
         Ok(Configuration {
             ethereum: EthereumConfig {
                 url: eth_url,
@@ -139,6 +157,7 @@ Hint: Register your own account or run your own Ethereum node and put the real U
             sequencer_url,
             python_subprocesses,
             sqlite_wal,
+            poll_pending,
         })
     }
 

--- a/crates/pathfinder/src/config/file.rs
+++ b/crates/pathfinder/src/config/file.rs
@@ -22,6 +22,8 @@ struct FileConfig {
     python_subprocesses: Option<String>,
     #[serde(rename = "sqlite-wal")]
     sqlite_wal: Option<String>,
+    #[serde(rename = "poll-pending")]
+    poll_pending: Option<String>,
 }
 
 impl FileConfig {
@@ -38,6 +40,7 @@ impl FileConfig {
         .with(ConfigOption::SequencerHttpUrl, self.sequencer_url)
         .with(ConfigOption::PythonSubprocesses, self.python_subprocesses)
         .with(ConfigOption::EnableSQLiteWriteAheadLogging, self.sqlite_wal)
+        .with(ConfigOption::PollPending, self.poll_pending)
     }
 }
 
@@ -132,6 +135,14 @@ password = "{}""#,
             cfg.take(ConfigOption::EnableSQLiteWriteAheadLogging),
             Some(value)
         );
+    }
+
+    #[test]
+    fn poll_pending() {
+        let value = "true".to_owned();
+        let toml = format!(r#"poll-pending = "{}""#, value);
+        let mut cfg = config_from_str(&toml).unwrap();
+        assert_eq!(cfg.take(ConfigOption::PollPending), Some(value));
     }
 
     #[test]

--- a/crates/pathfinder/src/ethereum/state_update.rs
+++ b/crates/pathfinder/src/ethereum/state_update.rs
@@ -45,11 +45,11 @@ pub struct StateUpdate {
     pub contract_updates: Vec<ContractUpdate>,
 }
 
-impl From<crate::sequencer::reply::state_update::StateDiff> for StateUpdate {
-    fn from(diff: crate::sequencer::reply::state_update::StateDiff) -> Self {
+impl From<&crate::sequencer::reply::state_update::StateDiff> for StateUpdate {
+    fn from(diff: &crate::sequencer::reply::state_update::StateDiff) -> Self {
         let deployed_contracts = diff
             .deployed_contracts
-            .into_iter()
+            .iter()
             .map(|contract| DeployedContract {
                 address: contract.address,
                 hash: contract.contract_hash,
@@ -60,7 +60,7 @@ impl From<crate::sequencer::reply::state_update::StateDiff> for StateUpdate {
 
         let contract_updates = diff
             .storage_diffs
-            .into_iter()
+            .iter()
             .map(|contract_update| {
                 let storage_updates = contract_update
                     .1
@@ -72,7 +72,7 @@ impl From<crate::sequencer::reply::state_update::StateDiff> for StateUpdate {
                     .collect();
 
                 ContractUpdate {
-                    address: contract_update.0,
+                    address: *contract_update.0,
                     storage_updates,
                 }
             })

--- a/crates/pathfinder/src/ethereum/state_update.rs
+++ b/crates/pathfinder/src/ethereum/state_update.rs
@@ -53,7 +53,8 @@ impl From<crate::sequencer::reply::state_update::StateDiff> for StateUpdate {
             .map(|contract| DeployedContract {
                 address: contract.address,
                 hash: contract.contract_hash,
-                call_data: vec![], // todo!("This is missing from sequencer API..."),
+                // TODO This is missing from sequencer API
+                call_data: vec![],
             })
             .collect::<Vec<_>>();
 

--- a/crates/pathfinder/src/ethereum/state_update.rs
+++ b/crates/pathfinder/src/ethereum/state_update.rs
@@ -64,7 +64,7 @@ impl From<&crate::sequencer::reply::state_update::StateDiff> for StateUpdate {
             .map(|contract_update| {
                 let storage_updates = contract_update
                     .1
-                    .into_iter()
+                    .iter()
                     .map(|diff| StorageUpdate {
                         address: diff.key,
                         value: diff.value,

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -788,17 +788,10 @@ mod tests {
 
         #[tokio::test]
         async fn genesis() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let genesis_hash = StarknetBlockHash(StarkHash::from_be_slice(b"genesis").unwrap());
             let params = rpc_params!(genesis_hash);
@@ -823,17 +816,10 @@ mod tests {
 
                 #[tokio::test]
                 async fn all() {
-                    let (storage, pending) = setup_storage().await;
-                    let pending = Arc::new(pending);
+                    let (storage, _) = setup_storage().await;
                     let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
-                    let api = RpcApi::new(
-                        storage,
-                        sequencer,
-                        Chain::Goerli,
-                        sync_state,
-                        pending.clone(),
-                    );
+                    let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                     let latest_hash =
                         StarknetBlockHash(StarkHash::from_be_slice(b"latest").unwrap());
@@ -855,17 +841,10 @@ mod tests {
 
                 #[tokio::test]
                 async fn only_mandatory() {
-                    let (storage, pending) = setup_storage().await;
-                    let pending = Arc::new(pending);
+                    let (storage, _) = setup_storage().await;
                     let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
-                    let api = RpcApi::new(
-                        storage,
-                        sequencer,
-                        Chain::Goerli,
-                        sync_state,
-                        pending.clone(),
-                    );
+                    let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                     let latest_hash =
                         StarknetBlockHash(StarkHash::from_be_slice(b"latest").unwrap());
@@ -890,17 +869,10 @@ mod tests {
 
                 #[tokio::test]
                 async fn all() {
-                    let (storage, pending) = setup_storage().await;
-                    let pending = Arc::new(pending);
+                    let (storage, _) = setup_storage().await;
                     let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
-                    let api = RpcApi::new(
-                        storage,
-                        sequencer,
-                        Chain::Goerli,
-                        sync_state,
-                        pending.clone(),
-                    );
+                    let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                     let latest_hash =
                         StarknetBlockHash(StarkHash::from_be_slice(b"latest").unwrap());
@@ -922,17 +894,10 @@ mod tests {
 
                 #[tokio::test]
                 async fn only_mandatory() {
-                    let (storage, pending) = setup_storage().await;
-                    let pending = Arc::new(pending);
+                    let (storage, _) = setup_storage().await;
                     let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
-                    let api = RpcApi::new(
-                        storage,
-                        sequencer,
-                        Chain::Goerli,
-                        sync_state,
-                        pending.clone(),
-                    );
+                    let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                     let latest_hash =
                         StarknetBlockHash(StarkHash::from_be_slice(b"latest").unwrap());
@@ -957,13 +922,8 @@ mod tests {
             let pending = Arc::new(pending);
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
+                .with_pending_data(pending.clone());
             let scope = BlockResponseScope::FullTransactions;
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(BlockHashOrTag::Tag(Tag::Pending), scope.clone());
@@ -979,17 +939,10 @@ mod tests {
 
         #[tokio::test]
         async fn invalid_block_hash() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(StarknetBlockHash(StarkHash::ZERO));
             let error = client(addr)
@@ -1011,17 +964,10 @@ mod tests {
 
         #[tokio::test]
         async fn genesis() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(StarknetBlockNumber(0));
             let block = client(addr)
@@ -1044,17 +990,10 @@ mod tests {
 
                 #[tokio::test]
                 async fn all() {
-                    let (storage, pending) = setup_storage().await;
-                    let pending = Arc::new(pending);
+                    let (storage, _) = setup_storage().await;
                     let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
-                    let api = RpcApi::new(
-                        storage,
-                        sequencer,
-                        Chain::Goerli,
-                        sync_state,
-                        pending.clone(),
-                    );
+                    let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                     let params = rpc_params!(
                         BlockNumberOrTag::Tag(Tag::Latest),
@@ -1073,17 +1012,10 @@ mod tests {
 
                 #[tokio::test]
                 async fn only_mandatory() {
-                    let (storage, pending) = setup_storage().await;
-                    let pending = Arc::new(pending);
+                    let (storage, _) = setup_storage().await;
                     let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
-                    let api = RpcApi::new(
-                        storage,
-                        sequencer,
-                        Chain::Goerli,
-                        sync_state,
-                        pending.clone(),
-                    );
+                    let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                     let params = rpc_params!(BlockNumberOrTag::Tag(Tag::Latest));
                     let block = client(addr)
@@ -1105,17 +1037,10 @@ mod tests {
 
                 #[tokio::test]
                 async fn all() {
-                    let (storage, pending) = setup_storage().await;
-                    let pending = Arc::new(pending);
+                    let (storage, _) = setup_storage().await;
                     let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
-                    let api = RpcApi::new(
-                        storage,
-                        sequencer,
-                        Chain::Goerli,
-                        sync_state,
-                        pending.clone(),
-                    );
+                    let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                     let params = by_name([
                         ("block_number", json!("latest")),
@@ -1140,17 +1065,10 @@ mod tests {
 
                 #[tokio::test]
                 async fn only_mandatory() {
-                    let (storage, pending) = setup_storage().await;
-                    let pending = Arc::new(pending);
+                    let (storage, _) = setup_storage().await;
                     let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
-                    let api = RpcApi::new(
-                        storage,
-                        sequencer,
-                        Chain::Goerli,
-                        sync_state,
-                        pending.clone(),
-                    );
+                    let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                     let params = by_name([("block_number", json!("latest"))]);
                     let block = client(addr)
@@ -1178,13 +1096,8 @@ mod tests {
             let pending = Arc::new(pending);
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
+                .with_pending_data(pending.clone());
             let scope = BlockResponseScope::FullTransactions;
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(BlockHashOrTag::Tag(Tag::Pending), scope.clone());
@@ -1200,17 +1113,10 @@ mod tests {
 
         #[tokio::test]
         async fn invalid_number() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(StarknetBlockNumber(123));
             let error = client(addr)
@@ -1231,17 +1137,10 @@ mod tests {
         #[tokio::test]
         #[should_panic]
         async fn genesis() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(*GENESIS_BLOCK_HASH);
             client(addr)
@@ -1253,17 +1152,10 @@ mod tests {
         #[tokio::test]
         #[should_panic]
         async fn latest() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(BlockHashOrTag::Tag(Tag::Latest));
             client(addr)
@@ -1274,17 +1166,10 @@ mod tests {
 
         #[tokio::test]
         async fn pending() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(BlockHashOrTag::Tag(Tag::Pending));
             let result = client(addr)
@@ -1306,17 +1191,10 @@ mod tests {
         async fn key_is_field_modulus() {
             use std::str::FromStr;
 
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 ContractAddress(StarkHash::from_be_slice(b"contract 0").unwrap()),
@@ -1340,17 +1218,10 @@ mod tests {
         async fn key_is_less_than_modulus_but_252_bits() {
             use std::str::FromStr;
 
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 ContractAddress(StarkHash::from_be_slice(b"contract 0").unwrap()),
@@ -1372,17 +1243,10 @@ mod tests {
 
         #[tokio::test]
         async fn non_existent_contract_address() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 ContractAddress(StarkHash::from_be_slice(b"nonexistent").unwrap()),
@@ -1398,17 +1262,10 @@ mod tests {
 
         #[tokio::test]
         async fn pre_deploy_block_hash() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 ContractAddress(StarkHash::from_be_slice(b"contract 1").unwrap()),
@@ -1426,17 +1283,10 @@ mod tests {
 
         #[tokio::test]
         async fn non_existent_block_hash() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 ContractAddress(StarkHash::from_be_slice(b"contract 1").unwrap()),
@@ -1454,17 +1304,10 @@ mod tests {
 
         #[tokio::test]
         async fn deployment_block() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 ContractAddress(StarkHash::from_be_slice(b"contract 1").unwrap()),
@@ -1489,17 +1332,10 @@ mod tests {
 
             #[tokio::test]
             async fn positional_args() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(
                     ContractAddress(StarkHash::from_be_slice(b"contract 1").unwrap()),
@@ -1518,17 +1354,10 @@ mod tests {
 
             #[tokio::test]
             async fn named_args() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = by_name([
                     (
@@ -1558,13 +1387,8 @@ mod tests {
             let pending = Arc::new(pending);
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
+                .with_pending_data(pending.clone());
 
             // Grab some pending data to test against.
             let pending_diff = pending.state_update().await.unwrap();
@@ -1615,18 +1439,11 @@ mod tests {
 
             #[tokio::test]
             async fn positional_args() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let hash = StarknetTransactionHash(StarkHash::from_be_slice(b"txn 0").unwrap());
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(hash);
                 let transaction = client(addr)
@@ -1638,18 +1455,11 @@ mod tests {
 
             #[tokio::test]
             async fn named_args() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let hash = StarknetTransactionHash(StarkHash::from_be_slice(b"txn 0").unwrap());
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = by_name([("transaction_hash", json!(hash))]);
                 let transaction = client(addr)
@@ -1662,17 +1472,10 @@ mod tests {
 
         #[tokio::test]
         async fn invalid_hash() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(*INVALID_TX_HASH);
             let error = client(addr)
@@ -1693,17 +1496,10 @@ mod tests {
 
         #[tokio::test]
         async fn genesis() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let genesis_hash = StarknetBlockHash(StarkHash::from_be_slice(b"genesis").unwrap());
             let params = rpc_params!(genesis_hash, 0);
@@ -1723,17 +1519,10 @@ mod tests {
 
             #[tokio::test]
             async fn positional_args() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(BlockHashOrTag::Tag(Tag::Latest), 0);
                 let txn = client(addr)
@@ -1748,17 +1537,10 @@ mod tests {
 
             #[tokio::test]
             async fn named_args() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = by_name([("block_hash", json!("latest")), ("index", json!(0))]);
                 let txn = client(addr)
@@ -1778,13 +1560,8 @@ mod tests {
             let pending = Arc::new(pending);
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
+                .with_pending_data(pending.clone());
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(BlockHashOrTag::Tag(Tag::Pending), 0);
             let transaction = client(addr)
@@ -1798,17 +1575,10 @@ mod tests {
 
         #[tokio::test]
         async fn invalid_block() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(StarknetBlockHash(StarkHash::ZERO), 0);
             let error = client(addr)
@@ -1820,17 +1590,10 @@ mod tests {
 
         #[tokio::test]
         async fn invalid_transaction_index() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let genesis_hash = StarknetBlockHash(StarkHash::from_be_slice(b"genesis").unwrap());
             let params = rpc_params!(genesis_hash, 123);
@@ -1852,17 +1615,10 @@ mod tests {
 
         #[tokio::test]
         async fn genesis() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(0, 0);
             let txn = client(addr)
@@ -1881,17 +1637,10 @@ mod tests {
 
             #[tokio::test]
             async fn positional_args() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(BlockNumberOrTag::Tag(Tag::Latest), 0);
                 let txn = client(addr)
@@ -1906,17 +1655,10 @@ mod tests {
 
             #[tokio::test]
             async fn named_args() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = by_name([("block_number", json!("latest")), ("index", json!(0))]);
                 let txn = client(addr)
@@ -1936,13 +1678,8 @@ mod tests {
             let pending = Arc::new(pending);
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
+                .with_pending_data(pending.clone());
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(BlockNumberOrTag::Tag(Tag::Pending), 0);
             let transaction = client(addr)
@@ -1956,17 +1693,10 @@ mod tests {
 
         #[tokio::test]
         async fn invalid_block() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(123, 0);
             let error = client(addr)
@@ -1981,17 +1711,10 @@ mod tests {
 
         #[tokio::test]
         async fn invalid_transaction_index() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(0, 123);
             let error = client(addr)
@@ -2016,17 +1739,10 @@ mod tests {
 
             #[tokio::test]
             async fn positional_args() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let txn_hash = StarknetTransactionHash(StarkHash::from_be_slice(b"txn 0").unwrap());
                 let params = rpc_params!(txn_hash);
@@ -2043,17 +1759,10 @@ mod tests {
 
             #[tokio::test]
             async fn named_args() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let txn_hash = StarknetTransactionHash(StarkHash::from_be_slice(b"txn 0").unwrap());
                 let params = by_name([("transaction_hash", json!(txn_hash))]);
@@ -2071,17 +1780,10 @@ mod tests {
 
         #[tokio::test]
         async fn invalid() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let txn_hash = StarknetTransactionHash(StarkHash::from_be_slice(b"not found").unwrap());
             let params = rpc_params!(txn_hash);
@@ -2108,17 +1810,10 @@ mod tests {
 
             #[tokio::test]
             async fn returns_invalid_contract_class_hash_for_nonexistent_class() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(*INVALID_CLASS_HASH);
                 let error = client(addr)
@@ -2130,8 +1825,7 @@ mod tests {
 
             #[tokio::test]
             async fn returns_program_and_entry_points_for_known_class() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
 
                 let mut conn = storage.connection().unwrap();
                 let transaction = conn.transaction().unwrap();
@@ -2141,13 +1835,7 @@ mod tests {
 
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = rpc_params!(class_hash);
@@ -2167,8 +1855,7 @@ mod tests {
 
             #[tokio::test]
             async fn returns_program_and_entry_points_for_known_class() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
 
                 let mut conn = storage.connection().unwrap();
                 let transaction = conn.transaction().unwrap();
@@ -2178,13 +1865,7 @@ mod tests {
 
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = by_name([("class_hash", json!(class_hash))]);
@@ -2210,17 +1891,10 @@ mod tests {
 
             #[tokio::test]
             async fn returns_contract_not_found_for_nonexistent_contract() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(*INVALID_CONTRACT_ADDR);
                 let error = client(addr)
@@ -2232,8 +1906,7 @@ mod tests {
 
             #[tokio::test]
             async fn returns_class_hash_for_existing_contract() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
 
                 let mut conn = storage.connection().unwrap();
                 let transaction = conn.transaction().unwrap();
@@ -2243,13 +1916,7 @@ mod tests {
 
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(contract_address);
                 let class_hash = client(addr)
@@ -2267,8 +1934,7 @@ mod tests {
 
             #[tokio::test]
             async fn returns_class_hash_for_existing_contract() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
 
                 let mut conn = storage.connection().unwrap();
                 let transaction = conn.transaction().unwrap();
@@ -2278,13 +1944,7 @@ mod tests {
 
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = by_name([("contract_address", json!(contract_address))]);
@@ -2306,17 +1966,10 @@ mod tests {
 
         #[tokio::test]
         async fn invalid_contract_address() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(*INVALID_CONTRACT_ADDR);
             let error = client(addr)
@@ -2328,17 +1981,10 @@ mod tests {
 
         #[tokio::test]
         async fn returns_not_found_if_we_dont_know_about_the_contract() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
             let not_found = client(addr)
@@ -2359,8 +2005,7 @@ mod tests {
             use crate::core::ContractClass;
             use futures::stream::TryStreamExt;
 
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
 
             let mut conn = storage.connection().unwrap();
             let transaction = conn.transaction().unwrap();
@@ -2370,13 +2015,7 @@ mod tests {
 
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
             let client = client(addr);
@@ -2411,8 +2050,7 @@ mod tests {
             use crate::core::ContractCode;
             use futures::stream::TryStreamExt;
 
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
 
             let mut conn = storage.connection().unwrap();
             let transaction = conn.transaction().unwrap();
@@ -2422,13 +2060,7 @@ mod tests {
 
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
             let client = client(addr);
@@ -2522,17 +2154,10 @@ mod tests {
 
         #[tokio::test]
         async fn genesis() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(StarknetBlockHash(
                 StarkHash::from_be_slice(b"genesis").unwrap()
@@ -2550,17 +2175,10 @@ mod tests {
 
             #[tokio::test]
             async fn positional_args() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(BlockHashOrTag::Tag(Tag::Latest));
                 let count = client(addr)
@@ -2572,17 +2190,10 @@ mod tests {
 
             #[tokio::test]
             async fn named_args() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = by_name([("block_hash", json!("latest"))]);
                 let count = client(addr)
@@ -2599,13 +2210,8 @@ mod tests {
             let pending = Arc::new(pending);
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
+                .with_pending_data(pending.clone());
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(BlockHashOrTag::Tag(Tag::Pending));
             let count = client(addr)
@@ -2618,17 +2224,10 @@ mod tests {
 
         #[tokio::test]
         async fn invalid() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(StarknetBlockHash(StarkHash::ZERO));
             let error = client(addr)
@@ -2646,17 +2245,10 @@ mod tests {
 
         #[tokio::test]
         async fn genesis() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(0);
             let count = client(addr)
@@ -2672,17 +2264,10 @@ mod tests {
 
             #[tokio::test]
             async fn positional_args() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(BlockNumberOrTag::Tag(Tag::Latest));
                 let count = client(addr)
@@ -2694,17 +2279,10 @@ mod tests {
 
             #[tokio::test]
             async fn named_args() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = by_name([("block_number", json!("latest"))]);
                 let count = client(addr)
@@ -2721,13 +2299,8 @@ mod tests {
             let pending = Arc::new(pending);
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
+                .with_pending_data(pending.clone());
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(BlockNumberOrTag::Tag(Tag::Pending));
             let count = client(addr)
@@ -2740,17 +2313,10 @@ mod tests {
 
         #[tokio::test]
         async fn invalid() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(123);
             let error = client(addr)
@@ -2781,17 +2347,10 @@ mod tests {
         #[ignore = "no longer works without setting up ext_py"]
         #[tokio::test]
         async fn latest_invoked_block() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
@@ -2816,17 +2375,10 @@ mod tests {
             #[ignore = "no longer works without setting up ext_py"]
             #[tokio::test]
             async fn positional_args() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(
                     Call {
@@ -2848,17 +2400,10 @@ mod tests {
             #[ignore = "no longer works without setting up ext_py"]
             #[tokio::test]
             async fn named_args() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = by_name([
                     (
@@ -2881,17 +2426,10 @@ mod tests {
         #[ignore = "no longer works without setting up ext_py"]
         #[tokio::test]
         async fn pending_block() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
@@ -2913,17 +2451,10 @@ mod tests {
         #[ignore = "no longer works without setting up ext_py"]
         #[tokio::test]
         async fn invalid_entry_point() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
@@ -2949,17 +2480,10 @@ mod tests {
         #[ignore = "no longer works without setting up ext_py"]
         #[tokio::test]
         async fn invalid_contract_address() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
@@ -2982,17 +2506,10 @@ mod tests {
         #[ignore = "no longer works without setting up ext_py"]
         #[tokio::test]
         async fn invalid_call_data() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
@@ -3015,17 +2532,10 @@ mod tests {
         #[ignore = "no longer works without setting up ext_py"]
         #[tokio::test]
         async fn uninitialized_contract() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
@@ -3048,17 +2558,10 @@ mod tests {
         #[ignore = "no longer works without setting up ext_py"]
         #[tokio::test]
         async fn invalid_block_hash() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
@@ -3081,17 +2584,10 @@ mod tests {
 
     #[tokio::test]
     async fn block_number() {
-        let (storage, pending) = setup_storage().await;
-        let pending = Arc::new(pending);
+        let (storage, _) = setup_storage().await;
         let sequencer = Client::new(Chain::Goerli).unwrap();
         let sync_state = Arc::new(SyncState::default());
-        let api = RpcApi::new(
-            storage,
-            sequencer,
-            Chain::Goerli,
-            sync_state,
-            pending.clone(),
-        );
+        let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
         let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
         let number = client(addr)
             .request::<u64>("starknet_blockNumber", rpc_params!())
@@ -3108,12 +2604,10 @@ mod tests {
             [Chain::Goerli, Chain::Mainnet]
                 .iter()
                 .map(|set_chain| async {
-                    let (storage, pending) = setup_storage().await;
-                    let pending = Arc::new(pending);
+                    let (storage, _) = setup_storage().await;
                     let sequencer = Client::new(*set_chain).unwrap();
                     let sync_state = Arc::new(SyncState::default());
-                    let api =
-                        RpcApi::new(storage, sequencer, *set_chain, sync_state, pending.clone());
+                    let api = RpcApi::new(storage, sequencer, *set_chain, sync_state);
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                     let params = rpc_params!();
                     client(addr)
@@ -3134,17 +2628,10 @@ mod tests {
     #[tokio::test]
     #[should_panic]
     async fn pending_transactions() {
-        let (storage, pending) = setup_storage().await;
-        let pending = Arc::new(pending);
+        let (storage, _) = setup_storage().await;
         let sequencer = Client::new(Chain::Goerli).unwrap();
         let sync_state = Arc::new(SyncState::default());
-        let api = RpcApi::new(
-            storage,
-            sequencer,
-            Chain::Goerli,
-            sync_state,
-            pending.clone(),
-        );
+        let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
         let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
         client(addr)
             .request::<()>("starknet_pendingTransactions", rpc_params!())
@@ -3155,17 +2642,10 @@ mod tests {
     #[tokio::test]
     #[should_panic]
     async fn protocol_version() {
-        let (storage, pending) = setup_storage().await;
-        let pending = Arc::new(pending);
+        let (storage, _) = setup_storage().await;
         let sequencer = Client::new(Chain::Goerli).unwrap();
         let sync_state = Arc::new(SyncState::default());
-        let api = RpcApi::new(
-            storage,
-            sequencer,
-            Chain::Goerli,
-            sync_state,
-            pending.clone(),
-        );
+        let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
         let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
         client(addr)
             .request::<StarknetProtocolVersion>("starknet_protocolVersion", rpc_params!())
@@ -3181,17 +2661,10 @@ mod tests {
 
         #[tokio::test]
         async fn not_syncing() {
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let syncing = client(addr)
                 .request::<Syncing>("starknet_syncing", rpc_params!())
@@ -3210,18 +2683,11 @@ mod tests {
                 highest: NumberedBlock::from(("abbacf", 3)),
             });
 
-            let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
+            let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             *sync_state.status.write().await = expected.clone();
-            let api = RpcApi::new(
-                storage,
-                sequencer,
-                Chain::Goerli,
-                sync_state,
-                pending.clone(),
-            );
+            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let syncing = client(addr)
                 .request::<Syncing>("starknet_syncing", rpc_params!())
@@ -3357,13 +2823,7 @@ mod tests {
                 let (storage, events) = setup();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    Arc::new(PendingData::default()),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = rpc_params!(EventFilter {
@@ -3394,13 +2854,7 @@ mod tests {
                 let (storage, events) = setup();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    Arc::new(PendingData::default()),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let expected_event = &events[1];
@@ -3433,13 +2887,7 @@ mod tests {
                 let (storage, events) = setup();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    Arc::new(PendingData::default()),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 const BLOCK_NUMBER: usize = 2;
@@ -3473,13 +2921,7 @@ mod tests {
                 let (storage, _events) = setup();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    Arc::new(PendingData::default()),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = rpc_params!(EventFilter {
@@ -3503,13 +2945,7 @@ mod tests {
                 let (storage, events) = setup();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    Arc::new(PendingData::default()),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let expected_events = &events[27..32];
@@ -3613,13 +3049,7 @@ mod tests {
                 let (storage, events) = setup();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    Arc::new(PendingData::default()),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params =
@@ -3644,13 +3074,7 @@ mod tests {
                 let (storage, events) = setup();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    Arc::new(PendingData::default()),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let expected_event = &events[1];
@@ -3790,17 +3214,10 @@ mod tests {
 
             #[tokio::test]
             async fn invoke_transaction() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = rpc_params!(
@@ -3829,17 +3246,10 @@ mod tests {
 
             #[tokio::test]
             async fn declare_transaction() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let sequencer = Client::integration().unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let contract_class = CONTRACT_DEFINITION.clone();
@@ -3872,17 +3282,10 @@ mod tests {
 
             #[tokio::test]
             async fn deploy_transaction() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let contract_definition = CONTRACT_DEFINITION.clone();
@@ -3934,17 +3337,10 @@ mod tests {
 
             #[tokio::test]
             async fn invoke_transaction() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = by_name([
@@ -3996,17 +3392,10 @@ mod tests {
 
             #[tokio::test]
             async fn declare_transaction() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let sequencer = Client::integration().unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = by_name([
@@ -4040,17 +3429,10 @@ mod tests {
 
             #[tokio::test]
             async fn deploy_transaction() {
-                let (storage, pending) = setup_storage().await;
-                let pending = Arc::new(pending);
+                let (storage, _) = setup_storage().await;
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(
-                    storage,
-                    sequencer,
-                    Chain::Goerli,
-                    sync_state,
-                    pending.clone(),
-                );
+                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = by_name([

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -1135,7 +1135,6 @@ mod tests {
         use crate::rpc::types::{reply::StateUpdate, BlockHashOrTag, Tag};
 
         #[tokio::test]
-        #[should_panic]
         async fn genesis() {
             let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
@@ -1146,11 +1145,10 @@ mod tests {
             client(addr)
                 .request::<StateUpdate>("starknet_getStateUpdateByHash", params)
                 .await
-                .unwrap();
+                .unwrap_err();
         }
 
         #[tokio::test]
-        #[should_panic]
         async fn latest() {
             let (storage, _) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
@@ -1161,7 +1159,7 @@ mod tests {
             client(addr)
                 .request::<StateUpdate>("starknet_getStateUpdateByHash", params)
                 .await
-                .unwrap();
+                .unwrap_err();
         }
 
         #[tokio::test]
@@ -2626,7 +2624,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[should_panic]
     async fn pending_transactions() {
         let (storage, _) = setup_storage().await;
         let sequencer = Client::new(Chain::Goerli).unwrap();
@@ -2636,11 +2633,10 @@ mod tests {
         client(addr)
             .request::<()>("starknet_pendingTransactions", rpc_params!())
             .await
-            .unwrap();
+            .unwrap_err();
     }
 
     #[tokio::test]
-    #[should_panic]
     async fn protocol_version() {
         let (storage, _) = setup_storage().await;
         let sequencer = Client::new(Chain::Goerli).unwrap();
@@ -2650,7 +2646,7 @@ mod tests {
         client(addr)
             .request::<StarknetProtocolVersion>("starknet_protocolVersion", rpc_params!())
             .await
-            .unwrap();
+            .unwrap_err();
     }
 
     mod syncing {

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -765,12 +765,7 @@ mod tests {
             db_task.await.expect("Database setup should succeed");
 
         let pending_data = PendingData::default();
-        pending_data
-            .set(Some((
-                Arc::new(pending_block),
-                Arc::new(pending_state_diff),
-            )))
-            .await;
+        pending_data.set(pending_block, pending_state_diff).await;
 
         (storage, pending_data)
     }

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -766,10 +766,7 @@ mod tests {
 
         let pending_data = PendingData::default();
         pending_data
-            .set(Some((
-                Box::new(pending_block),
-                Box::new(pending_state_diff),
-            )))
+            .set(Some((pending_block, pending_state_diff)))
             .await;
 
         (storage, pending_data)

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -718,7 +718,7 @@ mod tests {
             };
 
             let state_update =
-                crate::ethereum::state_update::StateUpdate::from(pending_state_diff.clone());
+                crate::ethereum::state_update::StateUpdate::from(&pending_state_diff);
 
             // Use a roll-back transaction to calculate pending state root.
             // This must not be committed as we don't want to inject the diff

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -474,7 +474,7 @@ mod tests {
             let contract0_code = CompressedContract {
                 abi: zstd_magic.clone(),
                 bytecode: zstd_magic.clone(),
-                definition: zstd_magic.clone(),
+                definition: zstd_magic,
                 hash: class0_hash,
             };
             let mut contract1_code = contract0_code.clone();

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -765,7 +765,9 @@ mod tests {
             db_task.await.expect("Database setup should succeed");
 
         let pending_data = PendingData::default();
-        pending_data.set(pending_block, pending_state_diff).await;
+        pending_data
+            .set(Arc::new(pending_block), Arc::new(pending_state_diff))
+            .await;
 
         (storage, pending_data)
     }

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -766,7 +766,10 @@ mod tests {
 
         let pending_data = PendingData::default();
         pending_data
-            .set(Some((pending_block, pending_state_diff)))
+            .set(Some((
+                Arc::new(pending_block),
+                Arc::new(pending_state_diff),
+            )))
             .await;
 
         (storage, pending_data)
@@ -915,6 +918,8 @@ mod tests {
 
         #[tokio::test]
         async fn pending() {
+            use std::ops::Deref;
+
             let (storage, pending) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
@@ -928,7 +933,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let expected = pending.block().await.unwrap();
+            let expected = pending.block().await.unwrap().deref().clone();
             let expected = Block::from_sequencer_scoped(expected.into(), scope);
             assert_eq!(block, expected);
         }
@@ -1088,6 +1093,8 @@ mod tests {
 
         #[tokio::test]
         async fn pending() {
+            use std::ops::Deref;
+
             let (storage, pending) = setup_storage().await;
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
@@ -1101,7 +1108,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let expected = pending.block().await.unwrap();
+            let expected = pending.block().await.unwrap().deref().clone();
             let expected = Block::from_sequencer_scoped(expected.into(), scope);
             assert_eq!(block, expected);
         }

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -916,7 +916,6 @@ mod tests {
         #[tokio::test]
         async fn pending() {
             let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
@@ -1090,7 +1089,6 @@ mod tests {
         #[tokio::test]
         async fn pending() {
             let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
@@ -1379,7 +1377,6 @@ mod tests {
         #[tokio::test]
         async fn pending_block() {
             let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
@@ -1552,7 +1549,6 @@ mod tests {
         #[tokio::test]
         async fn pending() {
             let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
@@ -1670,7 +1666,6 @@ mod tests {
         #[tokio::test]
         async fn pending() {
             let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
@@ -2202,7 +2197,6 @@ mod tests {
         #[tokio::test]
         async fn pending() {
             let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
@@ -2291,7 +2285,6 @@ mod tests {
         #[tokio::test]
         async fn pending() {
             let (storage, pending) = setup_storage().await;
-            let pending = Arc::new(pending);
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -398,7 +398,7 @@ mod tests {
             test_utils::*,
             Client,
         },
-        state::{state_tree::GlobalStateTree, SyncState},
+        state::{state_tree::GlobalStateTree, PendingData, SyncState},
         storage::{
             ContractCodeTable, ContractsTable, StarknetBlock, StarknetBlocksTable,
             StarknetTransactionsTable, Storage,
@@ -640,7 +640,13 @@ mod tests {
             let storage = setup_storage();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let genesis_hash = StarknetBlockHash(StarkHash::from_be_slice(b"genesis").unwrap());
             let params = rpc_params!(genesis_hash);
@@ -668,7 +674,13 @@ mod tests {
                     let storage = setup_storage();
                     let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
-                    let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                    let api = RpcApi::new(
+                        storage,
+                        sequencer,
+                        Chain::Goerli,
+                        sync_state,
+                        Arc::new(PendingData::default()),
+                    );
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                     let latest_hash =
                         StarknetBlockHash(StarkHash::from_be_slice(b"latest").unwrap());
@@ -693,7 +705,13 @@ mod tests {
                     let storage = setup_storage();
                     let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
-                    let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                    let api = RpcApi::new(
+                        storage,
+                        sequencer,
+                        Chain::Goerli,
+                        sync_state,
+                        Arc::new(PendingData::default()),
+                    );
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                     let latest_hash =
                         StarknetBlockHash(StarkHash::from_be_slice(b"latest").unwrap());
@@ -721,7 +739,13 @@ mod tests {
                     let storage = setup_storage();
                     let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
-                    let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                    let api = RpcApi::new(
+                        storage,
+                        sequencer,
+                        Chain::Goerli,
+                        sync_state,
+                        Arc::new(PendingData::default()),
+                    );
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                     let latest_hash =
                         StarknetBlockHash(StarkHash::from_be_slice(b"latest").unwrap());
@@ -746,7 +770,13 @@ mod tests {
                     let storage = setup_storage();
                     let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
-                    let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                    let api = RpcApi::new(
+                        storage,
+                        sequencer,
+                        Chain::Goerli,
+                        sync_state,
+                        Arc::new(PendingData::default()),
+                    );
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                     let latest_hash =
                         StarknetBlockHash(StarkHash::from_be_slice(b"latest").unwrap());
@@ -770,7 +800,13 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 BlockHashOrTag::Tag(Tag::Pending),
@@ -791,7 +827,13 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(StarknetBlockHash(StarkHash::ZERO));
             let error = client(addr)
@@ -816,7 +858,13 @@ mod tests {
             let storage = setup_storage();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(StarknetBlockNumber(0));
             let block = client(addr)
@@ -842,7 +890,13 @@ mod tests {
                     let storage = setup_storage();
                     let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
-                    let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                    let api = RpcApi::new(
+                        storage,
+                        sequencer,
+                        Chain::Goerli,
+                        sync_state,
+                        Arc::new(PendingData::default()),
+                    );
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                     let params = rpc_params!(
                         BlockNumberOrTag::Tag(Tag::Latest),
@@ -864,7 +918,13 @@ mod tests {
                     let storage = setup_storage();
                     let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
-                    let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                    let api = RpcApi::new(
+                        storage,
+                        sequencer,
+                        Chain::Goerli,
+                        sync_state,
+                        Arc::new(PendingData::default()),
+                    );
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                     let params = rpc_params!(BlockNumberOrTag::Tag(Tag::Latest));
                     let block = client(addr)
@@ -889,7 +949,13 @@ mod tests {
                     let storage = setup_storage();
                     let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
-                    let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                    let api = RpcApi::new(
+                        storage,
+                        sequencer,
+                        Chain::Goerli,
+                        sync_state,
+                        Arc::new(PendingData::default()),
+                    );
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                     let params = by_name([
                         ("block_number", json!("latest")),
@@ -917,7 +983,13 @@ mod tests {
                     let storage = setup_storage();
                     let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
-                    let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                    let api = RpcApi::new(
+                        storage,
+                        sequencer,
+                        Chain::Goerli,
+                        sync_state,
+                        Arc::new(PendingData::default()),
+                    );
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                     let params = by_name([("block_number", json!("latest"))]);
                     let block = client(addr)
@@ -944,7 +1016,13 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 BlockHashOrTag::Tag(Tag::Pending),
@@ -965,7 +1043,13 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(StarknetBlockNumber(123));
             let error = client(addr)
@@ -989,7 +1073,13 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(*GENESIS_BLOCK_HASH);
             client(addr)
@@ -1004,7 +1094,13 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(BlockHashOrTag::Tag(Tag::Latest));
             client(addr)
@@ -1019,7 +1115,13 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(BlockHashOrTag::Tag(Tag::Pending));
             client(addr)
@@ -1044,7 +1146,13 @@ mod tests {
             let storage = setup_storage();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 ContractAddress(StarkHash::from_be_slice(b"contract 0").unwrap()),
@@ -1071,7 +1179,13 @@ mod tests {
             let storage = setup_storage();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 ContractAddress(StarkHash::from_be_slice(b"contract 0").unwrap()),
@@ -1096,7 +1210,13 @@ mod tests {
             let storage = setup_storage();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 ContractAddress(StarkHash::from_be_slice(b"nonexistent").unwrap()),
@@ -1115,7 +1235,13 @@ mod tests {
             let storage = setup_storage();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 ContractAddress(StarkHash::from_be_slice(b"contract 1").unwrap()),
@@ -1136,7 +1262,13 @@ mod tests {
             let storage = setup_storage();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 ContractAddress(StarkHash::from_be_slice(b"contract 1").unwrap()),
@@ -1157,7 +1289,13 @@ mod tests {
             let storage = setup_storage();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 ContractAddress(StarkHash::from_be_slice(b"contract 1").unwrap()),
@@ -1185,7 +1323,13 @@ mod tests {
                 let storage = setup_storage();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(
                     ContractAddress(StarkHash::from_be_slice(b"contract 1").unwrap()),
@@ -1207,7 +1351,13 @@ mod tests {
                 let storage = setup_storage();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = by_name([
                     (
@@ -1236,7 +1386,13 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 *VALID_CONTRACT_ADDR,
@@ -1265,7 +1421,13 @@ mod tests {
                 let hash = StarknetTransactionHash(StarkHash::from_be_slice(b"txn 0").unwrap());
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(hash);
                 let transaction = client(addr)
@@ -1281,7 +1443,13 @@ mod tests {
                 let hash = StarknetTransactionHash(StarkHash::from_be_slice(b"txn 0").unwrap());
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = by_name([("transaction_hash", json!(hash))]);
                 let transaction = client(addr)
@@ -1297,7 +1465,13 @@ mod tests {
             let storage = setup_storage();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(*INVALID_TX_HASH);
             let error = client(addr)
@@ -1321,7 +1495,13 @@ mod tests {
             let storage = setup_storage();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let genesis_hash = StarknetBlockHash(StarkHash::from_be_slice(b"genesis").unwrap());
             let params = rpc_params!(genesis_hash, 0);
@@ -1344,7 +1524,13 @@ mod tests {
                 let storage = setup_storage();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(BlockHashOrTag::Tag(Tag::Latest), 0);
                 let txn = client(addr)
@@ -1362,7 +1548,13 @@ mod tests {
                 let storage = setup_storage();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = by_name([("block_hash", json!("latest")), ("index", json!(0))]);
                 let txn = client(addr)
@@ -1381,7 +1573,13 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(BlockHashOrTag::Tag(Tag::Pending), 0);
             client(addr)
@@ -1395,7 +1593,13 @@ mod tests {
             let storage = setup_storage();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(StarknetBlockHash(StarkHash::ZERO), 0);
             let error = client(addr)
@@ -1410,7 +1614,13 @@ mod tests {
             let storage = setup_storage();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let genesis_hash = StarknetBlockHash(StarkHash::from_be_slice(b"genesis").unwrap());
             let params = rpc_params!(genesis_hash, 123);
@@ -1435,7 +1645,13 @@ mod tests {
             let storage = setup_storage();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(0, 0);
             let txn = client(addr)
@@ -1457,7 +1673,13 @@ mod tests {
                 let storage = setup_storage();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(BlockNumberOrTag::Tag(Tag::Latest), 0);
                 let txn = client(addr)
@@ -1475,7 +1697,13 @@ mod tests {
                 let storage = setup_storage();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = by_name([("block_number", json!("latest")), ("index", json!(0))]);
                 let txn = client(addr)
@@ -1494,7 +1722,13 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(BlockNumberOrTag::Tag(Tag::Pending), 0);
             client(addr)
@@ -1508,7 +1742,13 @@ mod tests {
             let storage = setup_storage();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(123, 0);
             let error = client(addr)
@@ -1526,7 +1766,13 @@ mod tests {
             let storage = setup_storage();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(0, 123);
             let error = client(addr)
@@ -1554,7 +1800,13 @@ mod tests {
                 let storage = setup_storage();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let txn_hash = StarknetTransactionHash(StarkHash::from_be_slice(b"txn 0").unwrap());
                 let params = rpc_params!(txn_hash);
@@ -1574,7 +1826,13 @@ mod tests {
                 let storage = setup_storage();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let txn_hash = StarknetTransactionHash(StarkHash::from_be_slice(b"txn 0").unwrap());
                 let params = by_name([("transaction_hash", json!(txn_hash))]);
@@ -1595,7 +1853,13 @@ mod tests {
             let storage = setup_storage();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let txn_hash = StarknetTransactionHash(StarkHash::from_be_slice(b"not found").unwrap());
             let params = rpc_params!(txn_hash);
@@ -1625,7 +1889,13 @@ mod tests {
                 let storage = Storage::in_memory().unwrap();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(*INVALID_CLASS_HASH);
                 let error = client(addr)
@@ -1647,7 +1917,13 @@ mod tests {
 
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = rpc_params!(class_hash);
@@ -1677,7 +1953,13 @@ mod tests {
 
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = by_name([("class_hash", json!(class_hash))]);
@@ -1706,7 +1988,13 @@ mod tests {
                 let storage = Storage::in_memory().unwrap();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(*INVALID_CONTRACT_ADDR);
                 let error = client(addr)
@@ -1728,7 +2016,13 @@ mod tests {
 
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(contract_address);
                 let class_hash = client(addr)
@@ -1756,7 +2050,13 @@ mod tests {
 
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = by_name([("contract_address", json!(contract_address))]);
@@ -1781,7 +2081,13 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(*INVALID_CONTRACT_ADDR);
             let error = client(addr)
@@ -1796,7 +2102,13 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
             let not_found = client(addr)
@@ -1827,7 +2139,13 @@ mod tests {
 
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
             let client = client(addr);
@@ -1872,7 +2190,13 @@ mod tests {
 
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
             let client = client(addr);
@@ -1969,7 +2293,13 @@ mod tests {
             let storage = setup_storage();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(StarknetBlockHash(
                 StarkHash::from_be_slice(b"genesis").unwrap()
@@ -1990,7 +2320,13 @@ mod tests {
                 let storage = setup_storage();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(BlockHashOrTag::Tag(Tag::Latest));
                 let count = client(addr)
@@ -2005,7 +2341,13 @@ mod tests {
                 let storage = setup_storage();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = by_name([("block_hash", json!("latest"))]);
                 let count = client(addr)
@@ -2021,7 +2363,13 @@ mod tests {
             let storage = setup_storage();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(BlockHashOrTag::Tag(Tag::Pending));
             client(addr)
@@ -2035,7 +2383,13 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(StarknetBlockHash(StarkHash::ZERO));
             let error = client(addr)
@@ -2056,7 +2410,13 @@ mod tests {
             let storage = setup_storage();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(0);
             let count = client(addr)
@@ -2075,7 +2435,13 @@ mod tests {
                 let storage = setup_storage();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(BlockNumberOrTag::Tag(Tag::Latest));
                 let count = client(addr)
@@ -2090,7 +2456,13 @@ mod tests {
                 let storage = setup_storage();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = by_name([("block_number", json!("latest"))]);
                 let count = client(addr)
@@ -2106,7 +2478,13 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(BlockNumberOrTag::Tag(Tag::Pending));
             client(addr)
@@ -2120,7 +2498,13 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(123);
             let error = client(addr)
@@ -2154,7 +2538,13 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
@@ -2182,7 +2572,13 @@ mod tests {
                 let storage = Storage::in_memory().unwrap();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(
                     Call {
@@ -2207,7 +2603,13 @@ mod tests {
                 let storage = Storage::in_memory().unwrap();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = by_name([
                     (
@@ -2233,7 +2635,13 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
@@ -2258,7 +2666,13 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
@@ -2287,7 +2701,13 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
@@ -2313,7 +2733,13 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
@@ -2339,7 +2765,13 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
@@ -2365,7 +2797,13 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
@@ -2391,7 +2829,13 @@ mod tests {
         let storage = setup_storage();
         let sequencer = Client::new(Chain::Goerli).unwrap();
         let sync_state = Arc::new(SyncState::default());
-        let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+        let api = RpcApi::new(
+            storage,
+            sequencer,
+            Chain::Goerli,
+            sync_state,
+            Arc::new(PendingData::default()),
+        );
         let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
         let number = client(addr)
             .request::<u64>("starknet_blockNumber", rpc_params!())
@@ -2411,7 +2855,13 @@ mod tests {
                     let storage = Storage::in_memory().unwrap();
                     let sequencer = Client::new(*set_chain).unwrap();
                     let sync_state = Arc::new(SyncState::default());
-                    let api = RpcApi::new(storage, sequencer, *set_chain, sync_state);
+                    let api = RpcApi::new(
+                        storage,
+                        sequencer,
+                        *set_chain,
+                        sync_state,
+                        Arc::new(PendingData::default()),
+                    );
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                     let params = rpc_params!();
                     client(addr)
@@ -2435,7 +2885,13 @@ mod tests {
         let storage = Storage::in_memory().unwrap();
         let sequencer = Client::new(Chain::Goerli).unwrap();
         let sync_state = Arc::new(SyncState::default());
-        let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+        let api = RpcApi::new(
+            storage,
+            sequencer,
+            Chain::Goerli,
+            sync_state,
+            Arc::new(PendingData::default()),
+        );
         let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
         client(addr)
             .request::<()>("starknet_pendingTransactions", rpc_params!())
@@ -2449,7 +2905,13 @@ mod tests {
         let storage = Storage::in_memory().unwrap();
         let sequencer = Client::new(Chain::Goerli).unwrap();
         let sync_state = Arc::new(SyncState::default());
-        let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+        let api = RpcApi::new(
+            storage,
+            sequencer,
+            Chain::Goerli,
+            sync_state,
+            Arc::new(PendingData::default()),
+        );
         let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
         client(addr)
             .request::<StarknetProtocolVersion>("starknet_protocolVersion", rpc_params!())
@@ -2468,7 +2930,13 @@ mod tests {
             let storage = setup_storage();
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let syncing = client(addr)
                 .request::<Syncing>("starknet_syncing", rpc_params!())
@@ -2491,7 +2959,13 @@ mod tests {
             let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             *sync_state.status.write().await = expected.clone();
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(
+                storage,
+                sequencer,
+                Chain::Goerli,
+                sync_state,
+                Arc::new(PendingData::default()),
+            );
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let syncing = client(addr)
                 .request::<Syncing>("starknet_syncing", rpc_params!())
@@ -2627,7 +3101,13 @@ mod tests {
                 let (storage, events) = setup();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = rpc_params!(EventFilter {
@@ -2658,7 +3138,13 @@ mod tests {
                 let (storage, events) = setup();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let expected_event = &events[1];
@@ -2691,7 +3177,13 @@ mod tests {
                 let (storage, events) = setup();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 const BLOCK_NUMBER: usize = 2;
@@ -2725,7 +3217,13 @@ mod tests {
                 let (storage, _events) = setup();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = rpc_params!(EventFilter {
@@ -2749,7 +3247,13 @@ mod tests {
                 let (storage, events) = setup();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let expected_events = &events[27..32];
@@ -2853,7 +3357,13 @@ mod tests {
                 let (storage, events) = setup();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params =
@@ -2878,7 +3388,13 @@ mod tests {
                 let (storage, events) = setup();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let expected_event = &events[1];
@@ -3021,7 +3537,13 @@ mod tests {
                 let storage = setup_storage();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = rpc_params!(
@@ -3053,7 +3575,13 @@ mod tests {
                 let storage = setup_storage();
                 let sequencer = Client::integration().unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let contract_class = CONTRACT_DEFINITION.clone();
@@ -3089,7 +3617,13 @@ mod tests {
                 let storage = setup_storage();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let contract_definition = CONTRACT_DEFINITION.clone();
@@ -3144,7 +3678,13 @@ mod tests {
                 let storage = setup_storage();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = by_name([
@@ -3199,7 +3739,13 @@ mod tests {
                 let storage = setup_storage();
                 let sequencer = Client::integration().unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = by_name([
@@ -3236,7 +3782,13 @@ mod tests {
                 let storage = setup_storage();
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(
+                    storage,
+                    sequencer,
+                    Chain::Goerli,
+                    sync_state,
+                    Arc::new(PendingData::default()),
+                );
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = by_name([

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -119,7 +119,8 @@ impl RpcApi {
                     let scope = requested_scope.unwrap_or_default();
                     return Ok(Block::from_sequencer_scoped(block.into(), scope));
                 }
-                None => todo!("Return no pending data error"),
+                // Default to latest if pending data is not available.
+                None => StarknetBlocksBlockId::Latest,
             },
             BlockHashOrTag::Hash(hash) => hash.into(),
             BlockHashOrTag::Tag(Tag::Latest) => StarknetBlocksBlockId::Latest,
@@ -242,7 +243,8 @@ impl RpcApi {
                     let scope = requested_scope.unwrap_or_default();
                     return Ok(Block::from_sequencer_scoped(block.into(), scope));
                 }
-                None => todo!("Return no pending data error"),
+                // Default to latest if pending data is not available.
+                None => StarknetBlocksBlockId::Latest,
             },
         };
 
@@ -408,7 +410,8 @@ impl RpcApi {
                             None => StarknetBlocksBlockId::Latest,
                         }
                     }
-                    None => todo!("Return no pending data error"),
+                    // Default to latest if pending data is not available.
+                    None => StarknetBlocksBlockId::Latest,
                 }
             }
         };
@@ -555,7 +558,8 @@ impl RpcApi {
                             Ok(txn.into())
                         })
                 }
-                None => todo!("Return no pending data error"),
+                // Default to latest if pending data is not available.
+                None => StarknetBlocksBlockId::Latest,
             },
         };
 
@@ -623,7 +627,8 @@ impl RpcApi {
                             Ok(txn.into())
                         })
                 }
-                None => todo!("Return no pending data error"),
+                // Default to latest if pending data is not available.
+                None => StarknetBlocksBlockId::Latest,
             },
         };
 
@@ -905,7 +910,8 @@ impl RpcApi {
                     })?;
                     return Ok(count);
                 }
-                None => todo!("Return no pending data error"),
+                // Default to latest if pending data is not available.
+                None => StarknetBlocksBlockId::Latest,
             },
         };
 
@@ -964,7 +970,8 @@ impl RpcApi {
                     })?;
                     return Ok(count);
                 }
-                None => todo!("Return no pending data error"),
+                // Default to latest if pending data is not available.
+                None => StarknetBlocksBlockId::Latest,
             },
         };
 

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -115,8 +115,12 @@ impl RpcApi {
         let block_id = match block_hash {
             BlockHashOrTag::Tag(Tag::Pending) => match self.pending_data()?.block().await {
                 Some(block) => {
+                    use std::ops::Deref;
                     let scope = requested_scope.unwrap_or_default();
-                    return Ok(Block::from_sequencer_scoped(block.into(), scope));
+                    return Ok(Block::from_sequencer_scoped(
+                        block.deref().clone().into(),
+                        scope,
+                    ));
                 }
                 // Default to latest if pending data is not available.
                 None => StarknetBlocksBlockId::Latest,
@@ -239,8 +243,12 @@ impl RpcApi {
             BlockNumberOrTag::Tag(Tag::Latest) => StarknetBlocksBlockId::Latest,
             BlockNumberOrTag::Tag(Tag::Pending) => match self.pending_data()?.block().await {
                 Some(block) => {
+                    use std::ops::Deref;
                     let scope = requested_scope.unwrap_or_default();
-                    return Ok(Block::from_sequencer_scoped(block.into(), scope));
+                    return Ok(Block::from_sequencer_scoped(
+                        block.deref().clone().into(),
+                        scope,
+                    ));
                 }
                 // Default to latest if pending data is not available.
                 None => StarknetBlocksBlockId::Latest,

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -100,7 +100,7 @@ impl RpcApi {
         }
     }
 
-    async fn pending_data(&self) -> anyhow::Result<Arc<PendingData>> {
+    fn pending_data(&self) -> anyhow::Result<Arc<PendingData>> {
         self.pending_data
             .as_ref()
             .cloned()
@@ -114,7 +114,7 @@ impl RpcApi {
         requested_scope: Option<BlockResponseScope>,
     ) -> RpcResult<Block> {
         let block_id = match block_hash {
-            BlockHashOrTag::Tag(Tag::Pending) => match self.pending_data().await?.block().await {
+            BlockHashOrTag::Tag(Tag::Pending) => match self.pending_data()?.block().await {
                 Some(block) => {
                     let scope = requested_scope.unwrap_or_default();
                     return Ok(Block::from_sequencer_scoped(block.into(), scope));
@@ -237,7 +237,7 @@ impl RpcApi {
         let block_id = match block_number {
             BlockNumberOrTag::Number(number) => number.into(),
             BlockNumberOrTag::Tag(Tag::Latest) => StarknetBlocksBlockId::Latest,
-            BlockNumberOrTag::Tag(Tag::Pending) => match self.pending_data().await?.block().await {
+            BlockNumberOrTag::Tag(Tag::Pending) => match self.pending_data()?.block().await {
                 Some(block) => {
                     let scope = requested_scope.unwrap_or_default();
                     return Ok(Block::from_sequencer_scoped(block.into(), scope));
@@ -387,7 +387,7 @@ impl RpcApi {
             BlockHashOrTag::Tag(Tag::Pending) => {
                 // Pending storage will either be part of the pending state update,
                 // or it will come from latest if it isn't part of the pending diff.
-                match self.pending_data().await?.state_update().await {
+                match self.pending_data()?.state_update().await {
                     Some(update) => {
                         let pending_value = update
                             .state_diff
@@ -528,7 +528,7 @@ impl RpcApi {
         let block_id = match block_hash {
             BlockHashOrTag::Hash(hash) => StarknetBlocksBlockId::Hash(hash),
             BlockHashOrTag::Tag(Tag::Latest) => StarknetBlocksBlockId::Latest,
-            BlockHashOrTag::Tag(Tag::Pending) => match self.pending_data().await?.block().await {
+            BlockHashOrTag::Tag(Tag::Pending) => match self.pending_data()?.block().await {
                 Some(block) => {
                     return block
                         .transactions
@@ -596,7 +596,7 @@ impl RpcApi {
         let block_id = match block_number {
             BlockNumberOrTag::Number(number) => StarknetBlocksBlockId::Number(number),
             BlockNumberOrTag::Tag(Tag::Latest) => StarknetBlocksBlockId::Latest,
-            BlockNumberOrTag::Tag(Tag::Pending) => match self.pending_data().await?.block().await {
+            BlockNumberOrTag::Tag(Tag::Pending) => match self.pending_data()?.block().await {
                 Some(block) => {
                     return block
                         .transactions
@@ -860,7 +860,7 @@ impl RpcApi {
         let block_id = match block_hash {
             BlockHashOrTag::Hash(hash) => hash.into(),
             BlockHashOrTag::Tag(Tag::Latest) => StarknetBlocksBlockId::Latest,
-            BlockHashOrTag::Tag(Tag::Pending) => match self.pending_data().await?.block().await {
+            BlockHashOrTag::Tag(Tag::Pending) => match self.pending_data()?.block().await {
                 Some(block) => {
                     let count = block.transactions.len().try_into().map_err(|e| {
                         Error::Call(CallError::InvalidParams(anyhow::Error::new(e)))
@@ -919,7 +919,7 @@ impl RpcApi {
         let block_id = match block_number {
             BlockNumberOrTag::Number(number) => number.into(),
             BlockNumberOrTag::Tag(Tag::Latest) => StarknetBlocksBlockId::Latest,
-            BlockNumberOrTag::Tag(Tag::Pending) => match self.pending_data().await?.block().await {
+            BlockNumberOrTag::Tag(Tag::Pending) => match self.pending_data()?.block().await {
                 Some(block) => {
                     let count = block.transactions.len().try_into().map_err(|e| {
                         Error::Call(CallError::InvalidParams(anyhow::Error::new(e)))

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -498,17 +498,13 @@ impl RpcApi {
     ) -> RpcResult<Transaction> {
         // First check pending data as it is in-mem check and should be fast.
         if let Ok(pending) = self.pending_data() {
-            let pending_tx = pending
-                .block()
-                .await
-                .map(|block| {
-                    block
-                        .transactions
-                        .iter()
-                        .find(|tx| tx.transaction_hash == transaction_hash)
-                        .cloned()
-                })
-                .flatten();
+            let pending_tx = pending.block().await.and_then(|block| {
+                block
+                    .transactions
+                    .iter()
+                    .find(|tx| tx.transaction_hash == transaction_hash)
+                    .cloned()
+            });
 
             if let Some(pending_tx) = pending_tx {
                 return Ok(pending_tx.into());
@@ -689,17 +685,13 @@ impl RpcApi {
         // First check pending data as it is in-mem check and should be fast.
         // First check pending data as it is in-mem check and should be fast.
         if let Ok(pending) = self.pending_data() {
-            let pending_receipt = pending
-                .block()
-                .await
-                .map(|block| {
-                    block
-                        .transaction_receipts
-                        .iter()
-                        .find(|tx| tx.transaction_hash == transaction_hash)
-                        .cloned()
-                })
-                .flatten();
+            let pending_receipt = pending.block().await.and_then(|block| {
+                block
+                    .transaction_receipts
+                    .iter()
+                    .find(|tx| tx.transaction_hash == transaction_hash)
+                    .cloned()
+            });
             if let Some(pending_receipt) = pending_receipt {
                 return Ok(TransactionReceipt::with_block_status(
                     pending_receipt,

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -486,6 +486,24 @@ impl RpcApi {
         &self,
         transaction_hash: StarknetTransactionHash,
     ) -> RpcResult<Transaction> {
+        // First check pending data as it is in-mem check and should be fast.
+        let pending_tx = self
+            .pending_data()?
+            .block()
+            .await
+            .map(|block| {
+                block
+                    .transactions
+                    .iter()
+                    .find(|tx| tx.transaction_hash == transaction_hash)
+                    .cloned()
+            })
+            .flatten();
+
+        if let Some(pending_tx) = pending_tx {
+            return Ok(pending_tx.into());
+        }
+
         let storage = self.storage.clone();
         let span = tracing::Span::current();
 
@@ -655,6 +673,26 @@ impl RpcApi {
         &self,
         transaction_hash: StarknetTransactionHash,
     ) -> RpcResult<TransactionReceipt> {
+        // First check pending data as it is in-mem check and should be fast.
+        let pending_receipt = self
+            .pending_data()?
+            .block()
+            .await
+            .map(|block| {
+                block
+                    .transaction_receipts
+                    .iter()
+                    .find(|tx| tx.transaction_hash == transaction_hash)
+                    .cloned()
+            })
+            .flatten();
+        if let Some(pending_receipt) = pending_receipt {
+            return Ok(TransactionReceipt::with_status(
+                pending_receipt,
+                BlockStatus::Pending,
+            ));
+        }
+
         let storage = self.storage.clone();
         let span = tracing::Span::current();
 

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -380,7 +380,7 @@ impl RpcApi {
                             .state_diff
                             .storage_diffs
                             .get(&contract_address)
-                            .map(|storage| {
+                            .and_then(|storage| {
                                 storage.iter().find_map(|update| {
                                     if update.key == key {
                                         Some(update.value)
@@ -388,8 +388,7 @@ impl RpcApi {
                                         None
                                     }
                                 })
-                            })
-                            .flatten();
+                            });
 
                         match pending_value {
                             Some(value) => return Ok(value),
@@ -520,8 +519,7 @@ impl RpcApi {
                 Some(block) => {
                     return block
                         .transactions
-                        .iter()
-                        .nth(index)
+                        .get(index)
                         .map_or(Err(ErrorCode::InvalidTransactionIndex.into()), |txn| {
                             Ok(txn.into())
                         })
@@ -589,8 +587,7 @@ impl RpcApi {
                 Some(block) => {
                     return block
                         .transactions
-                        .iter()
-                        .nth(index)
+                        .get(index)
                         .map_or(Err(ErrorCode::InvalidTransactionIndex.into()), |txn| {
                             Ok(txn.into())
                         })

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -44,7 +44,7 @@ pub struct RpcApi {
     call_handle: Option<ext_py::Handle>,
     shared_gas_price: Option<Cached>,
     sync_state: Arc<SyncState>,
-    pending_data: Option<Arc<PendingData>>,
+    pending_data: Option<PendingData>,
 }
 
 #[derive(Debug)]
@@ -93,17 +93,16 @@ impl RpcApi {
         }
     }
 
-    pub fn with_pending_data(self, pending_data: Arc<PendingData>) -> Self {
+    pub fn with_pending_data(self, pending_data: PendingData) -> Self {
         Self {
             pending_data: Some(pending_data),
             ..self
         }
     }
 
-    fn pending_data(&self) -> anyhow::Result<Arc<PendingData>> {
+    fn pending_data(&self) -> anyhow::Result<&PendingData> {
         self.pending_data
             .as_ref()
-            .cloned()
             .ok_or_else(|| anyhow::anyhow!("Pending data not supported in this configuration"))
     }
 
@@ -692,7 +691,7 @@ impl RpcApi {
             })
             .flatten();
         if let Some(pending_receipt) = pending_receipt {
-            return Ok(TransactionReceipt::with_status(
+            return Ok(TransactionReceipt::with_block_status(
                 pending_receipt,
                 BlockStatus::Pending,
             ));

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -59,6 +59,12 @@ pub enum MaybePendingBlock {
     Pending(PendingBlock),
 }
 
+impl From<PendingBlock> for MaybePendingBlock {
+    fn from(pending: PendingBlock) -> Self {
+        MaybePendingBlock::Pending(pending)
+    }
+}
+
 #[cfg(test)]
 impl From<Block> for MaybePendingBlock {
     fn from(block: Block) -> Self {

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -481,7 +481,7 @@ mod tests {
             state,
             sync::l1::sync,
             sync::l2::sync,
-            Arc::new(sync::PendingData::default()),
+            sync::PendingData::default(),
             None,
         )
         .await

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -461,6 +461,9 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[ignore = "this is manual testing only, but we should really use the binary for this"]
     async fn go_sync() {
+        use std::sync::Arc;
+        use tokio::sync::RwLock;
+
         let storage = crate::storage::Storage::migrate(
             std::path::PathBuf::from("testing.sqlite"),
             crate::storage::JournalMode::WAL,
@@ -469,7 +472,7 @@ mod tests {
         let chain = crate::core::Chain::Goerli;
         let transport = crate::ethereum::transport::HttpTransport::test_transport(chain);
         let sequencer = crate::sequencer::Client::new(chain).unwrap();
-        let state = std::sync::Arc::new(sync::State::default());
+        let state = Arc::new(sync::State::default());
 
         sync::sync(
             storage,
@@ -479,6 +482,8 @@ mod tests {
             state,
             sync::l1::sync,
             sync::l2::sync,
+            Arc::new(RwLock::new(None)),
+            None,
         )
         .await
         .unwrap();

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -17,7 +17,7 @@ pub(crate) mod state_tree;
 mod sync;
 
 pub use class_hash::compute_class_hash;
-pub use sync::{l1, l2, sync, State as SyncState};
+pub use sync::{l1, l2, sync, PendingData, State as SyncState};
 
 #[derive(Clone, PartialEq)]
 pub struct CompressedContract {
@@ -462,7 +462,6 @@ mod tests {
     #[ignore = "this is manual testing only, but we should really use the binary for this"]
     async fn go_sync() {
         use std::sync::Arc;
-        use tokio::sync::RwLock;
 
         let storage = crate::storage::Storage::migrate(
             std::path::PathBuf::from("testing.sqlite"),
@@ -482,7 +481,7 @@ mod tests {
             state,
             sync::l1::sync,
             sync::l2::sync,
-            Arc::new(RwLock::new(None)),
+            Arc::new(sync::PendingData::default()),
             None,
         )
         .await

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -45,9 +45,13 @@ impl Default for State {
     }
 }
 
+struct PendingInner {
+    pub block: Arc<PendingBlock>,
+    pub state_update: Arc<sequencer::reply::StateUpdate>,
+}
 #[derive(Default, Clone)]
 pub struct PendingData {
-    inner: Arc<RwLock<Option<(Arc<PendingBlock>, Arc<sequencer::reply::StateUpdate>)>>>,
+    inner: Arc<RwLock<Option<PendingInner>>>,
 }
 
 impl PendingData {
@@ -56,7 +60,10 @@ impl PendingData {
         block: Arc<PendingBlock>,
         state_update: Arc<sequencer::reply::StateUpdate>,
     ) {
-        *self.inner.write().await = Some((block, state_update));
+        *self.inner.write().await = Some(PendingInner {
+            block,
+            state_update,
+        });
     }
 
     pub async fn clear(&self) {
@@ -68,7 +75,7 @@ impl PendingData {
             .read()
             .await
             .as_ref()
-            .map(|inner| inner.0.clone())
+            .map(|inner| inner.block.clone())
     }
 
     pub async fn state_update(&self) -> Option<Arc<sequencer::reply::StateUpdate>> {
@@ -76,7 +83,7 @@ impl PendingData {
             .read()
             .await
             .as_ref()
-            .map(|inner| inner.1.clone())
+            .map(|inner| inner.state_update.clone())
     }
 }
 

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -360,6 +360,7 @@ where
                     tracing::info!("Updated pending block");
                 }
                 None => {
+                    pending_data.clear().await;
                     // L2 sync process failed; restart it.
                     match l2_handle.await.context("Join L2 sync process handle")? {
                         Ok(()) => {

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -47,16 +47,19 @@ impl Default for State {
 
 #[derive(Default, Clone)]
 pub struct PendingData {
-    inner: Arc<RwLock<Option<(PendingBlock, sequencer::reply::StateUpdate)>>>,
+    inner: Arc<RwLock<Option<(Arc<PendingBlock>, Arc<sequencer::reply::StateUpdate>)>>>,
 }
 
 impl PendingData {
-    pub async fn set(&self, value: Option<(PendingBlock, sequencer::reply::StateUpdate)>) {
+    pub async fn set(
+        &self,
+        value: Option<(Arc<PendingBlock>, Arc<sequencer::reply::StateUpdate>)>,
+    ) {
         let mut inner = self.inner.write().await;
         *inner = value;
     }
 
-    pub async fn block(&self) -> Option<PendingBlock> {
+    pub async fn block(&self) -> Option<Arc<PendingBlock>> {
         self.inner
             .read()
             .await
@@ -64,7 +67,7 @@ impl PendingData {
             .map(|inner| inner.0.clone())
     }
 
-    pub async fn state_update(&self) -> Option<sequencer::reply::StateUpdate> {
+    pub async fn state_update(&self) -> Option<Arc<sequencer::reply::StateUpdate>> {
         self.inner
             .read()
             .await
@@ -348,7 +351,7 @@ where
                 }
                 Some(l2::Event::Pending(pending)) => {
                     // TODO: apply state_update and verify state_update.new_root
-                    pending_data.set(Some((pending.0, pending.1))).await;
+                    pending_data.set(Some((Arc::new(pending.0), Arc::new(pending.1)))).await;
 
                     tracing::info!("Updated pending block");
                 }

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -355,8 +355,10 @@ where
                     tracing::trace!("Query for existence of contracts: {:?}", contracts);
                 }
                 Some(l2::Event::Pending(block, state_update)) => {
-                    let latest_root = tokio::task::block_in_place(||
-                        StarknetBlocksTable::get(&db_conn, StarknetBlocksBlockId::Latest)
+                    let latest_root = tokio::task::block_in_place(|| {
+                            let tx = db_conn.transaction()?;
+                            StarknetBlocksTable::get(&tx, StarknetBlocksBlockId::Latest)
+                        }
                     )
                     .context("Query latest state root for pending update")?
                     .map(|block| block.root)

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -369,7 +369,7 @@ where
                     match new_root == diff.new_root {
                         true => {
                             pending_data.set(block, diff).await;
-                            tracing::info!("Updated pending block");
+                            tracing::debug!("Updated pending data");
                         }
                         false => {
                             pending_data.clear().await;

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -45,7 +45,7 @@ impl Default for State {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct PendingData {
     inner: Arc<RwLock<Option<(PendingBlock, sequencer::reply::StateUpdate)>>>,
 }
@@ -83,7 +83,7 @@ pub async fn sync<Transport, SequencerClient, F1, F2, L1Sync, L2Sync>(
     state: Arc<State>,
     mut l1_sync: L1Sync,
     l2_sync: L2Sync,
-    pending_data: Arc<PendingData>,
+    pending_data: PendingData,
     pending_poll_interval: Option<std::time::Duration>,
 ) -> anyhow::Result<()>
 where
@@ -1017,7 +1017,7 @@ mod tests {
                 sync_state.clone(),
                 l1,
                 l2_noop,
-                Arc::new(PendingData::default()),
+                PendingData::default(),
                 None,
             ));
 
@@ -1087,7 +1087,7 @@ mod tests {
                 Arc::new(state::SyncState::default()),
                 l1,
                 l2_noop,
-                Arc::new(PendingData::default()),
+                PendingData::default(),
                 None,
             ));
 
@@ -1153,7 +1153,7 @@ mod tests {
             Arc::new(state::SyncState::default()),
             l1,
             l2_noop,
-            Arc::new(PendingData::default()),
+            PendingData::default(),
             None,
         ));
 
@@ -1188,7 +1188,7 @@ mod tests {
             Arc::new(state::SyncState::default()),
             l1,
             l2_noop,
-            Arc::new(PendingData::default()),
+            PendingData::default(),
             None,
         ));
 
@@ -1262,7 +1262,7 @@ mod tests {
                 sync_state.clone(),
                 l1_noop,
                 l2,
-                Arc::new(PendingData::default()),
+                PendingData::default(),
                 None,
             ));
 
@@ -1327,7 +1327,7 @@ mod tests {
                 Arc::new(state::SyncState::default()),
                 l1_noop,
                 l2,
-                Arc::new(PendingData::default()),
+                PendingData::default(),
                 None,
             ));
 
@@ -1387,7 +1387,7 @@ mod tests {
             Arc::new(state::SyncState::default()),
             l1_noop,
             l2,
-            Arc::new(PendingData::default()),
+            PendingData::default(),
             None,
         ));
 
@@ -1434,7 +1434,7 @@ mod tests {
             Arc::new(state::SyncState::default()),
             l1_noop,
             l2,
-            Arc::new(PendingData::default()),
+            PendingData::default(),
             None,
         ));
     }
@@ -1481,7 +1481,7 @@ mod tests {
             Arc::new(state::SyncState::default()),
             l1_noop,
             l2,
-            Arc::new(PendingData::default()),
+            PendingData::default(),
             None,
         ));
     }
@@ -1509,7 +1509,7 @@ mod tests {
             Arc::new(state::SyncState::default()),
             l1_noop,
             l2,
-            Arc::new(PendingData::default()),
+            PendingData::default(),
             None,
         ));
 

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -357,8 +357,9 @@ where
                     // Update state tree to determine new state root, but rollback the changes as we do
                     // not want to persist them.
                     let new_root = tokio::task::block_in_place(|| {
-
-                        let tx = db_conn.transaction()?;
+                        let tx = db_conn
+                            .transaction_with_behavior(TransactionBehavior::Immediate)
+                            .context("Create database transaction")?;
                         let state_diff = (&diff.state_diff).into();
                         let new_root = update_starknet_state(&tx, state_diff).context("Updating Starknet state")?;
                         tx.rollback()?;
@@ -373,9 +374,9 @@ where
                         false => {
                             pending_data.clear().await;
                             tracing::error!(
-                                head=%diff.old_root, 
-                                pending=%diff.new_root, 
-                                calculated=%new_root, 
+                                head=%diff.old_root,
+                                pending=%diff.new_root,
+                                calculated=%new_root,
                                 "Pending state root mismatch"
                             );
                         }

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -1,5 +1,6 @@
 pub mod l1;
 pub mod l2;
+mod pending;
 
 use std::future::Future;
 use std::sync::Arc;

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -56,6 +56,22 @@ impl PendingData {
         let mut inner = self.inner.write().await;
         *inner = value;
     }
+
+    pub async fn block(&self) -> Option<PendingBlock> {
+        self.inner
+            .read()
+            .await
+            .as_ref()
+            .map(|inner| (*inner.0).clone())
+    }
+
+    pub async fn state_update(&self) -> Option<sequencer::reply::StateUpdate> {
+        self.inner
+            .read()
+            .await
+            .as_ref()
+            .map(|inner| (*inner.1).clone())
+    }
 }
 
 impl Default for PendingData {

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -1,5 +1,5 @@
-use std::collections::HashSet;
 use std::time::Duration;
+use std::{collections::HashSet, sync::Arc};
 
 use anyhow::Context;
 use tokio::sync::{mpsc, oneshot};
@@ -49,7 +49,7 @@ pub enum Event {
     /// for each contract using the [oneshot::channel].
     QueryContractExistance(Vec<ClassHash>, oneshot::Sender<Vec<bool>>),
     /// A new L2 pending update was polled.
-    Pending(Box<(PendingBlock, sequencer::reply::StateUpdate)>),
+    Pending(Arc<PendingBlock>, Arc<sequencer::reply::StateUpdate>),
 }
 
 pub async fn sync(

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -80,7 +80,10 @@ pub async fn sync(
                             let head_hash = head_hash
                                 .expect("Head hash should exist when entering pending mode");
                             crate::state::sync::pending::poll_pending(
-                                &tx_event, &sequencer, head_hash, interval,
+                                tx_event.clone(),
+                                &sequencer,
+                                head_hash,
+                                interval,
                             )
                             .await
                             .context("Polling pending block")?;

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -49,7 +49,7 @@ pub enum Event {
     /// for each contract using the [oneshot::channel].
     QueryContractExistance(Vec<ClassHash>, oneshot::Sender<Vec<bool>>),
     /// A new L2 pending update was polled.
-    Pending(Box<PendingBlock>, Box<sequencer::reply::StateUpdate>),
+    Pending(Box<(PendingBlock, sequencer::reply::StateUpdate)>),
 }
 
 pub async fn sync(

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -76,6 +76,7 @@ pub async fn sync(
                     // Poll pending if it is enabled, otherwise just wait to poll head again.
                     match pending_poll_interval {
                         Some(interval) => {
+                            tracing::trace!("Entering pending mode");
                             let head = head_meta
                                 .expect("Head hash should exist when entering pending mode");
                             crate::state::sync::pending::poll_pending(

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -148,7 +148,7 @@ pub async fn sync(
         let t_deploy = t_deploy.elapsed();
 
         // Map from sequencer type to the actual type... we should declutter these types.
-        let update = StateUpdate::from(state_update.state_diff);
+        let update = StateUpdate::from(&state_update.state_diff);
 
         head = Some((next, block_hash, state_update.new_root));
 

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -1,0 +1,57 @@
+/// Poll's the Sequencer's pending block and emits [Event::Pending]
+/// until the pending block is no longer connected to our current head.
+///
+/// This disconnect is detected whenever
+/// - `pending.block_hash != head`, or
+/// - `pending` is a fully formed block and not [PendingBlock]
+pub async fn poll_pending(
+    tx_event: &tokio::sync::mpsc::Sender<super::l2::Event>,
+    sequencer: &impl crate::sequencer::ClientApi,
+    head: crate::core::StarknetBlockHash,
+    poll_interval: std::time::Duration,
+) -> anyhow::Result<()> {
+    use crate::core::BlockId;
+    use anyhow::Context;
+
+    loop {
+        use crate::sequencer::reply::MaybePendingBlock;
+
+        let block = match sequencer
+            .block(BlockId::Pending)
+            .await
+            .context("Download block")?
+        {
+            MaybePendingBlock::Block(block) => {
+                tracing::debug!(hash=%block.block_hash, "Found full block, exiting pending mode.");
+                return Ok(());
+            }
+            MaybePendingBlock::Pending(pending) if pending.parent_hash != head => {
+                tracing::debug!(
+                    pending=%pending.parent_hash, head=%head,
+                    "Pending block's parent hash does not match head, exiting pending mode"
+                );
+                return Ok(());
+            }
+            MaybePendingBlock::Pending(pending) => pending,
+        };
+
+        // Download the pending state diff.
+        let state_update = sequencer
+            .state_update(BlockId::Pending)
+            .await
+            .context("Download state update")?;
+        if state_update.block_hash.is_some() {
+            tracing::debug!("Found full state update, exiting pending mode.");
+            return Ok(());
+        }
+
+        // Emit new pending data.
+        use crate::state::l2::Event::Pending;
+        tx_event
+            .send(Pending(Box::new(block), Box::new(state_update)))
+            .await
+            .context("Event channel closed")?;
+
+        tokio::time::sleep(poll_interval).await;
+    }
+}

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -30,11 +30,11 @@ pub async fn poll_pending(
                 continue;
             }
             MaybePendingBlock::Block(block) => {
-                tracing::debug!(hash=%block.block_hash, "Found full block, exiting pending mode.");
+                tracing::trace!(hash=%block.block_hash, "Found full block, exiting pending mode.");
                 return Ok(());
             }
             MaybePendingBlock::Pending(pending) if pending.parent_hash != head.0 => {
-                tracing::debug!(
+                tracing::trace!(
                     pending=%pending.parent_hash, head=%head.0,
                     "Pending block's parent hash does not match head, exiting pending mode"
                 );
@@ -49,11 +49,11 @@ pub async fn poll_pending(
             .await
             .context("Download pending state update")?;
         if state_update.block_hash.is_some() {
-            tracing::debug!("Found full state update, exiting pending mode.");
+            tracing::trace!("Found full state update, exiting pending mode.");
             return Ok(());
         }
         if state_update.old_root != head.1 {
-            tracing::debug!(pending=%state_update.old_root, head=%head.1, "Pending state update's old root does not match head, exiting pending mode.");
+            tracing::trace!(pending=%state_update.old_root, head=%head.1, "Pending state update's old root does not match head, exiting pending mode.");
             return Ok(());
         }
 

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -5,7 +5,7 @@
 /// - `pending.block_hash != head`, or
 /// - `pending` is a fully formed block and not [PendingBlock]
 pub async fn poll_pending(
-    tx_event: &tokio::sync::mpsc::Sender<super::l2::Event>,
+    tx_event: tokio::sync::mpsc::Sender<super::l2::Event>,
     sequencer: &impl crate::sequencer::ClientApi,
     head: crate::core::StarknetBlockHash,
     poll_interval: std::time::Duration,

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -24,6 +24,11 @@ pub async fn poll_pending(
             .await
             .context("Download pending block")?
         {
+            MaybePendingBlock::Block(block) if block.block_hash == head.0 => {
+                tracing::trace!(hash=%block.block_hash, "Found current head from pending mode");
+                tokio::time::sleep(poll_interval).await;
+                continue;
+            }
             MaybePendingBlock::Block(block) => {
                 tracing::debug!(hash=%block.block_hash, "Found full block, exiting pending mode.");
                 return Ok(());

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -14,6 +14,8 @@ pub async fn poll_pending(
     use crate::core::BlockId;
     use anyhow::Context;
 
+    use std::sync::Arc;
+
     loop {
         use crate::sequencer::reply::MaybePendingBlock;
 
@@ -53,7 +55,7 @@ pub async fn poll_pending(
         // Emit new pending data.
         use crate::state::l2::Event::Pending;
         tx_event
-            .send(Pending(Box::new((block, state_update))))
+            .send(Pending(Arc::new(block), Arc::new(state_update)))
             .await
             .context("Event channel closed")?;
 
@@ -285,6 +287,6 @@ mod tests {
             .unwrap();
 
         use crate::state::l2::Event::Pending;
-        assert_matches!(result, Pending(pending) if pending.0 == *PENDING_BLOCK && pending.1 == *PENDING_DIFF);
+        assert_matches!(result, Pending(block, diff) if *block == *PENDING_BLOCK && *diff == *PENDING_DIFF);
     }
 }

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -55,3 +55,201 @@ pub async fn poll_pending(
         tokio::time::sleep(poll_interval).await;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::poll_pending;
+    use crate::{
+        core::{
+            GasPrice, GlobalRoot, SequencerAddress, StarknetBlockHash, StarknetBlockNumber,
+            StarknetBlockTimestamp,
+        },
+        sequencer,
+    };
+
+    use assert_matches::assert_matches;
+    use stark_hash::StarkHash;
+
+    lazy_static::lazy_static!(
+        pub static ref PARENT_HASH: StarknetBlockHash =  StarknetBlockHash::from_hex_str("1234").unwrap();
+        pub static ref PARENT_ROOT: GlobalRoot = GlobalRoot(StarkHash::from_be_slice(b"parent root").unwrap());
+
+        pub static ref NEXT_BLOCK: sequencer::reply::Block = sequencer::reply::Block{
+            block_hash: StarknetBlockHash::from_hex_str("0xabcd").unwrap(),
+            block_number: StarknetBlockNumber(1),
+            gas_price: None,
+            parent_block_hash: *PARENT_HASH,
+            sequencer_address: None,
+            state_root: *PARENT_ROOT,
+            status: sequencer::reply::Status::AcceptedOnL2,
+            timestamp: StarknetBlockTimestamp(10),
+            transaction_receipts: Vec::new(),
+            transactions: Vec::new(),
+            starknet_version: None,
+        };
+
+        pub static ref PENDING_DIFF: sequencer::reply::StateUpdate = sequencer::reply::StateUpdate {
+            block_hash: None,
+            new_root: GlobalRoot(StarkHash::from_be_slice(b"new root").unwrap()),
+            old_root: *PARENT_ROOT,
+            state_diff: sequencer::reply::state_update::StateDiff {
+                storage_diffs: std::collections::HashMap::new(),
+                deployed_contracts: Vec::new(),
+                declared_contracts: Vec::new(),
+            }
+        };
+
+        pub static ref PENDING_BLOCK: sequencer::reply::PendingBlock = sequencer::reply::PendingBlock {
+            gas_price: GasPrice(11),
+            parent_hash: NEXT_BLOCK.parent_block_hash,
+            sequencer_address: SequencerAddress(StarkHash::from_be_slice(b"seqeunecer address").unwrap()),
+            status: sequencer::reply::Status::Pending,
+            timestamp: StarknetBlockTimestamp(20),
+            transaction_receipts: Vec::new(),
+            transactions: Vec::new(),
+            starknet_version: None,
+        };
+    );
+
+    /// Arbitrary timeout for receiving emits on the tokio channel. Otherwise failing tests will
+    /// need to timeout naturally which may be forever.
+    const TEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+    #[tokio::test]
+    async fn exits_on_full_block() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let mut sequencer = sequencer::MockClientApi::new();
+
+        // Give a pending state update and full block.
+        sequencer.expect_block().returning(move |_| {
+            Ok(sequencer::reply::MaybePendingBlock::Block(
+                NEXT_BLOCK.clone(),
+            ))
+        });
+        sequencer
+            .expect_state_update()
+            .returning(move |_| Ok(PENDING_DIFF.clone()));
+
+        let jh = tokio::spawn(async move {
+            poll_pending(tx, &sequencer, *PARENT_HASH, std::time::Duration::ZERO).await
+        });
+
+        let result = tokio::time::timeout(TEST_TIMEOUT, rx.recv())
+            .await
+            .expect("Channel should be dropped");
+        assert_matches!(result, None);
+        jh.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn exits_on_full_state_diff() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let mut sequencer = sequencer::MockClientApi::new();
+
+        // A full diff has the block hash set.
+        let mut full_diff = PENDING_DIFF.clone();
+        full_diff.block_hash = Some(NEXT_BLOCK.block_hash);
+
+        sequencer.expect_block().returning(move |_| {
+            Ok(sequencer::reply::MaybePendingBlock::Pending(
+                PENDING_BLOCK.clone(),
+            ))
+        });
+        sequencer
+            .expect_state_update()
+            .returning(move |_| Ok(full_diff.clone()));
+
+        let jh = tokio::spawn(async move {
+            poll_pending(tx, &sequencer, *PARENT_HASH, std::time::Duration::ZERO).await
+        });
+
+        let result = tokio::time::timeout(TEST_TIMEOUT, rx.recv())
+            .await
+            .expect("Channel should be dropped");
+        assert_matches!(result, None);
+        jh.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn exits_on_block_discontinuity() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let mut sequencer = sequencer::MockClientApi::new();
+
+        let mut pending_block = PENDING_BLOCK.clone();
+        pending_block.parent_hash = StarknetBlockHash::from_hex_str("0xFFFFFF").unwrap();
+        sequencer.expect_block().returning(move |_| {
+            Ok(sequencer::reply::MaybePendingBlock::Pending(
+                pending_block.clone(),
+            ))
+        });
+        sequencer
+            .expect_state_update()
+            .returning(move |_| Ok(PENDING_DIFF.clone()));
+
+        let jh = tokio::spawn(async move {
+            poll_pending(tx, &sequencer, *PARENT_HASH, std::time::Duration::ZERO).await
+        });
+
+        let result = tokio::time::timeout(TEST_TIMEOUT, rx.recv())
+            .await
+            .expect("Channel should be dropped");
+        assert_matches!(result, None);
+        jh.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn exits_on_state_diff_discontinuity() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let mut sequencer = sequencer::MockClientApi::new();
+
+        sequencer.expect_block().returning(move |_| {
+            Ok(sequencer::reply::MaybePendingBlock::Pending(
+                PENDING_BLOCK.clone(),
+            ))
+        });
+
+        let mut disconnected_diff = PENDING_DIFF.clone();
+        disconnected_diff.old_root =
+            GlobalRoot(StarkHash::from_be_slice(b"different old root").unwrap());
+        sequencer
+            .expect_state_update()
+            .returning(move |_| Ok(disconnected_diff.clone()));
+
+        let jh = tokio::spawn(async move {
+            poll_pending(tx, &sequencer, *PARENT_HASH, std::time::Duration::ZERO).await
+        });
+
+        let result = tokio::time::timeout(TEST_TIMEOUT, rx.recv())
+            .await
+            .expect("Channel should be dropped");
+        assert_matches!(result, None);
+        jh.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn success() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let mut sequencer = sequencer::MockClientApi::new();
+
+        sequencer.expect_block().returning(move |_| {
+            Ok(sequencer::reply::MaybePendingBlock::Pending(
+                PENDING_BLOCK.clone(),
+            ))
+        });
+        sequencer
+            .expect_state_update()
+            .returning(move |_| Ok(PENDING_DIFF.clone()));
+
+        let _jh = tokio::spawn(async move {
+            poll_pending(tx, &sequencer, *PARENT_HASH, std::time::Duration::ZERO).await
+        });
+
+        let result = tokio::time::timeout(TEST_TIMEOUT, rx.recv())
+            .await
+            .expect("Event should be emitted")
+            .unwrap();
+
+        use crate::state::l2::Event::Pending;
+        assert_matches!(result, Pending(block, diff) if *block == *PENDING_BLOCK && *diff == *PENDING_DIFF);
+    }
+}

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -1,9 +1,9 @@
-/// Poll's the Sequencer's pending block and emits [Event::Pending]
+/// Poll's the Sequencer's pending block and emits [Event::Pending](super::l2::Event::Pending)
 /// until the pending block is no longer connected to our current head.
 ///
 /// This disconnect is detected whenever
 /// - `pending.parent_hash != head`, or
-/// - `pending` is a fully formed block and not [PendingBlock], or
+/// - `pending` is a fully formed block and not [PendingBlock](crate::sequencer::reply::MaybePendingBlock::Pending), or
 /// - the state update parent root does not match head.
 pub async fn poll_pending(
     tx_event: tokio::sync::mpsc::Sender<super::l2::Event>,


### PR DESCRIPTION
This PR adds support for querying and storing pending data locally.

Currently, this PR:
1. Adds `poll-pending = true|false` config option
    - defaults to false
    - only valid on mainnet 
2. starts polling pending data whenever we are at head of chain, until the pending block is disconnected from our local chain
    - poll interval is 5s
    - polling is started when we hit head of chain (if enabled)
    - polling is stopped once `pending` returns a full block or its parent hash does not match our local head
3. Uses pending data in the RPC API where applicable, but is still missing events support.

Todo:
- [x] test polling
- [x] ~~support events in pending~~ I think I'll leave this for a separate PR since it also requires rpc api changes
- [x] ~~rpc error for pending not existing~~ this has been handled by defaulting to `latest` if pending is unavailable
- [x] verify the pending state root