### PR TITLE
refactor(stark_hash): replace rand with rand_core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2884,7 +2884,7 @@ dependencies = [
  "ff",
  "hex",
  "pretty_assertions",
- "rand",
+ "rand_core",
  "serde",
  "serde_json",
  "stark_curve",

--- a/crates/stark_hash/Cargo.toml
+++ b/crates/stark_hash/Cargo.toml
@@ -19,7 +19,7 @@ ff = { version = "0.12", default-features = false, features = [
     "derive",
     "alloc",
 ] }
-rand = "0.8"
+rand_core = "0.6.3"
 serde = "1.0.134"
 stark_curve = { path = "../stark_curve" }
 

--- a/crates/stark_hash/src/hash.rs
+++ b/crates/stark_hash/src/hash.rs
@@ -104,7 +104,7 @@ impl StarkHash {
         }
     }
 
-    pub fn random<R: rand::RngCore>(rng: R) -> Self {
+    pub fn random<R: rand_core::RngCore>(rng: R) -> Self {
         use ff::Field;
         StarkHash(FieldElement::random(rng).to_repr().0)
     }


### PR DESCRIPTION
I think libraries are meant to lean on rand_core, and we already need the rand over at pathfinder (bench) side.

Rand introduced in #515.