### PR TITLE
feat(rpc/v0.2): implement `starknet_getClass`

### DIFF
--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -281,6 +281,8 @@ mod tests {
         CanonicalBlocksTable::insert(&db_txn, block1.number, block1.hash).unwrap();
         CanonicalBlocksTable::insert(&db_txn, block2.number, block2.hash).unwrap();
 
+        ContractCodeTable::update_declared_on_if_null(&db_txn, class0_hash, block1.hash).unwrap();
+
         let txn0_hash = StarknetTransactionHash(starkhash_bytes!(b"txn 0"));
         // TODO introduce other types of transactions too
         let txn0 = InvokeTransactionV0 {

--- a/crates/pathfinder/src/rpc/serde.rs
+++ b/crates/pathfinder/src/rpc/serde.rs
@@ -288,6 +288,13 @@ serde_with::serde_conv!(
     |s: &str| bytes_from_hex_str::<32>(s).map(H256::from)
 );
 
+serde_with::serde_conv!(
+    pub U64AsHexStr,
+    u64,
+    |u: &u64| bytes_to_hex_str(&u.to_be_bytes()),
+    |s: String| bytes_from_hex_str::<8>(&s).map(u64::from_be_bytes)
+);
+
 /// A helper conversion function. Only use with __sequencer API related types__.
 fn starkhash_from_biguint(b: BigUint) -> Result<StarkHash, OverflowError> {
     StarkHash::from_be_slice(&b.to_bytes_be())

--- a/crates/pathfinder/src/rpc/v02.rs
+++ b/crates/pathfinder/src/rpc/v02.rs
@@ -173,6 +173,7 @@ where
 // Registers all methods for the v0.2 API
 pub fn register_all_methods(module: &mut jsonrpsee::RpcModule<RpcContext>) -> anyhow::Result<()> {
     register_method_with_no_input(module, "starknet_chainId", method::chain_id::chain_id)?;
+    register_method(module, "starknet_getClass", method::get_class::get_class)?;
     register_method(
         module,
         "starknet_getClassHashAt",

--- a/crates/pathfinder/src/rpc/v02/method.rs
+++ b/crates/pathfinder/src/rpc/v02/method.rs
@@ -1,6 +1,7 @@
 pub(super) mod chain_id;
 pub(super) mod estimate_fee;
 pub(super) mod get_block_transaction_count;
+pub(super) mod get_class;
 pub(super) mod get_class_hash_at;
 pub(super) mod get_nonce;
 pub(super) mod get_state_update;

--- a/crates/pathfinder/src/rpc/v02/method/get_class.rs
+++ b/crates/pathfinder/src/rpc/v02/method/get_class.rs
@@ -1,0 +1,327 @@
+use crate::core::{BlockId, ClassHash};
+use crate::rpc::v02::types::ContractClass;
+use crate::rpc::v02::RpcContext;
+
+use anyhow::Context;
+use rusqlite::OptionalExtension;
+
+crate::rpc::error::generate_rpc_error_subset!(GetClassError: BlockNotFound, ClassHashNotFound);
+
+#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+pub struct GetClassInput {
+    block_id: BlockId,
+    class_hash: ClassHash,
+}
+
+pub async fn get_class(
+    context: RpcContext,
+    input: GetClassInput,
+) -> Result<ContractClass, GetClassError> {
+    let block = match input.block_id {
+        BlockId::Pending => {
+            if is_pending_class(&context.pending_data, input.class_hash).await {
+                BlockId::Pending
+            } else {
+                BlockId::Latest
+            }
+        }
+        other => other,
+    };
+
+    let span = tracing::Span::current();
+    let jh = tokio::task::spawn_blocking(move || -> Result<ContractClass, GetClassError> {
+        let _g = span.enter();
+        let mut db = context
+            .storage
+            .connection()
+            .context("Opening database connection")?;
+        let tx = db.transaction().context("Creating database transaction")?;
+
+        let definition = match block {
+            BlockId::Pending => read_pending(&tx, input.class_hash),
+            BlockId::Number(number) => read_at_number(&tx, input.class_hash, number),
+            BlockId::Hash(hash) => read_at_hash(&tx, input.class_hash, hash),
+            BlockId::Latest => read_latest(&tx, input.class_hash),
+        }?;
+
+        let definition =
+            zstd::decode_all(&*definition).context("Decompressing class definition")?;
+        let class = ContractClass::from_definition_bytes(&definition)
+            .context("Parsing class definition")?;
+
+        Ok(class)
+    });
+
+    jh.await.context("Reading class from database")?
+}
+
+/// Returns the class definition data.
+///
+/// This is useful only if you are already certain this class was declared.
+fn read_pending(
+    tx: &rusqlite::Transaction<'_>,
+    class: ClassHash,
+) -> Result<Vec<u8>, GetClassError> {
+    tx.query_row(
+        "SELECT definition FROM contract_code WHERE hash=?",
+        rusqlite::params! { class },
+        |row| {
+            let def = row.get_ref_unwrap(0).as_blob()?.to_owned();
+            Ok(def)
+        },
+    )
+    .optional()
+    .context("Reading class definition from database")?
+    .ok_or(GetClassError::ClassHashNotFound)
+}
+
+/// Returns the class definition data iff it was declared on a canonical block.
+fn read_latest(tx: &rusqlite::Transaction<'_>, class: ClassHash) -> Result<Vec<u8>, GetClassError> {
+    // This works because declared_on is only set if the class was declared in a canonical block.
+    tx.query_row(
+        "SELECT definition FROM contract_code WHERE hash=? AND declared_on IS NOT NULL",
+        rusqlite::params! { class },
+        |row| {
+            let def = row.get_ref_unwrap(0).as_blob()?.to_owned();
+            Ok(def)
+        },
+    )
+    .optional()
+    .context("Reading class definition from database")?
+    .ok_or(GetClassError::ClassHashNotFound)
+}
+
+/// Returns the class definition data iff it was declared on or before the given block hash.
+/// The block hash provided must also form part of the canonical chain.
+fn read_at_hash(
+    tx: &rusqlite::Transaction<'_>,
+    class: ClassHash,
+    block: crate::core::StarknetBlockHash,
+) -> Result<Vec<u8>, GetClassError> {
+    let number = tx
+        .query_row(
+            "SELECT number FROM canonical_blocks WHERE hash=?",
+            rusqlite::params! { block },
+            |row| {
+                let number = row.get_ref_unwrap(0).as_i64()?;
+                Ok(number)
+            },
+        )
+        .optional()
+        .context("Reading block number from database")?
+        .ok_or(GetClassError::BlockNotFound)?;
+
+    tx.query_row(
+        r"SELECT definition FROM contract_code code JOIN canonical_blocks blocks ON (code.declared_on = blocks.hash) 
+        WHERE code.hash=? AND blocks.number <= ?",
+        rusqlite::params! { class, number },
+        |row| {
+            let def = row.get_ref_unwrap(0).as_blob()?.to_owned();
+            Ok(def)
+        },
+    )
+    .optional()
+    .context("Reading class definition from database")?
+    .ok_or(GetClassError::ClassHashNotFound)
+}
+
+/// Returns the class definition data iff it was declared on or before the given block number.
+fn read_at_number(
+    tx: &rusqlite::Transaction<'_>,
+    class: ClassHash,
+    block: crate::core::StarknetBlockNumber,
+) -> Result<Vec<u8>, GetClassError> {
+    // Check that the block number exists. This has to happen first as the <= check
+    // in the class selection query will work even if the block number exceeds what
+    // is available in canonical_blocks.
+    let latest = tx
+        .query_row("SELECT MAX(number) FROM canonical_blocks", [], |row| {
+            let num = row.get_ref_unwrap(0).as_i64()?;
+            Ok(num)
+        })
+        .context("Reading latest block number")?;
+    if block.get() > latest as u64 {
+        return Err(GetClassError::BlockNotFound);
+    }
+
+    tx.query_row(
+        r"SELECT definition FROM contract_code code JOIN canonical_blocks blocks ON (code.declared_on = blocks.hash) 
+        WHERE code.hash=? AND blocks.number <= ?",
+        rusqlite::params! { class, block },
+        |row| {
+            let def = row.get_ref_unwrap(0).as_blob()?.to_owned();
+            Ok(def)
+        },
+    )
+    .optional()
+    .context("Reading class definition from database")?
+    .ok_or(GetClassError::ClassHashNotFound)
+}
+
+/// Returns true if the class is declared or deployed in the pending state.
+async fn is_pending_class(pending: &Option<crate::state::PendingData>, hash: ClassHash) -> bool {
+    let state_diff = match pending {
+        Some(pending) => match pending.state_update().await {
+            Some(pending) => pending,
+            None => return false,
+        },
+        None => return false,
+    };
+
+    let declared = state_diff.state_diff.declared_contracts.iter().cloned();
+    let deployed = state_diff
+        .state_diff
+        .deployed_contracts
+        .iter()
+        .map(|contract| contract.class_hash);
+
+    deployed.chain(declared).any(|item| item == hash)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::starkhash_bytes;
+    use assert_matches::assert_matches;
+
+    mod parsing {
+        use crate::core::StarknetBlockHash;
+        use crate::starkhash;
+
+        use super::*;
+
+        use jsonrpsee::types::Params;
+
+        #[test]
+        fn positional_args() {
+            let positional = r#"[
+                { "block_hash": "0xabcde" },
+                "0x12345"
+            ]"#;
+            let positional = Params::new(Some(positional));
+
+            let input = positional.parse::<GetClassInput>().unwrap();
+            let expected = GetClassInput {
+                block_id: StarknetBlockHash(starkhash!("0abcde")).into(),
+                class_hash: ClassHash(starkhash!("012345")),
+            };
+            assert_eq!(input, expected);
+        }
+
+        #[test]
+        fn named_args() {
+            let positional = r#"{
+                "block_id": { "block_hash": "0xabcde" },
+                "class_hash": "0x12345"
+            }"#;
+            let positional = Params::new(Some(positional));
+
+            let input = positional.parse::<GetClassInput>().unwrap();
+            let expected = GetClassInput {
+                block_id: StarknetBlockHash(starkhash!("0abcde")).into(),
+                class_hash: ClassHash(starkhash!("012345")),
+            };
+            assert_eq!(input, expected);
+        }
+    }
+
+    #[test]
+    fn read_pending() {
+        let context = RpcContext::for_tests();
+        let mut conn = context.storage.connection().unwrap();
+        let tx = conn.transaction().unwrap();
+
+        let valid = ClassHash(starkhash_bytes!(b"class 0 hash"));
+        super::read_pending(&tx, valid).unwrap();
+
+        let invalid = ClassHash(starkhash_bytes!(b"invalid"));
+        let error = super::read_pending(&tx, invalid).unwrap_err();
+        assert_matches!(error, GetClassError::ClassHashNotFound);
+    }
+
+    #[test]
+    fn read_latest() {
+        let context = RpcContext::for_tests();
+        let mut conn = context.storage.connection().unwrap();
+        let tx = conn.transaction().unwrap();
+
+        let valid = ClassHash(starkhash_bytes!(b"class 0 hash"));
+        super::read_latest(&tx, valid).unwrap();
+
+        let invalid = ClassHash(starkhash_bytes!(b"invalid"));
+        let error = super::read_latest(&tx, invalid).unwrap_err();
+        assert_matches!(error, GetClassError::ClassHashNotFound);
+
+        // This class is defined, but is not declared in any canonical block.
+        let invalid = ClassHash(starkhash_bytes!(b"class 1 hash"));
+        let error = super::read_latest(&tx, invalid).unwrap_err();
+        assert_matches!(error, GetClassError::ClassHashNotFound);
+    }
+
+    #[test]
+    fn read_at_number() {
+        use crate::core::StarknetBlockNumber;
+
+        let context = RpcContext::for_tests();
+        let mut conn = context.storage.connection().unwrap();
+        let tx = conn.transaction().unwrap();
+
+        // This class is declared in block 1.
+        let valid = ClassHash(starkhash_bytes!(b"class 0 hash"));
+        super::read_at_number(&tx, valid, StarknetBlockNumber::new_or_panic(1)).unwrap();
+
+        let error = super::read_at_number(&tx, valid, StarknetBlockNumber::GENESIS).unwrap_err();
+        assert_matches!(error, GetClassError::ClassHashNotFound);
+
+        let invalid = ClassHash(starkhash_bytes!(b"invalid"));
+        let error =
+            super::read_at_number(&tx, invalid, StarknetBlockNumber::new_or_panic(2)).unwrap_err();
+        assert_matches!(error, GetClassError::ClassHashNotFound);
+
+        // This class is defined, but is not declared in any canonical block.
+        let invalid = ClassHash(starkhash_bytes!(b"class 1 hash"));
+        let error =
+            super::read_at_number(&tx, invalid, StarknetBlockNumber::new_or_panic(2)).unwrap_err();
+        assert_matches!(error, GetClassError::ClassHashNotFound);
+
+        // Class exists, but block number does not.
+        let valid = ClassHash(starkhash_bytes!(b"class 0 hash"));
+        let error = super::read_at_number(&tx, valid, StarknetBlockNumber::MAX).unwrap_err();
+        assert_matches!(error, GetClassError::BlockNotFound);
+    }
+
+    #[test]
+    fn read_at_hash() {
+        use crate::core::StarknetBlockHash;
+
+        let context = RpcContext::for_tests();
+        let mut conn = context.storage.connection().unwrap();
+        let tx = conn.transaction().unwrap();
+
+        // This class is declared in block 1.
+        let valid = ClassHash(starkhash_bytes!(b"class 0 hash"));
+        let block1_hash = StarknetBlockHash(starkhash_bytes!(b"block 1"));
+        super::read_at_hash(&tx, valid, block1_hash).unwrap();
+
+        let block0_hash = StarknetBlockHash(starkhash_bytes!(b"genesis"));
+        let error = super::read_at_hash(&tx, valid, block0_hash).unwrap_err();
+        assert_matches!(error, GetClassError::ClassHashNotFound);
+
+        let invalid = ClassHash(starkhash_bytes!(b"invalid"));
+        let latest_hash = StarknetBlockHash(starkhash_bytes!(b"latest"));
+        let error = super::read_at_hash(&tx, invalid, latest_hash).unwrap_err();
+        assert_matches!(error, GetClassError::ClassHashNotFound);
+
+        // This class is defined, but is not declared in any canonical block.
+        let invalid = ClassHash(starkhash_bytes!(b"class 1 hash"));
+        let latest_hash = StarknetBlockHash(starkhash_bytes!(b"latest"));
+        let error = super::read_at_hash(&tx, invalid, latest_hash).unwrap_err();
+        assert_matches!(error, GetClassError::ClassHashNotFound);
+
+        // Class exists, but block hash does not.
+        let valid = ClassHash(starkhash_bytes!(b"class 0 hash"));
+        let invalid_block = StarknetBlockHash(starkhash_bytes!(b"invalid"));
+        let error = super::read_at_hash(&tx, valid, invalid_block).unwrap_err();
+        assert_matches!(error, GetClassError::BlockNotFound);
+    }
+}

--- a/crates/pathfinder/src/rpc/v02/types.rs
+++ b/crates/pathfinder/src/rpc/v02/types.rs
@@ -1,5 +1,8 @@
 //! Common data structures used by the JSON-RPC API methods.
 
+mod class;
+pub use class::*;
+
 /// Groups all strictly input types of the RPC API.
 pub mod request {
     use crate::{

--- a/crates/pathfinder/src/rpc/v02/types/class.rs
+++ b/crates/pathfinder/src/rpc/v02/types/class.rs
@@ -1,0 +1,178 @@
+use crate::rpc::serde::U64AsHexStr;
+
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+use stark_hash::StarkHash;
+
+impl ContractClass {
+    pub fn from_definition_bytes(data: &[u8]) -> anyhow::Result<ContractClass> {
+        let mut json = serde_json::from_slice::<serde_json::Value>(data).context("Parsing json")?;
+        let json_obj = json
+            .as_object_mut()
+            .context("Class definition is not a json object")?;
+
+        let entry = json_obj
+            .get_mut("entry_points_by_type")
+            .context("entry_points_by_type property is missing")?
+            .take();
+        let entry =
+            serde_json::from_value::<ContractEntryPoints>(entry).context("Parsing entry points")?;
+
+        // ABI is optional.
+        let abi = json_obj.get_mut("abi").and_then(|json| {
+            let json = json.take();
+            // ABIs are set by users and not verified by starknet, therefore ABIs
+            // can fail to parse (and just be nonsense). Discard these ABIs.
+            serde_json::from_value::<Vec<ContractAbiEntry>>(json).ok()
+        });
+
+        let program = json_obj
+            .get_mut("program")
+            .context("program property is missing")?
+            .to_string();
+
+        // Program is expected to be a gzip-compressed then base64 encoded representation of the JSON.
+        let mut gzip_encoder =
+            flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        serde_json::to_writer(&mut gzip_encoder, &program).context("Compressing program")?;
+        let compressed_program = gzip_encoder
+            .finish()
+            .context("Finalizing program compression")?;
+        let encoded_program = base64::encode(compressed_program);
+        let program = encoded_program;
+
+        Ok(ContractClass {
+            program,
+            entry_points_by_type: entry,
+            abi,
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ContractClass {
+    program: String,
+    entry_points_by_type: ContractEntryPoints,
+    abi: Option<Vec<ContractAbiEntry>>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[serde(deny_unknown_fields)]
+struct ContractEntryPoints {
+    constructor: Vec<ContractEntryPoint>,
+    external: Vec<ContractEntryPoint>,
+    l1_handler: Vec<ContractEntryPoint>,
+}
+
+#[serde_with::serde_as]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+struct ContractEntryPoint {
+    #[serde_as(as = "U64AsHexStr")]
+    offset: u64,
+    selector: StarkHash,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+#[serde(deny_unknown_fields)]
+enum ContractAbiEntry {
+    Function(FunctionAbiEntry),
+    Event(EventAbiEntry),
+    Struct(StructAbiEntry),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "lowercase")]
+#[serde(deny_unknown_fields)]
+enum StructAbiType {
+    Struct,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "lowercase")]
+#[serde(deny_unknown_fields)]
+enum EventAbiType {
+    Event,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields)]
+enum FunctionAbiType {
+    Function,
+    L1Handler,
+    // This is missing from the v0.2 RPC specification and will be added in the
+    // next version. We add it as a deviation from the current spec, since it is
+    // effectively a bug in the v0.2 specification.
+    Constructor,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+struct StructAbiEntry {
+    r#type: StructAbiType,
+    name: String,
+    size: u64,
+    members: Vec<StructMember>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+struct StructMember {
+    #[serde(flatten)]
+    parameter: TypedParameter,
+    offset: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+struct EventAbiEntry {
+    r#type: EventAbiType,
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    keys: Option<Vec<TypedParameter>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    data: Option<Vec<TypedParameter>>,
+    // FIXME: This is not part of the spec, but is present in many ABIs.
+    // Must be confirmed by StarkWare still whether to accept it.
+    #[serde(skip_serializing)]
+    #[serde(default)]
+    #[serde(rename = "inputs")]
+    _inputs: Option<Vec<TypedParameter>>,
+    // FIXME: This is not part of the spec, but is present in some ABIs.
+    // Must be confirmed by StarkWare still whether to accept it.
+    #[serde(skip_serializing)]
+    #[serde(default)]
+    #[serde(rename = "outputs")]
+    _outputs: Option<Vec<TypedParameter>>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+struct FunctionAbiEntry {
+    r#type: FunctionAbiType,
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    inputs: Option<Vec<TypedParameter>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    outputs: Option<Vec<TypedParameter>>,
+    // This is valid but unverifiable part of the ABI, so it is excluded from
+    // serialization for RPC (and is not part of the spec).
+    #[serde(skip_serializing)]
+    #[serde(default)]
+    #[serde(rename = "stateMutability")]
+    _state_mutability: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+struct TypedParameter {
+    name: String,
+    r#type: String,
+}

--- a/crates/pathfinder/src/rpc/v02/types/class.rs
+++ b/crates/pathfinder/src/rpc/v02/types/class.rs
@@ -121,8 +121,12 @@ struct StructAbiEntry {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 struct StructMember {
-    #[serde(flatten)]
-    parameter: TypedParameter,
+    // Serde does not support deny_unknown_fields + flatten, so we
+    // flatten TypedParameter manually here.
+    #[serde(rename = "name")]
+    typed_parameter_name: String,
+    #[serde(rename = "type")]
+    typed_parameter_type: String,
     offset: u64,
 }
 


### PR DESCRIPTION
I've pre-emptively moved the class definition into its own types file. It will also be used by `starknet_getClassAt`.

I've run the class definition parsing against all mainnet and testnet classes. The ABI currently fails for a single class, which has an ABI: `[ "bogus": "bogus" ]` so I think that's okay.

There are two parts of the ABI which are currently still marked with `TODO` because StarkWare still needs to comment on whether they are a bug and should be catered for, or whether we just reject those ABIs.

Closes #595 