### PR TITLE
docs(contrib): special requirements for py/ future licensing

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,4 +410,4 @@ dual licensed as above, without any additional terms or conditions.
 If you would like to contribute to the `py/` parts, which interface with
 [`cairo-lang`](https://github.com/starkware-libs/cairo-lang), please include a
 mention that you agree to relicense the python parts as necessary to abide with
-future `cairo-lang` license.:
+future `cairo-lang` license. See `contributing.md` for more information.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Updating a `pathfinder` node from source is fairly straight forward and is a sim
 Start by updating the `pathfinder` repository to the desired version. From within your `pathfinder` folder:
 
 ```bash
-git fetch 
+git fetch
 git checkout <version-tag>
 ```
 

--- a/README.md
+++ b/README.md
@@ -406,3 +406,8 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
+
+If you would like to contribute to the `py/` parts, which interface with
+[`cairo-lang`](https://github.com/starkware-libs/cairo-lang), please include a
+mention that you agree to relicense the python parts as necessary to abide with
+future `cairo-lang` license.:

--- a/contributing.md
+++ b/contributing.md
@@ -10,6 +10,19 @@ finding a place to contribute actual code can be difficult. If you do feel like
 tackling an open issue, please do comment on the issue or open a PR. We are
 happy to guide you through the process.
 
+## `py/` directory
+
+The main purpose of the `py/` is to interface with [`cairo-lang`] which
+currently has a custom license. It is possible we will have to change the
+license of `py/` in future to accommodate these changes. When contributing to
+python parts under `py/` please agree to future relicensing to stay compatible
+with any future [`cairo-lang`] license by including this text in your PR:
+
+> As the author of this PR I explicitly agree to any relicensing of my
+> contributions under `py/` directory per repository's contributing.md.
+
+[`cairo-lang`]: https://github.com/starkware-libs/cairo-lang
+
 ## Pull-requests
 
 Keeping these points in mind will increase the odds of a successful PR:

--- a/contributing.md
+++ b/contributing.md
@@ -2,9 +2,13 @@
 
 Welcome, and thank you for your interest in contributing to Pathfinder!
 
-The easiest way to do so is to open issues for questions, bug reports and areas where documentation is lacking.
+The easiest way to do so is to open issues for questions, bug reports and areas
+where documentation is lacking.
 
-At this stage the code and documentation is still in a pretty rough shape, so finding a place to contribute actual code can be difficult. If you do feel like tackling an open issue, please do comment on the issue or open a PR. We are happy to guide you through the process.
+At this stage the code and documentation is still in a pretty rough shape, so
+finding a place to contribute actual code can be difficult. If you do feel like
+tackling an open issue, please do comment on the issue or open a PR. We are
+happy to guide you through the process.
 
 ## Pull-requests
 

--- a/contributing.md
+++ b/contributing.md
@@ -19,7 +19,7 @@ python parts under `py/` please agree to future relicensing to stay compatible
 with any future [`cairo-lang`] license by including this text in your PR:
 
 > As the author of this PR I explicitly agree to any relicensing of my
-> contributions under `py/` directory per repository's contributing.md.
+> contributions under `py/` directory as per repository's contributing.md.
 
 [`cairo-lang`]: https://github.com/starkware-libs/cairo-lang
 


### PR DESCRIPTION
the [cairo-lang license](https://github.com/starkware-libs/cairo-lang/blob/master/LICENSE.txt) is custom, and it is unknown what it will be in future. Try to be explicit about this with regards to this in the contributing.md. I don't know if the legalese holds any water but at least it highlights the issue.

Possible relicensing could be that `py/` becomes GPL or whatever. This is not an issue for pathfinder especially if the py/src/call.py is not combined to the distributed binary.