### PR TITLE
fixtures for rpc serialization

### DIFF
--- a/crates/pathfinder/fixtures/rpc/0.21.0/block.json
+++ b/crates/pathfinder/fixtures/rpc/0.21.0/block.json
@@ -1,0 +1,58 @@
+[
+    {
+        "status": "ACCEPTED_ON_L1",
+        "block_hash": "0x0",
+        "parent_hash": "0x1",
+        "block_number": 0,
+        "new_root": "0x2",
+        "timestamp": 1,
+        "sequencer_address": "0x3",
+        "transactions": [
+            {
+                "type": "DECLARE",
+                "txn_hash": "0x4",
+                "max_fee": "0x5",
+                "version": "0x6",
+                "signature": [
+                    "0x7"
+                ],
+                "nonce": "0x8",
+                "class_hash": "0x9",
+                "sender_address": "0xa"
+            },
+            {
+                "type": "INVOKE",
+                "txn_hash": "0x4",
+                "max_fee": "0x5",
+                "version": "0x6",
+                "signature": [
+                    "0x7"
+                ],
+                "nonce": "0x8",
+                "contract_address": "0xb",
+                "entry_point_selector": "0xc",
+                "calldata": [
+                    "0xd"
+                ]
+            },
+            {
+                "type": "DEPLOY",
+                "txn_hash": "0xe",
+                "contract_address": "0xf",
+                "class_hash": "0x10",
+                "constructor_calldata": [
+                    "0x11"
+                ]
+            }
+        ]
+    },
+    {
+        "status": "ACCEPTED_ON_L1",
+        "parent_hash": "0x1",
+        "timestamp": 1,
+        "sequencer_address": "0x3",
+        "transactions": [
+            "0x4"
+        ]
+    }
+]

--- a/crates/pathfinder/fixtures/rpc/0.21.0/receipt.json
+++ b/crates/pathfinder/fixtures/rpc/0.21.0/receipt.json
@@ -1,0 +1,53 @@
+[
+    {
+        "txn_hash": "0x0",
+        "actual_fee": "0x1",
+        "status": "ACCEPTED_ON_L1",
+        "statusData": "blah",
+        "messages_sent": [
+            {
+                "to_address": "0x2",
+                "payload": [
+                    "0x3"
+                ]
+            }
+        ],
+        "l1_origin_message": {
+            "from_address": "0x4",
+            "payload": [
+                "0x5"
+            ]
+        },
+        "events": [
+            {
+                "from_address": "0x6",
+                "keys": [
+                    "0x7"
+                ],
+                "data": [
+                    "0x8"
+                ]
+            }
+        ]
+    },
+    {
+        "txn_hash": "0x0",
+        "actual_fee": "0x1",
+        "status": "ACCEPTED_ON_L1",
+        "messages_sent": [
+            {
+                "to_address": "0x2",
+                "payload": [
+                    "0x3"
+                ]
+            }
+        ],
+        "events": []
+    },
+    {
+        "txn_hash": "0x0",
+        "actual_fee": "0x1",
+        "status": "ACCEPTED_ON_L1",
+        "statusData": "blah"
+    }
+]

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -411,9 +411,10 @@ impl ClientApi for Client {
 pub mod test_utils {
     use crate::{
         core::{
-            CallParam, ClassHash, ConstructorParam, ContractAddress, EntryPoint, StarknetBlockHash,
-            StarknetBlockNumber, StarknetTransactionHash, StarknetTransactionIndex, StorageAddress,
-            StorageValue,
+            CallParam, ClassHash, ConstructorParam, ContractAddress, EntryPoint, GlobalRoot,
+            SequencerAddress, StarknetBlockHash, StarknetBlockNumber, StarknetTransactionHash,
+            StarknetTransactionIndex, StorageAddress, StorageValue, TransactionNonce,
+            TransactionSignatureElem,
         },
         rpc::types::{BlockHashOrTag, BlockNumberOrTag},
     };
@@ -434,10 +435,14 @@ pub mod test_utils {
     impl_from_hex_str!(ConstructorParam);
     impl_from_hex_str!(ContractAddress);
     impl_from_hex_str!(EntryPoint);
+    impl_from_hex_str!(GlobalRoot);
+    impl_from_hex_str!(SequencerAddress);
     impl_from_hex_str!(StarknetBlockHash);
     impl_from_hex_str!(StarknetTransactionHash);
     impl_from_hex_str!(StorageAddress);
     impl_from_hex_str!(StorageValue);
+    impl_from_hex_str!(TransactionSignatureElem);
+    impl_from_hex_str!(TransactionNonce);
 
     lazy_static::lazy_static! {
         pub static ref GENESIS_BLOCK_NUMBER: BlockNumberOrTag = BlockNumberOrTag::Number(StarknetBlockNumber(0u64));

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -411,7 +411,8 @@ impl ClientApi for Client {
 pub mod test_utils {
     use crate::{
         core::{
-            CallParam, ClassHash, ConstructorParam, ContractAddress, EntryPoint, GlobalRoot,
+            CallParam, ClassHash, ConstructorParam, ContractAddress, EntryPoint, EventData,
+            EventKey, GlobalRoot, L1ToL2MessagePayloadElem, L2ToL1MessagePayloadElem,
             SequencerAddress, StarknetBlockHash, StarknetBlockNumber, StarknetTransactionHash,
             StarknetTransactionIndex, StorageAddress, StorageValue, TransactionNonce,
             TransactionSignatureElem,
@@ -435,7 +436,11 @@ pub mod test_utils {
     impl_from_hex_str!(ConstructorParam);
     impl_from_hex_str!(ContractAddress);
     impl_from_hex_str!(EntryPoint);
+    impl_from_hex_str!(EventData);
+    impl_from_hex_str!(EventKey);
     impl_from_hex_str!(GlobalRoot);
+    impl_from_hex_str!(L1ToL2MessagePayloadElem);
+    impl_from_hex_str!(L2ToL1MessagePayloadElem);
     impl_from_hex_str!(SequencerAddress);
     impl_from_hex_str!(StarknetBlockHash);
     impl_from_hex_str!(StarknetTransactionHash);


### PR DESCRIPTION
At the moment I didn't find any tool to automate random json generation based on open-rpc schema, so I resorted to just hand-crafting those 2 tests as regressions in Block, Txn, and Receipt serialization are probable to repeat and the current rpc tests won't fail in some specific cases. Recently those were:
- nulls popping out because there's undocumented side-effect of `serde(flatten)` on `skip_serializing_none`,
- `*AsDecStr*` used because of a copy-paste error from similar `sequencer::reply` code.

----

This PR builds on top of #451.