### PR TITLE
fix(sync): start write txs as immediate

### DIFF
--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 
 use anyhow::Context;
-use rusqlite::{Connection, Transaction};
+use rusqlite::{Connection, Transaction, TransactionBehavior};
 use stark_hash::StarkHash;
 use tokio::sync::{mpsc, RwLock};
 
@@ -394,7 +394,7 @@ async fn update_sync_status_latest(
 async fn l1_update(connection: &mut Connection, updates: &[StateUpdateLog]) -> anyhow::Result<()> {
     tokio::task::block_in_place(move || {
         let transaction = connection
-            .transaction()
+            .transaction_with_behavior(TransactionBehavior::Immediate)
             .context("Create database transaction")?;
 
         for update in updates {
@@ -442,7 +442,7 @@ async fn l1_reorg(
 ) -> anyhow::Result<()> {
     tokio::task::block_in_place(move || {
         let transaction = connection
-            .transaction()
+            .transaction_with_behavior(TransactionBehavior::Immediate)
             .context("Create database transaction")?;
 
         L1StateTable::reorg(&transaction, reorg_tail).context("Delete L1 state from database")?;
@@ -471,7 +471,7 @@ async fn l2_update(
 ) -> anyhow::Result<()> {
     tokio::task::block_in_place(move || {
         let transaction = connection
-            .transaction()
+            .transaction_with_behavior(TransactionBehavior::Immediate)
             .context("Create database transaction")?;
 
         let new_root =
@@ -546,7 +546,7 @@ async fn l2_reorg(
 ) -> anyhow::Result<()> {
     tokio::task::block_in_place(move || {
         let transaction = connection
-            .transaction()
+            .transaction_with_behavior(TransactionBehavior::Immediate)
             .context("Create database transaction")?;
 
         // TODO: clean up state tree's as well...


### PR DESCRIPTION
Sync should be the only one writing, but it might still be blocked because litestream is doing backup, leading into errors like:

```
Sync process ended unexpected with: Err(Update L2 state to 36363

Caused by:
    0: Updating Starknet state
    1: Update contract state
    2: Apply contract storage tree changes
    3: Failed to insert edge node
    4: database is locked
    5: Error code 517: Cannot promote read transaction to write transaction because of writes by another connection)
```

In this case, sqlite doesn't do any busy_timeout waiting, but it just fails instantly. This is because of serializable transactions I guess, which makes the transaction requiring a full retry. However, if we just `BEGIN IMMEDIATE` as documented, most of these should be avoided.

Cc: #293 