### PR TITLE
feat(rpc): `starknet_blockHashAndNumber`

### DIFF
--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -14,9 +14,7 @@ use crate::{
     rpc::{
         api::{BlockResponseScope, RpcApi},
         serde::{CallSignatureElemAsDecimalStr, FeeAsHexStr, TransactionVersionAsHexStr},
-        types::{
-            request::{Call, ContractCall, EventFilter},
-        },
+        types::request::{Call, ContractCall, EventFilter},
     },
     sequencer::request::add_transaction::ContractDefinition,
 };

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -15,7 +15,6 @@ use crate::{
         api::{BlockResponseScope, RpcApi},
         serde::{CallSignatureElemAsDecimalStr, FeeAsHexStr, TransactionVersionAsHexStr},
         types::{
-            request::OverflowingStorageAddress,
             request::{Call, ContractCall, EventFilter},
         },
     },
@@ -140,7 +139,7 @@ Hint: If you are looking to run two instances of pathfinder, you must configure 
         pub struct NamedArgs {
             pub contract_address: ContractAddress,
             // Accept overflowing type here to report INVALID_STORAGE_KEY properly
-            pub key: OverflowingStorageAddress,
+            pub key: crate::core::StorageAddress,
             pub block_id: BlockId,
         }
         let params = params.parse::<NamedArgs>()?;
@@ -1024,14 +1023,10 @@ mod tests {
                 .unwrap(),
                 BlockId::Latest
             );
-            let error = client(addr)
+            client(addr)
                 .request::<StorageValue>("starknet_getStorageAt", params)
                 .await
                 .unwrap_err();
-            assert_eq!(
-                crate::rpc::types::reply::ErrorCode::InvalidStorageKey,
-                error
-            );
         }
 
         #[tokio::test]
@@ -1051,14 +1046,10 @@ mod tests {
                 .unwrap(),
                 BlockId::Latest
             );
-            let error = client(addr)
+            client(addr)
                 .request::<StorageValue>("starknet_getStorageAt", params)
                 .await
                 .unwrap_err();
-            assert_eq!(
-                crate::rpc::types::reply::ErrorCode::InvalidStorageKey,
-                error
-            );
         }
 
         #[tokio::test]

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -136,7 +136,6 @@ Hint: If you are looking to run two instances of pathfinder, you must configure 
         #[derive(Debug, Deserialize)]
         pub struct NamedArgs {
             pub contract_address: ContractAddress,
-            // Accept overflowing type here to report INVALID_STORAGE_KEY properly
             pub key: crate::core::StorageAddress,
             pub block_id: BlockId,
         }

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -889,9 +889,8 @@ impl RpcApi {
             StarknetBlocksTable::get_latest_number(&tx)
                 .context("Reading latest block number from database")
                 .map_err(internal_server_error)?
-                .context("Database is empty")
-                .map_err(internal_server_error)
                 .map(|number| number.0)
+                .ok_or_else(|| Error::from(ErrorCode::NoBlocks))
         });
 
         jh.await

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -241,6 +241,15 @@ pub mod reply {
         pub transactions: Transactions,
     }
 
+    #[derive(Clone, Debug, Serialize, PartialEq)]
+    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+    pub struct BlockHashAndNumber {
+        #[serde(rename = "block_hash")]
+        pub hash: StarknetBlockHash,
+        #[serde(rename = "block_number")]
+        pub number: StarknetBlockNumber,
+    }
+
     impl Block {
         /// Constructs [Block] from [RawBlock]
         pub fn from_raw(block: RawBlock, transactions: Transactions) -> Self {

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -312,14 +312,13 @@ pub mod reply {
         ContractNotFound = 20,
         InvalidMessageSelector = 21,
         InvalidCallData = 22,
-        InvalidStorageKey = 23,
         InvalidBlockId = 24,
         InvalidTransactionHash = 25,
         InvalidTransactionIndex = 27,
         InvalidContractClassHash = 28,
         PageSizeTooBig = 31,
+        NoBlocks = 32,
         ContractError = 40,
-        InvalidContractDefinition = 50,
     }
 
     /// We can have this equality and should have it in order to use it for tests. It is meant to
@@ -367,14 +366,13 @@ pub mod reply {
                 20 => ContractNotFound,
                 21 => InvalidMessageSelector,
                 22 => InvalidCallData,
-                23 => InvalidStorageKey,
                 24 => InvalidBlockId,
                 25 => InvalidTransactionHash,
                 27 => InvalidTransactionIndex,
                 28 => InvalidContractClassHash,
                 31 => PageSizeTooBig,
+                32 => NoBlocks,
                 40 => ContractError,
-                50 => InvalidContractDefinition,
                 x => return Err(x),
             })
         }
