### PR TITLE
feat(py): add lru cache for patricia_nodes

### DIFF
--- a/py/requirements-dev.in
+++ b/py/requirements-dev.in
@@ -7,3 +7,4 @@ pytest==6.2.5
 flake8==4.0.1
 black==21.12b0
 zstandard==0.17.0
+cachetools==5.0.0

--- a/py/requirements-dev.txt
+++ b/py/requirements-dev.txt
@@ -24,7 +24,9 @@ bitarray==1.2.2
 black==21.12b0
     # via -r requirements-dev.in
 cachetools==5.0.0
-    # via cairo-lang
+    # via
+    #   -r requirements-dev.in
+    #   cairo-lang
 cairo-lang==0.10.0
     # via -r requirements-dev.in
 certifi==2021.10.8


### PR DESCRIPTION
this should have non-negleable perf improvement on long call/estimate_fee runs.

cachetools is used instead of functools.lru_cache because apparently latter leaks instances using it.

cache is limited to only `patricia_node` prefixed keys, because only those and `starknet_storage_leaf`'s are repeatedly fetched from the Storage by PatriciaStateReader. However only `patricia_node`'s require looking it up from the database.

cache stats are added in timings reported by `call.py`. maxsize=512 was figured out with Harrison & Stetson method.