### PR TITLE
Revert mold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v1
       - uses: rui314/setup-mold@v1
         with:
           mold-version: 1.4.1
@@ -27,9 +28,6 @@ jobs:
           EOF
 
           cat $HOME/.cargo/config.toml
-      - uses: Swatinem/rust-cache@v1
-        with:
-          key: "mold"
       - run: |
           cargo test --no-run --workspace --locked
           timeout 5m cargo test -p pathfinder -- --skip ethereum::
@@ -123,6 +121,7 @@ jobs:
           flake8 src/
 
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v1
       - uses: rui314/setup-mold@v1
         with:
           mold-version: 1.4.1
@@ -138,9 +137,6 @@ jobs:
 
           cat $HOME/.cargo/config.toml
 
-      - uses: Swatinem/rust-cache@v1
-        with:
-          key: "mold"
       - name: Integration (rust)
         run: |
           source py/.venv/bin/activate
@@ -154,23 +150,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly
-      - uses: rui314/setup-mold@v1
-        with:
-          mold-version: 1.4.1
-          make-default: false
-      - name: Enable mold
-        run: |
-          mkdir -p $HOME/.cargo
-          cat << EOF >> $HOME/.cargo/config.toml
-          [target.x86_64-unknown-linux-gnu]
-          linker = "/usr/bin/clang"
-          rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]
-          EOF
-
-          cat $HOME/.cargo/config.toml
       - uses: Swatinem/rust-cache@v1
-        with:
-          key: "mold"
       - run: cargo install cargo-fuzz
       - name: stark_hash
         run: cargo fuzz build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,20 +14,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v1
-      - uses: rui314/setup-mold@v1
-        with:
-          mold-version: 1.4.1
-          make-default: false
-      - name: Enable mold
-        run: |
-          mkdir -p $HOME/.cargo
-          cat << EOF >> $HOME/.cargo/config.toml
-          [target.x86_64-unknown-linux-gnu]
-          linker = "/usr/bin/clang"
-          rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]
-          EOF
-
-          cat $HOME/.cargo/config.toml
       - run: |
           cargo test --no-run --workspace --locked
           timeout 5m cargo test -p pathfinder -- --skip ethereum::
@@ -122,20 +108,6 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v1
-      - uses: rui314/setup-mold@v1
-        with:
-          mold-version: 1.4.1
-          make-default: false
-      - name: Enable mold
-        run: |
-          mkdir -p $HOME/.cargo
-          cat << EOF >> $HOME/.cargo/config.toml
-          [target.x86_64-unknown-linux-gnu]
-          linker = "/usr/bin/clang"
-          rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]
-          EOF
-
-          cat $HOME/.cargo/config.toml
 
       - name: Integration (rust)
         run: |


### PR DESCRIPTION
In #537 and #538 tried using mold on gha but it seems it didn't really have impact. Maybe we try it for a while and then either revert or keep with it.

`rust-cache` action should be upgraded to v2, separatedly. It will conflict with this PR.