### PR TITLE
feat(rpc): implement `starknet_getTransactionByBlockIdAndIndex`

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,8 +297,7 @@ starknet_getBlockWithTxHashes
 starknet_getStorageAt
 # Transaction information
 starknet_getTransactionByHash
-starknet_getTransactionByBlockHashAndIndex
-starknet_getTransactionByBlockNumberAndIndex
+starknet_getTransactionByBlockIdAndIndex
 starknet_getTransactionReceipt
 # Block transaction counts
 starknet_getBlockTransactionCountByHash

--- a/crates/load-test/src/main.rs
+++ b/crates/load-test/src/main.rs
@@ -319,8 +319,8 @@ async fn get_transaction_by_block_hash_and_index(
 ) -> MethodResult<StarknetTransaction> {
     post_jsonrpc_request(
         user,
-        "starknet_getTransactionByBlockHashAndIndex",
-        json!({ "block_hash": block_hash, "index": index }),
+        "starknet_getTransactionByBlockIdAndIndex",
+        json!({ "block_id": {"block_hash": block_hash}, "index": index }),
     )
     .await
 }
@@ -332,8 +332,8 @@ async fn get_transaction_by_block_number_and_index(
 ) -> MethodResult<StarknetTransaction> {
     post_jsonrpc_request(
         user,
-        "starknet_getTransactionByBlockNumberAndIndex",
-        json!({ "block_number": block_number, "index": index }),
+        "starknet_getTransactionByBlockIdAndIndex",
+        json!({ "block_id": {"block_number": block_number}, "index": index }),
     )
     .await
 }

--- a/crates/pathfinder/rpc_examples.sh
+++ b/crates/pathfinder/rpc_examples.sh
@@ -30,12 +30,10 @@ rpc_call '[{"jsonrpc":"2.0","id":"16","method":"starknet_getStorageAt","params":
 
 rpc_call '{"jsonrpc":"2.0","id":"19","method":"starknet_getTransactionByHash","params":["0x74ec6667e6057becd3faff77d9ab14aecf5dde46edb7c599ee771f70f9e80ba"]}'
 
-rpc_call '[{"jsonrpc":"2.0","id":"20","method":"starknet_getTransactionByBlockHashAndIndex","params":["latest", 0]},
-{"jsonrpc":"2.0","id":"21","method":"starknet_getTransactionByBlockNumberAndIndex","params":["latest", 0]},
-{"jsonrpc":"2.0","id":"22","method":"starknet_getTransactionByBlockHashAndIndex","params":["pending", 0]},
-{"jsonrpc":"2.0","id":"23","method":"starknet_getTransactionByBlockNumberAndIndex","params":["pending", 0]},
-{"jsonrpc":"2.0","id":"24","method":"starknet_getTransactionByBlockHashAndIndex","params":["0x3871c8a0c3555687515a07f365f6f5b1d8c2ae953f7844575b8bde2b2efed27", 4]},
-{"jsonrpc":"2.0","id":"25","method":"starknet_getTransactionByBlockNumberAndIndex","params":[21348, 4]}]'
+rpc_call '[{"jsonrpc":"2.0","id":"20","method":"starknet_getTransactionByBlockIdAndIndex","params":["latest", 0]},
+{"jsonrpc":"2.0","id":"22","method":"starknet_getTransactionByBlockIdAndIndex","params":["pending", 0]},
+{"jsonrpc":"2.0","id":"24","method":"starknet_getTransactionByBlockIdAndIndex","params":[{"block_hash": "0x3871c8a0c3555687515a07f365f6f5b1d8c2ae953f7844575b8bde2b2efed27"}, 4]},
+{"jsonrpc":"2.0","id":"25","method":"starknet_getTransactionByBlockNumberAndIndex","params":[{"block_number": 21348}, 4]}]'
 
 rpc_call '{"jsonrpc":"2.0","id":"26","method":"starknet_getTransactionReceipt","params":["0x74ec6667e6057becd3faff77d9ab14aecf5dde46edb7c599ee771f70f9e80ba"]}'
 


### PR DESCRIPTION
Instead of the previous `starknet_getTransactionByBlock{Hash,Numer}AndIndex`
methods, this new method takes a block_id parameter that can either be
a hash, a number or a tag.