### PR TITLE
build: rekey caches for mold, enable for fuzzing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,20 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly
+      - uses: rui314/setup-mold@v1
+        with:
+          mold-version: 1.4.1
+          make-default: false
+      - name: Enable mold
+        run: |
+          mkdir -p $HOME/.cargo
+          cat << EOF >> $HOME/.cargo/config.toml
+          [target.x86_64-unknown-linux-gnu]
+          linker = "/usr/bin/clang"
+          rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]
+          EOF
+
+          cat $HOME/.cargo/config.toml
       - uses: Swatinem/rust-cache@v1
       - run: cargo install cargo-fuzz
       - name: stark_hash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
 
           cat $HOME/.cargo/config.toml
       - uses: Swatinem/rust-cache@v1
+        with:
+          key: "mold"
       - run: |
           cargo test --no-run --workspace --locked
           timeout 5m cargo test -p pathfinder -- --skip ethereum::
@@ -137,6 +139,8 @@ jobs:
           cat $HOME/.cargo/config.toml
 
       - uses: Swatinem/rust-cache@v1
+        with:
+          key: "mold"
       - name: Integration (rust)
         run: |
           source py/.venv/bin/activate
@@ -165,6 +169,8 @@ jobs:
 
           cat $HOME/.cargo/config.toml
       - uses: Swatinem/rust-cache@v1
+        with:
+          key: "mold"
       - run: cargo install cargo-fuzz
       - name: stark_hash
         run: cargo fuzz build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v1
       - uses: rui314/setup-mold@v1
         with:
           mold-version: 1.4.1
@@ -28,6 +27,7 @@ jobs:
           EOF
 
           cat $HOME/.cargo/config.toml
+      - uses: Swatinem/rust-cache@v1
       - run: |
           cargo test --no-run --workspace --locked
           timeout 5m cargo test -p pathfinder -- --skip ethereum::
@@ -121,7 +121,6 @@ jobs:
           flake8 src/
 
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v1
       - uses: rui314/setup-mold@v1
         with:
           mold-version: 1.4.1
@@ -137,6 +136,7 @@ jobs:
 
           cat $HOME/.cargo/config.toml
 
+      - uses: Swatinem/rust-cache@v1
       - name: Integration (rust)
         run: |
           source py/.venv/bin/activate


### PR DESCRIPTION
Caching does not seem to get cleared in long runtime of https://github.com/eqlabs/pathfinder/actions/runs/2934439089, which is based on the merged main after #537. rust-cache's cache key generation should be sensitive to the configuration files, so lets see if this triggers a cache miss.

No it didn't, so trying with mold keyed caches. After merging to main and building there, we should see a rebased PR now use the caches.