### PR TITLE
feat(rpc/v02): add `starknet_getTransactionByHash` implementation

### DIFF
--- a/crates/pathfinder/src/rpc/v02.rs
+++ b/crates/pathfinder/src/rpc/v02.rs
@@ -1,1 +1,38 @@
+use crate::{state::PendingData, storage::Storage};
+
+pub mod method;
 pub mod types;
+
+pub struct RpcContext {
+    pub storage: Storage,
+    pub pending_data: Option<PendingData>,
+}
+
+impl RpcContext {
+    pub fn new(storage: Storage) -> Self {
+        Self {
+            storage,
+            pending_data: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn for_tests() -> std::sync::Arc<Self> {
+        let storage = super::tests::setup_storage();
+        std::sync::Arc::new(Self::new(storage))
+    }
+
+    pub fn with_pending_data(self, pending_data: PendingData) -> Self {
+        Self {
+            pending_data: Some(pending_data),
+            ..self
+        }
+    }
+
+    #[cfg(test)]
+    pub async fn for_tests_with_pending() -> std::sync::Arc<Self> {
+        let storage = super::tests::setup_storage();
+        let pending_data = super::tests::create_pending_data(storage.clone()).await;
+        std::sync::Arc::new(Self::new(storage).with_pending_data(pending_data))
+    }
+}

--- a/crates/pathfinder/src/rpc/v02/method.rs
+++ b/crates/pathfinder/src/rpc/v02/method.rs
@@ -1,0 +1,1 @@
+pub(super) mod get_transaction_by_hash;

--- a/crates/pathfinder/src/rpc/v02/method/get_transaction_by_hash.rs
+++ b/crates/pathfinder/src/rpc/v02/method/get_transaction_by_hash.rs
@@ -1,0 +1,173 @@
+use anyhow::Context;
+
+use crate::core::StarknetTransactionHash;
+use crate::rpc::v02::types::reply::Transaction;
+use crate::rpc::v02::RpcContext;
+use crate::storage::StarknetTransactionsTable;
+
+#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+pub struct GetTransactionByHashInput {
+    transaction_hash: StarknetTransactionHash,
+}
+
+crate::rpc::error::generate_rpc_error_subset!(GetTransactionByHashError: TxnHashNotFound);
+
+#[allow(dead_code)]
+pub async fn get_transaction_by_hash(
+    context: std::sync::Arc<RpcContext>,
+    input: GetTransactionByHashInput,
+) -> Result<Transaction, GetTransactionByHashError> {
+    if let Some(pending) = &context.pending_data {
+        let pending_tx = pending.block().await.and_then(|block| {
+            block
+                .transactions
+                .iter()
+                .find(|tx| tx.hash() == input.transaction_hash)
+                .cloned()
+        });
+
+        if let Some(pending_tx) = pending_tx {
+            return Ok(pending_tx.into());
+        }
+    }
+
+    let storage = context.storage.clone();
+    let span = tracing::Span::current();
+
+    let jh = tokio::task::spawn_blocking(move || {
+        let _g = span.enter();
+        let mut db = storage
+            .connection()
+            .context("Opening database connection")?;
+
+        let db_tx = db.transaction().context("Creating database transaction")?;
+
+        // Get the transaction from storage.
+        StarknetTransactionsTable::get_transaction(&db_tx, input.transaction_hash)
+            .context("Reading transaction from database")?
+            .ok_or(GetTransactionByHashError::TxnHashNotFound)
+            .map(|tx| tx.into())
+    });
+
+    jh.await.context("Database read panic or shutting down")?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{
+        ContractAddress, EntryPoint, Fee, StarknetTransactionHash, TransactionNonce,
+    };
+    use crate::{starkhash, starkhash_bytes};
+    use stark_hash::StarkHash;
+
+    mod parsing {
+        use super::*;
+
+        use jsonrpsee::types::Params;
+
+        #[test]
+        fn positional_args() {
+            let positional = r#"[
+                "0xdeadbeef"
+            ]"#;
+            let positional = Params::new(Some(positional));
+
+            let input = positional.parse::<GetTransactionByHashInput>().unwrap();
+            assert_eq!(
+                input,
+                GetTransactionByHashInput {
+                    transaction_hash: StarknetTransactionHash(starkhash!("deadbeef"))
+                }
+            )
+        }
+
+        #[test]
+        fn named_args() {
+            let named_args = r#"{
+                "transaction_hash": "0xdeadbeef"
+            }"#;
+            let named_args = Params::new(Some(named_args));
+
+            let input = named_args.parse::<GetTransactionByHashInput>().unwrap();
+            assert_eq!(
+                input,
+                GetTransactionByHashInput {
+                    transaction_hash: StarknetTransactionHash(starkhash!("deadbeef"))
+                }
+            )
+        }
+    }
+
+    mod errors {
+        use super::*;
+
+        #[tokio::test]
+        async fn hash_not_found() {
+            let context = RpcContext::for_tests();
+            let input = GetTransactionByHashInput {
+                transaction_hash: StarknetTransactionHash(starkhash_bytes!(b"non_existent")),
+            };
+
+            let result = get_transaction_by_hash(context, input).await;
+
+            assert_matches::assert_matches!(
+                result,
+                Err(GetTransactionByHashError::TxnHashNotFound)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn success() {
+        let context = RpcContext::for_tests();
+        let input = GetTransactionByHashInput {
+            transaction_hash: StarknetTransactionHash(starkhash_bytes!(b"txn 0")),
+        };
+
+        let result = get_transaction_by_hash(context, input).await.unwrap();
+        use crate::rpc::v02::types::reply;
+        assert_eq!(
+            result,
+            Transaction::Invoke(reply::InvokeTransaction::V0(reply::InvokeTransactionV0 {
+                common: reply::CommonInvokeTransactionProperties {
+                    hash: StarknetTransactionHash(starkhash_bytes!(b"txn 0")),
+                    max_fee: Fee(web3::types::H128::zero()),
+                    signature: vec![],
+                    nonce: TransactionNonce(StarkHash::ZERO),
+                },
+                contract_address: ContractAddress::new_or_panic(starkhash_bytes!(b"contract 0")),
+                entry_point_selector: EntryPoint(StarkHash::ZERO),
+                calldata: vec![],
+            }))
+        )
+    }
+
+    #[tokio::test]
+    async fn pending() {
+        let context = RpcContext::for_tests_with_pending().await;
+
+        let input = GetTransactionByHashInput {
+            transaction_hash: StarknetTransactionHash(starkhash_bytes!(b"pending tx hash 0")),
+        };
+
+        let result = get_transaction_by_hash(context, input).await.unwrap();
+        use crate::rpc::v02::types::reply;
+        assert_eq!(
+            result,
+            Transaction::Invoke(reply::InvokeTransaction::V0(reply::InvokeTransactionV0 {
+                common: reply::CommonInvokeTransactionProperties {
+                    hash: StarknetTransactionHash(starkhash_bytes!(b"pending tx hash 0")),
+                    max_fee: Fee(web3::types::H128::zero()),
+                    signature: vec![],
+                    nonce: TransactionNonce(StarkHash::ZERO),
+                },
+                contract_address: ContractAddress::new_or_panic(starkhash_bytes!(
+                    b"pending contract addr 0"
+                )),
+                entry_point_selector: EntryPoint(starkhash_bytes!(b"entry point 0")),
+                calldata: vec![],
+            }))
+        )
+    }
+}


### PR DESCRIPTION
The method's not registered yet, so not really accessible with JSON-RPC.