### PR TITLE
feat: plumb the pending data into calls and estimate fees

### DIFF
--- a/crates/pathfinder/src/cairo/ext_py/ser.rs
+++ b/crates/pathfinder/src/cairo/ext_py/ser.rs
@@ -318,7 +318,7 @@ mod tests {
         assert_eq!("[]", s);
     }
 
-    /// It is important that this is not [] or {}, see [`serialize_none_updates`].
+    /// It is important that this is not `[]` or `{}`, see [`serialize_none_updates`].
     #[test]
     fn serialize_none_deployed_contracts() {
         use super::DeployedContractsWrapper;

--- a/crates/pathfinder/src/cairo/ext_py/ser.rs
+++ b/crates/pathfinder/src/cairo/ext_py/ser.rs
@@ -275,11 +275,14 @@ mod tests {
         assert_eq!(expected, s);
     }
 
+    /// It is important this outcome is different from the empty list or dict, because the None and
+    /// non-None values now carry a difference at the python side.
+    ///
+    /// See python test `test_call.py::test_call_on_reorgged_pending_block`.
     #[test]
     fn serialize_none_updates() {
         use super::ContractUpdatesWrapper;
 
-        // this could be an empty object just as well
         let expected = "null";
         let s = serde_json::to_string(&ContractUpdatesWrapper(None)).unwrap();
         assert_eq!(expected, s);
@@ -315,11 +318,11 @@ mod tests {
         assert_eq!("[]", s);
     }
 
+    /// It is important that this is not [] or {}, see [`serialize_none_updates`].
     #[test]
     fn serialize_none_deployed_contracts() {
         use super::DeployedContractsWrapper;
 
-        // in python's view, this is an optional, whichever [] or null would work
         let expected = r#"null"#;
         let s = serde_json::to_string(&DeployedContractsWrapper(None)).unwrap();
         assert_eq!(expected, s);

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -85,6 +85,15 @@ impl PendingData {
             .as_ref()
             .map(|inner| inner.state_update.clone())
     }
+
+    pub async fn state_update_on_parent_block(
+        &self,
+    ) -> Option<(StarknetBlockHash, Arc<sequencer::reply::StateUpdate>)> {
+        let g = self.inner.read().await;
+        let inner = g.as_ref()?;
+
+        Some((inner.block.parent_hash, inner.state_update.clone()))
+    }
 }
 
 /// Implements the main sync loop, where L1 and L2 sync results are combined.

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -36,6 +36,10 @@ def main():
         sys.exit(1)
 
     with sqlite3.connect(database_path) as connection:
+        # this is not a sort of "usual" isolation_level switch with sqlite like
+        # read_uncommited or anything like that. instead this asks that the
+        # python side doesn't inspect the queries and try to manage autocommit
+        # like behaviour around them.
         connection.isolation_level = None
 
         connection.execute("BEGIN")

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -3,6 +3,7 @@ from call import (
     do_loop,
     EXPECTED_SCHEMA_REVISION,
     int_param,
+    int_hash_or_latest,
     loop_inner,
     maybe_pending_updates,
     maybe_pending_deployed,
@@ -620,6 +621,80 @@ def test_call_on_pending_deployed_through_existing():
     # already have, add a method or a return value to call_increase_value.
     (verb, output, _timings) = loop_inner(con, command)
     assert output == []
+
+
+def test_call_on_reorgged_pending_block():
+    """
+    This was discussed during the pending implementation:
+
+    When calling or estimating the fee on a pending block, rust side will
+    always execute it on a specific block (pending's parent block). If that
+    block is not found, we should default to the latest block IFF there are
+    pending updates or deploys.
+
+    This now gives meaning to the `pending_{updates,deployed}: None` vs.
+    `pending_{updates,deployed}: <default>` cases.
+    """
+
+    con = inmemory_with_tables()
+    contract_address = populate_test_contract_with_132_on_3(con)
+
+    existing_block = int_hash_or_latest(f'0x{(b"some blockhash somewhere").hex()}')
+    reorgged_block = int_hash_or_latest(f'0x{(b"this block got reorgged").hex()}')
+
+    commands = []
+
+    commands.append(
+        (
+            {
+                "command": "call",
+                "at_block": existing_block,
+                "contract_address": contract_address,
+                "entry_point_selector": "get_value",
+                "calldata": [132],
+                "gas_price": None,
+                "chain": StarknetChainId.MAINNET,
+                "pending_updates": {
+                    contract_address: [
+                        {"key": 132, "value": 5},
+                    ]
+                },
+                "pending_deployed": maybe_pending_deployed([]),
+            },
+            [5],
+        )
+    )
+
+    commands.append(
+        (
+            {
+                "command": "call",
+                # this block is not found
+                "at_block": reorgged_block,
+                "contract_address": contract_address,
+                "entry_point_selector": "get_value",
+                "calldata": [132],
+                "gas_price": None,
+                "chain": StarknetChainId.MAINNET,
+                # because the block is not found, the updates are not used
+                "pending_updates": {
+                    contract_address: [
+                        {"key": 132, "value": 5},
+                    ]
+                },
+                "pending_deployed": maybe_pending_deployed([]),
+            },
+            [3],
+        )
+    )
+
+    # existing test cases calling on non-existing blocks should work as they have been,
+    # because they don't define any value for pending stuffs
+
+    con.execute("BEGIN")
+    for command, expected in commands:
+        (verb, output, _timings) = loop_inner(con, command)
+        assert output == expected
 
 
 # Rest of the test cases require a mainnet or goerli database in some path.

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -391,6 +391,7 @@ def test_no_such_block():
         con,
         (
             # there's only block 1
+            # it is important that none of these have pending_updates or pending_deployed
             f'{{ "command": "call", "at_block": 99999999999, "contract_address": {contract_address}, "entry_point_selector": "get_value", "calldata": [132], "gas_price": null, "chain": "GOERLI" }}',
             f'{{ "command": "call", "at_block": "0x{(b"no such block").hex()}", "contract_address": {contract_address}, "entry_point_selector": "get_value", "calldata": [132], "gas_price": null, "chain": "GOERLI" }}',
             f'{{ "command": "call", "at_block": "latest", "contract_address": {contract_address}, "entry_point_selector": "get_value", "calldata": [132], "gas_price": null, "chain": "GOERLI" }}',


### PR DESCRIPTION
While planning this, biggest changes from #462 are:
- rust side calls python with explicit hash when there are pending changes
    - if python side cannot find the block, it'll disregard the pending changes and use latest block instead, but only if there were non-null `pending_updates` or non-null `pending_deployed`
    - this could happen because of a reorg
- rpc serialization now uses null's meaningfully (before they were unimportant)

Python side has tests for this... ~I guess I'll add the same test on rust side tomorrow.~