### PR TITLE
test(rpc): add replacement for jsonrpsee's HttpClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,7 +807,7 @@ dependencies = [
  "futures-sink",
  "nanorand",
  "pin-project",
- "spin 0.9.3",
+ "spin",
 ]
 
 [[package]]
@@ -1232,22 +1232,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
-dependencies = [
- "http",
- "hyper",
- "log",
- "rustls",
- "rustls-native-certs",
- "tokio",
- "tokio-rustls",
- "webpki-roots",
-]
-
-[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,32 +1397,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d02a921aa22006ed979c2e1c407fd21302ac6049e5b544634ec5ec41516363d"
 dependencies = [
  "jsonrpsee-core",
- "jsonrpsee-http-client",
  "jsonrpsee-http-server",
  "jsonrpsee-types",
- "jsonrpsee-ws-client",
  "jsonrpsee-ws-server",
-]
-
-[[package]]
-name = "jsonrpsee-client-transport"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4d7c4b01e336c32fc17034560291fa0690170aedace93ae746e9aa119a5b91"
-dependencies = [
- "futures-util",
- "http",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "pin-project",
- "rustls-native-certs",
- "soketto",
- "thiserror",
- "tokio",
- "tokio-rustls",
- "tokio-util 0.7.0",
- "tracing",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1463,25 +1424,6 @@ dependencies = [
  "serde",
  "serde_json",
  "soketto",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-http-client"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157df2774b82fddf37a297fd5c8f711601b158176608f86d2adb5d227c524506"
-dependencies = [
- "async-trait",
- "hyper",
- "hyper-rustls",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "rustc-hash",
- "serde",
- "serde_json",
  "thiserror",
  "tokio",
  "tracing",
@@ -1518,17 +1460,6 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-ws-client"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c10011be7e04339bdc8b5a8e3542eb5aa1aa08465d5c897044ce00b03ea8535b"
-dependencies = [
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
 ]
 
 [[package]]
@@ -2543,21 +2474,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted",
- "web-sys",
- "winapi",
-]
-
-[[package]]
 name = "rlp"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2610,39 +2526,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver 1.0.7",
-]
-
-[[package]]
-name = "rustls"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
-dependencies = [
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca9ebdfa27d3fc180e42879037b5338ab1c040c06affd00d8338598e7800943"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
-dependencies = [
- "base64",
 ]
 
 [[package]]
@@ -2702,16 +2585,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "sct"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "secp256k1"
@@ -2956,12 +2829,6 @@ dependencies = [
  "rand",
  "sha-1",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -3329,17 +3196,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27d5f2b839802bd8267fa19b0530f5a08b9c08cd417976be2a65d130fe1c11b"
-dependencies = [
- "rustls",
- "tokio",
- "webpki",
-]
-
-[[package]]
 name = "tokio-stream"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3664,12 +3520,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3900,25 +3750,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "url",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552ceb903e957524388c4d3475725ff2c8b7960922063af6ce53c9a43da07449"
-dependencies = [
- "webpki",
 ]
 
 [[package]]

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -55,7 +55,7 @@ zstd = "0.10"
 assert_matches = "1.5.0"
 flate2 = "1.0.23"
 http = "0.2.6"
-jsonrpsee = { version = "0.11.0", features = ["server", "client"] }
+jsonrpsee = { version = "0.11.0", features = ["server", "async-client"] }
 mockall = "0.11.0"
 pretty_assertions = "1.0.0"
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -1,6 +1,8 @@
 //! StarkNet node JSON-RPC related modules.
 pub mod api;
 pub mod serde;
+#[cfg(test)]
+pub mod test_client;
 pub mod types;
 
 use crate::{
@@ -380,7 +382,7 @@ Hint: If you are looking to run two instances of pathfinder, you must configure 
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{test_client::client, *};
     use crate::{
         core::{
             Chain, ClassHash, ContractAddress, EventData, EventKey, GasPrice, GlobalRoot,
@@ -403,12 +405,7 @@ mod tests {
         },
     };
     use assert_matches::assert_matches;
-    use jsonrpsee::{
-        core::client::ClientT as Client,
-        http_client::{HttpClient, HttpClientBuilder},
-        rpc_params,
-        types::ParamsSer,
-    };
+    use jsonrpsee::{core::client::ClientT as Client, rpc_params, types::ParamsSer};
     use pretty_assertions::assert_eq;
     use serde_json::json;
     use stark_hash::StarkHash;
@@ -416,20 +413,11 @@ mod tests {
         collections::BTreeMap,
         net::{Ipv4Addr, SocketAddrV4},
         sync::Arc,
-        time::Duration,
     };
 
     /// Helper function: produces named rpc method args map.
     fn by_name<const N: usize>(params: [(&'_ str, serde_json::Value); N]) -> Option<ParamsSer<'_>> {
         Some(BTreeMap::from(params).into())
-    }
-
-    /// Helper rpc client
-    fn client(addr: SocketAddr) -> HttpClient {
-        HttpClientBuilder::default()
-            .request_timeout(Duration::from_secs(120))
-            .build(format!("http://{}", addr))
-            .expect("Failed to create HTTP-RPC client")
     }
 
     lazy_static::lazy_static! {

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -405,7 +405,7 @@ mod tests {
         },
     };
     use assert_matches::assert_matches;
-    use jsonrpsee::{core::client::ClientT as Client, rpc_params, types::ParamsSer};
+    use jsonrpsee::{rpc_params, types::ParamsSer};
     use pretty_assertions::assert_eq;
     use serde_json::json;
     use stark_hash::StarkHash;

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -396,7 +396,7 @@ mod tests {
                 Event, ExecutionResources, Receipt, Transaction, Type,
             },
             test_utils::*,
-            Client as SeqClient,
+            Client,
         },
         state::{state_tree::GlobalStateTree, SyncState},
         storage::{
@@ -638,7 +638,7 @@ mod tests {
         #[tokio::test]
         async fn genesis() {
             let storage = setup_storage();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -666,7 +666,7 @@ mod tests {
                 #[tokio::test]
                 async fn all() {
                     let storage = setup_storage();
-                    let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                    let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
                     let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -691,7 +691,7 @@ mod tests {
                 #[tokio::test]
                 async fn only_mandatory() {
                     let storage = setup_storage();
-                    let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                    let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
                     let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -719,7 +719,7 @@ mod tests {
                 #[tokio::test]
                 async fn all() {
                     let storage = setup_storage();
-                    let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                    let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
                     let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -744,7 +744,7 @@ mod tests {
                 #[tokio::test]
                 async fn only_mandatory() {
                     let storage = setup_storage();
-                    let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                    let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
                     let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -768,7 +768,7 @@ mod tests {
         #[tokio::test]
         async fn pending() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -789,7 +789,7 @@ mod tests {
         #[tokio::test]
         async fn invalid_block_hash() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -814,7 +814,7 @@ mod tests {
         #[tokio::test]
         async fn genesis() {
             let storage = setup_storage();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -840,7 +840,7 @@ mod tests {
                 #[tokio::test]
                 async fn all() {
                     let storage = setup_storage();
-                    let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                    let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
                     let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -862,7 +862,7 @@ mod tests {
                 #[tokio::test]
                 async fn only_mandatory() {
                     let storage = setup_storage();
-                    let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                    let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
                     let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -887,7 +887,7 @@ mod tests {
                 #[tokio::test]
                 async fn all() {
                     let storage = setup_storage();
-                    let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                    let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
                     let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -915,7 +915,7 @@ mod tests {
                 #[tokio::test]
                 async fn only_mandatory() {
                     let storage = setup_storage();
-                    let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                    let sequencer = Client::new(Chain::Goerli).unwrap();
                     let sync_state = Arc::new(SyncState::default());
                     let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -942,7 +942,7 @@ mod tests {
         #[tokio::test]
         async fn pending() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -963,7 +963,7 @@ mod tests {
         #[tokio::test]
         async fn invalid_number() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -987,7 +987,7 @@ mod tests {
         #[should_panic]
         async fn genesis() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1002,7 +1002,7 @@ mod tests {
         #[should_panic]
         async fn latest() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1017,7 +1017,7 @@ mod tests {
         #[should_panic]
         async fn pending() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1042,7 +1042,7 @@ mod tests {
             use std::str::FromStr;
 
             let storage = setup_storage();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1069,7 +1069,7 @@ mod tests {
             use std::str::FromStr;
 
             let storage = setup_storage();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1094,7 +1094,7 @@ mod tests {
         #[tokio::test]
         async fn non_existent_contract_address() {
             let storage = setup_storage();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1113,7 +1113,7 @@ mod tests {
         #[tokio::test]
         async fn pre_deploy_block_hash() {
             let storage = setup_storage();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1134,7 +1134,7 @@ mod tests {
         #[tokio::test]
         async fn non_existent_block_hash() {
             let storage = setup_storage();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1155,7 +1155,7 @@ mod tests {
         #[tokio::test]
         async fn deployment_block() {
             let storage = setup_storage();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1183,7 +1183,7 @@ mod tests {
             #[tokio::test]
             async fn positional_args() {
                 let storage = setup_storage();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1205,7 +1205,7 @@ mod tests {
             #[tokio::test]
             async fn named_args() {
                 let storage = setup_storage();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1234,7 +1234,7 @@ mod tests {
         #[tokio::test]
         async fn pending_block() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1263,7 +1263,7 @@ mod tests {
             async fn positional_args() {
                 let storage = setup_storage();
                 let hash = StarknetTransactionHash(StarkHash::from_be_slice(b"txn 0").unwrap());
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1279,7 +1279,7 @@ mod tests {
             async fn named_args() {
                 let storage = setup_storage();
                 let hash = StarknetTransactionHash(StarkHash::from_be_slice(b"txn 0").unwrap());
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1295,7 +1295,7 @@ mod tests {
         #[tokio::test]
         async fn invalid_hash() {
             let storage = setup_storage();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1319,7 +1319,7 @@ mod tests {
         #[tokio::test]
         async fn genesis() {
             let storage = setup_storage();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1342,7 +1342,7 @@ mod tests {
             #[tokio::test]
             async fn positional_args() {
                 let storage = setup_storage();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1360,7 +1360,7 @@ mod tests {
             #[tokio::test]
             async fn named_args() {
                 let storage = setup_storage();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1379,7 +1379,7 @@ mod tests {
         #[tokio::test]
         async fn pending() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1393,7 +1393,7 @@ mod tests {
         #[tokio::test]
         async fn invalid_block() {
             let storage = setup_storage();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1408,7 +1408,7 @@ mod tests {
         #[tokio::test]
         async fn invalid_transaction_index() {
             let storage = setup_storage();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1433,7 +1433,7 @@ mod tests {
         #[tokio::test]
         async fn genesis() {
             let storage = setup_storage();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1455,7 +1455,7 @@ mod tests {
             #[tokio::test]
             async fn positional_args() {
                 let storage = setup_storage();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1473,7 +1473,7 @@ mod tests {
             #[tokio::test]
             async fn named_args() {
                 let storage = setup_storage();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1492,7 +1492,7 @@ mod tests {
         #[tokio::test]
         async fn pending() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1506,7 +1506,7 @@ mod tests {
         #[tokio::test]
         async fn invalid_block() {
             let storage = setup_storage();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1524,7 +1524,7 @@ mod tests {
         #[tokio::test]
         async fn invalid_transaction_index() {
             let storage = setup_storage();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1552,7 +1552,7 @@ mod tests {
             #[tokio::test]
             async fn positional_args() {
                 let storage = setup_storage();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1572,7 +1572,7 @@ mod tests {
             #[tokio::test]
             async fn named_args() {
                 let storage = setup_storage();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1593,7 +1593,7 @@ mod tests {
         #[tokio::test]
         async fn invalid() {
             let storage = setup_storage();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1623,7 +1623,7 @@ mod tests {
             #[tokio::test]
             async fn returns_invalid_contract_class_hash_for_nonexistent_class() {
                 let storage = Storage::in_memory().unwrap();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1645,7 +1645,7 @@ mod tests {
                     setup_class_and_contract(&transaction).unwrap();
                 transaction.commit().unwrap();
 
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1675,7 +1675,7 @@ mod tests {
                     setup_class_and_contract(&transaction).unwrap();
                 transaction.commit().unwrap();
 
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1704,7 +1704,7 @@ mod tests {
             #[tokio::test]
             async fn returns_contract_not_found_for_nonexistent_contract() {
                 let storage = Storage::in_memory().unwrap();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1726,7 +1726,7 @@ mod tests {
                     setup_class_and_contract(&transaction).unwrap();
                 transaction.commit().unwrap();
 
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1754,7 +1754,7 @@ mod tests {
                     setup_class_and_contract(&transaction).unwrap();
                 transaction.commit().unwrap();
 
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1779,7 +1779,7 @@ mod tests {
         #[tokio::test]
         async fn invalid_contract_address() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1794,7 +1794,7 @@ mod tests {
         #[tokio::test]
         async fn returns_not_found_if_we_dont_know_about_the_contract() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1825,7 +1825,7 @@ mod tests {
                 setup_class_and_contract(&transaction).unwrap();
             transaction.commit().unwrap();
 
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1870,7 +1870,7 @@ mod tests {
                 setup_class_and_contract(&transaction).unwrap();
             transaction.commit().unwrap();
 
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1967,7 +1967,7 @@ mod tests {
         #[tokio::test]
         async fn genesis() {
             let storage = setup_storage();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -1988,7 +1988,7 @@ mod tests {
             #[tokio::test]
             async fn positional_args() {
                 let storage = setup_storage();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2003,7 +2003,7 @@ mod tests {
             #[tokio::test]
             async fn named_args() {
                 let storage = setup_storage();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2019,7 +2019,7 @@ mod tests {
         #[tokio::test]
         async fn pending() {
             let storage = setup_storage();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2033,7 +2033,7 @@ mod tests {
         #[tokio::test]
         async fn invalid() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2054,7 +2054,7 @@ mod tests {
         #[tokio::test]
         async fn genesis() {
             let storage = setup_storage();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2073,7 +2073,7 @@ mod tests {
             #[tokio::test]
             async fn positional_args() {
                 let storage = setup_storage();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2088,7 +2088,7 @@ mod tests {
             #[tokio::test]
             async fn named_args() {
                 let storage = setup_storage();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2104,7 +2104,7 @@ mod tests {
         #[tokio::test]
         async fn pending() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2118,7 +2118,7 @@ mod tests {
         #[tokio::test]
         async fn invalid() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2152,7 +2152,7 @@ mod tests {
         #[tokio::test]
         async fn latest_invoked_block() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2180,7 +2180,7 @@ mod tests {
             #[tokio::test]
             async fn positional_args() {
                 let storage = Storage::in_memory().unwrap();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2205,7 +2205,7 @@ mod tests {
             #[tokio::test]
             async fn named_args() {
                 let storage = Storage::in_memory().unwrap();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2231,7 +2231,7 @@ mod tests {
         #[tokio::test]
         async fn pending_block() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2256,7 +2256,7 @@ mod tests {
         #[tokio::test]
         async fn invalid_entry_point() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2285,7 +2285,7 @@ mod tests {
         #[tokio::test]
         async fn invalid_contract_address() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2311,7 +2311,7 @@ mod tests {
         #[tokio::test]
         async fn invalid_call_data() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2337,7 +2337,7 @@ mod tests {
         #[tokio::test]
         async fn uninitialized_contract() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2363,7 +2363,7 @@ mod tests {
         #[tokio::test]
         async fn invalid_block_hash() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2389,7 +2389,7 @@ mod tests {
     #[tokio::test]
     async fn block_number() {
         let storage = setup_storage();
-        let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+        let sequencer = Client::new(Chain::Goerli).unwrap();
         let sync_state = Arc::new(SyncState::default());
         let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
         let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2409,7 +2409,7 @@ mod tests {
                 .iter()
                 .map(|set_chain| async {
                     let storage = Storage::in_memory().unwrap();
-                    let sequencer = SeqClient::new(*set_chain).unwrap();
+                    let sequencer = Client::new(*set_chain).unwrap();
                     let sync_state = Arc::new(SyncState::default());
                     let api = RpcApi::new(storage, sequencer, *set_chain, sync_state);
                     let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2433,7 +2433,7 @@ mod tests {
     #[should_panic]
     async fn pending_transactions() {
         let storage = Storage::in_memory().unwrap();
-        let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+        let sequencer = Client::new(Chain::Goerli).unwrap();
         let sync_state = Arc::new(SyncState::default());
         let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
         let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2447,7 +2447,7 @@ mod tests {
     #[should_panic]
     async fn protocol_version() {
         let storage = Storage::in_memory().unwrap();
-        let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+        let sequencer = Client::new(Chain::Goerli).unwrap();
         let sync_state = Arc::new(SyncState::default());
         let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
         let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2466,7 +2466,7 @@ mod tests {
         #[tokio::test]
         async fn not_syncing() {
             let storage = setup_storage();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2488,7 +2488,7 @@ mod tests {
             });
 
             let storage = setup_storage();
-            let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Goerli).unwrap();
             let sync_state = Arc::new(SyncState::default());
             *sync_state.status.write().await = expected.clone();
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
@@ -2625,7 +2625,7 @@ mod tests {
             #[tokio::test]
             async fn get_events_with_empty_filter() {
                 let (storage, events) = setup();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2656,7 +2656,7 @@ mod tests {
             #[tokio::test]
             async fn get_events_with_fully_specified_filter() {
                 let (storage, events) = setup();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2689,7 +2689,7 @@ mod tests {
             #[tokio::test]
             async fn get_events_by_block() {
                 let (storage, events) = setup();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2723,7 +2723,7 @@ mod tests {
             #[tokio::test]
             async fn get_events_with_invalid_page_size() {
                 let (storage, _events) = setup();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2747,7 +2747,7 @@ mod tests {
             #[tokio::test]
             async fn get_events_by_key_with_paging() {
                 let (storage, events) = setup();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2851,7 +2851,7 @@ mod tests {
             #[tokio::test]
             async fn get_events_with_empty_filter() {
                 let (storage, events) = setup();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -2876,7 +2876,7 @@ mod tests {
             #[tokio::test]
             async fn get_events_with_fully_specified_filter() {
                 let (storage, events) = setup();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -3019,7 +3019,7 @@ mod tests {
             #[tokio::test]
             async fn invoke_transaction() {
                 let storage = setup_storage();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -3051,7 +3051,7 @@ mod tests {
             #[tokio::test]
             async fn declare_transaction() {
                 let storage = setup_storage();
-                let sequencer = SeqClient::integration().unwrap();
+                let sequencer = Client::integration().unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -3087,7 +3087,7 @@ mod tests {
             #[tokio::test]
             async fn deploy_transaction() {
                 let storage = setup_storage();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -3142,7 +3142,7 @@ mod tests {
             #[tokio::test]
             async fn invoke_transaction() {
                 let storage = setup_storage();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -3197,7 +3197,7 @@ mod tests {
             #[tokio::test]
             async fn declare_transaction() {
                 let storage = setup_storage();
-                let sequencer = SeqClient::integration().unwrap();
+                let sequencer = Client::integration().unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
@@ -3234,7 +3234,7 @@ mod tests {
             #[tokio::test]
             async fn deploy_transaction() {
                 let storage = setup_storage();
-                let sequencer = SeqClient::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();

--- a/crates/pathfinder/src/rpc/test_client.rs
+++ b/crates/pathfinder/src/rpc/test_client.rs
@@ -1,0 +1,201 @@
+///! A drop-in replacement for `jsonrpsee::http_client::HttpClient` meant only for testing the RPC API,
+///! which is supposed to provide better error reporting, especially wrt serde errors.
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use jsonrpsee::core::client::{ClientT, IdKind, RequestIdManager};
+use jsonrpsee::core::{Error, TEN_MB_SIZE_BYTES};
+use jsonrpsee::types::error::CallError;
+use jsonrpsee::types::{ErrorResponse, ParamsSer, RequestSer, Response};
+use serde::de::DeserializeOwned;
+
+/// Convenience function to save on boilerplate in the tests
+pub fn client(addr: SocketAddr) -> TestClient {
+    TestClientBuilder::default()
+        .request_timeout(Duration::from_secs(120))
+        .build(addr)
+        .expect("Failed to create test HTTP-RPC client")
+}
+
+/// Test Http Client Builder.
+#[derive(Debug)]
+pub struct TestClientBuilder {
+    max_request_body_size: u32,
+    request_timeout: Duration,
+    max_concurrent_requests: usize,
+    id_kind: IdKind,
+}
+
+#[allow(dead_code)]
+impl TestClientBuilder {
+    /// Sets the maximum size of a request body in bytes (default is 10 MiB).
+    pub fn max_request_body_size(mut self, size: u32) -> Self {
+        self.max_request_body_size = size;
+        self
+    }
+
+    /// Set request timeout (default is 60 seconds).
+    pub fn request_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = timeout;
+        self
+    }
+
+    /// Set max concurrent requests.
+    pub fn max_concurrent_requests(mut self, max: usize) -> Self {
+        self.max_concurrent_requests = max;
+        self
+    }
+
+    /// Configure the data type of the request object ID (default is number).
+    pub fn id_format(mut self, id_kind: IdKind) -> Self {
+        self.id_kind = id_kind;
+        self
+    }
+
+    /// Build the HTTP client with target to connect to.
+    pub fn build(self, target: std::net::SocketAddr) -> Result<TestClient, Error> {
+        let transport = reqwest::Client::builder()
+            .timeout(self.request_timeout)
+            .build()
+            .map_err(|e| Error::Transport(e.into()))?;
+
+        Ok(TestClient {
+            transport,
+            target: reqwest::Url::parse(&format!("http://{target}")).unwrap(),
+            id_manager: Arc::new(RequestIdManager::new(
+                self.max_concurrent_requests,
+                self.id_kind,
+            )),
+        })
+    }
+}
+
+impl Default for TestClientBuilder {
+    fn default() -> Self {
+        Self {
+            max_request_body_size: TEN_MB_SIZE_BYTES,
+            request_timeout: Duration::from_secs(120),
+            max_concurrent_requests: 256,
+            id_kind: IdKind::Number,
+        }
+    }
+}
+
+/// JSON-RPC HTTP Client that provides functionality to perform method calls.
+#[derive(Debug, Clone)]
+pub struct TestClient {
+    /// HTTP transport client.
+    transport: reqwest::Client,
+    /// Url to which requests will be sent.
+    target: reqwest::Url,
+    /// Request ID manager.
+    id_manager: Arc<RequestIdManager>,
+}
+
+#[async_trait]
+impl ClientT for TestClient {
+    async fn notification<'a>(&self, _: &'a str, _: Option<ParamsSer<'a>>) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    /// Perform a request towards the server.
+    ///
+    /// The difference from [`jsonrpsee::http_client::HttpClient::request`] is that
+    /// this method reports the core reason for response `R` serde error,
+    /// while the former just ignores it.
+    async fn request<'a, R>(
+        &self,
+        method: &'a str,
+        params: Option<ParamsSer<'a>>,
+    ) -> Result<R, Error>
+    where
+        R: DeserializeOwned,
+    {
+        let guard = self.id_manager.next_request_id()?;
+        let id = guard.inner();
+        let request = RequestSer::new(&id, method, params);
+        let request = serde_json::to_vec(&request).map_err(Error::ParseError)?;
+
+        const CONTENT_TYPE_JSON: &str = "application/json";
+
+        let body = match self
+            .transport
+            .post(self.target.clone())
+            .header(
+                reqwest::header::CONTENT_TYPE,
+                reqwest::header::HeaderValue::from_static(CONTENT_TYPE_JSON),
+            )
+            .header(
+                reqwest::header::ACCEPT,
+                reqwest::header::HeaderValue::from_static(CONTENT_TYPE_JSON),
+            )
+            .body(request)
+            .send()
+            .await
+        {
+            Ok(response) => match response.bytes().await {
+                Ok(body) => body,
+                Err(error) => return Err(Error::Transport(error.into())),
+            },
+            Err(error) => {
+                if error.is_timeout() {
+                    return Err(Error::RequestTimeout);
+                } else {
+                    return Err(Error::Transport(error.into()));
+                }
+            }
+        };
+
+        let json_rpc_response: Response<'_, R> = match serde_json::from_slice(&body) {
+            Ok(response) => response,
+            Err(error) => {
+                let json_rpc_error_response: ErrorResponse<'_> = match serde_json::from_slice(&body)
+                {
+                    Ok(error_response) => error_response,
+                    Err(_) =>
+                    // We failed to deserialize into `ErrorResponse`.
+                    //
+                    // So, if there is no valid
+                    // 1. JSON-RPC [response object](https://www.jsonrpc.org/specification#response_object) in the reply,
+                    // 2. or [JSON-RPC error response object](https://www.jsonrpc.org/specification#error_object) in the reply,
+                    // 3. it's got to be an RPC API serialization error on our (server) side.
+                    //
+                    // This (3) error is simply ignored by `jsonrpsee::http_client::HttpClient`
+                    // so we used to end up with a `ParseError` which resulted from trying to deserialize
+                    // a response `R` from our API that had some serialization bug into
+                    // a `jsonrpsee::types::ErrorResponse` which will always fail with a
+                    // misleading "no such field >error<" message.
+                    //
+                    // We could also use a `ParseError` here but it would not be as informative.
+                    {
+                        return Err(Error::Custom(format!(
+                            "Error deserializing {}, {error}",
+                            std::any::type_name::<R>()
+                        )))
+                    }
+                };
+                return Err(Error::Call(CallError::Custom(
+                    json_rpc_error_response.error_object().clone().into_owned(),
+                )));
+            }
+        };
+
+        if json_rpc_response.id == id {
+            Ok(json_rpc_response.result)
+        } else {
+            Err(Error::InvalidRequestId)
+        }
+    }
+
+    async fn batch_request<'a, R>(
+        &self,
+        _: Vec<(&'a str, Option<ParamsSer<'a>>)>,
+    ) -> Result<Vec<R>, Error>
+    where
+        R: DeserializeOwned + Default + Clone,
+    {
+        unimplemented!()
+    }
+}

--- a/crates/pathfinder/src/rpc/test_client.rs
+++ b/crates/pathfinder/src/rpc/test_client.rs
@@ -4,12 +4,12 @@ use std::net::SocketAddr;
 use std::sync::atomic::AtomicU64;
 use std::time::Duration;
 
-use jsonrpsee::core::{Error, TEN_MB_SIZE_BYTES};
+use jsonrpsee::core::Error;
 use jsonrpsee::types::error::CallError;
 use jsonrpsee::types::{ErrorResponse, Id, ParamsSer, RequestSer, Response};
 use serde::de::DeserializeOwned;
 
-/// Convenience function to save on boilerplate in the tests
+/// Create an RPC [`TestClient`] with a timeout of 120 seconds.
 pub fn client(addr: SocketAddr) -> TestClient {
     TestClientBuilder::default()
         .request_timeout(Duration::from_secs(120))
@@ -20,18 +20,11 @@ pub fn client(addr: SocketAddr) -> TestClient {
 /// Test Http Client Builder.
 #[derive(Debug)]
 pub struct TestClientBuilder {
-    max_request_body_size: u32,
     request_timeout: Duration,
 }
 
 #[allow(dead_code)]
 impl TestClientBuilder {
-    /// Sets the maximum size of a request body in bytes (default is 10 MiB).
-    pub fn max_request_body_size(mut self, size: u32) -> Self {
-        self.max_request_body_size = size;
-        self
-    }
-
     /// Set request timeout (default is 120 seconds).
     pub fn request_timeout(mut self, timeout: Duration) -> Self {
         self.request_timeout = timeout;
@@ -56,7 +49,6 @@ impl TestClientBuilder {
 impl Default for TestClientBuilder {
     fn default() -> Self {
         Self {
-            max_request_body_size: TEN_MB_SIZE_BYTES,
             request_timeout: Duration::from_secs(120),
         }
     }

--- a/crates/pathfinder/src/rpc/test_client.rs
+++ b/crates/pathfinder/src/rpc/test_client.rs
@@ -4,8 +4,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use async_trait::async_trait;
-use jsonrpsee::core::client::{ClientT, IdKind, RequestIdManager};
+use jsonrpsee::core::client::{IdKind, RequestIdManager};
 use jsonrpsee::core::{Error, TEN_MB_SIZE_BYTES};
 use jsonrpsee::types::error::CallError;
 use jsonrpsee::types::{ErrorResponse, ParamsSer, RequestSer, Response};
@@ -94,18 +93,13 @@ pub struct TestClient {
     id_manager: Arc<RequestIdManager>,
 }
 
-#[async_trait]
-impl ClientT for TestClient {
-    async fn notification<'a>(&self, _: &'a str, _: Option<ParamsSer<'a>>) -> Result<(), Error> {
-        unimplemented!()
-    }
-
+impl TestClient {
     /// Perform a request towards the server.
     ///
     /// The difference from [`jsonrpsee::http_client::HttpClient::request`] is that
     /// this method reports the core reason for response `R` serde error,
     /// while the former just ignores it.
-    async fn request<'a, R>(
+    pub async fn request<'a, R>(
         &self,
         method: &'a str,
         params: Option<ParamsSer<'a>>,
@@ -187,15 +181,5 @@ impl ClientT for TestClient {
         } else {
             Err(Error::InvalidRequestId)
         }
-    }
-
-    async fn batch_request<'a, R>(
-        &self,
-        _: Vec<(&'a str, Option<ParamsSer<'a>>)>,
-    ) -> Result<Vec<R>, Error>
-    where
-        R: DeserializeOwned + Default + Clone,
-    {
-        unimplemented!()
     }
 }


### PR DESCRIPTION
This is a workaround for `jsonrpsee::http_client::HttpClient` used in the rpc tests reporting a senseless error from our perspective when serde errors are encountered within any of the `RpcApi` output types (`rpc::types::reply::*`).

I wanted to avoid forking (because then we would have to maintain the fork) or relying on submitting a PR to the crate (which means we have to follow the very latest release in which the PR would get merged, not to mention if it ultimately would).

This way, I think, we have better control of the kind of errors reported and the way those errors are reported to make any future test fixing easier.