### PR TITLE
fix(rpc): follow-up transaction/receipt property rename in 0.30.0

### DIFF
--- a/crates/pathfinder/fixtures/rpc/0.30.0/block.json
+++ b/crates/pathfinder/fixtures/rpc/0.30.0/block.json
@@ -10,7 +10,7 @@
         "transactions": [
             {
                 "type": "DECLARE",
-                "txn_hash": "0x4",
+                "transaction_hash": "0x4",
                 "max_fee": "0x5",
                 "version": "0x6",
                 "signature": [
@@ -22,7 +22,7 @@
             },
             {
                 "type": "INVOKE",
-                "txn_hash": "0x4",
+                "transaction_hash": "0x4",
                 "max_fee": "0x5",
                 "version": "0x6",
                 "signature": [
@@ -37,7 +37,7 @@
             },
             {
                 "type": "DEPLOY",
-                "txn_hash": "0xe",
+                "transaction_hash": "0xe",
                 "contract_address": "0xf",
                 "class_hash": "0x10",
                 "constructor_calldata": [

--- a/crates/pathfinder/fixtures/rpc/0.30.0/receipt.json
+++ b/crates/pathfinder/fixtures/rpc/0.30.0/receipt.json
@@ -1,6 +1,6 @@
 [
     {
-        "txn_hash": "0x0",
+        "transaction_hash": "0x0",
         "actual_fee": "0x1",
         "status": "ACCEPTED_ON_L1",
         "statusData": "blah",
@@ -31,7 +31,7 @@
         ]
     },
     {
-        "txn_hash": "0x0",
+        "transaction_hash": "0x0",
         "actual_fee": "0x1",
         "status": "ACCEPTED_ON_L1",
         "messages_sent": [
@@ -45,7 +45,7 @@
         "events": []
     },
     {
-        "txn_hash": "0x0",
+        "transaction_hash": "0x0",
         "actual_fee": "0x1",
         "status": "ACCEPTED_ON_L1",
         "statusData": "blah"


### PR DESCRIPTION
Version 0.30.0 of the OpenRPC specification has renamed these properties.