### PR TITLE
feat: support integration network

### DIFF
--- a/crates/pathfinder/examples/call_against_sequencer.rs
+++ b/crates/pathfinder/examples/call_against_sequencer.rs
@@ -43,7 +43,7 @@ async fn main() {
     tracing_subscriber::fmt::init();
 
     // non-configurable options, which might become command line options:
-    let network = pathfinder_lib::core::Chain::Goerli;
+    let network = pathfinder_lib::core::Chain::Testnet;
 
     let db_file = std::env::args()
         .nth(1)
@@ -60,7 +60,7 @@ async fn main() {
             // awaitable signal will work
             let _: Result<(), _> = stop_rx.await;
         },
-        pathfinder_lib::core::Chain::Goerli,
+        pathfinder_lib::core::Chain::Testnet,
     )
     .await
     .unwrap();

--- a/crates/pathfinder/examples/fact_retrieval.rs
+++ b/crates/pathfinder/examples/fact_retrieval.rs
@@ -47,7 +47,7 @@ async fn main() {
 
     let chain = match chain {
         EthereumChain::Mainnet => Chain::Mainnet,
-        EthereumChain::Goerli => Chain::Goerli,
+        EthereumChain::Goerli => Chain::Testnet,
     };
 
     // Get the state update event at the given block.

--- a/crates/pathfinder/examples/fact_retrieval.rs
+++ b/crates/pathfinder/examples/fact_retrieval.rs
@@ -26,7 +26,7 @@ use std::str::FromStr;
 
 use clap::Arg;
 use pathfinder_lib::{
-    core::{EthereumBlockHash, StarknetBlockNumber},
+    core::{Chain, EthereumBlockHash, EthereumChain, StarknetBlockNumber},
     ethereum::{
         log::{MetaLog, StateUpdateLog},
         state_update::StateUpdate,
@@ -44,6 +44,11 @@ async fn main() {
         .chain()
         .await
         .expect("Failed to identify Ethereum network");
+
+    let chain = match chain {
+        EthereumChain::Mainnet => Chain::Mainnet,
+        EthereumChain::Goerli => Chain::Goerli,
+    };
 
     // Get the state update event at the given block.
     let filter = FilterBuilder::default()

--- a/crates/pathfinder/examples/verify_block_hashes.rs
+++ b/crates/pathfinder/examples/verify_block_hashes.rs
@@ -21,7 +21,7 @@ fn main() -> anyhow::Result<()> {
     let chain_name = std::env::args().nth(1).unwrap();
     let chain = match chain_name.as_str() {
         "mainnet" => Chain::Mainnet,
-        "goerli" => Chain::Goerli,
+        "goerli" => Chain::Testnet,
         _ => panic!("Expected chain name: mainnet/goerli"),
     };
 

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -2,7 +2,8 @@
 
 use anyhow::Context;
 use pathfinder_lib::{
-    cairo, config, core,
+    cairo, config,
+    core::{self, Chain, EthereumChain},
     ethereum::transport::{EthereumTransport, HttpTransport},
     monitoring, rpc, sequencer, state,
     storage::{JournalMode, Storage},
@@ -49,9 +50,14 @@ async fn main() -> anyhow::Result<()> {
 Hint: Make sure the provided ethereum.url and ethereum.password are good.",
     )?;
 
-    let database_path = config.data_directory.join(match ethereum_chain {
-        core::Chain::Mainnet => "mainnet.sqlite",
-        core::Chain::Goerli => "goerli.sqlite",
+    let starknet_chain = match ethereum_chain {
+        EthereumChain::Mainnet => Chain::Mainnet,
+        EthereumChain::Goerli => Chain::Goerli,
+    };
+
+    let database_path = config.data_directory.join(match starknet_chain {
+        Chain::Mainnet => "mainnet.sqlite",
+        Chain::Goerli => "goerli.sqlite",
     });
     let journal_mode = match config.sqlite_wal {
         false => JournalMode::Rollback,
@@ -59,20 +65,20 @@ Hint: Make sure the provided ethereum.url and ethereum.password are good.",
     };
     let storage = Storage::migrate(database_path.clone(), journal_mode).unwrap();
     info!(location=?database_path, "Database migrated.");
-    verify_database_chain(&storage, ethereum_chain).context("Verifying database")?;
+    verify_database_chain(&storage, starknet_chain).context("Verifying database")?;
 
     let sequencer = match config.sequencer_url {
         Some(url) => {
             info!(?url, "Using custom Sequencer address");
             let client = sequencer::Client::with_url(url).unwrap();
             let sequencer_chain = client.chain().await.unwrap();
-            if sequencer_chain != ethereum_chain {
-                tracing::error!(sequencer=%sequencer_chain, ethereum=%ethereum_chain, "Sequencer and Ethereum network mismatch");
-                anyhow::bail!("Sequencer and Ethereum network mismatch. Sequencer is on {sequencer_chain} but Ethereum is on {ethereum_chain}");
+            if sequencer_chain != starknet_chain {
+                tracing::error!(sequencer=%sequencer_chain, ethereum=%starknet_chain, "Sequencer and Ethereum network mismatch");
+                anyhow::bail!("Sequencer and Ethereum network mismatch. Sequencer is on {sequencer_chain} but Ethereum is on {starknet_chain}");
             }
             client
         }
-        None => sequencer::Client::new(ethereum_chain).unwrap(),
+        None => sequencer::Client::new(starknet_chain).unwrap(),
     };
     let sync_state = Arc::new(state::SyncState::default());
     let pending_state = state::PendingData::default();
@@ -87,7 +93,7 @@ Hint: Make sure the provided ethereum.url and ethereum.password are good.",
         storage.path().into(),
         config.python_subprocesses,
         futures::future::pending(),
-        ethereum_chain,
+        starknet_chain,
     )
     .await
     .context(
@@ -97,7 +103,7 @@ Hint: Make sure the provided ethereum.url and ethereum.password are good.",
     let sync_handle = tokio::spawn(state::sync(
         storage.clone(),
         eth_transport.clone(),
-        ethereum_chain,
+        starknet_chain,
         sequencer.clone(),
         sync_state.clone(),
         state::l1::sync,
@@ -108,7 +114,7 @@ Hint: Make sure the provided ethereum.url and ethereum.password are good.",
 
     let shared = rpc::api::Cached::new(Arc::new(eth_transport));
 
-    let api = rpc::api::RpcApi::new(storage, sequencer, ethereum_chain, sync_state)
+    let api = rpc::api::RpcApi::new(storage, sequencer, starknet_chain, sync_state)
         .with_call_handling(call_handle)
         .with_eth_gas_price(shared);
     let api = match config.poll_pending {

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -52,7 +52,10 @@ Hint: Make sure the provided ethereum.url and ethereum.password are good.",
 
     let starknet_chain = match ethereum_chain {
         EthereumChain::Mainnet => Chain::Mainnet,
-        EthereumChain::Goerli => Chain::Testnet,
+        EthereumChain::Goerli => match config.integration {
+            true => Chain::Integration,
+            false => Chain::Testnet,
+        },
     };
 
     let database_path = config.data_directory.join(match starknet_chain {

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -50,12 +50,13 @@ async fn main() -> anyhow::Result<()> {
 Hint: Make sure the provided ethereum.url and ethereum.password are good.",
     )?;
 
-    let starknet_chain = match ethereum_chain {
-        EthereumChain::Mainnet => Chain::Mainnet,
-        EthereumChain::Goerli => match config.integration {
-            true => Chain::Integration,
-            false => Chain::Testnet,
-        },
+    let starknet_chain = match (ethereum_chain, config.integration) {
+        (EthereumChain::Mainnet, false) => Chain::Mainnet,
+        (EthereumChain::Goerli, false) => Chain::Testnet,
+        (EthereumChain::Goerli, true) => Chain::Integration,
+        (EthereumChain::Mainnet, true) => {
+            anyhow::bail!("'--integration flag' is invalid on Ethereum mainnet");
+        }
     };
 
     let database_path = config.data_directory.join(match starknet_chain {

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -52,12 +52,12 @@ Hint: Make sure the provided ethereum.url and ethereum.password are good.",
 
     let starknet_chain = match ethereum_chain {
         EthereumChain::Mainnet => Chain::Mainnet,
-        EthereumChain::Goerli => Chain::Goerli,
+        EthereumChain::Goerli => Chain::Testnet,
     };
 
     let database_path = config.data_directory.join(match starknet_chain {
         Chain::Mainnet => "mainnet.sqlite",
-        Chain::Goerli => "goerli.sqlite",
+        Chain::Testnet => "goerli.sqlite",
         Chain::Integration => "integration.sqlite",
     });
     let journal_mode = match config.sqlite_wal {

--- a/crates/pathfinder/src/bin/pathfinder.rs
+++ b/crates/pathfinder/src/bin/pathfinder.rs
@@ -58,6 +58,7 @@ Hint: Make sure the provided ethereum.url and ethereum.password are good.",
     let database_path = config.data_directory.join(match starknet_chain {
         Chain::Mainnet => "mainnet.sqlite",
         Chain::Goerli => "goerli.sqlite",
+        Chain::Integration => "integration.sqlite",
     });
     let journal_mode = match config.sqlite_wal {
         false => JournalMode::Rollback,

--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -321,7 +321,7 @@ mod tests {
             async move {
                 let _ = shutdown_rx.await;
             },
-            crate::core::Chain::Goerli,
+            crate::core::Chain::Testnet,
         )
         .await
         .unwrap();
@@ -397,7 +397,7 @@ mod tests {
                 let _ = shutdown_rx.await;
             },
             // chain doesn't matter here because we are not estimating any real transaction
-            crate::core::Chain::Goerli,
+            crate::core::Chain::Testnet,
         )
         .await
         .unwrap();
@@ -492,7 +492,7 @@ mod tests {
             async move {
                 let _ = shutdown_rx.await;
             },
-            crate::core::Chain::Goerli,
+            crate::core::Chain::Testnet,
         )
         .await
         .unwrap();
@@ -557,7 +557,7 @@ mod tests {
             async move {
                 let _ = shutdown_rx.await;
             },
-            crate::core::Chain::Goerli,
+            crate::core::Chain::Testnet,
         )
         .await
         .unwrap();

--- a/crates/pathfinder/src/cairo/ext_py/ser.rs
+++ b/crates/pathfinder/src/cairo/ext_py/ser.rs
@@ -48,7 +48,7 @@ impl From<crate::core::Chain> for UsedChain {
     fn from(c: crate::core::Chain) -> Self {
         match c {
             crate::core::Chain::Mainnet => UsedChain::Mainnet,
-            crate::core::Chain::Goerli => UsedChain::Goerli,
+            crate::core::Chain::Testnet => UsedChain::Goerli,
             crate::core::Chain::Integration => UsedChain::Integration,
         }
     }

--- a/crates/pathfinder/src/cairo/ext_py/ser.rs
+++ b/crates/pathfinder/src/cairo/ext_py/ser.rs
@@ -40,6 +40,8 @@ pub(crate) enum UsedChain {
     Mainnet,
     #[serde(rename = "GOERLI")]
     Goerli,
+    #[serde(rename = "INTEGRATION")]
+    Integration,
 }
 
 impl From<crate::core::Chain> for UsedChain {
@@ -47,6 +49,7 @@ impl From<crate::core::Chain> for UsedChain {
         match c {
             crate::core::Chain::Mainnet => UsedChain::Mainnet,
             crate::core::Chain::Goerli => UsedChain::Goerli,
+            crate::core::Chain::Integration => UsedChain::Integration,
         }
     }
 }

--- a/crates/pathfinder/src/cairo/ext_py/ser.rs
+++ b/crates/pathfinder/src/cairo/ext_py/ser.rs
@@ -40,8 +40,6 @@ pub(crate) enum UsedChain {
     Mainnet,
     #[serde(rename = "GOERLI")]
     Goerli,
-    #[serde(rename = "INTEGRATION")]
-    Integration,
 }
 
 impl From<crate::core::Chain> for UsedChain {
@@ -49,7 +47,7 @@ impl From<crate::core::Chain> for UsedChain {
         match c {
             crate::core::Chain::Mainnet => UsedChain::Mainnet,
             crate::core::Chain::Testnet => UsedChain::Goerli,
-            crate::core::Chain::Integration => UsedChain::Integration,
+            crate::core::Chain::Integration => UsedChain::Goerli,
         }
     }
 }

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -31,6 +31,8 @@ pub enum ConfigOption {
     PollPending,
     /// Enables and sets the monitoring endpoint
     MonitorAddress,
+    /// Chooses Integration network instead of testnet.
+    Integration,
 }
 
 impl Display for ConfigOption {
@@ -47,6 +49,7 @@ impl Display for ConfigOption {
             }
             ConfigOption::PollPending => f.write_str("Enable pending block polling"),
             ConfigOption::MonitorAddress => f.write_str("Pathfinder monitoring address"),
+            ConfigOption::Integration => f.write_str("Select integration network"),
         }
     }
 }
@@ -79,6 +82,8 @@ pub struct Configuration {
     pub poll_pending: bool,
     /// The node's monitoring address and port.
     pub monitoring_addr: Option<SocketAddr>,
+    /// Select integration network.
+    pub integration: bool,
 }
 
 impl Configuration {

--- a/crates/pathfinder/src/config/builder.rs
+++ b/crates/pathfinder/src/config/builder.rs
@@ -89,6 +89,7 @@ Hint: Register your own account or run your own Ethereum node and put the real U
                 })
             })
             .transpose()?;
+        let integration = self.take(ConfigOption::Integration).is_some();
 
         // Optional parameters with defaults.
         let data_directory = self
@@ -174,6 +175,7 @@ Hint: Register your own account or run your own Ethereum node and put the real U
             sqlite_wal,
             poll_pending,
             monitoring_addr,
+            integration,
         })
     }
 

--- a/crates/pathfinder/src/config/cli.rs
+++ b/crates/pathfinder/src/config/cli.rs
@@ -171,7 +171,7 @@ Examples:
         .arg(
             Arg::new(INTEGRATION)
                 .long(INTEGRATION)
-                // .hide(true)
+                .hide(true)
                 .takes_value(false)
         )
 }

--- a/crates/pathfinder/src/config/cli.rs
+++ b/crates/pathfinder/src/config/cli.rs
@@ -16,6 +16,7 @@ const PYTHON_SUBPROCESSES_KEY: &str = "python-subprocesses";
 const SQLITE_WAL: &str = "sqlite-wal";
 const POLL_PENDING: &str = "poll-pending";
 const MONITOR_ADDRESS: &str = "monitor-address";
+const INTEGRATION: &str = "integration";
 
 /// Parses the cmd line arguments and returns the optional
 /// configuration file's path and the specified configuration options.
@@ -50,6 +51,8 @@ where
     let sqlite_wal = args.value_of(SQLITE_WAL).map(|s| s.to_owned());
     let poll_pending = args.value_of(POLL_PENDING).map(|s| s.to_owned());
     let monitor_address = args.value_of(MONITOR_ADDRESS).map(|s| s.to_owned());
+    // Hack around our builder requiring Strings, but this arg just needs to be present.
+    let integration = args.is_present(INTEGRATION).then_some(String::new());
 
     let cfg = ConfigBuilder::default()
         .with(ConfigOption::EthereumHttpUrl, ethereum_url)
@@ -60,7 +63,8 @@ where
         .with(ConfigOption::PythonSubprocesses, python_subprocesses)
         .with(ConfigOption::EnableSQLiteWriteAheadLogging, sqlite_wal)
         .with(ConfigOption::PollPending, poll_pending)
-        .with(ConfigOption::MonitorAddress, monitor_address);
+        .with(ConfigOption::MonitorAddress, monitor_address)
+        .with(ConfigOption::Integration, integration);
 
     Ok((config_filepath, cfg))
 }
@@ -163,6 +167,12 @@ Examples:
                 .takes_value(true)
                 .value_name("IP:PORT")
                 .env("PATHFINDER_MONITOR_ADDRESS")
+        )
+        .arg(
+            Arg::new(INTEGRATION)
+                .long(INTEGRATION)
+                // .hide(true)
+                .takes_value(false)
         )
 }
 

--- a/crates/pathfinder/src/consts.rs
+++ b/crates/pathfinder/src/consts.rs
@@ -8,7 +8,7 @@ pub const USER_AGENT: &str = concat!(
     env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT")
 );
 
-pub const GOERLI_GENESIS_HASH: StarknetBlockHash = StarknetBlockHash(crate::starkhash!(
+pub const TESTNET_GENESIS_HASH: StarknetBlockHash = StarknetBlockHash(crate::starkhash!(
     "07d328a71faf48c5c3857e99f20a77b18522480956d1cd5bff1ff2df3c8b427b"
 ));
 

--- a/crates/pathfinder/src/consts.rs
+++ b/crates/pathfinder/src/consts.rs
@@ -15,3 +15,7 @@ pub const GOERLI_GENESIS_HASH: StarknetBlockHash = StarknetBlockHash(crate::star
 pub const MAINNET_GENESIS_HASH: StarknetBlockHash = StarknetBlockHash(crate::starkhash!(
     "047C3637B57C2B079B93C61539950C17E868A28F46CDEF28F88521067F21E943"
 ));
+
+pub const INTEGRATION_GENESIS_HASH: StarknetBlockHash = StarknetBlockHash(crate::starkhash!(
+    "03ae41b0f023e53151b0c8ab8b9caafb7005d5f41c9ab260276d5bdc49726279"
+));

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -377,22 +377,20 @@ pub enum EthereumChain {
 /// Starknet chain.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Chain {
-    /// The Ethereum mainnet chain.
     Mainnet,
-    /// The Ethereum Goerli test network chain.
     Goerli,
+    Integration,
 }
-
-const MAINNET_CHAIN_ID: StarkHash = StarkHash::from_u128(0x534e5f4d41494eu128);
-const GOERLI_CHAIN_ID: StarkHash = StarkHash::from_u128(0x534e5f474f45524c49u128);
 
 impl Chain {
     pub const fn starknet_chain_id(&self) -> StarkHash {
         match self {
             // SN_MAIN
-            Chain::Mainnet => MAINNET_CHAIN_ID,
+            Chain::Mainnet => StarkHash::from_u128(0x534e5f4d41494eu128),
             // SN_GOERLI
-            Chain::Goerli => GOERLI_CHAIN_ID,
+            Chain::Goerli => StarkHash::from_u128(0x534e5f474f45524c49u128),
+            // SN_INTEGRATION
+            Chain::Integration => StarkHash::from_u128(0x534E5F494E544547524154494F4E),
         }
     }
 }
@@ -402,6 +400,7 @@ impl std::fmt::Display for Chain {
         match self {
             Chain::Mainnet => f.write_str("Mainnet"),
             Chain::Goerli => f.write_str("Görli"),
+            Chain::Integration => f.write_str("Integration"),
         }
     }
 }

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -369,6 +369,13 @@ impl From<StarknetBlockHash> for BlockId {
 
 /// Ethereum network chains running Starknet.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EthereumChain {
+    Mainnet,
+    Goerli,
+}
+
+/// Starknet chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Chain {
     /// The Ethereum mainnet chain.
     Mainnet,

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -378,7 +378,7 @@ pub enum EthereumChain {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Chain {
     Mainnet,
-    Goerli,
+    Testnet,
     Integration,
 }
 
@@ -388,7 +388,7 @@ impl Chain {
             // SN_MAIN
             Chain::Mainnet => StarkHash::from_u128(0x534e5f4d41494eu128),
             // SN_GOERLI
-            Chain::Goerli => StarkHash::from_u128(0x534e5f474f45524c49u128),
+            Chain::Testnet => StarkHash::from_u128(0x534e5f474f45524c49u128),
             // SN_INTEGRATION
             Chain::Integration => StarkHash::from_u128(0x534E5F494E544547524154494F4E),
         }
@@ -399,7 +399,7 @@ impl std::fmt::Display for Chain {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Chain::Mainnet => f.write_str("Mainnet"),
-            Chain::Goerli => f.write_str("Görli"),
+            Chain::Testnet => f.write_str("Görli"),
             Chain::Integration => f.write_str("Integration"),
         }
     }

--- a/crates/pathfinder/src/ethereum.rs
+++ b/crates/pathfinder/src/ethereum.rs
@@ -136,13 +136,13 @@ impl TryFrom<&web3::types::Log> for EthOrigin {
 #[cfg(test)]
 mod tests {
     mod chain {
-        use crate::core::Chain;
+        use crate::core::{Chain, EthereumChain};
         use crate::ethereum::transport::{EthereumTransport, HttpTransport};
 
         #[tokio::test]
         async fn goerli() {
-            let expected_chain = Chain::Goerli;
-            let transport = HttpTransport::test_transport(expected_chain);
+            let expected_chain = EthereumChain::Goerli;
+            let transport = HttpTransport::test_transport(Chain::Goerli);
             let chain = transport.chain().await.unwrap();
 
             assert_eq!(chain, expected_chain);
@@ -150,8 +150,8 @@ mod tests {
 
         #[tokio::test]
         async fn mainnet() {
-            let expected_chain = Chain::Mainnet;
-            let transport = HttpTransport::test_transport(expected_chain);
+            let expected_chain = EthereumChain::Mainnet;
+            let transport = HttpTransport::test_transport(Chain::Mainnet);
             let chain = transport.chain().await.unwrap();
 
             assert_eq!(chain, expected_chain);

--- a/crates/pathfinder/src/ethereum.rs
+++ b/crates/pathfinder/src/ethereum.rs
@@ -140,9 +140,18 @@ mod tests {
         use crate::ethereum::transport::{EthereumTransport, HttpTransport};
 
         #[tokio::test]
-        async fn goerli() {
+        async fn testnet() {
             let expected_chain = EthereumChain::Goerli;
-            let transport = HttpTransport::test_transport(Chain::Goerli);
+            let transport = HttpTransport::test_transport(Chain::Testnet);
+            let chain = transport.chain().await.unwrap();
+
+            assert_eq!(chain, expected_chain);
+        }
+
+        #[tokio::test]
+        async fn integration() {
+            let expected_chain = EthereumChain::Goerli;
+            let transport = HttpTransport::test_transport(Chain::Integration);
             let chain = transport.chain().await.unwrap();
 
             assert_eq!(chain, expected_chain);

--- a/crates/pathfinder/src/ethereum/contract.rs
+++ b/crates/pathfinder/src/ethereum/contract.rs
@@ -24,7 +24,7 @@ const MAINNET_ADDRESSES: ContractAddresses = ContractAddresses {
 };
 
 /// Starknet contract addresses on L1 Goerli for testnet.
-const GOERLI_ADDRESSES: ContractAddresses = ContractAddresses {
+const TESTNET_ADDRESSES: ContractAddresses = ContractAddresses {
     core: H160([
         222, 41, 208, 96, 212, 89, 1, 251, 25, 237, 108, 110, 149, 158, 178, 45, 134, 38, 112, 142,
     ]),
@@ -47,16 +47,14 @@ const INTEGRATION_ADDRESSES: ContractAddresses = ContractAddresses {
     ]),
     // FIXME: This was copied from testnet addresses as this info is not available from the gateway.
     //        Currently not important as it is not used.
-    mempage: H160([
-        116, 55, 137, 255, 47, 248, 43, 251, 144, 112, 9, 201, 145, 26, 125, 166, 54, 211, 79, 167,
-    ]),
+    mempage: TESTNET_ADDRESSES.mempage,
 };
 
 /// Returns the Starknet contract addresses for the given L2 chain.
 pub fn addresses(chain: Chain) -> ContractAddresses {
     match chain {
         Chain::Mainnet => MAINNET_ADDRESSES,
-        Chain::Goerli => GOERLI_ADDRESSES,
+        Chain::Testnet => TESTNET_ADDRESSES,
         Chain::Integration => INTEGRATION_ADDRESSES,
     }
 }
@@ -154,7 +152,7 @@ mod tests {
             // ABI was updated.
 
             #[tokio::test]
-            async fn goerli() {
+            async fn testnet() {
                 // Checks that Starknet's core proxy contract still points to the same
                 // core implementation contract. If this address changes, we should
                 // update the address and more importantly, the ABI.
@@ -169,11 +167,11 @@ mod tests {
                     "/resources/contracts/core_proxy.json"
                 ));
 
-                let transport = HttpTransport::test_transport(Chain::Goerli);
+                let transport = HttpTransport::test_transport(Chain::Testnet);
 
                 let core_proxy = web3::contract::Contract::from_json(
                     transport.eth(),
-                    GOERLI_ADDRESSES.core,
+                    TESTNET_ADDRESSES.core,
                     CORE_PROXY_ABI,
                 )
                 .unwrap();
@@ -275,26 +273,26 @@ mod tests {
     mod address {
         use super::*;
 
-        mod goerli {
+        mod testnet {
             use super::*;
             use pretty_assertions::assert_eq;
 
             #[test]
             fn core() {
                 let expect = H160::from_str("0xde29d060D45901Fb19ED6C6e959EB22d8626708e").unwrap();
-                assert_eq!(GOERLI_ADDRESSES.core, expect);
+                assert_eq!(TESTNET_ADDRESSES.core, expect);
             }
 
             #[test]
             fn gps() {
                 let expect = H160::from_str("0x5EF3C980Bf970FcE5BbC217835743ea9f0388f4F").unwrap();
-                assert_eq!(GOERLI_ADDRESSES.gps, expect);
+                assert_eq!(TESTNET_ADDRESSES.gps, expect);
             }
 
             #[test]
             fn mempage() {
                 let expect = H160::from_str("0x743789ff2fF82Bfb907009C9911a7dA636D34FA7").unwrap();
-                assert_eq!(GOERLI_ADDRESSES.mempage, expect);
+                assert_eq!(TESTNET_ADDRESSES.mempage, expect);
             }
         }
 

--- a/crates/pathfinder/src/ethereum/log/fetch/backward.rs
+++ b/crates/pathfinder/src/ethereum/log/fetch/backward.rs
@@ -206,7 +206,7 @@ mod tests {
 
         // We use the same log type twice; this shouldn't matter and let's us check
         // the block number sequence.
-        let chain = crate::core::Chain::Goerli;
+        let chain = crate::core::Chain::Testnet;
         let mut fetcher = BackwardLogFetcher::<StateUpdateLog, StateUpdateLog>::new(
             EitherMetaLog::Left(update_log.clone()),
             chain,

--- a/crates/pathfinder/src/ethereum/log/fetch/forward.rs
+++ b/crates/pathfinder/src/ethereum/log/fetch/forward.rs
@@ -249,7 +249,7 @@ mod tests {
 
         let genesis_block = starknet_genesis_log.origin.block.number;
 
-        let chain = crate::core::Chain::Goerli;
+        let chain = crate::core::Chain::Testnet;
         let mut root_fetcher =
             LogFetcher::<StateUpdateLog>::new(Some(starknet_genesis_log), chain, genesis_block);
         let transport = HttpTransport::test_transport(chain);

--- a/crates/pathfinder/src/ethereum/state_update.rs
+++ b/crates/pathfinder/src/ethereum/state_update.rs
@@ -170,7 +170,7 @@ mod tests {
             block_number: StarknetBlockNumber::new_or_panic(16407),
         };
 
-        let chain = crate::core::Chain::Goerli;
+        let chain = crate::core::Chain::Testnet;
         let transport = HttpTransport::test_transport(chain);
         let update = StateUpdate::retrieve(&transport, update_log, chain)
             .await

--- a/crates/pathfinder/src/ethereum/state_update/state_root.rs
+++ b/crates/pathfinder/src/ethereum/state_update/state_root.rs
@@ -10,7 +10,7 @@ pub struct StateRootFetcher(LogFetcher<StateUpdateLog>);
 /// The Mainnet Ethereum block containing the Starknet genesis [StateUpdateLog].
 const MAINNET_GENESIS: EthereumBlockNumber = EthereumBlockNumber(13_627_224);
 /// The Goerli Ethereum block containing the Starknet genesis [StateUpdateLog] for testnet.
-const GOERLI_GENESIS: EthereumBlockNumber = EthereumBlockNumber(5_854_324);
+const TESTNET_GENESIS: EthereumBlockNumber = EthereumBlockNumber(5_854_324);
 /// The Goerli Ethereum block containing the Starknet genesis [StateUpdateLog] for integration.
 /// FIXME(MIRKO) before much further.
 const INTEGRATION_GENESIS: EthereumBlockNumber = EthereumBlockNumber(5_854_324);
@@ -19,7 +19,7 @@ impl StateRootFetcher {
     pub fn new(head: Option<StateUpdateLog>, chain: Chain) -> Self {
         let genesis = match chain {
             Chain::Mainnet => MAINNET_GENESIS,
-            Chain::Goerli => GOERLI_GENESIS,
+            Chain::Testnet => TESTNET_GENESIS,
             Chain::Integration => INTEGRATION_GENESIS,
         };
 
@@ -58,7 +58,7 @@ mod tests {
     async fn first_fetch() {
         // The first state root retrieved should be the genesis event,
         // with a sequence number of 0.
-        let chain = Chain::Goerli;
+        let chain = Chain::Testnet;
         let transport = HttpTransport::test_transport(chain);
 
         let mut uut = StateRootFetcher::new(None, chain);
@@ -105,12 +105,12 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn goerli() {
-            // Checks `GOERLI_GENESIS` contains the actual Starknet genesis StateUpdateLog
-            let chain = Chain::Goerli;
+        async fn testnet() {
+            // Checks `TESTNET_GENESIS` contains the actual Starknet genesis StateUpdateLog
+            let chain = Chain::Testnet;
             let transport = HttpTransport::test_transport(chain);
 
-            let block_number = BlockNumber::Number(GOERLI_GENESIS.0.into());
+            let block_number = BlockNumber::Number(TESTNET_GENESIS.0.into());
 
             let filter = FilterBuilder::default()
                 .address(vec![StateUpdateLog::contract_address(chain)])
@@ -155,7 +155,7 @@ mod tests {
             // Seed with a incorrect update at the L1 genesis block.
             // This should get interpretted as a reorg once the correct
             // first L2 update log is found.
-            let chain = Chain::Goerli;
+            let chain = Chain::Testnet;
             let transport = HttpTransport::test_transport(chain);
 
             // Note that block_number must be 0 so that we pull all of L1 history.
@@ -186,7 +186,7 @@ mod tests {
             // Seed with an origin beyond the current L1 chain state.
             // This should be interpreted as a reorg as this update
             // won't be found.
-            let chain = Chain::Goerli;
+            let chain = Chain::Testnet;
             let transport = HttpTransport::test_transport(chain);
 
             let latest_on_chain = transport.block_number().await.unwrap();

--- a/crates/pathfinder/src/ethereum/state_update/state_root.rs
+++ b/crates/pathfinder/src/ethereum/state_update/state_root.rs
@@ -9,14 +9,18 @@ pub struct StateRootFetcher(LogFetcher<StateUpdateLog>);
 
 /// The Mainnet Ethereum block containing the Starknet genesis [StateUpdateLog].
 const MAINNET_GENESIS: EthereumBlockNumber = EthereumBlockNumber(13_627_224);
-/// The Goerli Ethereum block containing the Starknet genesis [StateUpdateLog].
+/// The Goerli Ethereum block containing the Starknet genesis [StateUpdateLog] for testnet.
 const GOERLI_GENESIS: EthereumBlockNumber = EthereumBlockNumber(5_854_324);
+/// The Goerli Ethereum block containing the Starknet genesis [StateUpdateLog] for integration.
+/// FIXME(MIRKO) before much further.
+const INTEGRATION_GENESIS: EthereumBlockNumber = EthereumBlockNumber(5_854_324);
 
 impl StateRootFetcher {
     pub fn new(head: Option<StateUpdateLog>, chain: Chain) -> Self {
         let genesis = match chain {
             Chain::Mainnet => MAINNET_GENESIS,
             Chain::Goerli => GOERLI_GENESIS,
+            Chain::Integration => INTEGRATION_GENESIS,
         };
 
         let inner = LogFetcher::<StateUpdateLog>::new(head, chain, genesis);

--- a/crates/pathfinder/src/ethereum/transport.rs
+++ b/crates/pathfinder/src/ethereum/transport.rs
@@ -96,7 +96,7 @@ impl HttpTransport {
         use crate::core::Chain;
         let key_prefix = match chain {
             Chain::Mainnet => "PATHFINDER_ETHEREUM_HTTP_MAINNET",
-            Chain::Goerli | Chain::Integration => "PATHFINDER_ETHEREUM_HTTP_GOERLI",
+            Chain::Testnet | Chain::Integration => "PATHFINDER_ETHEREUM_HTTP_GOERLI",
         };
 
         let url_key = format!("{}_URL", key_prefix);
@@ -281,7 +281,7 @@ mod tests {
                 )
                 .build();
 
-            let transport = HttpTransport::test_transport(Chain::Goerli);
+            let transport = HttpTransport::test_transport(Chain::Testnet);
 
             let result = transport.logs(filter).await;
             assert_matches!(result, Ok(logs) if logs.len() == 85);
@@ -296,7 +296,7 @@ mod tests {
                 .to_block(BlockNumber::Latest)
                 .build();
 
-            let transport = HttpTransport::test_transport(Chain::Goerli);
+            let transport = HttpTransport::test_transport(Chain::Testnet);
 
             let result = transport.logs(filter).await;
             assert_matches!(result, Err(LogsError::QueryLimit));
@@ -310,7 +310,7 @@ mod tests {
             // Infura and Alchemy handle this differently.
             //  - Infura accepts the query as valid and simply returns logs for whatever part of the range it has.
             //  - Alchemy throws a RPC::ServerError which `HttpTransport::logs` maps to `UnknownBlock`.
-            let transport = HttpTransport::test_transport(Chain::Goerli);
+            let transport = HttpTransport::test_transport(Chain::Testnet);
             let latest = transport.block_number().await.unwrap();
 
             let filter = FilterBuilder::default()

--- a/crates/pathfinder/src/ethereum/transport.rs
+++ b/crates/pathfinder/src/ethereum/transport.rs
@@ -1,7 +1,6 @@
 //! Wrapper for the parts of the [`Web3::eth()`](https://docs.rs/web3/latest/web3/api/struct.Eth.html) API that [the ethereum module](super) uses.
-use crate::config::EthereumConfig;
-use crate::core::Chain;
 use crate::retry::Retry;
+use crate::{config::EthereumConfig, core::EthereumChain};
 
 use std::future::Future;
 use std::num::NonZeroU64;
@@ -36,7 +35,7 @@ pub enum LogsError {
 pub trait EthereumTransport {
     async fn block(&self, block: BlockId) -> web3::Result<Option<Block<H256>>>;
     async fn block_number(&self) -> web3::Result<u64>;
-    async fn chain(&self) -> anyhow::Result<Chain>;
+    async fn chain(&self) -> anyhow::Result<EthereumChain>;
     async fn logs(&self, filter: Filter) -> std::result::Result<Vec<Log>, LogsError>;
     async fn transaction(&self, id: TransactionId) -> web3::Result<Option<Transaction>>;
     async fn gas_price(&self) -> web3::Result<U256>;
@@ -93,7 +92,8 @@ impl HttpTransport {
     ///
     /// Mainnet: PATHFINDER_ETHEREUM_HTTP_MAINNET_URL
     ///          PATHFINDER_ETHEREUM_HTTP_MAINNET_PASSWORD (optional)
-    pub fn test_transport(chain: Chain) -> Self {
+    pub fn test_transport(chain: crate::core::Chain) -> Self {
+        use crate::core::Chain;
         let key_prefix = match chain {
             Chain::Mainnet => "PATHFINDER_ETHEREUM_HTTP_MAINNET",
             Chain::Goerli => "PATHFINDER_ETHEREUM_HTTP_GOERLI",
@@ -133,15 +133,15 @@ impl EthereumTransport for HttpTransport {
             .map(|n| n.as_u64())
     }
 
-    /// Identifies the Ethereum [Chain] behind the given Ethereum transport.
+    /// Identifies the [EthereumChain] behind the given Ethereum transport.
     ///
-    /// Will error if it's not one of the valid Starknet [Chain] variants.
+    /// Will error if it's not one of the valid Starknet [EthereumChain] variants.
     /// Internaly wraps [`Web3::chain_id()`](https://docs.rs/web3/latest/web3/api/struct.Eth.html#method.chain_id)
     /// into exponential retry on __all__ errors.
-    async fn chain(&self) -> anyhow::Result<Chain> {
+    async fn chain(&self) -> anyhow::Result<EthereumChain> {
         match retry(|| self.0.eth().chain_id(), log_and_always_retry).await? {
-            id if id == U256::from(1u32) => Ok(Chain::Mainnet),
-            id if id == U256::from(5u32) => Ok(Chain::Goerli),
+            id if id == U256::from(1u32) => Ok(EthereumChain::Mainnet),
+            id if id == U256::from(5u32) => Ok(EthereumChain::Goerli),
             other => anyhow::bail!("Unsupported chain ID: {}", other),
         }
     }

--- a/crates/pathfinder/src/ethereum/transport.rs
+++ b/crates/pathfinder/src/ethereum/transport.rs
@@ -96,7 +96,7 @@ impl HttpTransport {
         use crate::core::Chain;
         let key_prefix = match chain {
             Chain::Mainnet => "PATHFINDER_ETHEREUM_HTTP_MAINNET",
-            Chain::Goerli => "PATHFINDER_ETHEREUM_HTTP_GOERLI",
+            Chain::Goerli | Chain::Integration => "PATHFINDER_ETHEREUM_HTTP_GOERLI",
         };
 
         let url_key = format!("{}_URL", key_prefix);

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -857,9 +857,9 @@ mod tests {
         ) {
             let storage = setup_storage();
             let pending_data = create_pending_data(storage.clone()).await;
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state)
                 .with_pending_data(pending_data.clone());
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
@@ -951,9 +951,9 @@ mod tests {
         #[tokio::test]
         async fn invalid_block_id() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(BlockId::Hash(StarknetBlockHash(StarkHash::ZERO)));
             let error = client(addr)
@@ -1019,9 +1019,9 @@ mod tests {
             use std::str::FromStr;
 
             let storage = setup_storage();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 ContractAddress::new_or_panic(starkhash_bytes!(b"contract 0")),
@@ -1042,9 +1042,9 @@ mod tests {
             use std::str::FromStr;
 
             let storage = setup_storage();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 ContractAddress::new_or_panic(starkhash_bytes!(b"contract 0")),
@@ -1063,9 +1063,9 @@ mod tests {
         #[tokio::test]
         async fn non_existent_contract_address() {
             let storage = setup_storage();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 ContractAddress::new_or_panic(starkhash_bytes!(b"nonexistent")),
@@ -1082,9 +1082,9 @@ mod tests {
         #[tokio::test]
         async fn pre_deploy_block_hash() {
             let storage = setup_storage();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 ContractAddress::new_or_panic(starkhash_bytes!(b"contract 1")),
@@ -1101,9 +1101,9 @@ mod tests {
         #[tokio::test]
         async fn non_existent_block_hash() {
             let storage = setup_storage();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 ContractAddress::new_or_panic(starkhash_bytes!(b"contract 1")),
@@ -1120,9 +1120,9 @@ mod tests {
         #[tokio::test]
         async fn deployment_block() {
             let storage = setup_storage();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 ContractAddress::new_or_panic(starkhash_bytes!(b"contract 1")),
@@ -1143,9 +1143,9 @@ mod tests {
             #[tokio::test]
             async fn positional_args() {
                 let storage = setup_storage();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(
                     ContractAddress::new_or_panic(starkhash_bytes!(b"contract 1")),
@@ -1162,9 +1162,9 @@ mod tests {
             #[tokio::test]
             async fn named_args() {
                 let storage = setup_storage();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = by_name([
                     ("contract_address", json! {starkhash_bytes!(b"contract 1")}),
@@ -1183,9 +1183,9 @@ mod tests {
         async fn pending_block() {
             let storage = setup_storage();
             let pending_data = create_pending_data(storage.clone()).await;
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state)
                 .with_pending_data(pending_data.clone());
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             // Pick an arbitrary pending storage update to query.
@@ -1216,9 +1216,9 @@ mod tests {
             async fn positional_args() {
                 let storage = setup_storage();
                 let hash = StarknetTransactionHash(starkhash_bytes!(b"txn 0"));
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(hash);
                 let transaction = client(addr)
@@ -1232,9 +1232,9 @@ mod tests {
             async fn named_args() {
                 let storage = setup_storage();
                 let hash = StarknetTransactionHash(starkhash_bytes!(b"txn 0"));
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = by_name([("transaction_hash", json!(hash))]);
                 let transaction = client(addr)
@@ -1248,9 +1248,9 @@ mod tests {
             async fn pending() {
                 let storage = setup_storage();
                 let pending_data = create_pending_data(storage.clone()).await;
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state)
                     .with_pending_data(pending_data.clone());
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 // Select an arbitrary pending transaction to query.
@@ -1269,9 +1269,9 @@ mod tests {
         #[tokio::test]
         async fn invalid_hash() {
             let storage = setup_storage();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(INVALID_TX_HASH);
             let error = client(addr)
@@ -1292,9 +1292,9 @@ mod tests {
 
         async fn check_result<F: Fn(&Transaction)>(params: Option<ParamsSer<'_>>, check_fn: F) {
             let storage = setup_storage();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
             let txn = client(addr)
@@ -1365,9 +1365,9 @@ mod tests {
         async fn pending() {
             let storage = setup_storage();
             let pending_data = create_pending_data(storage.clone()).await;
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state)
                 .with_pending_data(pending_data.clone());
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
@@ -1388,9 +1388,9 @@ mod tests {
         #[tokio::test]
         async fn invalid_block() {
             let storage = setup_storage();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(BlockId::Hash(StarknetBlockHash(StarkHash::ZERO)), 0);
             let error = client(addr)
@@ -1403,9 +1403,9 @@ mod tests {
         #[tokio::test]
         async fn invalid_transaction_index() {
             let storage = setup_storage();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let genesis_hash = StarknetBlockHash(starkhash_bytes!(b"genesis"));
             let genesis_id = BlockId::Hash(genesis_hash);
@@ -1433,9 +1433,9 @@ mod tests {
             #[tokio::test]
             async fn positional_args() {
                 let storage = setup_storage();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let txn_hash = StarknetTransactionHash(starkhash_bytes!(b"txn 0"));
                 let params = rpc_params!(txn_hash);
@@ -1456,9 +1456,9 @@ mod tests {
             #[tokio::test]
             async fn named_args() {
                 let storage = setup_storage();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let txn_hash = StarknetTransactionHash(starkhash_bytes!(b"txn 0"));
                 let params = by_name([("transaction_hash", json!(txn_hash))]);
@@ -1480,9 +1480,9 @@ mod tests {
             async fn pending() {
                 let storage = setup_storage();
                 let pending_data = create_pending_data(storage.clone()).await;
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state)
                     .with_pending_data(pending_data.clone());
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 // Select an arbitrary pending transaction to query.
@@ -1509,9 +1509,9 @@ mod tests {
         #[tokio::test]
         async fn invalid() {
             let storage = setup_storage();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let txn_hash = StarknetTransactionHash(starkhash_bytes!(b"not found"));
             let params = rpc_params!(txn_hash);
@@ -1539,9 +1539,9 @@ mod tests {
             #[tokio::test]
             async fn returns_invalid_contract_class_hash_for_nonexistent_class() {
                 let storage = Storage::in_memory().unwrap();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(INVALID_CLASS_HASH);
                 let error = client(addr)
@@ -1561,9 +1561,9 @@ mod tests {
                     setup_class_and_contract(&transaction).unwrap();
                 transaction.commit().unwrap();
 
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = rpc_params!(class_hash);
@@ -1591,9 +1591,9 @@ mod tests {
                     setup_class_and_contract(&transaction).unwrap();
                 transaction.commit().unwrap();
 
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = by_name([("class_hash", json!(class_hash))]);
@@ -1619,9 +1619,9 @@ mod tests {
             #[tokio::test]
             async fn returns_contract_not_found_for_nonexistent_contract() {
                 let storage = Storage::in_memory().unwrap();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(BlockId::Latest, INVALID_CONTRACT_ADDR);
                 let error = client(addr)
@@ -1634,9 +1634,9 @@ mod tests {
             #[tokio::test]
             async fn returns_class_hash_for_existing_contract() {
                 let storage = setup_storage();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let contract_address =
@@ -1653,9 +1653,9 @@ mod tests {
             #[tokio::test]
             async fn returns_not_found_for_existing_contract_that_is_not_yet_deployed() {
                 let storage = setup_storage();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let contract_address =
@@ -1675,9 +1675,9 @@ mod tests {
             async fn pending() {
                 let storage = setup_storage();
                 let pending_data = create_pending_data(storage.clone()).await;
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state)
                     .with_pending_data(pending_data.clone());
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
@@ -1700,9 +1700,9 @@ mod tests {
             #[tokio::test]
             async fn returns_class_hash_for_existing_contract() {
                 let storage = setup_storage();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let contract_address =
@@ -1731,9 +1731,9 @@ mod tests {
         #[tokio::test]
         async fn invalid_contract_address() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(BlockId::Latest, INVALID_CONTRACT_ADDR);
             let error = client(addr)
@@ -1746,9 +1746,9 @@ mod tests {
         #[tokio::test]
         async fn returns_not_found_if_we_dont_know_about_the_contract() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
             let not_found = client(addr)
@@ -1777,9 +1777,9 @@ mod tests {
                 setup_class_and_contract(&transaction).unwrap();
             transaction.commit().unwrap();
 
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
             let client = client(addr);
@@ -1817,9 +1817,9 @@ mod tests {
                 setup_class_and_contract(&transaction).unwrap();
             transaction.commit().unwrap();
 
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
             let not_found = client(addr)
@@ -1840,9 +1840,9 @@ mod tests {
         async fn pending() {
             let storage = setup_storage();
             let pending_data = create_pending_data(storage.clone()).await;
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state)
                 .with_pending_data(pending_data.clone());
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
@@ -1956,9 +1956,9 @@ mod tests {
         #[tokio::test]
         async fn genesis() {
             let storage = setup_storage();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(BlockId::Hash(StarknetBlockHash(starkhash_bytes!(
                 b"genesis"
@@ -1977,9 +1977,9 @@ mod tests {
             #[tokio::test]
             async fn positional_args() {
                 let storage = setup_storage();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(BlockId::Latest);
                 let count = client(addr)
@@ -1992,9 +1992,9 @@ mod tests {
             #[tokio::test]
             async fn named_args() {
                 let storage = setup_storage();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = by_name([("block_id", json!("latest"))]);
                 let count = client(addr)
@@ -2009,9 +2009,9 @@ mod tests {
         async fn pending() {
             let storage = setup_storage();
             let pending_data = create_pending_data(storage.clone()).await;
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state)
                 .with_pending_data(pending_data.clone());
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let expected = pending_data.block().await.unwrap().transactions.len();
@@ -2026,9 +2026,9 @@ mod tests {
         #[tokio::test]
         async fn invalid_hash() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(BlockId::Hash(StarknetBlockHash(StarkHash::ZERO)));
             let error = client(addr)
@@ -2041,9 +2041,9 @@ mod tests {
         #[tokio::test]
         async fn invalid_number() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(BlockId::Number(StarknetBlockNumber::new_or_panic(123)));
             let error = client(addr)
@@ -2063,9 +2063,9 @@ mod tests {
         async fn with_pending() {
             let storage = setup_storage();
             let pending_data = create_pending_data(storage.clone()).await;
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state)
                 .with_pending_data(pending_data.clone());
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
@@ -2093,9 +2093,9 @@ mod tests {
             // empty pending data, which should result in `starknet_pendingTransactions` using
             // the `latest` transactions instead.
             let pending_data = PendingData::default();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage.clone(), sequencer, Chain::Goerli, sync_state)
+            let api = RpcApi::new(storage.clone(), sequencer, Chain::Testnet, sync_state)
                 .with_pending_data(pending_data.clone());
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
@@ -2121,9 +2121,9 @@ mod tests {
         use crate::core::ContractNonce;
 
         let storage = setup_storage();
-        let sequencer = Client::new(Chain::Goerli).unwrap();
+        let sequencer = Client::new(Chain::Testnet).unwrap();
         let sync_state = Arc::new(SyncState::default());
-        let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state.clone());
+        let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state.clone());
         let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
         // This contract is created in `setup_storage` and has a nonce set to 0x1.
@@ -2178,9 +2178,9 @@ mod tests {
         #[tokio::test]
         async fn latest_invoked_block() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
@@ -2206,9 +2206,9 @@ mod tests {
             #[tokio::test]
             async fn positional_args() {
                 let storage = Storage::in_memory().unwrap();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = rpc_params!(
                     Call {
@@ -2231,9 +2231,9 @@ mod tests {
             #[tokio::test]
             async fn named_args() {
                 let storage = Storage::in_memory().unwrap();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
                 let params = by_name([
                     (
@@ -2257,9 +2257,9 @@ mod tests {
         #[tokio::test]
         async fn pending_block() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
@@ -2282,9 +2282,9 @@ mod tests {
         #[tokio::test]
         async fn invalid_entry_point() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
@@ -2311,9 +2311,9 @@ mod tests {
         #[tokio::test]
         async fn invalid_contract_address() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
@@ -2337,9 +2337,9 @@ mod tests {
         #[tokio::test]
         async fn invalid_call_data() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
@@ -2363,9 +2363,9 @@ mod tests {
         #[tokio::test]
         async fn uninitialized_contract() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
@@ -2389,9 +2389,9 @@ mod tests {
         #[tokio::test]
         async fn invalid_block_hash() {
             let storage = Storage::in_memory().unwrap();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let params = rpc_params!(
                 Call {
@@ -2415,9 +2415,9 @@ mod tests {
     #[tokio::test]
     async fn block_number() {
         let storage = setup_storage();
-        let sequencer = Client::new(Chain::Goerli).unwrap();
+        let sequencer = Client::new(Chain::Testnet).unwrap();
         let sync_state = Arc::new(SyncState::default());
-        let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+        let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
         let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
         let number = client(addr)
             .request::<u64>("starknet_blockNumber", rpc_params!())
@@ -2429,9 +2429,9 @@ mod tests {
     #[tokio::test]
     async fn block_hash_and_number() {
         let storage = setup_storage();
-        let sequencer = Client::new(Chain::Goerli).unwrap();
+        let sequencer = Client::new(Chain::Testnet).unwrap();
         let sync_state = Arc::new(SyncState::default());
-        let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+        let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
         let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
         let latest = client(addr)
             .request::<BlockHashAndNumber>("starknet_blockHashAndNumber", rpc_params!())
@@ -2449,7 +2449,7 @@ mod tests {
         use futures::stream::StreamExt;
 
         assert_eq!(
-            [Chain::Goerli, Chain::Mainnet]
+            [Chain::Testnet, Chain::Mainnet]
                 .iter()
                 .map(|set_chain| async {
                     let storage = Storage::in_memory().unwrap();
@@ -2482,9 +2482,9 @@ mod tests {
         #[tokio::test]
         async fn not_syncing() {
             let storage = setup_storage();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let syncing = client(addr)
                 .request::<Syncing>("starknet_syncing", rpc_params!())
@@ -2504,10 +2504,10 @@ mod tests {
             });
 
             let storage = setup_storage();
-            let sequencer = Client::new(Chain::Goerli).unwrap();
+            let sequencer = Client::new(Chain::Testnet).unwrap();
             let sync_state = Arc::new(SyncState::default());
             *sync_state.status.write().await = expected.clone();
-            let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
             let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
             let syncing = client(addr)
                 .request::<Syncing>("starknet_syncing", rpc_params!())
@@ -2539,9 +2539,9 @@ mod tests {
             #[tokio::test]
             async fn get_events_with_empty_filter() {
                 let (storage, events) = setup();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = rpc_params!(EventFilter {
@@ -2570,9 +2570,9 @@ mod tests {
             #[tokio::test]
             async fn get_events_with_fully_specified_filter() {
                 let (storage, events) = setup();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let expected_event = &events[1];
@@ -2603,9 +2603,9 @@ mod tests {
             #[tokio::test]
             async fn get_events_by_block() {
                 let (storage, events) = setup();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 const BLOCK_NUMBER: usize = 2;
@@ -2637,9 +2637,9 @@ mod tests {
             #[tokio::test]
             async fn get_events_with_invalid_page_size() {
                 let (storage, _events) = setup();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = rpc_params!(EventFilter {
@@ -2661,9 +2661,9 @@ mod tests {
             #[tokio::test]
             async fn get_events_by_key_with_paging() {
                 let (storage, events) = setup();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let expected_events = &events[27..32];
@@ -2765,9 +2765,9 @@ mod tests {
             #[tokio::test]
             async fn get_events_with_empty_filter() {
                 let (storage, events) = setup();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = by_name([(
@@ -2792,9 +2792,9 @@ mod tests {
             #[tokio::test]
             async fn get_events_with_fully_specified_filter() {
                 let (storage, events) = setup();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let expected_event = &events[1];
@@ -2839,9 +2839,9 @@ mod tests {
             async fn backward_range() {
                 let storage = setup_storage();
                 let pending_data = create_pending_data(storage.clone()).await;
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state)
                     .with_pending_data(pending_data);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
@@ -2864,9 +2864,9 @@ mod tests {
             async fn all_events() {
                 let storage = setup_storage();
                 let pending_data = create_pending_data(storage.clone()).await;
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state)
                     .with_pending_data(pending_data);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
@@ -2911,9 +2911,9 @@ mod tests {
             async fn paging() {
                 let storage = setup_storage();
                 let pending_data = create_pending_data(storage.clone()).await;
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state)
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state)
                     .with_pending_data(pending_data);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
@@ -3039,9 +3039,9 @@ mod tests {
             #[tokio::test]
             async fn invoke_transaction() {
                 let storage = setup_storage();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = rpc_params!(
@@ -3070,7 +3070,7 @@ mod tests {
                 let storage = setup_storage();
                 let sequencer = Client::integration().unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let contract_class = CONTRACT_DEFINITION.clone();
@@ -3098,9 +3098,9 @@ mod tests {
             #[tokio::test]
             async fn deploy_transaction() {
                 let storage = setup_storage();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let contract_definition = CONTRACT_DEFINITION.clone();
@@ -3144,9 +3144,9 @@ mod tests {
             #[tokio::test]
             async fn invoke_transaction() {
                 let storage = setup_storage();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = by_name([
@@ -3198,7 +3198,7 @@ mod tests {
                 let storage = setup_storage();
                 let sequencer = Client::integration().unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = by_name([
@@ -3227,9 +3227,9 @@ mod tests {
             #[tokio::test]
             async fn deploy_transaction() {
                 let storage = setup_storage();
-                let sequencer = Client::new(Chain::Goerli).unwrap();
+                let sequencer = Client::new(Chain::Testnet).unwrap();
                 let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+                let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
                 let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
 
                 let params = by_name([

--- a/crates/pathfinder/src/rpc/test_setup.rs
+++ b/crates/pathfinder/src/rpc/test_setup.rs
@@ -290,9 +290,9 @@ where
         use std::sync::Arc;
 
         let storage = self.storage;
-        let sequencer = Client::new(Chain::Goerli).unwrap();
+        let sequencer = Client::new(Chain::Testnet).unwrap();
         let sync_state = Arc::new(SyncState::default());
-        let api = RpcApi::new(storage, sequencer, Chain::Goerli, sync_state);
+        let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state);
         let (__handle, addr) = run_server(
             SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)),
             api,

--- a/crates/pathfinder/src/sequencer.rs
+++ b/crates/pathfinder/src/sequencer.rs
@@ -118,6 +118,7 @@ impl Client {
         let url = match chain {
             Chain::Mainnet => Url::parse("https://alpha-mainnet.starknet.io/").unwrap(),
             Chain::Goerli => Url::parse("https://alpha4.starknet.io/").unwrap(),
+            Chain::Integration => Url::parse("https://external.integration.starknet.io").unwrap(),
         };
 
         Self::with_url(url)

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -474,7 +474,7 @@ mod tests {
             crate::storage::JournalMode::WAL,
         )
         .unwrap();
-        let chain = crate::core::Chain::Goerli;
+        let chain = crate::core::Chain::Testnet;
         let transport = crate::ethereum::transport::HttpTransport::test_transport(chain);
         let sequencer = crate::sequencer::Client::new(chain).unwrap();
         let state = Arc::new(sync::State::default());

--- a/crates/pathfinder/src/state/block_hash.rs
+++ b/crates/pathfinder/src/state/block_hash.rs
@@ -163,7 +163,7 @@ mod meta {
     pub fn for_chain(chain: Chain) -> &'static BlockHashMetaInfo {
         match chain {
             Chain::Mainnet => &MAINNET_METAINFO,
-            Chain::Goerli => &TESTNET_METAINFO,
+            Chain::Testnet => &TESTNET_METAINFO,
             Chain::Integration => todo!("Block hash meta data TBD"),
         }
     }
@@ -504,7 +504,7 @@ mod tests {
         let block: Block = serde_json::from_slice(json).unwrap();
 
         assert_eq!(
-            verify_block_hash(&block, Chain::Goerli, block.block_hash).unwrap(),
+            verify_block_hash(&block, Chain::Testnet, block.block_hash).unwrap(),
             VerifyResult::Match
         );
     }
@@ -519,7 +519,7 @@ mod tests {
         let block: Block = serde_json::from_slice(json).unwrap();
 
         assert_eq!(
-            verify_block_hash(&block, Chain::Goerli, block.block_hash).unwrap(),
+            verify_block_hash(&block, Chain::Testnet, block.block_hash).unwrap(),
             VerifyResult::Match
         );
     }
@@ -535,7 +535,7 @@ mod tests {
         let block: Block = serde_json::from_slice(json).unwrap();
 
         assert_eq!(
-            verify_block_hash(&block, Chain::Goerli, block.block_hash,).unwrap(),
+            verify_block_hash(&block, Chain::Testnet, block.block_hash,).unwrap(),
             VerifyResult::Match
         );
     }
@@ -550,7 +550,7 @@ mod tests {
         let block: Block = serde_json::from_slice(json).unwrap();
 
         assert_eq!(
-            verify_block_hash(&block, Chain::Goerli, block.block_hash).unwrap(),
+            verify_block_hash(&block, Chain::Testnet, block.block_hash).unwrap(),
             VerifyResult::Match
         );
     }

--- a/crates/pathfinder/src/state/block_hash.rs
+++ b/crates/pathfinder/src/state/block_hash.rs
@@ -164,6 +164,7 @@ mod meta {
         match chain {
             Chain::Mainnet => &MAINNET_METAINFO,
             Chain::Goerli => &TESTNET_METAINFO,
+            Chain::Integration => todo!("Block hash meta data TBD"),
         }
     }
 }

--- a/crates/pathfinder/src/state/block_hash.rs
+++ b/crates/pathfinder/src/state/block_hash.rs
@@ -160,11 +160,22 @@ mod meta {
         )),
     };
 
+    /// FIXME:  This currently disables block hash verfication until we figure out where is valid.
+    const INTEGRATION_METAINFO: BlockHashMetaInfo = BlockHashMetaInfo {
+        first_0_7_block: StarknetBlockNumber::new_or_panic(0),
+        not_verifiable_range: Some(
+            StarknetBlockNumber::new_or_panic(0)..StarknetBlockNumber::new_or_panic(1000000),
+        ),
+        fallback_sequencer_address: SequencerAddress(starkhash!(
+            "046a89ae102987331d369645031b49c27738ed096f2789c24449966da4c6de6b"
+        )),
+    };
+
     pub fn for_chain(chain: Chain) -> &'static BlockHashMetaInfo {
         match chain {
             Chain::Mainnet => &MAINNET_METAINFO,
             Chain::Testnet => &TESTNET_METAINFO,
-            Chain::Integration => todo!("Block hash meta data TBD"),
+            Chain::Integration => &INTEGRATION_METAINFO,
         }
     }
 }

--- a/crates/pathfinder/src/state/class_hash.rs
+++ b/crates/pathfinder/src/state/class_hash.rs
@@ -410,7 +410,7 @@ mod json {
             );
             let contract = crate::core::ContractAddress::new_or_panic(contract);
 
-            let chain = crate::core::Chain::Goerli;
+            let chain = crate::core::Chain::Testnet;
             let sequencer = crate::sequencer::Client::new(chain).unwrap();
             let contract_definition = sequencer
                 .full_contract(contract)
@@ -438,7 +438,7 @@ mod json {
             let expected = ClassHash(starkhash!(
                 "056b96c1d1bbfa01af44b465763d1b71150fa00c6c9d54c3947f57e979ff68c3"
             ));
-            let sequencer = sequencer::Client::new(crate::core::Chain::Goerli).unwrap();
+            let sequencer = sequencer::Client::new(crate::core::Chain::Testnet).unwrap();
 
             let contract_definition = sequencer.full_contract(address).await.unwrap();
             let extract = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -867,7 +867,7 @@ pub fn head_poll_interval(chain: crate::core::Chain) -> std::time::Duration {
     use std::time::Duration;
 
     match chain {
-        // 5 minute interval for a 30 hour block time.
+        // 5 minute interval for a 30 minute block time.
         Mainnet => Duration::from_secs(60 * 5),
         // 30 second interval for a 2 minute block time.
         Testnet | Integration => Duration::from_secs(30),

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -870,7 +870,7 @@ pub fn head_poll_interval(chain: crate::core::Chain) -> std::time::Duration {
         // 5 minute interval for a 30 hour block time.
         Mainnet => Duration::from_secs(60 * 5),
         // 30 second interval for a 2 minute block time.
-        Goerli => Duration::from_secs(30),
+        Goerli | Integration => Duration::from_secs(30),
     }
 }
 

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -870,7 +870,7 @@ pub fn head_poll_interval(chain: crate::core::Chain) -> std::time::Duration {
         // 5 minute interval for a 30 hour block time.
         Mainnet => Duration::from_secs(60 * 5),
         // 30 second interval for a 2 minute block time.
-        Goerli | Integration => Duration::from_secs(30),
+        Testnet | Integration => Duration::from_secs(30),
     }
 }
 
@@ -1157,7 +1157,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn l1_update() {
-        let chain = Chain::Goerli;
+        let chain = Chain::Testnet;
         let sync_state = Arc::new(state::SyncState::default());
 
         lazy_static::lazy_static! {
@@ -1278,7 +1278,7 @@ mod tests {
             let _jh = tokio::spawn(state::sync(
                 storage.clone(),
                 FakeTransport,
-                Chain::Goerli,
+                Chain::Testnet,
                 FakeSequencer,
                 Arc::new(state::SyncState::default()),
                 l1,
@@ -1347,7 +1347,7 @@ mod tests {
         let _jh = tokio::spawn(state::sync(
             storage,
             FakeTransport,
-            Chain::Goerli,
+            Chain::Testnet,
             FakeSequencer,
             Arc::new(state::SyncState::default()),
             l1,
@@ -1382,7 +1382,7 @@ mod tests {
         let _jh = tokio::spawn(state::sync(
             storage,
             FakeTransport,
-            Chain::Goerli,
+            Chain::Testnet,
             FakeSequencer,
             Arc::new(state::SyncState::default()),
             l1,
@@ -1408,7 +1408,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn l2_update() {
-        let chain = Chain::Goerli;
+        let chain = Chain::Testnet;
         let sync_state = Arc::new(state::SyncState::default());
 
         // Incoming L2 update
@@ -1524,7 +1524,7 @@ mod tests {
             let _jh = tokio::spawn(state::sync(
                 storage.clone(),
                 FakeTransport,
-                Chain::Goerli,
+                Chain::Testnet,
                 FakeSequencer,
                 Arc::new(state::SyncState::default()),
                 l1_noop,
@@ -1587,7 +1587,7 @@ mod tests {
         let _jh = tokio::spawn(state::sync(
             storage,
             FakeTransport,
-            Chain::Goerli,
+            Chain::Testnet,
             FakeSequencer,
             Arc::new(state::SyncState::default()),
             l1_noop,
@@ -1634,7 +1634,7 @@ mod tests {
         let _jh = tokio::spawn(state::sync(
             storage,
             FakeTransport,
-            Chain::Goerli,
+            Chain::Testnet,
             FakeSequencer,
             Arc::new(state::SyncState::default()),
             l1_noop,
@@ -1681,7 +1681,7 @@ mod tests {
         let _jh = tokio::spawn(state::sync(
             storage,
             FakeTransport,
-            Chain::Goerli,
+            Chain::Testnet,
             FakeSequencer,
             Arc::new(state::SyncState::default()),
             l1_noop,
@@ -1709,7 +1709,7 @@ mod tests {
         let _jh = tokio::spawn(state::sync(
             storage,
             FakeTransport,
-            Chain::Goerli,
+            Chain::Testnet,
             FakeSequencer,
             Arc::new(state::SyncState::default()),
             l1_noop,

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -919,7 +919,7 @@ mod tests {
             unimplemented!()
         }
 
-        async fn chain(&self) -> anyhow::Result<Chain> {
+        async fn chain(&self) -> anyhow::Result<crate::core::EthereumChain> {
             unimplemented!()
         }
 

--- a/crates/pathfinder/src/state/sync/l1.rs
+++ b/crates/pathfinder/src/state/sync/l1.rs
@@ -350,7 +350,7 @@ mod tests {
                 .in_sequence(&mut seq)
                 .return_once(|| mock_output);
 
-            tokio::spawn(sync_impl(mock_fetcher, tx_event, Chain::Goerli));
+            tokio::spawn(sync_impl(mock_fetcher, tx_event, Chain::Testnet));
 
             match rx_event.recv().await.unwrap() {
                 Event::Update(recv) => assert_eq!(recv, logs1),
@@ -389,7 +389,7 @@ mod tests {
             mock_fetcher
                 .expect_fetch_logs()
                 .return_once(move || Ok(logs));
-            let handle = tokio::spawn(sync_impl(mock_fetcher, tx_event, Chain::Goerli));
+            let handle = tokio::spawn(sync_impl(mock_fetcher, tx_event, Chain::Testnet));
 
             // Wrap this in a timeout so we don't wait forever in case of test failure.
             tokio::time::timeout(Duration::from_secs(2), handle)
@@ -472,7 +472,7 @@ mod tests {
                     .in_sequence(&mut seq)
                     .return_once(move || mock_output);
 
-                tokio::spawn(sync_impl(mock_fetcher, tx_event, Chain::Goerli));
+                tokio::spawn(sync_impl(mock_fetcher, tx_event, Chain::Testnet));
 
                 // Receive first log update event.
                 match rx_event.recv().await.unwrap() {
@@ -560,7 +560,7 @@ mod tests {
                     .in_sequence(&mut seq)
                     .return_once(move || mock_output);
 
-                tokio::spawn(sync_impl(mock_fetcher, tx_event, Chain::Goerli));
+                tokio::spawn(sync_impl(mock_fetcher, tx_event, Chain::Testnet));
 
                 // Receive the first log update event.
                 match rx_event.recv().await.unwrap() {
@@ -644,7 +644,7 @@ mod tests {
                     .in_sequence(&mut seq)
                     .return_once(move || mock_output);
 
-                tokio::spawn(sync_impl(mock_fetcher, tx_event, Chain::Goerli));
+                tokio::spawn(sync_impl(mock_fetcher, tx_event, Chain::Testnet));
 
                 // First log batch event.
                 match rx_event.recv().await.unwrap() {

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -894,7 +894,7 @@ mod tests {
                 );
 
                 // Let's run the UUT
-                let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Goerli, None));
+                let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Testnet, None));
 
                 let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
 
@@ -977,7 +977,7 @@ mod tests {
                     tx_event,
                     mock,
                     Some((BLOCK0_NUMBER, *BLOCK0_HASH, *GLOBAL_ROOT0)),
-                    Chain::Goerli,
+                    Chain::Testnet,
                     None,
                 ));
 
@@ -1096,7 +1096,7 @@ mod tests {
                 );
 
                 // Let's run the UUT
-                let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Goerli, None));
+                let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Testnet, None));
 
                 let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
 
@@ -1301,7 +1301,7 @@ mod tests {
                 );
 
                 // Run the UUT
-                let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Goerli, None));
+                let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Testnet, None));
 
                 let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
 
@@ -1581,7 +1581,7 @@ mod tests {
                 );
 
                 // Run the UUT
-                let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Goerli, None));
+                let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Testnet, None));
 
                 let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
 
@@ -1788,7 +1788,7 @@ mod tests {
                 );
 
                 // Run the UUT
-                let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Goerli, None));
+                let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Testnet, None));
 
                 let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
 
@@ -1984,7 +1984,7 @@ mod tests {
                 );
 
                 // Run the UUT
-                let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Goerli, None));
+                let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Testnet, None));
 
                 let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
 
@@ -2061,7 +2061,7 @@ mod tests {
                 );
 
                 // Run the UUT
-                let jh = tokio::spawn(sync(tx_event, mock, None, Chain::Goerli, None));
+                let jh = tokio::spawn(sync(tx_event, mock, None, Chain::Testnet, None));
 
                 // Wrap this in a timeout so we don't wait forever in case of test failure.
                 // Right now closing the channel causes an error.

--- a/crates/pathfinder/src/storage/schema/revision_0013.rs
+++ b/crates/pathfinder/src/storage/schema/revision_0013.rs
@@ -14,8 +14,8 @@ pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<()> {
         .optional()?;
 
     let (minimum_block, chain) = match genesis {
-        Some(Ok(x)) if x == crate::consts::GOERLI_GENESIS_HASH.0 => {
-            (231_579, crate::core::Chain::Goerli)
+        Some(Ok(x)) if x == crate::consts::TESTNET_GENESIS_HASH.0 => {
+            (231_579, crate::core::Chain::Testnet)
         }
         Some(Ok(x)) if x == crate::consts::MAINNET_GENESIS_HASH.0 => {
             (2700, crate::core::Chain::Mainnet)

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -4,7 +4,7 @@ use stark_hash::StarkHash;
 use web3::types::H256;
 
 use crate::{
-    consts::{TESTNET_GENESIS_HASH, INTEGRATION_GENESIS_HASH, MAINNET_GENESIS_HASH},
+    consts::{INTEGRATION_GENESIS_HASH, MAINNET_GENESIS_HASH, TESTNET_GENESIS_HASH},
     core::{
         Chain, ClassHash, ContractAddress, ContractNonce, ContractRoot, ContractStateHash,
         EthereumBlockHash, EthereumBlockNumber, EthereumLogIndex, EthereumTransactionHash,

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -4,7 +4,7 @@ use stark_hash::StarkHash;
 use web3::types::H256;
 
 use crate::{
-    consts::{GOERLI_GENESIS_HASH, INTEGRATION_GENESIS_HASH, MAINNET_GENESIS_HASH},
+    consts::{TESTNET_GENESIS_HASH, INTEGRATION_GENESIS_HASH, MAINNET_GENESIS_HASH},
     core::{
         Chain, ClassHash, ContractAddress, ContractNonce, ContractRoot, ContractStateHash,
         EthereumBlockHash, EthereumBlockNumber, EthereumLogIndex, EthereumTransactionHash,
@@ -390,7 +390,7 @@ impl StarknetBlocksTable {
 
         match genesis {
             None => Ok(None),
-            Some(hash) if hash == GOERLI_GENESIS_HASH => Ok(Some(Chain::Goerli)),
+            Some(hash) if hash == TESTNET_GENESIS_HASH => Ok(Some(Chain::Testnet)),
             Some(hash) if hash == MAINNET_GENESIS_HASH => Ok(Some(Chain::Mainnet)),
             Some(hash) if hash == INTEGRATION_GENESIS_HASH => Ok(Some(Chain::Integration)),
             Some(hash) => Err(anyhow::anyhow!("Unknown genesis block hash {}", hash.0)),

--- a/crates/pathfinder/src/storage/state.rs
+++ b/crates/pathfinder/src/storage/state.rs
@@ -4,7 +4,7 @@ use stark_hash::StarkHash;
 use web3::types::H256;
 
 use crate::{
-    consts::{GOERLI_GENESIS_HASH, MAINNET_GENESIS_HASH},
+    consts::{GOERLI_GENESIS_HASH, INTEGRATION_GENESIS_HASH, MAINNET_GENESIS_HASH},
     core::{
         Chain, ClassHash, ContractAddress, ContractNonce, ContractRoot, ContractStateHash,
         EthereumBlockHash, EthereumBlockNumber, EthereumLogIndex, EthereumTransactionHash,
@@ -392,6 +392,7 @@ impl StarknetBlocksTable {
             None => Ok(None),
             Some(hash) if hash == GOERLI_GENESIS_HASH => Ok(Some(Chain::Goerli)),
             Some(hash) if hash == MAINNET_GENESIS_HASH => Ok(Some(Chain::Mainnet)),
+            Some(hash) if hash == INTEGRATION_GENESIS_HASH => Ok(Some(Chain::Integration)),
             Some(hash) => Err(anyhow::anyhow!("Unknown genesis block hash {}", hash.0)),
         }
     }


### PR DESCRIPTION
This PR adds support for running pathfinder on the integration network. It facilitates this by adding a separate `EthereumChain` type which allows us to add `Chain::Integration` without touching Ethereum stuff directly.

The integration network is configured by providing `--integration` alongside a goerli L1 network. It will use `integration.sqlite` as its database filename. This cli option is hidden.

This PR once again touches many files (sorry), due to the required refactoring and renaming. This is mostly `Goerli -> Testnet` renaming (since both integration and testnet live on goerli). I once again recommend reviewing by commit to lessen the renaming noise..

Warning: I have not been able to test `--integration` properly, as L2 sync fails because we cannot parse the 0.10 blocks yet. However, testnet and mainnet continue to operate as expected with my limited testing.