### PR TITLE
feat: starknet_getNonce for v0.2.0

### DIFF
--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -359,8 +359,49 @@ Hint: If you are looking to run two instances of pathfinder, you must configure 
             },
         )?;
 
-        let module = module.into_inner();
+        let mut module = module.into_inner();
+        Self::register_method2(
+            &mut module,
+            "starknet_getNonce",
+            get_nonce::GetNonce::execute,
+        )?;
+
         Ok(server.start(module).map(|handle| (handle, local_addr))?)
+    }
+
+    fn register_method2<Input, Output, Error, MethodFuture, Method>(
+        module: &mut jsonrpsee::RpcModule<RpcApi>,
+        method_name: &'static str,
+        method: Method,
+    ) -> anyhow::Result<()>
+    where
+        Input: ::serde::de::DeserializeOwned + Send + Sync,
+        Output: 'static + ::serde::Serialize + Send + Sync,
+        Error: Into<error::RpcError>,
+        MethodFuture: std::future::Future<Output = Result<Output, Error>> + Send,
+        Method: (Fn(std::sync::Arc<RpcApi>, Input) -> MethodFuture) + Copy + Send + Sync + 'static,
+    {
+        use tracing::Instrument;
+
+        metrics::register_counter!("rpc_method_calls_total", "method" => method_name);
+
+        let method_callback = move |params: jsonrpsee::types::Params<'static>, context| {
+            let span = tracing::info_span!("rpc_method", name = method_name);
+            async move {
+                let input = params.parse::<Input>()?;
+                method(context, input).await.map_err(|err| {
+                    let rpc_err: error::RpcError = err.into();
+                    jsonrpsee::core::Error::from(rpc_err)
+                })
+            }
+            .instrument(span)
+        };
+
+        module
+            .register_async_method(method_name, method_callback)
+            .with_context(|| format!("Registering {method_name}"))?;
+
+        Ok(())
     }
 
     fn register_method<T: RpcMethod>(

--- a/crates/pathfinder/src/rpc/api.rs
+++ b/crates/pathfinder/src/rpc/api.rs
@@ -37,13 +37,13 @@ use super::types::reply::{
 
 /// Implements JSON-RPC endpoints.
 pub struct RpcApi {
-    storage: Storage,
-    sequencer: sequencer::Client,
-    chain: Chain,
-    call_handle: Option<ext_py::Handle>,
-    shared_gas_price: Option<Cached>,
-    sync_state: Arc<SyncState>,
-    pending_data: Option<PendingData>,
+    pub storage: Storage,
+    pub sequencer: sequencer::Client,
+    pub chain: Chain,
+    pub call_handle: Option<ext_py::Handle>,
+    pub shared_gas_price: Option<Cached>,
+    pub sync_state: Arc<SyncState>,
+    pub pending_data: Option<PendingData>,
 }
 
 #[derive(Debug)]
@@ -1496,7 +1496,7 @@ impl From<EventFilterError> for jsonrpsee::core::Error {
 //
 // This error is used for all instances of operations that are not explicitly specified in the StarkNet spec.
 // See <https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json>
-fn internal_server_error(e: impl std::fmt::Display) -> jsonrpsee::core::Error {
+pub fn internal_server_error(e: impl std::fmt::Display) -> jsonrpsee::core::Error {
     Error::Call(CallError::Custom(ErrorObject::owned(
         jsonrpsee::types::error::ErrorCode::InternalError.code(),
         format!("{}: {}", jsonrpsee::types::error::INTERNAL_ERROR_MSG, e),

--- a/crates/pathfinder/src/rpc/error.rs
+++ b/crates/pathfinder/src/rpc/error.rs
@@ -1,0 +1,57 @@
+#[derive(thiserror::Error, Debug)]
+pub enum RpcError {
+    #[error("Failed to write transaction")]
+    FailedToReceiveTxn,
+    #[error("Contract not found")]
+    ContractNotFound,
+    #[error("Invalid message selector")]
+    InvalidMessageSelector,
+    #[error("Invalid call data")]
+    InvalidCallData,
+    #[error("Block not found")]
+    BlockNotFound,
+    #[error("Transaction hash not found")]
+    TxnHashNotFound,
+    #[error("Invalid transaction index in a block")]
+    InvalidTxnIndex,
+    #[error("Class hash not found")]
+    ClassHashNotFoundUND,
+    #[error("Requested page size is too big")]
+    PageSizeTooBig,
+    #[error("There are no blocks")]
+    NoBlocks,
+    #[error("The supplied continuation token is invalid or unknown")]
+    InvalidContinuationToken,
+    #[error("Contract error")]
+    ContractError,
+    #[error(transparent)]
+    Internal(anyhow::Error),
+}
+
+impl RpcError {
+    pub fn code(&self) -> i32 {
+        match self {
+            RpcError::FailedToReceiveTxn => 1,
+            RpcError::ContractNotFound => 20,
+            RpcError::InvalidMessageSelector => 21,
+            RpcError::InvalidCallData => 22,
+            RpcError::BlockNotFound => 24,
+            RpcError::TxnHashNotFound => 25,
+            RpcError::InvalidTxnIndex => 27,
+            RpcError::ClassHashNotFoundUND => 28,
+            RpcError::PageSizeTooBig => 31,
+            RpcError::NoBlocks => 32,
+            RpcError::InvalidContinuationToken => 33,
+            RpcError::ContractError => 40,
+            RpcError::Internal(_) => jsonrpsee::types::error::ErrorCode::InternalError.code(),
+        }
+    }
+}
+
+impl From<RpcError> for jsonrpsee::core::error::Error {
+    fn from(err: RpcError) -> Self {
+        use jsonrpsee::types::error::{CallError, ErrorObject};
+
+        CallError::Custom(ErrorObject::owned(err.code(), err.to_string(), None::<()>)).into()
+    }
+}

--- a/crates/pathfinder/src/rpc/error.rs
+++ b/crates/pathfinder/src/rpc/error.rs
@@ -15,7 +15,7 @@ pub enum RpcError {
     #[error("Invalid transaction index in a block")]
     InvalidTxnIndex,
     #[error("Class hash not found")]
-    ClassHashNotFoundUND,
+    ClassHashNotFound,
     #[error("Requested page size is too big")]
     PageSizeTooBig,
     #[error("There are no blocks")]
@@ -38,7 +38,7 @@ impl RpcError {
             RpcError::BlockNotFound => 24,
             RpcError::TxnHashNotFound => 25,
             RpcError::InvalidTxnIndex => 27,
-            RpcError::ClassHashNotFoundUND => 28,
+            RpcError::ClassHashNotFound => 28,
             RpcError::PageSizeTooBig => 31,
             RpcError::NoBlocks => 32,
             RpcError::InvalidContinuationToken => 33,
@@ -54,4 +54,125 @@ impl From<RpcError> for jsonrpsee::core::error::Error {
 
         CallError::Custom(ErrorObject::owned(err.code(), err.to_string(), None::<()>)).into()
     }
+}
+
+/// Generates an enum subset of [RpcError] along with boilerplate for mapping the variants.
+///
+/// This is useful for RPC methods which may only emit a few of the [RpcError] variants as this
+/// macro can be used to quickly create the enum-subset with the required glue code.
+///
+/// ## Usage
+/// ```no_run
+/// rpc_error_subset!(<enum_name>: <variant a>, <variant b>, <variant N>);
+/// ```
+/// Note that the variants __must__ match the [RpcError] variant names and that [RpcError::Internal]
+/// is always included by default (and therefore should not be part of macro input).
+///
+/// ## Specifics
+/// This macro generates the following:
+///
+/// 1. New enum definition with `#[derive(Debug)]`
+/// 2. `impl From<NewEnum> for RpcError`
+/// 3. `impl From<anyhow::Error> for NewEnum`
+///
+/// It always includes the `Internal(anyhow::Error)` variant.
+///
+/// ## Example with expansion
+/// ```no_run
+/// // This macro invocation:
+/// rpc_error_subset!(MyEnum: BlockNotFound, NoBlocks);
+/// // expands to:
+/// #[derive(debug)]
+/// pub enum MyError {
+///     BlockNotFound,
+///     NoBlocks,
+///     Internal(anyhow::Error),
+/// }
+///
+/// impl From<MyError> for RpcError {
+///     fn from(x: MyError) -> Self {
+///         match x {
+///             MyError::BlockNotFound => Self::BlockNotFound,
+///             MyError::NoBlocks => Self::NoBlocks,
+///             MyError::Internal(internal) => Self::Internal(internal),
+///         }
+///     }
+/// }
+///
+/// impl From<anyhow::Error> for MyError {
+///     fn from(e: anyhow::Error) -> Self {
+///         Self::Internal(e)
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! rpc_error_subset {
+    // This macro uses the following advanced techniques:
+    //   - tt-muncher (https://danielkeep.github.io/tlborm/book/pat-incremental-tt-munchers.html)
+    //   - push-down-accumulation (https://danielkeep.github.io/tlborm/book/pat-push-down-accumulation.html)
+    //
+    // All macro arms (except the entry-point) begin with `@XXX` to prevent accidental usage.
+    //
+    // It would be possible to allow for custom `#[derive()]` and other attributes, but these are currently not supported.
+
+    // Entry-point for the macro
+    ($enum_name:ident: $($subset:tt),+) => {
+        crate::rpc_error_subset!(@enum_def, $enum_name, $($subset),+);
+        crate::rpc_error_subset!(@from_anyhow, $enum_name);
+        crate::rpc_error_subset!(@from_def, $enum_name, $($subset),+);
+    };
+    // Generates the enum definition, nothing tricky here.
+    (@enum_def, $enum_name:ident, $($subset:tt),+) => {
+        #[derive(Debug)]
+        pub enum $enum_name {
+            $($subset),+,
+            Internal(anyhow::Error),
+        }
+    };
+    // Generates From<anyhow::Error>, nothing tricky here.
+    (@from_anyhow, $enum_name:ident) => {
+        impl From<anyhow::Error> for $enum_name {
+            fn from(e: anyhow::Error) -> Self {
+                Self::Internal(e)
+            }
+        }
+    };
+    // Generates From<$enum_name> for RpcError, this macro arm itself is not tricky,
+    // however its child calls are.
+    //
+    // We pass down the variants, which will get tt-munched until we reach the base case.
+    // We also initialize the match "arms" (`{}`) as empty. These will be accumulated until
+    // we reach the base case at which point the match itself is generated using the arms.
+    //
+    // We cannot generate the match in this macro arm as each macro invocation must result in
+    // a valid AST (I think). This means that having the match at this level would require the
+    // child calls only return arm(s) -- which is not valid syntax by itself.
+    //
+    // By pushing the arms from this level downwards, and creating the match statement at the lowest
+    // level, we guarantee that only valid valid Rust will bubble back up.
+    (@from_def, $enum_name:ident, $($variants:ident),*) => {
+        impl From<$enum_name> for crate::rpc::error::RpcError {
+            fn from(x: $enum_name) -> Self {
+                crate::rpc_error_subset!(@parse, x, $enum_name, {}, $($variants),*)
+            }
+        }
+    };
+    // Termination case (no further input to munch). We generate the match statement here.
+    (@parse, $var:ident, $enum_name:ident, {$($arms:tt)*}, $(,)*) => {
+        match $var {
+            $($arms)*
+            $enum_name::Internal(internal) => Self::Internal(internal),
+        }
+    };
+    // Append variant to arms. Continue parsing the remaining variants.
+    (@parse, $var:ident, $enum_name:ident, {$($arms:tt)*}, $variant:ident, $($tail:ident),*) => {
+        crate::rpc_error_subset!(
+            @parse, $var, $enum_name,
+            {
+                $($arms)*
+                $enum_name::$variant => Self::$variant,
+            },
+            $($tail),*,
+        )
+    };
 }

--- a/crates/pathfinder/src/rpc/get_nonce.rs
+++ b/crates/pathfinder/src/rpc/get_nonce.rs
@@ -8,28 +8,7 @@ pub struct GetNonceInput {
     contract_address: crate::core::ContractAddress,
 }
 
-#[derive(Debug)]
-pub enum GetNonceErrors {
-    BlockNotFound,
-    ContractNotFound,
-    Internal(anyhow::Error),
-}
-
-impl From<GetNonceErrors> for super::error::RpcError {
-    fn from(e: GetNonceErrors) -> Self {
-        match e {
-            GetNonceErrors::BlockNotFound => super::error::RpcError::BlockNotFound,
-            GetNonceErrors::ContractNotFound => super::error::RpcError::ContractNotFound,
-            GetNonceErrors::Internal(internal) => super::error::RpcError::Internal(internal),
-        }
-    }
-}
-
-impl From<anyhow::Error> for GetNonceErrors {
-    fn from(e: anyhow::Error) -> Self {
-        GetNonceErrors::Internal(e)
-    }
-}
+crate::rpc_error_subset!(GetNonceError: BlockNotFound, ContractNotFound);
 
 #[async_trait::async_trait]
 impl super::RpcMethod for GetNonce {
@@ -39,7 +18,7 @@ impl super::RpcMethod for GetNonce {
 
     type Output = crate::core::ContractNonce;
 
-    type Error = GetNonceErrors;
+    type Error = GetNonceError;
 
     async fn execute(
         context: std::sync::Arc<super::api::RpcApi>,
@@ -189,7 +168,7 @@ mod tests {
 
             let result = GetNonce::execute(context, input).await;
 
-            assert_matches::assert_matches!(result, Err(GetNonceErrors::ContractNotFound));
+            assert_matches::assert_matches!(result, Err(GetNonceError::ContractNotFound));
         }
 
         #[tokio::test]
@@ -210,7 +189,7 @@ mod tests {
 
             let result = GetNonce::execute(context, input).await;
 
-            assert_matches::assert_matches!(result, Err(GetNonceErrors::BlockNotFound));
+            assert_matches::assert_matches!(result, Err(GetNonceError::BlockNotFound));
         }
     }
 }

--- a/crates/pathfinder/src/rpc/get_nonce.rs
+++ b/crates/pathfinder/src/rpc/get_nonce.rs
@@ -1,0 +1,214 @@
+use anyhow::Context;
+
+pub struct GetNonce;
+
+#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+pub struct GetNonceInput {
+    block_id: crate::core::BlockId,
+    contract_address: crate::core::ContractAddress,
+}
+
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum GetNonceErrors {
+    BlockNotFound,
+    ContractNotFound,
+}
+
+impl From<GetNonceErrors> for super::types::reply::ErrorCode {
+    fn from(e: GetNonceErrors) -> Self {
+        use super::types::reply::ErrorCode;
+        match e {
+            GetNonceErrors::BlockNotFound => ErrorCode::InvalidBlockId,
+            GetNonceErrors::ContractNotFound => ErrorCode::ContractNotFound,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl super::RpcMethod for GetNonce {
+    const NAME: &'static str = "starknet_getNonce";
+
+    type Input = GetNonceInput;
+
+    type Output = crate::core::ContractNonce;
+
+    type Errors = GetNonceErrors;
+
+    async fn execute(
+        context: std::sync::Arc<super::api::RpcApi>,
+        input: Self::Input,
+    ) -> anyhow::Result<Result<Self::Output, Self::Errors>> {
+        use crate::state::state_tree::GlobalStateTree;
+        use crate::storage::{StarknetBlocksBlockId, StarknetBlocksTable};
+
+        // We can potentially read the nonce from pending without having to reach out to the database.
+        use crate::core::BlockId;
+        let block_id = match input.block_id {
+            BlockId::Pending => {
+                if let Some(pending) = context.pending_data.clone() {
+                    if let Some(pending_state_update) = pending.state_update().await {
+                        if let Some(nonce) = pending_state_update
+                            .state_diff
+                            .nonces
+                            .get(&input.contract_address)
+                        {
+                            return Ok(Ok(*nonce));
+                        }
+                    }
+                };
+
+                StarknetBlocksBlockId::Latest
+            }
+            BlockId::Latest => StarknetBlocksBlockId::Latest,
+            BlockId::Hash(hash) => hash.into(),
+            BlockId::Number(number) => number.into(),
+        };
+
+        let storage = context.storage.clone();
+        let span = tracing::Span::current();
+        let jh = tokio::task::spawn_blocking(move || {
+            let _g = span.enter();
+            let mut db = storage
+                .connection()
+                .context("Opening database connection")?;
+            let tx = db.transaction().context("Creating database transaction")?;
+
+            // Use internal_server_error to indicate that the process of querying for a particular block failed,
+            // which is not the same as being sure that the block is not in the db.
+            let global_root = match StarknetBlocksTable::get_root(&tx, block_id)
+                .context("Fetching global root")?
+            {
+                Some(root) => root,
+                None => return anyhow::Ok(Err(Self::Errors::BlockNotFound)),
+            };
+
+            let global_state_tree =
+                GlobalStateTree::load(&tx, global_root).context("Loading global state tree")?;
+
+            let state_hash = global_state_tree
+                .get(input.contract_address)
+                .context("Get contract state hash from global state tree")?;
+
+            // There is a dedicated error code for a non-existent contract in the RPC API spec, so use it.
+            if state_hash.0 == stark_hash::StarkHash::ZERO {
+                return Ok(Err(Self::Errors::ContractNotFound));
+            }
+
+            let nonce = crate::storage::ContractsStateTable::get_nonce(&tx, state_hash)
+                .context("Reading contract nonce")?
+                // Since the contract does exist, the nonce should not be missing.
+                .context("Contract nonce is missing")?;
+
+            Ok(Ok(nonce))
+        });
+        let nonce = jh.await.context("Database read panic or shutting down")??;
+        Ok(nonce)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    use crate::{
+        core::{BlockId, ContractAddress},
+        rpc::RpcMethod,
+        state::SyncState,
+    };
+    use crate::{
+        core::{Chain, StarknetBlockHash},
+        rpc::api::RpcApi,
+        starkhash,
+    };
+    use crate::{rpc::tests::setup_storage, starkhash_bytes};
+
+    type SequencerClient = crate::sequencer::Client;
+
+    mod parsing {
+        use super::*;
+
+        #[test]
+        fn positional_args() {
+            use jsonrpsee::types::Params;
+
+            let positional = r#"[
+                { "block_hash": "0xabcde" },
+                "0x12345"
+            ]"#;
+            let positional = Params::new(Some(positional));
+
+            let input = positional
+                .parse::<<GetNonce as RpcMethod>::Input>()
+                .unwrap();
+            let expected = GetNonceInput {
+                block_id: StarknetBlockHash(starkhash!("0abcde")).into(),
+                contract_address: ContractAddress::new_or_panic(starkhash!("012345")),
+            };
+            assert_eq!(input, expected);
+        }
+
+        #[test]
+        fn named_args() {
+            use jsonrpsee::types::Params;
+
+            let positional = r#"{
+                "block_id": { "block_hash": "0xabcde" },
+                "contract_address": "0x12345"
+            }"#;
+            let positional = Params::new(Some(positional));
+
+            let input = positional
+                .parse::<<GetNonce as RpcMethod>::Input>()
+                .unwrap();
+            let expected = GetNonceInput {
+                block_id: StarknetBlockHash(starkhash!("0abcde")).into(),
+                contract_address: ContractAddress::new_or_panic(starkhash!("012345")),
+            };
+            assert_eq!(input, expected);
+        }
+    }
+
+    mod errors {
+        use super::*;
+
+        #[tokio::test]
+        async fn contract_not_found() {
+            let storage = setup_storage();
+            let sequencer = SequencerClient::new(Chain::Testnet).unwrap();
+            let sync_state = Arc::new(SyncState::default());
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state.clone());
+            let context = Arc::new(api);
+
+            let input = GetNonceInput {
+                block_id: BlockId::Latest,
+                contract_address: ContractAddress::new_or_panic(starkhash_bytes!(b"invalid")),
+            };
+
+            let result = GetNonce::execute(context, input).await.unwrap();
+
+            assert_eq!(result, Err(GetNonceErrors::ContractNotFound));
+        }
+
+        #[tokio::test]
+        async fn block_not_found() {
+            use crate::core::StarknetBlockHash;
+
+            let storage = setup_storage();
+            let sequencer = SequencerClient::new(Chain::Testnet).unwrap();
+            let sync_state = Arc::new(SyncState::default());
+            let api = RpcApi::new(storage, sequencer, Chain::Testnet, sync_state.clone());
+            let context = Arc::new(api);
+
+            let input = GetNonceInput {
+                block_id: BlockId::Hash(StarknetBlockHash(starkhash_bytes!(b"invalid"))),
+                // This contract does exist and is added in block 0.
+                contract_address: ContractAddress::new_or_panic(starkhash_bytes!(b"contract 0")),
+            };
+
+            let result = GetNonce::execute(context, input).await.unwrap();
+
+            assert_eq!(result, Err(GetNonceErrors::BlockNotFound));
+        }
+    }
+}


### PR DESCRIPTION
The primary aim of this PR is to prototype a different JSON-RPC approach. It has quite a few additions, not all of which I am convinced are good -- criticism and dissent are welcome. The idea is not to merge this, but rather discuss the idea (or suggest improvements to it).

In terms of `starknet_getNonce` this PR does update it to the `v0.2.0` version by adding the `block_id` input argument and appropriately handling it.

It adds an `async trait` which all RPC methods should implement. I was on the fence about the usefulness of this, but one thing I do like -- it has associated types for `Input`, `Output` and `Errors` which let one easily verify the code against the specification.

~~I also tried to extract the `map(internal_server_error)` one level higher by making the output of the trait function: `anyhow::Result<Result<Output, Errors>>` with the idea that the outer `anyhow::Err` will get mapped to `internal_server_error`. This has not worked quite as well as I had hoped because one does still need to be careful inside the impl and there is also a double `Result` now which is always awkward. But maybe there is something useful here; maybe one can flatten it somehow without automatigically casting errors incorrectly.~~

I have now added what I think is a better error type; although I'm unsure if it will hold up for the more complicated cases -- but I also don't see why it wouldn't.

I left the original rpc test in-place to minimize the diff, but the idea would be to move the test to the new file as well.

I also like how input parsing and business logic are separated. One could go further with testing if one also splits the business logic into smaller, separate functions.