### PR TITLE
feat: configuration for poll pending

### DIFF
--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -27,6 +27,8 @@ pub enum ConfigOption {
     PythonSubprocesses,
     /// Enable SQLite write-ahead logging.
     EnableSQLiteWriteAheadLogging,
+    /// Enable pending polling.
+    PollPending,
 }
 
 impl Display for ConfigOption {
@@ -41,6 +43,7 @@ impl Display for ConfigOption {
             ConfigOption::EnableSQLiteWriteAheadLogging => {
                 f.write_str("Enable SQLite write-ahead logging")
             }
+            ConfigOption::PollPending => f.write_str("Enable pending block polling"),
         }
     }
 }
@@ -69,6 +72,8 @@ pub struct Configuration {
     pub python_subprocesses: std::num::NonZeroUsize,
     /// Enable SQLite write-ahead logging.
     pub sqlite_wal: bool,
+    /// Enable pending polling.
+    pub poll_pending: bool,
 }
 
 impl Configuration {

--- a/crates/pathfinder/src/config/builder.rs
+++ b/crates/pathfinder/src/config/builder.rs
@@ -129,6 +129,24 @@ Hint: Register your own account or run your own Ethereum node and put the real U
             )
         })?;
 
+        let poll_pending = match self.take(ConfigOption::PollPending) {
+            Some(enable) => {
+                let enable = enable.to_lowercase();
+                match enable.as_str() {
+                    "true" => Ok(true),
+                    "false" => Ok(false),
+                    _ => Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        format!(
+                            "Invalid value '{}' for enable poll pending option, must be true|false",
+                            enable
+                        ),
+                    )),
+                }
+            }
+            None => Ok(false),
+        }?;
+
         Ok(Configuration {
             ethereum: EthereumConfig {
                 url: eth_url,
@@ -139,6 +157,7 @@ Hint: Register your own account or run your own Ethereum node and put the real U
             sequencer_url,
             python_subprocesses,
             sqlite_wal,
+            poll_pending,
         })
     }
 

--- a/crates/pathfinder/src/config/file.rs
+++ b/crates/pathfinder/src/config/file.rs
@@ -22,6 +22,8 @@ struct FileConfig {
     python_subprocesses: Option<String>,
     #[serde(rename = "sqlite-wal")]
     sqlite_wal: Option<String>,
+    #[serde(rename = "poll-pending")]
+    poll_pending: Option<String>,
 }
 
 impl FileConfig {
@@ -38,6 +40,7 @@ impl FileConfig {
         .with(ConfigOption::SequencerHttpUrl, self.sequencer_url)
         .with(ConfigOption::PythonSubprocesses, self.python_subprocesses)
         .with(ConfigOption::EnableSQLiteWriteAheadLogging, self.sqlite_wal)
+        .with(ConfigOption::PollPending, self.poll_pending)
     }
 }
 
@@ -132,6 +135,14 @@ password = "{}""#,
             cfg.take(ConfigOption::EnableSQLiteWriteAheadLogging),
             Some(value)
         );
+    }
+
+    #[test]
+    fn poll_pending() {
+        let value = "true".to_owned();
+        let toml = format!(r#"poll-pending = "{}""#, value);
+        let mut cfg = config_from_str(&toml).unwrap();
+        assert_eq!(cfg.take(ConfigOption::PollPending), Some(value));
     }
 
     #[test]


### PR DESCRIPTION
This PR follows #474 and adds configuration support to enable poll pending `--poll-pending=true|false`. It is the configuration portion of #446.

Some things worth pointing out:
1. This option is specifically disallowed on testnet. `pending` is meant as a work-around to mainnet's slow block times.
2. The current polling rate is hardcoded to 5s.

This does not yet do anything meaningful from the user's perspective as this is not yet connected to RPC. That will come in the next PR.