### PR TITLE
fix(rpc/types): add pending transaction receipt types

### DIFF
--- a/crates/pathfinder/fixtures/rpc/0.31.0/receipt.json
+++ b/crates/pathfinder/fixtures/rpc/0.31.0/receipt.json
@@ -4,6 +4,8 @@
         "actual_fee": "0x1",
         "status": "ACCEPTED_ON_L1",
         "status_data": "blah",
+        "block_hash": "0xaaa",
+        "block_number": 3,
         "messages_sent": [
             {
                 "to_address": "0x2",
@@ -34,6 +36,8 @@
         "transaction_hash": "0x0",
         "actual_fee": "0x1",
         "status": "ACCEPTED_ON_L1",
+        "block_hash": "0xaaa",
+        "block_number": 3,
         "messages_sent": [
             {
                 "to_address": "0x2",
@@ -48,6 +52,41 @@
         "transaction_hash": "0x0",
         "actual_fee": "0x1",
         "status": "ACCEPTED_ON_L1",
-        "status_data": "blah"
+        "status_data": "blah",
+        "block_hash": "0xaaa",
+        "block_number": 3
+    },
+    {
+        "transaction_hash": "0x1",
+        "actual_fee": "0x2",
+        "messages_sent": [
+            {
+                "to_address": "0x5",
+                "payload": [
+                    "0x6"
+                ]
+            }
+        ],
+        "l1_origin_message": {
+            "from_address": "0x77",
+            "payload": [
+                "0x7"
+            ]
+        },
+        "events": [
+            {
+                "from_address": "0xa6",
+                "keys": [
+                    "0xa7"
+                ],
+                "data": [
+                    "0xa8"
+                ]
+            }
+        ]
+    },
+    {
+        "transaction_hash": "0x1",
+        "actual_fee": "0x2"
     }
 ]

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -642,6 +642,7 @@ mod tests {
         ];
 
         let transaction_receipts = vec![
+            // FIXME: declare transactions don't have events, so this is invalid test data!
             Receipt {
                 actual_fee: None,
                 events: vec![
@@ -1537,6 +1538,13 @@ mod tests {
                     .unwrap();
                 // Only asserting the hash because translating from Sequencer receipt to RPC receipt is pita.
                 assert_eq!(receipt.hash(), expected.transaction_hash);
+                assert_matches!(
+                    receipt,
+                    // FIXME: this should test an invoke instead
+                    TransactionReceipt::PendingDeclareOrDeploy(declare) => {
+                        assert_eq!(declare.common.actual_fee, Fee(Default::default()));
+                    }
+                );
             }
         }
 

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -596,8 +596,8 @@ mod tests {
     /// i.e. the pending block's parent hash will be the latest block's hash from storage,
     /// and similarly for the pending state diffs state root.
     async fn create_pending_data(storage: Storage) -> PendingData {
-        use crate::core::{StorageValue, TransactionNonce};
-        use crate::sequencer::reply::transaction::{DeclareTransaction, DeployTransaction};
+        use crate::core::StorageValue;
+        use crate::sequencer::reply::transaction::DeployTransaction;
 
         let storage2 = storage.clone();
         let latest = tokio::task::spawn_blocking(move || {
@@ -613,18 +613,20 @@ mod tests {
         .unwrap();
 
         let transactions: Vec<Transaction> = vec![
-            DeclareTransaction {
-                class_hash: ClassHash(StarkHash::from_be_slice(b"pending class hash 0").unwrap()),
-                max_fee: Call::DEFAULT_MAX_FEE,
-                nonce: TransactionNonce(StarkHash::from_be_slice(b"pending nonce 0").unwrap()),
-                sender_address: ContractAddress(
+            InvokeTransaction {
+                calldata: vec![],
+                contract_address: ContractAddress(
                     StarkHash::from_be_slice(b"pending contract addr 0").unwrap(),
                 ),
+                entry_point_selector: EntryPoint(
+                    StarkHash::from_be_slice(b"entry point 0").unwrap(),
+                ),
+                entry_point_type: EntryPointType::External,
+                max_fee: Call::DEFAULT_MAX_FEE,
                 signature: vec![],
                 transaction_hash: StarknetTransactionHash(
                     StarkHash::from_be_slice(b"pending tx hash 0").unwrap(),
                 ),
-                version: TransactionVersion(web3::types::H256::from_low_u64_be(1)),
             }
             .into(),
             DeployTransaction {
@@ -642,7 +644,6 @@ mod tests {
         ];
 
         let transaction_receipts = vec![
-            // FIXME: declare transactions don't have events, so this is invalid test data!
             Receipt {
                 actual_fee: None,
                 events: vec![
@@ -678,25 +679,7 @@ mod tests {
             },
             Receipt {
                 actual_fee: None,
-                events: vec![
-                    Event {
-                        data: vec![],
-                        from_address: ContractAddress::from_hex_str("0xabcddddddd").unwrap(),
-                        keys: vec![EventKey(StarkHash::from_be_slice(b"pending key").unwrap())],
-                    },
-                    Event {
-                        data: vec![],
-                        from_address: ContractAddress::from_hex_str("0xabcddddddd").unwrap(),
-                        keys: vec![EventKey(StarkHash::from_be_slice(b"pending key").unwrap())],
-                    },
-                    Event {
-                        data: vec![],
-                        from_address: ContractAddress::from_hex_str("0xabcaaaaaaa").unwrap(),
-                        keys: vec![EventKey(
-                            StarkHash::from_be_slice(b"pending key 2").unwrap(),
-                        )],
-                    },
-                ],
+                events: vec![],
                 execution_resources: ExecutionResources {
                     builtin_instance_counter: BuiltinInstanceCounter::Empty(
                         EmptyBuiltinInstanceCounter {},
@@ -1540,9 +1523,9 @@ mod tests {
                 assert_eq!(receipt.hash(), expected.transaction_hash);
                 assert_matches!(
                     receipt,
-                    // FIXME: this should test an invoke instead
-                    TransactionReceipt::PendingDeclareOrDeploy(declare) => {
-                        assert_eq!(declare.common.actual_fee, Fee(Default::default()));
+                    TransactionReceipt::PendingInvoke(invoke) => {
+                        assert_eq!(invoke.common.actual_fee, Fee(Default::default()));
+                        assert_eq!(invoke.events.len(), 3);
                     }
                 );
             }

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -531,11 +531,7 @@ impl RpcApi {
             });
 
             if let Some((receipt, transaction)) = receipt_transaction {
-                return Ok(TransactionReceipt::with_block_status(
-                    receipt,
-                    BlockStatus::Pending,
-                    &transaction,
-                ));
+                return Ok(TransactionReceipt::pending_from(receipt, &transaction));
             };
         }
 
@@ -573,9 +569,11 @@ impl RpcApi {
                         .context("Reading transaction from database")
                         .map_err(internal_server_error)?
                     {
-                        Some(transaction) => Ok(TransactionReceipt::with_block_status(
+                        Some(transaction) => Ok(TransactionReceipt::with_block_data(
                             receipt,
                             block_status,
+                            block.hash,
+                            block.number,
                             &transaction,
                         )),
                         None => Err(ErrorCode::InvalidTransactionHash.into()),


### PR DESCRIPTION
These were marked required in version 0.29.0 of the specification.