### PR TITLE
Rpc/v0.2/get block with

### DIFF
--- a/crates/pathfinder/src/rpc/v02.rs
+++ b/crates/pathfinder/src/rpc/v02.rs
@@ -6,6 +6,7 @@ use crate::rpc::gas_price;
 use crate::{core::Chain, state::SyncState};
 use crate::{state::PendingData, storage::Storage};
 
+mod common;
 pub mod method;
 pub mod types;
 

--- a/crates/pathfinder/src/rpc/v02.rs
+++ b/crates/pathfinder/src/rpc/v02.rs
@@ -184,6 +184,16 @@ where
 // Registers all methods for the v0.2 API
 pub fn register_all_methods(module: &mut jsonrpsee::RpcModule<RpcContext>) -> anyhow::Result<()> {
     register_method_with_no_input(module, "starknet_chainId", method::chain_id::chain_id)?;
+    register_method(
+        module,
+        "starknet_getBlockWithTxHashes",
+        method::get_block::get_block_with_transaction_hashes,
+    )?;
+    register_method(
+        module,
+        "starknet_getBlockWithTxs",
+        method::get_block::get_block_with_transactions,
+    )?;
     register_method(module, "starknet_getClass", method::get_class::get_class)?;
     register_method(
         module,

--- a/crates/pathfinder/src/rpc/v02.rs
+++ b/crates/pathfinder/src/rpc/v02.rs
@@ -187,12 +187,12 @@ pub fn register_all_methods(module: &mut jsonrpsee::RpcModule<RpcContext>) -> an
     register_method(
         module,
         "starknet_getBlockWithTxHashes",
-        method::get_block::get_block_with_transaction_hashes,
+        method::get_block::get_block_with_tx_hashes,
     )?;
     register_method(
         module,
         "starknet_getBlockWithTxs",
-        method::get_block::get_block_with_transactions,
+        method::get_block::get_block_with_txs,
     )?;
     register_method(module, "starknet_getClass", method::get_class::get_class)?;
     register_method(

--- a/crates/pathfinder/src/rpc/v02/common.rs
+++ b/crates/pathfinder/src/rpc/v02/common.rs
@@ -1,0 +1,22 @@
+//! Common utilities shared among [`v02`](super) methods.
+use anyhow::Context;
+
+use crate::core::StarknetBlockNumber;
+use crate::rpc::v02::types::reply::BlockStatus;
+use crate::storage::RefsTable;
+
+/// Determines block status based on the current L1-L2 stored in the DB.
+pub fn get_block_status(
+    db_tx: &rusqlite::Transaction<'_>,
+    block_number: StarknetBlockNumber,
+) -> anyhow::Result<BlockStatus> {
+    // All our data is L2 accepted, check our L1-L2 head to see if this block has been accepted on L1.
+    let l1_l2_head =
+        RefsTable::get_l1_l2_head(db_tx).context("Read latest L1 head from database")?;
+    let block_status = match l1_l2_head {
+        Some(number) if number >= block_number => BlockStatus::AcceptedOnL1,
+        _ => BlockStatus::AcceptedOnL2,
+    };
+
+    Ok(block_status)
+}

--- a/crates/pathfinder/src/rpc/v02/method.rs
+++ b/crates/pathfinder/src/rpc/v02/method.rs
@@ -2,6 +2,7 @@ pub(super) mod add_invoke_transaction;
 pub(super) mod block_hash_and_number;
 pub(super) mod chain_id;
 pub(super) mod estimate_fee;
+pub(super) mod get_block;
 pub(super) mod get_block_transaction_count;
 pub(super) mod get_class;
 pub(super) mod get_class_at;

--- a/crates/pathfinder/src/rpc/v02/method/get_block.rs
+++ b/crates/pathfinder/src/rpc/v02/method/get_block.rs
@@ -1,0 +1,62 @@
+use crate::core::BlockId;
+use crate::rpc::v02::RpcContext;
+
+#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+pub struct GetBlockInput {
+    block_id: BlockId,
+}
+
+crate::rpc::error::generate_rpc_error_subset!(GetBlockError: BlockNotFound);
+
+#[allow(dead_code)]
+pub async fn get_block_with_transaction_hashes(
+    _context: RpcContext,
+    _input: GetBlockInput,
+) -> Result<(), GetBlockError> {
+    todo!()
+}
+
+#[allow(dead_code)]
+pub async fn get_block_with_transactions(
+    _context: RpcContext,
+    _input: GetBlockInput,
+) -> Result<(), GetBlockError> {
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{StarknetBlockHash, StarknetBlockNumber};
+    use crate::starkhash;
+    use jsonrpsee::types::Params;
+
+    #[test]
+    fn parsing() {
+        let number = BlockId::Number(StarknetBlockNumber::new_or_panic(123));
+        let hash = BlockId::Hash(StarknetBlockHash(starkhash!("beef")));
+
+        [
+            (r#"["pending"]"#, BlockId::Pending),
+            (r#"{"block_id": "pending"}"#, BlockId::Pending),
+            (r#"["latest"]"#, BlockId::Latest),
+            (r#"{"block_id": "latest"}"#, BlockId::Latest),
+            (r#"[{"block_number":123}]"#, number),
+            (r#"{"block_id": {"block_number":123}}"#, number),
+            (r#"[{"block_hash": "0xbeef"}]"#, hash),
+            (r#"{"block_id": {"block_hash": "0xbeef"}}"#, hash),
+        ]
+        .into_iter()
+        .enumerate()
+        .for_each(|(i, (input, expected))| {
+            let actual = Params::new(Some(input))
+                .parse::<GetBlockInput>()
+                .unwrap_or_else(|_| panic!("test case {i}: {input}"));
+            assert_eq!(
+                actual,
+                GetBlockInput { block_id: expected },
+                "test case {i}: {input}"
+            );
+        });
+    }
+}

--- a/crates/pathfinder/src/rpc/v02/method/get_block.rs
+++ b/crates/pathfinder/src/rpc/v02/method/get_block.rs
@@ -8,6 +8,7 @@ pub struct GetBlockInput {
 
 crate::rpc::error::generate_rpc_error_subset!(GetBlockError: BlockNotFound);
 
+/// Get block information with transaction hashes given the block id
 pub async fn get_block_with_transaction_hashes(
     context: RpcContext,
     input: GetBlockInput,
@@ -20,6 +21,7 @@ pub async fn get_block_with_transaction_hashes(
     .await
 }
 
+/// Get block information with full transactions given the block id
 pub async fn get_block_with_transactions(
     context: RpcContext,
     input: GetBlockInput,
@@ -32,6 +34,7 @@ pub async fn get_block_with_transactions(
     .await
 }
 
+/// Get block information given the block id
 async fn get_block(
     _context: RpcContext,
     _block_id: BlockId,

--- a/crates/pathfinder/src/rpc/v02/method/get_block.rs
+++ b/crates/pathfinder/src/rpc/v02/method/get_block.rs
@@ -52,7 +52,7 @@ async fn get_block(
         BlockId::Pending => {
             match context
                 .pending_data
-                .ok_or(anyhow!("Pending data not supported in this configuration"))?
+                .ok_or_else(|| anyhow!("Pending data not supported in this configuration"))?
                 .block()
                 .await
             {
@@ -372,7 +372,7 @@ mod tests {
         let result = get_block_with_txs(
             context.clone(),
             GetBlockInput {
-                block_id: block_id.clone(),
+                block_id: *block_id,
             },
         )
         .await;
@@ -382,7 +382,7 @@ mod tests {
         let result = get_block_with_tx_hashes(
             context.clone(),
             GetBlockInput {
-                block_id: block_id.clone(),
+                block_id: *block_id,
             },
         )
         .await;

--- a/crates/pathfinder/src/rpc/v02/method/get_block.rs
+++ b/crates/pathfinder/src/rpc/v02/method/get_block.rs
@@ -87,7 +87,7 @@ async fn get_block(
 
         let transactions = get_block_transactions(&transaction, block.number, scope)?;
 
-        Result::<types::Block, GetBlockError>::Ok(types::Block::from_raw(block, transactions))
+        Ok(types::Block::from_raw(block, transactions))
     })
     .await
     .context("Database read panic or shutting down")?

--- a/crates/pathfinder/src/rpc/v02/method/get_block.rs
+++ b/crates/pathfinder/src/rpc/v02/method/get_block.rs
@@ -15,7 +15,7 @@ pub struct GetBlockInput {
 crate::rpc::error::generate_rpc_error_subset!(GetBlockError: BlockNotFound);
 
 /// Get block information with transaction hashes given the block id
-pub async fn get_block_with_transaction_hashes(
+pub async fn get_block_with_tx_hashes(
     context: RpcContext,
     input: GetBlockInput,
 ) -> Result<types::Block, GetBlockError> {
@@ -28,7 +28,7 @@ pub async fn get_block_with_transaction_hashes(
 }
 
 /// Get block information with full transactions given the block id
-pub async fn get_block_with_transactions(
+pub async fn get_block_with_txs(
     context: RpcContext,
     input: GetBlockInput,
 ) -> Result<types::Block, GetBlockError> {

--- a/crates/pathfinder/src/rpc/v02/method/get_block.rs
+++ b/crates/pathfinder/src/rpc/v02/method/get_block.rs
@@ -8,20 +8,187 @@ pub struct GetBlockInput {
 
 crate::rpc::error::generate_rpc_error_subset!(GetBlockError: BlockNotFound);
 
-#[allow(dead_code)]
 pub async fn get_block_with_transaction_hashes(
+    context: RpcContext,
+    input: GetBlockInput,
+) -> Result<types::Block, GetBlockError> {
+    get_block(
+        context,
+        input.block_id,
+        types::BlockResponseScope::TransactionHashes,
+    )
+    .await
+}
+
+pub async fn get_block_with_transactions(
+    context: RpcContext,
+    input: GetBlockInput,
+) -> Result<types::Block, GetBlockError> {
+    get_block(
+        context,
+        input.block_id,
+        types::BlockResponseScope::FullTransactions,
+    )
+    .await
+}
+
+async fn get_block(
     _context: RpcContext,
-    _input: GetBlockInput,
-) -> Result<(), GetBlockError> {
+    _block_id: BlockId,
+    _scope: types::BlockResponseScope,
+) -> Result<types::Block, GetBlockError> {
     todo!()
 }
 
-#[allow(dead_code)]
-pub async fn get_block_with_transactions(
-    _context: RpcContext,
-    _input: GetBlockInput,
-) -> Result<(), GetBlockError> {
-    todo!()
+mod types {
+    use crate::core::{
+        GasPrice, GlobalRoot, SequencerAddress, StarknetBlockHash, StarknetBlockNumber,
+        StarknetBlockTimestamp, StarknetTransactionHash,
+    };
+    use crate::rpc::v02::types::reply::Transaction;
+    use crate::sequencer;
+    use serde::Serialize;
+    use serde_with::{serde_as, skip_serializing_none};
+    use stark_hash::StarkHash;
+    use std::convert::From;
+
+    /// Determines the type of response to block related queries.
+    #[derive(Copy, Clone, Debug)]
+    pub enum BlockResponseScope {
+        TransactionHashes,
+        FullTransactions,
+    }
+
+    /// L2 Block status as returned by the RPC API.
+    #[derive(Copy, Clone, Debug, Serialize, PartialEq, Eq)]
+    #[serde(deny_unknown_fields)]
+    pub enum BlockStatus {
+        #[serde(rename = "PENDING")]
+        Pending,
+        #[serde(rename = "ACCEPTED_ON_L2")]
+        AcceptedOnL2,
+        #[serde(rename = "ACCEPTED_ON_L1")]
+        AcceptedOnL1,
+        #[serde(rename = "REJECTED")]
+        Rejected,
+    }
+
+    impl From<sequencer::reply::Status> for BlockStatus {
+        fn from(status: sequencer::reply::Status) -> Self {
+            match status {
+                // TODO verify this mapping with Starkware
+                sequencer::reply::Status::AcceptedOnL1 => BlockStatus::AcceptedOnL1,
+                sequencer::reply::Status::AcceptedOnL2 => BlockStatus::AcceptedOnL2,
+                sequencer::reply::Status::NotReceived => BlockStatus::Rejected,
+                sequencer::reply::Status::Pending => BlockStatus::Pending,
+                sequencer::reply::Status::Received => BlockStatus::Pending,
+                sequencer::reply::Status::Rejected => BlockStatus::Rejected,
+                sequencer::reply::Status::Reverted => BlockStatus::Rejected,
+                sequencer::reply::Status::Aborted => BlockStatus::Rejected,
+            }
+        }
+    }
+
+    /// Wrapper for transaction data returned in block related queries,
+    /// chosen variant depends on [`BlockResponseScope`].
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[serde(deny_unknown_fields)]
+    #[serde(untagged)]
+    pub enum Transactions {
+        Full(Vec<Transaction>),
+        HashesOnly(Vec<StarknetTransactionHash>),
+    }
+
+    /// L2 Block as returned by the RPC API.
+    #[serde_as]
+    #[skip_serializing_none]
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[serde(deny_unknown_fields)]
+    pub struct Block {
+        pub status: BlockStatus,
+        pub block_hash: Option<StarknetBlockHash>,
+        pub parent_hash: StarknetBlockHash,
+        pub block_number: Option<StarknetBlockNumber>,
+        pub new_root: Option<GlobalRoot>,
+        pub timestamp: StarknetBlockTimestamp,
+        pub sequencer_address: SequencerAddress,
+        pub transactions: Transactions,
+    }
+
+    /// Convenience type for DB manipulation.
+    #[derive(Debug)]
+    pub struct RawBlock {
+        pub number: StarknetBlockNumber,
+        pub hash: StarknetBlockHash,
+        pub root: GlobalRoot,
+        pub parent_hash: StarknetBlockHash,
+        pub parent_root: GlobalRoot,
+        pub timestamp: StarknetBlockTimestamp,
+        pub status: BlockStatus,
+        pub sequencer: SequencerAddress,
+        pub gas_price: GasPrice,
+    }
+
+    impl Block {
+        /// Constructs [Block] from [RawBlock]
+        pub fn from_raw(block: RawBlock, transactions: Transactions) -> Self {
+            Self {
+                status: block.status,
+                block_hash: Some(block.hash),
+                parent_hash: block.parent_hash,
+                block_number: Some(block.number),
+                new_root: Some(block.root),
+                timestamp: block.timestamp,
+                sequencer_address: block.sequencer,
+                transactions,
+            }
+        }
+
+        /// Constructs [Block] from [sequencer's block representation](crate::sequencer::reply::Block)
+        pub fn from_sequencer_scoped(
+            block: sequencer::reply::MaybePendingBlock,
+            scope: BlockResponseScope,
+        ) -> Self {
+            let transactions = match scope {
+                BlockResponseScope::TransactionHashes => {
+                    let hashes = block.transactions().iter().map(|t| t.hash()).collect();
+
+                    Transactions::HashesOnly(hashes)
+                }
+                BlockResponseScope::FullTransactions => {
+                    let transactions = block.transactions().iter().map(|t| t.into()).collect();
+                    Transactions::Full(transactions)
+                }
+            };
+
+            use sequencer::reply::MaybePendingBlock;
+            match block {
+                MaybePendingBlock::Block(block) => Self {
+                    status: block.status.into(),
+                    block_hash: Some(block.block_hash),
+                    parent_hash: block.parent_block_hash,
+                    block_number: Some(block.block_number),
+                    new_root: Some(block.state_root),
+                    timestamp: block.timestamp,
+                    sequencer_address: block
+                        .sequencer_address
+                        // Default value for cairo <0.8.0 is 0
+                        .unwrap_or(SequencerAddress(StarkHash::ZERO)),
+                    transactions,
+                },
+                MaybePendingBlock::Pending(pending) => Self {
+                    status: pending.status.into(),
+                    block_hash: None,
+                    parent_hash: pending.parent_hash,
+                    block_number: None,
+                    new_root: None,
+                    timestamp: pending.timestamp,
+                    sequencer_address: pending.sequencer_address,
+                    transactions,
+                },
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/pathfinder/src/rpc/v02/method/get_transaction_receipt.rs
+++ b/crates/pathfinder/src/rpc/v02/method/get_transaction_receipt.rs
@@ -1,9 +1,9 @@
 use anyhow::Context;
 
-use crate::core::{StarknetBlockNumber, StarknetTransactionHash};
-use crate::rpc::v02::types::reply::BlockStatus;
+use crate::core::StarknetTransactionHash;
+use crate::rpc::v02::common::get_block_status;
 use crate::rpc::v02::RpcContext;
-use crate::storage::{RefsTable, StarknetBlocksTable, StarknetTransactionsTable};
+use crate::storage::{StarknetBlocksTable, StarknetTransactionsTable};
 
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
 pub struct GetTransactionReceiptInput {
@@ -80,22 +80,6 @@ pub async fn get_transaction_receipt(
     });
 
     jh.await.context("Database read panic or shutting down")?
-}
-
-/// Determines block status based on the current L1-L2 stored in the DB.
-fn get_block_status(
-    db_tx: &rusqlite::Transaction<'_>,
-    block_number: StarknetBlockNumber,
-) -> anyhow::Result<BlockStatus> {
-    // All our data is L2 accepted, check our L1-L2 head to see if this block has been accepted on L1.
-    let l1_l2_head =
-        RefsTable::get_l1_l2_head(db_tx).context("Read latest L1 head from database")?;
-    let block_status = match l1_l2_head {
-        Some(number) if number >= block_number => BlockStatus::AcceptedOnL1,
-        _ => BlockStatus::AcceptedOnL2,
-    };
-
-    Ok(block_status)
 }
 
 mod types {
@@ -532,7 +516,8 @@ mod types {
 mod tests {
     use super::*;
     use crate::core::{
-        ContractAddress, EventData, EventKey, Fee, StarknetBlockHash, StarknetTransactionHash,
+        ContractAddress, EventData, EventKey, Fee, StarknetBlockHash, StarknetBlockNumber,
+        StarknetTransactionHash,
     };
     use crate::{starkhash, starkhash_bytes};
 

--- a/crates/pathfinder/src/rpc/v02/types.rs
+++ b/crates/pathfinder/src/rpc/v02/types.rs
@@ -535,6 +535,22 @@ pub mod reply {
         Rejected,
     }
 
+    impl From<sequencer::reply::Status> for BlockStatus {
+        fn from(status: sequencer::reply::Status) -> Self {
+            match status {
+                // TODO verify this mapping with Starkware
+                sequencer::reply::Status::AcceptedOnL1 => BlockStatus::AcceptedOnL1,
+                sequencer::reply::Status::AcceptedOnL2 => BlockStatus::AcceptedOnL2,
+                sequencer::reply::Status::NotReceived => BlockStatus::Rejected,
+                sequencer::reply::Status::Pending => BlockStatus::Pending,
+                sequencer::reply::Status::Received => BlockStatus::Pending,
+                sequencer::reply::Status::Rejected => BlockStatus::Rejected,
+                sequencer::reply::Status::Reverted => BlockStatus::Rejected,
+                sequencer::reply::Status::Aborted => BlockStatus::Rejected,
+            }
+        }
+    }
+
     #[cfg(test)]
     mod tests {
         macro_rules! fixture {


### PR DESCRIPTION
Closes #588.
Closes #589.
This is more or less a copy of v0.1 aligned with the v0.2 architecture.
I added 2 new test cases, which are missing in v0.1 when requesting a pending block:
- return latest block if pending is enabled but empty
- return internal error if pending is disabled.

The test code is built around a single array of `(context, input, assert_handler)` to shed redundancy.