### PR TITLE
Fix load-test JSON-RPC API and upgrade goose

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "goose"
-version = "0.16.0"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a1b9de95ea08c665f53d16d3ae7dadd590b271c8a4dae1c96ea45a7df0d3b3a"
+checksum = "399f11c700b38d532ea3633bcb271a70979a20dcb1ee440574a70c5b60daa803"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1036,6 +1036,8 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "simplelog",
+ "strum",
+ "strum_macros",
  "tokio",
  "tokio-tungstenite",
  "tungstenite 0.15.0",
@@ -1151,6 +1153,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -2238,7 +2246,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.3.3",
  "itertools",
  "lazy_static",
  "log",
@@ -2932,6 +2940,25 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4faebde00e8ff94316c01800f9054fd2ba77d30d9e922541913051d1d978918b"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/crates/load-test/Cargo.toml
+++ b/crates/load-test/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-goose = "0.16.0"
+goose = "0.16.3"
 pathfinder = { path = "../pathfinder", features = ["rpc-full-serde"] }
 rand = "0.8.5"
 serde = { version = "1.0.130", features = ["derive"] }

--- a/crates/load-test/src/main.rs
+++ b/crates/load-test/src/main.rs
@@ -17,7 +17,7 @@ use stark_hash::StarkHash;
 
 use pathfinder_lib::{
     core::{
-        ContractAddress, StarknetBlockHash, StarknetBlockNumber, StarknetTransactionHash,
+        BlockId, ContractAddress, StarknetBlockHash, StarknetBlockNumber, StarknetTransactionHash,
         StarknetTransactionIndex, StorageAddress, StorageValue,
     },
     rpc::types::{
@@ -26,7 +26,6 @@ use pathfinder_lib::{
             TransactionReceipt as StarknetTransactionReceipt, Transactions as StarknetTransactions,
         },
         request::EventFilter,
-        BlockHashOrTag, BlockNumberOrTag,
     },
 };
 
@@ -92,23 +91,19 @@ async fn task_block_by_hash(user: &mut GooseUser) -> TransactionResult {
 async fn task_block_transaction_count_by_hash(user: &mut GooseUser) -> TransactionResult {
     get_block_transaction_count_by_hash(
         user,
-        BlockHashOrTag::Hash(StarknetBlockHash(
+        StarknetBlockHash(
             StarkHash::from_hex_str(
                 "0x58d8604f22510af5b120d1204ebf25292a79bfb09c4882c2e456abc2763d4a",
             )
             .unwrap(),
-        )),
+        ),
     )
     .await?;
     Ok(())
 }
 
 async fn task_block_transaction_count_by_number(user: &mut GooseUser) -> TransactionResult {
-    get_block_transaction_count_by_number(
-        user,
-        BlockNumberOrTag::Number(StarknetBlockNumber(1000)),
-    )
-    .await?;
+    get_block_transaction_count_by_number(user, StarknetBlockNumber(1000)).await?;
     Ok(())
 }
 
@@ -195,7 +190,7 @@ async fn task_call(user: &mut GooseUser) -> TransactionResult {
         // "set_value" entry point
         "0x3d7905601c217734671143d457f0db37f7f8883112abd34b92c4abfeafde0c3",
         // hash of mainnet block 0
-        BlockHashOrTag::Hash(StarknetBlockHash(
+        BlockId::Hash(StarknetBlockHash(
             StarkHash::from_hex_str(
                 "0x47c3637b57c2b079b93c61539950c17e868a28f46cdef28f88521067f21e943",
             )
@@ -259,7 +254,7 @@ async fn task_get_storage_at(user: &mut GooseUser) -> TransactionResult {
             )
             .unwrap(),
         ),
-        BlockHashOrTag::Hash(StarknetBlockHash(
+        BlockId::Hash(StarknetBlockHash(
             StarkHash::from_hex_str(
                 "0x58cfbc4ebe276882a28badaa9fe0fb545cba57314817e5f229c2c9cf1f7cc87",
             )
@@ -352,24 +347,24 @@ async fn get_transaction_receipt_by_hash(
 
 async fn get_block_transaction_count_by_hash(
     user: &mut GooseUser,
-    hash: BlockHashOrTag,
+    hash: StarknetBlockHash,
 ) -> MethodResult<u64> {
     post_jsonrpc_request(
         user,
-        "starknet_getBlockTransactionCountByHash",
-        json!({ "block_hash": hash }),
+        "starknet_getBlockTransactionCount",
+        json!({ "block_id": { "block_hash": hash } }),
     )
     .await
 }
 
 async fn get_block_transaction_count_by_number(
     user: &mut GooseUser,
-    number: BlockNumberOrTag,
+    number: StarknetBlockNumber,
 ) -> MethodResult<u64> {
     post_jsonrpc_request(
         user,
-        "starknet_getBlockTransactionCountByNumber",
-        json!({ "block_number": number }),
+        "starknet_getBlockTransactionCount",
+        json!({ "block_id": { "block_number": number } }),
     )
     .await
 }
@@ -394,12 +389,12 @@ async fn get_storage_at(
     user: &mut GooseUser,
     contract_address: ContractAddress,
     key: StorageAddress,
-    block_hash: BlockHashOrTag,
+    block_id: BlockId,
 ) -> MethodResult<StorageValue> {
     post_jsonrpc_request(
         user,
         "starknet_getStorageAt",
-        json!({ "contract_address": contract_address, "key": key, "block_hash": block_hash }),
+        json!({ "contract_address": contract_address, "key": key, "block_id": block_id }),
     )
     .await
 }
@@ -409,7 +404,7 @@ async fn call(
     contract_address: ContractAddress,
     call_data: &[&str],
     entry_point_selector: &str,
-    at_block: BlockHashOrTag,
+    at_block: BlockId,
 ) -> MethodResult<Vec<String>> {
     post_jsonrpc_request(
         user,
@@ -420,7 +415,7 @@ async fn call(
                 "calldata": call_data,
                 "entry_point_selector": entry_point_selector,
             },
-            "block_hash": at_block,
+            "block_id": at_block,
         }),
     )
     .await


### PR DESCRIPTION
This fixes the outdated JSON-RPC method names and parameters in all calls currently done by the load test.

This PR also upgrades `goose` to the latest release, so that the load test can be run for only a subset of scenarios with the `--scenarios` argument.