@@ -388,7 +386,6 @@ pub mod reply {
                 ErrorCode::ContractNotFound => "Contract not found",
                 ErrorCode::InvalidMessageSelector => "Invalid message selector",
                 ErrorCode::InvalidCallData => "Invalid call data",
-                ErrorCode::InvalidStorageKey => "Invalid storage key",
                 ErrorCode::InvalidBlockId => "Invalid block id",
                 ErrorCode::InvalidTransactionHash => "Invalid transaction hash",
                 ErrorCode::InvalidTransactionIndex => "Invalid transaction index in a block",
@@ -397,7 +394,7 @@ pub mod reply {
                 }
                 ErrorCode::PageSizeTooBig => "Requested page size is too big",
                 ErrorCode::ContractError => "Contract error",
-                ErrorCode::InvalidContractDefinition => "Invalid contract definition",
+                ErrorCode::NoBlocks => "There are no blocks",
             }
         }
     }

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -82,23 +82,10 @@ pub mod request {
             CallParam, CallSignatureElem, ContractAddress, EntryPoint, EventKey, Fee,
             TransactionVersion,
         },
-        rpc::serde::{
-            CallSignatureElemAsDecimalStr, FeeAsHexStr, H256AsNoLeadingZerosHexStr,
-            TransactionVersionAsHexStr,
-        },
+        rpc::serde::{CallSignatureElemAsDecimalStr, FeeAsHexStr, TransactionVersionAsHexStr},
     };
     use serde::Deserialize;
     use serde_with::{serde_as, skip_serializing_none};
