### PR TITLE
fix(rpc): properly return version and nonce for v1 invoke transactions

### DIFF
--- a/crates/pathfinder/src/rpc/types.rs
+++ b/crates/pathfinder/src/rpc/types.rs
@@ -693,10 +693,9 @@ pub mod reply {
                                 common: CommonTransactionProperties {
                                     hash: txn.transaction_hash,
                                     max_fee: txn.max_fee,
-                                    // no `version` in invoke transactions
-                                    version: TransactionVersion(Default::default()),
+                                    version: TransactionVersion(web3::types::H256::zero()),
                                     signature: txn.signature.clone(),
-                                    // no `nonce` in invoke transactions
+                                    // no `nonce` in v0 invoke transactions
                                     nonce: TransactionNonce(Default::default()),
                                 },
                                 contract_address: txn.contract_address,
@@ -710,11 +709,11 @@ pub mod reply {
                                 common: CommonTransactionProperties {
                                     hash: txn.transaction_hash,
                                     max_fee: txn.max_fee,
-                                    // no `version` in invoke transactions
-                                    version: TransactionVersion(Default::default()),
+                                    version: TransactionVersion(
+                                        web3::types::H256::from_low_u64_be(1),
+                                    ),
                                     signature: txn.signature.clone(),
-                                    // no `nonce` in invoke transactions
-                                    nonce: TransactionNonce(Default::default()),
+                                    nonce: txn.nonce,
                                 },
                                 contract_address: txn.contract_address,
                                 entry_point_selector: EntryPoint(StarkHash::ZERO),


### PR DESCRIPTION
We forgot to update the code with the new data in the v1 invoke
transaction type, so the RPC API was returning invalid version and nonce
(both zero) for v1 invoke transactions.