### PR TITLE
Starknet 0.10 transaction types

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,9 +352,10 @@ To check if it's running well use `docker-compose logs -f`.
 
 ## JSON-RPC API
 
-Pathfinder supports version `v0.1.0` of the StarkNet JSON-RPC [specification](https://github.com/starkware-libs/starknet-specs/blob/v0.1.0/api/starknet_api_openrpc.json), with the exception of `starknet_protocolVersion`. This method will be removed from the specification in its next version as its semantics and usage was questionable. We decided to not implement it.
-
-In addition, pathfinder also supports submitting transactions by passing these requests on to the StarkNet gateway. See [here](#transaction-write-api) for more details.
+Pathfinder supports version `v0.1.0` of the StarkNet JSON-RPC [specification](https://github.com/starkware-libs/starknet-specs/blob/v0.1.0/api/starknet_api_openrpc.json), with the following changes:
+- The `starknet_protocolVersion` method is not implemented. This method will be removed from the specification in its next version as its semantics and usage was questionable. We decided to not implement it.
+- To be able to represent L1 handler transactions introduced in Starknet 0.10, we use the `L1_HANDLER_TXN` type from `0.2.0-rc1` of the JSON-RPC specification.
+- Pathfinder supports submitting transactions by passing these requests on to the StarkNet gateway. See [here](#transaction-write-api) for more details.
 
 When browsing the specification project, please be aware of the following pitfalls:
 - It uses git tags for release versions. The link above should take you to the version supported by pathfinder.

--- a/crates/pathfinder/fixtures/sequencer/integration/block/1.json
+++ b/crates/pathfinder/fixtures/sequencer/integration/block/1.json
@@ -1,0 +1,139 @@
+{
+    "block_hash": "0x34e815552e42c5eb5233b99de2d3d7fd396e575df2719bf98e7ed2794494f86",
+    "parent_block_hash": "0x3ae41b0f023e53151b0c8ab8b9caafb7005d5f41c9ab260276d5bdc49726279",
+    "block_number": 1,
+    "state_root": "074abfb3f55d3f9c3967014e1a5ec7205949130ff8912dba0565daf70299144c",
+    "status": "ACCEPTED_ON_L1",
+    "gas_price": "0x0",
+    "transactions": [
+        {
+            "version": "0x0",
+            "contract_address": "0x30b81d3f0f4e2af48e211d9914d611422430cd6fac6a9df64136a6a879c1dc5",
+            "contract_address_salt": "0x6030390b01fe79d844330de00821c68206959c389ef744b2d315e27078f0ad",
+            "class_hash": "0x10455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8",
+            "constructor_calldata": [
+                "0x782142c3526899d48e6f1ce725f56b11cb462586c9f1340e4cfbcbebdd174f2",
+                "0x7dee1fa95f31fd5ffb0ad1c3313aa51d82d66adfbb65efb982eae696c4309b7"
+            ],
+            "transaction_hash": "0x782806917e338d148960fe9d801cabdf41c197d144db73cde4a16499321e2a",
+            "type": "DEPLOY"
+        },
+        {
+            "version": "0x0",
+            "contract_address": "0x703283db9c320db759d02c5255af47be11ac2e2dca4a27bca92b407e25e063b",
+            "contract_address_salt": "0x13b7e67ff6b2e1a5aac25134cc2765ea2a1bf36a7b94c92aa3fc4690978d1c5",
+            "class_hash": "0x10455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8",
+            "constructor_calldata": [
+                "0x26a1e7e74188cbc724a793c972ad09d5aba110c4c06dfae51ae078b321e957",
+                "0x461226574f9663500fc330295cea93b295389618c9eab30c3362fa14975d54c"
+            ],
+            "transaction_hash": "0x7e845e48e9e9350f4f638ab145ab58346e767396aa84a5f9b695a27332f301b",
+            "type": "DEPLOY"
+        },
+        {
+            "version": "0x0",
+            "contract_address": "0x3cafce8a34c9796e8f71209bcfcc2903dcad24b8d924944e88466b0cafd352",
+            "contract_address_salt": "0x25c239a162c5a7ace888ca39f295aad52b75174952f4ea8f3afed13cde4490a",
+            "class_hash": "0x10455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8",
+            "constructor_calldata": [
+                "0x1a315d6be5adafdd493b45672137525190b23b7f3a0ec91feafaa6ab48b0828",
+                "0x24740a6b71ae76d658a1ec1efb6f201ba9794ebeed49ca59c0efe63f4a3cca2"
+            ],
+            "transaction_hash": "0x5b99cc55d38c5dd909eeda916a2564364577a8d348b05c00de1419e1ff318e2",
+            "type": "DEPLOY"
+        },
+        {
+            "version": "0x0",
+            "contract_address": "0x7b196a359045d4d0c10f73bdf244a9e1205a615dbb754b8df40173364288534",
+            "entry_point_selector": "0x19a35a6e95cb7a3318dbb244f20975a1cd8587cc6b5259f15f61d7beb7ee43b",
+            "entry_point_type": "EXTERNAL",
+            "calldata": [
+                "0x64ed79a8ebe97485d3357bbfdf5f6bea0d9db3b5f1feb6e80d564a179122dc6",
+                "0x4e23b03fa17cab92b1fbcf15b4f6583736b7bef4be4d87559618265095adf32"
+            ],
+            "signature": [],
+            "transaction_hash": "0x53028e485df33f22d4a6cd3a539759bce78e940314906c3057d206b57d4ce3f",
+            "max_fee": "0x0",
+            "type": "INVOKE_FUNCTION"
+        }
+    ],
+    "timestamp": 1638978017,
+    "transaction_receipts": [
+        {
+            "transaction_index": 0,
+            "transaction_hash": "0x782806917e338d148960fe9d801cabdf41c197d144db73cde4a16499321e2a",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 29,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 0,
+                    "range_check_builtin": 0,
+                    "bitwise_builtin": 0,
+                    "output_builtin": 0,
+                    "ecdsa_builtin": 0,
+                    "ec_op_builtin": 0
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x0"
+        },
+        {
+            "transaction_index": 1,
+            "transaction_hash": "0x7e845e48e9e9350f4f638ab145ab58346e767396aa84a5f9b695a27332f301b",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 29,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 0,
+                    "range_check_builtin": 0,
+                    "bitwise_builtin": 0,
+                    "output_builtin": 0,
+                    "ecdsa_builtin": 0,
+                    "ec_op_builtin": 0
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x0"
+        },
+        {
+            "transaction_index": 2,
+            "transaction_hash": "0x5b99cc55d38c5dd909eeda916a2564364577a8d348b05c00de1419e1ff318e2",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 29,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 0,
+                    "range_check_builtin": 0,
+                    "bitwise_builtin": 0,
+                    "output_builtin": 0,
+                    "ecdsa_builtin": 0,
+                    "ec_op_builtin": 0
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x0"
+        },
+        {
+            "transaction_index": 3,
+            "transaction_hash": "0x53028e485df33f22d4a6cd3a539759bce78e940314906c3057d206b57d4ce3f",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 178,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 0,
+                    "range_check_builtin": 0,
+                    "bitwise_builtin": 0,
+                    "output_builtin": 0,
+                    "ecdsa_builtin": 0,
+                    "ec_op_builtin": 0
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x0"
+        }
+    ]
+}

--- a/crates/pathfinder/fixtures/sequencer/integration/block/216171.json
+++ b/crates/pathfinder/fixtures/sequencer/integration/block/216171.json
@@ -1,0 +1,388 @@
+{
+    "block_hash": "0x2283cd85b55d721ce686fe1f5e20000e74b0b9451896657b31002e6cfe895",
+    "parent_block_hash": "0x6a649d5bdc000b10ef31aa8d457d80e36301de385cf01a453f5669c139301ed",
+    "block_number": 216171,
+    "state_root": "07f81a46fd53dc8e705c96547d1a769bb68bc84e02c05beac251df231fa4b827",
+    "status": "ACCEPTED_ON_L1",
+    "gas_price": "0x5f5e0e0",
+    "transactions": [
+        {
+            "version": "0x0",
+            "class_hash": "0xa69700a89b1fa3648adff91c438b79c75f7dcb0f4798938a144cce221639d6",
+            "sender_address": "0x1",
+            "nonce": "0x0",
+            "max_fee": "0x0",
+            "transaction_hash": "0x2118844f9507004d562172aa01225b867f1578ca0a5499b87b426828181a5f1",
+            "signature": [],
+            "type": "DECLARE"
+        },
+        {
+            "version": "0x1",
+            "contract_address": "0x444453070729bf2db6a1f36541483c2952674e5de4bd05fcf538726b286bfa2",
+            "contract_address_salt": "0x58c17eac8461df294731bccb9c755934b8c138e92bbd976e534ca7a151009c6",
+            "class_hash": "0xa69700a89b1fa3648adff91c438b79c75f7dcb0f4798938a144cce221639d6",
+            "constructor_calldata": [
+                "0x53796d59fb57d29f8aa57700c590785090789f933e0b84c6964ff8b86ad3f26",
+                "0x7b265ab40ad2c0626b417dc422802501c8f21b3a40eace4fdc6011b79634d37"
+            ],
+            "transaction_hash": "0x4d354809fe2bae48e2c4141eb3df8b3cad66ccfd4cc86696e5051a86595d245",
+            "type": "DEPLOY"
+        },
+        {
+            "version": "0x1",
+            "contract_address": "0x6dec5ef1d559ba82f99e5a35cdad61bbc3c663d9f9bc3eda7660c0d2195c4f9",
+            "contract_address_salt": "0x38096d1613ef7c1bc012b7adc58afd6a82b2e12b88acc9c7497b0d4f8303c59",
+            "class_hash": "0xa69700a89b1fa3648adff91c438b79c75f7dcb0f4798938a144cce221639d6",
+            "constructor_calldata": [
+                "0xddd8459235d2cb2437ac44c0d957d3c68bda1fd34d015de3d1128c1a0f59ca",
+                "0x44805c2f6845ce4da2d884291b70dd45ea9e376dfc9d6b9d2088e5224679a88"
+            ],
+            "transaction_hash": "0xf6e62f12b1f0180d5d0418c39cebad0f0fd543df327aa51ac58a0242677e70",
+            "type": "DEPLOY"
+        },
+        {
+            "version": "0x0",
+            "class_hash": "0x5079dc27d18918ec7a81be5933620ba90d2191092d70b07110991f7d724920d",
+            "sender_address": "0x1",
+            "nonce": "0x0",
+            "max_fee": "0x0",
+            "transaction_hash": "0x62f3f08d61b98ffe2b83880a46341df6b78176be3fd4313ee1122e15c9d32fb",
+            "signature": [],
+            "type": "DECLARE"
+        },
+        {
+            "version": "0x1",
+            "contract_address": "0x5fb7f82414f88e8418bb5f973bbc8fcb660a91913da262f47ecf8e898b83b09",
+            "contract_address_salt": "0x3b9aca00",
+            "class_hash": "0x5079dc27d18918ec7a81be5933620ba90d2191092d70b07110991f7d724920d",
+            "constructor_calldata": [
+                "0x406a640b3b70dad390d661c088df1fbaeb5162a07d57cf29ba794e2b0e3c804"
+            ],
+            "transaction_hash": "0x4804f8978aa2d794933e734dc226721e84e9d471739068f96e8aead4625aca9",
+            "type": "DEPLOY"
+        },
+        {
+            "version": "0x1",
+            "contract_address": "0x577abc3e3ab491af6fdc1e185b71a6d04f7e71a525f9f57c19fc36ed0655a39",
+            "contract_address_salt": "0x3b9aca01",
+            "class_hash": "0x5079dc27d18918ec7a81be5933620ba90d2191092d70b07110991f7d724920d",
+            "constructor_calldata": [
+                "0x406a640b3b70dad390d661c088df1fbaeb5162a07d57cf29ba794e2b0e3c804"
+            ],
+            "transaction_hash": "0x792d2b1675a93da14b346d2619908f6a7c84f8f3efbeda94edd0f43d8271a9f",
+            "type": "DEPLOY"
+        },
+        {
+            "version": "0x1",
+            "contract_address": "0x4008054c206d2ab9346c58cec433e3b1b2bcd8b32f6fd9a31ee3c18e95d663e",
+            "contract_address_salt": "0x10df0ba2f99776b0e702ac695ef9fb429eedf13c873450ed0790dcd96e30d97",
+            "class_hash": "0xa69700a89b1fa3648adff91c438b79c75f7dcb0f4798938a144cce221639d6",
+            "constructor_calldata": [
+                "0x1f2694ed9c75f712264c374cac7cbdd218be037ac028e7023c012cd17ed5c7d",
+                "0x73bd309803364074fb3ae282bbe49d97803ce54a18300321c45750141331d24"
+            ],
+            "transaction_hash": "0x3bbdff8ca8724be35cd6c18df62c1a665cf77b3be3527b9b2f43a561c9d417f",
+            "type": "DEPLOY"
+        },
+        {
+            "version": "0x0",
+            "contract_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+            "entry_point_selector": "0x2d757788a8d8d6f21d1cd40bce38a8222d70654214e96ff95d8086e684fbee5",
+            "nonce": "0x20",
+            "calldata": [
+                "0xbe1259ff905cadbbaa62514388b71bdefb8aacc1",
+                "0x5fb7f82414f88e8418bb5f973bbc8fcb660a91913da262f47ecf8e898b83b09",
+                "0x4563918244f40000",
+                "0x0"
+            ],
+            "transaction_hash": "0x1b85068b298ffbb0ef33acc8952b7436c359883bd736b73e204c433a3eb9691",
+            "type": "L1_HANDLER"
+        },
+        {
+            "version": "0x0",
+            "contract_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+            "entry_point_selector": "0x2d757788a8d8d6f21d1cd40bce38a8222d70654214e96ff95d8086e684fbee5",
+            "nonce": "0x21",
+            "calldata": [
+                "0xbe1259ff905cadbbaa62514388b71bdefb8aacc1",
+                "0x577abc3e3ab491af6fdc1e185b71a6d04f7e71a525f9f57c19fc36ed0655a39",
+                "0x4563918244f40000",
+                "0x0"
+            ],
+            "transaction_hash": "0x8bae5e96e9447663df0ece2091f9cb57c1508e5cadae637ddba2735f1252e1",
+            "type": "L1_HANDLER"
+        },
+        {
+            "version": "0x1",
+            "contract_address": "0x5fb7f82414f88e8418bb5f973bbc8fcb660a91913da262f47ecf8e898b83b09",
+            "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+            "entry_point_type": "EXTERNAL",
+            "nonce": "0x0",
+            "calldata": [
+                "0x1",
+                "0x6dec5ef1d559ba82f99e5a35cdad61bbc3c663d9f9bc3eda7660c0d2195c4f9",
+                "0x317eb442b72a9fae758d4fb26830ed0d9f31c8e7da4dbff4e8c59ea6a158e7f",
+                "0x0",
+                "0x4",
+                "0x4",
+                "0x208fe2128403ae7268d7198149eb050f000e185502807824aeafe0ba209a402",
+                "0x2",
+                "0x4f25c0268650df4a937463a47c1647c1661bc18e8c00eb935495edf635a70b4",
+                "0x219e05e77b5b719d7ea800f81e9b10d4b92ad8041dcfddbecb34c0b8e95a3a7"
+            ],
+            "signature": [
+                "0x26affc2bfec681bb5089e77b510efc937d4f4b6131c2a24440df8293cd44b08",
+                "0x7a04bda29e80b977d1a372ecdd1cf82f5b3381fad3e65006f0b0dfad7278fb1"
+            ],
+            "transaction_hash": "0x3c6b5dc87a4cc53a6a24bc25f79d298532ea17de1b2c912e5be5683b975b1a0",
+            "max_fee": "0x2386f26fc10000",
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "version": "0x1",
+            "contract_address": "0x577abc3e3ab491af6fdc1e185b71a6d04f7e71a525f9f57c19fc36ed0655a39",
+            "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+            "entry_point_type": "EXTERNAL",
+            "nonce": "0x0",
+            "calldata": [
+                "0x1",
+                "0x444453070729bf2db6a1f36541483c2952674e5de4bd05fcf538726b286bfa2",
+                "0x3d7905601c217734671143d457f0db37f7f8883112abd34b92c4abfeafde0c3",
+                "0x0",
+                "0x2",
+                "0x2",
+                "0x6f822dfaeeb2df41db9787456ebaa08d5005086ee3f29bac094d88476244f83",
+                "0x6290fbaff0e6572495e25edd02da170a82a4271a2fb0af685ecc0e85d37aa1a"
+            ],
+            "signature": [
+                "0x35cda12f5853c5929534f6f10fb5aae864ce350f8910bddfb0bacfc4ba49a85",
+                "0x119e97ff0f8a396301ec161dae038c889a1d3d98362aa393fcbcbeeff884d00"
+            ],
+            "transaction_hash": "0x2711d87b73244ad6d9ede3d8424d4e07e48d57746391033ed9e14e7e2edc12b",
+            "max_fee": "0x2386f26fc10000",
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "version": "0x1",
+            "contract_address": "0x577abc3e3ab491af6fdc1e185b71a6d04f7e71a525f9f57c19fc36ed0655a39",
+            "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+            "entry_point_type": "EXTERNAL",
+            "nonce": "0x1",
+            "calldata": [
+                "0x1",
+                "0x444453070729bf2db6a1f36541483c2952674e5de4bd05fcf538726b286bfa2",
+                "0x3d7905601c217734671143d457f0db37f7f8883112abd34b92c4abfeafde0c3",
+                "0x0",
+                "0x2",
+                "0x2",
+                "0x783c5828588254d9d22880b3e35deae18faa6bf4f0f6c57491360e8c2756afd",
+                "0x1497d54b50f984c3e73c2330e727cef56714f697625c386c309d391e6fd742b"
+            ],
+            "signature": [
+                "0x5ed0b91f5553453c8257cd11b959183d668437f371aca974b7a799b6a5fac97",
+                "0x60058de151149b538ad23aefcd6dfc2da83bfbf2a8113c2517886140e0fe7e6"
+            ],
+            "transaction_hash": "0x178cd20a5a7bf1a989d626239c47bbf90af2ed25ac939e1aa46f553c32d4b19",
+            "max_fee": "0x2386f26fc10000",
+            "type": "INVOKE_FUNCTION"
+        }
+    ],
+    "timestamp": 1661773909,
+    "sequencer_address": "0x46a89ae102987331d369645031b49c27738ed096f2789c24449966da4c6de6b",
+    "transaction_receipts": [
+        {
+            "transaction_index": 0,
+            "transaction_hash": "0x2118844f9507004d562172aa01225b867f1578ca0a5499b87b426828181a5f1",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "actual_fee": "0x0"
+        },
+        {
+            "transaction_index": 1,
+            "transaction_hash": "0x4d354809fe2bae48e2c4141eb3df8b3cad66ccfd4cc86696e5051a86595d245",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 30,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x0"
+        },
+        {
+            "transaction_index": 2,
+            "transaction_hash": "0xf6e62f12b1f0180d5d0418c39cebad0f0fd543df327aa51ac58a0242677e70",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 30,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x0"
+        },
+        {
+            "transaction_index": 3,
+            "transaction_hash": "0x62f3f08d61b98ffe2b83880a46341df6b78176be3fd4313ee1122e15c9d32fb",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "actual_fee": "0x0"
+        },
+        {
+            "transaction_index": 4,
+            "transaction_hash": "0x4804f8978aa2d794933e734dc226721e84e9d471739068f96e8aead4625aca9",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 41,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x0"
+        },
+        {
+            "transaction_index": 5,
+            "transaction_hash": "0x792d2b1675a93da14b346d2619908f6a7c84f8f3efbeda94edd0f43d8271a9f",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 41,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x0"
+        },
+        {
+            "transaction_index": 6,
+            "transaction_hash": "0x3bbdff8ca8724be35cd6c18df62c1a665cf77b3be3527b9b2f43a561c9d417f",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 30,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x0"
+        },
+        {
+            "transaction_index": 7,
+            "transaction_hash": "0x1b85068b298ffbb0ef33acc8952b7436c359883bd736b73e204c433a3eb9691",
+            "l1_to_l2_consumed_message": {
+                "from_address": "0xBe1259ff905cAdBbAA62514388b71BdEfB8aacC1",
+                "to_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                "selector": "0x2d757788a8d8d6f21d1cd40bce38a8222d70654214e96ff95d8086e684fbee5",
+                "payload": [
+                    "0x5fb7f82414f88e8418bb5f973bbc8fcb660a91913da262f47ecf8e898b83b09",
+                    "0x4563918244f40000",
+                    "0x0"
+                ],
+                "nonce": "0x20"
+            },
+            "l2_to_l1_messages": [],
+            "events": [
+                {
+                    "from_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                    "keys": [
+                        "0x221e5a5008f7a28564f0eaa32cdeb0848d10657c449aed3e15d12150a7c2db3"
+                    ],
+                    "data": [
+                        "0x5fb7f82414f88e8418bb5f973bbc8fcb660a91913da262f47ecf8e898b83b09",
+                        "0x4563918244f40000",
+                        "0x0"
+                    ]
+                }
+            ],
+            "execution_resources": {
+                "n_steps": 635,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 2,
+                    "range_check_builtin": 12
+                },
+                "n_memory_holes": 20
+            },
+            "actual_fee": "0x0"
+        },
+        {
+            "transaction_index": 8,
+            "transaction_hash": "0x8bae5e96e9447663df0ece2091f9cb57c1508e5cadae637ddba2735f1252e1",
+            "l1_to_l2_consumed_message": {
+                "from_address": "0xBe1259ff905cAdBbAA62514388b71BdEfB8aacC1",
+                "to_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                "selector": "0x2d757788a8d8d6f21d1cd40bce38a8222d70654214e96ff95d8086e684fbee5",
+                "payload": [
+                    "0x577abc3e3ab491af6fdc1e185b71a6d04f7e71a525f9f57c19fc36ed0655a39",
+                    "0x4563918244f40000",
+                    "0x0"
+                ],
+                "nonce": "0x21"
+            },
+            "l2_to_l1_messages": [],
+            "events": [
+                {
+                    "from_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                    "keys": [
+                        "0x221e5a5008f7a28564f0eaa32cdeb0848d10657c449aed3e15d12150a7c2db3"
+                    ],
+                    "data": [
+                        "0x577abc3e3ab491af6fdc1e185b71a6d04f7e71a525f9f57c19fc36ed0655a39",
+                        "0x4563918244f40000",
+                        "0x0"
+                    ]
+                }
+            ],
+            "execution_resources": {
+                "n_steps": 631,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 2,
+                    "range_check_builtin": 12
+                },
+                "n_memory_holes": 22
+            },
+            "actual_fee": "0x0"
+        },
+        {
+            "transaction_index": 9,
+            "transaction_hash": "0x3c6b5dc87a4cc53a6a24bc25f79d298532ea17de1b2c912e5be5683b975b1a0",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 307,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 2,
+                    "range_check_builtin": 9
+                },
+                "n_memory_holes": 25
+            },
+            "actual_fee": "0x76c451cf60"
+        },
+        {
+            "transaction_index": 10,
+            "transaction_hash": "0x2711d87b73244ad6d9ede3d8424d4e07e48d57746391033ed9e14e7e2edc12b",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 167,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 2
+                },
+                "n_memory_holes": 3
+            },
+            "actual_fee": "0x59f1445420"
+        },
+        {
+            "transaction_index": 11,
+            "transaction_hash": "0x178cd20a5a7bf1a989d626239c47bbf90af2ed25ac939e1aa46f553c32d4b19",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 167,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 2
+                },
+                "n_memory_holes": 3
+            },
+            "actual_fee": "0x59f1445420"
+        }
+    ],
+    "starknet_version": "0.10.0"
+}

