### PR TITLE
fix(estimate_past_transactions): parse L1_HANDLER and v1 INVOKE txs

### DIFF
--- a/crates/pathfinder/src/cairo/ext_py/ser.rs
+++ b/crates/pathfinder/src/cairo/ext_py/ser.rs
@@ -1,6 +1,6 @@
 //! The json serializable types
 
-use crate::core::{CallParam, ContractAddress, ContractNonce, EntryPoint};
+use crate::core::{CallParam, ContractAddress, ContractNonce, EntryPoint, TransactionNonce};
 use crate::rpc::types::BlockHashOrTag;
 use crate::sequencer::reply::state_update::{DeployedContract, StorageDiff};
 use std::collections::HashMap;
@@ -12,11 +12,14 @@ pub(crate) struct ChildCommand<'a> {
     pub command: Verb,
     pub contract_address: &'a ContractAddress,
     pub calldata: &'a [CallParam],
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub entry_point_selector: Option<&'a EntryPoint>,
     pub at_block: &'a BlockHashNumberOrLatest,
     #[serde_as(as = "Option<&crate::rpc::serde::H256AsHexStr>")]
     pub gas_price: Option<&'a web3::types::H256>,
     pub signature: &'a [crate::core::CallSignatureElem],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nonce: Option<&'a TransactionNonce>,
     pub max_fee: &'a crate::core::Fee,
     #[serde_as(as = "crate::rpc::serde::TransactionVersionAsHexStr")]
     pub version: &'a crate::core::TransactionVersion,

--- a/crates/pathfinder/src/cairo/ext_py/sub_process.rs
+++ b/crates/pathfinder/src/cairo/ext_py/sub_process.rs
@@ -360,6 +360,11 @@ async fn process(
             // sometimes
             gas_price: None,
             signature: &call.signature,
+            nonce: if call.version.0.is_zero() {
+                None
+            } else {
+                Some(&call.nonce)
+            },
             max_fee: &call.max_fee,
             version: &call.version,
             chain: *chain,
@@ -382,6 +387,11 @@ async fn process(
             at_block,
             gas_price: gas_price.as_option(),
             signature: &call.signature,
+            nonce: if call.version.0.is_zero() {
+                None
+            } else {
+                Some(&call.nonce)
+            },
             max_fee: &call.max_fee,
             version: &call.version,
             chain: *chain,

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -78,7 +78,6 @@ def do_loop(connection, input_gen, output_file):
     required = {
         "at_block": int_hash_or_latest,
         "contract_address": int_param,
-        "entry_point_selector": string_or_int,
         "calldata": list_of_int,
         "command": required_command,
         "gas_price": required_gas_price,
@@ -93,6 +92,7 @@ def do_loop(connection, input_gen, output_file):
         "pending_deployed": maybe_pending_deployed,
         "pending_nonces": maybe_pending_nonces,
         "nonce": maybe_nonce,
+        "entry_point_selector": string_or_int,
     }
 
     logger = Logger()


### PR DESCRIPTION
This change also makes some changes to `ChildCommand` so that v1 invoke transactions can be represented:

- adds `nonce` as an optional field (should be None for v0 invokes)
- makes `entry_point_selector` optional, too