### PR TITLE
fix(readme): use the same UID/GID in Docker as on the host system

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ mkdir -p $HOME/pathfinder
 docker run \
   --rm \
   -p 9545:9545 \
+  --user "$(id -u):$(id -g)" \
   -e RUST_LOG=info \
   -e PATHFINDER_ETHEREUM_API_URL="https://goerli.infura.io/v3/<project-id>" \
   -v $HOME/pathfinder:/usr/share/pathfinder/data \


### PR DESCRIPTION
In the Dockerfile we're explicitly setting UID 1000 for pathfinder to
avoid running it as root. However, this causes issues in case the
permissions of the data directory make it non-writable for UID 1000.

Running the recommended commands with a user whose UID is not 1000 is
pretty much guaranteed to fail: the `mkdir` command creates a directory
that pathfinder won't be able to access in the container.

To make that command less prone to permission failures this change adds
`--user` that explicitly runs pathfinder _inside_ the container as the
UID/GID of the user on the host.