### PR TITLE
build: copy benches over as well

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN mkdir crates \
 COPY Cargo.toml Cargo.lock ./
 
 COPY crates/pathfinder/Cargo.toml crates/pathfinder/build.rs crates/pathfinder/
+COPY crates/pathfinder/benches crates/pathfinder/benches
 COPY crates/stark_curve/Cargo.toml crates/stark_curve/Cargo.toml
 COPY crates/stark_hash/Cargo.toml crates/stark_hash/Cargo.toml
 COPY crates/stark_hash/benches crates/stark_hash/benches


### PR DESCRIPTION
I missed this in #515; without it cargo build will not find the bench, and will feel bad about it.