### PR TITLE
docs(readme): update discord link again

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Pathfinder is currently in alpha so expect some rough edges but it is already us
 We appreciate any feedback, especially during this alpha period.
 This includes any documentation issues, feature requests and bugs that you may encounter.
 
-For help or to submit bug reports or feature requests, please open an issue or alternatively visit the StarkNet [discord channel](https://discord.gg/kk6z28VT).
+For help or to submit bug reports or feature requests, please open an issue or alternatively visit the StarkNet [discord channel](https://discord.com/invite/QypNMzkHbc).
 
 ## Installation (from source)
 


### PR DESCRIPTION
The previous PR's link was only valid for 7 days. This one is permanent and came from StarkWare.