### PR TITLE
Constify starkhash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,3 +114,16 @@ jobs:
           source py/.venv/bin/activate
           cargo test --no-run -p pathfinder
           timeout 5m cargo test -p pathfinder -- cairo::ext_py --ignored
+
+  fuzz_targets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly
+      - uses: Swatinem/rust-cache@v1
+      - run: cargo install cargo-fuzz
+      - name: stark_hash
+        run: cargo fuzz build
+        working-directory: crates/stark_hash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,6 +1176,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-literal"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
+
+[[package]]
 name = "http"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2007,6 +2013,7 @@ dependencies = [
  "flate2",
  "futures",
  "hex",
+ "hex-literal",
  "http",
  "jsonrpsee",
  "lazy_static",

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -28,6 +28,7 @@ enum-iterator = "0.7.0"
 flate2 = "1.0.23"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 hex = "0.4.3"
+hex-literal = "0.3"
 jsonrpsee = { version = "0.11.0", features = ["server"] }
 lazy_static = "1.4.0"
 num-bigint = { version = "0.4.3", features = ["serde"] }

--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -254,6 +254,7 @@ impl From<std::io::Error> for SubprocessError {
 mod tests {
 
     use super::sub_process::launch_python;
+    use crate::starkhash;
     use stark_hash::StarkHash;
     use std::path::PathBuf;
     use tokio::sync::oneshot;
@@ -335,13 +336,12 @@ mod tests {
                         handle.call(
                             super::Call {
                                 contract_address: crate::core::ContractAddress(
-                                    StarkHash::from_hex_str(
-                                        "057dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374",
+                                    starkhash!(
+                                        "057dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374"
                                     )
-                                    .unwrap(),
                                 ),
                                 calldata: vec![crate::core::CallParam(
-                                    StarkHash::from_hex_str("0x84").unwrap(),
+                                    starkhash!("84"),
                                 )],
                                 entry_point_selector: crate::core::EntryPoint::hashed(&b"get_value"[..]),
                                 signature: Default::default(),
@@ -403,15 +403,10 @@ mod tests {
         .unwrap();
 
         let call = super::Call {
-            contract_address: crate::core::ContractAddress(
-                StarkHash::from_hex_str(
-                    "057dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374",
-                )
-                .unwrap(),
-            ),
-            calldata: vec![crate::core::CallParam(
-                StarkHash::from_hex_str("0x84").unwrap(),
-            )],
+            contract_address: crate::core::ContractAddress(starkhash!(
+                "057dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374"
+            )),
+            calldata: vec![crate::core::CallParam(starkhash!("84"))],
             entry_point_selector: crate::core::EntryPoint::hashed(&b"get_value"[..]),
             signature: Default::default(),
             max_fee: super::Call::DEFAULT_MAX_FEE,
@@ -503,16 +498,11 @@ mod tests {
         .unwrap();
 
         let call = super::Call {
-            contract_address: crate::core::ContractAddress(
-                StarkHash::from_hex_str(
-                    // this is one bit off from other examples
-                    "057dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e375",
-                )
-                .unwrap(),
-            ),
-            calldata: vec![crate::core::CallParam(
-                StarkHash::from_hex_str("0x84").unwrap(),
-            )],
+            contract_address: crate::core::ContractAddress(starkhash!(
+                // this is one bit off from other examples
+                "057dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e375"
+            )),
+            calldata: vec![crate::core::CallParam(starkhash!("84"))],
             entry_point_selector: crate::core::EntryPoint::hashed(&b"get_value"[..]),
             signature: Default::default(),
             max_fee: super::Call::DEFAULT_MAX_FEE,
@@ -572,14 +562,11 @@ mod tests {
         .await
         .unwrap();
 
-        let target_contract = crate::core::ContractAddress(
-            StarkHash::from_hex_str(
-                "057dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374",
-            )
-            .unwrap(),
-        );
+        let target_contract = crate::core::ContractAddress(starkhash!(
+            "057dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374"
+        ));
 
-        let storage_address = StarkHash::from_hex_str("0x84").unwrap();
+        let storage_address = starkhash!("84");
 
         let call = super::Call {
             contract_address: target_contract,
@@ -612,9 +599,7 @@ mod tests {
                         target_contract,
                         vec![crate::sequencer::reply::state_update::StorageDiff {
                             key: crate::core::StorageAddress(storage_address),
-                            value: crate::core::StorageValue(
-                                StarkHash::from_hex_str("0x4").unwrap(),
-                            ),
+                            value: crate::core::StorageValue(starkhash!("04")),
                         }],
                     );
                     map
@@ -646,14 +631,10 @@ mod tests {
         )))
         .unwrap();
 
-        let address = StarkHash::from_hex_str(
-            "057dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374",
-        )
-        .unwrap();
-        let expected_hash = StarkHash::from_hex_str(
-            "050b2148c0d782914e0b12a1a32abe5e398930b7e914f82c65cb7afce0a0ab9b",
-        )
-        .unwrap();
+        let address =
+            starkhash!("057dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374");
+        let expected_hash =
+            starkhash!("050b2148c0d782914e0b12a1a32abe5e398930b7e914f82c65cb7afce0a0ab9b");
 
         let (abi, bytecode, hash) =
             crate::state::class_hash::extract_abi_code_hash(&*contract_definition).unwrap();

--- a/crates/pathfinder/src/cairo/ext_py/ser.rs
+++ b/crates/pathfinder/src/cairo/ext_py/ser.rs
@@ -245,7 +245,7 @@ impl TryFrom<crate::core::BlockId> for BlockHashNumberOrLatest {
 
 #[cfg(test)]
 mod tests {
-    use stark_hash::StarkHash;
+    use crate::starkhash;
 
     #[test]
     fn serialize_some_updates() {
@@ -258,15 +258,12 @@ mod tests {
         let map = {
             let mut map = HashMap::new();
             map.insert(
-                ContractAddress(
-                    StarkHash::from_hex_str(
-                        "0x7c38021eb1f890c5d572125302fe4a0d2f79d38b018d68a9fcd102145d4e451",
-                    )
-                    .unwrap(),
-                ),
+                ContractAddress(starkhash!(
+                    "07c38021eb1f890c5d572125302fe4a0d2f79d38b018d68a9fcd102145d4e451"
+                )),
                 vec![StorageDiff {
-                    key: StorageAddress(StarkHash::from_hex_str("0x5").unwrap()),
-                    value: StorageValue(StarkHash::from_hex_str("0x0").unwrap()),
+                    key: StorageAddress(starkhash!("05")),
+                    value: StorageValue(starkhash!("00")),
                 }],
             );
             map
@@ -296,18 +293,12 @@ mod tests {
 
         let expected = r#"[{"address":"0x7c38021eb1f890c5d572125302fe4a0d2f79d38b018d68a9fcd102145d4e451","contract_hash":"0x10455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8"}]"#;
         let contracts = vec![DeployedContract {
-            address: ContractAddress(
-                StarkHash::from_hex_str(
-                    "0x7c38021eb1f890c5d572125302fe4a0d2f79d38b018d68a9fcd102145d4e451",
-                )
-                .unwrap(),
-            ),
-            class_hash: ClassHash(
-                StarkHash::from_hex_str(
-                    "0x010455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8",
-                )
-                .unwrap(),
-            ),
+            address: ContractAddress(starkhash!(
+                "07c38021eb1f890c5d572125302fe4a0d2f79d38b018d68a9fcd102145d4e451"
+            )),
+            class_hash: ClassHash(starkhash!(
+                "010455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8"
+            )),
         }];
         let s = serde_json::to_string(&DeployedContractsWrapper(Some(&contracts))).unwrap();
         assert_eq!(expected, s);
@@ -332,6 +323,7 @@ mod tests {
     fn serialize_block_hash_num_latest() {
         use super::BlockHashNumberOrLatest;
         use crate::core::{StarknetBlockHash, StarknetBlockNumber};
+        use stark_hash::StarkHash;
 
         let data = &[
             (StarknetBlockHash(StarkHash::ZERO).into(), "\"0x0\""),

--- a/crates/pathfinder/src/consts.rs
+++ b/crates/pathfinder/src/consts.rs
@@ -1,7 +1,5 @@
 //! Repeated constants used around pathfinder
 
-use stark_hash::StarkHash;
-
 use crate::core::StarknetBlockHash;
 
 /// User agent used in http clients
@@ -10,18 +8,10 @@ pub const USER_AGENT: &str = concat!(
     env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT")
 );
 
-lazy_static::lazy_static!(
-    pub static ref GOERLI_GENESIS_HASH: StarknetBlockHash = StarknetBlockHash(
-        StarkHash::from_hex_str(
-            "0x7d328a71faf48c5c3857e99f20a77b18522480956d1cd5bff1ff2df3c8b427b",
-        )
-        .unwrap(),
-    );
+pub const GOERLI_GENESIS_HASH: StarknetBlockHash = StarknetBlockHash(crate::starkhash!(
+    "07d328a71faf48c5c3857e99f20a77b18522480956d1cd5bff1ff2df3c8b427b"
+));
 
-    pub static ref MAINNET_GENESIS_HASH: StarknetBlockHash = StarknetBlockHash(
-        StarkHash::from_hex_str(
-            "0x047C3637B57C2B079B93C61539950C17E868A28F46CDEF28F88521067F21E943",
-        )
-        .unwrap(),
-    );
-);
+pub const MAINNET_GENESIS_HASH: StarknetBlockHash = StarknetBlockHash(crate::starkhash!(
+    "047C3637B57C2B079B93C61539950C17E868A28F46CDEF28F88521067F21E943"
+));

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -385,18 +385,16 @@ pub enum Chain {
     Goerli,
 }
 
-lazy_static::lazy_static! {
-    static ref MAINNET_CHAIN_ID: StarkHash = StarkHash::from(0x534e5f4d41494eu128);
-    static ref GOERLI_CHAIN_ID: StarkHash = StarkHash::from(0x534e5f474f45524c49u128);
-}
+const MAINNET_CHAIN_ID: StarkHash = StarkHash::from_u128(0x534e5f4d41494eu128);
+const GOERLI_CHAIN_ID: StarkHash = StarkHash::from_u128(0x534e5f474f45524c49u128);
 
 impl Chain {
-    pub fn starknet_chain_id(&self) -> &'static StarkHash {
+    pub const fn starknet_chain_id(&self) -> StarkHash {
         match self {
             // SN_MAIN
-            Chain::Mainnet => &MAINNET_CHAIN_ID,
+            Chain::Mainnet => MAINNET_CHAIN_ID,
             // SN_GOERLI
-            Chain::Goerli => &GOERLI_CHAIN_ID,
+            Chain::Goerli => GOERLI_CHAIN_ID,
         }
     }
 }
@@ -516,11 +514,12 @@ mod tests {
         #[test]
         fn hash() {
             use crate::core::StarknetBlockHash;
+            use crate::starkhash;
             let result =
                 serde_json::from_str::<BlockId>(r#"{"block_hash": "0xdeadbeef"}"#).unwrap();
             assert_eq!(
                 result,
-                BlockId::Hash(StarknetBlockHash::from_hex_str("0xdeadbeef").unwrap())
+                BlockId::Hash(StarknetBlockHash(starkhash!("deadbeef")))
             );
         }
     }

--- a/crates/pathfinder/src/ethereum/state_update.rs
+++ b/crates/pathfinder/src/ethereum/state_update.rs
@@ -133,10 +133,7 @@ impl From<&crate::sequencer::reply::state_update::StateDiff> for StateUpdate {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
     use pretty_assertions::assert_eq;
-    use stark_hash::StarkHash;
     use web3::types::H256;
 
     use crate::core::{
@@ -144,6 +141,8 @@ mod tests {
         EthereumTransactionIndex, GlobalRoot, StarknetBlockNumber,
     };
     use crate::ethereum::{transport::HttpTransport, BlockOrigin, EthOrigin, TransactionOrigin};
+    use crate::starkhash;
+    use hex_literal::hex;
 
     use super::*;
 
@@ -152,31 +151,22 @@ mod tests {
         let update_log = StateUpdateLog {
             origin: EthOrigin {
                 block: BlockOrigin {
-                    hash: EthereumBlockHash(
-                        H256::from_str(
-                            "0x4de2eead55dfd20058fbbe77fb579cffb96985b26d86e24f1af361cf139b3a0d",
-                        )
-                        .unwrap(),
-                    ),
+                    hash: EthereumBlockHash(H256::from(hex!(
+                        "4de2eead55dfd20058fbbe77fb579cffb96985b26d86e24f1af361cf139b3a0d"
+                    ))),
                     number: EthereumBlockNumber(5973783),
                 },
                 transaction: TransactionOrigin {
-                    hash: EthereumTransactionHash(
-                        H256::from_str(
-                            "0xae7d1c87bc3a7ed34d129b5b037a0848f020bac1fa20082686399c88b538a6e2",
-                        )
-                        .unwrap(),
-                    ),
+                    hash: EthereumTransactionHash(H256::from(hex!(
+                        "ae7d1c87bc3a7ed34d129b5b037a0848f020bac1fa20082686399c88b538a6e2"
+                    ))),
                     index: EthereumTransactionIndex(4),
                 },
                 log_index: EthereumLogIndex(23),
             },
-            global_root: GlobalRoot(
-                StarkHash::from_hex_str(
-                    "1256D7337B57DD78AAA67563760FBDB561D7F51F335771E6D8D6CE60E4C1387",
-                )
-                .unwrap(),
-            ),
+            global_root: GlobalRoot(starkhash!(
+                "01256D7337B57DD78AAA67563760FBDB561D7F51F335771E6D8D6CE60E4C1387"
+            )),
             block_number: StarknetBlockNumber(16407),
         };
 
@@ -188,104 +178,146 @@ mod tests {
 
         let expected = StateUpdate {
             deployed_contracts: vec![DeployedContract {
-                address: ContractAddress(StarkHash::from_hex_str("6CF1C6DCA6DE4CE15DB3EB7AEE1C6191537C82E2F2DE22FE4426199EE50E9A").unwrap()),
-                hash: ClassHash(StarkHash::from_hex_str("484DE75F165C844F9D8C5B07A7D1A650A476815DC7A061126FD41BB998C043D").unwrap()),
-                call_data: vec![StarkHash::from_hex_str("5D7C088BB051DB0A4C5A9C435A2009E2A82EE896080DDF4E6E953770F313EAF").unwrap()],
+                address: ContractAddress(starkhash!(
+                    "6CF1C6DCA6DE4CE15DB3EB7AEE1C6191537C82E2F2DE22FE4426199EE50E9A"
+                )),
+                hash: ClassHash(starkhash!(
+                    "0484DE75F165C844F9D8C5B07A7D1A650A476815DC7A061126FD41BB998C043D"
+                )),
+                call_data: vec![starkhash!(
+                    "05D7C088BB051DB0A4C5A9C435A2009E2A82EE896080DDF4E6E953770F313EAF"
+                )],
             }],
             contract_updates: vec![
                 ContractUpdate {
-                address: ContractAddress(StarkHash::from_hex_str("6CF1C6DCA6DE4CE15DB3EB7AEE1C6191537C82E2F2DE22FE4426199EE50E9A").unwrap()),
-                storage_updates: vec![
-                    StorageUpdate {
-                        address: StorageAddress(StarkHash::from_hex_str("21683F821A0574472445355BE6D2B769119E8515F8376A1D7878523DFDECF7B").unwrap()),
-                        value: StorageValue(StarkHash::from_hex_str("6CF1C6DCA6DE4CE15DB3EB7AEE1C6191537C82E2F2DE22FE4426199EE50E9A").unwrap()),
-                    },
-                    StorageUpdate {
-                        address: StorageAddress(StarkHash::from_hex_str("3B28019CCFDBD30FFC65951D94BB85C9E2B8434111A000B5AFD533CE65F57A4").unwrap()),
-                        value: StorageValue(StarkHash::from_hex_str("5D7C088BB051DB0A4C5A9C435A2009E2A82EE896080DDF4E6E953770F313EAF").unwrap()),
-                    },
-                    StorageUpdate {
-                        address: StorageAddress(StarkHash::from_hex_str("3C0BA99F1A18BCDC81FCBCB6B4F15A9A6725F937075AED6FAC107FFCB147068").unwrap()),
-                        value: StorageValue(StarkHash::from_hex_str("1").unwrap()),
-                    },
-                ],
-            },
-            ContractUpdate {
-                address: ContractAddress(StarkHash::from_hex_str("FDB9F231A6C257D492DB4D091703ABA277E97B583AB9E3115B5A571FC22E4D").unwrap()),
-                storage_updates: vec![
-                    StorageUpdate {
-                        address: StorageAddress(StarkHash::from_hex_str("154D7895A89D2A9EA002F6455F0BE1F409302F4E3A53B06B86C8A83E12D343E").unwrap()),
-                        value: StorageValue(StarkHash::from_hex_str("6673A13BB9C8D4FD9ADFDF4AA0478BAFB4F6EE191D7BF31E3085136B803B0FC").unwrap()),
-                    },
-                ],
-            },
-            ContractUpdate {
-                address: ContractAddress(StarkHash::from_hex_str("29366B381BA18C53E9DB8A4476E0599C71CB63F001950D094CE23EDCD2CD81C").unwrap()),
-                storage_updates: vec![
-                    StorageUpdate {
-                        address: StorageAddress(StarkHash::from_hex_str("367FBE030560FA33F15D19C5A53436B3345771F3769607B168E9BAFB540E665").unwrap()),
-                        value: StorageValue(StarkHash::from_hex_str("8AC7230489E80000").unwrap()),
-                    },
-                    StorageUpdate {
-                        address: StorageAddress(StarkHash::from_hex_str("367FBE030560FA33F15D19C5A53436B3345771F3769607B168E9BAFB540E666").unwrap()),
-                        value: StorageValue(StarkHash::from_hex_str("0").unwrap()),
-                    },
-                ],
-            },
-            ContractUpdate {
-                address: ContractAddress(StarkHash::from_hex_str("2FC0D82D539509C5642B64F59299B7E9FD23C114BD2640BDC979602667F8C1F").unwrap()),
-                storage_updates: vec![
-                    StorageUpdate {
-                        address: StorageAddress(StarkHash::from_hex_str("D34C3A8EDE05D741C7C11C8A517FEB3FEFCC425ED633E4D93758446BA289BA").unwrap()),
-                        value: StorageValue(StarkHash::from_hex_str("7E5").unwrap()),
-                    },
-                ],
-            },
-            ContractUpdate {
-                address: ContractAddress(StarkHash::from_hex_str("4F664133F8C8C9A34B7D0B85AC09571BC92FBDC23CD7F82B0E8CEA3E3837B4C").unwrap()),
-                storage_updates: vec![
-                    StorageUpdate {
-                        address: StorageAddress(StarkHash::from_hex_str("D34C3A8EDE05D741C7C11C8A517FEB3FEFCC425ED633E4D93758446BA289BA").unwrap()),
-                        value: StorageValue(StarkHash::from_hex_str("7C7").unwrap()),
-                    },
-                ],
-            },
-            ContractUpdate {
-                address: ContractAddress(StarkHash::from_hex_str("69A7CFDF88197230CA4CE9377E1D8AAE7AD5E36E25DD35C7F3C73DAAD16940E").unwrap()),
-                storage_updates: vec![
-                    StorageUpdate {
-                        address: StorageAddress(StarkHash::from_hex_str("1CCC09C8A19948E048DE7ADD6929589945E25F22059C7345AAF7837188D8D05").unwrap()),
-                        value: StorageValue(StarkHash::from_hex_str("5A95504FA8DFC374D4072459027F6A50EAC084BB9F233DAE048C50FB8EECB8A").unwrap()),
-                    },
-                    StorageUpdate {
-                        address: StorageAddress(StarkHash::from_hex_str("31E7534F8DDB1628D6E07DB5C743E33403B9A0B57508A93F4C49582040A2F71").unwrap()),
-                        value: StorageValue(StarkHash::from_hex_str("0").unwrap()),
-                    },
-                    StorageUpdate {
-                        address: StorageAddress(StarkHash::from_hex_str("37501DF619C4FC4E96F6C0243F55E3ABE7D1ACA7DB9AF8F3740BA3696B3FDAC").unwrap()),
-                        value: StorageValue(StarkHash::from_hex_str("1").unwrap()),
-                    },
-                ],
-            },
-            ContractUpdate {
-                address: ContractAddress(StarkHash::from_hex_str("7075572D159FA30E93C6A917F75B5D664A99A7CEC4AF40FA7E6EF8094B7A3EE").unwrap()),
-                storage_updates: vec![
-                    StorageUpdate {
-                        address: StorageAddress(StarkHash::from_hex_str("5").unwrap()),
-                        value: StorageValue(StarkHash::from_hex_str("456").unwrap()),
-                    },
-                ],
-            },
-            ContractUpdate {
-                address: ContractAddress(StarkHash::from_hex_str("7C1069DD27607ABF370C745B9781183FDD7E8082AC39C4E57D858913EE7D022").unwrap()),
-                storage_updates: vec![
-                    StorageUpdate {
-                        address: StorageAddress(StarkHash::from_hex_str("5").unwrap()),
-                        value: StorageValue(StarkHash::from_hex_str("66").unwrap()),
-                    },
-                ],
-            },
-                ],
+                    address: ContractAddress(starkhash!(
+                        "6CF1C6DCA6DE4CE15DB3EB7AEE1C6191537C82E2F2DE22FE4426199EE50E9A"
+                    )),
+                    storage_updates: vec![
+                        StorageUpdate {
+                            address: StorageAddress(starkhash!(
+                                "021683F821A0574472445355BE6D2B769119E8515F8376A1D7878523DFDECF7B"
+                            )),
+                            value: StorageValue(starkhash!(
+                                "6CF1C6DCA6DE4CE15DB3EB7AEE1C6191537C82E2F2DE22FE4426199EE50E9A"
+                            )),
+                        },
+                        StorageUpdate {
+                            address: StorageAddress(starkhash!(
+                                "03B28019CCFDBD30FFC65951D94BB85C9E2B8434111A000B5AFD533CE65F57A4"
+                            )),
+                            value: StorageValue(starkhash!(
+                                "05D7C088BB051DB0A4C5A9C435A2009E2A82EE896080DDF4E6E953770F313EAF"
+                            )),
+                        },
+                        StorageUpdate {
+                            address: StorageAddress(starkhash!(
+                                "03C0BA99F1A18BCDC81FCBCB6B4F15A9A6725F937075AED6FAC107FFCB147068"
+                            )),
+                            value: StorageValue(starkhash!("01")),
+                        },
+                    ],
+                },
+                ContractUpdate {
+                    address: ContractAddress(starkhash!(
+                        "FDB9F231A6C257D492DB4D091703ABA277E97B583AB9E3115B5A571FC22E4D"
+                    )),
+                    storage_updates: vec![StorageUpdate {
+                        address: StorageAddress(starkhash!(
+                            "0154D7895A89D2A9EA002F6455F0BE1F409302F4E3A53B06B86C8A83E12D343E"
+                        )),
+                        value: StorageValue(starkhash!(
+                            "06673A13BB9C8D4FD9ADFDF4AA0478BAFB4F6EE191D7BF31E3085136B803B0FC"
+                        )),
+                    }],
+                },
+                ContractUpdate {
+                    address: ContractAddress(starkhash!(
+                        "029366B381BA18C53E9DB8A4476E0599C71CB63F001950D094CE23EDCD2CD81C"
+                    )),
+                    storage_updates: vec![
+                        StorageUpdate {
+                            address: StorageAddress(starkhash!(
+                                "0367FBE030560FA33F15D19C5A53436B3345771F3769607B168E9BAFB540E665"
+                            )),
+                            value: StorageValue(starkhash!("8AC7230489E80000")),
+                        },
+                        StorageUpdate {
+                            address: StorageAddress(starkhash!(
+                                "0367FBE030560FA33F15D19C5A53436B3345771F3769607B168E9BAFB540E666"
+                            )),
+                            value: StorageValue(starkhash!("00")),
+                        },
+                    ],
+                },
+                ContractUpdate {
+                    address: ContractAddress(starkhash!(
+                        "02FC0D82D539509C5642B64F59299B7E9FD23C114BD2640BDC979602667F8C1F"
+                    )),
+                    storage_updates: vec![StorageUpdate {
+                        address: StorageAddress(starkhash!(
+                            "D34C3A8EDE05D741C7C11C8A517FEB3FEFCC425ED633E4D93758446BA289BA"
+                        )),
+                        value: StorageValue(starkhash!("07E5")),
+                    }],
+                },
+                ContractUpdate {
+                    address: ContractAddress(starkhash!(
+                        "04F664133F8C8C9A34B7D0B85AC09571BC92FBDC23CD7F82B0E8CEA3E3837B4C"
+                    )),
+                    storage_updates: vec![StorageUpdate {
+                        address: StorageAddress(starkhash!(
+                            "D34C3A8EDE05D741C7C11C8A517FEB3FEFCC425ED633E4D93758446BA289BA"
+                        )),
+                        value: StorageValue(starkhash!("07C7")),
+                    }],
+                },
+                ContractUpdate {
+                    address: ContractAddress(starkhash!(
+                        "069A7CFDF88197230CA4CE9377E1D8AAE7AD5E36E25DD35C7F3C73DAAD16940E"
+                    )),
+                    storage_updates: vec![
+                        StorageUpdate {
+                            address: StorageAddress(starkhash!(
+                                "01CCC09C8A19948E048DE7ADD6929589945E25F22059C7345AAF7837188D8D05"
+                            )),
+                            value: StorageValue(starkhash!(
+                                "05A95504FA8DFC374D4072459027F6A50EAC084BB9F233DAE048C50FB8EECB8A"
+                            )),
+                        },
+                        StorageUpdate {
+                            address: StorageAddress(starkhash!(
+                                "031E7534F8DDB1628D6E07DB5C743E33403B9A0B57508A93F4C49582040A2F71"
+                            )),
+                            value: StorageValue(starkhash!("00")),
+                        },
+                        StorageUpdate {
+                            address: StorageAddress(starkhash!(
+                                "037501DF619C4FC4E96F6C0243F55E3ABE7D1ACA7DB9AF8F3740BA3696B3FDAC"
+                            )),
+                            value: StorageValue(starkhash!("01")),
+                        },
+                    ],
+                },
+                ContractUpdate {
+                    address: ContractAddress(starkhash!(
+                        "07075572D159FA30E93C6A917F75B5D664A99A7CEC4AF40FA7E6EF8094B7A3EE"
+                    )),
+                    storage_updates: vec![StorageUpdate {
+                        address: StorageAddress(starkhash!("05")),
+                        value: StorageValue(starkhash!("0456")),
+                    }],
+                },
+                ContractUpdate {
+                    address: ContractAddress(starkhash!(
+                        "07C1069DD27607ABF370C745B9781183FDD7E8082AC39C4E57D858913EE7D022"
+                    )),
+                    storage_updates: vec![StorageUpdate {
+                        address: StorageAddress(starkhash!("05")),
+                        value: StorageValue(starkhash!("66")),
+                    }],
+                },
+            ],
         };
 
         assert_eq!(update, expected);

--- a/crates/pathfinder/src/ethereum/state_update/parse.rs
+++ b/crates/pathfinder/src/ethereum/state_update/parse.rs
@@ -168,6 +168,7 @@ fn parse_starkhash(value: U256) -> Result<StarkHash> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::starkhash;
 
     fn u256_from_starkhash(hash: StarkHash) -> U256 {
         let bytes = hash.to_be_bytes();
@@ -253,15 +254,15 @@ mod tests {
 
     fn contract_update() -> ContractUpdate {
         ContractUpdate {
-            address: ContractAddress(StarkHash::from_hex_str("123456").unwrap()),
+            address: ContractAddress(starkhash!("123456")),
             storage_updates: vec![
                 StorageUpdate {
-                    address: StorageAddress(StarkHash::from_hex_str("1").unwrap()),
-                    value: StorageValue(StarkHash::from_hex_str("301").unwrap()),
+                    address: StorageAddress(starkhash!("01")),
+                    value: StorageValue(starkhash!("0301")),
                 },
                 StorageUpdate {
-                    address: StorageAddress(StarkHash::from_hex_str("2").unwrap()),
-                    value: StorageValue(StarkHash::from_hex_str("305").unwrap()),
+                    address: StorageAddress(starkhash!("02")),
+                    value: StorageValue(starkhash!("0305")),
                 },
             ],
         }
@@ -269,13 +270,9 @@ mod tests {
 
     fn deployed_contract() -> DeployedContract {
         DeployedContract {
-            address: ContractAddress(StarkHash::from_hex_str("45691").unwrap()),
-            hash: ClassHash(StarkHash::from_hex_str("22513").unwrap()),
-            call_data: vec![
-                StarkHash::from_hex_str("1").unwrap(),
-                StarkHash::from_hex_str("2").unwrap(),
-                StarkHash::from_hex_str("1230").unwrap(),
-            ],
+            address: ContractAddress(starkhash!("045691")),
+            hash: ClassHash(starkhash!("022513")),
+            call_data: vec![starkhash!("01"), starkhash!("02"), starkhash!("1230")],
         }
     }
 
@@ -311,13 +308,14 @@ mod tests {
 
     mod parse_storage_update {
         use super::*;
+        use crate::starkhash;
         use pretty_assertions::assert_eq;
 
         #[test]
         fn ok() {
             let update = StorageUpdate {
-                address: StorageAddress(StarkHash::from_hex_str("200").unwrap()),
-                value: StorageValue(StarkHash::from_hex_str("300").unwrap()),
+                address: StorageAddress(starkhash!("0200")),
+                value: StorageValue(starkhash!("0300")),
             };
             let data: Vec<U256> = update.clone().into();
 
@@ -329,8 +327,8 @@ mod tests {
         #[test]
         fn missing_data() {
             let update = StorageUpdate {
-                address: StorageAddress(StarkHash::from_hex_str("200").unwrap()),
-                value: StorageValue(StarkHash::from_hex_str("300").unwrap()),
+                address: StorageAddress(starkhash!("0200")),
+                value: StorageValue(starkhash!("0300")),
             };
             let mut data: Vec<U256> = update.into();
             data.pop();
@@ -342,6 +340,7 @@ mod tests {
 
     mod parse_contract_update {
         use super::*;
+        use crate::starkhash;
         use pretty_assertions::assert_eq;
 
         #[test]
@@ -357,7 +356,7 @@ mod tests {
         #[test]
         fn no_storage_updates() {
             let update = ContractUpdate {
-                address: ContractAddress(StarkHash::from_hex_str("123456").unwrap()),
+                address: ContractAddress(starkhash!("123456")),
                 storage_updates: Vec::new(),
             };
 

--- a/crates/pathfinder/src/ethereum/state_update/state_root.rs
+++ b/crates/pathfinder/src/ethereum/state_update/state_root.rs
@@ -130,7 +130,6 @@ mod tests {
     }
 
     mod reorg {
-        use stark_hash::StarkHash;
         use web3::types::H256;
 
         use crate::{
@@ -142,6 +141,7 @@ mod tests {
                 log::FetchError, transport::EthereumTransport, BlockOrigin, EthOrigin,
                 TransactionOrigin,
             },
+            starkhash,
         };
 
         use super::*;
@@ -169,7 +169,7 @@ mod tests {
                     },
                     log_index: EthereumLogIndex(11),
                 },
-                global_root: GlobalRoot(StarkHash::from_hex_str("12354").unwrap()),
+                global_root: GlobalRoot(starkhash!("012354")),
                 block_number: StarknetBlockNumber(3),
             };
 
@@ -199,7 +199,7 @@ mod tests {
                     },
                     log_index: EthereumLogIndex(11),
                 },
-                global_root: GlobalRoot(StarkHash::from_hex_str("12354").unwrap()),
+                global_root: GlobalRoot(starkhash!("012354")),
                 block_number: StarknetBlockNumber(3),
             };
 

--- a/crates/pathfinder/src/lib.rs
+++ b/crates/pathfinder/src/lib.rs
@@ -11,3 +11,15 @@ pub mod sequencer;
 pub mod state;
 pub mod storage;
 pub mod update;
+
+macro_rules! starkhash {
+    ($hex:expr) => {{
+        let bytes = hex_literal::hex!($hex);
+        match stark_hash::StarkHash::from_be_slice(bytes.as_slice()) {
+            Ok(sh) => sh,
+            Err(stark_hash::OverflowError) => panic!("Invalid constant: OverflowError"),
+        }
+    }};
+}
+
+pub(crate) use starkhash;

--- a/crates/pathfinder/src/lib.rs
+++ b/crates/pathfinder/src/lib.rs
@@ -22,4 +22,16 @@ macro_rules! starkhash {
     }};
 }
 
+#[allow(unused)]
+macro_rules! starkhash_bytes {
+    ($bytes:expr) => {{
+        match stark_hash::StarkHash::from_be_slice($bytes) {
+            Ok(sh) => sh,
+            Err(stark_hash::OverflowError) => panic!("Invalid constant: OverflowError"),
+        }
+    }};
+}
+
 pub(crate) use starkhash;
+#[cfg(test)]
+pub(crate) use starkhash_bytes;

--- a/crates/pathfinder/src/lib.rs
+++ b/crates/pathfinder/src/lib.rs
@@ -12,6 +12,8 @@ pub mod state;
 pub mod storage;
 pub mod update;
 
+/// Creates a [`stark_hash::StarkHash`] from an even hex string, resulting in compile-time error
+/// when invalid.
 macro_rules! starkhash {
     ($hex:expr) => {{
         let bytes = hex_literal::hex!($hex);
@@ -22,7 +24,9 @@ macro_rules! starkhash {
     }};
 }
 
-#[allow(unused)]
+/// Creates a [`stark_hash::StarkHash`] from a byte slice, resulting in compile-time error when
+/// invalid.
+#[cfg(test)]
 macro_rules! starkhash_bytes {
     ($bytes:expr) => {{
         match stark_hash::StarkHash::from_be_slice($bytes) {

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -365,6 +365,7 @@ mod tests {
             test_utils::*,
             Client,
         },
+        starkhash, starkhash_bytes,
         state::{state_tree::GlobalStateTree, PendingData, SyncState},
         storage::{
             ContractCodeTable, ContractsTable, StarknetBlock, StarknetBlocksTable,
@@ -404,26 +405,26 @@ mod tests {
         let mut connection = storage.connection().unwrap();
         let db_txn = connection.transaction().unwrap();
 
-        let contract0_addr = ContractAddress(StarkHash::from_be_slice(b"contract 0").unwrap());
-        let contract1_addr = ContractAddress(StarkHash::from_be_slice(b"contract 1").unwrap());
+        let contract0_addr = ContractAddress(starkhash_bytes!(b"contract 0"));
+        let contract1_addr = ContractAddress(starkhash_bytes!(b"contract 1"));
 
-        let class0_hash = ClassHash(StarkHash::from_be_slice(b"class 0 hash").unwrap());
-        let class1_hash = ClassHash(StarkHash::from_be_slice(b"class 1 hash").unwrap());
+        let class0_hash = ClassHash(starkhash_bytes!(b"class 0 hash"));
+        let class1_hash = ClassHash(starkhash_bytes!(b"class 1 hash"));
 
         let contract0_update = vec![];
 
-        let storage_addr = StorageAddress(StarkHash::from_be_slice(b"storage addr 0").unwrap());
+        let storage_addr = StorageAddress(starkhash_bytes!(b"storage addr 0"));
         let contract1_update0 = vec![StorageDiff {
             key: storage_addr,
-            value: StorageValue(StarkHash::from_be_slice(b"storage value 0").unwrap()),
+            value: StorageValue(starkhash_bytes!(b"storage value 0")),
         }];
         let contract1_update1 = vec![StorageDiff {
             key: storage_addr,
-            value: StorageValue(StarkHash::from_be_slice(b"storage value 1").unwrap()),
+            value: StorageValue(starkhash_bytes!(b"storage value 1")),
         }];
         let contract1_update2 = vec![StorageDiff {
             key: storage_addr,
-            value: StorageValue(StarkHash::from_be_slice(b"storage value 2").unwrap()),
+            value: StorageValue(starkhash_bytes!(b"storage value 2")),
         }];
 
         // We need to set the magic bytes for zstd compression to simulate a compressed
@@ -477,7 +478,7 @@ mod tests {
             .unwrap();
         let global_root2 = global_tree.apply().unwrap();
 
-        let genesis_hash = StarknetBlockHash(StarkHash::from_be_slice(b"genesis").unwrap());
+        let genesis_hash = StarknetBlockHash(starkhash_bytes!(b"genesis"));
         let block0 = StarknetBlock {
             number: StarknetBlockNumber::GENESIS,
             hash: genesis_hash,
@@ -486,29 +487,29 @@ mod tests {
             gas_price: GasPrice::ZERO,
             sequencer_address: SequencerAddress(StarkHash::ZERO),
         };
-        let block1_hash = StarknetBlockHash(StarkHash::from_be_slice(b"block 1").unwrap());
+        let block1_hash = StarknetBlockHash(starkhash_bytes!(b"block 1"));
         let block1 = StarknetBlock {
             number: StarknetBlockNumber(1),
             hash: block1_hash,
             root: global_root1,
             timestamp: StarknetBlockTimestamp(1),
             gas_price: GasPrice::from(1),
-            sequencer_address: SequencerAddress(StarkHash::from_be_slice(&[1u8]).unwrap()),
+            sequencer_address: SequencerAddress(starkhash_bytes!(&[1u8])),
         };
-        let latest_hash = StarknetBlockHash(StarkHash::from_be_slice(b"latest").unwrap());
+        let latest_hash = StarknetBlockHash(starkhash_bytes!(b"latest"));
         let block2 = StarknetBlock {
             number: StarknetBlockNumber(2),
             hash: latest_hash,
             root: global_root2,
             timestamp: StarknetBlockTimestamp(2),
             gas_price: GasPrice::from(2),
-            sequencer_address: SequencerAddress(StarkHash::from_be_slice(&[2u8]).unwrap()),
+            sequencer_address: SequencerAddress(starkhash_bytes!(&[2u8])),
         };
         StarknetBlocksTable::insert(&db_txn, &block0, None).unwrap();
         StarknetBlocksTable::insert(&db_txn, &block1, None).unwrap();
         StarknetBlocksTable::insert(&db_txn, &block2, None).unwrap();
 
-        let txn0_hash = StarknetTransactionHash(StarkHash::from_be_slice(b"txn 0").unwrap());
+        let txn0_hash = StarknetTransactionHash(starkhash_bytes!(b"txn 0"));
         // TODO introduce other types of transactions too
         let txn0 = InvokeTransaction {
             calldata: vec![],
@@ -534,11 +535,11 @@ mod tests {
             transaction_hash: txn0_hash,
             transaction_index: StarknetTransactionIndex(0),
         };
-        let txn1_hash = StarknetTransactionHash(StarkHash::from_be_slice(b"txn 1").unwrap());
-        let txn2_hash = StarknetTransactionHash(StarkHash::from_be_slice(b"txn 2").unwrap());
-        let txn3_hash = StarknetTransactionHash(StarkHash::from_be_slice(b"txn 3").unwrap());
-        let txn4_hash = StarknetTransactionHash(StarkHash::from_be_slice(b"txn 4 ").unwrap());
-        let txn5_hash = StarknetTransactionHash(StarkHash::from_be_slice(b"txn 5").unwrap());
+        let txn1_hash = StarknetTransactionHash(starkhash_bytes!(b"txn 1"));
+        let txn2_hash = StarknetTransactionHash(starkhash_bytes!(b"txn 2"));
+        let txn3_hash = StarknetTransactionHash(starkhash_bytes!(b"txn 3"));
+        let txn4_hash = StarknetTransactionHash(starkhash_bytes!(b"txn 4 "));
+        let txn5_hash = StarknetTransactionHash(starkhash_bytes!(b"txn 5"));
         let mut txn1 = txn0.clone();
         let mut txn2 = txn0.clone();
         let mut txn3 = txn0.clone();
@@ -566,11 +567,9 @@ mod tests {
         let mut receipt4 = receipt0.clone();
         let mut receipt5 = receipt0.clone();
         receipt0.events = vec![Event {
-            data: vec![EventData(
-                StarkHash::from_be_slice(b"event 0 data").unwrap(),
-            )],
-            from_address: ContractAddress(StarkHash::from_be_slice(b"event 0 from addr").unwrap()),
-            keys: vec![EventKey(StarkHash::from_be_slice(b"event 0 key").unwrap())],
+            data: vec![EventData(starkhash_bytes!(b"event 0 data"))],
+            from_address: ContractAddress(starkhash_bytes!(b"event 0 from addr")),
+            keys: vec![EventKey(starkhash_bytes!(b"event 0 key"))],
         }];
         receipt1.transaction_hash = txn1_hash;
         receipt2.transaction_hash = txn2_hash;
@@ -616,30 +615,20 @@ mod tests {
         let transactions: Vec<Transaction> = vec![
             InvokeTransaction {
                 calldata: vec![],
-                contract_address: ContractAddress(
-                    StarkHash::from_be_slice(b"pending contract addr 0").unwrap(),
-                ),
-                entry_point_selector: EntryPoint(
-                    StarkHash::from_be_slice(b"entry point 0").unwrap(),
-                ),
+                contract_address: ContractAddress(starkhash_bytes!(b"pending contract addr 0")),
+                entry_point_selector: EntryPoint(starkhash_bytes!(b"entry point 0")),
                 entry_point_type: EntryPointType::External,
                 max_fee: Call::DEFAULT_MAX_FEE,
                 signature: vec![],
-                transaction_hash: StarknetTransactionHash(
-                    StarkHash::from_be_slice(b"pending tx hash 0").unwrap(),
-                ),
+                transaction_hash: StarknetTransactionHash(starkhash_bytes!(b"pending tx hash 0")),
             }
             .into(),
             DeployTransaction {
-                contract_address: ContractAddress::from_hex_str("0x1122355").unwrap(),
-                contract_address_salt: ContractAddressSalt(
-                    StarkHash::from_be_slice(b"salty").unwrap(),
-                ),
-                class_hash: ClassHash(StarkHash::from_be_slice(b"pending class hash 1").unwrap()),
+                contract_address: ContractAddress(starkhash!("01122355")),
+                contract_address_salt: ContractAddressSalt(starkhash_bytes!(b"salty")),
+                class_hash: ClassHash(starkhash_bytes!(b"pending class hash 1")),
                 constructor_calldata: vec![],
-                transaction_hash: StarknetTransactionHash(
-                    StarkHash::from_be_slice(b"pending tx hash 1").unwrap(),
-                ),
+                transaction_hash: StarknetTransactionHash(starkhash_bytes!(b"pending tx hash 1")),
             }
             .into(),
         ];
@@ -650,20 +639,18 @@ mod tests {
                 events: vec![
                     Event {
                         data: vec![],
-                        from_address: ContractAddress::from_hex_str("0xabcddddddd").unwrap(),
-                        keys: vec![EventKey(StarkHash::from_be_slice(b"pending key").unwrap())],
+                        from_address: ContractAddress(starkhash!("abcddddddd")),
+                        keys: vec![EventKey(starkhash_bytes!(b"pending key"))],
                     },
                     Event {
                         data: vec![],
-                        from_address: ContractAddress::from_hex_str("0xabcddddddd").unwrap(),
-                        keys: vec![EventKey(StarkHash::from_be_slice(b"pending key").unwrap())],
+                        from_address: ContractAddress(starkhash!("abcddddddd")),
+                        keys: vec![EventKey(starkhash_bytes!(b"pending key"))],
                     },
                     Event {
                         data: vec![],
-                        from_address: ContractAddress::from_hex_str("0xabcaaaaaaa").unwrap(),
-                        keys: vec![EventKey(
-                            StarkHash::from_be_slice(b"pending key 2").unwrap(),
-                        )],
+                        from_address: ContractAddress(starkhash!("abcaaaaaaa")),
+                        keys: vec![EventKey(starkhash_bytes!(b"pending key 2"))],
                     },
                 ],
                 execution_resources: ExecutionResources {
@@ -698,9 +685,7 @@ mod tests {
         let block = crate::sequencer::reply::PendingBlock {
             gas_price: GasPrice::from_be_slice(b"gas price").unwrap(),
             parent_hash: latest.hash,
-            sequencer_address: SequencerAddress(
-                StarkHash::from_be_slice(b"pending sequencer address").unwrap(),
-            ),
+            sequencer_address: SequencerAddress(starkhash_bytes!(b"pending sequencer address")),
             status: crate::sequencer::reply::Status::Pending,
             timestamp: StarknetBlockTimestamp(1234567),
             transaction_receipts,
@@ -711,40 +696,24 @@ mod tests {
         use crate::sequencer::reply as seq_reply;
         let deployed_contracts = vec![
             seq_reply::state_update::DeployedContract {
-                address: ContractAddress(
-                    StarkHash::from_be_slice(b"pending contract 0 address").unwrap(),
-                ),
-                class_hash: ClassHash(
-                    StarkHash::from_be_slice(b"pending contract 0 hash").unwrap(),
-                ),
+                address: ContractAddress(starkhash_bytes!(b"pending contract 0 address")),
+                class_hash: ClassHash(starkhash_bytes!(b"pending contract 0 hash")),
             },
             seq_reply::state_update::DeployedContract {
-                address: ContractAddress(
-                    StarkHash::from_be_slice(b"pending contract 1 address").unwrap(),
-                ),
-                class_hash: ClassHash(
-                    StarkHash::from_be_slice(b"pending contract 1 hash").unwrap(),
-                ),
+                address: ContractAddress(starkhash_bytes!(b"pending contract 1 address")),
+                class_hash: ClassHash(starkhash_bytes!(b"pending contract 1 hash")),
             },
         ];
         let storage_diffs = [(
             deployed_contracts[1].address,
             vec![
                 seq_reply::state_update::StorageDiff {
-                    key: StorageAddress(
-                        StarkHash::from_be_slice(b"pending storage key 0").unwrap(),
-                    ),
-                    value: StorageValue(
-                        StarkHash::from_be_slice(b"pending storage value 0").unwrap(),
-                    ),
+                    key: StorageAddress(starkhash_bytes!(b"pending storage key 0")),
+                    value: StorageValue(starkhash_bytes!(b"pending storage value 0")),
                 },
                 seq_reply::state_update::StorageDiff {
-                    key: StorageAddress(
-                        StarkHash::from_be_slice(b"pending storage key 1").unwrap(),
-                    ),
-                    value: StorageValue(
-                        StarkHash::from_be_slice(b"pending storage value 1").unwrap(),
-                    ),
+                    key: StorageAddress(starkhash_bytes!(b"pending storage key 1")),
+                    value: StorageValue(starkhash_bytes!(b"pending storage value 1")),
                 },
             ],
         )]
@@ -835,7 +804,7 @@ mod tests {
 
         #[tokio::test]
         async fn genesis_by_hash() {
-            let genesis_hash = StarknetBlockHash(StarkHash::from_be_slice(b"genesis").unwrap());
+            let genesis_hash = StarknetBlockHash(starkhash_bytes!(b"genesis"));
             let genesis_id = BlockId::Hash(genesis_hash);
             let params = rpc_params!(genesis_id);
 
@@ -878,7 +847,7 @@ mod tests {
 
         #[tokio::test]
         async fn genesis_by_number() {
-            let genesis_hash = StarknetBlockHash(StarkHash::from_be_slice(b"genesis").unwrap());
+            let genesis_hash = StarknetBlockHash(starkhash_bytes!(b"genesis"));
             let genesis_id = BlockId::Number(StarknetBlockNumber::GENESIS);
             let params = rpc_params!(genesis_id);
 
@@ -898,8 +867,7 @@ mod tests {
 
                 #[tokio::test]
                 async fn all() {
-                    let latest_hash =
-                        StarknetBlockHash(StarkHash::from_be_slice(b"latest").unwrap());
+                    let latest_hash = StarknetBlockHash(starkhash_bytes!(b"latest"));
                     let params = rpc_params!(BlockId::Latest);
 
                     check_result(params, move |block, _| {
@@ -917,8 +885,7 @@ mod tests {
 
                 #[tokio::test]
                 async fn all() {
-                    let latest_hash =
-                        StarknetBlockHash(StarkHash::from_be_slice(b"latest").unwrap());
+                    let latest_hash = StarknetBlockHash(starkhash_bytes!(b"latest"));
                     let params = by_name([("block_id", json!("latest"))]);
 
                     check_result(params, move |block, _| {
@@ -1015,7 +982,7 @@ mod tests {
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
-                ContractAddress(StarkHash::from_be_slice(b"contract 0").unwrap()),
+                ContractAddress(starkhash_bytes!(b"contract 0")),
                 web3::types::H256::from_str(
                     "0x0800000000000011000000000000000000000000000000000000000000000001"
                 )
@@ -1038,7 +1005,7 @@ mod tests {
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
-                ContractAddress(StarkHash::from_be_slice(b"contract 0").unwrap()),
+                ContractAddress(starkhash_bytes!(b"contract 0")),
                 web3::types::H256::from_str(
                     "0x0800000000000000000000000000000000000000000000000000000000000000"
                 )
@@ -1059,8 +1026,8 @@ mod tests {
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
-                ContractAddress(StarkHash::from_be_slice(b"nonexistent").unwrap()),
-                StorageAddress(StarkHash::from_be_slice(b"storage addr 0").unwrap()),
+                ContractAddress(starkhash_bytes!(b"nonexistent")),
+                StorageAddress(starkhash_bytes!(b"storage addr 0")),
                 BlockId::Latest
             );
             let error = client(addr)
@@ -1078,11 +1045,9 @@ mod tests {
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
-                ContractAddress(StarkHash::from_be_slice(b"contract 1").unwrap()),
-                StorageAddress(StarkHash::from_be_slice(b"storage addr 0").unwrap()),
-                BlockId::Hash(StarknetBlockHash(
-                    StarkHash::from_be_slice(b"genesis").unwrap()
-                ))
+                ContractAddress(starkhash_bytes!(b"contract 1")),
+                StorageAddress(starkhash_bytes!(b"storage addr 0")),
+                BlockId::Hash(StarknetBlockHash(starkhash_bytes!(b"genesis")))
             );
             let error = client(addr)
                 .request::<StorageValue>("starknet_getStorageAt", params)
@@ -1099,11 +1064,9 @@ mod tests {
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
-                ContractAddress(StarkHash::from_be_slice(b"contract 1").unwrap()),
-                StorageAddress(StarkHash::from_be_slice(b"storage addr 0").unwrap()),
-                BlockId::Hash(StarknetBlockHash(
-                    StarkHash::from_be_slice(b"nonexistent").unwrap()
-                ))
+                ContractAddress(starkhash_bytes!(b"contract 1")),
+                StorageAddress(starkhash_bytes!(b"storage addr 0")),
+                BlockId::Hash(StarknetBlockHash(starkhash_bytes!(b"nonexistent")))
             );
             let error = client(addr)
                 .request::<StorageValue>("starknet_getStorageAt", params)
@@ -1120,20 +1083,15 @@ mod tests {
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
-                ContractAddress(StarkHash::from_be_slice(b"contract 1").unwrap()),
-                StorageAddress(StarkHash::from_be_slice(b"storage addr 0").unwrap()),
-                BlockId::Hash(StarknetBlockHash(
-                    StarkHash::from_be_slice(b"block 1").unwrap()
-                ))
+                ContractAddress(starkhash_bytes!(b"contract 1")),
+                StorageAddress(starkhash_bytes!(b"storage addr 0")),
+                BlockId::Hash(StarknetBlockHash(starkhash_bytes!(b"block 1")))
             );
             let value = client(addr)
                 .request::<StorageValue>("starknet_getStorageAt", params)
                 .await
                 .unwrap();
-            assert_eq!(
-                value.0,
-                StarkHash::from_be_slice(b"storage value 1").unwrap()
-            );
+            assert_eq!(value.0, starkhash_bytes!(b"storage value 1"));
         }
 
         mod latest_block {
@@ -1148,18 +1106,15 @@ mod tests {
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(
-                    ContractAddress(StarkHash::from_be_slice(b"contract 1").unwrap()),
-                    StorageAddress(StarkHash::from_be_slice(b"storage addr 0").unwrap()),
+                    ContractAddress(starkhash_bytes!(b"contract 1")),
+                    StorageAddress(starkhash_bytes!(b"storage addr 0")),
                     BlockId::Latest
                 );
                 let value = client(addr)
                     .request::<StorageValue>("starknet_getStorageAt", params)
                     .await
                     .unwrap();
-                assert_eq!(
-                    value.0,
-                    StarkHash::from_be_slice(b"storage value 2").unwrap()
-                );
+                assert_eq!(value.0, starkhash_bytes!(b"storage value 2"));
             }
 
             #[tokio::test]
@@ -1170,24 +1125,15 @@ mod tests {
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = by_name([
-                    (
-                        "contract_address",
-                        json! {StarkHash::from_be_slice(b"contract 1").unwrap()},
-                    ),
-                    (
-                        "key",
-                        json! {StarkHash::from_be_slice(b"storage addr 0").unwrap()},
-                    ),
+                    ("contract_address", json! {starkhash_bytes!(b"contract 1")}),
+                    ("key", json! {starkhash_bytes!(b"storage addr 0")}),
                     ("block_id", json! {"latest"}),
                 ]);
                 let value = client(addr)
                     .request::<StorageValue>("starknet_getStorageAt", params)
                     .await
                     .unwrap();
-                assert_eq!(
-                    value.0,
-                    StarkHash::from_be_slice(b"storage value 2").unwrap()
-                );
+                assert_eq!(value.0, starkhash_bytes!(b"storage value 2"));
             }
         }
 
@@ -1227,7 +1173,7 @@ mod tests {
             #[tokio::test]
             async fn positional_args() {
                 let storage = setup_storage();
-                let hash = StarknetTransactionHash(StarkHash::from_be_slice(b"txn 0").unwrap());
+                let hash = StarknetTransactionHash(starkhash_bytes!(b"txn 0"));
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
@@ -1243,7 +1189,7 @@ mod tests {
             #[tokio::test]
             async fn named_args() {
                 let storage = setup_storage();
-                let hash = StarknetTransactionHash(StarkHash::from_be_slice(b"txn 0").unwrap());
+                let hash = StarknetTransactionHash(starkhash_bytes!(b"txn 0"));
                 let sequencer = Client::new(Chain::Goerli).unwrap();
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
@@ -1285,7 +1231,7 @@ mod tests {
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
-            let params = rpc_params!(*INVALID_TX_HASH);
+            let params = rpc_params!(INVALID_TX_HASH);
             let error = client(addr)
                 .request::<Transaction>("starknet_getTransactionByHash", params)
                 .await
@@ -1319,13 +1265,13 @@ mod tests {
 
         #[tokio::test]
         async fn genesis_by_hash() {
-            let genesis_hash = StarknetBlockHash(StarkHash::from_be_slice(b"genesis").unwrap());
+            let genesis_hash = StarknetBlockHash(starkhash_bytes!(b"genesis"));
             let genesis_id = BlockId::Hash(genesis_hash);
             let params = rpc_params!(genesis_id, 0);
             check_result(params, move |txn| {
                 assert_eq!(
                     txn.hash(),
-                    StarknetTransactionHash(StarkHash::from_be_slice(b"txn 0").unwrap())
+                    StarknetTransactionHash(starkhash_bytes!(b"txn 0"))
                 )
             })
             .await;
@@ -1338,7 +1284,7 @@ mod tests {
             check_result(params, move |txn| {
                 assert_eq!(
                     txn.hash(),
-                    StarknetTransactionHash(StarkHash::from_be_slice(b"txn 0").unwrap())
+                    StarknetTransactionHash(starkhash_bytes!(b"txn 0"))
                 )
             })
             .await;
@@ -1354,7 +1300,7 @@ mod tests {
                 check_result(params, move |txn| {
                     assert_eq!(
                         txn.hash(),
-                        StarknetTransactionHash(StarkHash::from_be_slice(b"txn 3").unwrap())
+                        StarknetTransactionHash(starkhash_bytes!(b"txn 3"))
                     );
                 })
                 .await;
@@ -1366,7 +1312,7 @@ mod tests {
                 check_result(params, move |txn| {
                     assert_eq!(
                         txn.hash(),
-                        StarknetTransactionHash(StarkHash::from_be_slice(b"txn 3").unwrap())
+                        StarknetTransactionHash(starkhash_bytes!(b"txn 3"))
                     );
                 })
                 .await;
@@ -1419,7 +1365,7 @@ mod tests {
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
-            let genesis_hash = StarknetBlockHash(StarkHash::from_be_slice(b"genesis").unwrap());
+            let genesis_hash = StarknetBlockHash(starkhash_bytes!(b"genesis"));
             let genesis_id = BlockId::Hash(genesis_hash);
             let params = rpc_params!(genesis_id, 123);
             let error = client(addr)
@@ -1449,7 +1395,7 @@ mod tests {
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
-                let txn_hash = StarknetTransactionHash(StarkHash::from_be_slice(b"txn 0").unwrap());
+                let txn_hash = StarknetTransactionHash(starkhash_bytes!(b"txn 0"));
                 let params = rpc_params!(txn_hash);
                 let receipt = client(addr)
                     .request::<TransactionReceipt>("starknet_getTransactionReceipt", params)
@@ -1460,7 +1406,7 @@ mod tests {
                     receipt,
                     TransactionReceipt::Invoke(invoke) => assert_eq!(
                         invoke.events[0].keys[0],
-                        EventKey(StarkHash::from_be_slice(b"event 0 key").unwrap())
+                        EventKey(starkhash_bytes!(b"event 0 key"))
                     )
                 );
             }
@@ -1472,7 +1418,7 @@ mod tests {
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
-                let txn_hash = StarknetTransactionHash(StarkHash::from_be_slice(b"txn 0").unwrap());
+                let txn_hash = StarknetTransactionHash(starkhash_bytes!(b"txn 0"));
                 let params = by_name([("transaction_hash", json!(txn_hash))]);
                 let receipt = client(addr)
                     .request::<TransactionReceipt>("starknet_getTransactionReceipt", params)
@@ -1483,7 +1429,7 @@ mod tests {
                     receipt,
                     TransactionReceipt::Invoke(invoke) => assert_eq!(
                         invoke.events[0].keys[0],
-                        EventKey(StarkHash::from_be_slice(b"event 0 key").unwrap())
+                        EventKey(starkhash_bytes!(b"event 0 key"))
                     )
                 );
             }
@@ -1525,7 +1471,7 @@ mod tests {
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
-            let txn_hash = StarknetTransactionHash(StarkHash::from_be_slice(b"not found").unwrap());
+            let txn_hash = StarknetTransactionHash(starkhash_bytes!(b"not found"));
             let params = rpc_params!(txn_hash);
             let error = client(addr)
                 .request::<TransactionReceipt>("starknet_getTransactionReceipt", params)
@@ -1555,7 +1501,7 @@ mod tests {
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
-                let params = rpc_params!(*INVALID_CLASS_HASH);
+                let params = rpc_params!(INVALID_CLASS_HASH);
                 let error = client(addr)
                     .request::<ContractClass>("starknet_getClass", params)
                     .await
@@ -1635,7 +1581,7 @@ mod tests {
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
-                let params = rpc_params!(BlockId::Latest, *INVALID_CONTRACT_ADDR);
+                let params = rpc_params!(BlockId::Latest, INVALID_CONTRACT_ADDR);
                 let error = client(addr)
                     .request::<ClassHash>("starknet_getClassHashAt", params)
                     .await
@@ -1651,15 +1597,13 @@ mod tests {
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
-                let contract_address =
-                    ContractAddress(StarkHash::from_be_slice(b"contract 1").unwrap());
+                let contract_address = ContractAddress(starkhash_bytes!(b"contract 1"));
                 let params = rpc_params!(BlockId::Latest, contract_address);
                 let class_hash = client(addr)
                     .request::<ClassHash>("starknet_getClassHashAt", params)
                     .await
                     .unwrap();
-                let expected_class_hash =
-                    ClassHash(StarkHash::from_be_slice(b"class 1 hash").unwrap());
+                let expected_class_hash = ClassHash(starkhash_bytes!(b"class 1 hash"));
                 assert_eq!(class_hash, expected_class_hash);
             }
 
@@ -1671,8 +1615,7 @@ mod tests {
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
-                let contract_address =
-                    ContractAddress(StarkHash::from_be_slice(b"contract 1").unwrap());
+                let contract_address = ContractAddress(starkhash_bytes!(b"contract 1"));
                 let params = rpc_params!(
                     BlockId::Number(StarknetBlockNumber::GENESIS),
                     contract_address
@@ -1718,8 +1661,7 @@ mod tests {
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
-                let contract_address =
-                    ContractAddress(StarkHash::from_be_slice(b"contract 1").unwrap());
+                let contract_address = ContractAddress(starkhash_bytes!(b"contract 1"));
                 let params = by_name([
                     ("block_id", json!("latest")),
                     ("contract_address", json!(contract_address)),
@@ -1728,8 +1670,7 @@ mod tests {
                     .request::<ClassHash>("starknet_getClassHashAt", params)
                     .await
                     .unwrap();
-                let expected_class_hash =
-                    ClassHash(StarkHash::from_be_slice(b"class 1 hash").unwrap());
+                let expected_class_hash = ClassHash(starkhash_bytes!(b"class 1 hash"));
                 assert_eq!(class_hash, expected_class_hash);
             }
         }
@@ -1749,7 +1690,7 @@ mod tests {
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
-            let params = rpc_params!(BlockId::Latest, *INVALID_CONTRACT_ADDR);
+            let params = rpc_params!(BlockId::Latest, INVALID_CONTRACT_ADDR);
             let error = client(addr)
                 .request::<ContractClass>("starknet_getClassAt", params)
                 .await
@@ -1870,7 +1811,7 @@ mod tests {
 
     mod contract_setup {
         use crate::{
-            core::StorageValue, sequencer::reply::state_update::StorageDiff,
+            core::StorageValue, sequencer::reply::state_update::StorageDiff, starkhash,
             state::update_contract_state, storage::StarknetBlocksBlockId,
         };
 
@@ -1887,16 +1828,11 @@ mod tests {
             let buffer = zstd::decode_all(std::io::Cursor::new(contract_definition))?;
             let contract_definition = Bytes::from(buffer);
 
-            let contract_address = ContractAddress(
-                StarkHash::from_hex_str(
-                    "057dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374",
-                )
-                .unwrap(),
-            );
-            let expected_hash = StarkHash::from_hex_str(
-                "050b2148c0d782914e0b12a1a32abe5e398930b7e914f82c65cb7afce0a0ab9b",
-            )
-            .unwrap();
+            let contract_address = ContractAddress(starkhash!(
+                "057dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374"
+            ));
+            let expected_hash =
+                starkhash!("050b2148c0d782914e0b12a1a32abe5e398930b7e914f82c65cb7afce0a0ab9b");
 
             let (abi, bytecode, hash) =
                 crate::state::class_hash::extract_abi_code_hash(&*contract_definition)?;
@@ -1926,10 +1862,10 @@ mod tests {
             let program = base64::encode(program);
 
             // insert a new block whose state includes the contract
-            let storage_addr = StorageAddress(StarkHash::from_be_slice(b"storage addr").unwrap());
+            let storage_addr = StorageAddress(starkhash_bytes!(b"storage addr"));
             let storage_diff = vec![StorageDiff {
                 key: storage_addr,
-                value: StorageValue(StarkHash::from_be_slice(b"storage_value").unwrap()),
+                value: StorageValue(starkhash_bytes!(b"storage_value")),
             }];
             let block2 = StarknetBlocksTable::get(
                 transaction,
@@ -1947,11 +1883,11 @@ mod tests {
 
             let block3 = StarknetBlock {
                 number: StarknetBlockNumber(3),
-                hash: StarknetBlockHash(StarkHash::from_be_slice(b"block 3 hash").unwrap()),
+                hash: StarknetBlockHash(starkhash_bytes!(b"block 3 hash")),
                 root: global_tree.apply().unwrap(),
                 timestamp: StarknetBlockTimestamp(3),
                 gas_price: GasPrice::from(3),
-                sequencer_address: SequencerAddress(StarkHash::from_be_slice(&[3u8]).unwrap()),
+                sequencer_address: SequencerAddress(starkhash_bytes!(&[3u8])),
             };
 
             StarknetBlocksTable::insert(transaction, &block3, None).unwrap();
@@ -1971,9 +1907,9 @@ mod tests {
             let sync_state = Arc::new(SyncState::default());
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
-            let params = rpc_params!(BlockId::Hash(StarknetBlockHash(
-                StarkHash::from_be_slice(b"genesis").unwrap()
-            )));
+            let params = rpc_params!(BlockId::Hash(StarknetBlockHash(starkhash_bytes!(
+                b"genesis"
+            ))));
             let count = client(addr)
                 .request::<u64>("starknet_getBlockTransactionCount", params)
                 .await
@@ -2138,7 +2074,7 @@ mod tests {
         let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
         // This contract is created in `setup_storage`
-        let valid_contract = ContractAddress(StarkHash::from_be_slice(b"contract 0").unwrap());
+        let valid_contract = ContractAddress(starkhash_bytes!(b"contract 0"));
 
         // With no version set yet -- this occurs when `getNonce` is called before
         // we have received a `latest` update from the gateway at pathfinder startup.
@@ -2157,7 +2093,7 @@ mod tests {
         assert_eq!(version, ContractNonce(StarkHash::ZERO));
 
         // Invalid contract should error.
-        let invalid_contract = ContractAddress(StarkHash::from_be_slice(b"invalid").unwrap());
+        let invalid_contract = ContractAddress(starkhash_bytes!(b"invalid"));
         let error = client(addr)
             .request::<ContractNonce>("starknet_getNonce", rpc_params!(invalid_contract))
             .await
@@ -2180,15 +2116,20 @@ mod tests {
         use crate::{
             core::{CallParam, CallResultValue},
             rpc::types::request::Call,
+            starkhash,
         };
         use pretty_assertions::assert_eq;
 
-        lazy_static::lazy_static! {
-            static ref INVOKE_CONTRACT_BLOCK_ID: BlockId = BlockId::Hash(StarknetBlockHash::from_hex_str("0x03871c8a0c3555687515a07f365f6f5b1d8c2ae953f7844575b8bde2b2efed27").unwrap());
-            static ref PRE_DEPLOY_CONTRACT_BLOCK_ID: BlockId = BlockId::Hash(StarknetBlockHash::from_hex_str("0x05ef884a311df4339c8df791ce19bf305d7cf299416666b167bc56dd2d1f435f").unwrap());
-            static ref INVALID_BLOCK_ID: BlockId = BlockId::Hash(StarknetBlockHash::from_hex_str("0x06d328a71faf48c5c3857e99f20a77b18522480956d1cd5bff1ff2df3c8b427b").unwrap());
-            static ref CALL_DATA: Vec<CallParam> = vec![CallParam::from_hex_str("1234").unwrap()];
-        }
+        const INVOKE_CONTRACT_BLOCK_ID: BlockId = BlockId::Hash(StarknetBlockHash(starkhash!(
+            "03871c8a0c3555687515a07f365f6f5b1d8c2ae953f7844575b8bde2b2efed27"
+        )));
+        const PRE_DEPLOY_CONTRACT_BLOCK_ID: BlockId = BlockId::Hash(StarknetBlockHash(starkhash!(
+            "05ef884a311df4339c8df791ce19bf305d7cf299416666b167bc56dd2d1f435f"
+        )));
+        const INVALID_BLOCK_ID: BlockId = BlockId::Hash(StarknetBlockHash(starkhash!(
+            "06d328a71faf48c5c3857e99f20a77b18522480956d1cd5bff1ff2df3c8b427b"
+        )));
+        const CALL_DATA: [CallParam; 1] = [CallParam(starkhash!("1234"))];
 
         #[ignore = "no longer works without setting up ext_py"]
         #[tokio::test]
@@ -2200,14 +2141,14 @@ mod tests {
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
-                    calldata: CALL_DATA.clone(),
-                    contract_address: *VALID_CONTRACT_ADDR,
-                    entry_point_selector: *VALID_ENTRY_POINT,
+                    calldata: CALL_DATA.to_vec(),
+                    contract_address: VALID_CONTRACT_ADDR,
+                    entry_point_selector: VALID_ENTRY_POINT,
                     signature: Default::default(),
                     max_fee: Call::DEFAULT_MAX_FEE,
                     version: Call::DEFAULT_VERSION,
                 },
-                *INVOKE_CONTRACT_BLOCK_ID
+                INVOKE_CONTRACT_BLOCK_ID
             );
             client(addr)
                 .request::<Vec<CallResultValue>>("starknet_call", params)
@@ -2228,9 +2169,9 @@ mod tests {
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(
                     Call {
-                        calldata: CALL_DATA.clone(),
-                        contract_address: *VALID_CONTRACT_ADDR,
-                        entry_point_selector: *VALID_ENTRY_POINT,
+                        calldata: CALL_DATA.to_vec(),
+                        contract_address: VALID_CONTRACT_ADDR,
+                        entry_point_selector: VALID_ENTRY_POINT,
                         signature: Default::default(),
                         max_fee: Call::DEFAULT_MAX_FEE,
                         version: Call::DEFAULT_VERSION,
@@ -2255,9 +2196,9 @@ mod tests {
                     (
                         "request",
                         json!({
-                            "calldata": CALL_DATA.clone(),
-                            "contract_address": *VALID_CONTRACT_ADDR,
-                            "entry_point_selector": *VALID_ENTRY_POINT,
+                            "calldata": &CALL_DATA,
+                            "contract_address": VALID_CONTRACT_ADDR,
+                            "entry_point_selector": VALID_ENTRY_POINT,
                         }),
                     ),
                     ("block_id", json!("latest")),
@@ -2279,9 +2220,9 @@ mod tests {
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
-                    calldata: CALL_DATA.clone(),
-                    contract_address: *VALID_CONTRACT_ADDR,
-                    entry_point_selector: *VALID_ENTRY_POINT,
+                    calldata: CALL_DATA.to_vec(),
+                    contract_address: VALID_CONTRACT_ADDR,
+                    entry_point_selector: VALID_ENTRY_POINT,
                     signature: Default::default(),
                     max_fee: Call::DEFAULT_MAX_FEE,
                     version: Call::DEFAULT_VERSION,
@@ -2304,9 +2245,9 @@ mod tests {
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
-                    calldata: CALL_DATA.clone(),
-                    contract_address: *VALID_CONTRACT_ADDR,
-                    entry_point_selector: *INVALID_ENTRY_POINT,
+                    calldata: CALL_DATA.to_vec(),
+                    contract_address: VALID_CONTRACT_ADDR,
+                    entry_point_selector: INVALID_ENTRY_POINT,
                     signature: Default::default(),
                     max_fee: Call::DEFAULT_MAX_FEE,
                     version: Call::DEFAULT_VERSION,
@@ -2333,9 +2274,9 @@ mod tests {
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
-                    calldata: CALL_DATA.clone(),
-                    contract_address: *INVALID_CONTRACT_ADDR,
-                    entry_point_selector: *VALID_ENTRY_POINT,
+                    calldata: CALL_DATA.to_vec(),
+                    contract_address: INVALID_CONTRACT_ADDR,
+                    entry_point_selector: VALID_ENTRY_POINT,
                     signature: Default::default(),
                     max_fee: Call::DEFAULT_MAX_FEE,
                     version: Call::DEFAULT_VERSION,
@@ -2360,8 +2301,8 @@ mod tests {
             let params = rpc_params!(
                 Call {
                     calldata: vec![],
-                    contract_address: *VALID_CONTRACT_ADDR,
-                    entry_point_selector: *VALID_ENTRY_POINT,
+                    contract_address: VALID_CONTRACT_ADDR,
+                    entry_point_selector: VALID_ENTRY_POINT,
                     signature: Default::default(),
                     max_fee: Call::DEFAULT_MAX_FEE,
                     version: Call::DEFAULT_VERSION,
@@ -2385,14 +2326,14 @@ mod tests {
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
-                    calldata: CALL_DATA.clone(),
-                    contract_address: *VALID_CONTRACT_ADDR,
-                    entry_point_selector: *VALID_ENTRY_POINT,
+                    calldata: CALL_DATA.to_vec(),
+                    contract_address: VALID_CONTRACT_ADDR,
+                    entry_point_selector: VALID_ENTRY_POINT,
                     signature: Default::default(),
                     max_fee: Call::DEFAULT_MAX_FEE,
                     version: Call::DEFAULT_VERSION,
                 },
-                *PRE_DEPLOY_CONTRACT_BLOCK_ID
+                PRE_DEPLOY_CONTRACT_BLOCK_ID
             );
             let error = client(addr)
                 .request::<Vec<CallResultValue>>("starknet_call", params)
@@ -2411,14 +2352,14 @@ mod tests {
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
-                    calldata: CALL_DATA.clone(),
-                    contract_address: *VALID_CONTRACT_ADDR,
-                    entry_point_selector: *VALID_ENTRY_POINT,
+                    calldata: CALL_DATA.to_vec(),
+                    contract_address: VALID_CONTRACT_ADDR,
+                    entry_point_selector: VALID_ENTRY_POINT,
                     signature: Default::default(),
                     max_fee: Call::DEFAULT_MAX_FEE,
                     version: Call::DEFAULT_VERSION,
                 },
-                *INVALID_BLOCK_ID
+                INVALID_BLOCK_ID
             );
             let error = client(addr)
                 .request::<Vec<CallResultValue>>("starknet_call", params)
@@ -2454,7 +2395,7 @@ mod tests {
             .await
             .unwrap();
         let expected = BlockHashAndNumber {
-            hash: StarknetBlockHash(StarkHash::from_be_slice(b"latest").unwrap()),
+            hash: StarknetBlockHash(starkhash_bytes!(b"latest")),
             number: StarknetBlockNumber(2),
         };
         assert_eq!(latest, expected);
@@ -2548,6 +2489,7 @@ mod tests {
 
         mod positional_args {
             use super::*;
+            use crate::starkhash;
 
             use pretty_assertions::assert_eq;
 
@@ -2596,7 +2538,7 @@ mod tests {
                     to_block: Some(expected_event.block_number.unwrap().into()),
                     address: Some(expected_event.from_address),
                     // we're using a key which is present in _all_ events
-                    keys: vec![EventKey(StarkHash::from_hex_str("deadbeef").unwrap())],
+                    keys: vec![EventKey(starkhash!("deadbeef"))],
                     page_size: test_utils::NUM_EVENTS,
                     page_number: 0,
                 });
@@ -2992,6 +2934,7 @@ mod tests {
             use crate::{
                 core::{ByteCodeOffset, CallParam, ClassHash, EntryPoint},
                 sequencer::request::contract::{EntryPointType, SelectorAndOffset},
+                starkhash,
             };
 
             use pretty_assertions::assert_eq;
@@ -3000,73 +2943,45 @@ mod tests {
             lazy_static::lazy_static! {
                 pub static ref CALL: ContractCall = ContractCall {
                     contract_address: ContractAddress(
-                        StarkHash::from_hex_str(
-                            "0x23371b227eaecd8e8920cd429357edddd2cd0f3fee6abaacca08d3ab82a7cdd",
-                        )
-                        .unwrap(),
+                        starkhash!("023371b227eaecd8e8920cd429357edddd2cd0f3fee6abaacca08d3ab82a7cdd")
                     ),
                     calldata: vec![
-                        CallParam(StarkHash::from_hex_str("0x1").unwrap()),
-                        CallParam(
-                            StarkHash::from_hex_str(
-                                "0x677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1",
-                            )
-                            .unwrap(),
-                        ),
-                        CallParam(
-                            StarkHash::from_hex_str(
-                                "0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320",
-                            )
-                            .unwrap(),
-                        ),
-                        CallParam(StarkHash::ZERO),
-                        CallParam(StarkHash::from_hex_str("0x1").unwrap()),
-                        CallParam(StarkHash::from_hex_str("0x1").unwrap()),
-                        CallParam(StarkHash::from_hex_str("0x2b").unwrap()),
-                        CallParam(StarkHash::ZERO),
+                        CallParam(starkhash!("01")),
+                        CallParam(starkhash!("0677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1")),
+                        CallParam(starkhash!("0362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320")),
+                        CallParam(starkhash!("00")),
+                        CallParam(starkhash!("01")),
+                        CallParam(starkhash!("01")),
+                        CallParam(starkhash!("2b")),
+                        CallParam(starkhash!("00")),
                     ],
-                    entry_point_selector: EntryPoint(
-                        StarkHash::from_hex_str(
-                            "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
-                        )
-                        .unwrap(),
-                    ),
+                    entry_point_selector: EntryPoint(starkhash!("015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"))
                 };
                 pub static ref SIGNATURE: Vec<CallSignatureElem> = vec![
-                    CallSignatureElem(
-                        StarkHash::from_hex_str(
-                            "0x7dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5",
-                        )
-                        .unwrap(),
-                    ),
-                    CallSignatureElem(
-                        StarkHash::from_hex_str(
-                            "0x71456dded17015d1234779889d78f3e7c763ddcfd2662b19e7843c7542614f8",
-                        )
-                        .unwrap(),
-                    ),
+                    CallSignatureElem(starkhash!("07dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5")),
+                    CallSignatureElem(starkhash!("071456dded17015d1234779889d78f3e7c763ddcfd2662b19e7843c7542614f8")),
                 ];
                 pub static ref MAX_FEE: Fee = Fee(5444010076217u128.to_be_bytes().into());
                 pub static ref TRANSACTION_VERSION: TransactionVersion = TransactionVersion(H256::zero());
 
                 pub static ref ENTRY_POINTS_BY_TYPE: HashMap<EntryPointType, Vec<SelectorAndOffset>> =
-                HashMap::from([
-                    (EntryPointType::Constructor, vec![]),
-                    (
-                        EntryPointType::External,
-                        vec![
-                            SelectorAndOffset {
-                                offset: ByteCodeOffset(StarkHash::from_hex_str("0x3a").unwrap()),
-                                selector: EntryPoint::hashed(&b"increase_balance"[..]),
-                            },
-                            SelectorAndOffset{
-                                offset: ByteCodeOffset(StarkHash::from_hex_str("0x5b").unwrap()),
-                                selector: EntryPoint::hashed(&b"get_balance"[..]),
-                            },
-                        ],
-                    ),
-                    (EntryPointType::L1Handler, vec![]),
-                ]);
+                    HashMap::from([
+                        (EntryPointType::Constructor, vec![]),
+                        (
+                            EntryPointType::External,
+                            vec![
+                                SelectorAndOffset {
+                                    offset: ByteCodeOffset(starkhash!("3a")),
+                                    selector: EntryPoint::hashed(&b"increase_balance"[..]),
+                                },
+                                SelectorAndOffset{
+                                    offset: ByteCodeOffset(starkhash!("5b")),
+                                    selector: EntryPoint::hashed(&b"get_balance"[..]),
+                                },
+                            ],
+                        ),
+                        (EntryPointType::L1Handler, vec![]),
+                    ]);
                 pub static ref PROGRAM: String = CONTRACT_DEFINITION_JSON["program"]
                     .as_str()
                     .unwrap()
@@ -3100,12 +3015,9 @@ mod tests {
                 assert_eq!(
                     rpc_result,
                     InvokeTransactionResult {
-                        transaction_hash: StarknetTransactionHash(
-                            StarkHash::from_hex_str(
-                                "0x389dd0629f42176cc8b6c43acefc0713d0064ecdfc0470e0fc179f53421a38b"
-                            )
-                            .unwrap()
-                        )
+                        transaction_hash: StarknetTransactionHash(starkhash!(
+                            "0389dd0629f42176cc8b6c43acefc0713d0064ecdfc0470e0fc179f53421a38b"
+                        ))
                     }
                 );
             }
@@ -3130,18 +3042,12 @@ mod tests {
                 assert_eq!(
                     rpc_result,
                     DeclareTransactionResult {
-                        transaction_hash: StarknetTransactionHash(
-                            StarkHash::from_hex_str(
-                                "0x077ccba4df42cf0f74a8eb59a96d7880fae371edca5d000ca5f9985652c8a8ed"
-                            )
-                            .unwrap()
-                        ),
-                        class_hash: ClassHash(
-                            StarkHash::from_hex_str(
-                                "0x0711941b11a8236b8cca42b664e19342ac7300abb1dc44957763cb65877c2708"
-                            )
-                            .unwrap()
-                        ),
+                        transaction_hash: StarknetTransactionHash(starkhash!(
+                            "077ccba4df42cf0f74a8eb59a96d7880fae371edca5d000ca5f9985652c8a8ed"
+                        )),
+                        class_hash: ClassHash(starkhash!(
+                            "0711941b11a8236b8cca42b664e19342ac7300abb1dc44957763cb65877c2708"
+                        )),
                     }
                 );
             }
@@ -3155,12 +3061,9 @@ mod tests {
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let contract_definition = CONTRACT_DEFINITION.clone();
-                let contract_address_salt = ContractAddressSalt(
-                    StarkHash::from_hex_str(
-                        "0x5864b5e296c05028ac2bbc4a4c1378f56a3489d13e581f21d566bb94580f76d",
-                    )
-                    .unwrap(),
-                );
+                let contract_address_salt = ContractAddressSalt(starkhash!(
+                    "05864b5e296c05028ac2bbc4a4c1378f56a3489d13e581f21d566bb94580f76d"
+                ));
                 let constructor_calldata: Vec<ConstructorParam> = vec![];
 
                 let params = rpc_params!(
@@ -3177,25 +3080,19 @@ mod tests {
                 assert_eq!(
                     rpc_result,
                     DeployTransactionResult {
-                        transaction_hash: StarknetTransactionHash(
-                            StarkHash::from_hex_str(
-                                "0x057ed4b4c76a1ca0ba044a654dd3ee2d0d3e550343d739350a22aacdd524110d"
-                            )
-                            .unwrap()
-                        ),
-                        contract_address: ContractAddress(
-                            StarkHash::from_hex_str(
-                                "0x03926aea98213ec34fe9783d803237d221c54c52344422e1f4942a5b340fa6ad"
-                            )
-                            .unwrap()
-                        ),
+                        transaction_hash: StarknetTransactionHash(starkhash!(
+                            "057ed4b4c76a1ca0ba044a654dd3ee2d0d3e550343d739350a22aacdd524110d"
+                        )),
+                        contract_address: ContractAddress(starkhash!(
+                            "03926aea98213ec34fe9783d803237d221c54c52344422e1f4942a5b340fa6ad"
+                        )),
                     }
                 );
             }
         }
 
         mod named_args {
-            use crate::core::ClassHash;
+            use crate::{core::ClassHash, starkhash};
 
             use super::*;
 
@@ -3246,12 +3143,9 @@ mod tests {
                 assert_eq!(
                     rpc_result,
                     InvokeTransactionResult {
-                        transaction_hash: StarknetTransactionHash(
-                            StarkHash::from_hex_str(
-                                "0x389dd0629f42176cc8b6c43acefc0713d0064ecdfc0470e0fc179f53421a38b"
-                            )
-                            .unwrap()
-                        )
+                        transaction_hash: StarknetTransactionHash(starkhash!(
+                            "0389dd0629f42176cc8b6c43acefc0713d0064ecdfc0470e0fc179f53421a38b"
+                        ))
                     }
                 );
             }
@@ -3277,18 +3171,12 @@ mod tests {
                 assert_eq!(
                     rpc_result,
                     DeclareTransactionResult {
-                        transaction_hash: StarknetTransactionHash(
-                            StarkHash::from_hex_str(
-                                "0x077ccba4df42cf0f74a8eb59a96d7880fae371edca5d000ca5f9985652c8a8ed"
-                            )
-                            .unwrap()
-                        ),
-                        class_hash: ClassHash(
-                            StarkHash::from_hex_str(
-                                "0x0711941b11a8236b8cca42b664e19342ac7300abb1dc44957763cb65877c2708"
-                            )
-                            .unwrap()
-                        ),
+                        transaction_hash: StarknetTransactionHash(starkhash!(
+                            "077ccba4df42cf0f74a8eb59a96d7880fae371edca5d000ca5f9985652c8a8ed"
+                        )),
+                        class_hash: ClassHash(starkhash!(
+                            "0711941b11a8236b8cca42b664e19342ac7300abb1dc44957763cb65877c2708"
+                        )),
                     }
                 );
             }
@@ -3318,18 +3206,12 @@ mod tests {
                 assert_eq!(
                     rpc_result,
                     DeployTransactionResult {
-                        transaction_hash: StarknetTransactionHash(
-                            StarkHash::from_hex_str(
-                                "0x057ed4b4c76a1ca0ba044a654dd3ee2d0d3e550343d739350a22aacdd524110d"
-                            )
-                            .unwrap()
-                        ),
-                        contract_address: ContractAddress(
-                            StarkHash::from_hex_str(
-                                "0x03926aea98213ec34fe9783d803237d221c54c52344422e1f4942a5b340fa6ad"
-                            )
-                            .unwrap()
-                        ),
+                        transaction_hash: StarknetTransactionHash(starkhash!(
+                            "057ed4b4c76a1ca0ba044a654dd3ee2d0d3e550343d739350a22aacdd524110d"
+                        )),
+                        contract_address: ContractAddress(starkhash!(
+                            "03926aea98213ec34fe9783d803237d221c54c52344422e1f4942a5b340fa6ad"
+                        )),
                     }
                 );
             }

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -1344,7 +1344,7 @@ impl RpcApi {
             .add_declare_transaction(
                 contract_class,
                 // actual address dumped from a `starknet declare` call
-                ContractAddress(StarkHash::from_hex_str("0x1").unwrap()),
+                ContractAddress(crate::starkhash!("01")),
                 Fee(0u128.to_be_bytes().into()),
                 vec![],
                 TransactionNonce(StarkHash::ZERO),

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -1213,6 +1213,7 @@ pub mod reply {
         /// - `*AsDecimalStr*` creeping in from `sequencer::reply` as opposed to spec.
         mod serde {
             use super::super::*;
+            use crate::starkhash;
             use pretty_assertions::assert_eq;
 
             #[test]
@@ -1220,48 +1221,42 @@ pub mod reply {
                 impl Block {
                     pub fn test_data() -> Self {
                         let common = CommonTransactionProperties {
-                            hash: StarknetTransactionHash::from_hex_str("0x4").unwrap(),
+                            hash: StarknetTransactionHash(starkhash!("04")),
                             max_fee: Fee(web3::types::H128::from_low_u64_be(0x5)),
                             version: TransactionVersion(web3::types::H256::from_low_u64_be(0x6)),
-                            signature: vec![TransactionSignatureElem::from_hex_str("0x7").unwrap()],
-                            nonce: TransactionNonce::from_hex_str("0x8").unwrap(),
+                            signature: vec![TransactionSignatureElem(starkhash!("07"))],
+                            nonce: TransactionNonce(starkhash!("08")),
                         };
                         Self {
                             status: BlockStatus::AcceptedOnL1,
-                            block_hash: Some(StarknetBlockHash::from_hex_str("0x0").unwrap()),
-                            parent_hash: StarknetBlockHash::from_hex_str("0x1").unwrap(),
+                            block_hash: Some(StarknetBlockHash(starkhash!("00"))),
+                            parent_hash: StarknetBlockHash(starkhash!("01")),
                             block_number: Some(StarknetBlockNumber::GENESIS),
-                            new_root: Some(GlobalRoot::from_hex_str("0x2").unwrap()),
+                            new_root: Some(GlobalRoot(starkhash!("02"))),
                             timestamp: StarknetBlockTimestamp(1),
-                            sequencer_address: SequencerAddress::from_hex_str("0x3").unwrap(),
+                            sequencer_address: SequencerAddress(starkhash!("03")),
                             transactions: Transactions::Full(vec![
                                 Transaction::Declare(DeclareTransaction {
                                     common: common.clone(),
-                                    class_hash: ClassHash::from_hex_str("0x9").unwrap(),
-                                    sender_address: ContractAddress::from_hex_str("0xa").unwrap(),
+                                    class_hash: ClassHash(starkhash!("09")),
+                                    sender_address: ContractAddress(starkhash!("0a")),
                                 }),
                                 Transaction::Invoke(InvokeTransaction {
                                     common,
-                                    contract_address: ContractAddress::from_hex_str("0xb").unwrap(),
-                                    entry_point_selector: EntryPoint::from_hex_str("0xc").unwrap(),
-                                    calldata: vec![CallParam::from_hex_str("0xd").unwrap()],
+                                    contract_address: ContractAddress(starkhash!("0b")),
+                                    entry_point_selector: EntryPoint(starkhash!("0c")),
+                                    calldata: vec![CallParam(starkhash!("0d"))],
                                 }),
                                 Transaction::Deploy(DeployTransaction {
-                                    hash: StarknetTransactionHash::from_hex_str("0xe").unwrap(),
+                                    hash: StarknetTransactionHash(starkhash!("0e")),
 
                                     version: TransactionVersion(
                                         web3::types::H256::from_low_u64_be(1),
                                     ),
-                                    contract_address: ContractAddress::from_hex_str("0xf").unwrap(),
-                                    contract_address_salt: ContractAddressSalt::from_hex_str(
-                                        "0xee",
-                                    )
-                                    .unwrap(),
-                                    class_hash: ClassHash::from_hex_str("0x10").unwrap(),
-                                    constructor_calldata: vec![ConstructorParam::from_hex_str(
-                                        "0x11",
-                                    )
-                                    .unwrap()],
+                                    contract_address: ContractAddress(starkhash!("0f")),
+                                    contract_address_salt: ContractAddressSalt(starkhash!("ee")),
+                                    class_hash: ClassHash(starkhash!("10")),
+                                    constructor_calldata: vec![ConstructorParam(starkhash!("11"))],
                                 }),
                             ]),
                         }
@@ -1276,9 +1271,9 @@ pub mod reply {
                         block_hash: None,
                         block_number: None,
                         new_root: None,
-                        transactions: Transactions::HashesOnly(vec![
-                            StarknetTransactionHash::from_hex_str("0x4").unwrap(),
-                        ]),
+                        transactions: Transactions::HashesOnly(vec![StarknetTransactionHash(
+                            starkhash!("04"),
+                        )]),
                         ..Block::test_data()
                     },
                 ];
@@ -1298,11 +1293,11 @@ pub mod reply {
                 impl CommonTransactionReceiptProperties {
                     pub fn test_data() -> Self {
                         Self {
-                            transaction_hash: StarknetTransactionHash::from_hex_str("0x0").unwrap(),
+                            transaction_hash: StarknetTransactionHash(starkhash!("00")),
                             actual_fee: Fee(web3::types::H128::from_low_u64_be(0x1)),
                             status: TransactionStatus::AcceptedOnL1,
                             status_data: Some("blah".to_string()),
-                            block_hash: StarknetBlockHash::from_hex_str("0xaaa").unwrap(),
+                            block_hash: StarknetBlockHash(starkhash!("0aaa")),
                             block_number: StarknetBlockNumber(3),
                         }
                     }
@@ -1311,7 +1306,7 @@ pub mod reply {
                 impl CommonPendingTransactionReceiptProperties {
                     pub fn test_data() -> Self {
                         Self {
-                            transaction_hash: StarknetTransactionHash::from_hex_str("0x1").unwrap(),
+                            transaction_hash: StarknetTransactionHash(starkhash!("01")),
                             actual_fee: Fee(web3::types::H128::from_low_u64_be(0x2)),
                         }
                     }
@@ -1325,24 +1320,22 @@ pub mod reply {
                                 to_address: crate::core::EthereumAddress(
                                     web3::types::H160::from_low_u64_be(0x2),
                                 ),
-                                payload: vec![crate::core::L2ToL1MessagePayloadElem::from_hex_str(
-                                    "0x3",
-                                )
-                                .unwrap()],
+                                payload: vec![crate::core::L2ToL1MessagePayloadElem(starkhash!(
+                                    "03"
+                                ))],
                             }],
                             l1_origin_message: Some(transaction_receipt::MessageToL2 {
                                 from_address: crate::core::EthereumAddress(
                                     web3::types::H160::from_low_u64_be(0x4),
                                 ),
-                                payload: vec![crate::core::L1ToL2MessagePayloadElem::from_hex_str(
-                                    "0x5",
-                                )
-                                .unwrap()],
+                                payload: vec![crate::core::L1ToL2MessagePayloadElem(starkhash!(
+                                    "05"
+                                ))],
                             }),
                             events: vec![transaction_receipt::Event {
-                                from_address: ContractAddress::from_hex_str("0x6").unwrap(),
-                                keys: vec![EventKey::from_hex_str("0x7").unwrap()],
-                                data: vec![EventData::from_hex_str("0x8").unwrap()],
+                                from_address: ContractAddress(starkhash!("06")),
+                                keys: vec![EventKey(starkhash!("07"))],
+                                data: vec![EventData(starkhash!("08"))],
                             }],
                         }
                     }
@@ -1356,24 +1349,22 @@ pub mod reply {
                                 to_address: crate::core::EthereumAddress(
                                     web3::types::H160::from_low_u64_be(0x5),
                                 ),
-                                payload: vec![crate::core::L2ToL1MessagePayloadElem::from_hex_str(
-                                    "0x6",
-                                )
-                                .unwrap()],
+                                payload: vec![crate::core::L2ToL1MessagePayloadElem(starkhash!(
+                                    "06"
+                                ))],
                             }],
                             l1_origin_message: Some(transaction_receipt::MessageToL2 {
                                 from_address: crate::core::EthereumAddress(
                                     web3::types::H160::from_low_u64_be(0x77),
                                 ),
-                                payload: vec![crate::core::L1ToL2MessagePayloadElem::from_hex_str(
-                                    "0x7",
-                                )
-                                .unwrap()],
+                                payload: vec![crate::core::L1ToL2MessagePayloadElem(starkhash!(
+                                    "07"
+                                ))],
                             }),
                             events: vec![transaction_receipt::Event {
-                                from_address: ContractAddress::from_hex_str("0xa6").unwrap(),
-                                keys: vec![EventKey::from_hex_str("0xa7").unwrap()],
-                                data: vec![EventData::from_hex_str("0xa8").unwrap()],
+                                from_address: ContractAddress(starkhash!("a6")),
+                                keys: vec![EventKey(starkhash!("a7"))],
+                                data: vec![EventData(starkhash!("a8"))],
                             }],
                         }
                     }

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -411,66 +411,62 @@ impl ClientApi for Client {
 pub mod test_utils {
     use crate::{
         core::{
-            CallParam, ClassHash, ConstructorParam, ContractAddress, ContractAddressSalt,
-            EntryPoint, EventData, EventKey, GlobalRoot, L1ToL2MessagePayloadElem,
-            L2ToL1MessagePayloadElem, SequencerAddress, StarknetBlockHash, StarknetBlockNumber,
-            StarknetTransactionHash, StarknetTransactionIndex, StorageAddress, StorageValue,
-            TransactionNonce, TransactionSignatureElem,
+            CallParam, ClassHash, ContractAddress, EntryPoint, StarknetBlockHash,
+            StarknetBlockNumber, StarknetTransactionHash, StarknetTransactionIndex, StorageAddress,
         },
         rpc::types::{BlockHashOrTag, BlockNumberOrTag},
+        starkhash,
     };
-    use stark_hash::{HexParseError, StarkHash};
+    use stark_hash::StarkHash;
 
-    macro_rules! impl_from_hex_str {
-        ($type:ty) => {
-            impl $type {
-                pub fn from_hex_str(s: &str) -> std::result::Result<Self, HexParseError> {
-                    Ok(Self(StarkHash::from_hex_str(s)?))
-                }
-            }
-        };
-    }
-
-    impl_from_hex_str!(CallParam);
-    impl_from_hex_str!(ClassHash);
-    impl_from_hex_str!(ConstructorParam);
-    impl_from_hex_str!(ContractAddress);
-    impl_from_hex_str!(ContractAddressSalt);
-    impl_from_hex_str!(EntryPoint);
-    impl_from_hex_str!(EventData);
-    impl_from_hex_str!(EventKey);
-    impl_from_hex_str!(GlobalRoot);
-    impl_from_hex_str!(L1ToL2MessagePayloadElem);
-    impl_from_hex_str!(L2ToL1MessagePayloadElem);
-    impl_from_hex_str!(SequencerAddress);
-    impl_from_hex_str!(StarknetBlockHash);
-    impl_from_hex_str!(StarknetTransactionHash);
-    impl_from_hex_str!(StorageAddress);
-    impl_from_hex_str!(StorageValue);
-    impl_from_hex_str!(TransactionSignatureElem);
-    impl_from_hex_str!(TransactionNonce);
-
+    pub const GENESIS_BLOCK_NUMBER: BlockNumberOrTag =
+        BlockNumberOrTag::Number(StarknetBlockNumber::GENESIS);
+    pub const INVALID_BLOCK_NUMBER: BlockNumberOrTag =
+        BlockNumberOrTag::Number(StarknetBlockNumber::MAX);
+    pub const GENESIS_BLOCK_HASH: BlockHashOrTag = BlockHashOrTag::Hash(StarknetBlockHash(
+        starkhash!("07d328a71faf48c5c3857e99f20a77b18522480956d1cd5bff1ff2df3c8b427b"),
+    ));
+    pub const INVALID_BLOCK_HASH: BlockHashOrTag = BlockHashOrTag::Hash(StarknetBlockHash(
+        starkhash!("06d328a71faf48c5c3857e99f20a77b18522480956d1cd5bff1ff2df3c8b427b"),
+    ));
+    pub const PRE_DEPLOY_CONTRACT_BLOCK_HASH: BlockHashOrTag =
+        BlockHashOrTag::Hash(StarknetBlockHash(starkhash!(
+            "05ef884a311df4339c8df791ce19bf305d7cf299416666b167bc56dd2d1f435f"
+        )));
+    pub const INVOKE_CONTRACT_BLOCK_HASH: BlockHashOrTag = BlockHashOrTag::Hash(StarknetBlockHash(
+        starkhash!("03871c8a0c3555687515a07f365f6f5b1d8c2ae953f7844575b8bde2b2efed27"),
+    ));
+    pub const VALID_TX_HASH: StarknetTransactionHash = StarknetTransactionHash(starkhash!(
+        "0493d8fab73af67e972788e603aee18130facd3c7685f16084ecd98b07153e24"
+    ));
+    pub const INVALID_TX_HASH: StarknetTransactionHash = StarknetTransactionHash(starkhash!(
+        "0393d8fab73af67e972788e603aee18130facd3c7685f16084ecd98b07153e24"
+    ));
+    pub const VALID_CONTRACT_ADDR: ContractAddress = ContractAddress(starkhash!(
+        "06fbd460228d843b7fbef670ff15607bf72e19fa94de21e29811ada167b4ca39"
+    ));
+    pub const INVALID_CONTRACT_ADDR: ContractAddress = ContractAddress(starkhash!(
+        "05fbd460228d843b7fbef670ff15607bf72e19fa94de21e29811ada167b4ca39"
+    ));
+    pub const VALID_ENTRY_POINT: EntryPoint = EntryPoint(starkhash!(
+        "0362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320"
+    ));
+    pub const INVALID_ENTRY_POINT: EntryPoint = EntryPoint(StarkHash::ZERO);
+    pub const INVALID_TX_INDEX: StarknetTransactionIndex = StarknetTransactionIndex(u64::MAX);
+    pub const VALID_KEY: StorageAddress = StorageAddress(starkhash!(
+        "0206F38F7E4F15E87567361213C28F235CCCDAA1D7FD34C9DB1DFE9489C6A091"
+    ));
     lazy_static::lazy_static! {
-        pub static ref GENESIS_BLOCK_NUMBER: BlockNumberOrTag = BlockNumberOrTag::Number(StarknetBlockNumber::GENESIS);
-        pub static ref INVALID_BLOCK_NUMBER: BlockNumberOrTag = BlockNumberOrTag::Number(StarknetBlockNumber::MAX);
-        pub static ref GENESIS_BLOCK_HASH: BlockHashOrTag = BlockHashOrTag::Hash(StarknetBlockHash::from_hex_str("0x07d328a71faf48c5c3857e99f20a77b18522480956d1cd5bff1ff2df3c8b427b").unwrap());
-        pub static ref INVALID_BLOCK_HASH: BlockHashOrTag = BlockHashOrTag::Hash(StarknetBlockHash::from_hex_str("0x06d328a71faf48c5c3857e99f20a77b18522480956d1cd5bff1ff2df3c8b427b").unwrap());
-        pub static ref PRE_DEPLOY_CONTRACT_BLOCK_HASH: BlockHashOrTag = BlockHashOrTag::Hash(StarknetBlockHash::from_hex_str("0x05ef884a311df4339c8df791ce19bf305d7cf299416666b167bc56dd2d1f435f").unwrap());
-        pub static ref INVOKE_CONTRACT_BLOCK_HASH: BlockHashOrTag = BlockHashOrTag::Hash(StarknetBlockHash::from_hex_str("0x03871c8a0c3555687515a07f365f6f5b1d8c2ae953f7844575b8bde2b2efed27").unwrap());
-        pub static ref VALID_TX_HASH: StarknetTransactionHash = StarknetTransactionHash::from_hex_str("0x0493d8fab73af67e972788e603aee18130facd3c7685f16084ecd98b07153e24").unwrap();
-        pub static ref INVALID_TX_HASH: StarknetTransactionHash = StarknetTransactionHash::from_hex_str("0x0393d8fab73af67e972788e603aee18130facd3c7685f16084ecd98b07153e24").unwrap();
-        pub static ref VALID_CONTRACT_ADDR: ContractAddress = ContractAddress::from_hex_str("0x06fbd460228d843b7fbef670ff15607bf72e19fa94de21e29811ada167b4ca39").unwrap();
-        pub static ref INVALID_CONTRACT_ADDR: ContractAddress = ContractAddress::from_hex_str("0x05fbd460228d843b7fbef670ff15607bf72e19fa94de21e29811ada167b4ca39").unwrap();
-        pub static ref VALID_ENTRY_POINT: EntryPoint = EntryPoint::from_hex_str("0x0362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320").unwrap();
-        pub static ref INVALID_ENTRY_POINT: EntryPoint = EntryPoint(StarkHash::ZERO);
-        pub static ref INVALID_TX_INDEX: StarknetTransactionIndex = StarknetTransactionIndex(u64::MAX);
-        pub static ref VALID_KEY: StorageAddress = StorageAddress::from_hex_str("0x0206F38F7E4F15E87567361213C28F235CCCDAA1D7FD34C9DB1DFE9489C6A091").unwrap();
         pub static ref VALID_KEY_DEC: String = crate::rpc::serde::starkhash_to_dec_str(&VALID_KEY.0);
-        pub static ref VALID_CALL_DATA: Vec<CallParam> = vec![CallParam::from_hex_str("0x4d2").unwrap()];
-        /// Class hash for VALID_CONTRACT_ADDR
-        pub static ref VALID_CLASS_HASH: ClassHash = ClassHash::from_hex_str("0x021a7f43387573b68666669a0ed764252ce5367708e696e31967764a90b429c2").unwrap();
-        pub static ref INVALID_CLASS_HASH: ClassHash = ClassHash::from_hex_str("0x031a7f43387573b68666669a0ed764252ce5367708e696e31967764a90b429c2").unwrap();
     }
+    pub const VALID_CALL_DATA: [CallParam; 1] = [CallParam(starkhash!("04d2"))];
+    /// Class hash for VALID_CONTRACT_ADDR
+    pub const VALID_CLASS_HASH: ClassHash = ClassHash(starkhash!(
+        "021a7f43387573b68666669a0ed764252ce5367708e696e31967764a90b429c2"
+    ));
+    pub const INVALID_CLASS_HASH: ClassHash = ClassHash(starkhash!(
+        "031a7f43387573b68666669a0ed764252ce5367708e696e31967764a90b429c2"
+    ));
 }
 
 #[cfg(test)]
@@ -660,31 +656,29 @@ mod tests {
 
     mod block_matches_by_hash_on {
         use super::*;
+        use crate::starkhash;
 
         #[tokio::test]
         async fn genesis() {
             let (_jh, client) = setup([
                 (
-                    format!(
-                        "/feeder_gateway/get_block?blockHash={}",
-                        *GENESIS_BLOCK_HASH
-                    ),
+                    format!("/feeder_gateway/get_block?blockHash={}", GENESIS_BLOCK_HASH),
                     response!("0.9.0/block/genesis.json"),
                 ),
                 (
                     format!(
                         "/feeder_gateway/get_block?blockNumber={}",
-                        *GENESIS_BLOCK_NUMBER
+                        GENESIS_BLOCK_NUMBER
                     ),
                     response!("0.9.0/block/genesis.json"),
                 ),
             ]);
             let by_hash = client
-                .block(BlockId::from(*GENESIS_BLOCK_HASH))
+                .block(BlockId::from(GENESIS_BLOCK_HASH))
                 .await
                 .unwrap();
             let by_number = client
-                .block(BlockId::from(*GENESIS_BLOCK_NUMBER))
+                .block(BlockId::from(GENESIS_BLOCK_NUMBER))
                 .await
                 .unwrap();
             assert_eq!(by_hash, by_number);
@@ -704,10 +698,9 @@ mod tests {
             ]);
             let by_hash = client
                 .block(
-                    StarknetBlockHash::from_hex_str(
-                        "0x40ffdbd9abbc4fc64652c50db94a29bce65c183316f304a95df624de708e746",
-                    )
-                    .unwrap()
+                    StarknetBlockHash(starkhash!(
+                        "040ffdbd9abbc4fc64652c50db94a29bce65c183316f304a95df624de708e746"
+                    ))
                     .into(),
                 )
                 .await
@@ -750,14 +743,11 @@ mod tests {
         #[test_log::test(tokio::test)]
         async fn invalid_hash() {
             let (_jh, client) = setup([(
-                format!(
-                    "/feeder_gateway/get_block?blockHash={}",
-                    *INVALID_BLOCK_HASH
-                ),
+                format!("/feeder_gateway/get_block?blockHash={}", INVALID_BLOCK_HASH),
                 StarknetErrorCode::BlockNotFound.into_response(),
             )]);
             let error = client
-                .block(BlockId::from(*INVALID_BLOCK_HASH))
+                .block(BlockId::from(INVALID_BLOCK_HASH))
                 .await
                 .unwrap_err();
             assert_matches!(
@@ -771,12 +761,12 @@ mod tests {
             let (_jh, client) = setup([(
                 format!(
                     "/feeder_gateway/get_block?blockNumber={}",
-                    *INVALID_BLOCK_NUMBER
+                    INVALID_BLOCK_NUMBER
                 ),
                 StarknetErrorCode::BlockNotFound.into_response(),
             )]);
             let error = client
-                .block(BlockId::from(*INVALID_BLOCK_NUMBER))
+                .block(BlockId::from(INVALID_BLOCK_NUMBER))
                 .await
                 .unwrap_err();
             assert_matches!(
@@ -838,9 +828,9 @@ mod tests {
             let error = client
                 .call(
                     request::Call {
-                        calldata: VALID_CALL_DATA.clone(),
-                        contract_address: *VALID_CONTRACT_ADDR,
-                        entry_point_selector: *INVALID_ENTRY_POINT,
+                        calldata: VALID_CALL_DATA.to_vec(),
+                        contract_address: VALID_CONTRACT_ADDR,
+                        entry_point_selector: INVALID_ENTRY_POINT,
                         signature: vec![],
                     },
                     BlockHashOrTag::Tag(Tag::Latest),
@@ -862,9 +852,9 @@ mod tests {
             let error = client
                 .call(
                     request::Call {
-                        calldata: VALID_CALL_DATA.clone(),
-                        contract_address: *INVALID_CONTRACT_ADDR,
-                        entry_point_selector: *VALID_ENTRY_POINT,
+                        calldata: VALID_CALL_DATA.to_vec(),
+                        contract_address: INVALID_CONTRACT_ADDR,
+                        entry_point_selector: VALID_ENTRY_POINT,
                         signature: vec![],
                     },
                     BlockHashOrTag::Tag(Tag::Latest),
@@ -882,7 +872,7 @@ mod tests {
             let (_jh, client) = setup([(
                 format!(
                     "/feeder_gateway/call_contract?blockHash={}",
-                    *INVOKE_CONTRACT_BLOCK_HASH
+                    INVOKE_CONTRACT_BLOCK_HASH
                 ),
                 StarknetErrorCode::TransactionFailed.into_response(),
             )]);
@@ -890,11 +880,11 @@ mod tests {
                 .call(
                     request::Call {
                         calldata: vec![],
-                        contract_address: *VALID_CONTRACT_ADDR,
-                        entry_point_selector: *VALID_ENTRY_POINT,
+                        contract_address: VALID_CONTRACT_ADDR,
+                        entry_point_selector: VALID_ENTRY_POINT,
                         signature: vec![],
                     },
-                    *INVOKE_CONTRACT_BLOCK_HASH,
+                    INVOKE_CONTRACT_BLOCK_HASH,
                 )
                 .await
                 .unwrap_err();
@@ -909,7 +899,7 @@ mod tests {
             let (_jh, client) = setup([(
                 format!(
                     "/feeder_gateway/call_contract?blockHash={}",
-                    *GENESIS_BLOCK_HASH
+                    GENESIS_BLOCK_HASH
                 ),
                 StarknetErrorCode::UninitializedContract.into_response(),
             )]);
@@ -917,11 +907,11 @@ mod tests {
                 .call(
                     request::Call {
                         calldata: vec![],
-                        contract_address: *VALID_CONTRACT_ADDR,
-                        entry_point_selector: *VALID_ENTRY_POINT,
+                        contract_address: VALID_CONTRACT_ADDR,
+                        entry_point_selector: VALID_ENTRY_POINT,
                         signature: vec![],
                     },
-                    *GENESIS_BLOCK_HASH,
+                    GENESIS_BLOCK_HASH,
                 )
                 .await
                 .unwrap_err();
@@ -936,19 +926,19 @@ mod tests {
             let (_jh, client) = setup([(
                 format!(
                     "/feeder_gateway/call_contract?blockHash={}",
-                    *INVALID_BLOCK_HASH
+                    INVALID_BLOCK_HASH
                 ),
                 StarknetErrorCode::BlockNotFound.into_response(),
             )]);
             let error = client
                 .call(
                     request::Call {
-                        calldata: VALID_CALL_DATA.clone(),
-                        contract_address: *VALID_CONTRACT_ADDR,
-                        entry_point_selector: *VALID_ENTRY_POINT,
+                        calldata: VALID_CALL_DATA.to_vec(),
+                        contract_address: VALID_CONTRACT_ADDR,
+                        entry_point_selector: VALID_ENTRY_POINT,
                         signature: vec![],
                     },
-                    *INVALID_BLOCK_HASH,
+                    INVALID_BLOCK_HASH,
                 )
                 .await
                 .unwrap_err();
@@ -963,19 +953,19 @@ mod tests {
             let (_jh, client) = setup([(
                 format!(
                     "/feeder_gateway/call_contract?blockHash={}",
-                    *INVOKE_CONTRACT_BLOCK_HASH
+                    INVOKE_CONTRACT_BLOCK_HASH
                 ),
                 (r#"{"result":[]}"#, 200),
             )]);
             client
                 .call(
                     request::Call {
-                        calldata: VALID_CALL_DATA.clone(),
-                        contract_address: *VALID_CONTRACT_ADDR,
-                        entry_point_selector: *VALID_ENTRY_POINT,
+                        calldata: VALID_CALL_DATA.to_vec(),
+                        contract_address: VALID_CONTRACT_ADDR,
+                        entry_point_selector: VALID_ENTRY_POINT,
                         signature: vec![],
                     },
-                    *INVOKE_CONTRACT_BLOCK_HASH,
+                    INVOKE_CONTRACT_BLOCK_HASH,
                 )
                 .await
                 .unwrap();
@@ -990,9 +980,9 @@ mod tests {
             client
                 .call(
                     request::Call {
-                        calldata: VALID_CALL_DATA.clone(),
-                        contract_address: *VALID_CONTRACT_ADDR,
-                        entry_point_selector: *VALID_ENTRY_POINT,
+                        calldata: VALID_CALL_DATA.to_vec(),
+                        contract_address: VALID_CONTRACT_ADDR,
+                        entry_point_selector: VALID_ENTRY_POINT,
                         signature: vec![],
                     },
                     BlockHashOrTag::Tag(Tag::Latest),
@@ -1010,9 +1000,9 @@ mod tests {
             client
                 .call(
                     request::Call {
-                        calldata: VALID_CALL_DATA.clone(),
-                        contract_address: *VALID_CONTRACT_ADDR,
-                        entry_point_selector: *VALID_ENTRY_POINT,
+                        calldata: VALID_CALL_DATA.to_vec(),
+                        contract_address: VALID_CONTRACT_ADDR,
+                        entry_point_selector: VALID_ENTRY_POINT,
                         signature: vec![],
                     },
                     BlockHashOrTag::Tag(Tag::Pending),
@@ -1031,12 +1021,12 @@ mod tests {
             let (_jh, client) = setup([(
                 format!(
                     "/feeder_gateway/get_full_contract?contractAddress={}",
-                    *INVALID_CONTRACT_ADDR
+                    INVALID_CONTRACT_ADDR
                 ),
                 StarknetErrorCode::UninitializedContract.into_response(),
             )]);
             let error = client
-                .full_contract(*INVALID_CONTRACT_ADDR)
+                .full_contract(INVALID_CONTRACT_ADDR)
                 .await
                 .unwrap_err();
             assert_matches!(
@@ -1050,11 +1040,11 @@ mod tests {
             let (_jh, client) = setup([(
                 format!(
                     "/feeder_gateway/get_full_contract?contractAddress={}",
-                    *VALID_CONTRACT_ADDR
+                    VALID_CONTRACT_ADDR
                 ),
                 (r#"{"hello":"world"}"#, 200),
             )]);
-            let bytes = client.full_contract(*VALID_CONTRACT_ADDR).await.unwrap();
+            let bytes = client.full_contract(VALID_CONTRACT_ADDR).await.unwrap();
             serde_json::from_slice::<serde_json::value::Value>(&bytes).unwrap();
         }
     }
@@ -1068,11 +1058,11 @@ mod tests {
             let (_jh, client) = setup([(
                 format!(
                     "/feeder_gateway/get_class_by_hash?classHash={}",
-                    *INVALID_CLASS_HASH
+                    INVALID_CLASS_HASH
                 ),
                 StarknetErrorCode::UndeclaredClass.into_response(),
             )]);
-            let error = client.class_by_hash(*INVALID_CLASS_HASH).await.unwrap_err();
+            let error = client.class_by_hash(INVALID_CLASS_HASH).await.unwrap_err();
             assert_matches!(
                 error,
                 SequencerError::StarknetError(e) => assert_eq!(e.code, StarknetErrorCode::UndeclaredClass)
@@ -1084,11 +1074,11 @@ mod tests {
             let (_jh, client) = setup([(
                 format!(
                     "/feeder_gateway/get_class_by_hash?classHash={}",
-                    *VALID_CLASS_HASH
+                    VALID_CLASS_HASH
                 ),
                 (r#"{"hello":"world"}"#, 200),
             )]);
-            let bytes = client.class_by_hash(*VALID_CLASS_HASH).await.unwrap();
+            let bytes = client.class_by_hash(VALID_CLASS_HASH).await.unwrap();
             serde_json::from_slice::<serde_json::value::Value>(&bytes).unwrap();
         }
     }
@@ -1102,12 +1092,12 @@ mod tests {
             let (_jh, client) = setup([(
                 format!(
                     "/feeder_gateway/get_class_hash_at?contractAddress={}",
-                    *INVALID_CONTRACT_ADDR
+                    INVALID_CONTRACT_ADDR
                 ),
                 StarknetErrorCode::UninitializedContract.into_response(),
             )]);
             let error = client
-                .class_hash_at(*INVALID_CONTRACT_ADDR)
+                .class_hash_at(INVALID_CONTRACT_ADDR)
                 .await
                 .unwrap_err();
             assert_matches!(
@@ -1121,16 +1111,17 @@ mod tests {
             let (_jh, client) = setup([(
                 format!(
                     "/feeder_gateway/get_class_hash_at?contractAddress={}",
-                    *VALID_CONTRACT_ADDR
+                    VALID_CONTRACT_ADDR
                 ),
                 (r#""0x01""#, 200),
             )]);
-            client.class_hash_at(*VALID_CONTRACT_ADDR).await.unwrap();
+            client.class_hash_at(VALID_CONTRACT_ADDR).await.unwrap();
         }
     }
 
     mod storage {
         use super::*;
+        use crate::starkhash;
         use pretty_assertions::assert_eq;
 
         #[test_log::test(tokio::test)]
@@ -1138,14 +1129,14 @@ mod tests {
             let (_jh, client) = setup([(
                 format!(
                     "/feeder_gateway/get_storage_at?contractAddress={}&key={}&blockNumber=latest",
-                    *INVALID_CONTRACT_ADDR, *VALID_KEY_DEC
+                    INVALID_CONTRACT_ADDR, *VALID_KEY_DEC
                 ),
                 (r#""0x0""#, 200),
             )]);
             let result = client
                 .storage(
-                    *INVALID_CONTRACT_ADDR,
-                    *VALID_KEY,
+                    INVALID_CONTRACT_ADDR,
+                    VALID_KEY,
                     BlockHashOrTag::Tag(Tag::Latest),
                 )
                 .await
@@ -1158,13 +1149,13 @@ mod tests {
             let (_jh, client) = setup([(
                 format!(
                     "/feeder_gateway/get_storage_at?contractAddress={}&key=0&blockNumber=latest",
-                    *VALID_CONTRACT_ADDR
+                    VALID_CONTRACT_ADDR
                 ),
                 (r#""0x0""#, 200),
             )]);
             let result = client
                 .storage(
-                    *VALID_CONTRACT_ADDR,
+                    VALID_CONTRACT_ADDR,
                     StorageAddress(StarkHash::ZERO),
                     BlockHashOrTag::Tag(Tag::Latest),
                 )
@@ -1178,12 +1169,12 @@ mod tests {
             let (_jh, client) = setup([(
                 format!(
                     "/feeder_gateway/get_storage_at?contractAddress={}&key={}&blockHash={}",
-                    *VALID_CONTRACT_ADDR, *VALID_KEY_DEC, *INVALID_BLOCK_HASH
+                    VALID_CONTRACT_ADDR, *VALID_KEY_DEC, INVALID_BLOCK_HASH
                 ),
                 StarknetErrorCode::BlockNotFound.into_response(),
             )]);
             let error = client
-                .storage(*VALID_CONTRACT_ADDR, *VALID_KEY, *INVALID_BLOCK_HASH)
+                .storage(VALID_CONTRACT_ADDR, VALID_KEY, INVALID_BLOCK_HASH)
                 .await
                 .unwrap_err();
             assert_matches!(
@@ -1197,22 +1188,15 @@ mod tests {
             let (_jh, client) = setup([(
                 format!(
                     "/feeder_gateway/get_storage_at?contractAddress={}&key={}&blockHash={}",
-                    *VALID_CONTRACT_ADDR, *VALID_KEY_DEC, *INVOKE_CONTRACT_BLOCK_HASH
+                    VALID_CONTRACT_ADDR, *VALID_KEY_DEC, INVOKE_CONTRACT_BLOCK_HASH
                 ),
                 (r#""0x1e240""#, 200),
             )]);
             let result = client
-                .storage(
-                    *VALID_CONTRACT_ADDR,
-                    *VALID_KEY,
-                    *INVOKE_CONTRACT_BLOCK_HASH,
-                )
+                .storage(VALID_CONTRACT_ADDR, VALID_KEY, INVOKE_CONTRACT_BLOCK_HASH)
                 .await
                 .unwrap();
-            assert_eq!(
-                result,
-                StorageValue(StarkHash::from_hex_str("0x1e240").unwrap())
-            );
+            assert_eq!(result, StorageValue(starkhash!("01e240")));
         }
 
         #[tokio::test]
@@ -1220,22 +1204,19 @@ mod tests {
             let (_jh, client) = setup([(
                 format!(
                     "/feeder_gateway/get_storage_at?contractAddress={}&key={}&blockNumber=latest",
-                    *VALID_CONTRACT_ADDR, *VALID_KEY_DEC,
+                    VALID_CONTRACT_ADDR, *VALID_KEY_DEC,
                 ),
                 (r#""0x1e240""#, 200),
             )]);
             let result = client
                 .storage(
-                    *VALID_CONTRACT_ADDR,
-                    *VALID_KEY,
+                    VALID_CONTRACT_ADDR,
+                    VALID_KEY,
                     BlockHashOrTag::Tag(Tag::Latest),
                 )
                 .await
                 .unwrap();
-            assert_eq!(
-                result,
-                StorageValue(StarkHash::from_hex_str("0x1e240").unwrap())
-            );
+            assert_eq!(result, StorageValue(starkhash!("01e240")));
         }
 
         #[tokio::test]
@@ -1243,27 +1224,25 @@ mod tests {
             let (_jh, client) = setup([(
                 format!(
                     "/feeder_gateway/get_storage_at?contractAddress={}&key={}&blockNumber=pending",
-                    *VALID_CONTRACT_ADDR, *VALID_KEY_DEC
+                    VALID_CONTRACT_ADDR, *VALID_KEY_DEC
                 ),
                 (r#""0x1e240""#, 200),
             )]);
             let result = client
                 .storage(
-                    *VALID_CONTRACT_ADDR,
-                    *VALID_KEY,
+                    VALID_CONTRACT_ADDR,
+                    VALID_KEY,
                     BlockHashOrTag::Tag(Tag::Pending),
                 )
                 .await
                 .unwrap();
-            assert_eq!(
-                result,
-                StorageValue(StarkHash::from_hex_str("0x1e240").unwrap())
-            );
+            assert_eq!(result, StorageValue(starkhash!("01e240")));
         }
     }
 
     mod transaction {
         use super::{reply::Status, *};
+        use crate::starkhash;
         use pretty_assertions::assert_eq;
 
         #[tokio::test]
@@ -1274,12 +1253,9 @@ mod tests {
             )]);
             assert_eq!(
                 client
-                    .transaction(
-                        StarknetTransactionHash::from_hex_str(
-                            "0x587d93f2339b7f2beda040187dbfcb9e076ce4a21eb8d15ae64819718817fbe"
-                        )
-                        .unwrap()
-                    )
+                    .transaction(StarknetTransactionHash(starkhash!(
+                        "0587d93f2339b7f2beda040187dbfcb9e076ce4a21eb8d15ae64819718817fbe"
+                    )))
                     .await
                     .unwrap()
                     .status,
@@ -1295,12 +1271,9 @@ mod tests {
             )]);
             assert_eq!(
                 client
-                    .transaction(
-                        StarknetTransactionHash::from_hex_str(
-                            "0x3d7623443283d9a0cec946492db78b06d57642a551745ddfac8d3f1f4fcc2a8"
-                        )
-                        .unwrap()
-                    )
+                    .transaction(StarknetTransactionHash(starkhash!(
+                        "03d7623443283d9a0cec946492db78b06d57642a551745ddfac8d3f1f4fcc2a8"
+                    )))
                     .await
                     .unwrap()
                     .status,
@@ -1316,12 +1289,9 @@ mod tests {
             )]);
             assert_eq!(
                 client
-                    .transaction(
-                        StarknetTransactionHash::from_hex_str(
-                            "0x587d93f2339b7f2beda040187dbfcb9e076ce4a21eb8d15ae64819718817fbe"
-                        )
-                        .unwrap()
-                    )
+                    .transaction(StarknetTransactionHash(starkhash!(
+                        "0587d93f2339b7f2beda040187dbfcb9e076ce4a21eb8d15ae64819718817fbe"
+                    )))
                     .await
                     .unwrap()
                     .status,
@@ -1334,12 +1304,12 @@ mod tests {
             let (_jh, client) = setup([(
                 format!(
                     "/feeder_gateway/get_transaction?transactionHash={}",
-                    *INVALID_TX_HASH
+                    INVALID_TX_HASH
                 ),
                 (r#"{"status": "NOT_RECEIVED"}"#, 200),
             )]);
             assert_eq!(
-                client.transaction(*INVALID_TX_HASH).await.unwrap().status,
+                client.transaction(INVALID_TX_HASH).await.unwrap().status,
                 Status::NotReceived,
             );
         }
@@ -1347,6 +1317,7 @@ mod tests {
 
     mod transaction_status {
         use super::{reply::Status, *};
+        use crate::starkhash;
 
         #[tokio::test]
         async fn accepted() {
@@ -1356,12 +1327,9 @@ mod tests {
             )]);
             assert_eq!(
                 client
-                    .transaction_status(
-                        StarknetTransactionHash::from_hex_str(
-                            "0x79cc07feed4f4046276aea23ddcea8b2f956d14f2bfe97382fa333a11169205"
-                        )
-                        .unwrap()
-                    )
+                    .transaction_status(StarknetTransactionHash(starkhash!(
+                        "079cc07feed4f4046276aea23ddcea8b2f956d14f2bfe97382fa333a11169205"
+                    )))
                     .await
                     .unwrap()
                     .tx_status,
@@ -1374,13 +1342,13 @@ mod tests {
             let (_jh, client) = setup([(
                 format!(
                     "/feeder_gateway/get_transaction_status?transactionHash={}",
-                    *INVALID_TX_HASH
+                    INVALID_TX_HASH
                 ),
                 (r#"{"tx_status": "NOT_RECEIVED"}"#, 200),
             )]);
             assert_eq!(
                 client
-                    .transaction_status(*INVALID_TX_HASH)
+                    .transaction_status(INVALID_TX_HASH)
                     .await
                     .unwrap()
                     .tx_status,
@@ -1397,7 +1365,10 @@ mod tests {
             },
             *,
         };
-        use crate::core::{ContractAddress, GlobalRoot};
+        use crate::{
+            core::{ContractAddress, GlobalRoot},
+            starkhash,
+        };
         use pretty_assertions::assert_eq;
         use std::collections::{BTreeSet, HashMap};
 
@@ -1442,18 +1413,18 @@ mod tests {
                 (
                     format!(
                         "/feeder_gateway/get_state_update?blockHash={}",
-                        *GENESIS_BLOCK_HASH
+                        GENESIS_BLOCK_HASH
                     ),
                     response!("0.9.0/state_update/genesis.json"),
                 ),
             ]);
             let by_number: OrderedStateUpdate = client
-                .state_update(BlockId::from(*GENESIS_BLOCK_NUMBER))
+                .state_update(BlockId::from(GENESIS_BLOCK_NUMBER))
                 .await
                 .unwrap()
                 .into();
             let by_hash: OrderedStateUpdate = client
-                .state_update(BlockId::from(*GENESIS_BLOCK_HASH))
+                .state_update(BlockId::from(GENESIS_BLOCK_HASH))
                 .await
                 .unwrap()
                 .into();
@@ -1480,10 +1451,9 @@ mod tests {
                 .into();
             let by_hash: OrderedStateUpdate = client
                 .state_update(
-                    StarknetBlockHash::from_hex_str(
-                        "0x40ffdbd9abbc4fc64652c50db94a29bce65c183316f304a95df624de708e746",
-                    )
-                    .unwrap()
+                    StarknetBlockHash(starkhash!(
+                        "040ffdbd9abbc4fc64652c50db94a29bce65c183316f304a95df624de708e746"
+                    ))
                     .into(),
                 )
                 .await
@@ -1502,12 +1472,12 @@ mod tests {
             let (_jh, client) = setup([(
                 format!(
                     "/feeder_gateway/get_state_update?blockNumber={}",
-                    *INVALID_BLOCK_NUMBER
+                    INVALID_BLOCK_NUMBER
                 ),
                 StarknetErrorCode::BlockNotFound.into_response(),
             )]);
             let error = client
-                .state_update(BlockId::from(*INVALID_BLOCK_NUMBER))
+                .state_update(BlockId::from(INVALID_BLOCK_NUMBER))
                 .await
                 .unwrap_err();
             assert_matches!(
@@ -1521,12 +1491,12 @@ mod tests {
             let (_jh, client) = setup([(
                 format!(
                     "/feeder_gateway/get_state_update?blockHash={}",
-                    *INVALID_BLOCK_HASH
+                    INVALID_BLOCK_HASH
                 ),
                 StarknetErrorCode::BlockNotFound.into_response(),
             )]);
             let error = client
-                .state_update(BlockId::from(*INVALID_BLOCK_HASH))
+                .state_update(BlockId::from(INVALID_BLOCK_HASH))
                 .await
                 .unwrap_err();
             assert_matches!(
@@ -1588,6 +1558,7 @@ mod tests {
         use crate::{
             core::{ByteCodeOffset, CallParam, CallSignatureElem, EntryPoint},
             sequencer::request::contract::{EntryPointType, SelectorAndOffset},
+            starkhash,
         };
 
         use web3::types::H256;
@@ -1600,49 +1571,34 @@ mod tests {
                 "/gateway/add_transaction",
                 StarknetErrorCode::UnsupportedSelectorForFee.into_response(),
             )]);
-            let  error = client
+            let error = client
                 .add_invoke_transaction(
                     Call {
-                        contract_address: ContractAddress(
-                            StarkHash::from_hex_str(
-                                "0x23371b227eaecd8e8920cd429357edddd2cd0f3fee6abaacca08d3ab82a7cdd",
-                            )
-                            .unwrap(),
-                        ),
+                        contract_address: ContractAddress(starkhash!(
+                            "023371b227eaecd8e8920cd429357edddd2cd0f3fee6abaacca08d3ab82a7cdd"
+                        )),
                         calldata: vec![
-                            CallParam(StarkHash::from_hex_str("0x1").unwrap()),
-                            CallParam(
-                                StarkHash::from_hex_str(
-                                    "0x677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1",
-                                )
-                                .unwrap(),
-                            ),
-                            CallParam(
-                                StarkHash::from_hex_str(
-                                    "0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320",
-                                )
-                                .unwrap(),
-                            ),
+                            CallParam(starkhash!("01")),
+                            CallParam(starkhash!(
+                                "0677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1"
+                            )),
+                            CallParam(starkhash!(
+                                "0362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320"
+                            )),
                             CallParam(StarkHash::ZERO),
-                            CallParam(StarkHash::from_hex_str("0x1").unwrap()),
-                            CallParam(StarkHash::from_hex_str("0x1").unwrap()),
-                            CallParam(StarkHash::from_hex_str("0x2b").unwrap()),
+                            CallParam(starkhash!("01")),
+                            CallParam(starkhash!("01")),
+                            CallParam(starkhash!("2b")),
                             CallParam(StarkHash::ZERO),
                         ],
                         entry_point_selector: EntryPoint(StarkHash::ZERO),
                         signature: vec![
-                            CallSignatureElem(
-                                StarkHash::from_hex_str(
-                                    "0x7dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5"
-                                )
-                                .unwrap(),
-                            ),
-                            CallSignatureElem(
-                                StarkHash::from_hex_str(
-                                    "0x71456dded17015d1234779889d78f3e7c763ddcfd2662b19e7843c7542614f8"
-                                )
-                                .unwrap(),
-                            ),
+                            CallSignatureElem(starkhash!(
+                                "07dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5"
+                            )),
+                            CallSignatureElem(starkhash!(
+                                "071456dded17015d1234779889d78f3e7c763ddcfd2662b19e7843c7542614f8"
+                            )),
                         ],
                     },
                     Fee(5444010076217u128.to_be_bytes().into()),
@@ -1669,51 +1625,33 @@ mod tests {
             client
                 .add_invoke_transaction(
                     Call {
-                        contract_address: ContractAddress(
-                            StarkHash::from_hex_str(
-                                "0x23371b227eaecd8e8920cd429357edddd2cd0f3fee6abaacca08d3ab82a7cdd",
-                            )
-                            .unwrap(),
-                        ),
+                        contract_address: ContractAddress(starkhash!(
+                            "023371b227eaecd8e8920cd429357edddd2cd0f3fee6abaacca08d3ab82a7cdd"
+                        )),
                         calldata: vec![
-                            CallParam(StarkHash::from_hex_str("0x1").unwrap()),
-                            CallParam(
-                                StarkHash::from_hex_str(
-                                    "0x677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1",
-                                )
-                                .unwrap(),
-                            ),
-                            CallParam(
-                                StarkHash::from_hex_str(
-                                    "0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320",
-                                )
-                                .unwrap(),
-                            ),
+                            CallParam(starkhash!("01")),
+                            CallParam(starkhash!(
+                                "0677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1"
+                            )),
+                            CallParam(starkhash!(
+                                "0362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320"
+                            )),
                             CallParam(StarkHash::ZERO),
-                            CallParam(StarkHash::from_hex_str("0x1").unwrap()),
-                            CallParam(StarkHash::from_hex_str("0x1").unwrap()),
-                            CallParam(StarkHash::from_hex_str("0x2b").unwrap()),
+                            CallParam(starkhash!("01")),
+                            CallParam(starkhash!("01")),
+                            CallParam(starkhash!("2b")),
                             CallParam(StarkHash::ZERO),
                         ],
-                        entry_point_selector: EntryPoint(
-                            StarkHash::from_hex_str(
-                                "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
-                            )
-                            .unwrap(),
-                        ),
+                        entry_point_selector: EntryPoint(starkhash!(
+                            "015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+                        )),
                         signature: vec![
-                            CallSignatureElem(
-                                StarkHash::from_hex_str(
-                                    "0x7dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5",
-                                )
-                                .unwrap(),
-                            ),
-                            CallSignatureElem(
-                                StarkHash::from_hex_str(
-                                    "0x71456dded17015d1234779889d78f3e7c763ddcfd2662b19e7843c7542614f8",
-                                )
-                                .unwrap(),
-                            ),
+                            CallSignatureElem(starkhash!(
+                                "07dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5"
+                            )),
+                            CallSignatureElem(starkhash!(
+                                "071456dded17015d1234779889d78f3e7c763ddcfd2662b19e7843c7542614f8"
+                            )),
                         ],
                     },
                     Fee(5444010076217u128.to_be_bytes().into()),
@@ -1758,7 +1696,7 @@ mod tests {
                 .add_declare_transaction(
                     contract_class,
                     // actual address dumped from a `starknet declare` call
-                    ContractAddress(StarkHash::from_hex_str("0x1").unwrap()),
+                    ContractAddress(starkhash!("01")),
                     Fee(0u128.to_be_bytes().into()),
                     vec![],
                     TransactionNonce(StarkHash::ZERO),
@@ -1783,15 +1721,12 @@ mod tests {
             )]);
             client
                 .add_deploy_transaction(
-                    ContractAddressSalt(
-                        StarkHash::from_hex_str(
-                            "0x5864b5e296c05028ac2bbc4a4c1378f56a3489d13e581f21d566bb94580f76d",
-                        )
-                        .unwrap(),
-                    ),
+                    ContractAddressSalt(starkhash!(
+                        "05864b5e296c05028ac2bbc4a4c1378f56a3489d13e581f21d566bb94580f76d"
+                    )),
                     // Regression: use a dummy constructor param here to make sure that
                     // it is serialized properly
-                    vec![ConstructorParam::from_hex_str("0x01").unwrap()],
+                    vec![ConstructorParam(starkhash!("01"))],
                     contract_definition,
                     None,
                 )
@@ -1811,20 +1746,16 @@ mod tests {
                                 EntryPointType::External,
                                 vec![
                                     SelectorAndOffset {
-                                        offset: ByteCodeOffset(StarkHash::from_hex_str("0x3a").unwrap()),
-                                        selector: EntryPoint(StarkHash::from_hex_str(
-                                                "0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320",
-                                            )
-                                            .unwrap()
+                                        offset: ByteCodeOffset(starkhash!("3a")),
+                                        selector: EntryPoint(starkhash!(
+                                                "0362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320")
                                         ),
                                     },
                                     SelectorAndOffset{
-                                        offset: ByteCodeOffset(StarkHash::from_hex_str("0x5b").unwrap()),
-                                        selector: EntryPoint(StarkHash::from_hex_str(
-                                                "0x39e11d48192e4333233c7eb19d10ad67c362bb28580c604d67884c85da39695",
-                                            )
-                                            .unwrap()
-                                        ),
+                                        offset: ByteCodeOffset(starkhash!("5b")),
+                                        selector: EntryPoint(starkhash!(
+                                                "039e11d48192e4333233c7eb19d10ad67c362bb28580c604d67884c85da39695"
+                                        )),
                                     },
                                 ],
                             ),

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -159,8 +159,8 @@ impl Client {
             .block_hash;
 
         match genesis_hash {
-            goerli if goerli == *GOERLI_GENESIS_HASH => Ok(Chain::Goerli),
-            mainnet if mainnet == *MAINNET_GENESIS_HASH => Ok(Chain::Mainnet),
+            goerli if goerli == GOERLI_GENESIS_HASH => Ok(Chain::Goerli),
+            mainnet if mainnet == MAINNET_GENESIS_HASH => Ok(Chain::Mainnet),
             other => Err(anyhow::anyhow!("Unknown genesis block hash: {}", other.0)),
         }
     }

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -456,11 +456,11 @@ pub mod state_update {
         #[test]
         fn contract_field_backward_compatibility() {
             use super::{ClassHash, ContractAddress, DeployedContract};
-            use stark_hash::StarkHash;
+            use crate::starkhash;
 
             let expected = DeployedContract {
-                address: ContractAddress(StarkHash::from_hex_str("0x01").unwrap()),
-                class_hash: ClassHash(StarkHash::from_hex_str("0x02").unwrap()),
+                address: ContractAddress(starkhash!("01")),
+                class_hash: ClassHash(starkhash!("02")),
             };
 
             // cario <0.9.0
@@ -527,7 +527,7 @@ pub mod add_transaction {
 
     #[cfg(test)]
     mod serde_test {
-        use stark_hash::StarkHash;
+        use crate::starkhash;
 
         use super::*;
 
@@ -536,12 +536,9 @@ pub mod add_transaction {
             let result = serde_json::from_str::<InvokeResponse>(r#"{"code": "TRANSACTION_RECEIVED", "transaction_hash": "0x389dd0629f42176cc8b6c43acefc0713d0064ecdfc0470e0fc179f53421a38b"}"#).unwrap();
             let expected = InvokeResponse {
                 code: "TRANSACTION_RECEIVED".to_owned(),
-                transaction_hash: StarknetTransactionHash(
-                    StarkHash::from_hex_str(
-                        "0x389dd0629f42176cc8b6c43acefc0713d0064ecdfc0470e0fc179f53421a38b",
-                    )
-                    .unwrap(),
-                ),
+                transaction_hash: StarknetTransactionHash(starkhash!(
+                    "0389dd0629f42176cc8b6c43acefc0713d0064ecdfc0470e0fc179f53421a38b"
+                )),
             };
             assert_eq!(expected, result);
         }
@@ -551,18 +548,12 @@ pub mod add_transaction {
             let result = serde_json::from_str::<DeployResponse>(r#"{"code": "TRANSACTION_RECEIVED", "transaction_hash": "0x296fb89b8a1c7487a1d4b27e1a1e33f440b05548e64980d06052bc089b1a51f", "address": "0x677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1"}"#).unwrap();
             let expected = DeployResponse {
                 code: "TRANSACTION_RECEIVED".to_owned(),
-                transaction_hash: StarknetTransactionHash(
-                    StarkHash::from_hex_str(
-                        "0x296fb89b8a1c7487a1d4b27e1a1e33f440b05548e64980d06052bc089b1a51f",
-                    )
-                    .unwrap(),
-                ),
-                address: ContractAddress(
-                    StarkHash::from_hex_str(
-                        "0x677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1",
-                    )
-                    .unwrap(),
-                ),
+                transaction_hash: StarknetTransactionHash(starkhash!(
+                    "0296fb89b8a1c7487a1d4b27e1a1e33f440b05548e64980d06052bc089b1a51f"
+                )),
+                address: ContractAddress(starkhash!(
+                    "0677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1"
+                )),
             };
             assert_eq!(expected, result);
         }

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -99,26 +99,18 @@ fn calculate_contract_state_hash(hash: ClassHash, root: ContractRoot) -> Contrac
 mod tests {
     use super::{calculate_contract_state_hash, sync};
     use crate::core::{ClassHash, ContractRoot, ContractStateHash};
-    use stark_hash::StarkHash;
+    use crate::starkhash;
 
     #[test]
     fn hash() {
-        let root = StarkHash::from_hex_str(
-            "04fb440e8ca9b74fc12a22ebffe0bc0658206337897226117b985434c239c028",
-        )
-        .unwrap();
+        let root = starkhash!("04fb440e8ca9b74fc12a22ebffe0bc0658206337897226117b985434c239c028");
         let root = ContractRoot(root);
 
-        let hash = StarkHash::from_hex_str(
-            "02ff4903e17f87b298ded00c44bfeb22874c5f73be2ced8f1d9d9556fb509779",
-        )
-        .unwrap();
+        let hash = starkhash!("02ff4903e17f87b298ded00c44bfeb22874c5f73be2ced8f1d9d9556fb509779");
         let hash = ClassHash(hash);
 
-        let expected = StarkHash::from_hex_str(
-            "07161b591c893836263a64f2a7e0d829c92f6956148a60ce5e99a3f55c7973f3",
-        )
-        .unwrap();
+        let expected =
+            starkhash!("07161b591c893836263a64f2a7e0d829c92f6956148a60ce5e99a3f55c7973f3");
         let expected = ContractStateHash(expected);
 
         let result = calculate_contract_state_hash(hash, root);

--- a/crates/pathfinder/src/state/class_hash.rs
+++ b/crates/pathfinder/src/state/class_hash.rs
@@ -363,10 +363,9 @@ mod json {
         async fn first() {
             // this test is a bit on the slow side because of the download and because of the long
             // processing time in dev builds. expected --release speed is 9 contracts/s.
-            let expected = stark_hash::StarkHash::from_hex_str(
-                "0031da92cf5f54bcb81b447e219e2b791b23f3052d12b6c9abd04ff2e5626576",
-            )
-            .unwrap();
+            let expected = crate::starkhash!(
+                "0031da92cf5f54bcb81b447e219e2b791b23f3052d12b6c9abd04ff2e5626576"
+            );
 
             // this is quite big payload, ~500kB
             let resp = reqwest::get("https://external.integration.starknet.io/feeder_gateway/get_full_contract?blockNumber=latest&contractAddress=0x4ae0618c330c59559a59a27d143dd1c07cd74cf4e5e5a7cd85d53c6bf0e89dc")
@@ -396,22 +395,19 @@ mod json {
 
             assert_eq!(
                 hash.0,
-                stark_hash::StarkHash::from_hex_str(
+                crate::starkhash!(
                     "050b2148c0d782914e0b12a1a32abe5e398930b7e914f82c65cb7afce0a0ab9b"
                 )
-                .unwrap()
             );
         }
 
         #[tokio::test]
         async fn genesis_contract() {
             use crate::sequencer::ClientApi;
-            use stark_hash::StarkHash;
 
-            let contract = StarkHash::from_hex_str(
-                "0x0546BA9763D33DC59A070C0D87D94F2DCAFA82C4A93B5E2BF5AE458B0013A9D3",
-            )
-            .unwrap();
+            let contract = crate::starkhash!(
+                "0546BA9763D33DC59A070C0D87D94F2DCAFA82C4A93B5E2BF5AE458B0013A9D3"
+            );
             let contract = crate::core::ContractAddress(contract);
 
             let chain = crate::core::Chain::Goerli;
@@ -432,22 +428,16 @@ mod json {
             use super::super::extract_abi_code_hash;
             use crate::core::{ClassHash, ContractAddress};
             use crate::sequencer::{self, ClientApi};
-            use stark_hash::StarkHash;
+            use crate::starkhash;
 
             // Known contract which triggered a hash mismatch failure.
-            let address = ContractAddress(
-                StarkHash::from_hex_str(
-                    "0x0400D86342F474F14AAE562587F30855E127AD661F31793C49414228B54516EC",
-                )
-                .unwrap(),
-            );
+            let address = ContractAddress(starkhash!(
+                "0400D86342F474F14AAE562587F30855E127AD661F31793C49414228B54516EC"
+            ));
 
-            let expected = ClassHash(
-                StarkHash::from_hex_str(
-                    "0x056b96c1d1bbfa01af44b465763d1b71150fa00c6c9d54c3947f57e979ff68c3",
-                )
-                .unwrap(),
-            );
+            let expected = ClassHash(starkhash!(
+                "056b96c1d1bbfa01af44b465763d1b71150fa00c6c9d54c3947f57e979ff68c3"
+            ));
             let sequencer = sequencer::Client::new(crate::core::Chain::Goerli).unwrap();
 
             let contract_definition = sequencer.full_contract(address).await.unwrap();
@@ -520,17 +510,14 @@ mod tests {
     #[test]
     fn truncated_keccak_matches_pythonic() {
         use super::truncated_keccak;
+        use crate::starkhash;
         use sha3::{Digest, Keccak256};
-        use stark_hash::StarkHash;
         let all_set = Keccak256::digest(&[0xffu8; 32]);
         assert!(all_set[0] > 0xf);
         let truncated = truncated_keccak(all_set.into());
         assert_eq!(
             truncated,
-            StarkHash::from_hex_str(
-                "01c584056064687e149968cbab758a3376d22aedc6a55823d1b3ecbee81b8fb9"
-            )
-            .unwrap()
+            starkhash!("01c584056064687e149968cbab758a3376d22aedc6a55823d1b3ecbee81b8fb9")
         );
     }
 }

--- a/crates/pathfinder/src/state/merkle_node.rs
+++ b/crates/pathfinder/src/state/merkle_node.rs
@@ -270,6 +270,7 @@ mod tests {
 
     mod binary {
         use super::*;
+        use crate::starkhash;
         use bitvec::bitvec;
 
         #[test]
@@ -277,12 +278,8 @@ mod tests {
             let uut = BinaryNode {
                 hash: None,
                 height: 1,
-                left: Rc::new(RefCell::new(Node::Leaf(
-                    StarkHash::from_hex_str("abc").unwrap(),
-                ))),
-                right: Rc::new(RefCell::new(Node::Leaf(
-                    StarkHash::from_hex_str("def").unwrap(),
-                ))),
+                left: Rc::new(RefCell::new(Node::Leaf(starkhash!("0abc")))),
+                right: Rc::new(RefCell::new(Node::Leaf(starkhash!("0def")))),
             };
 
             let mut zero_key = bitvec![Msb0, u8; 1; 251];
@@ -300,12 +297,8 @@ mod tests {
 
         #[test]
         fn get_child() {
-            let left = Rc::new(RefCell::new(Node::Leaf(
-                StarkHash::from_hex_str("abc").unwrap(),
-            )));
-            let right = Rc::new(RefCell::new(Node::Leaf(
-                StarkHash::from_hex_str("def").unwrap(),
-            )));
+            let left = Rc::new(RefCell::new(Node::Leaf(starkhash!("0abc"))));
+            let right = Rc::new(RefCell::new(Node::Leaf(starkhash!("0def"))));
 
             let uut = BinaryNode {
                 hash: None,
@@ -329,8 +322,8 @@ mod tests {
                 "0615bb8d47888d2987ad0c63fc06e9e771930986a4dd8adc55617febfcf3639e",
             )
             .unwrap();
-            let left = StarkHash::from_hex_str("1234").unwrap();
-            let right = StarkHash::from_hex_str("abcd").unwrap();
+            let left = starkhash!("1234");
+            let right = starkhash!("abcd");
 
             let left = Rc::new(RefCell::new(Node::Unresolved(left)));
             let right = Rc::new(RefCell::new(Node::Unresolved(right)));
@@ -349,9 +342,9 @@ mod tests {
     }
 
     mod edge {
-        use bitvec::bitvec;
-
         use super::*;
+        use crate::starkhash;
+        use bitvec::bitvec;
 
         #[test]
         fn hash() {
@@ -363,7 +356,7 @@ mod tests {
                 "1d937094c09b5f8e26a662d21911871e3cbc6858d55cc49af9848ea6fed4e9",
             )
             .unwrap();
-            let child = StarkHash::from_hex_str("1234ABCD").unwrap();
+            let child = starkhash!("1234ABCD");
             let child = Rc::new(RefCell::new(Node::Unresolved(child)));
             // Path = 42 in binary.
             let path = bitvec![Msb0, u8; 1, 0, 1, 0, 1, 0];
@@ -382,13 +375,12 @@ mod tests {
 
         mod path_matches {
             use super::*;
+            use crate::starkhash;
 
             #[test]
             fn full() {
-                let key = StarkHash::from_hex_str("123456789abcdef").unwrap();
-                let child = Rc::new(RefCell::new(Node::Leaf(
-                    StarkHash::from_hex_str("abc").unwrap(),
-                )));
+                let key = starkhash!("0123456789abcdef");
+                let child = Rc::new(RefCell::new(Node::Leaf(starkhash!("0abc"))));
 
                 let uut = EdgeNode {
                     hash: None,
@@ -402,10 +394,8 @@ mod tests {
 
             #[test]
             fn prefix() {
-                let key = StarkHash::from_hex_str("123456789abcdef").unwrap();
-                let child = Rc::new(RefCell::new(Node::Leaf(
-                    StarkHash::from_hex_str("abc").unwrap(),
-                )));
+                let key = starkhash!("0123456789abcdef");
+                let child = Rc::new(RefCell::new(Node::Leaf(starkhash!("0abc"))));
 
                 let path = key.view_bits()[..45].to_bitvec();
 
@@ -421,10 +411,8 @@ mod tests {
 
             #[test]
             fn suffix() {
-                let key = StarkHash::from_hex_str("123456789abcdef").unwrap();
-                let child = Rc::new(RefCell::new(Node::Leaf(
-                    StarkHash::from_hex_str("abc").unwrap(),
-                )));
+                let key = starkhash!("0123456789abcdef");
+                let child = Rc::new(RefCell::new(Node::Leaf(starkhash!("0abc"))));
 
                 let path = key.view_bits()[50..].to_bitvec();
 
@@ -440,10 +428,8 @@ mod tests {
 
             #[test]
             fn middle_slice() {
-                let key = StarkHash::from_hex_str("123456789abcdef").unwrap();
-                let child = Rc::new(RefCell::new(Node::Leaf(
-                    StarkHash::from_hex_str("abc").unwrap(),
-                )));
+                let key = starkhash!("0123456789abcdef");
+                let child = Rc::new(RefCell::new(Node::Leaf(starkhash!("0abc"))));
 
                 let path = key.view_bits()[230..235].to_bitvec();
 

--- a/crates/pathfinder/src/state/merkle_tree.rs
+++ b/crates/pathfinder/src/state/merkle_tree.rs
@@ -658,6 +658,7 @@ impl NodeStorage for () {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::starkhash;
     use bitvec::prelude::*;
 
     #[test]
@@ -666,10 +667,7 @@ mod tests {
         let transaction = conn.transaction().unwrap();
         let uut = MerkleTree::load("test".to_string(), &transaction, StarkHash::ZERO).unwrap();
 
-        let key = StarkHash::from_hex_str("99cadc82")
-            .unwrap()
-            .view_bits()
-            .to_bitvec();
+        let key = starkhash!("99cadc82").view_bits().to_bitvec();
         assert_eq!(uut.get(&key).unwrap(), StarkHash::ZERO);
     }
 
@@ -678,7 +676,7 @@ mod tests {
         let mut conn = rusqlite::Connection::open_in_memory().unwrap();
         let transaction = conn.transaction().unwrap();
 
-        let non_root = StarkHash::from_hex_str("99cadc82").unwrap();
+        let non_root = starkhash!("99cadc82");
         MerkleTree::load("test".to_string(), &transaction, non_root).unwrap_err();
     }
 
@@ -692,22 +690,13 @@ mod tests {
             let mut uut =
                 MerkleTree::load("test".to_string(), &transaction, StarkHash::ZERO).unwrap();
 
-            let key0 = StarkHash::from_hex_str("99cadc82")
-                .unwrap()
-                .view_bits()
-                .to_bitvec();
-            let key1 = StarkHash::from_hex_str("901823")
-                .unwrap()
-                .view_bits()
-                .to_bitvec();
-            let key2 = StarkHash::from_hex_str("8975")
-                .unwrap()
-                .view_bits()
-                .to_bitvec();
+            let key0 = starkhash!("99cadc82").view_bits().to_bitvec();
+            let key1 = starkhash!("901823").view_bits().to_bitvec();
+            let key2 = starkhash!("8975").view_bits().to_bitvec();
 
-            let val0 = StarkHash::from_hex_str("891127cbaf").unwrap();
-            let val1 = StarkHash::from_hex_str("82233127cbaf").unwrap();
-            let val2 = StarkHash::from_hex_str("891124667aacde7cbaf").unwrap();
+            let val0 = starkhash!("891127cbaf");
+            let val1 = starkhash!("82233127cbaf");
+            let val2 = starkhash!("0891124667aacde7cbaf");
 
             uut.set(&key0, val0).unwrap();
             uut.set(&key1, val1).unwrap();
@@ -725,12 +714,9 @@ mod tests {
             let mut uut =
                 MerkleTree::load("test".to_string(), &transaction, StarkHash::ZERO).unwrap();
 
-            let key = StarkHash::from_hex_str("123")
-                .unwrap()
-                .view_bits()
-                .to_bitvec();
-            let old_value = StarkHash::from_hex_str("abc").unwrap();
-            let new_value = StarkHash::from_hex_str("def").unwrap();
+            let key = starkhash!("0123").view_bits().to_bitvec();
+            let old_value = starkhash!("0abc");
+            let new_value = starkhash!("0def");
 
             uut.set(&key, old_value).unwrap();
             uut.set(&key, new_value).unwrap();
@@ -749,11 +735,8 @@ mod tests {
             let mut uut =
                 MerkleTree::load("test".to_string(), &transaction, StarkHash::ZERO).unwrap();
 
-            let key = StarkHash::from_hex_str("123")
-                .unwrap()
-                .view_bits()
-                .to_bitvec();
-            let value = StarkHash::from_hex_str("abc").unwrap();
+            let key = starkhash!("0123").view_bits().to_bitvec();
+            let value = starkhash!("0abc");
 
             uut.set(&key, value).unwrap();
 
@@ -781,8 +764,8 @@ mod tests {
             let mut key1 = bitvec![Msb0, u8; 0; 251];
             key1.set(50, true);
 
-            let value0 = StarkHash::from_hex_str("abc").unwrap();
-            let value1 = StarkHash::from_hex_str("def").unwrap();
+            let value0 = starkhash!("0abc");
+            let value1 = starkhash!("0def");
 
             let mut conn = rusqlite::Connection::open_in_memory().unwrap();
             let transaction = conn.transaction().unwrap();
@@ -845,8 +828,8 @@ mod tests {
             let mut key1 = bitvec![Msb0, u8; 0; 251];
             key1.set(0, true);
 
-            let value0 = StarkHash::from_hex_str("abc").unwrap();
-            let value1 = StarkHash::from_hex_str("def").unwrap();
+            let value0 = starkhash!("0abc");
+            let value1 = starkhash!("0def");
 
             let mut conn = rusqlite::Connection::open_in_memory().unwrap();
             let transaction = conn.transaction().unwrap();
@@ -893,16 +876,10 @@ mod tests {
 
         #[test]
         fn binary_leaves() {
-            let key0 = StarkHash::from_hex_str("0")
-                .unwrap()
-                .view_bits()
-                .to_bitvec();
-            let key1 = StarkHash::from_hex_str("1")
-                .unwrap()
-                .view_bits()
-                .to_bitvec();
-            let value0 = StarkHash::from_hex_str("abc").unwrap();
-            let value1 = StarkHash::from_hex_str("def").unwrap();
+            let key0 = starkhash!("00").view_bits().to_bitvec();
+            let key1 = starkhash!("01").view_bits().to_bitvec();
+            let value0 = starkhash!("0abc");
+            let value1 = starkhash!("0def");
 
             let mut conn = rusqlite::Connection::open_in_memory().unwrap();
             let transaction = conn.transaction().unwrap();
@@ -922,7 +899,7 @@ mod tests {
                 .expect("root should be an edge");
             // The edge's path will be the full key path excluding the final bit.
             // The final bit is represented by the following binary node.
-            let mut expected_path = key0.clone();
+            let mut expected_path = key0.to_bitvec();
             expected_path.pop();
 
             assert_eq!(edge.path, expected_path);
@@ -965,10 +942,7 @@ mod tests {
             let mut uut =
                 MerkleTree::load("test".to_string(), &transaction, StarkHash::ZERO).unwrap();
 
-            let key = StarkHash::from_hex_str("123abc")
-                .unwrap()
-                .view_bits()
-                .to_bitvec();
+            let key = starkhash!("123abc").view_bits().to_bitvec();
             uut.delete_leaf(&key).unwrap();
 
             assert_eq!(*uut.root.borrow(), Node::Unresolved(StarkHash::ZERO));
@@ -981,11 +955,8 @@ mod tests {
             let mut uut =
                 MerkleTree::load("test".to_string(), &transaction, StarkHash::ZERO).unwrap();
 
-            let key = StarkHash::from_hex_str("123")
-                .unwrap()
-                .view_bits()
-                .to_bitvec();
-            let value = StarkHash::from_hex_str("abc").unwrap();
+            let key = starkhash!("0123").view_bits().to_bitvec();
+            let value = starkhash!("0abc");
 
             uut.set(&key, value).unwrap();
             uut.delete_leaf(&key).unwrap();
@@ -1001,22 +972,13 @@ mod tests {
             let mut uut =
                 MerkleTree::load("test".to_string(), &transaction, StarkHash::ZERO).unwrap();
 
-            let key0 = StarkHash::from_hex_str("99cadc82")
-                .unwrap()
-                .view_bits()
-                .to_bitvec();
-            let key1 = StarkHash::from_hex_str("901823")
-                .unwrap()
-                .view_bits()
-                .to_bitvec();
-            let key2 = StarkHash::from_hex_str("8975")
-                .unwrap()
-                .view_bits()
-                .to_bitvec();
+            let key0 = starkhash!("99cadc82").view_bits().to_bitvec();
+            let key1 = starkhash!("901823").view_bits().to_bitvec();
+            let key2 = starkhash!("8975").view_bits().to_bitvec();
 
-            let val0 = StarkHash::from_hex_str("1").unwrap();
-            let val1 = StarkHash::from_hex_str("2").unwrap();
-            let val2 = StarkHash::from_hex_str("3").unwrap();
+            let val0 = starkhash!("01");
+            let val1 = starkhash!("02");
+            let val2 = starkhash!("03");
 
             uut.set(&key0, val0).unwrap();
             uut.set(&key1, val1).unwrap();
@@ -1040,22 +1002,13 @@ mod tests {
             let mut uut =
                 MerkleTree::load("test".to_string(), &transaction, StarkHash::ZERO).unwrap();
 
-            let key0 = StarkHash::from_hex_str("99cadc82")
-                .unwrap()
-                .view_bits()
-                .to_bitvec();
-            let key1 = StarkHash::from_hex_str("901823")
-                .unwrap()
-                .view_bits()
-                .to_bitvec();
-            let key2 = StarkHash::from_hex_str("8975")
-                .unwrap()
-                .view_bits()
-                .to_bitvec();
+            let key0 = starkhash!("99cadc82").view_bits().to_bitvec();
+            let key1 = starkhash!("901823").view_bits().to_bitvec();
+            let key2 = starkhash!("8975").view_bits().to_bitvec();
 
-            let val0 = StarkHash::from_hex_str("1").unwrap();
-            let val1 = StarkHash::from_hex_str("2").unwrap();
-            let val2 = StarkHash::from_hex_str("3").unwrap();
+            let val0 = starkhash!("01");
+            let val1 = starkhash!("02");
+            let val2 = starkhash!("03");
 
             uut.set(&key0, val0).unwrap();
             uut.set(&key1, val1).unwrap();
@@ -1083,51 +1036,42 @@ mod tests {
 
             let leaves = [
                 (
-                    "0x01A2FD9B06EAB5BCA4D3885EE4C42736E835A57399FF8B7F6083A92FD2A20095",
-                    "0x0215AA555E0CE3E462423D18B7216378D3CCD5D94D724AC7897FBC83FAAA4ED4",
+                    starkhash!("01A2FD9B06EAB5BCA4D3885EE4C42736E835A57399FF8B7F6083A92FD2A20095"),
+                    starkhash!("0215AA555E0CE3E462423D18B7216378D3CCD5D94D724AC7897FBC83FAAA4ED4"),
                 ),
                 (
-                    "0x07AC69285B869DC3E8B305C748A0B867B2DE3027AECEBA51158ECA3B7354D76F",
-                    "0x065C85592F29501D97A2EA1CCF2BA867E6A838D602F4E7A7391EFCBF66958386",
+                    starkhash!("07AC69285B869DC3E8B305C748A0B867B2DE3027AECEBA51158ECA3B7354D76F"),
+                    starkhash!("065C85592F29501D97A2EA1CCF2BA867E6A838D602F4E7A7391EFCBF66958386"),
                 ),
                 (
-                    "0x05C71AB5EF6A5E9DBC7EFD5C61554AB36039F60E5BA076833102E24344524566",
-                    "0x060970DF8E8A19AF3F41B78E93B845EC074A0AED4E96D18C6633580722B93A28",
+                    starkhash!("05C71AB5EF6A5E9DBC7EFD5C61554AB36039F60E5BA076833102E24344524566"),
+                    starkhash!("060970DF8E8A19AF3F41B78E93B845EC074A0AED4E96D18C6633580722B93A28"),
                 ),
                 (
-                    "0x0000000000000000000000000000000000000000000000000000000000000005",
-                    "0x000000000000000000000000000000000000000000000000000000000000022B",
+                    starkhash!("0000000000000000000000000000000000000000000000000000000000000005"),
+                    starkhash!("000000000000000000000000000000000000000000000000000000000000022B"),
                 ),
                 (
-                    "0x0000000000000000000000000000000000000000000000000000000000000005",
-                    "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    starkhash!("0000000000000000000000000000000000000000000000000000000000000005"),
+                    starkhash!("0000000000000000000000000000000000000000000000000000000000000000"),
                 ),
             ];
 
             // Add the first four leaves and commit them to storage.
             for (key, val) in &leaves[..4] {
-                let key = StarkHash::from_hex_str(key)
-                    .unwrap()
-                    .view_bits()
-                    .to_bitvec();
-                let val = StarkHash::from_hex_str(val).unwrap();
-                uut.set(&key, val).unwrap();
+                let key = key.view_bits();
+                uut.set(key, *val).unwrap();
             }
             let root = uut.commit().unwrap();
 
             // Delete the final leaf; this exercises the bug as the nodes are all in storage (unresolved).
             let mut uut = MerkleTree::load("test".to_string(), &transaction, root).unwrap();
-            let key = StarkHash::from_hex_str(leaves[4].0)
-                .unwrap()
-                .view_bits()
-                .to_bitvec();
-            let val = StarkHash::from_hex_str(leaves[4].1).unwrap();
+            let key = leaves[4].0.view_bits().to_bitvec();
+            let val = leaves[4].1;
             uut.set(&key, val).unwrap();
             let root = uut.commit().unwrap();
-            let expect = StarkHash::from_hex_str(
-                "05f3b2b98faef39c60dbbb459dbe63d1d10f1688af47fbc032f2cab025def896",
-            )
-            .unwrap();
+            let expect =
+                starkhash!("05f3b2b98faef39c60dbbb459dbe63d1d10f1688af47fbc032f2cab025def896");
             assert_eq!(root, expect);
         }
 
@@ -1139,22 +1083,13 @@ mod tests {
                 let mut conn = rusqlite::Connection::open_in_memory().unwrap();
                 let transaction = conn.transaction().unwrap();
 
-                let key0 = StarkHash::from_hex_str("99cadc82")
-                    .unwrap()
-                    .view_bits()
-                    .to_bitvec();
-                let key1 = StarkHash::from_hex_str("901823")
-                    .unwrap()
-                    .view_bits()
-                    .to_bitvec();
-                let key2 = StarkHash::from_hex_str("8975")
-                    .unwrap()
-                    .view_bits()
-                    .to_bitvec();
+                let key0 = starkhash!("99cadc82").view_bits().to_bitvec();
+                let key1 = starkhash!("901823").view_bits().to_bitvec();
+                let key2 = starkhash!("8975").view_bits().to_bitvec();
 
-                let val0 = StarkHash::from_hex_str("1").unwrap();
-                let val1 = StarkHash::from_hex_str("2").unwrap();
-                let val2 = StarkHash::from_hex_str("3").unwrap();
+                let val0 = starkhash!("01");
+                let val1 = starkhash!("02");
+                let val2 = starkhash!("03");
 
                 let mut uut =
                     MerkleTree::load("test".to_string(), &transaction, StarkHash::ZERO).unwrap();
@@ -1190,22 +1125,13 @@ mod tests {
                 let mut conn = rusqlite::Connection::open_in_memory().unwrap();
                 let transaction = conn.transaction().unwrap();
 
-                let key0 = StarkHash::from_hex_str("99cadc82")
-                    .unwrap()
-                    .view_bits()
-                    .to_bitvec();
-                let key1 = StarkHash::from_hex_str("901823")
-                    .unwrap()
-                    .view_bits()
-                    .to_bitvec();
-                let key2 = StarkHash::from_hex_str("8975")
-                    .unwrap()
-                    .view_bits()
-                    .to_bitvec();
+                let key0 = starkhash!("99cadc82").view_bits().to_bitvec();
+                let key1 = starkhash!("901823").view_bits().to_bitvec();
+                let key2 = starkhash!("8975").view_bits().to_bitvec();
 
-                let val0 = StarkHash::from_hex_str("1").unwrap();
-                let val1 = StarkHash::from_hex_str("2").unwrap();
-                let val2 = StarkHash::from_hex_str("3").unwrap();
+                let val0 = starkhash!("01");
+                let val1 = starkhash!("02");
+                let val2 = starkhash!("03");
 
                 let mut uut =
                     MerkleTree::load("test".to_string(), &transaction, StarkHash::ZERO).unwrap();
@@ -1245,22 +1171,13 @@ mod tests {
                 let mut conn = rusqlite::Connection::open_in_memory().unwrap();
                 let transaction = conn.transaction().unwrap();
 
-                let key0 = StarkHash::from_hex_str("99cadc82")
-                    .unwrap()
-                    .view_bits()
-                    .to_bitvec();
-                let key1 = StarkHash::from_hex_str("901823")
-                    .unwrap()
-                    .view_bits()
-                    .to_bitvec();
-                let key2 = StarkHash::from_hex_str("8975")
-                    .unwrap()
-                    .view_bits()
-                    .to_bitvec();
+                let key0 = starkhash!("99cadc82").view_bits().to_bitvec();
+                let key1 = starkhash!("901823").view_bits().to_bitvec();
+                let key2 = starkhash!("8975").view_bits().to_bitvec();
 
-                let val0 = StarkHash::from_hex_str("1").unwrap();
-                let val1 = StarkHash::from_hex_str("2").unwrap();
-                let val2 = StarkHash::from_hex_str("3").unwrap();
+                let val0 = starkhash!("01");
+                let val1 = starkhash!("02");
+                let val2 = starkhash!("03");
 
                 let mut uut =
                     MerkleTree::load("test".to_string(), &transaction, StarkHash::ZERO).unwrap();
@@ -1296,22 +1213,13 @@ mod tests {
                 let mut conn = rusqlite::Connection::open_in_memory().unwrap();
                 let transaction = conn.transaction().unwrap();
 
-                let key0 = StarkHash::from_hex_str("99cadc82")
-                    .unwrap()
-                    .view_bits()
-                    .to_bitvec();
-                let key1 = StarkHash::from_hex_str("901823")
-                    .unwrap()
-                    .view_bits()
-                    .to_bitvec();
-                let key2 = StarkHash::from_hex_str("8975")
-                    .unwrap()
-                    .view_bits()
-                    .to_bitvec();
+                let key0 = starkhash!("99cadc82").view_bits().to_bitvec();
+                let key1 = starkhash!("901823").view_bits().to_bitvec();
+                let key2 = starkhash!("8975").view_bits().to_bitvec();
 
-                let val0 = StarkHash::from_hex_str("1").unwrap();
-                let val1 = StarkHash::from_hex_str("2").unwrap();
-                let val2 = StarkHash::from_hex_str("3").unwrap();
+                let val0 = starkhash!("01");
+                let val1 = starkhash!("02");
+                let val2 = starkhash!("03");
 
                 let mut uut =
                     MerkleTree::load("test".to_string(), &transaction, StarkHash::ZERO).unwrap();
@@ -1350,11 +1258,8 @@ mod tests {
             let mut uut =
                 MerkleTree::load("test".to_string(), &transaction, StarkHash::ZERO).unwrap();
 
-            let key = StarkHash::from_hex_str("99cadc82")
-                .unwrap()
-                .view_bits()
-                .to_bitvec();
-            let val = StarkHash::from_hex_str("12345678").unwrap();
+            let key = starkhash!("99cadc82").view_bits().to_bitvec();
+            let val = starkhash!("12345678");
             uut.set(&key, val).unwrap();
 
             let root0 = uut.commit().unwrap();
@@ -1390,6 +1295,7 @@ mod tests {
 
     mod real_world {
         use super::*;
+        use crate::starkhash;
 
         #[test]
         fn simple() {
@@ -1400,32 +1306,20 @@ mod tests {
             let mut uut =
                 MerkleTree::load("test".to_string(), &transaction, StarkHash::ZERO).unwrap();
 
-            uut.set(
-                StarkHash::from_hex_str("0x1").unwrap().view_bits(),
-                StarkHash::from_hex_str("0x0").unwrap(),
-            )
-            .unwrap();
+            uut.set(starkhash!("01").view_bits(), starkhash!("00"))
+                .unwrap();
 
-            uut.set(
-                StarkHash::from_hex_str("0x86").unwrap().view_bits(),
-                StarkHash::from_hex_str("0x1").unwrap(),
-            )
-            .unwrap();
+            uut.set(starkhash!("86").view_bits(), starkhash!("01"))
+                .unwrap();
 
-            uut.set(
-                StarkHash::from_hex_str("0x87").unwrap().view_bits(),
-                StarkHash::from_hex_str("0x2").unwrap(),
-            )
-            .unwrap();
+            uut.set(starkhash!("87").view_bits(), starkhash!("02"))
+                .unwrap();
 
             let root = uut.commit().unwrap();
 
             assert_eq!(
                 root,
-                StarkHash::from_hex_str(
-                    "0x05458b9f8491e7c845bffa4cd36cdb3a7c29dcdf75f2809bd6f4ce65386facfc"
-                )
-                .unwrap()
+                starkhash!("05458b9f8491e7c845bffa4cd36cdb3a7c29dcdf75f2809bd6f4ce65386facfc")
             );
         }
 
@@ -1438,23 +1332,23 @@ mod tests {
             //
             // The bug was identified by comparing root and nodes against the python
             // utility in `root/py/src/test_generate_test_storage_tree.py`.
-            let leaves = vec![
-                ("0x5", "0x66"),
+            let leaves = [
+                (starkhash!("05"), starkhash!("66")),
                 (
-                    "0x1BF95D4B58F0741FEA29F94EE5A118D0847C8B7AE0173C2A570C9F74CCA9EA1",
-                    "0x7E5",
+                    starkhash!("01BF95D4B58F0741FEA29F94EE5A118D0847C8B7AE0173C2A570C9F74CCA9EA1"),
+                    starkhash!("07E5"),
                 ),
                 (
-                    "0x3C75C20765D020B0EC41B48BB8C5338AC4B619FC950D59994E844E1E1B9D2A9",
-                    "0x7C7",
+                    starkhash!("03C75C20765D020B0EC41B48BB8C5338AC4B619FC950D59994E844E1E1B9D2A9"),
+                    starkhash!("07C7"),
                 ),
                 (
-                    "0x4065B936C56F5908A981084DAFA66DC17600937DC80C52EEB834693BB811792",
-                    "0x7970C532B764BB36FAF5696B8BC1317505B8A4DC9EEE5DF4994671757975E4D",
+                    starkhash!("04065B936C56F5908A981084DAFA66DC17600937DC80C52EEB834693BB811792"),
+                    starkhash!("07970C532B764BB36FAF5696B8BC1317505B8A4DC9EEE5DF4994671757975E4D"),
                 ),
                 (
-                    "0x4B5FBB4904167E2E8195C35F7D4E78501A3FE95896794367C85B60B39AEFFC2",
-                    "0x232C969EAFC5B30C20648759D7FA1E2F4256AC6604E1921578101DCE4DFDF48",
+                    starkhash!("04B5FBB4904167E2E8195C35F7D4E78501A3FE95896794367C85B60B39AEFFC2"),
+                    starkhash!("0232C969EAFC5B30C20648759D7FA1E2F4256AC6604E1921578101DCE4DFDF48"),
                 ),
             ];
 
@@ -1466,20 +1360,14 @@ mod tests {
                 MerkleTree::load("test".to_string(), &transaction, StarkHash::ZERO).unwrap();
 
             for (key, val) in leaves {
-                let key = StarkHash::from_hex_str(key)
-                    .unwrap()
-                    .view_bits()
-                    .to_bitvec();
-                let val = StarkHash::from_hex_str(val).unwrap();
-                tree.set(&key, val).unwrap();
+                let key = key.view_bits();
+                tree.set(key, val).unwrap();
             }
 
             let root = tree.commit().unwrap();
 
-            let expected = StarkHash::from_hex_str(
-                "0x06ee9a8202b40f3f76f1a132f953faa2df78b3b33ccb2b4406431abdc99c2dfe",
-            )
-            .unwrap();
+            let expected =
+                starkhash!("06ee9a8202b40f3f76f1a132f953faa2df78b3b33ccb2b4406431abdc99c2dfe");
 
             assert_eq!(root, expected);
         }
@@ -1487,6 +1375,7 @@ mod tests {
 
     mod dfs {
         use super::{BinaryNode, EdgeNode, MerkleTree, Node};
+        use crate::starkhash;
         use bitvec::{bitvec, prelude::Msb0};
         use stark_hash::StarkHash;
         use std::cell::RefCell;
@@ -1511,8 +1400,8 @@ mod tests {
             let mut uut =
                 MerkleTree::load("test".to_string(), &transaction, StarkHash::ZERO).unwrap();
 
-            let key = StarkHash::from_hex_str("1").unwrap();
-            let value = StarkHash::from_hex_str("2").unwrap();
+            let key = starkhash!("01");
+            let value = starkhash!("02");
 
             uut.set(key.view_bits(), value).unwrap();
 
@@ -1541,10 +1430,10 @@ mod tests {
             let mut uut =
                 MerkleTree::load("test".to_string(), &transaction, StarkHash::ZERO).unwrap();
 
-            let key_left = StarkHash::from_hex_str("0").unwrap();
-            let value_left = StarkHash::from_hex_str("2").unwrap();
-            let key_right = StarkHash::from_hex_str("1").unwrap();
-            let value_right = StarkHash::from_hex_str("3").unwrap();
+            let key_left = starkhash!("00");
+            let value_left = starkhash!("02");
+            let key_right = starkhash!("01");
+            let value_right = starkhash!("03");
 
             uut.set(key_right.view_bits(), value_right).unwrap();
             uut.set(key_left.view_bits(), value_left).unwrap();
@@ -1581,12 +1470,12 @@ mod tests {
             let mut uut =
                 MerkleTree::load("test".to_string(), &transaction, StarkHash::ZERO).unwrap();
 
-            let key_a = StarkHash::from_hex_str("10").unwrap();
-            let value_a = StarkHash::from_hex_str("a").unwrap();
-            let key_b = StarkHash::from_hex_str("11").unwrap();
-            let value_b = StarkHash::from_hex_str("b").unwrap();
-            let key_c = StarkHash::from_hex_str("13").unwrap();
-            let value_c = StarkHash::from_hex_str("c").unwrap();
+            let key_a = starkhash!("10");
+            let value_a = starkhash!("0a");
+            let key_b = starkhash!("11");
+            let value_b = starkhash!("0b");
+            let key_c = starkhash!("13");
+            let value_c = starkhash!("0c");
 
             uut.set(key_c.view_bits(), value_c).unwrap();
             uut.set(key_a.view_bits(), value_a).unwrap();

--- a/crates/pathfinder/src/state/sync/l1.rs
+++ b/crates/pathfinder/src/state/sync/l1.rs
@@ -274,6 +274,7 @@ mod tests {
                 EthereumLogIndex, EthereumTransactionHash, EthereumTransactionIndex, GlobalRoot,
             },
             ethereum::{BlockOrigin, EthOrigin, TransactionOrigin},
+            starkhash,
         };
 
         use super::*;
@@ -304,7 +305,7 @@ mod tests {
                     },
                     log_index: EthereumLogIndex(10),
                 },
-                global_root: GlobalRoot(StarkHash::from_hex_str("123").unwrap()),
+                global_root: GlobalRoot(starkhash!("0123")),
                 block_number: StarknetBlockNumber::GENESIS,
             }];
 
@@ -320,7 +321,7 @@ mod tests {
                     },
                     log_index: EthereumLogIndex(2),
                 },
-                global_root: GlobalRoot(StarkHash::from_hex_str("456abc").unwrap()),
+                global_root: GlobalRoot(starkhash!("456abc")),
                 block_number: StarknetBlockNumber(1),
             }];
 
@@ -378,7 +379,7 @@ mod tests {
                     },
                     log_index: EthereumLogIndex(10),
                 },
-                global_root: GlobalRoot(StarkHash::from_hex_str("123").unwrap()),
+                global_root: GlobalRoot(starkhash!("0123")),
                 block_number: StarknetBlockNumber::GENESIS,
             }];
 

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -80,15 +80,15 @@ mod tests {
         sequencer,
     };
 
+    use crate::{starkhash, starkhash_bytes};
     use assert_matches::assert_matches;
-    use stark_hash::StarkHash;
 
     lazy_static::lazy_static!(
-        pub static ref PARENT_HASH: StarknetBlockHash =  StarknetBlockHash::from_hex_str("1234").unwrap();
-        pub static ref PARENT_ROOT: GlobalRoot = GlobalRoot(StarkHash::from_be_slice(b"parent root").unwrap());
+        pub static ref PARENT_HASH: StarknetBlockHash =  StarknetBlockHash(starkhash!("1234"));
+        pub static ref PARENT_ROOT: GlobalRoot = GlobalRoot(starkhash_bytes!(b"parent root"));
 
         pub static ref NEXT_BLOCK: sequencer::reply::Block = sequencer::reply::Block{
-            block_hash: StarknetBlockHash::from_hex_str("0xabcd").unwrap(),
+            block_hash: StarknetBlockHash(starkhash!("abcd")),
             block_number: StarknetBlockNumber(1),
             gas_price: None,
             parent_block_hash: *PARENT_HASH,
@@ -103,7 +103,7 @@ mod tests {
 
         pub static ref PENDING_DIFF: sequencer::reply::StateUpdate = sequencer::reply::StateUpdate {
             block_hash: None,
-            new_root: GlobalRoot(StarkHash::from_be_slice(b"new root").unwrap()),
+            new_root: GlobalRoot(starkhash_bytes!(b"new root")),
             old_root: *PARENT_ROOT,
             state_diff: sequencer::reply::state_update::StateDiff {
                 storage_diffs: std::collections::HashMap::new(),
@@ -115,7 +115,7 @@ mod tests {
         pub static ref PENDING_BLOCK: sequencer::reply::PendingBlock = sequencer::reply::PendingBlock {
             gas_price: GasPrice(11),
             parent_hash: NEXT_BLOCK.parent_block_hash,
-            sequencer_address: SequencerAddress(StarkHash::from_be_slice(b"seqeunecer address").unwrap()),
+            sequencer_address: SequencerAddress(starkhash_bytes!(b"seqeunecer address")),
             status: sequencer::reply::Status::Pending,
             timestamp: StarknetBlockTimestamp(20),
             transaction_receipts: Vec::new(),
@@ -201,7 +201,7 @@ mod tests {
         let mut sequencer = sequencer::MockClientApi::new();
 
         let mut pending_block = PENDING_BLOCK.clone();
-        pending_block.parent_hash = StarknetBlockHash::from_hex_str("0xFFFFFF").unwrap();
+        pending_block.parent_hash = StarknetBlockHash(starkhash!("FFFFFF"));
         sequencer.expect_block().returning(move |_| {
             Ok(sequencer::reply::MaybePendingBlock::Pending(
                 pending_block.clone(),
@@ -240,8 +240,7 @@ mod tests {
         });
 
         let mut disconnected_diff = PENDING_DIFF.clone();
-        disconnected_diff.old_root =
-            GlobalRoot(StarkHash::from_be_slice(b"different old root").unwrap());
+        disconnected_diff.old_root = GlobalRoot(starkhash_bytes!(b"different old root"));
         sequencer
             .expect_state_update()
             .returning(move |_| Ok(disconnected_diff.clone()));

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -220,6 +220,7 @@ pub(crate) mod test_utils {
         sequencer::reply::transaction::{
             self, DeclareTransaction, DeployTransaction, EntryPointType, InvokeTransaction,
         },
+        starkhash,
     };
 
     use stark_hash::StarkHash;
@@ -259,11 +260,15 @@ pub(crate) mod test_utils {
         let transactions = (0..NUM_TRANSACTIONS).map(|i| match i % TRANSACTIONS_PER_BLOCK {
             x if x < INVOKE_TRANSACTIONS_PER_BLOCK => {
                 transaction::Transaction::Invoke(InvokeTransaction {
-                    calldata: vec![CallParam::from_hex_str(&"0".repeat(i + 3)).unwrap()],
+                    calldata: vec![CallParam(
+                        StarkHash::from_hex_str(&"0".repeat(i + 3)).unwrap(),
+                    )],
                     contract_address: ContractAddress(
                         StarkHash::from_hex_str(&"1".repeat(i + 3)).unwrap(),
                     ),
-                    entry_point_selector: EntryPoint::from_hex_str(&"2".repeat(i + 3)).unwrap(),
+                    entry_point_selector: EntryPoint(
+                        StarkHash::from_hex_str(&"2".repeat(i + 3)).unwrap(),
+                    ),
                     entry_point_type: if i & 1 == 0 {
                         EntryPointType::External
                     } else {
@@ -326,7 +331,7 @@ pub(crate) mod test_utils {
                     )],
                     keys: vec![
                         EventKey(StarkHash::from_hex_str(&"d".repeat(i + 3)).unwrap()),
-                        EventKey(StarkHash::from_hex_str("deadbeef").unwrap()),
+                        EventKey(starkhash!("deadbeef")),
                     ],
                 }]
             } else {

--- a/crates/pathfinder/src/storage/contract.rs
+++ b/crates/pathfinder/src/storage/contract.rs
@@ -192,6 +192,7 @@ impl ContractsTable {
 
 #[cfg(test)]
 mod tests {
+    use crate::starkhash;
     use crate::storage::Storage;
 
     use super::*;
@@ -202,8 +203,8 @@ mod tests {
         let mut conn = storage.connection().unwrap();
         let transaction = conn.transaction().unwrap();
 
-        let address = ContractAddress(StarkHash::from_hex_str("abc").unwrap());
-        let hash = ClassHash(StarkHash::from_hex_str("123").unwrap());
+        let address = ContractAddress(starkhash!("0abc"));
+        let hash = ClassHash(starkhash!("0123"));
 
         ContractsTable::upsert(&transaction, address, hash).unwrap_err();
     }
@@ -214,8 +215,8 @@ mod tests {
         let mut conn = storage.connection().unwrap();
         let transaction = conn.transaction().unwrap();
 
-        let address = ContractAddress(StarkHash::from_hex_str("abc").unwrap());
-        let hash = ClassHash(StarkHash::from_hex_str("123").unwrap());
+        let address = ContractAddress(starkhash!("0abc"));
+        let hash = ClassHash(starkhash!("0123"));
         let definition = vec![9, 13, 25];
 
         ContractCodeTable::insert(&transaction, hash, &[][..], &[][..], &definition[..]).unwrap();
@@ -252,7 +253,7 @@ mod tests {
     }
 
     fn setup_class(transaction: &Transaction<'_>) -> (ClassHash, &'static [u8], serde_json::Value) {
-        let hash = ClassHash(StarkHash::from_hex_str("123").unwrap());
+        let hash = ClassHash(starkhash!("0123"));
 
         // list of objects
         let abi = br#"[{"this":"looks"},{"like": "this"}]"#;
@@ -275,7 +276,7 @@ mod tests {
         let transaction = connection.transaction().unwrap();
 
         let (hash, _, _) = setup_class(&transaction);
-        let non_existent = ClassHash(StarkHash::from_hex_str("456").unwrap());
+        let non_existent = ClassHash(starkhash!("0456"));
 
         let result = ContractCodeTable::exists(&transaction, &[hash, non_existent]).unwrap();
         let expected = vec![true, false];

--- a/crates/pathfinder/src/storage/merkle_tree.rs
+++ b/crates/pathfinder/src/storage/merkle_tree.rs
@@ -396,12 +396,13 @@ mod tests {
 
     mod serde {
         use super::*;
+        use crate::starkhash;
 
         #[test]
         fn edge() {
             // Tests all different possible path lengths. This is an area of concern as we are serializing
             // and deserializing big endian bit paths to a fixed size big endian array.
-            let child = StarkHash::from_hex_str("123abc").unwrap();
+            let child = starkhash!("123abc");
             // 251 randomly generated bits.
             let bits251 = bitvec![Msb0, u8; 1,0,0,1,1,0,1,1,0,0,1,1,1,1,0,0,1,1,1,0,1,0,0,1,0,1,0,1,1,0,0,0,
                                                            1,1,1,1,1,1,1,0,1,1,0,1,0,0,1,1,1,0,0,1,0,1,1,1,0,0,0,1,0,1,0,0,
@@ -427,8 +428,8 @@ mod tests {
         #[test]
         fn binary() {
             let original = PersistedNode::Binary(PersistedBinaryNode {
-                left: StarkHash::from_hex_str("123").unwrap(),
-                right: StarkHash::from_hex_str("abc").unwrap(),
+                left: starkhash!("0123"),
+                right: starkhash!("0abc"),
             });
 
             let serialized = original.clone().serialize();
@@ -440,6 +441,7 @@ mod tests {
 
     mod reference_count {
         use super::*;
+        use crate::starkhash;
 
         #[test]
         fn increment() {
@@ -447,10 +449,10 @@ mod tests {
             let transaction = conn.transaction().unwrap();
             let uut = RcNodeStorage::open("test".to_string(), &transaction).unwrap();
 
-            let key = StarkHash::from_hex_str("123abc").unwrap();
+            let key = starkhash!("123abc");
             let node = PersistedNode::Binary(PersistedBinaryNode {
-                left: StarkHash::from_hex_str("321").unwrap(),
-                right: StarkHash::from_hex_str("abc").unwrap(),
+                left: starkhash!("0321"),
+                right: starkhash!("0abc"),
             });
 
             uut.upsert(key, node).unwrap();
@@ -470,10 +472,10 @@ mod tests {
             let transaction = conn.transaction().unwrap();
             let uut = RcNodeStorage::open("test".to_string(), &transaction).unwrap();
 
-            let key = StarkHash::from_hex_str("123abc").unwrap();
+            let key = starkhash!("123abc");
             let node = PersistedNode::Binary(PersistedBinaryNode {
-                left: StarkHash::from_hex_str("321").unwrap(),
-                right: StarkHash::from_hex_str("abc").unwrap(),
+                left: starkhash!("0321"),
+                right: starkhash!("0abc"),
             });
 
             uut.upsert(key, node).unwrap();
@@ -496,10 +498,10 @@ mod tests {
             let transaction = conn.transaction().unwrap();
             let uut = RcNodeStorage::open("test".to_string(), &transaction).unwrap();
 
-            let key = StarkHash::from_hex_str("123abc").unwrap();
+            let key = starkhash!("123abc");
             let node = PersistedNode::Binary(PersistedBinaryNode {
-                left: StarkHash::from_hex_str("321").unwrap(),
-                right: StarkHash::from_hex_str("abc").unwrap(),
+                left: starkhash!("0321"),
+                right: starkhash!("0abc"),
             });
 
             uut.upsert(key, node.clone()).unwrap();
@@ -511,6 +513,7 @@ mod tests {
 
     mod insert_get {
         use super::*;
+        use crate::starkhash;
 
         #[test]
         fn missing() {
@@ -518,7 +521,7 @@ mod tests {
             let transaction = conn.transaction().unwrap();
             let uut = RcNodeStorage::open("test".to_string(), &transaction).unwrap();
 
-            let key = StarkHash::from_hex_str("123abc").unwrap();
+            let key = starkhash!("123abc");
             assert_eq!(uut.get(key).unwrap(), None);
         }
 
@@ -528,13 +531,13 @@ mod tests {
             let transaction = conn.transaction().unwrap();
             let uut = RcNodeStorage::open("test".to_string(), &transaction).unwrap();
 
-            let left_child_key = StarkHash::from_hex_str("123abc").unwrap();
+            let left_child_key = starkhash!("123abc");
             let left_child = PersistedNode::Leaf;
 
-            let right_child_key = StarkHash::from_hex_str("ddd111").unwrap();
+            let right_child_key = starkhash!("ddd111");
             let right_child = PersistedNode::Leaf;
 
-            let parent_key = StarkHash::from_hex_str("def123").unwrap();
+            let parent_key = starkhash!("def123");
             let parent = PersistedNode::Binary(PersistedBinaryNode {
                 left: left_child_key,
                 right: right_child_key,
@@ -559,10 +562,10 @@ mod tests {
             let transaction = conn.transaction().unwrap();
             let uut = RcNodeStorage::open("test".to_string(), &transaction).unwrap();
 
-            let child_key = StarkHash::from_hex_str("123abc").unwrap();
+            let child_key = starkhash!("123abc");
             let child = PersistedNode::Leaf;
 
-            let parent_key = StarkHash::from_hex_str("def123").unwrap();
+            let parent_key = starkhash!("def123");
             let parent = PersistedNode::Edge(PersistedEdgeNode {
                 path: bitvec![Msb0, u8; 1, 0, 0],
                 child: child_key,
@@ -583,7 +586,7 @@ mod tests {
             let transaction = conn.transaction().unwrap();
             let uut = RcNodeStorage::open("test".to_string(), &transaction).unwrap();
 
-            let key = StarkHash::from_hex_str("123abc").unwrap();
+            let key = starkhash!("123abc");
             let node = PersistedNode::Leaf;
 
             uut.upsert(key, node.clone()).unwrap();
@@ -593,6 +596,7 @@ mod tests {
 
     mod delete {
         use super::*;
+        use crate::starkhash;
 
         #[test]
         fn leaf() {
@@ -600,7 +604,7 @@ mod tests {
             let transaction = conn.transaction().unwrap();
             let uut = RcNodeStorage::open("test".to_string(), &transaction).unwrap();
 
-            let key = StarkHash::from_hex_str("123abc").unwrap();
+            let key = starkhash!("123abc");
             let node = PersistedNode::Leaf;
 
             uut.upsert(key, node.clone()).unwrap();
@@ -616,13 +620,13 @@ mod tests {
             let transaction = conn.transaction().unwrap();
             let uut = RcNodeStorage::open("test".to_string(), &transaction).unwrap();
 
-            let left_child_key = StarkHash::from_hex_str("123abc").unwrap();
+            let left_child_key = starkhash!("123abc");
             let left_child = PersistedNode::Leaf;
 
-            let right_child_key = StarkHash::from_hex_str("ddd111").unwrap();
+            let right_child_key = starkhash!("ddd111");
             let right_child = PersistedNode::Leaf;
 
-            let parent_key = StarkHash::from_hex_str("def123").unwrap();
+            let parent_key = starkhash!("def123");
             let parent = PersistedNode::Binary(PersistedBinaryNode {
                 left: left_child_key,
                 right: right_child_key,
@@ -644,10 +648,10 @@ mod tests {
             let transaction = conn.transaction().unwrap();
             let uut = RcNodeStorage::open("test".to_string(), &transaction).unwrap();
 
-            let child_key = StarkHash::from_hex_str("123abc").unwrap();
+            let child_key = starkhash!("123abc");
             let child = PersistedNode::Leaf;
 
-            let parent_key = StarkHash::from_hex_str("def123").unwrap();
+            let parent_key = starkhash!("def123");
             let parent = PersistedNode::Edge(PersistedEdgeNode {
                 path: bitvec![Msb0, u8; 1, 0, 0],
                 child: child_key,
@@ -667,11 +671,11 @@ mod tests {
             let transaction = conn.transaction().unwrap();
             let uut = RcNodeStorage::open("test".to_string(), &transaction).unwrap();
 
-            let leaf_key = StarkHash::from_hex_str("123abc").unwrap();
+            let leaf_key = starkhash!("123abc");
             let leaf_node = PersistedNode::Leaf;
 
-            let parent_key_1 = StarkHash::from_hex_str("111").unwrap();
-            let parent_key_2 = StarkHash::from_hex_str("222").unwrap();
+            let parent_key_1 = starkhash!("0111");
+            let parent_key_2 = starkhash!("0222");
 
             let parent_node_1 = PersistedNode::Edge(PersistedEdgeNode {
                 path: bitvec![Msb0, u8; 1, 0, 0],

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -453,8 +453,8 @@ impl StarknetBlocksTable {
 
         match genesis {
             None => Ok(None),
-            Some(hash) if hash == *GOERLI_GENESIS_HASH => Ok(Some(Chain::Goerli)),
-            Some(hash) if hash == *MAINNET_GENESIS_HASH => Ok(Some(Chain::Mainnet)),
+            Some(hash) if hash == GOERLI_GENESIS_HASH => Ok(Some(Chain::Goerli)),
+            Some(hash) if hash == MAINNET_GENESIS_HASH => Ok(Some(Chain::Mainnet)),
             Some(hash) => Err(anyhow::anyhow!("Unknown genesis block hash {}", hash.0)),
         }
     }

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -645,7 +645,7 @@ impl StarknetTransactionsTable {
         let mut stmt = sqlite_tx
             .prepare(
                 r"SELECT tx FROM starknet_transactions
-                  WHERE starknet_transactions.block_hash = 
+                  WHERE starknet_transactions.block_hash =
                     (SELECT hash FROM starknet_blocks b WHERE b.number = (SELECT MAX(number) FROM starknet_blocks))
                   ORDER BY starknet_transactions.idx",
             )
@@ -1315,6 +1315,7 @@ mod tests {
 
     mod contracts {
         use super::*;
+        use crate::starkhash;
 
         #[test]
         fn get_root() {
@@ -1322,9 +1323,9 @@ mod tests {
             let mut connection = storage.connection().unwrap();
             let transaction = connection.transaction().unwrap();
 
-            let state_hash = ContractStateHash(StarkHash::from_hex_str("abc").unwrap());
-            let hash = ClassHash(StarkHash::from_hex_str("123").unwrap());
-            let root = ContractRoot(StarkHash::from_hex_str("def").unwrap());
+            let state_hash = ContractStateHash(starkhash!("0abc"));
+            let hash = ClassHash(starkhash!("0123"));
+            let root = ContractRoot(starkhash!("0def"));
 
             ContractsStateTable::upsert(&transaction, state_hash, hash, root).unwrap();
 
@@ -2026,14 +2027,15 @@ mod tests {
 
         use crate::core::{EntryPoint, EventData, Fee};
         use crate::sequencer::reply::transaction;
+        use crate::starkhash;
         use crate::storage::test_utils;
 
         #[test]
         fn event_data_serialization() {
             let data = vec![
-                EventData(StarkHash::from_hex_str("0x1").unwrap()),
-                EventData(StarkHash::from_hex_str("0x2").unwrap()),
-                EventData(StarkHash::from_hex_str("0x3").unwrap()),
+                EventData(starkhash!("01")),
+                EventData(starkhash!("02")),
+                EventData(starkhash!("03")),
             ];
             assert_eq!(
                 &StarknetEventsTable::event_data_to_bytes(&data),
@@ -2049,15 +2051,14 @@ mod tests {
         #[test]
         fn event_keys_to_base64_strings() {
             let event = transaction::Event {
-                from_address: ContractAddress::from_hex_str(
-                    "0x06fbd460228d843b7fbef670ff15607bf72e19fa94de21e29811ada167b4ca39",
-                )
-                .unwrap(),
+                from_address: ContractAddress(starkhash!(
+                    "06fbd460228d843b7fbef670ff15607bf72e19fa94de21e29811ada167b4ca39"
+                )),
                 data: vec![],
                 keys: vec![
-                    EventKey(StarkHash::from_hex_str("0x901823").unwrap()),
-                    EventKey(StarkHash::from_hex_str("0x901824").unwrap()),
-                    EventKey(StarkHash::from_hex_str("0x901825").unwrap()),
+                    EventKey(starkhash!("901823")),
+                    EventKey(starkhash!("901824")),
+                    EventKey(starkhash!("901825")),
                 ],
             };
             assert_eq!(
@@ -2078,7 +2079,7 @@ mod tests {
                 to_block: Some(expected_event.block_number),
                 contract_address: Some(expected_event.from_address),
                 // we're using a key which is present in _all_ events
-                keys: vec![EventKey(StarkHash::from_hex_str("deadbeef").unwrap())],
+                keys: vec![EventKey(starkhash!("deadbeef"))],
                 page_size: test_utils::NUM_EVENTS,
                 page_number: 0,
             };
@@ -2115,11 +2116,11 @@ mod tests {
 
             let block = StarknetBlock {
                 number: StarknetBlockNumber::GENESIS,
-                hash: StarknetBlockHash::from_hex_str("0x1234").unwrap(),
-                root: GlobalRoot(StarkHash::from_hex_str("0x1234").unwrap()),
+                hash: StarknetBlockHash(starkhash!("1234")),
+                root: GlobalRoot(starkhash!("1234")),
                 timestamp: StarknetBlockTimestamp(0),
                 gas_price: GasPrice(0),
-                sequencer_address: SequencerAddress(StarkHash::from_hex_str("0x1234").unwrap()),
+                sequencer_address: SequencerAddress(starkhash!("1234")),
             };
 
             // Note: hashes are reverse ordered to trigger the sorting bug.
@@ -2132,9 +2133,7 @@ mod tests {
                     entry_point_selector: EntryPoint(StarkHash::ZERO),
                     max_fee: Fee(H128::zero()),
                     signature: vec![],
-                    transaction_hash: StarknetTransactionHash(
-                        StarkHash::from_hex_str("0xF").unwrap(),
-                    ),
+                    transaction_hash: StarknetTransactionHash(starkhash!("0F")),
                 }),
                 transaction::Transaction::Invoke(transaction::InvokeTransaction {
                     calldata: vec![],
@@ -2144,9 +2143,7 @@ mod tests {
                     entry_point_selector: EntryPoint(StarkHash::ZERO),
                     max_fee: Fee(H128::zero()),
                     signature: vec![],
-                    transaction_hash: StarknetTransactionHash(
-                        StarkHash::from_hex_str("0x1").unwrap(),
-                    ),
+                    transaction_hash: StarknetTransactionHash(starkhash!("01")),
                 }),
             ];
 
@@ -2630,7 +2627,7 @@ mod tests {
     mod starknet_updates {
 
         use super::*;
-        use crate::storage::fixtures::{hash, with_n_state_updates};
+        use crate::storage::fixtures::with_n_state_updates;
 
         mod get {
             use super::*;
@@ -2650,8 +2647,9 @@ mod tests {
 
             #[test]
             fn none() {
+                use crate::starkhash;
                 with_n_state_updates(1, |_, tx, _| {
-                    let non_existent = StarknetBlockHash(hash!(0xFF));
+                    let non_existent = StarknetBlockHash(starkhash!("ff"));
                     let actual = StarknetStateUpdatesTable::get(tx, non_existent).unwrap();
                     assert!(actual.is_none());
                 })

--- a/crates/stark_hash/fuzz/.gitignore
+++ b/crates/stark_hash/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+Cargo.lock

--- a/crates/stark_hash/fuzz/Cargo.toml
+++ b/crates/stark_hash/fuzz/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "stark_hash-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.stark_hash]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "from_be_bytes"
+path = "fuzz_targets/from_be_bytes.rs"
+test = false
+doc = false

--- a/crates/stark_hash/fuzz/fuzz_targets/from_be_bytes.rs
+++ b/crates/stark_hash/fuzz/fuzz_targets/from_be_bytes.rs
@@ -1,0 +1,8 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: [u8; 32]| {
+    let constified = stark_hash::StarkHash::from_be_bytes(data);
+    let orig = stark_hash::StarkHash::from_be_bytes_orig(data);
+    assert_eq!(constified, orig);
+});

--- a/crates/stark_hash/src/hash.rs
+++ b/crates/stark_hash/src/hash.rs
@@ -65,12 +65,12 @@ impl StarkHash {
     pub const ZERO: StarkHash = StarkHash([0u8; 32]);
 
     /// Returns the big-endian representation of this [StarkHash].
-    pub fn to_be_bytes(self) -> [u8; 32] {
+    pub const fn to_be_bytes(self) -> [u8; 32] {
         self.0
     }
 
     /// Big-endian representation of this [StarkHash].
-    pub fn as_be_bytes(&self) -> &[u8; 32] {
+    pub const fn as_be_bytes(&self) -> &[u8; 32] {
         &self.0
     }
 
@@ -203,17 +203,42 @@ impl StarkHash {
     pub fn has_more_than_251_bits(&self) -> bool {
         self.0[0] & 0b1111_1000 > 0
     }
+
+    pub const fn from_u64(u: u64) -> Self {
+        const_expect!(
+            Self::from_be_slice(&u.to_be_bytes()),
+            "64 bits is less than 251 bits"
+        )
+    }
+
+    pub const fn from_u128(u: u128) -> Self {
+        const_expect!(
+            Self::from_be_slice(&u.to_be_bytes()),
+            "128 bits is less than 251 bits"
+        )
+    }
 }
+
+macro_rules! const_expect {
+    ($e:expr, $why:expr) => {{
+        match $e {
+            Ok(x) => x,
+            Err(_) => panic!(concat!("Expectation failed: ", $why)),
+        }
+    }};
+}
+
+use const_expect;
 
 impl From<u64> for StarkHash {
     fn from(value: u64) -> Self {
-        Self::from_be_slice(&value.to_be_bytes()).expect("64 bits is less than 251 bits")
+        Self::from_u64(value)
     }
 }
 
 impl From<u128> for StarkHash {
     fn from(value: u128) -> Self {
-        Self::from_be_slice(&value.to_be_bytes()).expect("128 bits is less than 251 bits")
+        Self::from_u128(value)
     }
 }
 

--- a/crates/stark_hash/src/hash.rs
+++ b/crates/stark_hash/src/hash.rs
@@ -75,13 +75,22 @@ impl StarkHash {
     }
 
     /// Convenience function which extends [StarkHash::from_be_bytes] to work with slices.
-    pub fn from_be_slice(bytes: &[u8]) -> Result<Self, OverflowError> {
+    pub const fn from_be_slice(bytes: &[u8]) -> Result<Self, OverflowError> {
         if bytes.len() > 32 {
             return Err(OverflowError);
         }
 
         let mut buf = [0u8; 32];
-        buf[32 - bytes.len()..].copy_from_slice(bytes);
+        let mut index = 0;
+
+        loop {
+            if index == bytes.len() {
+                break;
+            }
+
+            buf[32 - bytes.len() + index] = bytes[index];
+            index += 1;
+        }
 
         StarkHash::from_be_bytes(buf)
     }


### PR DESCRIPTION
- Adds `pathfinder_lib::starkhash!` which is a const macro using `hex_literal::hex`
- Adds `pathfinder_lib::starkhash_bytes!` which is another const macro for `b"some blockhash somewhere"` kind of usages
- Removes the `from_hex_str` implementations from types
- Replaces all usages of `StarkHash::from_hex_str` and delegates with `starkhash!`