### PR TITLE
feat(storage): allow for forks

### DIFF
--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -693,7 +693,8 @@ mod tests {
         .unwrap();
 
         tx.execute(
-            "insert into starknet_blocks (hash, number, timestamp, root, gas_price) values (?, 1, 1, ?, X'01')",
+            r"insert into starknet_blocks (hash, number, timestamp, root, gas_price, sequencer_address, version_id) 
+              values (?, 1, 1, ?, X'01', X'0000000000000000000000000000000000000000000000000000000000000000', X'00')",
             rusqlite::params![
                 &StarkHash::from_be_slice(&b"some blockhash somewhere"[..])
                     .unwrap()

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -368,8 +368,8 @@ mod tests {
         starkhash, starkhash_bytes,
         state::{state_tree::GlobalStateTree, PendingData, SyncState},
         storage::{
-            ContractCodeTable, ContractsTable, StarknetBlock, StarknetBlocksTable,
-            StarknetTransactionsTable, Storage,
+            CanonicalBlocksTable, ContractCodeTable, ContractsTable, StarknetBlock,
+            StarknetBlocksTable, StarknetTransactionsTable, Storage,
         },
     };
     use assert_matches::assert_matches;
@@ -508,6 +508,10 @@ mod tests {
         StarknetBlocksTable::insert(&db_txn, &block0, None).unwrap();
         StarknetBlocksTable::insert(&db_txn, &block1, None).unwrap();
         StarknetBlocksTable::insert(&db_txn, &block2, None).unwrap();
+
+        CanonicalBlocksTable::insert(&db_txn, block0.number, block0.hash).unwrap();
+        CanonicalBlocksTable::insert(&db_txn, block1.number, block1.hash).unwrap();
+        CanonicalBlocksTable::insert(&db_txn, block2.number, block2.hash).unwrap();
 
         let txn0_hash = StarknetTransactionHash(starkhash_bytes!(b"txn 0"));
         // TODO introduce other types of transactions too

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -15,9 +15,9 @@ use std::path::{Path, PathBuf};
 pub use contract::{ContractCodeTable, ContractsTable};
 pub use ethereum::{EthereumBlocksTable, EthereumTransactionsTable};
 pub use state::{
-    ContractsStateTable, EventFilterError, L1StateTable, L1TableBlockId, RefsTable, StarknetBlock,
-    StarknetBlocksBlockId, StarknetBlocksTable, StarknetEmittedEvent, StarknetEventFilter,
-    StarknetEventsTable, StarknetStateUpdatesTable, StarknetTransactionsTable,
+    CanonicalBlocksTable, ContractsStateTable, EventFilterError, L1StateTable, L1TableBlockId,
+    RefsTable, StarknetBlock, StarknetBlocksBlockId, StarknetBlocksTable, StarknetEmittedEvent,
+    StarknetEventFilter, StarknetEventsTable, StarknetStateUpdatesTable, StarknetTransactionsTable,
 };
 
 use anyhow::Context;
@@ -376,6 +376,8 @@ pub(crate) mod test_utils {
 
     /// Creates a storage instance in memory with a set of expected emitted events
     pub(crate) fn setup_test_storage() -> (Storage, Vec<StarknetEmittedEvent>) {
+        use crate::storage::CanonicalBlocksTable;
+
         let storage = Storage::in_memory().unwrap();
         let mut connection = storage.connection().unwrap();
         let tx = connection.transaction().unwrap();
@@ -385,6 +387,7 @@ pub(crate) mod test_utils {
 
         for (i, block) in blocks.iter().enumerate() {
             StarknetBlocksTable::insert(&tx, block, None).unwrap();
+            CanonicalBlocksTable::insert(&tx, block.number, block.hash).unwrap();
             StarknetTransactionsTable::upsert(
                 &tx,
                 block.hash,

--- a/crates/pathfinder/src/storage/schema.rs
+++ b/crates/pathfinder/src/storage/schema.rs
@@ -15,6 +15,7 @@ mod revision_0014;
 mod revision_0015;
 mod revision_0016;
 mod revision_0017;
+mod revision_0018;
 
 type MigrationFn = fn(&rusqlite::Transaction<'_>) -> anyhow::Result<()>;
 
@@ -39,5 +40,6 @@ pub fn migrations() -> &'static [MigrationFn] {
         revision_0015::migrate,
         revision_0016::migrate,
         revision_0017::migrate,
+        revision_0018::migrate,
     ]
 }

--- a/crates/pathfinder/src/storage/schema/revision_0018.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0018.rs
@@ -1,0 +1,202 @@
+use anyhow::Context;
+use rusqlite::Transaction;
+
+/// Primary goal of this migration is to allow for StarkNet block forks.
+///
+/// This is achieved by re-creating the `starknet_blocks` table, shifting the PK
+/// from `number` to `hash`. This in turn requires re-creating any tables with a FK
+/// on the original `starknet_blocks` table.
+///
+/// In addition, a `canonical_blocks` table is created to track the canonical block chain
+/// now that forks are allowed in `starknet_blocks`.
+pub(crate) fn migrate(tx: &Transaction<'_>) -> anyhow::Result<()> {
+    tx.execute(
+        r"-- Stores StarkNet block headers.
+CREATE TABLE starknet_blocks_new (
+    hash      BLOB    PRIMARY KEY NOT NULL,
+    number    INTEGER NOT NULL,
+    root      BLOB    NOT NULL,
+    timestamp INTEGER NOT NULL, 
+    gas_price BLOB    NOT NULL,
+    sequencer_address BLOB NOT NULL,
+    version_id INTEGER REFERENCES starknet_versions(id)
+)",
+        [],
+    )
+    .context("Creating new starknet_blocks table")?;
+
+    tx.execute(
+        "INSERT INTO starknet_blocks_new(hash,number,root,timestamp,gas_price) SELECT hash,number,root,timestamp,gas_price FROM starknet_blocks",
+        [],
+    )
+    .context("Copying starknet_blocks data")?;
+
+    create_canonical_chain(tx).context("Creating canonical_blocks table")?;
+    migrate_state_updates(tx).context("Migrating starknet_state_updates table")?;
+    migrate_events(tx).context("Migrating starknet_events table")?;
+
+    tx.execute("DROP TABLE starknet_blocks", [])
+        .context("Dropping old starknet_blocks table")?;
+    tx.execute(
+        "ALTER TABLE starknet_blocks_new RENAME TO starknet_blocks",
+        [],
+    )
+    .context("Renaming new starknet_blocks table")?;
+
+    Ok(())
+}
+
+/// Re-creates the `starknet_state_updates_new` table, updating the `block_hash` FK to
+/// reference the new `starknet_blocks_new` table.
+fn migrate_state_updates(tx: &Transaction<'_>) -> anyhow::Result<()> {
+    tx.execute(
+        r"-- Stores StarkNet state updates. 
+CREATE TABLE starknet_state_updates_new (
+    block_hash BLOB PRIMARY KEY NOT NULL,
+    data BLOB NOT NULL,
+    FOREIGN KEY(block_hash) REFERENCES starknet_blocks_new(hash) ON DELETE CASCADE
+)",
+        [],
+    )
+    .context("Creating new table")?;
+
+    tx.execute(
+        "INSERT INTO starknet_state_updates_new(block_hash, data) SELECT block_hash, data FROM starknet_state_updates",
+        [],
+    )
+    .context("Copying data")?;
+
+    tx.execute("DROP TABLE starknet_state_updates", [])
+        .context("Dropping old table")?;
+    tx.execute(
+        "ALTER TABLE starknet_state_updates_new RENAME TO starknet_state_updates",
+        [],
+    )
+    .context("Renaming new table")?;
+
+    Ok(())
+}
+
+/// Re-creates the `starknet_events` events table, updating the `block_number` FK
+/// to reference the `canonical_blocks` table instead.
+fn migrate_events(tx: &Transaction<'_>) -> anyhow::Result<()> {
+    tx.execute(
+        r"CREATE TABLE starknet_events_new (
+    block_number  INTEGER NOT NULL,
+    idx INTEGER NOT NULL,
+    transaction_hash BLOB NOT NULL,
+    from_address BLOB NOT NULL,
+    -- Keys are represented as base64 encoded strings separated by space
+    keys TEXT,
+    data BLOB,
+    FOREIGN KEY(block_number) REFERENCES canonical_blocks(number) ON DELETE CASCADE
+)",
+        [],
+    )
+    .context("Creating new table")?;
+
+    tx.execute(
+        r"-- Copy rowids to be sure that starknet_events_keys still references valid rows
+INSERT INTO starknet_events_new (rowid,block_number,idx,transaction_hash,from_address,keys,data)
+    SELECT rowid,block_number,idx,transaction_hash,from_address,keys,data FROM starknet_events",
+        [],
+    )
+    .context("Copying data")?;
+
+    // CREATE INDEX starknet_events_block_number ON starknet_events(block_number);
+    // CREATE INDEX starknet_events_from_address ON starknet_events(from_address);
+
+    tx.execute("DROP TABLE starknet_events", [])
+        .context("Dropping old table")?;
+
+    tx.execute(
+        "ALTER TABLE starknet_events_new RENAME TO starknet_events",
+        [],
+    )
+    .context("Renaming new table")?;
+
+    // Re-create triggers.
+    tx.execute(
+        r"CREATE TRIGGER starknet_events_ai
+    AFTER INSERT ON starknet_events
+    BEGIN
+        INSERT INTO starknet_events_keys(rowid, keys)
+        VALUES (
+            new.rowid,
+            new.keys
+        );
+    END;",
+        [],
+    )
+    .context("Creating after insert trigger")?;
+
+    tx.execute(
+        r"CREATE TRIGGER starknet_events_ad
+    AFTER DELETE ON starknet_events
+    BEGIN
+        INSERT INTO starknet_events_keys(starknet_events_keys, rowid, keys)
+        VALUES (
+            'delete',
+            old.rowid,
+            old.keys
+        );
+    END;",
+        [],
+    )
+    .context("Creating delete trigger")?;
+
+    tx.execute(
+        r"CREATE TRIGGER starknet_events_au
+    AFTER UPDATE ON starknet_events
+    BEGIN
+        INSERT INTO starknet_events_keys(starknet_events_keys, rowid, keys)
+        VALUES (
+            'delete',
+            old.rowid,
+            old.keys
+        );
+        INSERT INTO starknet_events_keys(rowid, keys)
+        VALUES (
+            new.rowid,
+            new.keys
+        );
+    END;",
+        [],
+    )
+    .context("Creating update trigger")?;
+
+    // Re-create indexs
+    tx.execute(
+        "CREATE INDEX starknet_events_block_number ON starknet_events(block_number)",
+        [],
+    )
+    .context("Creating block_number index")?;
+    tx.execute(
+        "CREATE INDEX starknet_events_from_address ON starknet_events(from_address)",
+        [],
+    )
+    .context("Creating from_address index")?;
+
+    Ok(())
+}
+
+/// Creates a new `canonical_blocks` table which holds the canonical StarkNet block chain.
+fn create_canonical_chain(tx: &Transaction<'_>) -> anyhow::Result<()> {
+    tx.execute(
+        r"-- Holds StarkNet's current canonical chain of blocks.
+CREATE TABLE canonical_blocks (
+    number INTEGER PRIMARY KEY NOT NULL,
+    hash   BLOB    NOT NULL,
+    FOREIGN KEY(hash) REFERENCES starknet_blocks_new(hash)
+)",
+        [],
+    )
+    .context("Creating table")?;
+    tx.execute(
+        "INSERT INTO canonical_blocks (number,hash) SELECT number, hash FROM starknet_blocks_new",
+        [],
+    )
+    .context("Inserting data")?;
+
+    Ok(())
+}

--- a/crates/pathfinder/src/storage/schema/revision_0018.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0018.rs
@@ -69,6 +69,17 @@ CREATE TABLE starknet_blocks_new (
 /// Re-creates the `starknet_events` events table, updating the `block_number` FK
 /// to reference the `canonical_blocks` table instead.
 fn migrate_events(tx: &Transaction<'_>) -> anyhow::Result<()> {
+    let row_count: usize = tx
+        .query_row("SELECT count(1) FROM starknet_events", [], |r| r.get(0))
+        .context("Count rows in starknet_events table")?;
+
+    if row_count > 0 {
+        tracing::info!(
+            %row_count,
+            "Migrating events table, this may take a while",
+        );
+    }
+
     tx.execute(
         r"CREATE TABLE starknet_events_new (
     id INTEGER PRIMARY KEY NOT NULL,

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -2147,6 +2147,7 @@ mod tests {
             let tx = connection.transaction().unwrap();
 
             StarknetBlocksTable::insert(&tx, &block, None).unwrap();
+            CanonicalBlocksTable::insert(&tx, block.number, block.hash).unwrap();
             StarknetTransactionsTable::upsert(
                 &tx,
                 block.hash,

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -508,7 +508,8 @@ impl StarknetTransactionsTable {
                 ]).context("Insert transaction data into transactions table")?;
 
             // insert events from receipt
-            StarknetEventsTable::insert_events(tx, block_number, transaction, &receipt.events)?;
+            StarknetEventsTable::insert_events(tx, block_number, transaction, &receipt.events)
+                .context("Inserting events")?;
         }
 
         Ok(())

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -1258,6 +1258,15 @@ impl CanonicalBlocksTable {
 
         Ok(())
     }
+
+    /// Removes all rows where `number >= reorg_tail`.
+    pub fn reorg(tx: &Transaction<'_>, reorg_tail: StarknetBlockNumber) -> anyhow::Result<()> {
+        tx.execute(
+            "DELETE FROM canonical_blocks WHERE number >= ?",
+            [reorg_tail],
+        )?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -1241,6 +1241,24 @@ impl StarknetStateUpdatesTable {
     }
 }
 
+/// Stores the canonical StarkNet block chain.
+pub struct CanonicalBlocksTable {}
+impl CanonicalBlocksTable {
+    pub fn insert(
+        tx: &Transaction<'_>,
+        number: StarknetBlockNumber,
+        hash: StarknetBlockHash,
+    ) -> anyhow::Result<()> {
+        let rows_changed = tx.execute(
+            "INSERT INTO canonical_blocks(number, hash) values(?,?)",
+            params![number, hash],
+        )?;
+        assert_eq!(rows_changed, 1);
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -7,7 +7,7 @@ from starkware.starkware_utils.error_handling import WebFriendlyException
 from starkware.storage.storage import Storage
 
 # used from tests, and the query which asserts that the schema is of expected version.
-EXPECTED_SCHEMA_REVISION = 17
+EXPECTED_SCHEMA_REVISION = 18
 EXPECTED_CAIRO_VERSION = "0.9.1"
 SUPPORTED_COMMANDS = frozenset(["call", "estimate_fee"])
 


### PR DESCRIPTION
### Description

This PR adds a migration which allows for forks in our database. This PR __does not__ make any large changes to how sync operates, nor does it change what the RPC API uses. This is purely to allow for forks with the database -- it does not build any in yet.

### Overview

To date `starknet_blocks` uses the block number as the primary key i.e. this must be unique. This allowed us to enforce only ever storing a single canonical chain of blocks. While useful, we now need to allow for forks to exist which will improve our ability to handle p2p situations.

This PR changes the primary key from block number to the hash instead. To achieve this with sqlite this requires recreating the table entirely.

### Tracking the canonical block chain

We still need to track the canonical chain somehow. This PR adds a new `canonical_blocks` table to do this.

### Events

`starknet_events` now references this `canonical_blocks` table instead of the `starknet_blocks` table. In order to do this, the table has to be re-created. This has the following implication:

> `starknet_getEvents` queries will only work on blocks within the canonical chain

This only matters if the event filter block range includes a hash which is on what we consider a fork. The alternative is creating a more manual (non-sqlite) paging function, where we iterate block-by-block backwards from the parent hash.

### Sync and RPC

These changes are intentionally minimal. The idea was to leave the status quo intact. Sync currently makes sure `starknet_blocks` and `canonical_blocks` are mirrors of each other -- i.e. we still only have a single canonical chain in both. This allows for RPC changing to incorporate the `canonical_blocks` table to be tackled in a separate PR.

### Original schema

This might help for reviewing the schema changes.

<details> <summary>expand</summary>

```sql
CREATE TABLE contract_code (
    hash       BLOB PRIMARY KEY,
    bytecode   BLOB,
    abi        BLOB,
    definition BLOB
);
CREATE TABLE contracts (
    address    BLOB PRIMARY KEY,
    hash       BLOB NOT NULL,

    FOREIGN KEY(hash) REFERENCES contract_code(hash)
);
CREATE TABLE contract_states (
    state_hash BLOB PRIMARY KEY,
    hash       BLOB NOT NULL,
    root       BLOB NOT NULL
);
CREATE TABLE l1_state (
    starknet_block_number      INTEGER PRIMARY KEY,
    starknet_global_root       BLOB    NOT NULL,
    ethereum_block_hash        BLOB    NOT NULL,
    ethereum_block_number      INTEGER NOT NULL,
    ethereum_transaction_hash  BLOB    NOT NULL,
    ethereum_transaction_index INTEGER NOT NULL,
    ethereum_log_index         INTEGER NOT NULL
);
CREATE TABLE starknet_blocks (
    number               INTEGER PRIMARY KEY,
    hash                 BLOB    NOT NULL,
    root                 BLOB    NOT NULL,
    timestamp            INTEGER NOT NULL, gas_price BLOB NOT NULL
    DEFAULT X'00000000000000000000000000000000', sequencer_address BLOB NOT NULL
    DEFAULT X'0000000000000000000000000000000000000000000000000000000000000000', version_id INTEGER REFERENCES starknet_versions(id)
);
CREATE TABLE refs (idx INTEGER PRIMARY KEY, l1_l2_head BLOB);
CREATE TABLE starknet_transactions (
    hash        BLOB PRIMARY KEY,
    idx         INTEGER NOT NULL,
    block_hash  BLOB NOT NULL,
    tx          BLOB,
    receipt     BLOB
);
CREATE TABLE tree_global(
    hash        BLOB PRIMARY KEY,
    data        BLOB,
    ref_count   INTEGER
);
CREATE TABLE tree_contracts(
    hash        BLOB PRIMARY KEY,
    data        BLOB,
    ref_count   INTEGER
);
CREATE INDEX starknet_transactions_block_hash ON starknet_transactions(block_hash);
CREATE TABLE IF NOT EXISTS "starknet_events" (
    id INTEGER PRIMARY KEY NOT NULL,
    block_number  INTEGER NOT NULL,
    idx INTEGER NOT NULL,
    transaction_hash BLOB NOT NULL,
    from_address BLOB NOT NULL,
    -- Keys are represented as base64 encoded strings separated by space
    keys TEXT,
    data BLOB,
    FOREIGN KEY(block_number) REFERENCES starknet_blocks(number)
    ON DELETE CASCADE
);
CREATE INDEX starknet_events_block_number ON starknet_events(block_number);
CREATE INDEX starknet_events_from_address ON starknet_events(from_address);
CREATE VIRTUAL TABLE starknet_events_keys USING fts5(
    keys,
    content='starknet_events',
    content_rowid='id',
    tokenize='ascii'
)
/* starknet_events_keys(keys) */;
CREATE TABLE IF NOT EXISTS 'starknet_events_keys_data'(id INTEGER PRIMARY KEY, block BLOB);
CREATE TABLE IF NOT EXISTS 'starknet_events_keys_idx'(segid, term, pgno, PRIMARY KEY(segid, term)) WITHOUT ROWID;
CREATE TABLE IF NOT EXISTS 'starknet_events_keys_docsize'(id INTEGER PRIMARY KEY, sz BLOB);
CREATE TABLE IF NOT EXISTS 'starknet_events_keys_config'(k PRIMARY KEY, v) WITHOUT ROWID;
CREATE TRIGGER starknet_events_ai
    AFTER INSERT ON starknet_events
    BEGIN
        INSERT INTO starknet_events_keys(rowid, keys)
        VALUES (
            new.id,
            new.keys
        );
    END;
CREATE TRIGGER starknet_events_ad
    AFTER DELETE ON starknet_events
    BEGIN
        INSERT INTO starknet_events_keys(starknet_events_keys, rowid, keys)
        VALUES (
            'delete',
            old.id,
            old.keys
        );
    END;
CREATE TRIGGER starknet_events_au
    AFTER UPDATE ON starknet_events
    BEGIN
        INSERT INTO starknet_events_keys(starknet_events_keys, rowid, keys)
        VALUES (
            'delete',
            old.id,
            old.keys
        );
        INSERT INTO starknet_events_keys(rowid, keys)
        VALUES (
            new.id,
            new.keys
        );
    END;
CREATE TABLE starknet_versions (id INTEGER NOT NULL PRIMARY KEY, version TEXT NOT NULL UNIQUE);
CREATE UNIQUE INDEX starknet_blocks_hash ON starknet_blocks(hash);
CREATE TABLE starknet_state_updates (
    block_hash BLOB PRIMARY KEY NOT NULL,
    data BLOB NOT NULL,
    FOREIGN KEY(block_hash) REFERENCES starknet_blocks(hash)
    ON DELETE CASCADE
);
```