### PR TITLE
fix(sync): move l1 sleep to intended task

### DIFF
--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -246,10 +246,12 @@ where
                     let (new_tx, new_rx) = mpsc::channel(1);
                     rx_l1 = new_rx;
 
-                    l1_handle = tokio::spawn({
+                    let fut = l1_sync(new_tx, transport.clone(), chain, l1_head);
+
+                    l1_handle = tokio::spawn(async move {
                         #[cfg(not(test))]
                         tokio::time::sleep(RESET_DELAY_ON_FAILURE).await;
-                        l1_sync(new_tx, transport.clone(), chain, l1_head)
+                        fut.await
                     });
                     tracing::info!("L1 sync process restarted.")
                 },


### PR DESCRIPTION
Same as before for L2 task in #570.

I may follow up with another commit to remove the `#[cfg(test)]` in favor of tokio test config.