### PR TITLE
Initial metrics support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,6 +1608,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b9b8653cec6897f73b519a43fba5ee3d50f62fe9af80b428accdcc093b4a849"
+dependencies = [
+ "ahash",
+ "metrics-macros",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731f8ecebd9f3a4aa847dfe75455e4757a45da40a7793d2f0b1f9b6ed18b23f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,6 +2040,7 @@ dependencies = [
  "http",
  "jsonrpsee",
  "lazy_static",
+ "metrics",
  "mockall",
  "num-bigint 0.4.3",
  "pretty_assertions",
@@ -2127,6 +2150,12 @@ checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b303a15aeda678da614ab23306232dbd282d532f8c5919cedd41b66b9dc96560"
 
 [[package]]
 name = "ppv-lite86"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,12 +1099,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -1332,7 +1341,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -1578,6 +1587,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,6 +1637,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics-exporter-prometheus"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8603921e1f54ef386189335f288441af761e0fc61bcb552168d9cedfe63ebc70"
+dependencies = [
+ "hyper",
+ "indexmap",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "parking_lot 0.12.0",
+ "portable-atomic",
+ "quanta",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "metrics-macros"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1627,6 +1664,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d24dc2dbae22bff6f1f9326ffce828c9f07ef9cc1e8002e5279f845432a30a"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.12.3",
+ "metrics",
+ "num_cpus",
+ "parking_lot 0.12.0",
+ "portable-atomic",
+ "quanta",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -2041,6 +2095,7 @@ dependencies = [
  "jsonrpsee",
  "lazy_static",
  "metrics",
+ "metrics-exporter-prometheus",
  "mockall",
  "num-bigint 0.4.3",
  "pretty_assertions",
@@ -2333,9 +2388,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "292972edad6bbecc137ab84c5e36421a4a6c979ea31d3cc73540dd04315b33e1"
 dependencies = [
  "byteorder",
- "hashbrown",
+ "hashbrown 0.11.2",
  "idna",
  "psl-types",
+]
+
+[[package]]
+name = "quanta"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e31331286705f455e56cca62e0e717158474ff02b7936c1fa596d983f4ae27"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -2408,6 +2479,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aa2540135b6a94f74c7bc90ad4b794f822026a894f3d7bcd185c100d13d4ad6"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2838,6 +2918,12 @@ dependencies = [
  "log",
  "termcolor",
 ]
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceb945e54128e09c43d8e4f1277851bd5044c6fc540bbaa2ad888f60b3da9ae7"
 
 [[package]]
 name = "slab"

--- a/README.md
+++ b/README.md
@@ -385,6 +385,11 @@ Pathfinder has a monitoring API which can be enabled with the `--monitor-address
 
 `/ready` provides a way of checking whether the node's JSON-RPC API is ready to be queried. It returns a `503 Service Unavailable` status until all startup tasks complete, and then `200 OK` from then on.
 
+### Metrics
+
+`/metrics` provides a [Prometheus](https://prometheus.io/) metrics scrape endpoint. Currently only one type of metric is available:
+- `rpc_method_calls_total` counter, where the key `method` should be used to point to a particular RPC method to retrieve that method's total call count, for example: `rpc_method_calls_total{method="starknet_getStateUpdate"}`.
+
 ## License
 
 Licensed under either of

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ Pathfinder has a monitoring API which can be enabled with the `--monitor-address
 ### Metrics
 
 `/metrics` provides a [Prometheus](https://prometheus.io/) metrics scrape endpoint. Currently only one type of metric is available:
-- `rpc_method_calls_total` counter, where the key `method` should be used to point to a particular RPC method to retrieve that method's total call count, for example: `rpc_method_calls_total{method="starknet_getStateUpdate"}`.
+- `rpc_method_calls_total` counter, where the label key `method` should be used to point to a particular RPC method to retrieve that method's total call count, for example: `rpc_method_calls_total{method="starknet_getStateUpdate"}`.
 
 ## License
 

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -31,6 +31,7 @@ hex = "0.4.3"
 hex-literal = "0.3"
 jsonrpsee = { version = "0.11.0", features = ["server"] }
 lazy_static = "1.4.0"
+metrics = "0.20.1"
 num-bigint = { version = "0.4.3", features = ["serde"] }
 r2d2 = "0.8.9"
 r2d2_sqlite = "0.20.0"

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -32,6 +32,7 @@ hex-literal = "0.3"
 jsonrpsee = { version = "0.11.0", features = ["server"] }
 lazy_static = "1.4.0"
 metrics = "0.20.1"
+metrics-exporter-prometheus = "0.11.0"
 num-bigint = { version = "0.4.3", features = ["serde"] }
 r2d2 = "0.8.9"
 r2d2_sqlite = "0.20.0"

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -32,14 +32,12 @@ async fn main() -> anyhow::Result<()> {
 
     permission_check(&config.data_directory)?;
 
-    let prometheus_handle = PrometheusBuilder::new()
-        .install_recorder()
-        .context("Creating Prometheus recorder")?;
-
     let pathfinder_ready = match config.monitoring_addr {
         Some(monitoring_addr) => {
             let ready = Arc::new(AtomicBool::new(false));
-            let prometheus_handle = prometheus_handle;
+            let prometheus_handle = PrometheusBuilder::new()
+                .install_recorder()
+                .context("Creating Prometheus recorder")?;
             let _jh =
                 monitoring::spawn_server(monitoring_addr, ready.clone(), prometheus_handle).await;
             Some(ready)

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -39,7 +39,7 @@ async fn main() -> anyhow::Result<()> {
     let pathfinder_ready = match config.monitoring_addr {
         Some(monitoring_addr) => {
             let ready = Arc::new(AtomicBool::new(false));
-            let prometheus_handle = Arc::new(prometheus_handle);
+            let prometheus_handle = prometheus_handle;
             let _jh =
                 monitoring::spawn_server(monitoring_addr, ready.clone(), prometheus_handle).await;
             Some(ready)

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -5,7 +5,8 @@ use pathfinder_lib::{
     cairo, config,
     core::{self, Chain, EthereumChain},
     ethereum::transport::{EthereumTransport, HttpTransport},
-    monitoring, rpc, sequencer, state,
+    monitoring::{self, DummyPrometheusHandle},
+    rpc, sequencer, state,
     storage::{JournalMode, Storage},
 };
 use std::sync::{atomic::AtomicBool, Arc};
@@ -33,7 +34,9 @@ async fn main() -> anyhow::Result<()> {
     let pathfinder_ready = match config.monitoring_addr {
         Some(monitoring_addr) => {
             let ready = Arc::new(AtomicBool::new(false));
-            let _jh = monitoring::spawn_server(monitoring_addr, ready.clone()).await;
+            let prometheus_handle = Arc::new(DummyPrometheusHandle);
+            let _jh =
+                monitoring::spawn_server(monitoring_addr, ready.clone(), prometheus_handle).await;
             Some(ready)
         }
         None => None,

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -136,7 +136,7 @@ Hint: Make sure the provided ethereum.url and ethereum.password are good.",
     };
 
     let (rpc_handle, local_addr) = rpc::RpcServer::new(config.http_rpc_addr, api)
-        .set_middleware(RpcMetricsMiddleware)
+        .with_middleware(RpcMetricsMiddleware)
         .run()
         .await
         .context("Starting the RPC server")?;

--- a/crates/pathfinder/src/monitoring.rs
+++ b/crates/pathfinder/src/monitoring.rs
@@ -1,3 +1,5 @@
+pub mod metrics;
+
 use std::sync::atomic::AtomicBool;
 
 use warp::Filter;

--- a/crates/pathfinder/src/monitoring/metrics.rs
+++ b/crates/pathfinder/src/monitoring/metrics.rs
@@ -39,3 +39,42 @@ pub mod middleware {
         }
     }
 }
+
+#[cfg(test)]
+pub mod test {
+    use metrics::{Recorder, SetRecorderError};
+    use std::sync::{Arc, Mutex, MutexGuard};
+
+    lazy_static::lazy_static! {
+        static ref RECORDER_LOCK: Arc<Mutex<()>> = Arc::new(Mutex::new(()));
+    }
+
+    /// Allows to safely set a `metrics::Recorder` for a particular test.
+    /// The recorder will be removed when this guard is dropped.
+    /// Internal mutex protects us from inter-test recorder races.
+    pub struct RecorderGuard<'a>(MutexGuard<'a, ()>);
+
+    impl<'a> RecorderGuard<'a> {
+        /// Locks the global mutex and sets the global `metrics::Recorder` for the current test.
+        /// The global recorder is cleared and the mutex is unlocked when the guard is dropped.
+        ///
+        /// The `recorder` passed to this function will be moved onto the heap and then __leaked__
+        /// but we don't really care as this is purely a testing aid.
+        pub fn lock<R>(recorder: R) -> Result<Self, SetRecorderError>
+        where
+            R: Recorder + 'static,
+        {
+            let guard = RECORDER_LOCK.lock().unwrap();
+
+            metrics::set_boxed_recorder(Box::new(recorder))?;
+
+            Ok(Self(guard))
+        }
+    }
+
+    impl<'a> Drop for RecorderGuard<'a> {
+        fn drop(&mut self) {
+            unsafe { metrics::clear_recorder() }
+        }
+    }
+}

--- a/crates/pathfinder/src/monitoring/metrics.rs
+++ b/crates/pathfinder/src/monitoring/metrics.rs
@@ -1,17 +1,14 @@
 pub mod middleware {
     use jsonrpsee::core::middleware::Middleware;
     use metrics::increment_counter;
-    use std::time::Instant;
 
     #[derive(Debug, Clone)]
     pub struct RpcMetricsMiddleware;
 
     impl Middleware for RpcMetricsMiddleware {
-        type Instant = Instant;
+        type Instant = ();
 
-        fn on_request(&self) -> Self::Instant {
-            Instant::now()
-        }
+        fn on_request(&self) -> Self::Instant {}
 
         fn on_call(&self, name: &str) {
             increment_counter!(format!("{name}_calls_total"));
@@ -25,11 +22,9 @@ pub mod middleware {
     }
 
     impl jsonrpsee::core::middleware::Middleware for MaybeRpcMetricsMiddleware {
-        type Instant = std::time::Instant;
+        type Instant = ();
 
-        fn on_request(&self) -> Self::Instant {
-            std::time::Instant::now()
-        }
+        fn on_request(&self) -> Self::Instant {}
 
         fn on_call(&self, name: &str) {
             match self {

--- a/crates/pathfinder/src/monitoring/metrics.rs
+++ b/crates/pathfinder/src/monitoring/metrics.rs
@@ -43,11 +43,9 @@ pub mod middleware {
 #[cfg(test)]
 pub mod test {
     use metrics::{Recorder, SetRecorderError};
-    use std::sync::{Arc, Mutex, MutexGuard};
+    use std::sync::{Mutex, MutexGuard};
 
-    lazy_static::lazy_static! {
-        static ref RECORDER_LOCK: Arc<Mutex<()>> = Arc::new(Mutex::new(()));
-    }
+    static RECORDER_LOCK: Mutex<()> = Mutex::new(());
 
     /// Allows to safely set a `metrics::Recorder` for a particular test.
     /// The recorder will be removed when this guard is dropped.

--- a/crates/pathfinder/src/monitoring/metrics.rs
+++ b/crates/pathfinder/src/monitoring/metrics.rs
@@ -14,7 +14,7 @@ pub mod middleware {
         }
 
         fn on_call(&self, name: &str) {
-            increment_counter!(format!("{name} calls total"));
+            increment_counter!(format!("{name}_calls_total"));
         }
     }
 

--- a/crates/pathfinder/src/monitoring/metrics.rs
+++ b/crates/pathfinder/src/monitoring/metrics.rs
@@ -1,0 +1,17 @@
+pub mod middleware {
+    use jsonrpsee::core::middleware::Middleware;
+    use std::time::Instant;
+
+    #[derive(Debug, Clone)]
+    pub struct RpcMetricsMiddleware;
+
+    impl Middleware for RpcMetricsMiddleware {
+        type Instant = Instant;
+
+        fn on_request(&self) -> Self::Instant {
+            Instant::now()
+        }
+
+        fn on_call(&self, _name: &str) {}
+    }
+}

--- a/crates/pathfinder/src/monitoring/metrics.rs
+++ b/crates/pathfinder/src/monitoring/metrics.rs
@@ -14,7 +14,7 @@ pub mod middleware {
         }
 
         fn on_call(&self, name: &str) {
-            increment_counter!(format!("{name} call count"));
+            increment_counter!(format!("{name} calls total"));
         }
     }
 

--- a/crates/pathfinder/src/monitoring/metrics.rs
+++ b/crates/pathfinder/src/monitoring/metrics.rs
@@ -17,4 +17,25 @@ pub mod middleware {
             increment_counter!(format!("{name} call count"));
         }
     }
+
+    #[derive(Debug, Clone)]
+    pub enum MaybeRpcMetricsMiddleware {
+        Middleware(RpcMetricsMiddleware),
+        Noop,
+    }
+
+    impl jsonrpsee::core::middleware::Middleware for MaybeRpcMetricsMiddleware {
+        type Instant = std::time::Instant;
+
+        fn on_request(&self) -> Self::Instant {
+            std::time::Instant::now()
+        }
+
+        fn on_call(&self, name: &str) {
+            match self {
+                MaybeRpcMetricsMiddleware::Middleware(x) => x.on_call(name),
+                MaybeRpcMetricsMiddleware::Noop => {}
+            }
+        }
+    }
 }

--- a/crates/pathfinder/src/monitoring/metrics.rs
+++ b/crates/pathfinder/src/monitoring/metrics.rs
@@ -21,7 +21,7 @@ pub mod middleware {
     #[derive(Debug, Clone)]
     pub enum MaybeRpcMetricsMiddleware {
         Middleware(RpcMetricsMiddleware),
-        Noop,
+        NoOp,
     }
 
     impl jsonrpsee::core::middleware::Middleware for MaybeRpcMetricsMiddleware {
@@ -34,7 +34,7 @@ pub mod middleware {
         fn on_call(&self, name: &str) {
             match self {
                 MaybeRpcMetricsMiddleware::Middleware(x) => x.on_call(name),
-                MaybeRpcMetricsMiddleware::Noop => {}
+                MaybeRpcMetricsMiddleware::NoOp => {}
             }
         }
     }

--- a/crates/pathfinder/src/monitoring/metrics.rs
+++ b/crates/pathfinder/src/monitoring/metrics.rs
@@ -1,5 +1,6 @@
 pub mod middleware {
     use jsonrpsee::core::middleware::Middleware;
+    use metrics::increment_counter;
     use std::time::Instant;
 
     #[derive(Debug, Clone)]
@@ -12,6 +13,8 @@ pub mod middleware {
             Instant::now()
         }
 
-        fn on_call(&self, _name: &str) {}
+        fn on_call(&self, name: &str) {
+            increment_counter!(format!("{name} call count"));
+        }
     }
 }

--- a/crates/pathfinder/src/monitoring/metrics.rs
+++ b/crates/pathfinder/src/monitoring/metrics.rs
@@ -1,6 +1,5 @@
 pub mod middleware {
     use jsonrpsee::core::middleware::Middleware;
-    use metrics::increment_counter;
 
     #[derive(Debug, Clone)]
     pub struct RpcMetricsMiddleware;
@@ -11,7 +10,7 @@ pub mod middleware {
         fn on_request(&self) -> Self::Instant {}
 
         fn on_call(&self, name: &str) {
-            increment_counter!(format!("{name}_calls_total"));
+            metrics::increment_counter!("rpc_method_calls_total", "method" => name.to_owned());
         }
     }
 

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -85,7 +85,7 @@ impl RpcServer {
         }
     }
 
-    pub fn set_middleware(self, middleware: RpcMetricsMiddleware) -> Self {
+    pub fn with_middleware(self, middleware: RpcMetricsMiddleware) -> Self {
         Self {
             middleware: MaybeRpcMetricsMiddleware::Middleware(middleware),
             ..self
@@ -2534,7 +2534,7 @@ mod tests {
                     let api = RpcApi::new(storage, sequencer, *set_chain, sync_state);
 
                     let (__handle, addr) = RpcServer::new(*LOCALHOST, api)
-                        .set_middleware(RpcMetricsMiddleware)
+                        .with_middleware(RpcMetricsMiddleware)
                         .run()
                         .await
                         .unwrap();

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -56,7 +56,7 @@ impl<Context: Send + Sync + 'static> RpcModuleWrapper<Context> {
     {
         use tracing::Instrument;
 
-        metrics::register_counter!(format!("{method_name} call count"));
+        metrics::register_counter!(format!("{method_name} calls total"));
 
         self.0.register_async_method(method_name, move |p, c| {
             // why info here? it's the same used in warp tracing filter for example.

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -81,7 +81,7 @@ impl RpcServer {
         Self {
             addr,
             api,
-            middleware: MaybeRpcMetricsMiddleware::Noop,
+            middleware: MaybeRpcMetricsMiddleware::NoOp,
         }
     }
 

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -56,7 +56,7 @@ impl<Context: Send + Sync + 'static> RpcModuleWrapper<Context> {
     {
         use tracing::Instrument;
 
-        metrics::register_counter!(format!("{method_name}_calls_total"));
+        metrics::register_counter!("rpc_method_calls_total", "method" => method_name);
 
         self.0.register_async_method(method_name, move |p, c| {
             // why info here? it's the same used in warp tracing filter for example.
@@ -2484,7 +2484,7 @@ mod tests {
         use crate::monitoring::metrics::{middleware::RpcMetricsMiddleware, test::RecorderGuard};
         use futures::stream::StreamExt;
         use metrics::{
-            Counter, CounterFn, Gauge, Histogram, Key, KeyName, Recorder, SharedString, Unit,
+            Counter, CounterFn, Gauge, Histogram, Key, KeyName, Label, Recorder, SharedString, Unit,
         };
         use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -2496,7 +2496,12 @@ mod tests {
             fn describe_gauge(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
             fn describe_histogram(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
             fn register_counter(&self, key: &Key) -> Counter {
-                if key.name() == "starknet_chainId_calls_total" {
+                if *key
+                    == Key::from_parts(
+                        "rpc_method_calls_total",
+                        vec![Label::new("method", "starknet_chainId")],
+                    )
+                {
                     Counter::from_arc(self.0.clone())
                 } else {
                     Counter::noop()

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -56,7 +56,7 @@ impl<Context: Send + Sync + 'static> RpcModuleWrapper<Context> {
     {
         use tracing::Instrument;
 
-        metrics::register_counter!(format!("{method_name} calls total"));
+        metrics::register_counter!(format!("{method_name}_calls_total"));
 
         self.0.register_async_method(method_name, move |p, c| {
             // why info here? it's the same used in warp tracing filter for example.
@@ -2498,7 +2498,7 @@ mod tests {
             fn describe_gauge(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
             fn describe_histogram(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
             fn register_counter(&self, key: &Key) -> Counter {
-                if key.name() == "starknet_chainId calls total" {
+                if key.name() == "starknet_chainId_calls_total" {
                     Counter::from_arc(self.0.clone())
                 } else {
                     Counter::noop()

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -409,8 +409,6 @@ mod tests {
     };
     use web3::types::H256;
 
-    /// Helper function: wrap rpc server creation without any monitoring middleware
-
     /// Starts the HTTP-RPC server.
     pub async fn run_server(
         addr: SocketAddr,

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -2483,7 +2483,7 @@ mod tests {
 
     #[tokio::test]
     async fn chain_id_with_call_counter_metric() {
-        use crate::monitoring::metrics::middleware::RpcMetricsMiddleware;
+        use crate::monitoring::metrics::{middleware::RpcMetricsMiddleware, test::RecorderGuard};
         use futures::stream::StreamExt;
         use metrics::{
             Counter, CounterFn, Gauge, Histogram, Key, KeyName, Recorder, SharedString, Unit,
@@ -2522,7 +2522,9 @@ mod tests {
         }
 
         let counter = Arc::new(FakeCounterFn(AtomicU64::default()));
-        metrics::set_boxed_recorder(Box::new(FakeRecorder(counter.clone()))).unwrap();
+
+        // Other concurrent tests could be setting their own recorders
+        let _guard = RecorderGuard::lock(FakeRecorder(counter.clone())).unwrap();
 
         assert_eq!(
             [Chain::Testnet, Chain::Mainnet]

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -56,6 +56,8 @@ impl<Context: Send + Sync + 'static> RpcModuleWrapper<Context> {
     {
         use tracing::Instrument;
 
+        metrics::register_counter!(format!("{method_name} call count"));
+
         self.0.register_async_method(method_name, move |p, c| {
             // why info here? it's the same used in warp tracing filter for example.
             let span = tracing::info_span!("rpc_method", name = method_name);

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -13,6 +13,7 @@ use crate::{
         ContractAddressSalt, Fee, StarknetTransactionHash, StarknetTransactionIndex,
         TransactionVersion,
     },
+    monitoring::metrics::middleware::RpcMetricsMiddleware,
     rpc::{
         api::{BlockResponseScope, RpcApi},
         serde::{CallSignatureElemAsDecimalStr, FeeAsHexStr, TransactionVersionAsHexStr},
@@ -73,6 +74,7 @@ pub async fn run_server(
     api: RpcApi,
 ) -> Result<(HttpServerHandle, SocketAddr), anyhow::Error> {
     let server = HttpServerBuilder::default()
+        .set_middleware(RpcMetricsMiddleware)
         .build(addr)
         .await
         .map_err(|e| match e {

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -13,7 +13,7 @@ use crate::{
         ContractAddressSalt, Fee, StarknetTransactionHash, StarknetTransactionIndex,
         TransactionVersion,
     },
-    monitoring::metrics::middleware::RpcMetricsMiddleware,
+    monitoring::metrics::middleware::{MaybeRpcMetricsMiddleware, RpcMetricsMiddleware},
     rpc::{
         api::{BlockResponseScope, RpcApi},
         serde::{CallSignatureElemAsDecimalStr, FeeAsHexStr, TransactionVersionAsHexStr},
@@ -70,282 +70,302 @@ impl<Context: Send + Sync + 'static> RpcModuleWrapper<Context> {
     }
 }
 
-/// Starts the HTTP-RPC server.
-pub async fn run_server(
+pub struct RpcServer {
     addr: SocketAddr,
     api: RpcApi,
-) -> Result<(HttpServerHandle, SocketAddr), anyhow::Error> {
-    let server = HttpServerBuilder::default()
-        .set_middleware(RpcMetricsMiddleware)
-        .build(addr)
-        .await
-        .map_err(|e| match e {
-            jsonrpsee::core::Error::Transport(_) => {
-                use std::error::Error;
+    middleware: MaybeRpcMetricsMiddleware,
+}
 
-                if let Some(inner) = e.source().and_then(|inner| inner.downcast_ref::<std::io::Error>()) {
-                    if let std::io::ErrorKind::AddrInUse = inner.kind() {
-                        return anyhow::Error::new(e)
-                        .context(format!("RPC address is already in use: {addr}.
+impl RpcServer {
+    pub fn new(addr: SocketAddr, api: RpcApi) -> Self {
+        Self {
+            addr,
+            api,
+            middleware: MaybeRpcMetricsMiddleware::Noop,
+        }
+    }
+
+    pub fn set_middleware(self, middleware: RpcMetricsMiddleware) -> Self {
+        Self {
+            middleware: MaybeRpcMetricsMiddleware::Middleware(middleware),
+            ..self
+        }
+    }
+
+    /// Starts the HTTP-RPC server.
+    pub async fn run(self) -> Result<(HttpServerHandle, SocketAddr), anyhow::Error> {
+        let server = HttpServerBuilder::default()
+            .set_middleware(self.middleware)
+            .build(self.addr)
+            .await
+            .map_err(|e| match e {
+                jsonrpsee::core::Error::Transport(_) => {
+                    use std::error::Error;
+
+                    if let Some(inner) = e.source().and_then(|inner| inner.downcast_ref::<std::io::Error>()) {
+                        if let std::io::ErrorKind::AddrInUse = inner.kind() {
+                            return anyhow::Error::new(e)
+                            .context(format!("RPC address is already in use: {}.
 
 Hint: This usually means you are already running another instance of pathfinder.
 Hint: If this happens when upgrading, make sure to shut down the first one first.
-Hint: If you are looking to run two instances of pathfinder, you must configure them with different http rpc addresses."))
+Hint: If you are looking to run two instances of pathfinder, you must configure them with different http rpc addresses.", self.addr))
+                        }
                     }
+
+                    anyhow::Error::new(e)
                 }
-
-                anyhow::Error::new(e)
+                _ => anyhow::Error::new(e),
+            })?;
+        let local_addr = server.local_addr()?;
+        let mut module = RpcModuleWrapper(RpcModule::new(self.api));
+        module.register_async_method(
+            "starknet_getBlockWithTxHashes",
+            |params, context| async move {
+                #[derive(Debug, Deserialize)]
+                struct NamedArgs {
+                    block_id: BlockId,
+                }
+                let params = params.parse::<NamedArgs>()?;
+                context
+                    .get_block(params.block_id, BlockResponseScope::TransactionHashes)
+                    .await
+            },
+        )?;
+        module.register_async_method("starknet_getBlockWithTxs", |params, context| async move {
+            #[derive(Debug, Deserialize)]
+            struct NamedArgs {
+                block_id: BlockId,
             }
-            _ => anyhow::Error::new(e),
+            let params = params.parse::<NamedArgs>()?;
+            context
+                .get_block(params.block_id, BlockResponseScope::FullTransactions)
+                .await
         })?;
-    let local_addr = server.local_addr()?;
-    let mut module = RpcModuleWrapper(RpcModule::new(api));
-    module.register_async_method(
-        "starknet_getBlockWithTxHashes",
-        |params, context| async move {
+        module.register_async_method("starknet_getStateUpdate", |params, context| async move {
             #[derive(Debug, Deserialize)]
             struct NamedArgs {
                 block_id: BlockId,
             }
             let params = params.parse::<NamedArgs>()?;
-            context
-                .get_block(params.block_id, BlockResponseScope::TransactionHashes)
-                .await
-        },
-    )?;
-    module.register_async_method("starknet_getBlockWithTxs", |params, context| async move {
-        #[derive(Debug, Deserialize)]
-        struct NamedArgs {
-            block_id: BlockId,
-        }
-        let params = params.parse::<NamedArgs>()?;
-        context
-            .get_block(params.block_id, BlockResponseScope::FullTransactions)
-            .await
-    })?;
-    module.register_async_method("starknet_getStateUpdate", |params, context| async move {
-        #[derive(Debug, Deserialize)]
-        struct NamedArgs {
-            block_id: BlockId,
-        }
-        let params = params.parse::<NamedArgs>()?;
-        context.get_state_update(params.block_id).await
-    })?;
-    module.register_async_method("starknet_getStorageAt", |params, context| async move {
-        #[derive(Debug, Deserialize)]
-        struct NamedArgs {
-            contract_address: ContractAddress,
-            key: crate::core::StorageAddress,
-            block_id: BlockId,
-        }
-        let params = params.parse::<NamedArgs>()?;
-        context
-            .get_storage_at(params.contract_address, params.key, params.block_id)
-            .await
-    })?;
-    module.register_async_method(
-        "starknet_getTransactionByHash",
-        |params, context| async move {
+            context.get_state_update(params.block_id).await
+        })?;
+        module.register_async_method("starknet_getStorageAt", |params, context| async move {
             #[derive(Debug, Deserialize)]
             struct NamedArgs {
-                transaction_hash: StarknetTransactionHash,
+                contract_address: ContractAddress,
+                key: crate::core::StorageAddress,
+                block_id: BlockId,
+            }
+            let params = params.parse::<NamedArgs>()?;
+            context
+                .get_storage_at(params.contract_address, params.key, params.block_id)
+                .await
+        })?;
+        module.register_async_method(
+            "starknet_getTransactionByHash",
+            |params, context| async move {
+                #[derive(Debug, Deserialize)]
+                struct NamedArgs {
+                    transaction_hash: StarknetTransactionHash,
+                }
+                context
+                    .get_transaction_by_hash(params.parse::<NamedArgs>()?.transaction_hash)
+                    .await
+            },
+        )?;
+        module.register_async_method(
+            "starknet_getTransactionByBlockIdAndIndex",
+            |params, context| async move {
+                #[derive(Debug, Deserialize)]
+                struct NamedArgs {
+                    block_id: BlockId,
+                    index: StarknetTransactionIndex,
+                }
+                let params = params.parse::<NamedArgs>()?;
+                context
+                    .get_transaction_by_block_id_and_index(params.block_id, params.index)
+                    .await
+            },
+        )?;
+        module.register_async_method(
+            "starknet_getTransactionReceipt",
+            |params, context| async move {
+                #[derive(Debug, Deserialize)]
+                struct NamedArgs {
+                    transaction_hash: StarknetTransactionHash,
+                }
+                context
+                    .get_transaction_receipt(params.parse::<NamedArgs>()?.transaction_hash)
+                    .await
+            },
+        )?;
+        module.register_async_method("starknet_getClass", |params, context| async move {
+            #[derive(Debug, Deserialize)]
+            struct NamedArgs {
+                class_hash: ClassHash,
             }
             context
-                .get_transaction_by_hash(params.parse::<NamedArgs>()?.transaction_hash)
+                .get_class(params.parse::<NamedArgs>()?.class_hash)
                 .await
-        },
-    )?;
-    module.register_async_method(
-        "starknet_getTransactionByBlockIdAndIndex",
-        |params, context| async move {
+        })?;
+        module.register_async_method("starknet_getClassHashAt", |params, context| async move {
             #[derive(Debug, Deserialize)]
             struct NamedArgs {
                 block_id: BlockId,
-                index: StarknetTransactionIndex,
+                contract_address: ContractAddress,
             }
             let params = params.parse::<NamedArgs>()?;
             context
-                .get_transaction_by_block_id_and_index(params.block_id, params.index)
+                .get_class_hash_at(params.block_id, params.contract_address)
                 .await
-        },
-    )?;
-    module.register_async_method(
-        "starknet_getTransactionReceipt",
-        |params, context| async move {
-            #[derive(Debug, Deserialize)]
-            struct NamedArgs {
-                transaction_hash: StarknetTransactionHash,
-            }
-            context
-                .get_transaction_receipt(params.parse::<NamedArgs>()?.transaction_hash)
-                .await
-        },
-    )?;
-    module.register_async_method("starknet_getClass", |params, context| async move {
-        #[derive(Debug, Deserialize)]
-        struct NamedArgs {
-            class_hash: ClassHash,
-        }
-        context
-            .get_class(params.parse::<NamedArgs>()?.class_hash)
-            .await
-    })?;
-    module.register_async_method("starknet_getClassHashAt", |params, context| async move {
-        #[derive(Debug, Deserialize)]
-        struct NamedArgs {
-            block_id: BlockId,
-            contract_address: ContractAddress,
-        }
-        let params = params.parse::<NamedArgs>()?;
-        context
-            .get_class_hash_at(params.block_id, params.contract_address)
-            .await
-    })?;
-    module.register_async_method("starknet_getClassAt", |params, context| async move {
-        #[derive(Debug, Deserialize)]
-        struct NamedArgs {
-            block_id: BlockId,
-            contract_address: ContractAddress,
-        }
-        let params = params.parse::<NamedArgs>()?;
-        context
-            .get_class_at(params.block_id, params.contract_address)
-            .await
-    })?;
-    module.register_async_method(
-        "starknet_getBlockTransactionCount",
-        |params, context| async move {
+        })?;
+        module.register_async_method("starknet_getClassAt", |params, context| async move {
             #[derive(Debug, Deserialize)]
             struct NamedArgs {
                 block_id: BlockId,
-            }
-            context
-                .get_block_transaction_count(params.parse::<NamedArgs>()?.block_id)
-                .await
-        },
-    )?;
-    module.register_async_method("starknet_getNonce", |params, context| async move {
-        #[derive(Debug, Deserialize)]
-        struct NamedArgs {
-            contract_address: ContractAddress,
-        }
-        context
-            .get_nonce(params.parse::<NamedArgs>()?.contract_address)
-            .await
-    })?;
-    module.register_async_method("starknet_call", |params, context| async move {
-        #[derive(Debug, Deserialize)]
-        struct NamedArgs {
-            request: Call,
-            block_id: BlockId,
-        }
-        let params = params.parse::<NamedArgs>()?;
-        context.call(params.request, params.block_id).await
-    })?;
-    module.register_async_method("starknet_estimateFee", |params, context| async move {
-        #[derive(Debug, Deserialize)]
-        struct NamedArgs {
-            request: Call,
-            block_id: BlockId,
-        }
-        let params = params.parse::<NamedArgs>()?;
-        context.estimate_fee(params.request, params.block_id).await
-    })?;
-    module.register_async_method("starknet_blockNumber", |_, context| async move {
-        context.block_number().await
-    })?;
-    module.register_async_method("starknet_blockHashAndNumber", |_, context| async move {
-        context.block_hash_and_number().await
-    })?;
-    module.register_async_method("starknet_chainId", |_, context| async move {
-        context.chain_id().await
-    })?;
-    module.register_async_method("starknet_pendingTransactions", |_, context| async move {
-        context.pending_transactions().await
-    })?;
-    module.register_async_method("starknet_syncing", |_, context| async move {
-        context.syncing().await
-    })?;
-    module.register_async_method("starknet_getEvents", |params, context| async move {
-        #[derive(Debug, Deserialize)]
-        struct NamedArgs {
-            filter: EventFilter,
-        }
-        let request = params.parse::<NamedArgs>()?.filter;
-        context.get_events(request).await
-    })?;
-    module.register_async_method(
-        "starknet_addInvokeTransaction",
-        |params, context| async move {
-            #[serde_with::serde_as]
-            #[derive(Debug, Deserialize)]
-            struct NamedArgs {
-                function_invocation: ContractCall,
-                #[serde_as(as = "Vec<CallSignatureElemAsDecimalStr>")]
-                signature: Vec<CallSignatureElem>,
-                #[serde_as(as = "FeeAsHexStr")]
-                max_fee: Fee,
-                #[serde_as(as = "TransactionVersionAsHexStr")]
-                version: TransactionVersion,
+                contract_address: ContractAddress,
             }
             let params = params.parse::<NamedArgs>()?;
             context
-                .add_invoke_transaction(
-                    params.function_invocation,
-                    params.signature,
-                    params.max_fee,
-                    params.version,
-                )
+                .get_class_at(params.block_id, params.contract_address)
                 .await
-        },
-    )?;
-    module.register_async_method(
-        "starknet_addDeclareTransaction",
-        |params, context| async move {
-            #[serde_with::serde_as]
+        })?;
+        module.register_async_method(
+            "starknet_getBlockTransactionCount",
+            |params, context| async move {
+                #[derive(Debug, Deserialize)]
+                struct NamedArgs {
+                    block_id: BlockId,
+                }
+                context
+                    .get_block_transaction_count(params.parse::<NamedArgs>()?.block_id)
+                    .await
+            },
+        )?;
+        module.register_async_method("starknet_getNonce", |params, context| async move {
             #[derive(Debug, Deserialize)]
             struct NamedArgs {
-                contract_class: ContractDefinition,
-                #[serde_as(as = "TransactionVersionAsHexStr")]
-                version: TransactionVersion,
-                // An undocumented parameter that we forward to the sequencer API
-                // A deploy token is required to deploy contracts on Starknet mainnet only.
-                #[serde(default)]
-                token: Option<String>,
+                contract_address: ContractAddress,
             }
-            let params = params.parse::<NamedArgs>()?;
             context
-                .add_declare_transaction(params.contract_class, params.version, params.token)
+                .get_nonce(params.parse::<NamedArgs>()?.contract_address)
                 .await
-        },
-    )?;
-    module.register_async_method(
-        "starknet_addDeployTransaction",
-        |params, context| async move {
+        })?;
+        module.register_async_method("starknet_call", |params, context| async move {
             #[derive(Debug, Deserialize)]
             struct NamedArgs {
-                contract_address_salt: ContractAddressSalt,
-                constructor_calldata: Vec<ConstructorParam>,
-                contract_definition: ContractDefinition,
-                // An undocumented parameter that we forward to the sequencer API
-                // A deploy token is required to deploy contracts on Starknet mainnet only.
-                #[serde(default)]
-                token: Option<String>,
+                request: Call,
+                block_id: BlockId,
             }
             let params = params.parse::<NamedArgs>()?;
-            context
-                .add_deploy_transaction(
-                    params.contract_address_salt,
-                    params.constructor_calldata,
-                    params.contract_definition,
-                    params.token,
-                )
-                .await
-        },
-    )?;
+            context.call(params.request, params.block_id).await
+        })?;
+        module.register_async_method("starknet_estimateFee", |params, context| async move {
+            #[derive(Debug, Deserialize)]
+            struct NamedArgs {
+                request: Call,
+                block_id: BlockId,
+            }
+            let params = params.parse::<NamedArgs>()?;
+            context.estimate_fee(params.request, params.block_id).await
+        })?;
+        module.register_async_method("starknet_blockNumber", |_, context| async move {
+            context.block_number().await
+        })?;
+        module.register_async_method("starknet_blockHashAndNumber", |_, context| async move {
+            context.block_hash_and_number().await
+        })?;
+        module.register_async_method("starknet_chainId", |_, context| async move {
+            context.chain_id().await
+        })?;
+        module.register_async_method("starknet_pendingTransactions", |_, context| async move {
+            context.pending_transactions().await
+        })?;
+        module.register_async_method("starknet_syncing", |_, context| async move {
+            context.syncing().await
+        })?;
+        module.register_async_method("starknet_getEvents", |params, context| async move {
+            #[derive(Debug, Deserialize)]
+            struct NamedArgs {
+                filter: EventFilter,
+            }
+            let request = params.parse::<NamedArgs>()?.filter;
+            context.get_events(request).await
+        })?;
+        module.register_async_method(
+            "starknet_addInvokeTransaction",
+            |params, context| async move {
+                #[serde_with::serde_as]
+                #[derive(Debug, Deserialize)]
+                struct NamedArgs {
+                    function_invocation: ContractCall,
+                    #[serde_as(as = "Vec<CallSignatureElemAsDecimalStr>")]
+                    signature: Vec<CallSignatureElem>,
+                    #[serde_as(as = "FeeAsHexStr")]
+                    max_fee: Fee,
+                    #[serde_as(as = "TransactionVersionAsHexStr")]
+                    version: TransactionVersion,
+                }
+                let params = params.parse::<NamedArgs>()?;
+                context
+                    .add_invoke_transaction(
+                        params.function_invocation,
+                        params.signature,
+                        params.max_fee,
+                        params.version,
+                    )
+                    .await
+            },
+        )?;
+        module.register_async_method(
+            "starknet_addDeclareTransaction",
+            |params, context| async move {
+                #[serde_with::serde_as]
+                #[derive(Debug, Deserialize)]
+                struct NamedArgs {
+                    contract_class: ContractDefinition,
+                    #[serde_as(as = "TransactionVersionAsHexStr")]
+                    version: TransactionVersion,
+                    // An undocumented parameter that we forward to the sequencer API
+                    // A deploy token is required to deploy contracts on Starknet mainnet only.
+                    #[serde(default)]
+                    token: Option<String>,
+                }
+                let params = params.parse::<NamedArgs>()?;
+                context
+                    .add_declare_transaction(params.contract_class, params.version, params.token)
+                    .await
+            },
+        )?;
+        module.register_async_method(
+            "starknet_addDeployTransaction",
+            |params, context| async move {
+                #[derive(Debug, Deserialize)]
+                struct NamedArgs {
+                    contract_address_salt: ContractAddressSalt,
+                    constructor_calldata: Vec<ConstructorParam>,
+                    contract_definition: ContractDefinition,
+                    // An undocumented parameter that we forward to the sequencer API
+                    // A deploy token is required to deploy contracts on Starknet mainnet only.
+                    #[serde(default)]
+                    token: Option<String>,
+                }
+                let params = params.parse::<NamedArgs>()?;
+                context
+                    .add_deploy_transaction(
+                        params.contract_address_salt,
+                        params.constructor_calldata,
+                        params.contract_definition,
+                        params.token,
+                    )
+                    .await
+            },
+        )?;
 
-    let module = module.into_inner();
-    Ok(server.start(module).map(|handle| (handle, local_addr))?)
+        let module = module.into_inner();
+        Ok(server.start(module).map(|handle| (handle, local_addr))?)
+    }
 }
 
 #[cfg(test)]
@@ -357,7 +377,7 @@ mod tests {
             GlobalRoot, SequencerAddress, StarknetBlockHash, StarknetBlockNumber,
             StarknetBlockTimestamp, StorageAddress,
         },
-        rpc::{run_server, types::reply::BlockHashAndNumber},
+        rpc::types::reply::BlockHashAndNumber,
         sequencer::{
             reply::{
                 state_update::StorageDiff,
@@ -388,6 +408,16 @@ mod tests {
         sync::Arc,
     };
     use web3::types::H256;
+
+    /// Helper function: wrap rpc server creation without any monitoring middleware
+
+    /// Starts the HTTP-RPC server.
+    pub async fn run_server(
+        addr: SocketAddr,
+        api: RpcApi,
+    ) -> Result<(HttpServerHandle, SocketAddr), anyhow::Error> {
+        RpcServer::new(addr, api).run().await
+    }
 
     /// Helper function: produces named rpc method args map.
     fn by_name<const N: usize>(params: [(&'_ str, serde_json::Value); N]) -> Option<ParamsSer<'_>> {

--- a/crates/pathfinder/src/rpc/test_setup.rs
+++ b/crates/pathfinder/src/rpc/test_setup.rs
@@ -280,7 +280,7 @@ where
         use crate::core::Chain;
         use crate::rpc::{
             test_client::client,
-            {run_server, RpcApi},
+            {RpcApi, RpcServer},
         };
         use crate::sequencer::Client;
         use crate::state::SyncState;
@@ -293,10 +293,11 @@ where
         let sequencer = Client::new(Chain::Testnet).unwrap();
         let sync_state = Arc::new(SyncState::default());
         let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
-        let (__handle, addr) = run_server(
+        let (__handle, addr) = RpcServer::new(
             SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)),
             api,
         )
+        .run()
         .await
         .unwrap();
 


### PR DESCRIPTION
This PR is the second attempt at adding metrics to pathfinder ([feature request issue](https://github.com/eqlabs/pathfinder/issues/258), [first attempt](https://github.com/eqlabs/pathfinder/pull/317)),

- It's based on the [metrics](https://docs.rs/metrics/0.20.1/metrics/) and [metrics-exporter-prometheus](https://docs.rs/metrics-exporter-prometheus/latest/metrics_exporter_prometheus/) crates.
- The default prometheus exporter is not used, instead the payload is rendered in the `/metrics` route.
- Only the basic total call counters were added for RPC methods to keep the PR small.
- `RecorderGuard` should be used when installing a per-test recorder, which takes care of recorder removal and avoids races between tests (`metrics` forces a global recorder instance per binary).
- At the moment I'm using `format!()` to build the counter labels but this can be sped up ~5x if using a `BTreeMap<&'static str, &'static str>` for method name vs counter name lookup instead (benchmark is disposable so not included in the PR). I haven't added this yet as I assumed that this extra heap allocation is negligible in terms of performance when taking the DB operations into account.
