### PR TITLE
fix(rpc): use from_block and to_block in event filter

### DIFF
--- a/crates/pathfinder/rpc_examples.sh
+++ b/crates/pathfinder/rpc_examples.sh
@@ -146,7 +146,7 @@ rpc_call '{
     "jsonrpc": "2.0",
     "method": "starknet_getEvents",
     "params": [
-        {"fromBlock": 800, "toBlock": 1701, "page_size": 1000, "page_number": 0}
+        {"from_block": 800, "to_block": 1701, "page_size": 1000, "page_number": 0}
     ],
     "id": 0
 }'

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -2780,10 +2780,10 @@ mod tests {
                 let params = by_name([(
                     "filter",
                     json!({
-                        "fromBlock": {
+                        "from_block": {
                             "block_number": expected_event.block_number.unwrap().get()
                         },
-                        "toBlock": {
+                        "to_block": {
                             "block_number": expected_event.block_number.unwrap().get()
                         },
                         "address": expected_event.from_address,

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -145,9 +145,9 @@ pub mod request {
     #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Serialize))]
     #[serde(deny_unknown_fields)]
     pub struct EventFilter {
-        #[serde(default, rename = "fromBlock")]
+        #[serde(default, alias = "fromBlock")]
         pub from_block: Option<crate::core::BlockId>,
-        #[serde(default, rename = "toBlock")]
+        #[serde(default, alias = "toBlock")]
         pub to_block: Option<crate::core::BlockId>,
         #[serde(default)]
         pub address: Option<ContractAddress>,


### PR DESCRIPTION
v0.1.0 of the JSON-RPC specification requires `from_block` and
`to_block` in the event filter object. We somehow failed to make
this change in pathfinder and were using the old `fromBlock`
and `toBlock` names.

This change keeps the old names as aliases so that we don't break the
API for users who have updated their code to account for the bug.

Fixes #536.