### PR TITLE
fix(ext_py): set nonce to None for version 0 transactions for estimateFee

### DIFF
--- a/crates/pathfinder/src/cairo/ext_py/sub_process.rs
+++ b/crates/pathfinder/src/cairo/ext_py/sub_process.rs
@@ -360,7 +360,7 @@ async fn process(
             // sometimes
             gas_price: None,
             signature: &call.signature,
-            nonce: if call.version.0.is_zero() {
+            nonce: if call.version.is_zero() {
                 None
             } else {
                 Some(&call.nonce)
@@ -387,7 +387,7 @@ async fn process(
             at_block,
             gas_price: gas_price.as_option(),
             signature: &call.signature,
-            nonce: if call.version.0.is_zero() {
+            nonce: if call.version.is_zero() {
                 None
             } else {
                 Some(&call.nonce)

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -201,6 +201,22 @@ pub struct TransactionNonce(pub StarkHash);
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct TransactionVersion(pub H256);
 
+impl TransactionVersion {
+    /// Checks if version is zero, handling QUERY_VERSION_BASE.
+    ///
+    /// QUERY_VERSION_BASE (2**128) is a large constant that gets
+    /// added to the real version to make sure transactions constructed for
+    /// call or estimateFee cannot be submitted for inclusion on the chain.
+    /// When checking if the transaction version is zero we should check
+    /// only the lower 128 bits of the value.
+    pub fn is_zero(&self) -> bool {
+        let lower = &self.0.as_bytes()[16..];
+        let lower =
+            u128::from_be_bytes(lower.try_into().expect("slice should be the right length"));
+        lower == 0
+    }
+}
+
 /// An Ethereum address.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct EthereumAddress(pub H160);


### PR DESCRIPTION
cairo-lang code checks that nonce is None for version 0 transactions when we're doing estimateFee.

We did have a check for version 0 transactions in the ext_py code, but we did not handle the QUERY_VERSION_BASE offset (that's used by clients when submitting transactions for `starknet_call` and `starknet_estimateFee`).

This change makes sure that we properly check for version 0.