### PR TITLE
refactor: hide privates for 251-bit types

### DIFF
--- a/crates/load-test/src/main.rs
+++ b/crates/load-test/src/main.rs
@@ -179,7 +179,7 @@ async fn task_call(user: &mut GooseUser) -> TransactionResult {
     // https://voyager.online/contract/0x06ee3440b08a9c805305449ec7f7003f27e9f7e287b83610952ec36bdc5a6bae
     call(
         user,
-        ContractAddress(
+        ContractAddress::new_or_panic(
             StarkHash::from_hex_str(
                 "0x06ee3440b08a9c805305449ec7f7003f27e9f7e287b83610952ec36bdc5a6bae",
             )
@@ -217,7 +217,7 @@ async fn task_get_events(user: &mut GooseUser) -> TransactionResult {
         EventFilter {
             from_block: Some(StarknetBlockNumber::new_or_panic(1000).into()),
             to_block: Some(StarknetBlockNumber::new_or_panic(1100).into()),
-            address: Some(ContractAddress(
+            address: Some(ContractAddress::new_or_panic(
                 StarkHash::from_hex_str(
                     "0x103114c4c5ac233a360d39a9217b9067be6979f3d08e1cf971fd22baf8f8713",
                 )
@@ -246,13 +246,13 @@ async fn task_get_storage_at(user: &mut GooseUser) -> TransactionResult {
     // "value": "0x44054cde571399c485119e55cf0b9fc7dcc151fb3486f70020d3ee4d7b20f8d"}]
     get_storage_at(
         user,
-        ContractAddress(
+        ContractAddress::new_or_panic(
             StarkHash::from_hex_str(
                 "0x27a761524e94ed6d0c882e232bb4d34f12aae1b906e29c62dc682b526349056",
             )
             .unwrap(),
         ),
-        StorageAddress(
+        StorageAddress::new_or_panic(
             StarkHash::from_hex_str(
                 "0x79deb98f1f7fc9a64df7073f93ce645a5f6a7588c34773ba76fdc879a2346e1",
             )

--- a/crates/pathfinder/examples/estimate_past_transactions.rs
+++ b/crates/pathfinder/examples/estimate_past_transactions.rs
@@ -155,14 +155,14 @@ fn feed_work(
         let call = match tx {
             SimpleTransaction::Invoke(tx)
                 if !previously_declared_deployed_in_the_same_block
-                    .contains(&tx.contract_address.0) =>
+                    .contains(tx.contract_address.get()) =>
             {
                 tx.into()
             }
             SimpleTransaction::Invoke(SimpleInvoke {
                 contract_address, ..
             }) => {
-                tracing::debug!(contract_address=%contract_address.0, "same block deployed contract found");
+                tracing::debug!(contract_address=%contract_address.get(), "same block deployed contract found");
                 same_tx_deploy_call += 1;
                 continue;
             }
@@ -172,7 +172,7 @@ fn feed_work(
             }
             SimpleTransaction::Deploy(SimpleDeploy { contract_address }) => {
                 deploys += 1;
-                previously_declared_deployed_in_the_same_block.insert(contract_address.0);
+                previously_declared_deployed_in_the_same_block.insert(*contract_address.get());
                 continue;
             }
         };

--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -335,7 +335,7 @@ mod tests {
                     async move {
                         handle.call(
                             super::Call {
-                                contract_address: crate::core::ContractAddress(
+                                contract_address: crate::core::ContractAddress::new_or_panic(
                                     starkhash!(
                                         "057dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374"
                                     )
@@ -403,7 +403,7 @@ mod tests {
         .unwrap();
 
         let call = super::Call {
-            contract_address: crate::core::ContractAddress(starkhash!(
+            contract_address: crate::core::ContractAddress::new_or_panic(starkhash!(
                 "057dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374"
             )),
             calldata: vec![crate::core::CallParam(starkhash!("84"))],
@@ -498,7 +498,7 @@ mod tests {
         .unwrap();
 
         let call = super::Call {
-            contract_address: crate::core::ContractAddress(starkhash!(
+            contract_address: crate::core::ContractAddress::new_or_panic(starkhash!(
                 // this is one bit off from other examples
                 "057dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e375"
             )),
@@ -562,7 +562,7 @@ mod tests {
         .await
         .unwrap();
 
-        let target_contract = crate::core::ContractAddress(starkhash!(
+        let target_contract = crate::core::ContractAddress::new_or_panic(starkhash!(
             "057dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374"
         ));
 
@@ -598,7 +598,7 @@ mod tests {
                     map.insert(
                         target_contract,
                         vec![crate::sequencer::reply::state_update::StorageDiff {
-                            key: crate::core::StorageAddress(storage_address),
+                            key: crate::core::StorageAddress::new_or_panic(storage_address),
                             value: crate::core::StorageValue(starkhash!("04")),
                         }],
                     );
@@ -644,8 +644,12 @@ mod tests {
         crate::storage::ContractCodeTable::insert(tx, hash, &abi, &bytecode, &contract_definition)
             .unwrap();
 
-        crate::storage::ContractsTable::upsert(tx, crate::core::ContractAddress(address), hash)
-            .unwrap();
+        crate::storage::ContractsTable::upsert(
+            tx,
+            crate::core::ContractAddress::new_or_panic(address),
+            hash,
+        )
+        .unwrap();
 
         // this will create the table, not created by migration
         crate::state::state_tree::ContractsStateTree::load(

--- a/crates/pathfinder/src/cairo/ext_py/ser.rs
+++ b/crates/pathfinder/src/cairo/ext_py/ser.rs
@@ -106,7 +106,7 @@ impl<'a> serde::Serialize for DiffElement<'a> {
     {
         use serde::ser::SerializeMap;
         let mut map = serializer.serialize_map(Some(2))?;
-        map.serialize_entry("key", &self.0.key.0)?;
+        map.serialize_entry("key", &self.0.key.get())?;
         map.serialize_entry("value", &self.0.value.0)?;
         map.end()
     }
@@ -258,11 +258,11 @@ mod tests {
         let map = {
             let mut map = HashMap::new();
             map.insert(
-                ContractAddress(starkhash!(
+                ContractAddress::new_or_panic(starkhash!(
                     "07c38021eb1f890c5d572125302fe4a0d2f79d38b018d68a9fcd102145d4e451"
                 )),
                 vec![StorageDiff {
-                    key: StorageAddress(starkhash!("05")),
+                    key: StorageAddress::new_or_panic(starkhash!("05")),
                     value: StorageValue(starkhash!("00")),
                 }],
             );
@@ -293,7 +293,7 @@ mod tests {
 
         let expected = r#"[{"address":"0x7c38021eb1f890c5d572125302fe4a0d2f79d38b018d68a9fcd102145d4e451","contract_hash":"0x10455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8"}]"#;
         let contracts = vec![DeployedContract {
-            address: ContractAddress(starkhash!(
+            address: ContractAddress::new_or_panic(starkhash!(
                 "07c38021eb1f890c5d572125302fe4a0d2f79d38b018d68a9fcd102145d4e451"
             )),
             class_hash: ClassHash(starkhash!(

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -8,90 +8,12 @@ use web3::types::{H128, H160, H256};
 
 mod macros;
 
-macro_rules! merkletree_key_newtype {
-    ($target:ty) => {
-        impl $target {
-            pub const fn new(hash: StarkHash) -> Option<Self> {
-                if hash.has_more_than_251_bits() {
-                    None
-                } else {
-                    Some(Self(hash))
-                }
-            }
-
-            pub const fn new_or_panic(hash: StarkHash) -> Self {
-                match Self::new(hash) {
-                    Some(key) => key,
-                    None => panic!("Too many bits, need less for MPT keys"),
-                }
-            }
-
-            pub const fn get(&self) -> &StarkHash {
-                &self.0
-            }
-
-            pub fn view_bits(&self) -> &bitvec::slice::BitSlice<bitvec::order::Msb0, u8> {
-                self.0.view_bits()
-            }
-        }
-    };
-}
-
-macro_rules! merkletree_key_deserialization {
-    ($target:ty) => {
-        impl $target {
-            pub fn deserialize_value<E>(original: &str, raw: StarkHash) -> Result<Self, E>
-            where
-                E: serde::de::Error,
-            {
-                Self::new(raw).ok_or_else(|| {
-                    serde::de::Error::invalid_value(
-                        serde::de::Unexpected::Str(original),
-                        &"At most 251-bit value",
-                    )
-                })
-            }
-        }
-
-        impl<'de> serde::Deserialize<'de> for $target {
-            fn deserialize<D>(de: D) -> Result<Self, D::Error>
-            where
-                D: serde::Deserializer<'de>,
-            {
-                struct StarkHash251;
-
-                impl<'de> serde::de::Visitor<'de> for StarkHash251 {
-                    type Value = $target;
-
-                    fn expecting(
-                        &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
-                        formatter.write_str("A hex string with at most 251 bits set.")
-                    }
-
-                    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-                    where
-                        E: serde::de::Error,
-                    {
-                        let hash = StarkHash::from_hex_str(v).map_err(serde::de::Error::custom)?;
-
-                        <$target>::deserialize_value(v, hash)
-                    }
-                }
-
-                de.deserialize_str(StarkHash251)
-            }
-        }
-    };
-}
-
 /// The address of a StarkNet contract.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize, PartialOrd, Ord)]
 pub struct ContractAddress(StarkHash);
 
-merkletree_key_newtype!(ContractAddress);
-merkletree_key_deserialization!(ContractAddress);
+macros::starkhash251::newtype!(ContractAddress);
+macros::starkhash251::deserialization!(ContractAddress);
 
 /// A nonce that is associated with a particular deployed StarkNet contract
 /// distinguishing it from other contracts that use the same contract class.
@@ -177,8 +99,8 @@ pub struct ByteCodeWord(pub StarkHash);
 #[derive(Copy, Clone, PartialEq, Eq, Serialize, PartialOrd, Ord)]
 pub struct StorageAddress(StarkHash);
 
-merkletree_key_newtype!(StorageAddress);
-merkletree_key_deserialization!(StorageAddress);
+macros::starkhash251::newtype!(StorageAddress);
+macros::starkhash251::deserialization!(StorageAddress);
 
 /// The value of a storage element for a StarkNet contract.
 #[derive(Copy, Clone, PartialEq, Eq, Deserialize, Serialize, PartialOrd, Ord)]

--- a/crates/pathfinder/src/ethereum/state_update.rs
+++ b/crates/pathfinder/src/ethereum/state_update.rs
@@ -178,7 +178,7 @@ mod tests {
 
         let expected = StateUpdate {
             deployed_contracts: vec![DeployedContract {
-                address: ContractAddress(starkhash!(
+                address: ContractAddress::new_or_panic(starkhash!(
                     "6CF1C6DCA6DE4CE15DB3EB7AEE1C6191537C82E2F2DE22FE4426199EE50E9A"
                 )),
                 hash: ClassHash(starkhash!(
@@ -190,12 +190,12 @@ mod tests {
             }],
             contract_updates: vec![
                 ContractUpdate {
-                    address: ContractAddress(starkhash!(
+                    address: ContractAddress::new_or_panic(starkhash!(
                         "6CF1C6DCA6DE4CE15DB3EB7AEE1C6191537C82E2F2DE22FE4426199EE50E9A"
                     )),
                     storage_updates: vec![
                         StorageUpdate {
-                            address: StorageAddress(starkhash!(
+                            address: StorageAddress::new_or_panic(starkhash!(
                                 "021683F821A0574472445355BE6D2B769119E8515F8376A1D7878523DFDECF7B"
                             )),
                             value: StorageValue(starkhash!(
@@ -203,7 +203,7 @@ mod tests {
                             )),
                         },
                         StorageUpdate {
-                            address: StorageAddress(starkhash!(
+                            address: StorageAddress::new_or_panic(starkhash!(
                                 "03B28019CCFDBD30FFC65951D94BB85C9E2B8434111A000B5AFD533CE65F57A4"
                             )),
                             value: StorageValue(starkhash!(
@@ -211,7 +211,7 @@ mod tests {
                             )),
                         },
                         StorageUpdate {
-                            address: StorageAddress(starkhash!(
+                            address: StorageAddress::new_or_panic(starkhash!(
                                 "03C0BA99F1A18BCDC81FCBCB6B4F15A9A6725F937075AED6FAC107FFCB147068"
                             )),
                             value: StorageValue(starkhash!("01")),
@@ -219,11 +219,11 @@ mod tests {
                     ],
                 },
                 ContractUpdate {
-                    address: ContractAddress(starkhash!(
+                    address: ContractAddress::new_or_panic(starkhash!(
                         "FDB9F231A6C257D492DB4D091703ABA277E97B583AB9E3115B5A571FC22E4D"
                     )),
                     storage_updates: vec![StorageUpdate {
-                        address: StorageAddress(starkhash!(
+                        address: StorageAddress::new_or_panic(starkhash!(
                             "0154D7895A89D2A9EA002F6455F0BE1F409302F4E3A53B06B86C8A83E12D343E"
                         )),
                         value: StorageValue(starkhash!(
@@ -232,18 +232,18 @@ mod tests {
                     }],
                 },
                 ContractUpdate {
-                    address: ContractAddress(starkhash!(
+                    address: ContractAddress::new_or_panic(starkhash!(
                         "029366B381BA18C53E9DB8A4476E0599C71CB63F001950D094CE23EDCD2CD81C"
                     )),
                     storage_updates: vec![
                         StorageUpdate {
-                            address: StorageAddress(starkhash!(
+                            address: StorageAddress::new_or_panic(starkhash!(
                                 "0367FBE030560FA33F15D19C5A53436B3345771F3769607B168E9BAFB540E665"
                             )),
                             value: StorageValue(starkhash!("8AC7230489E80000")),
                         },
                         StorageUpdate {
-                            address: StorageAddress(starkhash!(
+                            address: StorageAddress::new_or_panic(starkhash!(
                                 "0367FBE030560FA33F15D19C5A53436B3345771F3769607B168E9BAFB540E666"
                             )),
                             value: StorageValue(starkhash!("00")),
@@ -251,34 +251,34 @@ mod tests {
                     ],
                 },
                 ContractUpdate {
-                    address: ContractAddress(starkhash!(
+                    address: ContractAddress::new_or_panic(starkhash!(
                         "02FC0D82D539509C5642B64F59299B7E9FD23C114BD2640BDC979602667F8C1F"
                     )),
                     storage_updates: vec![StorageUpdate {
-                        address: StorageAddress(starkhash!(
+                        address: StorageAddress::new_or_panic(starkhash!(
                             "D34C3A8EDE05D741C7C11C8A517FEB3FEFCC425ED633E4D93758446BA289BA"
                         )),
                         value: StorageValue(starkhash!("07E5")),
                     }],
                 },
                 ContractUpdate {
-                    address: ContractAddress(starkhash!(
+                    address: ContractAddress::new_or_panic(starkhash!(
                         "04F664133F8C8C9A34B7D0B85AC09571BC92FBDC23CD7F82B0E8CEA3E3837B4C"
                     )),
                     storage_updates: vec![StorageUpdate {
-                        address: StorageAddress(starkhash!(
+                        address: StorageAddress::new_or_panic(starkhash!(
                             "D34C3A8EDE05D741C7C11C8A517FEB3FEFCC425ED633E4D93758446BA289BA"
                         )),
                         value: StorageValue(starkhash!("07C7")),
                     }],
                 },
                 ContractUpdate {
-                    address: ContractAddress(starkhash!(
+                    address: ContractAddress::new_or_panic(starkhash!(
                         "069A7CFDF88197230CA4CE9377E1D8AAE7AD5E36E25DD35C7F3C73DAAD16940E"
                     )),
                     storage_updates: vec![
                         StorageUpdate {
-                            address: StorageAddress(starkhash!(
+                            address: StorageAddress::new_or_panic(starkhash!(
                                 "01CCC09C8A19948E048DE7ADD6929589945E25F22059C7345AAF7837188D8D05"
                             )),
                             value: StorageValue(starkhash!(
@@ -286,13 +286,13 @@ mod tests {
                             )),
                         },
                         StorageUpdate {
-                            address: StorageAddress(starkhash!(
+                            address: StorageAddress::new_or_panic(starkhash!(
                                 "031E7534F8DDB1628D6E07DB5C743E33403B9A0B57508A93F4C49582040A2F71"
                             )),
                             value: StorageValue(starkhash!("00")),
                         },
                         StorageUpdate {
-                            address: StorageAddress(starkhash!(
+                            address: StorageAddress::new_or_panic(starkhash!(
                                 "037501DF619C4FC4E96F6C0243F55E3ABE7D1ACA7DB9AF8F3740BA3696B3FDAC"
                             )),
                             value: StorageValue(starkhash!("01")),
@@ -300,20 +300,20 @@ mod tests {
                     ],
                 },
                 ContractUpdate {
-                    address: ContractAddress(starkhash!(
+                    address: ContractAddress::new_or_panic(starkhash!(
                         "07075572D159FA30E93C6A917F75B5D664A99A7CEC4AF40FA7E6EF8094B7A3EE"
                     )),
                     storage_updates: vec![StorageUpdate {
-                        address: StorageAddress(starkhash!("05")),
+                        address: StorageAddress::new_or_panic(starkhash!("05")),
                         value: StorageValue(starkhash!("0456")),
                     }],
                 },
                 ContractUpdate {
-                    address: ContractAddress(starkhash!(
+                    address: ContractAddress::new_or_panic(starkhash!(
                         "07C1069DD27607ABF370C745B9781183FDD7E8082AC39C4E57D858913EE7D022"
                     )),
                     storage_updates: vec![StorageUpdate {
-                        address: StorageAddress(starkhash!("05")),
+                        address: StorageAddress::new_or_panic(starkhash!("05")),
                         value: StorageValue(starkhash!("66")),
                     }],
                 },

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -405,15 +405,15 @@ mod tests {
         let mut connection = storage.connection().unwrap();
         let db_txn = connection.transaction().unwrap();
 
-        let contract0_addr = ContractAddress(starkhash_bytes!(b"contract 0"));
-        let contract1_addr = ContractAddress(starkhash_bytes!(b"contract 1"));
+        let contract0_addr = ContractAddress::new_or_panic(starkhash_bytes!(b"contract 0"));
+        let contract1_addr = ContractAddress::new_or_panic(starkhash_bytes!(b"contract 1"));
 
         let class0_hash = ClassHash(starkhash_bytes!(b"class 0 hash"));
         let class1_hash = ClassHash(starkhash_bytes!(b"class 1 hash"));
 
         let contract0_update = vec![];
 
-        let storage_addr = StorageAddress(starkhash_bytes!(b"storage addr 0"));
+        let storage_addr = StorageAddress::new_or_panic(starkhash_bytes!(b"storage addr 0"));
         let contract1_update0 = vec![StorageDiff {
             key: storage_addr,
             value: StorageValue(starkhash_bytes!(b"storage value 0")),
@@ -552,7 +552,7 @@ mod tests {
         txn3.contract_address = contract1_addr;
         txn4.transaction_hash = txn4_hash;
 
-        txn4.contract_address = ContractAddress(StarkHash::ZERO);
+        txn4.contract_address = ContractAddress::new_or_panic(StarkHash::ZERO);
         let mut txn5 = txn4.clone();
         txn5.transaction_hash = txn5_hash;
         let txn0 = Transaction::Invoke(txn0);
@@ -568,7 +568,7 @@ mod tests {
         let mut receipt5 = receipt0.clone();
         receipt0.events = vec![Event {
             data: vec![EventData(starkhash_bytes!(b"event 0 data"))],
-            from_address: ContractAddress(starkhash_bytes!(b"event 0 from addr")),
+            from_address: ContractAddress::new_or_panic(starkhash_bytes!(b"event 0 from addr")),
             keys: vec![EventKey(starkhash_bytes!(b"event 0 key"))],
         }];
         receipt1.transaction_hash = txn1_hash;
@@ -615,7 +615,9 @@ mod tests {
         let transactions: Vec<Transaction> = vec![
             InvokeTransaction {
                 calldata: vec![],
-                contract_address: ContractAddress(starkhash_bytes!(b"pending contract addr 0")),
+                contract_address: ContractAddress::new_or_panic(starkhash_bytes!(
+                    b"pending contract addr 0"
+                )),
                 entry_point_selector: EntryPoint(starkhash_bytes!(b"entry point 0")),
                 entry_point_type: EntryPointType::External,
                 max_fee: Call::DEFAULT_MAX_FEE,
@@ -624,7 +626,7 @@ mod tests {
             }
             .into(),
             DeployTransaction {
-                contract_address: ContractAddress(starkhash!("01122355")),
+                contract_address: ContractAddress::new_or_panic(starkhash!("01122355")),
                 contract_address_salt: ContractAddressSalt(starkhash_bytes!(b"salty")),
                 class_hash: ClassHash(starkhash_bytes!(b"pending class hash 1")),
                 constructor_calldata: vec![],
@@ -639,17 +641,17 @@ mod tests {
                 events: vec![
                     Event {
                         data: vec![],
-                        from_address: ContractAddress(starkhash!("abcddddddd")),
+                        from_address: ContractAddress::new_or_panic(starkhash!("abcddddddd")),
                         keys: vec![EventKey(starkhash_bytes!(b"pending key"))],
                     },
                     Event {
                         data: vec![],
-                        from_address: ContractAddress(starkhash!("abcddddddd")),
+                        from_address: ContractAddress::new_or_panic(starkhash!("abcddddddd")),
                         keys: vec![EventKey(starkhash_bytes!(b"pending key"))],
                     },
                     Event {
                         data: vec![],
-                        from_address: ContractAddress(starkhash!("abcaaaaaaa")),
+                        from_address: ContractAddress::new_or_panic(starkhash!("abcaaaaaaa")),
                         keys: vec![EventKey(starkhash_bytes!(b"pending key 2"))],
                     },
                 ],
@@ -696,11 +698,15 @@ mod tests {
         use crate::sequencer::reply as seq_reply;
         let deployed_contracts = vec![
             seq_reply::state_update::DeployedContract {
-                address: ContractAddress(starkhash_bytes!(b"pending contract 0 address")),
+                address: ContractAddress::new_or_panic(starkhash_bytes!(
+                    b"pending contract 0 address"
+                )),
                 class_hash: ClassHash(starkhash_bytes!(b"pending contract 0 hash")),
             },
             seq_reply::state_update::DeployedContract {
-                address: ContractAddress(starkhash_bytes!(b"pending contract 1 address")),
+                address: ContractAddress::new_or_panic(starkhash_bytes!(
+                    b"pending contract 1 address"
+                )),
                 class_hash: ClassHash(starkhash_bytes!(b"pending contract 1 hash")),
             },
         ];
@@ -708,11 +714,11 @@ mod tests {
             deployed_contracts[1].address,
             vec![
                 seq_reply::state_update::StorageDiff {
-                    key: StorageAddress(starkhash_bytes!(b"pending storage key 0")),
+                    key: StorageAddress::new_or_panic(starkhash_bytes!(b"pending storage key 0")),
                     value: StorageValue(starkhash_bytes!(b"pending storage value 0")),
                 },
                 seq_reply::state_update::StorageDiff {
-                    key: StorageAddress(starkhash_bytes!(b"pending storage key 1")),
+                    key: StorageAddress::new_or_panic(starkhash_bytes!(b"pending storage key 1")),
                     value: StorageValue(starkhash_bytes!(b"pending storage value 1")),
                 },
             ],
@@ -988,7 +994,7 @@ mod tests {
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
-                ContractAddress(starkhash_bytes!(b"contract 0")),
+                ContractAddress::new_or_panic(starkhash_bytes!(b"contract 0")),
                 web3::types::H256::from_str(
                     "0x0800000000000011000000000000000000000000000000000000000000000001"
                 )
@@ -1011,7 +1017,7 @@ mod tests {
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
-                ContractAddress(starkhash_bytes!(b"contract 0")),
+                ContractAddress::new_or_panic(starkhash_bytes!(b"contract 0")),
                 web3::types::H256::from_str(
                     "0x0800000000000000000000000000000000000000000000000000000000000000"
                 )
@@ -1032,8 +1038,8 @@ mod tests {
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
-                ContractAddress(starkhash_bytes!(b"nonexistent")),
-                StorageAddress(starkhash_bytes!(b"storage addr 0")),
+                ContractAddress::new_or_panic(starkhash_bytes!(b"nonexistent")),
+                StorageAddress::new_or_panic(starkhash_bytes!(b"storage addr 0")),
                 BlockId::Latest
             );
             let error = client(addr)
@@ -1051,8 +1057,8 @@ mod tests {
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
-                ContractAddress(starkhash_bytes!(b"contract 1")),
-                StorageAddress(starkhash_bytes!(b"storage addr 0")),
+                ContractAddress::new_or_panic(starkhash_bytes!(b"contract 1")),
+                StorageAddress::new_or_panic(starkhash_bytes!(b"storage addr 0")),
                 BlockId::Hash(StarknetBlockHash(starkhash_bytes!(b"genesis")))
             );
             let error = client(addr)
@@ -1070,8 +1076,8 @@ mod tests {
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
-                ContractAddress(starkhash_bytes!(b"contract 1")),
-                StorageAddress(starkhash_bytes!(b"storage addr 0")),
+                ContractAddress::new_or_panic(starkhash_bytes!(b"contract 1")),
+                StorageAddress::new_or_panic(starkhash_bytes!(b"storage addr 0")),
                 BlockId::Hash(StarknetBlockHash(starkhash_bytes!(b"nonexistent")))
             );
             let error = client(addr)
@@ -1089,8 +1095,8 @@ mod tests {
             let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
-                ContractAddress(starkhash_bytes!(b"contract 1")),
-                StorageAddress(starkhash_bytes!(b"storage addr 0")),
+                ContractAddress::new_or_panic(starkhash_bytes!(b"contract 1")),
+                StorageAddress::new_or_panic(starkhash_bytes!(b"storage addr 0")),
                 BlockId::Hash(StarknetBlockHash(starkhash_bytes!(b"block 1")))
             );
             let value = client(addr)
@@ -1112,8 +1118,8 @@ mod tests {
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(
-                    ContractAddress(starkhash_bytes!(b"contract 1")),
-                    StorageAddress(starkhash_bytes!(b"storage addr 0")),
+                    ContractAddress::new_or_panic(starkhash_bytes!(b"contract 1")),
+                    StorageAddress::new_or_panic(starkhash_bytes!(b"storage addr 0")),
                     BlockId::Latest
                 );
                 let value = client(addr)
@@ -1603,7 +1609,8 @@ mod tests {
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
-                let contract_address = ContractAddress(starkhash_bytes!(b"contract 1"));
+                let contract_address =
+                    ContractAddress::new_or_panic(starkhash_bytes!(b"contract 1"));
                 let params = rpc_params!(BlockId::Latest, contract_address);
                 let class_hash = client(addr)
                     .request::<ClassHash>("starknet_getClassHashAt", params)
@@ -1621,7 +1628,8 @@ mod tests {
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
-                let contract_address = ContractAddress(starkhash_bytes!(b"contract 1"));
+                let contract_address =
+                    ContractAddress::new_or_panic(starkhash_bytes!(b"contract 1"));
                 let params = rpc_params!(
                     BlockId::Number(StarknetBlockNumber::GENESIS),
                     contract_address
@@ -1667,7 +1675,8 @@ mod tests {
                 let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
-                let contract_address = ContractAddress(starkhash_bytes!(b"contract 1"));
+                let contract_address =
+                    ContractAddress::new_or_panic(starkhash_bytes!(b"contract 1"));
                 let params = by_name([
                     ("block_id", json!("latest")),
                     ("contract_address", json!(contract_address)),
@@ -1837,7 +1846,7 @@ mod tests {
             let buffer = zstd::decode_all(std::io::Cursor::new(contract_definition))?;
             let contract_definition = Bytes::from(buffer);
 
-            let contract_address = ContractAddress(starkhash!(
+            let contract_address = ContractAddress::new_or_panic(starkhash!(
                 "057dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374"
             ));
             let expected_hash =
@@ -1871,7 +1880,7 @@ mod tests {
             let program = base64::encode(program);
 
             // insert a new block whose state includes the contract
-            let storage_addr = StorageAddress(starkhash_bytes!(b"storage addr"));
+            let storage_addr = StorageAddress::new_or_panic(starkhash_bytes!(b"storage addr"));
             let storage_diff = vec![StorageDiff {
                 key: storage_addr,
                 value: StorageValue(starkhash_bytes!(b"storage_value")),
@@ -2083,7 +2092,7 @@ mod tests {
         let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
         // This contract is created in `setup_storage`
-        let valid_contract = ContractAddress(starkhash_bytes!(b"contract 0"));
+        let valid_contract = ContractAddress::new_or_panic(starkhash_bytes!(b"contract 0"));
 
         // With no version set yet -- this occurs when `getNonce` is called before
         // we have received a `latest` update from the gateway at pathfinder startup.
@@ -2102,7 +2111,7 @@ mod tests {
         assert_eq!(version, ContractNonce(StarkHash::ZERO));
 
         // Invalid contract should error.
-        let invalid_contract = ContractAddress(starkhash_bytes!(b"invalid"));
+        let invalid_contract = ContractAddress::new_or_panic(starkhash_bytes!(b"invalid"));
         let error = client(addr)
             .request::<ContractNonce>("starknet_getNonce", rpc_params!(invalid_contract))
             .await
@@ -2951,7 +2960,7 @@ mod tests {
 
             lazy_static::lazy_static! {
                 pub static ref CALL: ContractCall = ContractCall {
-                    contract_address: ContractAddress(
+                    contract_address: ContractAddress::new_or_panic(
                         starkhash!("023371b227eaecd8e8920cd429357edddd2cd0f3fee6abaacca08d3ab82a7cdd")
                     ),
                     calldata: vec![
@@ -3092,7 +3101,7 @@ mod tests {
                         transaction_hash: StarknetTransactionHash(starkhash!(
                             "057ed4b4c76a1ca0ba044a654dd3ee2d0d3e550343d739350a22aacdd524110d"
                         )),
-                        contract_address: ContractAddress(starkhash!(
+                        contract_address: ContractAddress::new_or_panic(starkhash!(
                             "03926aea98213ec34fe9783d803237d221c54c52344422e1f4942a5b340fa6ad"
                         )),
                     }
@@ -3218,7 +3227,7 @@ mod tests {
                         transaction_hash: StarknetTransactionHash(starkhash!(
                             "057ed4b4c76a1ca0ba044a654dd3ee2d0d3e550343d739350a22aacdd524110d"
                         )),
-                        contract_address: ContractAddress(starkhash!(
+                        contract_address: ContractAddress::new_or_panic(starkhash!(
                             "03926aea98213ec34fe9783d803237d221c54c52344422e1f4942a5b340fa6ad"
                         )),
                     }

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -1344,7 +1344,7 @@ impl RpcApi {
             .add_declare_transaction(
                 contract_class,
                 // actual address dumped from a `starknet declare` call
-                ContractAddress(crate::starkhash!("01")),
+                ContractAddress::new_or_panic(crate::starkhash!("01")),
                 Fee(0u128.to_be_bytes().into()),
                 vec![],
                 TransactionNonce(StarkHash::ZERO),

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -1239,11 +1239,13 @@ pub mod reply {
                                 Transaction::Declare(DeclareTransaction {
                                     common: common.clone(),
                                     class_hash: ClassHash(starkhash!("09")),
-                                    sender_address: ContractAddress(starkhash!("0a")),
+                                    sender_address: ContractAddress::new_or_panic(starkhash!("0a")),
                                 }),
                                 Transaction::Invoke(InvokeTransaction {
                                     common,
-                                    contract_address: ContractAddress(starkhash!("0b")),
+                                    contract_address: ContractAddress::new_or_panic(starkhash!(
+                                        "0b"
+                                    )),
                                     entry_point_selector: EntryPoint(starkhash!("0c")),
                                     calldata: vec![CallParam(starkhash!("0d"))],
                                 }),
@@ -1253,7 +1255,9 @@ pub mod reply {
                                     version: TransactionVersion(
                                         web3::types::H256::from_low_u64_be(1),
                                     ),
-                                    contract_address: ContractAddress(starkhash!("0f")),
+                                    contract_address: ContractAddress::new_or_panic(starkhash!(
+                                        "0f"
+                                    )),
                                     contract_address_salt: ContractAddressSalt(starkhash!("ee")),
                                     class_hash: ClassHash(starkhash!("10")),
                                     constructor_calldata: vec![ConstructorParam(starkhash!("11"))],
@@ -1333,7 +1337,7 @@ pub mod reply {
                                 ))],
                             }),
                             events: vec![transaction_receipt::Event {
-                                from_address: ContractAddress(starkhash!("06")),
+                                from_address: ContractAddress::new_or_panic(starkhash!("06")),
                                 keys: vec![EventKey(starkhash!("07"))],
                                 data: vec![EventData(starkhash!("08"))],
                             }],
@@ -1362,7 +1366,7 @@ pub mod reply {
                                 ))],
                             }),
                             events: vec![transaction_receipt::Event {
-                                from_address: ContractAddress(starkhash!("a6")),
+                                from_address: ContractAddress::new_or_panic(starkhash!("a6")),
                                 keys: vec![EventKey(starkhash!("a7"))],
                                 data: vec![EventData(starkhash!("a8"))],
                             }],

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -442,21 +442,21 @@ pub mod test_utils {
     pub const INVALID_TX_HASH: StarknetTransactionHash = StarknetTransactionHash(starkhash!(
         "0393d8fab73af67e972788e603aee18130facd3c7685f16084ecd98b07153e24"
     ));
-    pub const VALID_CONTRACT_ADDR: ContractAddress = ContractAddress(starkhash!(
+    pub const VALID_CONTRACT_ADDR: ContractAddress = ContractAddress::new_or_panic(starkhash!(
         "06fbd460228d843b7fbef670ff15607bf72e19fa94de21e29811ada167b4ca39"
     ));
-    pub const INVALID_CONTRACT_ADDR: ContractAddress = ContractAddress(starkhash!(
+    pub const INVALID_CONTRACT_ADDR: ContractAddress = ContractAddress::new_or_panic(starkhash!(
         "05fbd460228d843b7fbef670ff15607bf72e19fa94de21e29811ada167b4ca39"
     ));
     pub const VALID_ENTRY_POINT: EntryPoint = EntryPoint(starkhash!(
         "0362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320"
     ));
     pub const INVALID_ENTRY_POINT: EntryPoint = EntryPoint(StarkHash::ZERO);
-    pub const VALID_KEY: StorageAddress = StorageAddress(starkhash!(
+    pub const VALID_KEY: StorageAddress = StorageAddress::new_or_panic(starkhash!(
         "0206F38F7E4F15E87567361213C28F235CCCDAA1D7FD34C9DB1DFE9489C6A091"
     ));
     lazy_static::lazy_static! {
-        pub static ref VALID_KEY_DEC: String = crate::rpc::serde::starkhash_to_dec_str(&VALID_KEY.0);
+        pub static ref VALID_KEY_DEC: String = crate::rpc::serde::starkhash_to_dec_str(VALID_KEY.get());
     }
     pub const VALID_CALL_DATA: [CallParam; 1] = [CallParam(starkhash!("04d2"))];
     /// Class hash for VALID_CONTRACT_ADDR
@@ -481,7 +481,7 @@ mod tests {
     impl std::fmt::Display for crate::core::ContractAddress {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut buf = [0u8; 2 + 64];
-            let s = self.0.as_hex_str(&mut buf);
+            let s = self.get().as_hex_str(&mut buf);
             f.write_str(s)
         }
     }
@@ -1155,7 +1155,7 @@ mod tests {
             let result = client
                 .storage(
                     VALID_CONTRACT_ADDR,
-                    StorageAddress(StarkHash::ZERO),
+                    StorageAddress::new_or_panic(StarkHash::ZERO),
                     BlockHashOrTag::Tag(Tag::Latest),
                 )
                 .await
@@ -1573,7 +1573,7 @@ mod tests {
             let error = client
                 .add_invoke_transaction(
                     Call {
-                        contract_address: ContractAddress(starkhash!(
+                        contract_address: ContractAddress::new_or_panic(starkhash!(
                             "023371b227eaecd8e8920cd429357edddd2cd0f3fee6abaacca08d3ab82a7cdd"
                         )),
                         calldata: vec![
@@ -1624,7 +1624,7 @@ mod tests {
             client
                 .add_invoke_transaction(
                     Call {
-                        contract_address: ContractAddress(starkhash!(
+                        contract_address: ContractAddress::new_or_panic(starkhash!(
                             "023371b227eaecd8e8920cd429357edddd2cd0f3fee6abaacca08d3ab82a7cdd"
                         )),
                         calldata: vec![
@@ -1695,7 +1695,7 @@ mod tests {
                 .add_declare_transaction(
                     contract_class,
                     // actual address dumped from a `starknet declare` call
-                    ContractAddress(starkhash!("01")),
+                    ContractAddress::new_or_panic(starkhash!("01")),
                     Fee(0u128.to_be_bytes().into()),
                     vec![],
                     TransactionNonce(StarkHash::ZERO),

--- a/crates/pathfinder/src/sequencer/builder.rs
+++ b/crates/pathfinder/src/sequencer/builder.rs
@@ -191,7 +191,7 @@ impl<'a> Request<'a, stage::Params> {
     }
 
     pub fn with_contract_address(self, address: ContractAddress) -> Self {
-        self.add_param("contractAddress", &address.0.to_hex_str())
+        self.add_param("contractAddress", &address.get().to_hex_str())
     }
 
     pub fn with_class_hash(self, class_hash: ClassHash) -> Self {
@@ -207,7 +207,7 @@ impl<'a> Request<'a, stage::Params> {
 
     pub fn with_storage_address(self, address: StorageAddress) -> Self {
         use crate::rpc::serde::starkhash_to_dec_str;
-        self.add_param("key", &starkhash_to_dec_str(&address.0))
+        self.add_param("key", &starkhash_to_dec_str(address.get()))
     }
 
     pub fn with_transaction_hash(self, hash: StarknetTransactionHash) -> Self {

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -459,7 +459,7 @@ pub mod state_update {
             use crate::starkhash;
 
             let expected = DeployedContract {
-                address: ContractAddress(starkhash!("01")),
+                address: ContractAddress::new_or_panic(starkhash!("01")),
                 class_hash: ClassHash(starkhash!("02")),
             };
 
@@ -551,7 +551,7 @@ pub mod add_transaction {
                 transaction_hash: StarknetTransactionHash(starkhash!(
                     "0296fb89b8a1c7487a1d4b27e1a1e33f440b05548e64980d06052bc089b1a51f"
                 )),
-                address: ContractAddress(starkhash!(
+                address: ContractAddress::new_or_panic(starkhash!(
                     "0677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1"
                 )),
             };

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -130,7 +130,7 @@ mod tests {
         // let s = crate::storage::Storage::in_memory().unwrap();
 
         // let contract_hash = ClassHash(StarkHash::from_hex_str("0x11").unwrap());
-        // let contract_addr = ContractAddress(StarkHash::from_hex_str("1").unwrap());
+        // let contract_addr = ContractAddress::new_or_panic(StarkHash::from_hex_str("1").unwrap());
         // let contract_deploy = DeployedContract {
         //     address: contract_addr,
         //     hash: contract_hash,
@@ -261,9 +261,9 @@ mod tests {
         // let unique_hash =
         //     ClassHash(StarkHash::from_be_slice(&b"this is unique contract"[..]).unwrap());
 
-        // let one = ContractAddress(StarkHash::from_hex_str("1").unwrap());
-        // let two = ContractAddress(StarkHash::from_hex_str("2").unwrap());
-        // let three = ContractAddress(StarkHash::from_hex_str("3").unwrap());
+        // let one = ContractAddress::new_or_panic(StarkHash::from_hex_str("1").unwrap());
+        // let two = ContractAddress::new_or_panic(StarkHash::from_hex_str("2").unwrap());
+        // let three = ContractAddress::new_or_panic(StarkHash::from_hex_str("3").unwrap());
 
         // let one_deploy = DeployedContract {
         //     address: one,
@@ -289,7 +289,7 @@ mod tests {
         //     contract_updates: vec![ContractUpdate {
         //         address: one,
         //         storage_updates: vec![StorageUpdate {
-        //             address: StorageAddress(StarkHash::from_hex_str("1").unwrap()),
+        //             address: StorageAddress::new_or_panic(StarkHash::from_hex_str("1").unwrap()),
         //             value: StorageValue(StarkHash::from_hex_str("dead").unwrap()),
         //         }],
         //     }],

--- a/crates/pathfinder/src/state/block_hash.rs
+++ b/crates/pathfinder/src/state/block_hash.rs
@@ -374,7 +374,7 @@ fn calculate_event_hash(event: &Event) -> StarkHash {
     let data_hash = data_hash.finalize();
 
     let mut event_hash = HashChain::default();
-    event_hash.update(event.from_address.0);
+    event_hash.update(*event.from_address.get());
     event_hash.update(keys_hash);
     event_hash.update(data_hash);
 
@@ -405,7 +405,7 @@ mod tests {
         use crate::core::{ContractAddress, EventData, EventKey};
 
         let event = Event {
-            from_address: ContractAddress(starkhash!("deadbeef")),
+            from_address: ContractAddress::new_or_panic(starkhash!("deadbeef")),
             data: vec![
                 EventData(starkhash!("05")),
                 EventData(starkhash!("06")),
@@ -435,7 +435,7 @@ mod tests {
 
         let transaction = Transaction::Invoke(InvokeTransaction {
             calldata: vec![],
-            contract_address: ContractAddress(starkhash!("deadbeef")),
+            contract_address: ContractAddress::new_or_panic(starkhash!("deadbeef")),
             entry_point_type: EntryPointType::External,
             entry_point_selector: EntryPoint(starkhash!("0e")),
             max_fee: Fee(0u128.to_be_bytes().into()),

--- a/crates/pathfinder/src/state/class_hash.rs
+++ b/crates/pathfinder/src/state/class_hash.rs
@@ -408,7 +408,7 @@ mod json {
             let contract = crate::starkhash!(
                 "0546BA9763D33DC59A070C0D87D94F2DCAFA82C4A93B5E2BF5AE458B0013A9D3"
             );
-            let contract = crate::core::ContractAddress(contract);
+            let contract = crate::core::ContractAddress::new_or_panic(contract);
 
             let chain = crate::core::Chain::Goerli;
             let sequencer = crate::sequencer::Client::new(chain).unwrap();
@@ -431,7 +431,7 @@ mod json {
             use crate::starkhash;
 
             // Known contract which triggered a hash mismatch failure.
-            let address = ContractAddress(starkhash!(
+            let address = ContractAddress::new_or_panic(starkhash!(
                 "0400D86342F474F14AAE562587F30855E127AD661F31793C49414228B54516EC"
             ));
 

--- a/crates/pathfinder/src/state/state_tree.rs
+++ b/crates/pathfinder/src/state/state_tree.rs
@@ -29,12 +29,12 @@ impl<'a> ContractsStateTree<'a> {
 
     #[allow(dead_code)]
     pub fn get(&self, address: StorageAddress) -> anyhow::Result<StorageValue> {
-        let value = self.tree.get(address.0.view_bits())?;
+        let value = self.tree.get(address.view_bits())?;
         Ok(StorageValue(value))
     }
 
     pub fn set(&mut self, address: StorageAddress, value: StorageValue) -> anyhow::Result<()> {
-        self.tree.set(address.0.view_bits(), value.0)
+        self.tree.set(address.view_bits(), value.0)
     }
 
     /// Applies and persists any changes. Returns the new tree root.
@@ -59,7 +59,7 @@ impl<'a> GlobalStateTree<'a> {
     }
 
     pub fn get(&self, address: ContractAddress) -> anyhow::Result<ContractStateHash> {
-        let value = self.tree.get(address.0.view_bits())?;
+        let value = self.tree.get(address.view_bits())?;
         Ok(ContractStateHash(value))
     }
 
@@ -68,7 +68,7 @@ impl<'a> GlobalStateTree<'a> {
         address: ContractAddress,
         value: ContractStateHash,
     ) -> anyhow::Result<()> {
-        self.tree.set(address.0.view_bits(), value.0)
+        self.tree.set(address.view_bits(), value.0)
     }
 
     /// Applies and persists any changes. Returns the new global root.

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -580,9 +580,9 @@ mod tests {
             static ref GLOBAL_ROOT2_V2: GlobalRoot = GlobalRoot(StarkHash::from_be_slice(b"global root 2 v2").unwrap());
             static ref GLOBAL_ROOT3: GlobalRoot = GlobalRoot(StarkHash::from_be_slice(b"global root 3").unwrap());
 
-            static ref CONTRACT0_ADDR: ContractAddress = ContractAddress(StarkHash::from_be_slice(b"contract 0 addr").unwrap());
-            static ref CONTRACT0_ADDR_V2: ContractAddress = ContractAddress(StarkHash::from_be_slice(b"contract 0 addr v2").unwrap());
-            static ref CONTRACT1_ADDR: ContractAddress = ContractAddress(StarkHash::from_be_slice(b"contract 1 addr").unwrap());
+            static ref CONTRACT0_ADDR: ContractAddress = ContractAddress::new_or_panic(StarkHash::from_be_slice(b"contract 0 addr").unwrap());
+            static ref CONTRACT0_ADDR_V2: ContractAddress = ContractAddress::new_or_panic(StarkHash::from_be_slice(b"contract 0 addr v2").unwrap());
+            static ref CONTRACT1_ADDR: ContractAddress = ContractAddress::new_or_panic(StarkHash::from_be_slice(b"contract 1 addr").unwrap());
 
             static ref CONTRACT0_HASH: ClassHash = ClassHash(
                 StarkHash::from_hex_str(
@@ -607,8 +607,8 @@ mod tests {
             static ref CONTRACT0_DEF_V2: bytes::Bytes = bytes::Bytes::from(format!("{}0 v2{}", DEF0, DEF1));
             static ref CONTRACT1_DEF: bytes::Bytes = bytes::Bytes::from(format!("{}1{}", DEF0, DEF1));
 
-            static ref STORAGE_KEY0: StorageAddress = StorageAddress(StarkHash::from_be_slice(b"contract 0 storage addr 0").unwrap());
-            static ref STORAGE_KEY1: StorageAddress = StorageAddress(StarkHash::from_be_slice(b"contract 1 storage addr 0").unwrap());
+            static ref STORAGE_KEY0: StorageAddress = StorageAddress::new_or_panic(StarkHash::from_be_slice(b"contract 0 storage addr 0").unwrap());
+            static ref STORAGE_KEY1: StorageAddress = StorageAddress::new_or_panic(StarkHash::from_be_slice(b"contract 1 storage addr 0").unwrap());
 
             static ref STORAGE_VAL0: StorageValue = StorageValue(StarkHash::from_be_slice(b"contract 0 storage val 0").unwrap());
             static ref STORAGE_VAL0_V2: StorageValue = StorageValue(StarkHash::from_be_slice(b"contract 0 storage val 0 v2").unwrap());

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -263,7 +263,7 @@ pub(crate) mod test_utils {
                     calldata: vec![CallParam(
                         StarkHash::from_hex_str(&"0".repeat(i + 3)).unwrap(),
                     )],
-                    contract_address: ContractAddress(
+                    contract_address: ContractAddress::new_or_panic(
                         StarkHash::from_hex_str(&"1".repeat(i + 3)).unwrap(),
                     ),
                     entry_point_selector: EntryPoint(
@@ -288,7 +288,7 @@ pub(crate) mod test_utils {
                 .contains(&x) =>
             {
                 transaction::Transaction::Deploy(DeployTransaction {
-                    contract_address: ContractAddress(
+                    contract_address: ContractAddress::new_or_panic(
                         StarkHash::from_hex_str(&"5".repeat(i + 3)).unwrap(),
                     ),
                     contract_address_salt: ContractAddressSalt(
@@ -307,7 +307,7 @@ pub(crate) mod test_utils {
                 class_hash: ClassHash(StarkHash::from_hex_str(&"a".repeat(i + 3)).unwrap()),
                 max_fee: Fee(H128::zero()),
                 nonce: TransactionNonce(StarkHash::from_hex_str(&"b".repeat(i + 3)).unwrap()),
-                sender_address: ContractAddress(
+                sender_address: ContractAddress::new_or_panic(
                     StarkHash::from_hex_str(&"c".repeat(i + 3)).unwrap(),
                 ),
                 signature: vec![TransactionSignatureElem(
@@ -323,7 +323,7 @@ pub(crate) mod test_utils {
             actual_fee: None,
             events: if i % TRANSACTIONS_PER_BLOCK < EVENTS_PER_BLOCK {
                 vec![transaction::Event {
-                    from_address: ContractAddress(
+                    from_address: ContractAddress::new_or_panic(
                         StarkHash::from_hex_str(&"2".repeat(i + 3)).unwrap(),
                     ),
                     data: vec![EventData(

--- a/crates/pathfinder/src/storage/contract.rs
+++ b/crates/pathfinder/src/storage/contract.rs
@@ -7,7 +7,6 @@ use anyhow::Context;
 use flate2::{write::GzEncoder, Compression};
 use rusqlite::{named_params, Connection, OptionalExtension, Transaction};
 
-
 /// Stores StarkNet contract information, specifically a contract's
 ///
 /// - [hash](ClassHash)

--- a/crates/pathfinder/src/storage/fixtures.rs
+++ b/crates/pathfinder/src/storage/fixtures.rs
@@ -52,19 +52,19 @@ impl StateUpdate {
             old_root: GlobalRoot(hash!(2, h)),
             state_diff: StateDiff {
                 storage_diffs: vec![StorageDiff {
-                    address: ContractAddress(hash!(3, h)),
-                    key: StorageAddress(hash!(4, h)),
+                    address: ContractAddress::new_or_panic(hash!(3, h)),
+                    key: StorageAddress::new_or_panic(hash!(4, h)),
                     value: StorageValue(hash!(5, h)),
                 }],
                 declared_contracts: vec![DeclaredContract {
                     class_hash: ClassHash(hash!(6, h)),
                 }],
                 deployed_contracts: vec![DeployedContract {
-                    address: ContractAddress(hash!(7, h)),
+                    address: ContractAddress::new_or_panic(hash!(7, h)),
                     class_hash: ClassHash(hash!(8, h)),
                 }],
                 nonces: vec![Nonce {
-                    contract_address: ContractAddress(hash!(9, h)),
+                    contract_address: ContractAddress::new_or_panic(hash!(9, h)),
                     nonce: ContractNonce(hash!(10, h)),
                 }],
             },

--- a/crates/pathfinder/src/storage/schema/revision_0007.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0007.rs
@@ -314,7 +314,7 @@ pub(crate) fn migrate_with(
                         ":block_number": block_number,
                         ":idx": idx,
                         ":transaction_hash": transaction_hash,
-                        ":from_address": &tx.contract_address.0.as_be_bytes()[..],
+                        ":from_address": tx.contract_address,
                         ":keys": &serialized_keys,
                         ":data": &serialized_data,
                     ]

--- a/crates/pathfinder/src/storage/schema/revision_0011.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0011.rs
@@ -78,7 +78,7 @@ pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<()> {
                     .execute(named_params![
                         ":idx": idx,
                         ":transaction_hash": transaction_hash,
-                        ":from_address": &event.from_address.0.as_be_bytes()[..],
+                        ":from_address": event.from_address,
                     ])
                     .context("Insert event data into events table")?;
 

--- a/crates/pathfinder/src/storage/schema/revision_0015.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0015.rs
@@ -3,7 +3,7 @@ use rusqlite::{named_params, Transaction as RusqliteTransaction};
 
 use web3::types::H128;
 
-use crate::core::{Fee};
+use crate::core::Fee;
 
 // This is a copy of the sequencer reply types _without_ deny_unknown_fields
 // The point is that with the old `struct Transaction` we had some optional

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -1988,7 +1988,7 @@ mod tests {
         #[test]
         fn event_keys_to_base64_strings() {
             let event = transaction::Event {
-                from_address: ContractAddress(starkhash!(
+                from_address: ContractAddress::new_or_panic(starkhash!(
                     "06fbd460228d843b7fbef670ff15607bf72e19fa94de21e29811ada167b4ca39"
                 )),
                 data: vec![],
@@ -2049,7 +2049,7 @@ mod tests {
                 .map(|idx| Event {
                     data: Vec::new(),
                     keys: Vec::new(),
-                    from_address: ContractAddress(
+                    from_address: ContractAddress::new_or_panic(
                         StarkHash::from_be_slice(&idx.to_be_bytes()).unwrap(),
                     ),
                 })
@@ -2069,7 +2069,7 @@ mod tests {
                 transaction::Transaction::Invoke(transaction::InvokeTransaction {
                     calldata: vec![],
                     // Only required because event insert rejects if this is None
-                    contract_address: ContractAddress(StarkHash::ZERO),
+                    contract_address: ContractAddress::new_or_panic(StarkHash::ZERO),
                     entry_point_type: transaction::EntryPointType::External,
                     entry_point_selector: EntryPoint(StarkHash::ZERO),
                     max_fee: Fee(H128::zero()),
@@ -2079,7 +2079,7 @@ mod tests {
                 transaction::Transaction::Invoke(transaction::InvokeTransaction {
                     calldata: vec![],
                     // Only required because event insert rejects if this is None
-                    contract_address: ContractAddress(StarkHash::ZERO),
+                    contract_address: ContractAddress::new_or_panic(StarkHash::ZERO),
                     entry_point_type: transaction::EntryPointType::External,
                     entry_point_selector: EntryPoint(StarkHash::ZERO),
                     max_fee: Fee(H128::zero()),

--- a/crates/stark_hash/src/hash.rs
+++ b/crates/stark_hash/src/hash.rs
@@ -200,7 +200,7 @@ impl StarkHash {
     ///
     /// Every [`StarkHash`] that is used to traverse a Merkle-Patricia Tree
     /// must not exceed 251 bits, since 251 is the height of the tree.
-    pub fn has_more_than_251_bits(&self) -> bool {
+    pub const fn has_more_than_251_bits(&self) -> bool {
         self.0[0] & 0b1111_1000 > 0
     }
 


### PR DESCRIPTION
On the roll; similar to #510 but this time for 251-bit types.

Nothing to review for Michael, just had to constify the previously forgotten `has_more_than_251_bits()`.

Should be ready to go but this depends on #510.