### PR TITLE
refactor: use more transactions

### DIFF
--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -2588,15 +2588,16 @@ mod tests {
 
         fn setup() -> (Storage, Vec<EmittedEvent>) {
             let storage = Storage::in_memory().unwrap();
-            let connection = storage.connection().unwrap();
+            let mut connection = storage.connection().unwrap();
+            let tx = connection.transaction().unwrap();
 
             let blocks = crate::storage::test_utils::create_blocks::<NUM_BLOCKS>();
             let transactions_and_receipts = create_transactions_and_receipts();
 
             for (i, block) in blocks.iter().enumerate() {
-                StarknetBlocksTable::insert(&connection, block).unwrap();
+                StarknetBlocksTable::insert(&tx, block).unwrap();
                 StarknetTransactionsTable::upsert(
-                    &connection,
+                    &tx,
                     block.hash,
                     block.number,
                     &transactions_and_receipts
@@ -2622,6 +2623,8 @@ mod tests {
                     }
                 })
                 .collect();
+
+            tx.commit().unwrap();
 
             (storage, events)
         }

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -6,10 +6,10 @@ use tokio::sync::{mpsc, oneshot};
 
 use crate::core::{Chain, ClassHash, StarknetBlockHash, StarknetBlockNumber};
 use crate::ethereum::state_update::{ContractUpdate, DeployedContract, StateUpdate, StorageUpdate};
+use crate::sequencer;
 use crate::sequencer::error::SequencerError;
 use crate::sequencer::reply::state_update::{Contract, StateDiff};
 use crate::sequencer::reply::Block;
-use crate::sequencer::{self};
 use crate::state::block_hash::{verify_block_hash, VerifyResult};
 use crate::state::class_hash::extract_abi_code_hash;
 use crate::state::CompressedContract;


### PR DESCRIPTION
this will make sure that all db access is transactional, which it
already was. hooray! also, I can add new stuff, which only works in
transactions.