--- a/crates/pathfinder/fixtures/sequencer/integration/block/216591.json
+++ b/crates/pathfinder/fixtures/sequencer/integration/block/216591.json
@@ -1,0 +1,85 @@
+{
+    "block_hash": "0x67171fe1637e5bd5fcc2ac9762e1263ec693d7535dc59969643f93c440a9af1",
+    "parent_block_hash": "0xf276b1bf3d22a17f3631e7df244f85e4fb0eb58234914bf1e1e264e31dfa07",
+    "block_number": 216591,
+    "state_root": "018bfd6b1f7f613801b6de17678cde95ce17d7ca57c2c361c473eeb8da11884f",
+    "status": "ACCEPTED_ON_L1",
+    "gas_price": "0x8401f7e",
+    "transactions": [
+        {
+            "version": "0x1",
+            "contract_address": "0x577abc3e3ab491af6fdc1e185b71a6d04f7e71a525f9f57c19fc36ed0655a39",
+            "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+            "entry_point_type": "EXTERNAL",
+            "nonce": "0xcb",
+            "calldata": [
+                "0x1",
+                "0x1b27285a7420fbf7fbae8a38b23d4b8202893a253967b0829ebe9ac9eb27e78",
+                "0x2913ee03e5e3308c41e308bd391ea4faac9b9cb5062c76a6b3ab4f65397e106",
+                "0x0",
+                "0xe",
+                "0xe",
+                "0x2",
+                "0x61e74582fa300e79d36989da5c807016035293950ea824d31bae17484e43819",
+                "0x7cc3467d7063bca6c73209559ef1ca908a5b37c94e190ff49a6b973c5d36ce6",
+                "0xa",
+                "0x2b173af31e72e831d069728ce52a5ba5227545300e69459b8c6bc04a4926839",
+                "0x156bf08e644f280be11c32d8e32b5e4219ccdf694c1fe34e1e11061af91f33a",
+                "0x4639fa77f75d587cfbe23db088065aee06e63085c91dba0205d931cf0956a8b",
+                "0x271c7470daf9d0495fc9741da60911487e44b0290d8cc7f6d2e13fa143450d6",
+                "0x3999b4d761715d4d5c81c0fbfca209e97f6947f7c77d2e4ccfa9ab21f03331d",
+                "0x343ddbe188b9ad0f02838116645216ffedb988c3a5e8ecfcd8f0051016edc7c",
+                "0x9e3cb7eeb40ab7c71b153a8bbbfbce9278223c2412bcd34044afcd0d17c5bd",
+                "0x7875996afa2caa516ada5e228ce4ee43763faee14f2d8e8926f16b1d4eaf05e",
+                "0x4af7944f76e031cf9f288dc346caa5201f9c84993c86d4ba83fb314ccd5de74",
+                "0x5cbd6c770057caf2c6c08f166dc11669bf3abff6e5adbd4edfa01987dfb63c5"
+            ],
+            "signature": [
+                "0x14441c931e7c3d4e725c584e9c481f9bb1af9c565621b6dba61d83c6a7dffc2",
+                "0x3abdf98ab5137530c39de50de553c120d052ce389db1019f420f29001ccea21"
+            ],
+            "transaction_hash": "0x223a52d3081ae0b0c83464fe33b424981975a98ff9bba82345e3c035741420",
+            "max_fee": "0x2386f26fc10000",
+            "type": "INVOKE_FUNCTION"
+        }
+    ],
+    "timestamp": 1661849727,
+    "sequencer_address": "0x46a89ae102987331d369645031b49c27738ed096f2789c24449966da4c6de6b",
+    "transaction_receipts": [
+        {
+            "transaction_index": 0,
+            "transaction_hash": "0x223a52d3081ae0b0c83464fe33b424981975a98ff9bba82345e3c035741420",
+            "l2_to_l1_messages": [],
+            "events": [
+                {
+                    "from_address": "0x1b27285a7420fbf7fbae8a38b23d4b8202893a253967b0829ebe9ac9eb27e78",
+                    "keys": [
+                        "0x61e74582fa300e79d36989da5c807016035293950ea824d31bae17484e43819",
+                        "0x7cc3467d7063bca6c73209559ef1ca908a5b37c94e190ff49a6b973c5d36ce6"
+                    ],
+                    "data": [
+                        "0x2b173af31e72e831d069728ce52a5ba5227545300e69459b8c6bc04a4926839",
+                        "0x156bf08e644f280be11c32d8e32b5e4219ccdf694c1fe34e1e11061af91f33a",
+                        "0x4639fa77f75d587cfbe23db088065aee06e63085c91dba0205d931cf0956a8b",
+                        "0x271c7470daf9d0495fc9741da60911487e44b0290d8cc7f6d2e13fa143450d6",
+                        "0x3999b4d761715d4d5c81c0fbfca209e97f6947f7c77d2e4ccfa9ab21f03331d",
+                        "0x343ddbe188b9ad0f02838116645216ffedb988c3a5e8ecfcd8f0051016edc7c",
+                        "0x9e3cb7eeb40ab7c71b153a8bbbfbce9278223c2412bcd34044afcd0d17c5bd",
+                        "0x7875996afa2caa516ada5e228ce4ee43763faee14f2d8e8926f16b1d4eaf05e",
+                        "0x4af7944f76e031cf9f288dc346caa5201f9c84993c86d4ba83fb314ccd5de74",
+                        "0x5cbd6c770057caf2c6c08f166dc11669bf3abff6e5adbd4edfa01987dfb63c5"
+                    ]
+                }
+            ],
+            "execution_resources": {
+                "n_steps": 185,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 4
+                },
+                "n_memory_holes": 3
+            },
+            "actual_fee": "0x2d922df1f4"
+        }
+    ],
+    "starknet_version": "0.10.0"
+}

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -359,7 +359,8 @@ mod tests {
                 state_update::StorageDiff,
                 transaction::{
                     execution_resources::{BuiltinInstanceCounter, EmptyBuiltinInstanceCounter},
-                    EntryPointType, Event, ExecutionResources, InvokeTransaction, Receipt,
+                    EntryPointType, Event, ExecutionResources, InvokeTransaction,
+                    InvokeTransactionV0, Receipt,
                 },
             },
             test_utils::*,
