### PR TITLE
feat(ext_py): expose basic metrics on subprocesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,9 @@ Pathfinder has a monitoring API which can be enabled with the `--monitor-address
 
 `/metrics` provides a [Prometheus](https://prometheus.io/) metrics scrape endpoint. Currently only one type of metric is available:
 - `rpc_method_calls_total` counter, where the label key `method` should be used to point to a particular RPC method to retrieve that method's total call count, for example: `rpc_method_calls_total{method="starknet_getStateUpdate"}`.
+- `extpy_processes_launched_total` counter incremented each time python subprocess is launched
+- `extpy_processes_exited` counter with labels, incremented each time python subprocess exits normally
+- `extpy_processes_failed_total` counter, incremented each time python subprocess exits abnormally
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ Pathfinder has a monitoring API which can be enabled with the `--monitor-address
 `/metrics` provides a [Prometheus](https://prometheus.io/) metrics scrape endpoint. Currently only one type of metric is available:
 - `rpc_method_calls_total` counter, where the label key `method` should be used to point to a particular RPC method to retrieve that method's total call count, for example: `rpc_method_calls_total{method="starknet_getStateUpdate"}`.
 - `extpy_processes_launched_total` counter incremented each time python subprocess is launched
-- `extpy_processes_exited` counter with labels, incremented each time python subprocess exits normally
+- `extpy_processes_exited_total` counter with labels, incremented each time python subprocess exits normally
 - `extpy_processes_failed_total` counter, incremented each time python subprocess exits abnormally
 
 ## License

--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -14,12 +14,6 @@
 //! support "pending", a feature needs to be added which flushes the "open" pending to a
 //! global_state, and after that, calls can be made to it's `block_hash` for which we probably need
 //! to add an alternative way to use a hash directly rather as a root than assume it's a block hash.
-//!
-//! ## Metrics exported
-//!
-//! - `extpy_processes_launched_total` (incremented in service)
-//! - `extpy_processes_exited` (labeled, incremented in service)
-//! - `extpy_processes_failed_total` (incremented in service)
 
 use crate::core::CallResultValue;
 use crate::rpc::v01::types::{reply::FeeEstimate, request::Call};

--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -280,6 +280,9 @@ impl From<std::io::Error> for SubprocessError {
     }
 }
 
+/// Which process, with what opaque native reason exited because of which codepath was taken.
+type SubprocessExitInfo = (u32, Option<std::process::ExitStatus>, SubprocessExitReason);
+
 #[cfg(test)]
 mod tests {
     use super::sub_process::launch_python;

--- a/crates/pathfinder/src/cairo/ext_py/service.rs
+++ b/crates/pathfinder/src/cairo/ext_py/service.rs
@@ -181,17 +181,7 @@ pub async fn start(
 
 /// Returns if a new subprocess should be launched without wait
 fn on_joined_subprocess(
-    res: Result<
-        Result<
-            (
-                u32,
-                Option<std::process::ExitStatus>,
-                super::SubprocessExitReason,
-            ),
-            anyhow::Error,
-        >,
-        tokio::task::JoinError,
-    >,
+    res: Result<Result<super::SubprocessExitInfo, anyhow::Error>, tokio::task::JoinError>,
     processes_failed: &metrics::Counter,
 ) -> bool {
     match res {

--- a/crates/pathfinder/src/cairo/ext_py/service.rs
+++ b/crates/pathfinder/src/cairo/ext_py/service.rs
@@ -181,7 +181,7 @@ fn on_joined_subprocess(
 }
 
 static METRIC_LAUNCHED_PROCESSES: &str = "extpy_processes_launched_total";
-static METRIC_EXITED_PROCESSES: &str = "extpy_processes_exited";
+static METRIC_EXITED_PROCESSES: &str = "extpy_processes_exited_total";
 static METRIC_FAILED_PROCESSES: &str = "extpy_processes_failed_total";
 
 struct Metrics {


### PR DESCRIPTION
Adds the counters:

- extpy_processes_launched_total
- extpy_processes_exited_total -- labeled with the reason
- extpy_processes_failed_total

Against previous discussion didn't add any queuing counters, because those can already be calculated from the diff of started and completed call and estimatefee. Well, turns out there is only one counter for started requests. Later.