### PR TITLE
fix(rpc/tests): remove asserting on pending block not having a number and hash

### DIFF
--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -725,11 +725,7 @@ mod tests {
         async fn pending() {
             let params = rpc_params!(BlockId::Pending);
 
-            check_result(params, move |block| {
-                assert_eq!(block.block_number, None);
-                assert_eq!(block.block_hash, None);
-            })
-            .await;
+            check_result(params, move |_| {}).await;
         }
 
         #[tokio::test]


### PR DESCRIPTION
Occasionally the feeder gateway API returns finalized blocks as pending,
which causes this test to be flaky and fail occasionally.