### PR TITLE
chore: more variable time `stark_hash`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,7 +2996,6 @@ dependencies = [
  "assert_matches",
  "bitvec",
  "criterion",
- "ff",
  "hex",
  "pretty_assertions",
  "rand_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2998,6 +2998,7 @@ dependencies = [
  "criterion",
  "hex",
  "pretty_assertions",
+ "rand",
  "rand_core",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,8 +733,7 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 [[package]]
 name = "ff"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
+source = "git+https://github.com/eqlabs/ff?branch=var_time_eq#e4ce228a5da140465a620cb0a455fcb08f23fb52"
 dependencies = [
  "byteorder",
  "ff_derive",
@@ -745,8 +744,7 @@ dependencies = [
 [[package]]
 name = "ff_derive"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95dddd96655a8ef19cc0dd2cb7063fb159f1583af0dbf3c04805ebc7dcc15849"
+source = "git+https://github.com/eqlabs/ff?branch=var_time_eq#e4ce228a5da140465a620cb0a455fcb08f23fb52"
 dependencies = [
  "addchain",
  "cfg-if",

--- a/crates/stark_curve/Cargo.toml
+++ b/crates/stark_curve/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/lib.rs"
 [dependencies]
 # paritys scale codec locks us here
 bitvec = "0.20.4"
-ff = { version = "0.12", default-features = false, features = [
+ff = { git = "https://github.com/eqlabs/ff", branch = "var_time_eq", default-features = false, features = [
     "derive",
     "alloc",
 ] }

--- a/crates/stark_curve/src/lib.rs
+++ b/crates/stark_curve/src/lib.rs
@@ -7,3 +7,5 @@ pub use curve::{
     AffinePoint, ProjectivePoint, PEDERSEN_P0, PEDERSEN_P1, PEDERSEN_P2, PEDERSEN_P3, PEDERSEN_P4,
 };
 pub use field::{FieldElement, FieldElementRepr};
+
+pub use ff;

--- a/crates/stark_hash/Cargo.toml
+++ b/crates/stark_hash/Cargo.toml
@@ -24,6 +24,7 @@ assert_matches = "1.5.0"
 criterion = "0.3"
 hex = "0.4.3"
 pretty_assertions = "1.0.0"
+rand = "0.8"
 serde_json = "1.0.75"
 
 [[bench]]

--- a/crates/stark_hash/Cargo.toml
+++ b/crates/stark_hash/Cargo.toml
@@ -15,10 +15,6 @@ stark_curve = { path = "../stark_curve" }
 [dependencies]
 # paritys scale codec locks us here
 bitvec = "0.20.4"
-ff = { version = "0.12", default-features = false, features = [
-    "derive",
-    "alloc",
-] }
 rand_core = "0.6.3"
 serde = "1.0.134"
 stark_curve = { path = "../stark_curve" }

--- a/crates/stark_hash/README.md
+++ b/crates/stark_hash/README.md
@@ -1,0 +1,3 @@
+# `stark_hash`
+
+Builds upon `../stark_curve` and implements the StarkNet hashing algorithm. The implementation is not constant time.

--- a/crates/stark_hash/src/hash.rs
+++ b/crates/stark_hash/src/hash.rs
@@ -5,7 +5,7 @@ use std::fmt::Display;
 use stark_curve::{AffinePoint, FieldElement, FieldElementRepr, ProjectivePoint, PEDERSEN_P0};
 
 use bitvec::{field::BitField, order::Msb0, slice::BitSlice, view::BitView};
-use ff::PrimeField;
+use stark_curve::ff::PrimeField;
 
 include!(concat!(env!("OUT_DIR"), "/curve_consts.rs"));
 
@@ -105,7 +105,7 @@ impl StarkHash {
     }
 
     pub fn random<R: rand_core::RngCore>(rng: R) -> Self {
-        use ff::Field;
+        use stark_curve::ff::Field;
         StarkHash(FieldElement::random(rng).to_repr().0)
     }
 
@@ -173,7 +173,7 @@ impl StarkHash {
             if index == limbs.len() {
                 break;
             }
-            borrow = ff::derive::sbb(limbs[index], modulus[index], borrow).1;
+            borrow = stark_curve::ff::derive::sbb(limbs[index], modulus[index], borrow).1;
             index += 1;
         }
 


### PR DESCRIPTION
This comes at the cost of using a fork of `ff` which doesn't use constant-time Eq implementation. Luckily there are no changes required to switch back.

Adds benchmarks in stark_hash:
- random_stark_hash
- random_hashchain (len = 100)

"It works on my computer": criterion reports -23% or -24% for random_stark_hash and random_hashchain respectively, with core-pinning (taskset) with no frequency restrictions but with minimum 15s measurement time. Similarly executed but with minimum 30s measurement time pathfinder's `merkle_tree of 1000` show -20% time.

`ff` change:
- https://github.com/eqlabs/ff/commit/e4ce228a5da140465a620cb0a455fcb08f23fb52

I think it makes more sense for `PartialEq` to be variable time since there are the `ConstantTimeEq` implementations for FieldElement and Repr.