### PR TITLE
fix(ext_py): log unknown stderr lines on TRACE level

### DIFF
--- a/crates/pathfinder/src/cairo/ext_py/sub_process.rs
+++ b/crates/pathfinder/src/cairo/ext_py/sub_process.rs
@@ -261,7 +261,7 @@ async fn spawn(
                     (level, displayed.unwrap_or(std::borrow::Cow::Borrowed(rem)))
                 } else {
                     // this means that the line probably comes from beyond our code
-                    (tracing::Level::ERROR, std::borrow::Cow::Borrowed(buffer))
+                    (tracing::Level::TRACE, std::borrow::Cow::Borrowed(buffer))
                 };
 
                 // if the python script would turn out to be very chatty, this would become an issue


### PR DESCRIPTION
Log messages coming from our own Python code have a log level prefix, so
that we can log those lines on the right level on the Rust side.

However, in certain cases (like kill()-ing the subprocess) there might
be exception messages and stack traces coming from generic Python code.

When cancelling a request (due to the JSON-RPC client going away before
we've finished processing) we kill() Python subprocesses, this is part
of normal operation -- we certainly shouldn't log ERRORs in our logs.

This change moves the log level for these "unknown" stderr lines to
TRACE to make sure killing a subprocess does not lead to ERRORs in the
log. Throwing the baby out with the bathwater? Yes, to an extent this
is, since we won't print non kill()-related random tracebacks either.
But this is probably still better than getting errors in the logs during
for non-errors.

Fixes #466