### PR TITLE
chore(py): upgrade to cairo-lang 0.9.1

### DIFF
--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -423,9 +423,9 @@ mod tests {
         assert_eq!(
             at_block_fee,
             crate::rpc::types::reply::FeeEstimate {
-                consumed: H256::from_low_u64_be(3),
+                consumed: H256::from_low_u64_be(0x53f),
                 gas_price: H256::from_low_u64_be(1),
-                fee: H256::from_low_u64_be(4)
+                fee: H256::from_low_u64_be(0x540)
             }
         );
 
@@ -443,9 +443,9 @@ mod tests {
         assert_eq!(
             current_fee,
             crate::rpc::types::reply::FeeEstimate {
-                consumed: H256::from_low_u64_be(3),
+                consumed: H256::from_low_u64_be(0x53f),
                 gas_price: H256::from_low_u64_be(10),
-                fee: H256::from_low_u64_be(35)
+                fee: H256::from_low_u64_be(0x3478)
             }
         );
 

--- a/py/requirements-dev.in
+++ b/py/requirements-dev.in
@@ -1,5 +1,5 @@
 # see README.md
-cairo-lang==0.9.0
+cairo-lang==0.9.1
 # We don't use rlp directly, however this needs to be defined for it to help pip-compile
 eth-rlp==0.2.1
 pip-tools==6.6.2

--- a/py/requirements-dev.txt
+++ b/py/requirements-dev.txt
@@ -25,7 +25,7 @@ black==21.12b0
     # via -r requirements-dev.in
 cachetools==5.0.0
     # via cairo-lang
-cairo-lang==0.9.0
+cairo-lang==0.9.1
     # via -r requirements-dev.in
 certifi==2021.10.8
     # via requests

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -8,7 +8,7 @@ from starkware.storage.storage import Storage
 
 # used from tests, and the query which asserts that the schema is of expected version.
 EXPECTED_SCHEMA_REVISION = 14
-EXPECTED_CAIRO_VERSION = "0.9.0"
+EXPECTED_CAIRO_VERSION = "0.9.1"
 SUPPORTED_COMMANDS = frozenset(["call", "estimate_fee"])
 
 

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -419,7 +419,7 @@ def test_fee_estimate_on_positive_directly():
     (verb, output, _timings) = loop_inner(con, command)
 
     assert output == {
-        "gas_consumed": 3,
+        "gas_consumed": 0x0A07,
         "gas_price": 0,
         "overall_fee": 0,
     }
@@ -441,7 +441,7 @@ def test_fee_estimate_on_positive():
     assert first == {
         "status": "ok",
         "output": {
-            "gas_consumed": "0x" + (3).to_bytes(32, "big").hex(),
+            "gas_consumed": "0x" + (0x0A07).to_bytes(32, "big").hex(),
             "gas_price": "0x" + (0).to_bytes(32, "big").hex(),
             "overall_fee": "0x" + (0).to_bytes(32, "big").hex(),
         },
@@ -450,9 +450,9 @@ def test_fee_estimate_on_positive():
     assert second == {
         "status": "ok",
         "output": {
-            "gas_consumed": "0x" + (3).to_bytes(32, "big").hex(),
+            "gas_consumed": "0x" + (0x0A07).to_bytes(32, "big").hex(),
             "gas_price": "0x" + (10).to_bytes(32, "big").hex(),
-            "overall_fee": "0x" + (35).to_bytes(32, "big").hex(),
+            "overall_fee": "0x" + (0x644A).to_bytes(32, "big").hex(),
         },
     }
 

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -425,7 +425,7 @@ def test_fee_estimate_on_positive_directly():
     (verb, output, _timings) = loop_inner(con, command)
 
     assert output == {
-        "gas_consumed": 0x0A07,
+        "gas_consumed": 1343,
         "gas_price": 0,
         "overall_fee": 0,
     }
@@ -447,7 +447,7 @@ def test_fee_estimate_on_positive():
     assert first == {
         "status": "ok",
         "output": {
-            "gas_consumed": "0x" + (0x0A07).to_bytes(32, "big").hex(),
+            "gas_consumed": "0x" + (0x053F).to_bytes(32, "big").hex(),
             "gas_price": "0x" + (0).to_bytes(32, "big").hex(),
             "overall_fee": "0x" + (0).to_bytes(32, "big").hex(),
         },
@@ -456,9 +456,9 @@ def test_fee_estimate_on_positive():
     assert second == {
         "status": "ok",
         "output": {
-            "gas_consumed": "0x" + (0x0A07).to_bytes(32, "big").hex(),
+            "gas_consumed": "0x" + (0x053F).to_bytes(32, "big").hex(),
             "gas_price": "0x" + (10).to_bytes(32, "big").hex(),
-            "overall_fee": "0x" + (0x644A).to_bytes(32, "big").hex(),
+            "overall_fee": "0x" + (0x3478).to_bytes(32, "big").hex(),
         },
     }
 

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -88,13 +88,19 @@ def inmemory_with_tables():
             ethereum_log_index        INTEGER NOT NULL
         );
 
+        CREATE TABLE starknet_versions (
+            id      INTEGER NOT NULL PRIMARY KEY,
+            version TEXT NOT NULL UNIQUE
+        );
+
         CREATE TABLE starknet_blocks (
             number               INTEGER PRIMARY KEY,
             hash                 BLOB    NOT NULL,
             root                 BLOB    NOT NULL,
             timestamp            INTEGER NOT NULL,
             gas_price            BLOB    NOT NULL,
-            sequencer_address    BLOB    NOT NULL
+            sequencer_address    BLOB    NOT NULL,
+            version_id           INTEGER REFERENCES starknet_versions(id)
         );
         """
     )


### PR DESCRIPTION
Only the pythonic chores with some bumping of constants in tests.