### PR TITLE
fix: work around for L1_HANDLER gateway bug

### DIFF
--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -494,11 +494,17 @@ pub mod transaction {
     pub struct L1HandlerTransaction {
         pub contract_address: ContractAddress,
         pub entry_point_selector: EntryPoint,
+        // FIXME: remove once starkware fixes their gateway bug which was missing this field.
+        #[serde(default = "l1_handler_default_nonce")]
         pub nonce: TransactionNonce,
         pub calldata: Vec<CallParam>,
         pub transaction_hash: StarknetTransactionHash,
         #[serde_as(as = "TransactionVersionAsHexStr")]
         pub version: TransactionVersion,
+    }
+
+    const fn l1_handler_default_nonce() -> TransactionNonce {
+        TransactionNonce(stark_hash::StarkHash::ZERO)
     }
 
     impl From<DeclareTransaction> for Transaction {


### PR DESCRIPTION
This PR adds a work-around for a gateway bug.

The feeder gateway currently does not include the `nonce` field for `L1_HANDLER` transactions from historical blocks (pre StarkNet 0.10). This is blocking sync.