### PR TITLE
feat: monitoring endpoints

### DIFF
--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -62,7 +62,6 @@ mockall = "0.11.0"
 pretty_assertions = "1.0.0"
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
 tokio = { version = "1.11.0", features = ["test-util"] }
-warp = "0.3.2"
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["git"] }

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -49,6 +49,7 @@ tokio-retry = "0.3.0"
 toml = "0.5.8"
 tracing = "0.1.31"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
+warp = "0.3.2"
 web3 = "0.18.0"
 zstd = "0.10"
 

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -29,6 +29,8 @@ pub enum ConfigOption {
     EnableSQLiteWriteAheadLogging,
     /// Enable pending polling.
     PollPending,
+    /// Enables and sets the monitoring endpoint
+    MonitorAddress,
 }
 
 impl Display for ConfigOption {
@@ -44,6 +46,7 @@ impl Display for ConfigOption {
                 f.write_str("Enable SQLite write-ahead logging")
             }
             ConfigOption::PollPending => f.write_str("Enable pending block polling"),
+            ConfigOption::MonitorAddress => f.write_str("Pathfinder monitoring address"),
         }
     }
 }
@@ -74,6 +77,8 @@ pub struct Configuration {
     pub sqlite_wal: bool,
     /// Enable pending polling.
     pub poll_pending: bool,
+    /// The node's monitoring address and port.
+    pub monitoring_addr: Option<SocketAddr>,
 }
 
 impl Configuration {

--- a/crates/pathfinder/src/config/builder.rs
+++ b/crates/pathfinder/src/config/builder.rs
@@ -75,6 +75,21 @@ Hint: Register your own account or run your own Ethereum node and put the real U
             None => None,
         };
 
+        let monitoring_addr = self
+            .take(ConfigOption::MonitorAddress)
+            .map(|addr| {
+                addr.parse::<SocketAddr>().map_err(|err| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        format!(
+                            "Invalid monitoring listening interface and port ({}): {}",
+                            addr, err
+                        ),
+                    )
+                })
+            })
+            .transpose()?;
+
         // Optional parameters with defaults.
         let data_directory = self
             .take(ConfigOption::DataDirectory)
@@ -158,6 +173,7 @@ Hint: Register your own account or run your own Ethereum node and put the real U
             python_subprocesses,
             sqlite_wal,
             poll_pending,
+            monitoring_addr,
         })
     }
 

--- a/crates/pathfinder/src/config/file.rs
+++ b/crates/pathfinder/src/config/file.rs
@@ -24,6 +24,8 @@ struct FileConfig {
     sqlite_wal: Option<String>,
     #[serde(rename = "poll-pending")]
     poll_pending: Option<String>,
+    #[serde(rename = "monitor-address")]
+    monitor_address: Option<String>,
 }
 
 impl FileConfig {
@@ -41,6 +43,7 @@ impl FileConfig {
         .with(ConfigOption::PythonSubprocesses, self.python_subprocesses)
         .with(ConfigOption::EnableSQLiteWriteAheadLogging, self.sqlite_wal)
         .with(ConfigOption::PollPending, self.poll_pending)
+        .with(ConfigOption::MonitorAddress, self.monitor_address)
     }
 }
 
