### PR TITLE
fix(ext_py): avoid BrokenPipe exceptions in Python subprocesses

### DIFF
--- a/crates/pathfinder/src/cairo/ext_py/sub_process.rs
+++ b/crates/pathfinder/src/cairo/ext_py/sub_process.rs
@@ -135,7 +135,6 @@ pub(super) async fn launch_python(
 
     // important to close up the stdin not to deadlock
     drop(stdin);
-    drop(stdout);
 
     // give the subprocess a bit of time, since it might be less risky/better for sqlite to
     // exit/cleanup properly


### PR DESCRIPTION
When cancelling a request (due to the JSON-RPC client going away before
we've finished processing) we kill() Python subprocesses, this is part
of normal operation. However, currently we close stdin and stdout, wait
one second, and only then proceed with actually sending SIGKILL to the
subprocess.

In case the Python subprocess finishes processing the command when we
have already closed stdout then sending the result of the command will
fail with a BrokenPipe exception, leading to the exception being logged
as ERROR in the pathfinder log.

By removing the explicit close we're now closing stdout _only_ after
actually killing the subprocess. This avoids the BrokenPipe exception
because in the worst case (when there's not enough buffer space for
the result in the pipe we're using as stdout) the print() will just
block in the Python process before we're killing the process -- no
exception raised.

Fixes #466