-    use web3::types::H256;
-
-    /// The address of a storage element for a StarkNet contract.
-    ///
-    /// __This type is not checked for 251 bits overflow__ in contrast to
-    /// [`StarkHash`](stark_hash::StarkHash).
-    #[serde_as]
-    #[derive(Debug, Copy, Clone, Deserialize, PartialEq)]
-    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Serialize))]
-    pub struct OverflowingStorageAddress(#[serde_as(as = "H256AsNoLeadingZerosHexStr")] pub H256);
 
     /// Contains parameters passed to `starknet_call`.
     #[serde_as]

--- a/crates/pathfinder/src/sequencer/error.rs
+++ b/crates/pathfinder/src/sequencer/error.rs
@@ -29,7 +29,6 @@ impl From<SequencerError> for Error {
                 StarknetErrorCode::OutOfRangeTransactionHash => {
                     RpcErrorCode::InvalidTransactionHash.into()
                 }
-                StarknetErrorCode::OutOfRangeStorageKey => RpcErrorCode::InvalidStorageKey.into(),
                 StarknetErrorCode::TransactionFailed => RpcErrorCode::InvalidCallData.into(),
                 StarknetErrorCode::EntryPointNotFound => {
                     RpcErrorCode::InvalidMessageSelector.into()
@@ -37,9 +36,7 @@ impl From<SequencerError> for Error {
                 StarknetErrorCode::BlockNotFound if e.message.contains("Block number") => {
                     RpcErrorCode::InvalidBlockId.into()
                 }
-                StarknetErrorCode::InvalidContractDefinition => {
-                    RpcErrorCode::InvalidContractDefinition.into()
-                }
+                StarknetErrorCode::InvalidContractDefinition => RpcErrorCode::ContractError.into(),
                 StarknetErrorCode::BlockNotFound
                 | StarknetErrorCode::SchemaValidationError
                 | StarknetErrorCode::MalformedRequest
@@ -81,8 +78,6 @@ pub enum StarknetErrorCode {
     EntryPointNotFound,
     #[serde(rename = "StarknetErrorCode.OUT_OF_RANGE_CONTRACT_ADDRESS")]
     OutOfRangeContractAddress,
-    #[serde(rename = "StarknetErrorCode.OUT_OF_RANGE_CONTRACT_STORAGE_KEY")]
-    OutOfRangeStorageKey,
     #[serde(rename = "StarkErrorCode.SCHEMA_VALIDATION_ERROR")]
     SchemaValidationError,
     #[serde(rename = "StarknetErrorCode.TRANSACTION_FAILED")]

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -396,6 +396,32 @@ impl StarknetBlocksTable {
         }
     }
 
+    /// Returns the [hash](StarknetBlockHash) and [number](StarknetBlockNumber) of the latest block.
+    pub fn get_latest_hash_and_number(
+        tx: &Transaction<'_>,
+    ) -> anyhow::Result<Option<(StarknetBlockHash, StarknetBlockNumber)>> {
+        let mut statement =
+            tx.prepare("SELECT hash, number FROM starknet_blocks ORDER BY number DESC LIMIT 1")?;
+        let mut rows = statement.query([])?;
+        let row = rows.next().context("Iterate rows")?;
+        match row {
+            Some(row) => {
+                let hash = row
+                    .get_ref_unwrap("hash")
+                    .as_blob()
+                    .expect("hash column should exist");
+                let hash =
+                    StarkHash::from_be_slice(hash).expect("hash column should contain valid hash");
+                let hash = StarknetBlockHash(hash);
+
+                let number = row.get_ref_unwrap("number").as_i64().unwrap() as u64;
+                let number = StarknetBlockNumber(number);
+                Ok(Some((hash, number)))
+            }
+            None => Ok(None),
+        }
+    }
+
     pub fn get_number(
         tx: &Transaction<'_>,
         hash: StarknetBlockHash,
@@ -1736,6 +1762,30 @@ mod tests {
                 let tx = connection.transaction().unwrap();
 
                 assert_eq!(StarknetBlocksTable::get_latest_number(&tx).unwrap(), None);
+            }
+        }
+
+        mod get_latest_hash_and_number {
+            use super::*;
+
+            #[test]
+            fn some() {
+                with_default_blocks(|tx, blocks| {
+                    let latest = blocks.last().unwrap();
+                    assert_eq!(
+                        StarknetBlocksTable::get_latest_hash_and_number(tx).unwrap(),
+                        Some((latest.hash, latest.number))
+                    );
+                });
+            }
+
+            #[test]
+            fn none() {
+                let storage = Storage::in_memory().unwrap();
+                let mut connection = storage.connection().unwrap();
+                let tx = connection.transaction().unwrap();
+
+                assert_eq!(StarknetBlocksTable::get_latest_hash_and_number(&tx).unwrap(), None);
             }
         }
     }

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -1785,7 +1785,10 @@ mod tests {
                 let mut connection = storage.connection().unwrap();
                 let tx = connection.transaction().unwrap();
 
-                assert_eq!(StarknetBlocksTable::get_latest_hash_and_number(&tx).unwrap(), None);
+                assert_eq!(
+                    StarknetBlocksTable::get_latest_hash_and_number(&tx).unwrap(),
+                    None
+                );
             }
         }
     }

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -1714,6 +1714,30 @@ mod tests {
                 assert_eq!(rows.len(), 2, "nulls were not expected in {rows:?}");
             }
         }
+
+        mod get_latest_number {
+            use super::*;
+
+            #[test]
+            fn some() {
+                with_default_blocks(|tx, blocks| {
+                    let latest = blocks.last().unwrap().number;
+                    assert_eq!(
+                        StarknetBlocksTable::get_latest_number(tx).unwrap(),
+                        Some(latest)
+                    );
+                });
+            }
+
+            #[test]
+            fn none() {
+                let storage = Storage::in_memory().unwrap();
+                let mut connection = storage.connection().unwrap();
+                let tx = connection.transaction().unwrap();
+
+                assert_eq!(StarknetBlocksTable::get_latest_number(&tx).unwrap(), None);
+            }
+        }
     }
 
     mod starknet_events {


### PR DESCRIPTION
The primary purpose of this PR is to add support for [`starknet_blockHashAndNumber`](https://github.com/starkware-libs/starknet-specs/blob/v0.1.0/api/starknet_api_openrpc.json#L485-L507).

However, en-route there this PR also aligns our RPC errors witht the `0.1.0` spec. This required reworking how state key types get deserialized as there is no longer a custom RPC error for this.