### PR TITLE
chore: remove `starknet_protocolVersion`

### DIFF
--- a/crates/pathfinder/rpc_examples.sh
+++ b/crates/pathfinder/rpc_examples.sh
@@ -236,5 +236,4 @@ rpc_call '{
 # TODO not implemented yet
 # rpc_call '{"jsonrpc":"2.0","id":"37","method":"starknet_chainId"}'
 # rpc_call '{"jsonrpc":"2.0","id":"38","method":"starknet_pendingTransactions"}'
-# rpc_call '{"jsonrpc":"2.0","id":"39","method":"starknet_protocolVersion"}'
 # rpc_call '{"jsonrpc":"2.0","id":"40","method":"starknet_syncing"}'

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -187,10 +187,6 @@ pub struct EventKey(pub StarkHash);
 #[derive(Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct SequencerAddress(pub StarkHash);
 
-/// StarkNet protocol version.
-#[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
-pub struct StarknetProtocolVersion(pub H256);
-
 /// StarkNet fee value.
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub struct Fee(pub H128);

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -250,9 +250,6 @@ Hint: If you are looking to run two instances of pathfinder, you must configure 
     module.register_async_method("starknet_pendingTransactions", |_, context| async move {
         context.pending_transactions().await
     })?;
-    // module.register_async_method("starknet_protocolVersion", |_, context| async move {
-    //     context.protocol_version().await
-    // })?;
     module.register_async_method("starknet_syncing", |_, context| async move {
         context.syncing().await
     })?;
@@ -345,7 +342,7 @@ mod tests {
         core::{
             Chain, ClassHash, ContractAddress, EntryPoint, EventData, EventKey, GasPrice,
             GlobalRoot, SequencerAddress, StarknetBlockHash, StarknetBlockNumber,
-            StarknetBlockTimestamp, StarknetProtocolVersion, StorageAddress,
+            StarknetBlockTimestamp, StorageAddress,
         },
         rpc::{run_server, types::reply::BlockHashAndNumber},
         sequencer::{
@@ -2435,20 +2432,6 @@ mod tests {
                 format!("0x{}", hex::encode("SN_MAIN")),
             ]
         );
-    }
-
-    #[tokio::test]
-    #[should_panic]
-    async fn protocol_version() {
-        let storage = Storage::in_memory().unwrap();
-        let sequencer = Client::new(Chain::Goerli).unwrap();
-        let sync_state = Arc::new(SyncState::default());
-        let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
-        let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
-        client(addr)
-            .request::<StarknetProtocolVersion>("starknet_protocolVersion", rpc_params!())
-            .await
-            .unwrap();
     }
 
     mod syncing {

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -1015,11 +1015,6 @@ impl RpcApi {
         }
     }
 
-    // /// Returns the current starknet protocol version identifier, as supported by this node.
-    // pub async fn protocol_version(&self) -> RpcResult<StarknetProtocolVersion> {
-    //     todo!("Figure out where to take it from.")
-    // }
-
     /// Returns an object about the sync status, or false if the node is not synching.
     pub async fn syncing(&self) -> RpcResult<Syncing> {
         // Scoped so I don't have to think too hard about mutex guard drop semantics.


### PR DESCRIPTION
This will no longer form part of the RPC specification ([PR](https://github.com/starkware-libs/starknet-specs/pull/41)) and as such we won't implement it.

As an aside I've now noticed that none of my PR's have added/updated the examples..