@@ -143,6 +146,14 @@ password = "{}""#,
         let toml = format!(r#"poll-pending = "{}""#, value);
         let mut cfg = config_from_str(&toml).unwrap();
         assert_eq!(cfg.take(ConfigOption::PollPending), Some(value));
+    }
+
+    #[test]
+    fn monitor_address() {
+        let value = "address".to_owned();
+        let toml = format!(r#"monitor-address = "{}""#, value);
+        let mut cfg = config_from_str(&toml).unwrap();
+        assert_eq!(cfg.take(ConfigOption::MonitorAddress), Some(value));
     }
 
     #[test]

--- a/crates/pathfinder/src/lib.rs
+++ b/crates/pathfinder/src/lib.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod consts;
 pub mod core;
 pub mod ethereum;
+pub mod monitoring;
 pub mod retry;
 pub mod rpc;
 pub mod sequencer;

--- a/crates/pathfinder/src/monitoring.rs
+++ b/crates/pathfinder/src/monitoring.rs
@@ -1,29 +1,71 @@
+use std::sync::atomic::AtomicBool;
+
 use warp::Filter;
 
 /// Spawns a server which hosts a `/health` endpoint.
 pub async fn spawn_server(
     addr: impl Into<std::net::SocketAddr> + 'static,
+    readiness: std::sync::Arc<AtomicBool>,
 ) -> tokio::task::JoinHandle<()> {
-    let health = health_filter();
-
-    let server = warp::serve(health);
+    let server = warp::serve(routes(readiness));
     let server = server.bind(addr);
 
     tokio::spawn(async move { server.await })
 }
 
+fn routes(
+    readiness: std::sync::Arc<AtomicBool>,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    health_route().or(ready_route(readiness))
+}
+
 /// Always returns `Ok(200)` at `/health`.
-fn health_filter() -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+fn health_route() -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::get().and(warp::path!("health")).map(warp::reply)
+}
+
+/// Returns `Ok` if `readiness == true`, or `SERVICE_UNAVAILABLE` otherwise.
+fn ready_route(
+    readiness: std::sync::Arc<AtomicBool>,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    warp::get()
+        .and(warp::path!("ready"))
+        .map(move || -> std::sync::Arc<AtomicBool> { readiness.clone() })
+        .and_then(|readiness: std::sync::Arc<AtomicBool>| async move {
+            match readiness.load(std::sync::atomic::Ordering::Relaxed) {
+                true => Ok::<_, std::convert::Infallible>(warp::http::StatusCode::OK),
+                false => Ok(warp::http::StatusCode::SERVICE_UNAVAILABLE),
+            }
+        })
 }
 
 #[cfg(test)]
 mod tests {
+
     #[tokio::test]
-    async fn health_is_200() {
-        let filter = super::health_filter();
+    async fn health() {
+        use std::sync::atomic::AtomicBool;
+        use std::sync::Arc;
+
+        let readiness = Arc::new(AtomicBool::new(false));
+        let filter = super::routes(readiness);
         let response = warp::test::request().path("/health").reply(&filter).await;
 
-        assert_eq!(response.status(), 200);
+        assert_eq!(response.status(), http::StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn ready() {
+        use std::sync::atomic::AtomicBool;
+        use std::sync::Arc;
+
+        let readiness = Arc::new(AtomicBool::new(false));
+        let filter = super::routes(readiness.clone());
+        let response = warp::test::request().path("/ready").reply(&filter).await;
+        assert_eq!(response.status(), http::StatusCode::SERVICE_UNAVAILABLE);
+
+        readiness.store(true, std::sync::atomic::Ordering::Relaxed);
+        let response = warp::test::request().path("/ready").reply(&filter).await;
+        assert_eq!(response.status(), http::StatusCode::OK);
     }
 }

--- a/crates/pathfinder/src/monitoring.rs
+++ b/crates/pathfinder/src/monitoring.rs
@@ -1,0 +1,29 @@
+use warp::Filter;
+
+/// Spawns a server which hosts a `/health` endpoint.
+pub async fn spawn_server(
+    addr: impl Into<std::net::SocketAddr> + 'static,
+) -> tokio::task::JoinHandle<()> {
+    let health = health_filter();
+
+    let server = warp::serve(health);
+    let server = server.bind(addr);
+
+    tokio::spawn(async move { server.await })
+}
+
+/// Always returns `Ok(200)` at `/health`.
+fn health_filter() -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    warp::get().and(warp::path!("health")).map(warp::reply)
+}
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    async fn health_is_200() {
+        let filter = super::health_filter();
+        let response = warp::test::request().path("/health").reply(&filter).await;
+
+        assert_eq!(response.status(), 200);
+    }
+}


### PR DESCRIPTION
This PR adds a configurable monitoring endpoint, `--monitor-address` with `/health` and `/ready` routes.

This feature is disabled by default and becomes enabled when the monitoring address is configured.

`/health` always returns `OK` as our critical errors should always be fatal currently. We could try spend some more effort here, but I suspect it is not worth it at this time.

`/ready` returns `SERVICE_UNAVAILABLE` until all systems are up and running, and from then on returns `OK`.

We can add a `/metrics` route to this endpoint in the future.