### PR TITLE
fix(rpc/v02/types): fix handling of query versions for `BroadcastedInvokeTransaction`

### DIFF
--- a/crates/pathfinder/fixtures/rpc/0.44.0/broadcasted_transactions.json
+++ b/crates/pathfinder/fixtures/rpc/0.44.0/broadcasted_transactions.json
@@ -45,5 +45,18 @@
         "calldata": [
             "0xff"
         ]
+    },
+    {
+        "type": "INVOKE",
+        "version": "0x100000000000000000000000000000001",
+        "max_fee": "0x6",
+        "signature": [
+            "0x7"
+        ],
+        "nonce": "0x8",
+        "sender_address": "0xaaa",
+        "calldata": [
+            "0xff"
+        ]
     }
 ]

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -199,17 +199,18 @@ pub struct TransactionVersion(pub H256);
 
 impl TransactionVersion {
     /// Checks if version is zero, handling QUERY_VERSION_BASE.
+    pub fn is_zero(&self) -> bool {
+        self.without_query_version() == 0
+    }
+
+    /// Returns the transaction versin without QUERY_VERSION_BASE.
     ///
     /// QUERY_VERSION_BASE (2**128) is a large constant that gets
     /// added to the real version to make sure transactions constructed for
     /// call or estimateFee cannot be submitted for inclusion on the chain.
-    /// When checking if the transaction version is zero we should check
-    /// only the lower 128 bits of the value.
-    pub fn is_zero(&self) -> bool {
+    pub fn without_query_version(&self) -> u128 {
         let lower = &self.0.as_bytes()[16..];
-        let lower =
-            u128::from_be_bytes(lower.try_into().expect("slice should be the right length"));
-        lower == 0
+        u128::from_be_bytes(lower.try_into().expect("slice should be the right length"))
     }
 
     pub const ZERO: Self = Self(H256::zero());

--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -217,6 +217,12 @@ impl TransactionVersion {
     pub const ONE: Self = Self(H256(hex_literal::hex!(
         "0000000000000000000000000000000000000000000000000000000000000001"
     )));
+    pub const ZERO_WITH_QUERY_VERSION: Self = Self(H256(hex_literal::hex!(
+        "0000000000000000000000000000000100000000000000000000000000000000"
+    )));
+    pub const ONE_WITH_QUERY_VERSION: Self = Self(H256(hex_literal::hex!(
+        "0000000000000000000000000000000100000000000000000000000000000001"
+    )));
 }
 
 /// An Ethereum address.

--- a/crates/pathfinder/src/rpc/v02/method/estimate_fee.rs
+++ b/crates/pathfinder/src/rpc/v02/method/estimate_fee.rs
@@ -206,6 +206,7 @@ mod tests {
         fn test_invoke_txn() -> BroadcastedTransaction {
             BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V0(
                 crate::rpc::v02::types::request::BroadcastedInvokeTransactionV0 {
+                    version: TransactionVersion::ZERO_WITH_QUERY_VERSION,
                     max_fee: Fee(web3::types::H128::from_low_u64_be(0x6)),
                     signature: vec![TransactionSignatureElem(starkhash!("07"))],
                     nonce: TransactionNonce(starkhash!("08")),
@@ -223,7 +224,7 @@ mod tests {
             let positional = r#"[
                 {
                     "type": "INVOKE",
-                    "version": "0x0",
+                    "version": "0x100000000000000000000000000000000",
                     "max_fee": "0x6",
                     "signature": [
                         "0x7"
@@ -254,7 +255,7 @@ mod tests {
             let named_args = r#"{
                 "request": {
                     "type": "INVOKE",
-                    "version": "0x0",
+                    "version": "0x100000000000000000000000000000000",
                     "max_fee": "0x6",
                     "signature": [
                         "0x7"
@@ -294,6 +295,7 @@ mod tests {
         // Data from transaction 0xc52079f33dcb44a58904fac3803fd908ac28d6632b67179ee06f2daccb4b5.
         fn valid_mainnet_invoke_v0() -> BroadcastedInvokeTransactionV0 {
             BroadcastedInvokeTransactionV0 {
+                version: TransactionVersion::ZERO_WITH_QUERY_VERSION,
                 max_fee: Fee(Default::default()),
                 signature: vec![],
                 nonce: TransactionNonce(Default::default()),


### PR DESCRIPTION
Previously only version zero and one were accepted for `BroadcastedInvokeTransaction` but that was incorrect. Clients can add QUERY_VERSION_BASE (2**128) to the actual version when submitting a transaction for call or estimateFee. The Starknet gateway does not accept these transaction versions for inclusion on the chain so this mechanism prevents replaying these signed transactions through the gateway.
    
Closes #629