### PR TITLE
fix: nonces are not updated if no storage update

### DIFF
--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -747,7 +747,7 @@ fn update_starknet_state(
             &global_tree,
             transaction,
         )
-        .context("Update contract state")?;
+        .context("Update contract nonce")?;
 
         // Update the global state tree.
         global_tree


### PR DESCRIPTION
Nonces were only updated if the contract also has storage updates. This PR fixes this by also updating nonces without storage updates.

Overall, our sequencer struct isn't really ideal for this, as it makes these bugs easy to make. Would be much better to group nonces with their storage updates by contract address. Won't attempt that now.