### PR TITLE
feat(py): call/estimateFee with pending changes

### DIFF
--- a/crates/pathfinder/examples/call_against_sequencer.rs
+++ b/crates/pathfinder/examples/call_against_sequencer.rs
@@ -86,7 +86,7 @@ async fn main() {
             .map_err(Error::from);
 
         let local = handle
-            .call(args.request, args.block_hash, None)
+            .call(args.request, args.block_hash.try_into().unwrap(), None)
             .map_err(Error::from);
 
         let (local, seq) = tokio::join!(local, seq);

--- a/crates/pathfinder/examples/call_against_sequencer.rs
+++ b/crates/pathfinder/examples/call_against_sequencer.rs
@@ -86,7 +86,7 @@ async fn main() {
             .map_err(Error::from);
 
         let local = handle
-            .call(args.request, args.block_hash)
+            .call(args.request, args.block_hash, None)
             .map_err(Error::from);
 
         let (local, seq) = tokio::join!(local, seq);

--- a/crates/pathfinder/examples/estimate_past_transactions.rs
+++ b/crates/pathfinder/examples/estimate_past_transactions.rs
@@ -238,7 +238,7 @@ async fn estimate(
                 match next_work {
                     Some(Work {call, at_block, gas_price, actual_fee, span}) => {
                         let outer = span.clone();
-                        let fut = handle.estimate_fee(call, at_block, gas_price);
+                        let fut = handle.estimate_fee(call, at_block, gas_price, None);
                         waiting.push(async move {
                             ReadyResult {
                                 actual_fee,

--- a/crates/pathfinder/examples/estimate_past_transactions.rs
+++ b/crates/pathfinder/examples/estimate_past_transactions.rs
@@ -67,7 +67,7 @@ fn main() -> Result<(), anyhow::Error> {
 #[derive(Debug)]
 struct Work {
     call: pathfinder_lib::rpc::types::request::Call,
-    at_block: pathfinder_lib::rpc::types::BlockHashOrTag,
+    at_block: pathfinder_lib::core::StarknetBlockHash,
     gas_price: pathfinder_lib::cairo::ext_py::GasPriceSource,
     actual_fee: web3::types::H256,
     span: tracing::Span,
@@ -194,9 +194,7 @@ fn feed_work(
         sender
             .blocking_send(Work {
                 call,
-                at_block: pathfinder_lib::rpc::types::BlockHashOrTag::Hash(
-                    pathfinder_lib::core::StarknetBlockHash(target_hash),
-                ),
+                at_block: pathfinder_lib::core::StarknetBlockHash(target_hash),
                 // use the b.gas_price to get as close as possible
                 gas_price: pathfinder_lib::cairo::ext_py::GasPriceSource::Current(
                     gas_price_at_block,
@@ -238,7 +236,7 @@ async fn estimate(
                 match next_work {
                     Some(Work {call, at_block, gas_price, actual_fee, span}) => {
                         let outer = span.clone();
-                        let fut = handle.estimate_fee(call, at_block, gas_price, None);
+                        let fut = handle.estimate_fee(call, at_block.into(), gas_price, None);
                         waiting.push(async move {
                             ReadyResult {
                                 actual_fee,

--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -628,8 +628,6 @@ mod tests {
         let res = handle
             .call(
                 call,
-                // FIXME: pending should not be available, because we should always use latest for
-                // those cases
                 crate::rpc::types::Tag::Latest.try_into().unwrap(),
                 Some(update),
             )

--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -259,7 +259,7 @@ mod tests {
     use tokio::sync::oneshot;
 
     #[test_log::test(tokio::test)]
-    #[ignore]
+    #[ignore = "needs python venv"]
     async fn start_with_wrong_database_schema_fails() {
         let db_file = tempfile::NamedTempFile::new().unwrap();
 
@@ -291,7 +291,7 @@ mod tests {
     }
 
     #[test_log::test(tokio::test)]
-    #[ignore] // these tests require that you've entered into python venv
+    #[ignore = "needs python venv"]
     async fn call_like_in_python_ten_times() {
         use futures::stream::StreamExt;
 
@@ -368,7 +368,7 @@ mod tests {
     }
 
     #[test_log::test(tokio::test)]
-    #[ignore] // these tests require that you've entered into python venv
+    #[ignore = "needs python venv"]
     async fn estimate_fee_for_example() {
         // TODO: refactor the outer parts to a with_test_env or similar?
         let db_file = tempfile::NamedTempFile::new().unwrap();
@@ -470,7 +470,7 @@ mod tests {
     }
 
     #[test_log::test(tokio::test)]
-    #[ignore]
+    #[ignore = "needs python venv"]
     async fn call_with_unknown_contract() {
         let db_file = tempfile::NamedTempFile::new().unwrap();
 
@@ -538,7 +538,7 @@ mod tests {
     }
 
     #[test_log::test(tokio::test)]
-    #[ignore]
+    #[ignore = "needs python venv"]
     async fn call_with_pending_updates() {
         use crate::sequencer::reply::StateUpdate;
 

--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -567,7 +567,6 @@ mod tests {
             async move {
                 let _ = shutdown_rx.await;
             },
-            // chain doesn't matter here because we are not estimating any real transaction
             crate::core::Chain::Goerli,
         )
         .await

--- a/crates/pathfinder/src/cairo/ext_py/ser.rs
+++ b/crates/pathfinder/src/cairo/ext_py/ser.rs
@@ -160,7 +160,7 @@ impl<'a> serde::Serialize for DeployedContractElement<'a> {
     }
 }
 
-/// The tag pending should never be used With `ext_py`.
+/// Custom "when" without the Pending tag, which has no meaning crossing process boundaries.
 #[derive(Debug)]
 pub enum BlockHashNumberOrLatest {
     Hash(crate::core::StarknetBlockHash),

--- a/crates/pathfinder/src/cairo/ext_py/sub_process.rs
+++ b/crates/pathfinder/src/cairo/ext_py/sub_process.rs
@@ -353,6 +353,8 @@ async fn process(
             max_fee: &call.max_fee,
             version: &call.version,
             chain: *chain,
+            pending_updates: None.into(),
+            pending_deployed: None.into(),
         },
         Command::EstimateFee {
             call,
@@ -371,6 +373,8 @@ async fn process(
             max_fee: &call.max_fee,
             version: &call.version,
             chain: *chain,
+            pending_updates: None.into(),
+            pending_deployed: None.into(),
         },
     };
 

--- a/crates/pathfinder/src/cairo/ext_py/sub_process.rs
+++ b/crates/pathfinder/src/cairo/ext_py/sub_process.rs
@@ -339,6 +339,7 @@ async fn process(
             call,
             at_block,
             chain,
+            diffs: maybe_diffs,
             ..
         } => ChildCommand {
             command: Verb::Call,
@@ -353,14 +354,15 @@ async fn process(
             max_fee: &call.max_fee,
             version: &call.version,
             chain: *chain,
-            pending_updates: None.into(),
-            pending_deployed: None.into(),
+            pending_updates: maybe_diffs.as_ref().map(|x| &**x).into(),
+            pending_deployed: maybe_diffs.as_ref().map(|x| &**x).into(),
         },
         Command::EstimateFee {
             call,
             at_block,
             gas_price,
             chain,
+            diffs: maybe_diffs,
             ..
         } => ChildCommand {
             command: Verb::EstimateFee,
@@ -373,8 +375,8 @@ async fn process(
             max_fee: &call.max_fee,
             version: &call.version,
             chain: *chain,
-            pending_updates: None.into(),
-            pending_deployed: None.into(),
+            pending_updates: maybe_diffs.as_ref().map(|x| &**x).into(),
+            pending_deployed: maybe_diffs.as_ref().map(|x| &**x).into(),
         },
     };
 

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -771,7 +771,7 @@ impl RpcApi {
             (Some(h), &BlockHashOrTag::Hash(_) | &BlockHashOrTag::Tag(Tag::Latest)) => {
                 // we don't yet handle pending at all, and latest has been decided to be whatever
                 // block we have, which is exactly how the py/src/call.py handles it.
-                h.call(request, block_hash).map_err(Error::from).await
+                h.call(request, block_hash, None).map_err(Error::from).await
             }
             (Some(_), _) => {
                 // just forward it to the sequencer for now.
@@ -979,7 +979,7 @@ impl RpcApi {
             (Some(h), _, &BlockHashOrTag::Hash(_)) => {
                 // discussed during estimateFee work: when using block_hash use the gasPrice from
                 // the starknet_blocks::gas_price column, otherwise (tags) get the latest eth_gasPrice.
-                h.estimate_fee(request, block_hash, GasPriceSource::PastBlock)
+                h.estimate_fee(request, block_hash, GasPriceSource::PastBlock, None)
                     .await
                     .map_err(Error::from)
             }
@@ -992,9 +992,14 @@ impl RpcApi {
                     .await
                     .ok_or_else(|| internal_server_error("eth_gasPrice unavailable"))?;
 
-                h.estimate_fee(request, block_hash, GasPriceSource::Current(gas_price))
-                    .await
-                    .map_err(Error::from)
+                h.estimate_fee(
+                    request,
+                    block_hash,
+                    GasPriceSource::Current(gas_price),
+                    None,
+                )
+                .await
+                .map_err(Error::from)
             }
             (Some(_), Some(_), &BlockHashOrTag::Tag(Tag::Pending)) => {
                 Err(internal_server_error("Unimplemented"))

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -782,7 +782,8 @@ impl RpcApi {
                 .await
             }
             (Some(_), _) => {
-                // just forward it to the sequencer for now.
+                // FIXME: use latest PendingData and clone the inner arc as the diffs arg, use
+                // Latest as the block which to run on
                 self.sequencer
                     .call(request.into(), block_hash)
                     .map_ok(|x| x.result)
@@ -1010,6 +1011,8 @@ impl RpcApi {
                 .map_err(Error::from)
             }
             (Some(_), Some(_), &BlockHashOrTag::Tag(Tag::Pending)) => {
+                // FIXME: use latest PendingData and clone the inner arc as the diffs arg, use
+                // Latest as the block which to run on
                 Err(internal_server_error("Unimplemented"))
             }
             _ => {

--- a/py/setup.cfg
+++ b/py/setup.cfg
@@ -2,6 +2,7 @@
 # tool: prefix is required
 # cairo-lang generates too many of these
 addopts = -p no:warnings
+asyncio_mode = strict
 
 [flake8]
 # tool: prefix is not supported

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -699,15 +699,9 @@ async def do_call(
     for class_hash in pending_deployed.values():
         class_hashes.add(class_hash)
 
-    state_selector = StateSelector(
-        contract_addresses,
-        # we keep setting this to empty because we assume that the pending downloader
-        # has already stored all declared classes locally
-        class_hashes,
-    )
-    carried_state = await shared_state.get_filled_carried_state(
-        ffc, state_selector=state_selector
-    )
+    state_selector = StateSelector(contract_addresses, class_hashes)
+
+    carried_state = await shared_state.get_filled_carried_state(ffc, state_selector)
 
     for addr, contract_hash in pending_deployed.items():
         # using ContractState.empty will write zero to database, which we fail as intended

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -688,11 +688,16 @@ async def do_call(
     # exclude pending deploys, which should cause an issue reading them
     contract_addresses = contract_addresses ^ pending_deployed.keys()
 
+    class_hashes = set()
+
+    if contract_address in pending_deployed:
+        class_hashes.add(pending_deployed[contract_address])
+
     state_selector = StateSelector(
-        contract_addresses=contract_addresses,
+        contract_addresses,
         # we keep setting this to empty because we assume that the pending downloader
         # has already stored all declared classes locally
-        class_hashes=set()
+        class_hashes,
     )
     carried_state = await shared_state.get_filled_carried_state(
         ffc, state_selector=state_selector

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -690,8 +690,14 @@ async def do_call(
 
     class_hashes = set()
 
+    # include called contract's class hash to be loaded, it doesn't seem to be always
+    # automatically loaded, see test `test_call_on_pending_deployed`.
     if contract_address in pending_deployed:
         class_hashes.add(pending_deployed[contract_address])
+
+    # FIXME: it's unknown if this is really required, but we might end up loading up a lot of classes for nothing
+    for class_hash in pending_deployed.values():
+        class_hashes.add(class_hash)
 
     state_selector = StateSelector(
         contract_addresses,

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -328,10 +328,7 @@ def required_chain(s):
 
 def maybe_pending_updates(s):
     if s is None:
-        # returning {} here doesn't matter, since this function will not be called
-        # in case there is no key. so we still need to read with default from the
-        # command.
-        return None
+        return {}
 
     # currently just using the format from sequencers get_state_update
     return dict(
@@ -357,8 +354,7 @@ def maybe_pending_updates(s):
 
 def maybe_pending_deployed(deployed_contracts):
     if deployed_contracts is None:
-        # see `maybe_pending_updates` for rationale
-        return None
+        return {}
 
     # this accepts the form used in the sequencer state update
     # which is "prop": [ { "address": "0x...", "contract_hash": "0x..." }, ... ]

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -13,6 +13,7 @@ import io
 import json
 import pytest
 import copy
+from starkware.starknet.definitions.general_config import StarknetChainId
 
 
 # this is from 64a7f6aed9757d3d8d6c28bd972df73272b0cb0a of cairo-lang
@@ -282,7 +283,6 @@ def test_positive_directly():
     """
     this is like test_success but does it directly with the do_call, instead of the json wrapping, which hides exceptions which come from upgrading.
     """
-    from starkware.starknet.definitions.general_config import StarknetChainId
 
     con = inmemory_with_tables()
     contract_address = populate_test_contract_with_132_on_3(con)
@@ -412,8 +412,6 @@ def test_check_cairolang_version():
 
 
 def test_fee_estimate_on_positive_directly():
-    from starkware.starknet.definitions.general_config import StarknetChainId
-
     # fee estimation is a new thing on top of a call, but returning only the estimated fee
     con = inmemory_with_tables()
     contract_address = populate_test_contract_with_132_on_3(con)
@@ -491,8 +489,6 @@ def test_starknet_version_is_resolved():
 
 
 def test_call_on_pending_updated():
-    from starkware.starknet.definitions.general_config import StarknetChainId
-
     con = inmemory_with_tables()
     contract_address = populate_test_contract_with_132_on_3(con)
     con.execute("BEGIN")
@@ -525,8 +521,6 @@ def test_call_on_pending_updated():
 
 
 def test_call_on_pending_deployed():
-    from starkware.starknet.definitions.general_config import StarknetChainId
-
     con = inmemory_with_tables()
     _ = populate_test_contract_with_132_on_3(con)
     con.execute("BEGIN")
@@ -573,8 +567,6 @@ def test_call_on_pending_deployed():
 
 
 def test_call_on_pending_deployed_through_existing():
-    from starkware.starknet.definitions.general_config import StarknetChainId
-
     con = inmemory_with_tables()
     orig_contract_address = populate_test_contract_with_132_on_3(con)
     con.execute("BEGIN")
@@ -635,8 +627,6 @@ def test_call_on_pending_deployed_through_existing():
 
 @pytest.mark.skip(reason="this requires up to 2804 block synced database")
 def test_failing_mainnet_tx2():
-    from starkware.starknet.definitions.general_config import StarknetChainId
-
     con = sqlite3.connect("../../crates/pathfinder/mainnet.sqlite")
     con.execute("BEGIN")
 
@@ -695,8 +685,6 @@ def test_failing_mainnet_tx2():
 
 @pytest.mark.skip(reason="this requires an early goerli database")
 def test_positive_streamed_on_early_goerli_block_without_deployed():
-    from starkware.starknet.definitions.general_config import StarknetChainId
-
     con = sqlite3.connect("../../goerli.sqlite")
     con.execute("BEGIN")
 
@@ -748,8 +736,6 @@ def test_positive_streamed_on_early_goerli_block_without_deployed():
 
 @pytest.mark.skip(reason="this requires an early goerli database")
 def test_positive_streamed_on_early_goerli_block_with_deployed():
-    from starkware.starknet.definitions.general_config import StarknetChainId
-
     con = sqlite3.connect("../../goerli.sqlite")
     con.execute("BEGIN")
 

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -795,6 +795,15 @@ def test_positive_streamed_on_early_goerli_block_with_deployed():
     (verb, output, _timings) = loop_inner(con, with_updates)
     assert output == [0x22B]
 
+    # "tail case"
+    #
+    # I was initially confused why does this case seem to work without pushing
+    # all pending_deployed's contract_hashes to be loaded at the StateSelector,
+    # because such was required in the minimal standalone case but not here.
+    # the reason must be that other pending_updates had prompted fetching of
+    # the required (and shared) contract_hash so this didn't seem to require
+    # it.
+
     on_newly_deployed = {
         "command": "call",
         "at_block": 6,

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -666,18 +666,11 @@ def test_failing_mainnet_tx2():
 
     print(_timings)
 
-    # this is wrong answer, but good enough for now
-    # assert output == {
-    #     "gas_consumed": 0,
-    #     "gas_price": 21367239423,
-    #     "overall_fee": 21858685929729,
-    # }
-
-    # this is correct
+    # this is correct in 0.9.1
     assert output == {
-        "gas_consumed": 8732,
+        "gas_consumed": 10083,
         "gas_price": 21367239423,
-        "overall_fee": 186590486623319,
+        "overall_fee": 215446943464081,
     }
 
     assert output["overall_fee"] == 0xA9B3FBAC7457

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -635,7 +635,6 @@ def test_positive_streamed_on_early_goerli_block_with_deployed():
 
     # this matches sequencer state update
     pending_deployed = [
-        # FIXME: this is also a test.cairo, which has had many transactions
         {
             "address": "0x18b2088accbd652384e5ac545fd249095cb17bdc709868d1d748094d52b9f7d",
             "contract_hash": "0x010455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8",
@@ -666,3 +665,25 @@ def test_positive_streamed_on_early_goerli_block_with_deployed():
 
     (verb, output, _timings) = loop_inner(con, with_updates)
     assert output == [0x22B]
+
+    on_newly_deployed = {
+        "command": "call",
+        "at_block": 6,
+        "contract_address": int_param(
+            "0x18b2088accbd652384e5ac545fd249095cb17bdc709868d1d748094d52b9f7d"
+        ),
+        "entry_point_selector": "get_value",
+        "calldata": [5],
+        "gas_price": None,
+        "chain": StarknetChainId.MAINNET,
+        "pending_updates": pending_updates,
+        "pending_deployed": pending_deployed,
+    }
+
+    (verb, output, _timings) = loop_inner(con, on_newly_deployed)
+    assert output == [0x65]
+
+    del on_newly_deployed["pending_updates"][on_newly_deployed["contract_address"]]
+
+    (verb, output, _timings) = loop_inner(con, on_newly_deployed)
+    assert output == [0]

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -721,7 +721,7 @@ def test_positive_streamed_on_early_goerli_block_without_deployed():
         "entry_point_selector": "get_value",
         "calldata": [5],
         "gas_price": None,
-        "chain": StarknetChainId.MAINNET,
+        "chain": StarknetChainId.TESTNET,
     }
 
     with_updates = copy.deepcopy(without_updates)
@@ -782,7 +782,7 @@ def test_positive_streamed_on_early_goerli_block_with_deployed():
         "entry_point_selector": "get_value",
         "calldata": [5],
         "gas_price": None,
-        "chain": StarknetChainId.MAINNET,
+        "chain": StarknetChainId.TESTNET,
     }
 
     with_updates = copy.deepcopy(without_updates)


### PR DESCRIPTION
This PR adds support for "streamed updates", which basically means supporting pulling the pending block's state diff down to python.