### PR TITLE
feat(rpc/v0.2): chain_id

### DIFF
--- a/crates/pathfinder/src/rpc/v02.rs
+++ b/crates/pathfinder/src/rpc/v02.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::state::SyncState;
+use crate::{core::Chain, state::SyncState};
 use crate::{state::PendingData, storage::Storage};
 
 pub mod method;
@@ -11,13 +11,15 @@ pub struct RpcContext {
     pub storage: Storage,
     pub pending_data: Option<PendingData>,
     pub sync_status: Arc<SyncState>,
+    pub chain: Chain,
 }
 
 impl RpcContext {
-    pub fn new(storage: Storage, sync_status: Arc<SyncState>) -> Self {
+    pub fn new(storage: Storage, sync_status: Arc<SyncState>, chain: Chain) -> Self {
         Self {
             storage,
             sync_status,
+            chain,
             pending_data: None,
         }
     }
@@ -26,7 +28,7 @@ impl RpcContext {
     pub fn for_tests() -> Arc<Self> {
         let storage = super::tests::setup_storage();
         let sync_state = Arc::new(SyncState::default());
-        Arc::new(Self::new(storage, sync_state))
+        Arc::new(Self::new(storage, sync_state, Chain::Testnet))
     }
 
     pub fn with_pending_data(self, pending_data: PendingData) -> Self {

--- a/crates/pathfinder/src/rpc/v02/method.rs
+++ b/crates/pathfinder/src/rpc/v02/method.rs
@@ -1,3 +1,4 @@
+pub(super) mod chain_id;
 pub(super) mod get_nonce;
 pub(super) mod get_transaction_by_hash;
 pub(super) mod syncing;

--- a/crates/pathfinder/src/rpc/v02/method/chain_id.rs
+++ b/crates/pathfinder/src/rpc/v02/method/chain_id.rs
@@ -1,0 +1,36 @@
+use crate::rpc::v02::RpcContext;
+
+crate::rpc::error::generate_rpc_error_subset!(ChainIdError);
+
+#[allow(dead_code)]
+pub async fn chain_id(context: std::sync::Arc<RpcContext>) -> Result<String, ChainIdError> {
+    Ok(context.chain.starknet_chain_id().to_hex_str().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::Chain;
+    use crate::rpc::v02::RpcContext;
+
+    use super::chain_id;
+
+    #[tokio::test]
+    async fn mainnet() {
+        let mut context = (*RpcContext::for_tests()).clone();
+        context.chain = Chain::Mainnet;
+
+        let result = chain_id(std::sync::Arc::new(context)).await.unwrap();
+        let expected = format!("0x{}", hex::encode("SN_MAIN"));
+        assert_eq!(result, expected);
+    }
+
+    #[tokio::test]
+    async fn testnet() {
+        let mut context = (*RpcContext::for_tests()).clone();
+        context.chain = Chain::Testnet;
+
+        let result = chain_id(std::sync::Arc::new(context)).await.unwrap();
+        let expected = format!("0x{}", hex::encode("SN_GOERLI"));
+        assert_eq!(result, expected);
+    }
+}


### PR DESCRIPTION
Implements `starknet_chainId` for v0.2 of the RPC specification.

Closes #603.