@@ -382,6 +383,7 @@ mod tests {
         net::{Ipv4Addr, SocketAddrV4},
         sync::Arc,
     };
+    use web3::types::H256;
 
     /// Helper function: produces named rpc method args map.
     fn by_name<const N: usize>(params: [(&'_ str, serde_json::Value); N]) -> Option<ParamsSer<'_>> {
@@ -535,7 +537,7 @@ mod tests {
 
         let txn0_hash = StarknetTransactionHash(starkhash_bytes!(b"txn 0"));
         // TODO introduce other types of transactions too
-        let txn0 = InvokeTransaction {
+        let txn0 = InvokeTransactionV0 {
             calldata: vec![],
             contract_address: contract0_addr,
             entry_point_type: EntryPointType::External,
@@ -579,12 +581,12 @@ mod tests {
         txn4.contract_address = ContractAddress::new_or_panic(StarkHash::ZERO);
         let mut txn5 = txn4.clone();
         txn5.transaction_hash = txn5_hash;
-        let txn0 = Transaction::Invoke(txn0);
-        let txn1 = Transaction::Invoke(txn1);
-        let txn2 = Transaction::Invoke(txn2);
-        let txn3 = Transaction::Invoke(txn3);
-        let txn4 = Transaction::Invoke(txn4);
-        let txn5 = Transaction::Invoke(txn5);
+        let txn0 = Transaction::Invoke(txn0.into());
+        let txn1 = Transaction::Invoke(txn1.into());
+        let txn2 = Transaction::Invoke(txn2.into());
+        let txn3 = Transaction::Invoke(txn3.into());
+        let txn4 = Transaction::Invoke(txn4.into());
+        let txn5 = Transaction::Invoke(txn5.into());
         let mut receipt1 = receipt0.clone();
         let mut receipt2 = receipt0.clone();
         let mut receipt3 = receipt0.clone();
@@ -637,7 +639,7 @@ mod tests {
         .unwrap();
 
         let transactions: Vec<Transaction> = vec![
-            InvokeTransaction {
+            InvokeTransaction::V0(InvokeTransactionV0 {
                 calldata: vec![],
                 contract_address: ContractAddress::new_or_panic(starkhash_bytes!(
                     b"pending contract addr 0"
@@ -647,7 +649,7 @@ mod tests {
                 max_fee: Call::DEFAULT_MAX_FEE,
                 signature: vec![],
                 transaction_hash: StarknetTransactionHash(starkhash_bytes!(b"pending tx hash 0")),
-            }
+            })
             .into(),
             DeployTransaction {
                 contract_address: ContractAddress::new_or_panic(starkhash!("01122355")),

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -655,6 +655,7 @@ mod tests {
                 class_hash: ClassHash(starkhash_bytes!(b"pending class hash 1")),
                 constructor_calldata: vec![],
                 transaction_hash: StarknetTransactionHash(starkhash_bytes!(b"pending tx hash 1")),
+                version: TransactionVersion(H256::zero()),
             }
             .into(),
         ];

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -549,13 +549,13 @@ mod tests {
         let mut receipt0 = Receipt {
             actual_fee: None,
             events: vec![],
-            execution_resources: ExecutionResources {
+            execution_resources: Some(ExecutionResources {
                 builtin_instance_counter: BuiltinInstanceCounter::Empty(
                     EmptyBuiltinInstanceCounter {},
                 ),
                 n_memory_holes: 0,
                 n_steps: 0,
-            },
+            }),
             l1_to_l2_consumed_message: None,
             l2_to_l1_messages: vec![],
             transaction_hash: txn0_hash,
@@ -682,13 +682,13 @@ mod tests {
                         keys: vec![EventKey(starkhash_bytes!(b"pending key 2"))],
                     },
                 ],
-                execution_resources: ExecutionResources {
+                execution_resources: Some(ExecutionResources {
                     builtin_instance_counter: BuiltinInstanceCounter::Empty(
                         EmptyBuiltinInstanceCounter {},
                     ),
                     n_memory_holes: 0,
                     n_steps: 0,
-                },
+                }),
                 l1_to_l2_consumed_message: None,
                 l2_to_l1_messages: vec![],
                 transaction_hash: transactions[0].hash(),
@@ -697,13 +697,13 @@ mod tests {
             Receipt {
                 actual_fee: None,
                 events: vec![],
-                execution_resources: ExecutionResources {
+                execution_resources: Some(ExecutionResources {
                     builtin_instance_counter: BuiltinInstanceCounter::Empty(
                         EmptyBuiltinInstanceCounter {},
                     ),
                     n_memory_holes: 0,
                     n_steps: 0,
-                },
+                }),
                 l1_to_l2_consumed_message: None,
                 l2_to_l1_messages: vec![],
                 transaction_hash: transactions[1].hash(),

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -662,20 +662,41 @@ pub mod reply {
         fn from(txn: &sequencer::reply::transaction::Transaction) -> Self {
             match txn {
                 sequencer::reply::transaction::Transaction::Invoke(txn) => {
-                    Self::Invoke(InvokeTransaction {
-                        common: CommonTransactionProperties {
-                            hash: txn.transaction_hash,
-                            max_fee: txn.max_fee,
-                            // no `version` in invoke transactions
-                            version: TransactionVersion(Default::default()),
-                            signature: txn.signature.clone(),
-                            // no `nonce` in invoke transactions
-                            nonce: TransactionNonce(Default::default()),
-                        },
-                        contract_address: txn.contract_address,
-                        entry_point_selector: txn.entry_point_selector,
-                        calldata: txn.calldata.clone(),
-                    })
+                    match txn {
+                        sequencer::reply::transaction::InvokeTransaction::V0(txn) => {
+                            Self::Invoke(InvokeTransaction {
+                                common: CommonTransactionProperties {
+                                    hash: txn.transaction_hash,
+                                    max_fee: txn.max_fee,
+                                    // no `version` in invoke transactions
+                                    version: TransactionVersion(Default::default()),
+                                    signature: txn.signature.clone(),
+                                    // no `nonce` in invoke transactions
+                                    nonce: TransactionNonce(Default::default()),
+                                },
+                                contract_address: txn.contract_address,
+                                entry_point_selector: txn.entry_point_selector,
+                                calldata: txn.calldata.clone(),
+                            })
+                        }
+                        sequencer::reply::transaction::InvokeTransaction::V1(txn) => {
+                            // FIXME: use V1 RPC type here
+                            Self::Invoke(InvokeTransaction {
+                                common: CommonTransactionProperties {
+                                    hash: txn.transaction_hash,
+                                    max_fee: txn.max_fee,
+                                    // no `version` in invoke transactions
+                                    version: TransactionVersion(Default::default()),
+                                    signature: txn.signature.clone(),
+                                    // no `nonce` in invoke transactions
+                                    nonce: TransactionNonce(Default::default()),
+                                },
+                                contract_address: txn.contract_address,
+                                entry_point_selector: EntryPoint(StarkHash::ZERO),
+                                calldata: txn.calldata.clone(),
+                            })
+                        }
+                    }
                 }
                 sequencer::reply::transaction::Transaction::Declare(txn) => {
                     Self::Declare(DeclareTransaction {

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -721,6 +721,7 @@ pub mod reply {
                         constructor_calldata: txn.constructor_calldata.clone(),
                     })
                 }
+                sequencer::reply::transaction::Transaction::L1Handler(_txn) => todo!(),
             }
         }
     }
@@ -852,6 +853,7 @@ pub mod reply {
                             .collect(),
                     })
                 }
+                sequencer::reply::transaction::Transaction::L1Handler(_) => todo!(),
             }
         }
 
@@ -862,9 +864,9 @@ pub mod reply {
             block_number: StarknetBlockNumber,
             transaction: &sequencer::reply::transaction::Transaction,
         ) -> Self {
+            use sequencer::reply::transaction::Transaction::*;
             match transaction {
-                sequencer::reply::transaction::Transaction::Declare(_)
-                | sequencer::reply::transaction::Transaction::Deploy(_) => {
+                Declare(_) | Deploy(_) => {
                     Self::DeclareOrDeploy(DeclareOrDeployTransactionReceipt {
                         common: CommonTransactionReceiptProperties {
                             transaction_hash: receipt.transaction_hash,
@@ -879,7 +881,7 @@ pub mod reply {
                         },
                     })
                 }
-                sequencer::reply::transaction::Transaction::Invoke(_) => {
+                Invoke(_) => {
                     Self::Invoke(InvokeTransactionReceipt {
                         common: CommonTransactionReceiptProperties {
                             transaction_hash: receipt.transaction_hash,
@@ -907,6 +909,7 @@ pub mod reply {
                             .collect(),
                     })
                 }
+                L1Handler(_) => todo!(),
             }
         }
     }

--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -693,8 +693,7 @@ pub mod reply {
                 sequencer::reply::transaction::Transaction::Deploy(txn) => {
                     Self::Deploy(DeployTransaction {
                         hash: txn.transaction_hash,
-                        // no `version` in deploy transactions
-                        version: TransactionVersion(Default::default()),
+                        version: txn.version,
                         contract_address: txn.contract_address,
                         contract_address_salt: txn.contract_address_salt,
                         class_hash: txn.class_hash,

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -276,7 +276,8 @@ pub mod transaction {
         #[serde(default)]
         pub actual_fee: Option<Fee>,
         pub events: Vec<Event>,
-        pub execution_resources: ExecutionResources,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub execution_resources: Option<ExecutionResources>,
         pub l1_to_l2_consumed_message: Option<L1ToL2Message>,
         pub l2_to_l1_messages: Vec<L2ToL1Message>,
         pub transaction_hash: StarknetTransactionHash,

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -314,13 +314,12 @@ pub mod transaction {
             match self {
                 Transaction::Declare(t) => t.transaction_hash,
                 Transaction::Deploy(t) => t.transaction_hash,
-                Transaction::Invoke(t) => t.transaction_hash,
+                Transaction::Invoke(t) => match t {
+                    InvokeTransaction::V0(t) => t.transaction_hash,
+                    InvokeTransaction::V1(t) => t.transaction_hash,
+                },
             }
         }
-    }
-
-    fn default_transaction_version() -> TransactionVersion {
-        TransactionVersion(web3::types::H256::zero())
     }
 
     /// Represents deserialized L2 declare transaction data.
@@ -341,6 +340,10 @@ pub mod transaction {
         pub version: TransactionVersion,
     }
 
+    fn transaction_version_zero() -> TransactionVersion {
+        TransactionVersion(web3::types::H256::zero())
+    }
+
     /// Represents deserialized L2 deploy transaction data.
     #[serde_as]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -353,16 +356,65 @@ pub mod transaction {
         pub constructor_calldata: Vec<ConstructorParam>,
         pub transaction_hash: StarknetTransactionHash,
         #[serde_as(as = "TransactionVersionAsHexStr")]
-        #[serde(default = "default_transaction_version")]
+        #[serde(default = "transaction_version_zero")]
         pub version: TransactionVersion,
     }
+
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[serde(tag = "version")]
+    pub enum InvokeTransaction {
+        #[serde(rename = "0x0")]
+        V0(InvokeTransactionV0),
+        #[serde(rename = "0x1")]
+        V1(InvokeTransactionV1),
     }
 
-    /// Represents deserialized L2 invoke transaction data.
+    impl<'de> Deserialize<'de> for InvokeTransaction {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            use serde::de;
+            use web3::types::H256;
+
+            #[serde_as]
+            #[derive(Deserialize)]
+            struct Version {
+                #[serde_as(as = "TransactionVersionAsHexStr")]
+                #[serde(default = "transaction_version_zero")]
+                pub version: TransactionVersion,
+            }
+
+            let mut v = serde_json::Value::deserialize(deserializer)?;
+            let version = Version::deserialize(&v).map_err(de::Error::custom)?;
+            // remove "version", since v0 and v1 transactions use deny_unknown_fields
+            v.as_object_mut().unwrap().remove("version");
+            match version.version {
+                TransactionVersion(x) if x == H256::from_low_u64_be(0) => Ok(Self::V0(
+                    InvokeTransactionV0::deserialize(&v).map_err(de::Error::custom)?,
+                )),
+                TransactionVersion(x) if x == H256::from_low_u64_be(1) => Ok(Self::V1(
+                    InvokeTransactionV1::deserialize(&v).map_err(de::Error::custom)?,
+                )),
+                _v => Err(de::Error::custom("version must be 0 or 1")),
+            }
+        }
+    }
+
+    impl InvokeTransaction {
+        pub fn signature(&self) -> &[TransactionSignatureElem] {
+            match self {
+                Self::V0(tx) => tx.signature.as_ref(),
+                Self::V1(tx) => tx.signature.as_ref(),
+            }
+        }
+    }
+
+    /// Represents deserialized L2 invoke transaction v0 data.
     #[serde_as]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
     #[serde(deny_unknown_fields)]
-    pub struct InvokeTransaction {
+    pub struct InvokeTransactionV0 {
         #[serde_as(as = "Vec<CallParamAsDecimalStr>")]
         pub calldata: Vec<CallParam>,
         pub contract_address: ContractAddress,
@@ -372,6 +424,24 @@ pub mod transaction {
         pub max_fee: Fee,
         #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
         pub signature: Vec<TransactionSignatureElem>,
+        pub transaction_hash: StarknetTransactionHash,
+    }
+
+    /// Represents deserialized L2 invoke transaction v1 data.
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+    #[serde(deny_unknown_fields)]
+    pub struct InvokeTransactionV1 {
+        #[serde_as(as = "Vec<CallParamAsDecimalStr>")]
+        pub calldata: Vec<CallParam>,
+        pub contract_address: ContractAddress,
+        pub entry_point_selector: EntryPoint,
+        pub entry_point_type: EntryPointType,
+        #[serde_as(as = "FeeAsHexStr")]
+        pub max_fee: Fee,
+        #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
+        pub signature: Vec<TransactionSignatureElem>,
+        pub nonce: TransactionNonce,
         pub transaction_hash: StarknetTransactionHash,
     }
 
@@ -392,6 +462,19 @@ pub mod transaction {
             Self::Invoke(tx)
         }
     }
+
+    impl From<InvokeTransactionV0> for InvokeTransaction {
+        fn from(tx: InvokeTransactionV0) -> Self {
+            Self::V0(tx)
+        }
+    }
+
+    impl From<InvokeTransactionV1> for InvokeTransaction {
+        fn from(tx: InvokeTransactionV1) -> Self {
+            Self::V1(tx)
+        }
+    }
+
     /// Describes L2 transaction failure details.
     #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
     #[serde(deny_unknown_fields)]
@@ -587,6 +670,9 @@ mod tests {
                 .unwrap();
             serde_json::from_str::<MaybePendingBlock>(fixture!("0.8.2/block/1716.json")).unwrap();
             serde_json::from_str::<MaybePendingBlock>(fixture!("0.8.2/block/pending.json"))
+                .unwrap();
+            // This is from integration starknet_version 0.10 and contains the new version 1 invoke transaction.
+            serde_json::from_str::<MaybePendingBlock>(fixture!("integration/block/216591.json"))
                 .unwrap();
         }
 

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -319,6 +319,10 @@ pub mod transaction {
         }
     }
 
+    fn default_transaction_version() -> TransactionVersion {
+        TransactionVersion(web3::types::H256::zero())
+    }
+
     /// Represents deserialized L2 declare transaction data.
     #[serde_as]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -348,6 +352,10 @@ pub mod transaction {
         #[serde_as(as = "Vec<ConstructorParamAsDecimalStr>")]
         pub constructor_calldata: Vec<ConstructorParam>,
         pub transaction_hash: StarknetTransactionHash,
+        #[serde_as(as = "TransactionVersionAsHexStr")]
+        #[serde(default = "default_transaction_version")]
+        pub version: TransactionVersion,
+    }
     }
 
     /// Represents deserialized L2 invoke transaction data.

--- a/crates/pathfinder/src/state/block_hash.rs
+++ b/crates/pathfinder/src/state/block_hash.rs
@@ -344,7 +344,9 @@ fn calculate_transaction_hash_with_signature(tx: &Transaction) -> StarkHash {
             }
             hash.finalize()
         }
-        Transaction::Declare(_) | Transaction::Deploy(_) => *HASH_OF_EMPTY_LIST,
+        Transaction::Declare(_) | Transaction::Deploy(_) | Transaction::L1Handler(_) => {
+            *HASH_OF_EMPTY_LIST
+        }
     };
 
     stark_hash(tx.hash().0, signature_hash)

--- a/crates/pathfinder/src/state/block_hash.rs
+++ b/crates/pathfinder/src/state/block_hash.rs
@@ -339,7 +339,7 @@ fn calculate_transaction_hash_with_signature(tx: &Transaction) -> StarkHash {
     let signature_hash = match tx {
         Transaction::Invoke(tx) => {
             let mut hash = HashChain::default();
-            for signature in &tx.signature {
+            for signature in tx.signature() {
                 hash.update(signature.0);
             }
             hash.finalize()
@@ -413,7 +413,7 @@ fn number_of_events_in_block(block: &Block) -> usize {
 mod tests {
     use crate::{
         core::{EntryPoint, Fee},
-        sequencer::reply::transaction::{EntryPointType, InvokeTransaction},
+        sequencer::reply::transaction::{EntryPointType, InvokeTransaction, InvokeTransactionV0},
         starkhash,
     };
 
@@ -452,7 +452,7 @@ mod tests {
     fn test_final_transaction_hash() {
         use crate::core::{ContractAddress, StarknetTransactionHash, TransactionSignatureElem};
 
-        let transaction = Transaction::Invoke(InvokeTransaction {
+        let transaction = Transaction::Invoke(InvokeTransaction::V0(InvokeTransactionV0 {
             calldata: vec![],
             contract_address: ContractAddress::new_or_panic(starkhash!("deadbeef")),
             entry_point_type: EntryPointType::External,
@@ -463,7 +463,7 @@ mod tests {
                 TransactionSignatureElem(starkhash!("03")),
             ],
             transaction_hash: StarknetTransactionHash(starkhash!("01")),
-        });
+        }));
 
         // produced by the cairo-lang Python implementation:
         // `hex(calculate_single_tx_hash_with_signature(1, [2, 3], hash_function=pedersen_hash))`

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -378,7 +378,7 @@ where
                             use sequencer::reply::transaction::Transaction::*;
                             match tx {
                                 Declare(tx) => Some(tx.class_hash),
-                                Deploy(_) | Invoke(_) => None,
+                                Deploy(_) | Invoke(_) | L1Handler(_) => None,
                             }
                         });
                     let classes = deployed_classes

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -180,7 +180,7 @@ async fn declare_classes(
             use crate::sequencer::reply::transaction::Transaction::*;
             match tx {
                 Declare(tx) => Some(tx.class_hash),
-                Deploy(_) | Invoke(_) => None,
+                Deploy(_) | Invoke(_) | L1Handler(_) => None,
             }
         })
         // Get unique class hashes only. Its unlikely they would have dupes here, but rather safe than sorry.

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -204,6 +204,7 @@ pub(crate) mod test_utils {
         },
         sequencer::reply::transaction::{
             self, DeclareTransaction, DeployTransaction, EntryPointType, InvokeTransaction,
+            InvokeTransactionV0,
         },
         starkhash,
     };
@@ -244,7 +245,7 @@ pub(crate) mod test_utils {
     ) -> [(transaction::Transaction, transaction::Receipt); NUM_TRANSACTIONS] {
         let transactions = (0..NUM_TRANSACTIONS).map(|i| match i % TRANSACTIONS_PER_BLOCK {
             x if x < INVOKE_TRANSACTIONS_PER_BLOCK => {
-                transaction::Transaction::Invoke(InvokeTransaction {
+                transaction::Transaction::Invoke(InvokeTransaction::V0(InvokeTransactionV0 {
                     calldata: vec![CallParam(
                         StarkHash::from_hex_str(&"0".repeat(i + 3)).unwrap(),
                     )],
@@ -266,7 +267,7 @@ pub(crate) mod test_utils {
                     transaction_hash: StarknetTransactionHash(
                         StarkHash::from_hex_str(&"4".repeat(i + 3)).unwrap(),
                     ),
-                })
+                }))
             }
             x if (INVOKE_TRANSACTIONS_PER_BLOCK
                 ..INVOKE_TRANSACTIONS_PER_BLOCK + DEPLOY_TRANSACTIONS_PER_BLOCK)

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -286,6 +286,7 @@ pub(crate) mod test_utils {
                     transaction_hash: StarknetTransactionHash(
                         StarkHash::from_hex_str(&"9".repeat(i + 3)).unwrap(),
                     ),
+                    version: TransactionVersion(web3::types::H256::zero()),
                 })
             }
             _ => transaction::Transaction::Declare(DeclareTransaction {

--- a/crates/pathfinder/src/storage.rs
+++ b/crates/pathfinder/src/storage.rs
@@ -326,14 +326,14 @@ pub(crate) mod test_utils {
                 } else {
                     vec![]
                 },
-                execution_resources: transaction::ExecutionResources {
+                execution_resources: Some(transaction::ExecutionResources {
                     builtin_instance_counter:
                         transaction::execution_resources::BuiltinInstanceCounter::Empty(
                             transaction::execution_resources::EmptyBuiltinInstanceCounter {},
                         ),
                     n_steps: i as u64 + 987,
                     n_memory_holes: i as u64 + 1177,
-                },
+                }),
                 l1_to_l2_consumed_message: None,
                 l2_to_l1_messages: Vec::new(),
                 transaction_hash: tx.hash(),

--- a/crates/pathfinder/src/storage/schema/revision_0015.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0015.rs
@@ -442,7 +442,8 @@ mod tests {
         .unwrap()
         .unwrap();
 
-        assert_matches::assert_matches!(migrated_tx, crate::sequencer::reply::transaction::Transaction::Invoke(invoke) => {
+        use crate::sequencer::reply::transaction::{InvokeTransaction, Transaction};
+        assert_matches::assert_matches!(migrated_tx, Transaction::Invoke(InvokeTransaction::V0(invoke)) => {
             assert_eq!(invoke.max_fee.0, H128::zero());
         });
     }

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -2160,14 +2160,14 @@ mod tests {
                 transaction::Receipt {
                     actual_fee: None,
                     events: expected_events[..3].to_vec(),
-                    execution_resources: transaction::ExecutionResources {
+                    execution_resources: Some(transaction::ExecutionResources {
                         builtin_instance_counter:
                             transaction::execution_resources::BuiltinInstanceCounter::Empty(
                                 transaction::execution_resources::EmptyBuiltinInstanceCounter {},
                             ),
                         n_steps: 0,
                         n_memory_holes: 0,
-                    },
+                    }),
                     l1_to_l2_consumed_message: None,
                     l2_to_l1_messages: Vec::new(),
                     transaction_hash: transactions[0].hash(),
@@ -2176,14 +2176,14 @@ mod tests {
                 transaction::Receipt {
                     actual_fee: None,
                     events: expected_events[3..].to_vec(),
-                    execution_resources: transaction::ExecutionResources {
+                    execution_resources: Some(transaction::ExecutionResources {
                         builtin_instance_counter:
                             transaction::execution_resources::BuiltinInstanceCounter::Empty(
                                 transaction::execution_resources::EmptyBuiltinInstanceCounter {},
                             ),
                         n_steps: 0,
                         n_memory_holes: 0,
-                    },
+                    }),
                     l1_to_l2_consumed_message: None,
                     l2_to_l1_messages: Vec::new(),
                     transaction_hash: transactions[1].hash(),

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -2130,26 +2130,30 @@ mod tests {
 
             // Note: hashes are reverse ordered to trigger the sorting bug.
             let transactions = vec![
-                transaction::Transaction::Invoke(transaction::InvokeTransaction {
-                    calldata: vec![],
-                    // Only required because event insert rejects if this is None
-                    contract_address: ContractAddress::new_or_panic(StarkHash::ZERO),
-                    entry_point_type: transaction::EntryPointType::External,
-                    entry_point_selector: EntryPoint(StarkHash::ZERO),
-                    max_fee: Fee(H128::zero()),
-                    signature: vec![],
-                    transaction_hash: StarknetTransactionHash(starkhash!("0F")),
-                }),
-                transaction::Transaction::Invoke(transaction::InvokeTransaction {
-                    calldata: vec![],
-                    // Only required because event insert rejects if this is None
-                    contract_address: ContractAddress::new_or_panic(StarkHash::ZERO),
-                    entry_point_type: transaction::EntryPointType::External,
-                    entry_point_selector: EntryPoint(StarkHash::ZERO),
-                    max_fee: Fee(H128::zero()),
-                    signature: vec![],
-                    transaction_hash: StarknetTransactionHash(starkhash!("01")),
-                }),
+                transaction::Transaction::Invoke(transaction::InvokeTransaction::V0(
+                    transaction::InvokeTransactionV0 {
+                        calldata: vec![],
+                        // Only required because event insert rejects if this is None
+                        contract_address: ContractAddress::new_or_panic(StarkHash::ZERO),
+                        entry_point_type: transaction::EntryPointType::External,
+                        entry_point_selector: EntryPoint(StarkHash::ZERO),
+                        max_fee: Fee(H128::zero()),
+                        signature: vec![],
+                        transaction_hash: StarknetTransactionHash(starkhash!("0F")),
+                    },
+                )),
+                transaction::Transaction::Invoke(transaction::InvokeTransaction::V0(
+                    transaction::InvokeTransactionV0 {
+                        calldata: vec![],
+                        // Only required because event insert rejects if this is None
+                        contract_address: ContractAddress::new_or_panic(StarkHash::ZERO),
+                        entry_point_type: transaction::EntryPointType::External,
+                        entry_point_selector: EntryPoint(StarkHash::ZERO),
+                        max_fee: Fee(H128::zero()),
+                        signature: vec![],
+                        transaction_hash: StarknetTransactionHash(starkhash!("01")),
+                    },
+                )),
             ];
 
             let receipts = vec![


### PR DESCRIPTION
This PR:

- Adds a representation for the new invoke transaction version by converting `InvokeTransaction` into an enum with either a v0 or a v1 invoke transaction inside.
- Adds a defaulted `version` field to `deployTransaction` to match the REST representation on the feeder gateway.
- Adds a representation (sequencer/RPC) for the new L1 handler transaction type. The RPC [L1Handler transaction type from spec 0.2.0-rc1](https://github.com/starkware-libs/starknet-specs/blob/c74e12d0af311537febac8f1972168cf023cb257/api/starknet_api_openrpc.json#L1367) was added to fill the void created by a similar type in the feeder gateway api with cairo 0.10.0.
- Extends [Pending]DeclareOrDeploy variants to include [L1Handler receipts](https://github.com/starkware-libs/starknet-specs/blob/v0.2.0-rc1/api/starknet_api_openrpc.json#L1542).The RPC representation for this is taken from the `0.2.0-rc1` specification, 

