### PR TITLE
chore: bump lockfile to 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2075,7 +2075,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "assert_matches",


### PR DESCRIPTION
Forgotten amongst all the update bumping.