### PR TITLE
feat(rpc/v0.2): `syncing`

### DIFF
--- a/crates/pathfinder/src/rpc/v02.rs
+++ b/crates/pathfinder/src/rpc/v02.rs
@@ -1,25 +1,32 @@
+use std::sync::Arc;
+
+use crate::state::SyncState;
 use crate::{state::PendingData, storage::Storage};
 
 pub mod method;
 pub mod types;
 
+#[derive(Clone)]
 pub struct RpcContext {
     pub storage: Storage,
     pub pending_data: Option<PendingData>,
+    pub sync_status: Arc<SyncState>,
 }
 
 impl RpcContext {
-    pub fn new(storage: Storage) -> Self {
+    pub fn new(storage: Storage, sync_status: Arc<SyncState>) -> Self {
         Self {
             storage,
+            sync_status,
             pending_data: None,
         }
     }
 
     #[cfg(test)]
-    pub fn for_tests() -> std::sync::Arc<Self> {
+    pub fn for_tests() -> Arc<Self> {
         let storage = super::tests::setup_storage();
-        std::sync::Arc::new(Self::new(storage))
+        let sync_state = Arc::new(SyncState::default());
+        Arc::new(Self::new(storage, sync_state))
     }
 
     pub fn with_pending_data(self, pending_data: PendingData) -> Self {
@@ -30,9 +37,13 @@ impl RpcContext {
     }
 
     #[cfg(test)]
-    pub async fn for_tests_with_pending() -> std::sync::Arc<Self> {
-        let storage = super::tests::setup_storage();
-        let pending_data = super::tests::create_pending_data(storage.clone()).await;
-        std::sync::Arc::new(Self::new(storage).with_pending_data(pending_data))
+    pub async fn for_tests_with_pending() -> Arc<Self> {
+        // This is a bit silly with the arc in and out, but since its for tests the ergonomics of
+        // having Arc also constructed is nice.
+        let context = Self::for_tests();
+        let pending_data = super::tests::create_pending_data(context.storage.clone()).await;
+        let context = (*context).clone().with_pending_data(pending_data);
+
+        Arc::new(context)
     }
 }

--- a/crates/pathfinder/src/rpc/v02/method.rs
+++ b/crates/pathfinder/src/rpc/v02/method.rs
@@ -1,1 +1,2 @@
 pub(super) mod get_transaction_by_hash;
+pub(super) mod syncing;

--- a/crates/pathfinder/src/rpc/v02/method/syncing.rs
+++ b/crates/pathfinder/src/rpc/v02/method/syncing.rs
@@ -1,0 +1,152 @@
+use crate::{
+    core::{StarknetBlockHash, StarknetBlockNumber},
+    rpc::{serde::StarknetBlockNumberAsHexStr, v02::RpcContext},
+};
+
+use serde::Serialize;
+
+crate::rpc::error::generate_rpc_error_subset!(SyncingError);
+
+#[allow(dead_code)]
+pub async fn syncing(context: std::sync::Arc<RpcContext>) -> Result<SyncingOuput, SyncingError> {
+    // Scoped so I don't have to think too hard about mutex guard drop semantics.
+    let value = { context.sync_status.status.read().await.clone() };
+
+    use crate::rpc::v01::types::reply::Syncing;
+    let value = match value {
+        Syncing::False(_) => SyncingOuput::False,
+        Syncing::Status(status) => {
+            let status = SyncingStatus {
+                starting_block_num: status.starting.number,
+                current_block_num: status.current.number,
+                highest_block_num: status.highest.number,
+                starting_block_hash: status.starting.hash,
+                current_block_hash: status.current.hash,
+                highest_block_hash: status.highest.hash,
+            };
+            SyncingOuput::Status(status)
+        }
+    };
+
+    Ok(value)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+pub enum SyncingOuput {
+    False,
+    Status(SyncingStatus),
+}
+
+impl Serialize for SyncingOuput {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            SyncingOuput::False => serializer.serialize_str("false"),
+            SyncingOuput::Status(inner) => serializer.serialize_newtype_struct("status", &inner),
+        }
+    }
+}
+
+#[serde_with::serde_as]
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+pub struct SyncingStatus {
+    #[serde_as(as = "StarknetBlockNumberAsHexStr")]
+    starting_block_num: StarknetBlockNumber,
+    #[serde_as(as = "StarknetBlockNumberAsHexStr")]
+    current_block_num: StarknetBlockNumber,
+    #[serde_as(as = "StarknetBlockNumberAsHexStr")]
+    highest_block_num: StarknetBlockNumber,
+    starting_block_hash: StarknetBlockHash,
+    current_block_hash: StarknetBlockHash,
+    highest_block_hash: StarknetBlockHash,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SyncingOuput;
+    use crate::rpc::v02::RpcContext;
+    mod serde {
+        use super::super::{SyncingOuput, SyncingStatus};
+
+        #[test]
+        fn not_syncing() {
+            let json = serde_json::to_string(&SyncingOuput::False).unwrap();
+            assert_eq!(json, r#""false""#);
+        }
+
+        #[test]
+        fn syncing() {
+            use crate::core::{StarknetBlockHash, StarknetBlockNumber};
+            use crate::starkhash;
+
+            let status = SyncingStatus {
+                starting_block_num: StarknetBlockNumber::new_or_panic(0x12),
+                current_block_num: StarknetBlockNumber::new_or_panic(0x45),
+                highest_block_num: StarknetBlockNumber::new_or_panic(0x772),
+                starting_block_hash: StarknetBlockHash(starkhash!("abcdef")),
+                current_block_hash: StarknetBlockHash(starkhash!("12345677")),
+                highest_block_hash: StarknetBlockHash(starkhash!("1144ffaacc")),
+            };
+            let value = SyncingOuput::Status(status);
+            let json = serde_json::to_value(value).unwrap();
+
+            let expected = serde_json::json!( {
+                "starting_block_num": "0x12",
+                "current_block_num": "0x45",
+                "highest_block_num": "0x772",
+                "starting_block_hash": "0xabcdef",
+                "current_block_hash": "0x12345677",
+                "highest_block_hash": "0x1144ffaacc",
+            });
+
+            assert_eq!(json, expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn syncing() {
+        use crate::core::{StarknetBlockHash, StarknetBlockNumber};
+        use crate::rpc::v01::types::reply::syncing::NumberedBlock;
+        use crate::rpc::v01::types::reply::syncing::Status as V1Status;
+        use crate::rpc::v01::types::reply::Syncing as V1Syncing;
+
+        let status = V1Syncing::Status(V1Status {
+            starting: NumberedBlock::from(("aabb", 1)),
+            current: NumberedBlock::from(("ccddee", 2)),
+            highest: NumberedBlock::from(("eeffaacc", 3)),
+        });
+
+        let expected = super::SyncingStatus {
+            starting_block_num: StarknetBlockNumber::new_or_panic(1),
+            current_block_num: StarknetBlockNumber::new_or_panic(2),
+            highest_block_num: StarknetBlockNumber::new_or_panic(3),
+            starting_block_hash: StarknetBlockHash(crate::starkhash!("aabb")),
+            current_block_hash: StarknetBlockHash(crate::starkhash!("ccddee")),
+            highest_block_hash: StarknetBlockHash(crate::starkhash!("eeffaacc")),
+        };
+        let expected = SyncingOuput::Status(expected);
+
+        let context = RpcContext::for_tests();
+        *context.sync_status.status.write().await = status;
+
+        let result = super::syncing(context).await.unwrap();
+
+        assert_eq!(result, expected);
+    }
+
+    #[tokio::test]
+    async fn not_syncing() {
+        let status = crate::rpc::v01::types::reply::Syncing::False(false);
+
+        let context = RpcContext::for_tests();
+        *context.sync_status.status.write().await = status;
+
+        let result = super::syncing(context).await.unwrap();
+
+        assert_eq!(result, SyncingOuput::False);
+    }
+}


### PR DESCRIPTION
This PR implements `starknet_syncing` for RPC v0.2.

The RPC specification for the [method](https://github.com/starkware-libs/starknet-specs/blob/v0.2.0/api/starknet_api_openrpc.json#L547-L567) and [status](https://github.com/starkware-libs/starknet-specs/blob/v0.2.0/api/starknet_api_openrpc.json#L803-L832) type.

This method is unchanged from version 0.1 but I decided to try make it a bit more safe by not having a `bool` which may only be false situation.

We could also let `v0.1` use this type instead but I didn't see the need to fiddle with this.

Closes #605.