### PR TITLE
fix(storage/schema): add migration step fixing starknet_events schema

### DIFF
--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -30,7 +30,7 @@ const DB_VERSION_EMPTY: u32 = 0;
 /// Current database version.
 ///
 /// **Make sure** `EXPECTED_SCHEMA_REVISION` in `call.py` is also updated every time the value is incremented.
-const DB_VERSION_CURRENT: u32 = 16;
+const DB_VERSION_CURRENT: u32 = 17;
 /// Sqlite key used for the PRAGMA user version.
 const VERSION_KEY: &str = "user_version";
 
@@ -168,6 +168,7 @@ fn migrate_database(connection: &mut Connection) -> anyhow::Result<()> {
             13 => schema::revision_0014::migrate(&transaction).context("migrating from 13")?,
             14 => schema::revision_0015::migrate(&transaction).context("migrating from 14")?,
             15 => schema::revision_0016::migrate(&transaction).context("migrating from 15")?,
+            16 => schema::revision_0017::migrate(&transaction).context("migrating from 16")?,
             _ => unreachable!("Database version constraint was already checked!"),
         };
         transaction

--- a/crates/pathfinder/src/storage/schema.rs
+++ b/crates/pathfinder/src/storage/schema.rs
@@ -14,3 +14,4 @@ pub(crate) mod revision_0013;
 pub(crate) mod revision_0014;
 pub(crate) mod revision_0015;
 pub(crate) mod revision_0016;
+pub(crate) mod revision_0017;

--- a/crates/pathfinder/src/storage/schema/revision_0012.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0012.rs
@@ -15,6 +15,10 @@ pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<()> {
         "Upgrading events table schema and re-indexing events, this may take a while.",
     );
 
+    migrate_events_schema(transaction)
+}
+
+pub(super) fn migrate_events_schema(transaction: &Transaction<'_>) -> Result<(), anyhow::Error> {
     // When altering a table in a way that requires recreating it through copying and deletion
     // it is [recommended](https://www.sqlite.org/lang_altertable.html) to:
     // 1. create the new table with some temporary name

--- a/crates/pathfinder/src/storage/schema/revision_0017.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0017.rs
@@ -1,0 +1,34 @@
+use anyhow::Context;
+use rusqlite::Transaction;
+
+/// Fixes starknet_events table schema.
+///
+/// Our revision 12 migration step had a bug: it didn't upgrade the events schema
+/// in case the events table was empty, leaving us with a database where the
+/// starknet_events table didn't have a stable rowid (via an INTEGER PRIMARY KEY).
+pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<()> {
+    if is_upgrade_required(transaction)? {
+        super::revision_0012::migrate_events_schema(transaction)?
+    }
+
+    Ok(())
+}
+
+fn is_upgrade_required(transaction: &Transaction<'_>) -> anyhow::Result<bool> {
+    let mut stmt = transaction
+        .prepare("SELECT sql FROM sqlite_schema where tbl_name = 'starknet_events'")
+        .context("Preparing statement")?;
+    let mut rows = stmt.query([]).context("Executing query")?;
+    // Unwrap is safe because the schema for this table obviously contains more than
+    // zero SQL statements since we're guaranteed to have the starknet_events table.
+    // The first statement of the schema for this table is the creation of the table
+    // which could be missing the `id` primary key column.
+    let contains_id_column = rows
+        .next()?
+        .unwrap()
+        .get_ref_unwrap("sql")
+        .as_str()?
+        .contains("id INTEGER PRIMARY KEY NOT NULL");
+
+    Ok(!contains_id_column)
+}

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -7,7 +7,7 @@ from starkware.starkware_utils.error_handling import WebFriendlyException
 from starkware.storage.storage import Storage
 
 # used from tests, and the query which asserts that the schema is of expected version.
-EXPECTED_SCHEMA_REVISION = 16
+EXPECTED_SCHEMA_REVISION = 17
 EXPECTED_CAIRO_VERSION = "0.9.1"
 SUPPORTED_COMMANDS = frozenset(["call", "estimate_fee"])
 


### PR DESCRIPTION
 Our revision 12 step failed to do the schema upgrade in case the events table was empty.
 
 This change adds a new step that checks if we have the explicit `id` primary key in the `starknet_events` table -- and re-does the actual schema migration step of revision 12 if it has not been done yet.