### PR TITLE
fix(ethereum): update mainnet core contract implementation address

### DIFF
--- a/crates/pathfinder/src/ethereum/contract.rs
+++ b/crates/pathfinder/src/ethereum/contract.rs
@@ -206,7 +206,7 @@ mod tests {
                 // update the address and more importantly, the ABI.
 
                 // The current address of Starknet's core contract implementation.
-                const CORE_IMPL_ADDR: &str = "0x2B3B750f1f10c85c8A6D476Fc209A8DC7E4Ca3F8";
+                const CORE_IMPL_ADDR: &str = "0xe267213b0749bb94c575f6170812c887330d9ce3";
                 let expect_addr = H160::from_str(CORE_IMPL_ADDR).unwrap();
 
                 // The proxy's ABI.


### PR DESCRIPTION
This has changed during the Starknet 0.10.0 deployment.