### PR TITLE
feat(rpc)!: remove deprecated `starknet_getCode` JSON-RPC method

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,8 +305,6 @@ starknet_getClass
 starknet_getClassHashAt
 # The code of a specific contract
 starknet_getClassAt
-# The old, now deprecated name for starknet_getClassAt is also supported
-starknet_getCode
 # Call a StarkNet function without creating a transaction
 starknet_call
 # The latest StarkNet block height

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -30,13 +30,6 @@ pub struct ContractStateHash(pub StarkHash);
 #[derive(Copy, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ContractRoot(pub StarkHash);
 
-/// A Starknet contract's bytecode and ABI.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ContractCode {
-    pub bytecode: Vec<ByteCodeWord>,
-    pub abi: String,
-}
-
 // Bytecode and entry point list of a class
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ContractClass {


### PR DESCRIPTION
BREAKING CHANGE: this removes the above method, which has been deprecated since pathfinder v0.2.3-alpha.