### PR TITLE
426 related refactors

### DIFF
--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -132,7 +132,8 @@ impl RpcApi {
             let block = Self::get_raw_block_by_hash(&transaction, block_id)?;
             let scope = requested_scope.unwrap_or_default();
 
-            let transactions = Self::get_block_transactions(&transaction, block.number, scope)?;
+            let transactions =
+                Self::get_block_transactions(&transaction, block.number, block.status, scope)?;
 
             Ok(Block::from_raw(block, transactions))
         })
@@ -163,14 +164,13 @@ impl RpcApi {
     fn get_block_transactions(
         db_tx: &rusqlite::Transaction<'_>,
         block_number: StarknetBlockNumber,
+        block_status: BlockStatus,
         scope: BlockResponseScope,
     ) -> RpcResult<super::types::reply::Transactions> {
         let transactions_receipts =
             StarknetTransactionsTable::get_transaction_data_for_block(db_tx, block_number.into())
                 .context("Reading transactions from database")
                 .map_err(internal_server_error)?;
-
-        let block_status = Self::get_block_status(db_tx, block_number)?;
 
         use super::types::reply;
         let transactions = match scope {
@@ -258,7 +258,8 @@ impl RpcApi {
             let block = Self::get_raw_block_by_number(&transaction, block_id)?;
             let scope = requested_scope.unwrap_or_default();
 
-            let transactions = Self::get_block_transactions(&transaction, block.number, scope)?;
+            let transactions =
+                Self::get_block_transactions(&transaction, block.number, block.status, scope)?;
 
             Ok(Block::from_raw(block, transactions))
         })

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -143,7 +143,7 @@ impl RpcApi {
     }
 
     /// This function assumes that the block ID is valid i.e. it won't check if the block hash or number exist.
-    pub fn get_block_transactions(
+    fn get_block_transactions(
         db_tx: &rusqlite::Transaction<'_>,
         block_number: StarknetBlockNumber,
         scope: BlockResponseScope,

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -192,7 +192,7 @@ impl RpcApi {
                         .into_iter()
                         .map(|(t, r)| {
                             let t: Transaction = t.into();
-                            let r = TransactionReceipt::with_status(r, block_status);
+                            let r = TransactionReceipt::with_block_status(r, block_status);
 
                             reply::TransactionAndReceipt {
                                 txn_hash: t.txn_hash,
@@ -665,7 +665,7 @@ impl RpcApi {
 
                     let block_status = Self::get_block_status(&db_tx, block.number)?;
 
-                    Ok(TransactionReceipt::with_status(receipt, block_status))
+                    Ok(TransactionReceipt::with_block_status(receipt, block_status))
                 }
                 None => Err(ErrorCode::InvalidTransactionHash.into()),
             }

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -384,8 +384,10 @@ pub mod reply {
                         .zip(block.receipts().iter())
                         .map(|(t, r)| {
                             let t: Transaction = t.into();
-                            let r =
-                                TransactionReceipt::with_status(r.clone(), block.status().into());
+                            let r = TransactionReceipt::with_block_status(
+                                r.clone(),
+                                block.status().into(),
+                            );
 
                             TransactionAndReceipt {
                                 txn_hash: t.txn_hash,
@@ -698,7 +700,7 @@ pub mod reply {
     }
 
     impl TransactionReceipt {
-        pub fn with_status(
+        pub fn with_block_status(
             receipt: sequencer::reply::transaction::Receipt,
             status: BlockStatus,
         ) -> Self {


### PR DESCRIPTION
Some minor refactors that I mentioned in #426.

This is a post-0.2.5-release PR ofc.

-----------------
Changes:
- "privatize" `RpcApi::get_block_transactions`,
- refactor getting block status based on L1/L2 head to a separate function,
- deduplicate redundant calls to `RefsTable::get_l1_l2_head` (first in `get_raw_block_by_*` followed by `get_block_transactions`) in `get_block_by_[hash|number]`,
- rename `TransactionReceipt::with_status` to `TransactionReceipt::with_block_status`.