### PR TITLE
refactor(ext_py): use marshmallow-based deserialization in Python subprocess

### DIFF
--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -178,11 +178,12 @@ pub enum GasPriceSource {
 }
 
 impl GasPriceSource {
-    /// Convert to an option of H256, for serialization.
-    fn as_option(&self) -> Option<&web3::types::H256> {
+    const GAS_PRICE_ZERO: web3::types::H256 = web3::types::H256::zero();
+    /// Convert to `&H256`, for use in serialization.
+    fn as_price(&self) -> &web3::types::H256 {
         match self {
-            GasPriceSource::PastBlock => None,
-            GasPriceSource::Current(price) => Some(price),
+            GasPriceSource::PastBlock => &Self::GAS_PRICE_ZERO,
+            GasPriceSource::Current(price) => price,
         }
     }
 }

--- a/crates/pathfinder/src/cairo/ext_py/ser.rs
+++ b/crates/pathfinder/src/cairo/ext_py/ser.rs
@@ -93,7 +93,8 @@ impl<'a> serde::Serialize for ContractUpdatesWrapper<'a> {
             }
             map.end()
         } else {
-            serializer.serialize_none()
+            let map = serializer.serialize_map(Some(0))?;
+            map.end()
         }
     }
 }
@@ -155,7 +156,8 @@ impl<'a> serde::Serialize for DeployedContractsWrapper<'a> {
             }
             seq.end()
         } else {
-            serializer.serialize_none()
+            let seq = serializer.serialize_seq(Some(0))?;
+            seq.end()
         }
     }
 }
@@ -335,7 +337,7 @@ mod tests {
     fn serialize_none_updates() {
         use super::ContractUpdatesWrapper;
 
-        let expected = "null";
+        let expected = "{}";
         let s = serde_json::to_string(&ContractUpdatesWrapper(None)).unwrap();
         assert_eq!(expected, s);
     }
@@ -369,7 +371,7 @@ mod tests {
     fn serialize_none_deployed_contracts() {
         use super::DeployedContractsWrapper;
 
-        let expected = r#"null"#;
+        let expected = r#"[]"#;
         let s = serde_json::to_string(&DeployedContractsWrapper(None)).unwrap();
         assert_eq!(expected, s);
     }

--- a/crates/pathfinder/src/rpc/v02/method/estimate_fee.rs
+++ b/crates/pathfinder/src/rpc/v02/method/estimate_fee.rs
@@ -110,10 +110,8 @@ pub async fn estimate_fee(
     let (when, pending_update) =
         base_block_and_pending_for_call(input.block_id, &context.pending_data).await?;
 
-    let call: crate::rpc::v01::types::request::Call = input.request.try_into()?;
-
     let result = handle
-        .estimate_fee(call, when, gas_price, pending_update)
+        .estimate_fee(input.request, when, gas_price, pending_update)
         .await?;
 
     Ok(result.into())
@@ -395,7 +393,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn success() {
+        async fn successful_invoke_v0() {
             let (context, _join_handle) = test_context_with_call_handling().await;
 
             let input = EstimateFeeInput {

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -515,7 +515,7 @@ def resolve_block(connection, at_block, forced_gas_price):
 
     gas_price = int.from_bytes(gas_price, "big")
 
-    if forced_gas_price is not None:
+    if forced_gas_price != 0:
         # allow caller to override any; see rust side's GasPriceSource for more rationale
         gas_price = forced_gas_price
 

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -1,33 +1,187 @@
-import sys
-import json
-import time
-import sqlite3
 import asyncio
+import json
 import os
+import re
+import sqlite3
+import sys
+import time
+from abc import abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import ClassVar, Dict, List, Optional, Type
 
-# fallible import for exceptionless failure to start.
-#
-# this is the only starkware class imported outside, because SqliteAdapter
-# inherits this class.
+# import non-standard modules and detect if Python environment is not properly set up
 try:
-    from starkware.storage.storage import Storage
+    import marshmallow.exceptions
+    import marshmallow_dataclass
+    import marshmallow_oneofschema
     from cachetools import LRUCache
+    from marshmallow import Schema
+    from marshmallow import fields as mfields
+    from services.everest.definitions import fields as everest_fields
+    from starkware.starknet.definitions import fields
+    from starkware.starknet.definitions.general_config import StarknetChainId
+    from starkware.starknet.services.api.gateway.transaction import (
+        Transaction,
+    )
+    from starkware.storage.storage import Storage
 except ModuleNotFoundError:
-
-    class Storage:
-        fake = True
+    print(
+        "missing cairo-lang module: please reinstall dependencies to upgrade.",
+    )
+    sys.exit(1)
 
 
 # used from tests, and the query which asserts that the schema is of expected version.
 EXPECTED_SCHEMA_REVISION = 21
 EXPECTED_CAIRO_VERSION = "0.10.0"
-SUPPORTED_COMMANDS = frozenset(["call", "estimate_fee"])
 
 # used by the sqlite adapter to communicate "contract state not found, nor was the patricia tree key"
 NOT_FOUND_CONTRACT_STATE = b'{"contract_hash": "0000000000000000000000000000000000000000000000000000000000000000", "nonce": "0x0", "storage_commitment_tree": {"height": 251, "root": "0000000000000000000000000000000000000000000000000000000000000000"}}'
 
 # this is set by pathfinder automatically when #[cfg(debug_assertions)]
 DEV_MODE = os.environ.get("PATHFINDER_PROFILE") == "dev"
+
+
+class Verb(Enum):
+    CALL = 0
+    ESTIMATE_FEE = 1
+
+
+class Chain(Enum):
+    MAINNET = StarknetChainId.MAINNET
+    GOERLI = StarknetChainId.TESTNET
+
+
+felt_metadata = dict(
+    marshmallow_field=everest_fields.FeltField.get_marshmallow_field(required=True)
+)
+
+
+@marshmallow_dataclass.dataclass(frozen=True)
+class StorageDiff:
+    key: int = field(metadata=felt_metadata)
+    value: int = field(metadata=felt_metadata)
+
+
+class_hash_metadata = dict(
+    marshmallow_field=fields.ClassHashIntField.get_marshmallow_field(required=True)
+)
+
+
+@marshmallow_dataclass.dataclass(frozen=True)
+class DeployedContract:
+    address: int = field(metadata=fields.contract_address_metadata)
+    contract_hash: int = field(metadata=class_hash_metadata)
+
+
+pending_updates_metadata = dict(
+    marshmallow_field=mfields.Dict(
+        keys=fields.L2AddressField.get_marshmallow_field(),
+        values=mfields.List(mfields.Nested(StorageDiff.Schema())),
+        required=True,
+    )
+)
+
+pending_deployed_metadata = dict(
+    marshmallow_field=mfields.List(
+        mfields.Nested(DeployedContract.Schema()), required=True
+    )
+)
+
+pending_nonces_metadata = dict(
+    marshmallow_field=mfields.Dict(
+        keys=fields.L2AddressField.get_marshmallow_field(),
+        values=fields.NonceField.get_marshmallow_field(),
+        required=True,
+    )
+)
+
+
+@dataclass(frozen=True)
+class Command:
+    at_block: str
+    chain: Chain
+
+    @property
+    @classmethod
+    @abstractmethod
+    def verb(cls) -> Verb:
+        """
+        Returns the verb
+        """
+
+    @abstractmethod
+    def has_pending_data(self):
+        pass
+
+
+@marshmallow_dataclass.dataclass(frozen=True)
+class Call(Command):
+    verb: ClassVar[Verb] = Verb.CALL
+
+    pending_updates: Dict[int, List[StorageDiff]] = field(
+        metadata=pending_updates_metadata
+    )
+    pending_deployed: List[DeployedContract] = field(metadata=pending_deployed_metadata)
+    pending_nonces: Dict[int, int] = field(metadata=pending_nonces_metadata)
+
+    contract_address: int = field(metadata=fields.contract_address_metadata)
+    calldata: List[int] = field(metadata=fields.call_data_as_hex_metadata)
+    max_fee: int = field(metadata=fields.fee_metadata)
+    signature: List[int] = field(metadata=fields.signature_metadata)
+    nonce: Optional[int] = field(metadata=fields.optional_nonce_metadata)
+    entry_point_selector: Optional[int] = field(
+        default=None, metadata=fields.optional_entry_point_selector_metadata
+    )
+
+    gas_price: int = 0
+
+    def has_pending_data(self):
+        return (
+            len(self.pending_updates) > 0
+            or len(self.pending_deployed) > 0
+            or len(self.pending_nonces) > 0
+        )
+
+
+@marshmallow_dataclass.dataclass(frozen=True)
+class EstimateFee(Command):
+    verb: ClassVar[Verb] = Verb.ESTIMATE_FEE
+
+    pending_updates: Dict[int, List[StorageDiff]] = field(
+        metadata=pending_updates_metadata
+    )
+    pending_deployed: List[DeployedContract] = field(metadata=pending_deployed_metadata)
+    pending_nonces: Dict[int, int] = field(metadata=pending_nonces_metadata)
+
+    # zero means to use the gas price from the current block.
+    gas_price: int = field(metadata=fields.gas_price_metadata)
+
+    transaction: Transaction
+
+    def has_pending_data(self):
+        return (
+            len(self.pending_updates) > 0
+            or len(self.pending_deployed) > 0
+            or len(self.pending_nonces) > 0
+        )
+
+
+class CommandSchema(marshmallow_oneofschema.OneOfSchema):
+    type_field = "verb"
+    type_schemas: Dict[str, Type[Schema]] = {
+        Verb.CALL.name: Call.Schema,
+        Verb.ESTIMATE_FEE.name: EstimateFee.Schema,
+    }
+
+    at_block = mfields.Str()
+
+    def get_obj_type(self, obj):
+        return obj.verb.name
+
+
+Command.Schema = CommandSchema
 
 
 def main():
@@ -46,7 +200,7 @@ def main():
     # stderr is only for logging, it's piped to tracing::trace one line at a time
     sys.stderr.reconfigure(encoding="utf-8")
 
-    if (hasattr(Storage, "fake") and Storage.fake) or not check_cairolang_version():
+    if not check_cairolang_version():
         print(
             "unexpected cairo-lang version: please reinstall dependencies to upgrade.",
             flush=True,
@@ -86,26 +240,6 @@ def check_cairolang_version():
 def do_loop(connection, input_gen, output_file):
     from starkware.starkware_utils.error_handling import WebFriendlyException
 
-    required = {
-        "at_block": int_hash_or_latest,
-        "contract_address": int_param,
-        "calldata": list_of_int,
-        "command": required_command,
-        "gas_price": required_gas_price,
-        "chain": required_chain,
-    }
-
-    optional = {
-        "signature": list_of_int,
-        "max_fee": int_param,
-        "version": int_param,
-        "pending_updates": maybe_pending_updates,
-        "pending_deployed": maybe_pending_deployed,
-        "pending_nonces": maybe_pending_nonces,
-        "nonce": maybe_nonce,
-        "entry_point_selector": string_or_int,
-    }
-
     logger = Logger()
 
     if DEV_MODE:
@@ -126,7 +260,7 @@ def do_loop(connection, input_gen, output_file):
         timings = {}
 
         try:
-            command = parse_command(json.loads(line), required, optional)
+            command = Command.Schema().loads(line)
 
             parsed_at = time.time()
 
@@ -142,22 +276,22 @@ def do_loop(connection, input_gen, output_file):
             out = {"status": "error", "kind": "NO_SUCH_BLOCK"}
         except UnexpectedSchemaVersion:
             out = {"status": "error", "kind": "INVALID_SCHEMA_VERSION"}
-        except InvalidInput:
+        except marshmallow.exceptions.MarshmallowError:
             out = {"status": "error", "kind": "INVALID_INPUT"}
-        except WebFriendlyException as e:
-            if str(e.code) == "StarknetErrorCode.UNINITIALIZED_CONTRACT":
+        except WebFriendlyException as exc:
+            if str(exc.code) == "StarknetErrorCode.UNINITIALIZED_CONTRACT":
                 out = {"status": "error", "kind": "NO_SUCH_CONTRACT"}
-            elif str(e.code) == "StarknetErrorCode.ENTRY_POINT_NOT_FOUND_IN_CONTRACT":
+            elif str(exc.code) == "StarknetErrorCode.ENTRY_POINT_NOT_FOUND_IN_CONTRACT":
                 out = {"status": "error", "kind": "INVALID_ENTRY_POINT"}
             else:
-                report_failed(logger, command, e)
-                out = {"status": "failed", "exception": str(e.code)}
-        except Exception as e:
-            stringified = str(e)
+                report_failed(logger, command, exc)
+                out = {"status": "failed", "exception": str(exc.code)}
+        except Exception as exc:
+            stringified = str(exc)
 
             if len(stringified) > 200:
                 stringified = stringified[:197] + "..."
-            report_failed(logger, command, e)
+            report_failed(logger, command, exc)
             out = {"status": "failed", "exception": stringified}
         finally:
             connection.rollback()
@@ -187,47 +321,42 @@ def report_failed(logger, command, e):
         logger.debug(str(e))
 
 
-def loop_inner(connection, command):
+def loop_inner(connection, command: Command):
 
     if not check_schema(connection):
         raise UnexpectedSchemaVersion
 
-    verb = command["command"]
-    general_config = create_general_config(command["chain"])
+    general_config = create_general_config(command.chain.value)
 
-    at_block = command["at_block"]
-    # this will be None for v1 invoke function
-    selector = command.get("entry_point_selector", None)
-    signature = command.get("signature", [])
-    max_fee = command.get("max_fee", 0)
-    version = command.get("version", 0)
-    gas_price = command.get("gas_price", None)
+    at_block = int_hash_or_latest(command.at_block)
 
     timings = {}
     started_at = time.time()
-    pending_updates = command.get("pending_updates", None)
-    pending_deployed = command.get("pending_deployed", None)
-    pending_nonces = command.get("pending_nonces", None)
 
-    if type(selector) == str:
-        from starkware.starknet.public.abi import get_selector_from_name
+    # When calling or estimating the fee on a pending block, rust side will
+    # always execute it on a specific block (pending's parent block). If that
+    # block is not found, we should default to the latest block IFF there are
+    # pending updates or deploys or nonces.
+    fallback_to_latest = isinstance(at_block, bytes) and command.has_pending_data()
 
-        # rust side will always send us starkhashes but tests are more readable with names
-        selector = get_selector_from_name(selector)
-
-    fallback_to_latest = type(at_block) == bytes and (
-        pending_updates is not None or pending_deployed is not None
-    )
+    pending_updates = command.pending_updates
+    pending_deployed = command.pending_deployed
+    pending_nonces = command.pending_nonces
 
     # the later parts will have access to gas_price through this block_info
     try:
-        (block_info, global_root) = resolve_block(connection, at_block, gas_price)
+        (block_info, global_root) = resolve_block(
+            connection, at_block, command.gas_price
+        )
     except NoSuchBlock:
         if fallback_to_latest:
-            pending_updates = None
-            pending_deployed = None
+            pending_updates = {}
+            pending_deployed = []
+            pending_nonces = {}
 
-            (block_info, global_root) = resolve_block(connection, "latest", gas_price)
+            (block_info, global_root) = resolve_block(
+                connection, "latest", command.gas_price
+            )
         else:
             raise
 
@@ -236,48 +365,41 @@ def loop_inner(connection, command):
 
     adapter = SqliteAdapter(connection)
 
-    if verb == "call":
+    if isinstance(command, Call):
         result = asyncio.run(
             do_call(
                 adapter,
                 general_config,
                 global_root,
-                command["contract_address"],
-                selector,
-                command["calldata"],
-                signature,
-                command.get("nonce", None),
-                max_fee,
+                command.contract_address,
+                command.entry_point_selector,
+                command.calldata,
+                command.signature,
+                command.nonce,
+                command.max_fee,
                 block_info,
-                version,
+                0,
                 pending_updates,
                 pending_deployed,
                 pending_nonces,
             )
         )
-        ret = (verb, result.retdata, timings)
+        ret = (command.verb, result.retdata, timings)
     else:
-        assert verb == "estimate_fee"
-        # do everything with the inheritance scheme
+        assert isinstance(command, EstimateFee)
         fees = asyncio.run(
             do_estimate_fee(
                 adapter,
                 general_config,
                 global_root,
-                command["contract_address"],
-                selector,
-                command["calldata"],
-                signature,
-                command.get("nonce", None),
-                max_fee,
                 block_info,
-                version,
+                command.transaction,
                 pending_updates,
                 pending_deployed,
                 pending_nonces,
             )
         )
-        ret = (verb, fees, timings)
+        ret = (command.verb, fees, timings)
 
     timings["sql"] = {
         "timings": adapter.elapsed,
@@ -293,10 +415,10 @@ def render(verb, vals):
     def prefixed_hex(x):
         return f"0x{x.to_bytes(32, 'big').hex()}"
 
-    if verb == "call":
+    if verb == Verb.CALL:
         return list(map(prefixed_hex, vals))
     else:
-        assert verb == "estimate_fee"
+        assert verb == Verb.ESTIMATE_FEE
         return {
             "gas_consumed": prefixed_hex(vals["gas_consumed"]),
             "gas_price": prefixed_hex(vals["gas_price"]),
@@ -304,158 +426,22 @@ def render(verb, vals):
         }
 
 
-def parse_command(command, required, optional):
-    # it would be nice to use marshmallow but before we can lock with
-    # cairo-lang we cannot really add common dependencies
-    missing = required.keys() - command.keys()
-    assert len(missing) == 0, f"missing keys from command: {missing}"
-
-    extra = set()
-
-    converted = dict()
-
-    for k, v in command.items():
-        conv = required.get(k, None)
-        if conv is None:
-            conv = optional.get(k, None)
-        if conv is None:
-            extra += k
-            continue
-
-        try:
-            converted[k] = conv(v)
-        except Exception:
-            raise InvalidInput(k)
-
-    assert len(extra) == 0, f"extra keys from command: {extra}"
-
-    return converted
-
-
-def int_hash_or_latest(s):
-    if type(s) == int:
-        return s
+def int_hash_or_latest(s: str):
     if s == "latest":
         return s
     if s == "pending":
         # this is allowed in the rpc api but pathfinder doesn't create the blocks
         # this should had never come to us
         raise NoSuchBlock(s)
-    assert s[0:2] == "0x"
-    return len_safe_hex(s)
 
+    if re.match("^0x[0-9a-f]+$", s) is not None:
+        # block hash as bytes
+        return int(s, 16).to_bytes(length=32, byteorder="big")
+    if re.match("^[0-9]+$", s) is not None:
+        # block number
+        return int(s)
 
-def int_param(s):
-    if type(s) == int:
-        return s
-    if s.startswith("0x"):
-        return int.from_bytes(len_safe_hex(s), "big")
-    return int(s, 10)
-
-
-def len_safe_hex(s):
-    """
-    Over at the RPC side which pathfinder supports, sometimes hex without
-    leading zeros is needed, so they could come over to python as well.
-    bytes.fromhex doesn't support odd length hex, it gives a non-hex character
-    error.
-    """
-    if s.startswith("0x"):
-        s = s[2:]
-    if len(s) % 2 == 1:
-        s = "0" + s
-    return bytes.fromhex(s)
-
-
-def string_or_int(s):
-    if type(s) == int:
-        return s
-
-    if type(s) == str:
-        if s.startswith("0x"):
-            return int_param(s)
-        # not sure if this should be supported but strings get ran through the
-        # truncated keccak
-        return s
-
-    raise TypeError(f"expected string or int, not {type(s)}")
-
-
-def list_of_int(s):
-    assert type(s) == list, f"Expected list, got {type(s)}"
-    return list(map(int_param, s))
-
-
-def required_command(s):
-    assert s in SUPPORTED_COMMANDS
-    return s
-
-
-def required_gas_price(s):
-    if s is None:
-        # this means, use the block gas price
-        return None
-    elif type(s) == str:
-        return int.from_bytes(len_safe_hex(s), "big")
-    else:
-        assert type(s) == int, "expected gas_price to be an int"
-        return s
-
-
-def required_chain(s):
-    from starkware.starknet.definitions.general_config import StarknetChainId
-
-    # this is not done through genesis block but explicitly so that we can do
-    # tests more freely
-
-    if s == "MAINNET":
-        return StarknetChainId.MAINNET
-    else:
-        assert s == "GOERLI"
-        return StarknetChainId.TESTNET
-
-
-def maybe_pending_updates(s):
-    if s is None:
-        return None
-
-    # currently just accepting the format from sequencers get_state_update
-    return dict(
-        (
-            int_param(key),
-            list((int_param(val["key"]), int_param(val["value"])) for val in values),
-        )
-        for key, values in s.items()
-    )
-
-
-def maybe_pending_deployed(deployed_contracts):
-    if deployed_contracts is None:
-        return None
-
-    # this accepts the form used in the sequencer state update
-    # which is "prop": [ { "address": "0x...", "contract_hash": "0x..." }, ... ]
-    # internally we use just address => hash
-
-    return dict(
-        (int_param(x["address"]), len_safe_hex(x["contract_hash"]))
-        for x in deployed_contracts
-    )
-
-
-def maybe_pending_nonces(nonces):
-    if nonces is None:
-        return None
-
-    # accept a map addr => nonce
-    return dict((int_param(key), int_param(value)) for key, value in nonces.items())
-
-
-def maybe_nonce(nonce):
-    if nonce is None:
-        return None
-
-    return int_param(nonce)
+    raise ValueError(f"Invalid block id value: {s}")
 
 
 def check_schema(connection):
@@ -467,7 +453,7 @@ def check_schema(connection):
     return version == EXPECTED_SCHEMA_REVISION
 
 
-def resolve_block(connection, at_block, forced_gas_price):
+def resolve_block(connection, at_block, forced_gas_price: int):
     """
     forced_gas_price is the gas price we must use for this blockinfo, if None,
     the one from starknet_blocks will be used. this allows the caller to select
@@ -482,13 +468,13 @@ def resolve_block(connection, at_block, forced_gas_price):
         cursor = connection.execute(
             "select number, timestamp, root, gas_price, sequencer_address, sn_ver.version from starknet_blocks left join starknet_versions sn_ver on (sn_ver.id = version_id) order by number desc limit 1"
         )
-    elif type(at_block) == int:
+    elif isinstance(at_block, int):
         cursor = connection.execute(
             "select number, timestamp, root, gas_price, sequencer_address, sn_ver.version from starknet_blocks left join starknet_versions sn_ver on (sn_ver.id = version_id) where number = ?",
             [at_block],
         )
     else:
-        assert type(at_block) == bytes, f"expected bytes, got {type(at_block)}"
+        assert isinstance(at_block, bytes), f"expected bytes, got {type(at_block)}"
         if len(at_block) < 32:
             # left pad it, as the fields in db are fixed length for this occasion
             at_block = b"\x00" * (32 - len(at_block)) + at_block
@@ -509,9 +495,9 @@ def resolve_block(connection, at_block, forced_gas_price):
                 starknet_version,
             )
         ] = cursor
-    except ValueError:
+    except ValueError as exc:
         # zero rows, or wrong number of columns (unlikely)
-        raise NoSuchBlock(at_block)
+        raise NoSuchBlock(at_block) from exc
 
     gas_price = int.from_bytes(gas_price, "big")
 
@@ -537,11 +523,6 @@ class NoSuchBlock(Exception):
 class UnexpectedSchemaVersion(Exception):
     def __init__(self):
         super().__init__("Schema mismatch, is this pathfinders database file?")
-
-
-class InvalidInput(Exception):
-    def __init__(self, key):
-        super().__init__(f"Invalid input for key: {key}")
 
 
 class Logger:
@@ -702,6 +683,7 @@ class SqliteAdapter(Storage):
 
     def fetch_contract_definition(self, suffix):
         import itertools
+
         import zstandard
 
         # assert False, "we must rebuild the full json out of our columns"
@@ -752,23 +734,22 @@ async def do_call(
     """
     The actual call execution with cairo-lang.
     """
-    from starkware.storage.storage import FactFetchingContext
-    from starkware.starknet.business_logic.fact_state.patricia_state import (
-        PatriciaStateReader,
-    )
-    from starkware.starkware_utils.commitment_tree.patricia_tree.patricia_tree import (
-        PatriciaTree,
-    )
-    from starkware.starknet.business_logic.state.state import CachedState
-    from starkware.starknet.business_logic.fact_state.state import (
-        ExecutionResourcesManager,
-    )
+    from starkware.cairo.lang.vm.crypto import pedersen_hash_func
     from starkware.starknet.business_logic.execution.execute_entry_point import (
         ExecuteEntryPoint,
     )
-
+    from starkware.starknet.business_logic.fact_state.patricia_state import (
+        PatriciaStateReader,
+    )
+    from starkware.starknet.business_logic.fact_state.state import (
+        ExecutionResourcesManager,
+    )
+    from starkware.starknet.business_logic.state.state import CachedState
     from starkware.starknet.services.api.contract_class import EntryPointType
-    from starkware.cairo.lang.vm.crypto import pedersen_hash_func
+    from starkware.starkware_utils.commitment_tree.patricia_tree.patricia_tree import (
+        PatriciaTree,
+    )
+    from starkware.storage.storage import FactFetchingContext
 
     # hook up the sqlite adapter
     ffc = FactFetchingContext(storage=adapter, hash_func=pedersen_hash_func)
@@ -799,14 +780,8 @@ async def do_estimate_fee(
     adapter,
     general_config,
     root,
-    contract_address,
-    selector,
-    calldata,
-    signature,
-    nonce,
-    max_fee,
     block_info,
-    version,
+    transaction,
     pending_updates,
     pending_deployed,
     pending_nonces,
@@ -818,31 +793,22 @@ async def do_estimate_fee(
     deploy and perhaps declare transactions as well.
     """
 
-    from starkware.starknet.services.api.gateway.transaction import InvokeFunction
-    from starkware.starknet.services.utils.sequencer_api_utils import (
-        InternalAccountTransactionForSimulate,
-    )
-    from starkware.storage.storage import FactFetchingContext
+    from starkware.cairo.lang.vm.crypto import pedersen_hash_func
     from starkware.starknet.business_logic.fact_state.patricia_state import (
         PatriciaStateReader,
+    )
+    from starkware.starknet.business_logic.state.state import CachedState
+    from starkware.starknet.services.utils.sequencer_api_utils import (
+        InternalAccountTransactionForSimulate,
     )
     from starkware.starkware_utils.commitment_tree.patricia_tree.patricia_tree import (
         PatriciaTree,
     )
-    from starkware.starknet.business_logic.state.state import CachedState
-    from starkware.cairo.lang.vm.crypto import pedersen_hash_func
+    from starkware.storage.storage import FactFetchingContext
 
-    fun = InvokeFunction(
-        version=version,
-        max_fee=max_fee,
-        signature=signature,
-        nonce=nonce,
-        contract_address=contract_address,
-        calldata=calldata,
-        entry_point_selector=selector,
+    more = InternalAccountTransactionForSimulate.from_external(
+        transaction, general_config
     )
-
-    more = InternalAccountTransactionForSimulate.from_external(fun, general_config)
 
     ffc = FactFetchingContext(storage=adapter, hash_func=pedersen_hash_func)
     state_reader = PatriciaStateReader(PatriciaTree(root, 251), ffc)
@@ -862,25 +828,22 @@ async def do_estimate_fee(
     }
 
 
-def apply_pending(state, updates, deployed, nonces):
-    updates = updates if updates is not None else {}
-    deployed = deployed if deployed is not None else {}
-    nonces = nonces if nonces is not None else {}
-
-    for addr, class_hash in deployed.items():
-        assert type(class_hash) == bytes
-        state.cache._class_hash_reads[addr] = class_hash
+def apply_pending(
+    state,
+    updates: Dict[int, List[StorageDiff]],
+    deployed: List[DeployedContract],
+    nonces: Dict[int, int],
+):
+    for deployed_contract in deployed:
+        state.cache._class_hash_reads[
+            deployed_contract.address
+        ] = deployed_contract.contract_hash.to_bytes(length=32, byteorder="big")
 
     for addr, updates in updates.items():
-        assert type(addr) == int
-        for key, value in updates:
-            assert type(key) == int
-            assert type(value) == int
-            state.cache._storage_reads[(addr, key)] = value
+        for update in updates:
+            state.cache._storage_reads[(addr, update.key)] = update.value
 
     for addr, nonce in nonces.items():
-        assert type(addr) == int
-        assert type(nonce) == int
         # bypass the CachedState.increment_nonce which would give extra queries
         # per each, and only single step at a time
         state.cache._nonce_reads[addr] = nonce
@@ -890,18 +853,18 @@ def create_general_config(chain_id):
     """
     Separate fn because it's tricky to get a new instance with actual configuration
     """
-    from starkware.starknet.definitions.general_config import (
-        StarknetGeneralConfig,
-        N_STEPS_RESOURCE,
-        StarknetOsConfig,
-    )
     from starkware.cairo.lang.builtins.all_builtins import (
+        BITWISE_BUILTIN,
+        EC_OP_BUILTIN,
+        ECDSA_BUILTIN,
+        OUTPUT_BUILTIN,
         PEDERSEN_BUILTIN,
         RANGE_CHECK_BUILTIN,
-        ECDSA_BUILTIN,
-        BITWISE_BUILTIN,
-        OUTPUT_BUILTIN,
-        EC_OP_BUILTIN,
+    )
+    from starkware.starknet.definitions.general_config import (
+        N_STEPS_RESOURCE,
+        StarknetGeneralConfig,
+        StarknetOsConfig,
     )
 
     # given on 2022-06-07

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -1,23 +1,121 @@
-from call import (
-    check_cairolang_version,
-    do_loop,
-    EXPECTED_SCHEMA_REVISION,
-    int_param,
-    int_hash_or_latest,
-    loop_inner,
-    maybe_pending_updates,
-    maybe_pending_deployed,
-    maybe_pending_nonces,
-    resolve_block,
-    NOT_FOUND_CONTRACT_STATE,
-)
-import sqlite3
+import dataclasses
 import io
 import json
+import sqlite3
+
 import pytest
-import copy
-from starkware.starknet.definitions.general_config import StarknetChainId
+import zstandard
+from starkware.starknet.public.abi import get_selector_from_name
+from starkware.starknet.services.api.gateway.transaction import InvokeFunction, Declare
+from starkware.starknet.services.api.contract_class import ContractClass
 from starkware.starkware_utils.error_handling import WebFriendlyException
+
+import call
+from call import (
+    EXPECTED_SCHEMA_REVISION,
+    NOT_FOUND_CONTRACT_STATE,
+    Call,
+    Command,
+    EstimateFee,
+    check_cairolang_version,
+    do_loop,
+    loop_inner,
+    resolve_block,
+)
+
+
+def test_command_parsing_estimate_fee():
+    input = """{
+        "verb":"ESTIMATE_FEE",
+        "at_block":"0x736f6d6520626c6f636b6861736820736f6d657768657265",
+        "chain":"GOERLI",
+        "gas_price":"0xa",
+        "pending_updates":{"0x7c38021eb1f890c5d572125302fe4a0d2f79d38b018d68a9fcd102145d4e451":[{"key":"0x5","value":"0x0"}]},
+        "pending_deployed":[
+            {
+                "address":"0x7c38021eb1f890c5d572125302fe4a0d2f79d38b018d68a9fcd102145d4e451",
+                "contract_hash":"0x10455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8"
+            }
+        ],
+        "pending_nonces":{"0x123":"0x1"},
+        "transaction":{
+            "type":"INVOKE_FUNCTION",
+            "version":"0x100000000000000000000000000000000",
+            "max_fee":"0x0",
+            "signature":[],
+            "nonce":null,
+            "contract_address":"0x57dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374",
+            "entry_point_selector":"0x26813d396fdb198e9ead934e4f7a592a8b88a059e45ab0eb6ee53494e8d45b0",
+            "calldata":["132"]}
+    }"""
+    command = Command.Schema().loads(input)
+    assert command == EstimateFee(
+        at_block="0x736f6d6520626c6f636b6861736820736f6d657768657265",
+        chain=call.Chain.GOERLI,
+        gas_price=10,
+        pending_updates={
+            0x7C38021EB1F890C5D572125302FE4A0D2F79D38B018D68A9FCD102145D4E451: [
+                call.StorageDiff(key=5, value=0)
+            ]
+        },
+        pending_deployed=[
+            call.DeployedContract(
+                address=0x7C38021EB1F890C5D572125302FE4A0D2F79D38B018D68A9FCD102145D4E451,
+                contract_hash=0x10455C752B86932CE552F2B0FE81A880746649B9AEE7E0D842BF3F52378F9F8,
+            )
+        ],
+        pending_nonces={0x123: 1},
+        transaction=InvokeFunction(
+            version=0x100000000000000000000000000000000,
+            contract_address=0x57DDE83C18C0EFE7123C36A52D704CF27D5C38CDF0B1E1EDC3B0DAE3EE4E374,
+            calldata=[132],
+            entry_point_selector=0x26813D396FDB198E9EAD934E4F7A592A8B88A059E45AB0EB6EE53494E8D45B0,
+            nonce=None,
+            max_fee=0,
+            signature=[],
+        ),
+    )
+    assert command.has_pending_data()
+
+
+def test_command_parsing_call():
+    input = """{
+        "verb":"CALL",
+        "at_block":"latest",
+        "chain":"GOERLI",
+        "pending_updates":{
+            "0x57dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374":[
+                {"key":"0x84","value":"0x4"}
+            ]
+        },
+        "pending_deployed":[],
+        "pending_nonces":{},
+        "contract_address":"0x57dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374",
+        "calldata":["0x84"],
+        "max_fee":"0x00000000000000000000000000000000",
+        "signature":[],
+        "nonce":null,
+        "entry_point_selector":"0x26813d396fdb198e9ead934e4f7a592a8b88a059e45ab0eb6ee53494e8d45b0"
+    }"""
+    command = Command.Schema().loads(input)
+    assert command == Call(
+        at_block="latest",
+        chain=call.Chain.GOERLI,
+        pending_updates={
+            0x57DDE83C18C0EFE7123C36A52D704CF27D5C38CDF0B1E1EDC3B0DAE3EE4E374: [
+                call.StorageDiff(key=0x84, value=4)
+            ]
+        },
+        pending_deployed=[],
+        pending_nonces={},
+        contract_address=0x57DDE83C18C0EFE7123C36A52D704CF27D5C38CDF0B1E1EDC3B0DAE3EE4E374,
+        calldata=[0x84],
+        max_fee=0,
+        signature=[],
+        nonce=None,
+        entry_point_selector=0x26813D396FDB198E9EAD934E4F7A592A8B88A059E45AB0EB6EE53494E8D45B0,
+    )
+    assert command.has_pending_data()
 
 
 @pytest.mark.skip(
@@ -245,14 +343,17 @@ def default_132_on_3_scenario(con, input_jsons):
 
 def test_success():
     con = inmemory_with_tables()
-    contract_address = populate_test_contract_with_132_on_3(con)
+    contract_address = hex(populate_test_contract_with_132_on_3(con))
+    entry_point = hex(get_selector_from_name("get_value"))
+
+    common_command_data = f'"contract_address": "{contract_address}", "entry_point_selector": "{entry_point}", "calldata": ["0x84"], "signature": [], "gas_price": 0, "chain": "GOERLI", "pending_updates": {{}}, "pending_deployed": [], "pending_nonces": {{}}'
 
     output = default_132_on_3_scenario(
         con,
         [
-            f'{{ "command": "call", "at_block": 1, "contract_address": {contract_address}, "entry_point_selector": "get_value", "calldata": [132], "gas_price": null, "chain": "GOERLI" }}',
-            f'{{ "command": "call", "at_block": "0x{(b"some blockhash somewhere").hex()}", "contract_address": {contract_address}, "entry_point_selector": "get_value", "calldata": [132], "gas_price": null, "chain": "GOERLI" }}',
-            f'{{ "command": "call", "at_block": "latest", "contract_address": {contract_address}, "entry_point_selector": "get_value", "calldata": [132], "gas_price": null, "chain": "GOERLI" }}',
+            f'{{ "verb": "CALL", "at_block": "1", {common_command_data} }}',
+            f'{{ "verb": "CALL", "at_block": "0x{(b"some blockhash somewhere").hex()}", {common_command_data} }}',
+            f'{{ "verb": "CALL", "at_block": "latest", {common_command_data} }}',
         ],
     )
 
@@ -270,15 +371,19 @@ def test_positive_directly():
     con = inmemory_with_tables()
     contract_address = populate_test_contract_with_132_on_3(con)
 
-    command = {
-        "command": "call",
-        "at_block": 1,
-        "contract_address": contract_address,
-        "entry_point_selector": "get_value",
-        "calldata": [132],
-        "gas_price": None,
-        "chain": StarknetChainId.TESTNET,
-    }
+    command = Call(
+        at_block="1",
+        chain=call.Chain.GOERLI,
+        contract_address=contract_address,
+        entry_point_selector=get_selector_from_name("get_value"),
+        calldata=[132],
+        max_fee=0,
+        signature=[],
+        nonce=None,
+        pending_updates={},
+        pending_deployed=[],
+        pending_nonces={},
+    )
 
     con.execute("BEGIN")
 
@@ -290,11 +395,14 @@ def test_positive_directly():
 def test_called_contract_not_found():
     con = inmemory_with_tables()
     contract_address = populate_test_contract_with_132_on_3(con)
+    entry_point = hex(get_selector_from_name("get_value"))
+
+    common_command_data = f'"entry_point_selector": "{entry_point}", "calldata": ["0x84"], "signature": [], "gas_price": 0, "chain": "GOERLI", "pending_updates": {{}}, "pending_deployed": [], "pending_nonces": {{}}'
 
     output = default_132_on_3_scenario(
         con,
         [
-            f'{{ "command": "call", "at_block": 1, "contract_address": {contract_address + 1}, "entry_point_selector": "get_value", "calldata": [132], "gas_price": null, "chain": "GOERLI" }}'
+            f'{{ "verb": "CALL", "at_block": "1", "contract_address": "{hex(contract_address + 1)}", {common_command_data}}}'
         ],
     )
 
@@ -304,12 +412,15 @@ def test_called_contract_not_found():
 def test_nested_called_contract_not_found():
     con = inmemory_with_tables()
     contract_address = populate_test_contract_with_132_on_3(con)
+    entry_point = hex(get_selector_from_name("call_increase_value"))
+
+    common_command_data = '"signature": [], "gas_price": 0, "chain": "GOERLI", "pending_updates": {}, "pending_deployed": [], "pending_nonces": {}'
 
     output = default_132_on_3_scenario(
         con,
         [
             # call neighbouring contract, which doesn't exist in the global state tree
-            f'{{ "command": "call", "at_block": 1, "contract_address": {contract_address}, "entry_point_selector": "call_increase_value", "calldata": [{contract_address - 1}, 132, 4], "gas_price": null, "chain": "GOERLI" }}'
+            f'{{ "verb": "CALL", "at_block": "1", "contract_address": "{hex(contract_address)}", "entry_point_selector": "{entry_point}", "calldata": ["{hex(contract_address - 1)}", "0x84", "0x4"], {common_command_data} }}'
         ],
     )
 
@@ -320,12 +431,14 @@ def test_nested_called_contract_not_found():
 def test_invalid_entry_point():
     con = inmemory_with_tables()
     contract_address = populate_test_contract_with_132_on_3(con)
+    entry_point = hex(get_selector_from_name("call_increase_value2"))
 
+    common_command_data = '"signature": [], "gas_price": 0, "chain": "GOERLI", "pending_updates": {}, "pending_deployed": [], "pending_nonces": {}'
     output = default_132_on_3_scenario(
         con,
         [
             # call not found entry point with `call_increase_value` args
-            f'{{ "command": "call", "at_block": 1, "contract_address": {contract_address}, "entry_point_selector": "call_increase_value2", "calldata": [{contract_address - 1}, 132, 4], "gas_price": null, "chain": "GOERLI" }}'
+            f'{{ "verb": "CALL", "at_block": "1", "contract_address": "{hex(contract_address)}", "entry_point_selector": "{entry_point}", "calldata": ["{hex(contract_address - 1)}", "0x84", "0x4"], {common_command_data} }}'
         ],
     )
 
@@ -337,7 +450,10 @@ def test_invalid_entry_point():
 
 def test_invalid_schema_version():
     con = inmemory_with_tables()
-    contract_address = populate_test_contract_with_132_on_3(con)
+    contract_address = hex(populate_test_contract_with_132_on_3(con))
+    entry_point = hex(get_selector_from_name("get_value"))
+
+    common_command_data = f'"entry_point_selector": "{entry_point}", "calldata": ["0x84"], "signature": [], "gas_price": 0, "chain": "GOERLI", "pending_updates": {{}}, "pending_deployed": [], "pending_nonces": {{}}'
 
     con.execute("pragma user_version = 0")
     con.commit()
@@ -345,7 +461,7 @@ def test_invalid_schema_version():
     output = default_132_on_3_scenario(
         con,
         [
-            f'{{ "command": "call", "at_block": 1, "contract_address": {contract_address}, "entry_point_selector": "get_value", "calldata": [132], "gas_price": null, "chain": "GOERLI" }}'
+            f'{{ "verb": "CALL", "at_block": "1", "contract_address": "{contract_address}", {common_command_data} }}'
         ],
     )
 
@@ -354,7 +470,10 @@ def test_invalid_schema_version():
 
 def test_no_such_block():
     con = inmemory_with_tables()
-    contract_address = populate_test_contract_with_132_on_3(con)
+    contract_address = hex(populate_test_contract_with_132_on_3(con))
+    entry_point = hex(get_selector_from_name("get_value"))
+
+    common_command_data = f'"contract_address": "{contract_address}", "entry_point_selector": "{entry_point}", "calldata": ["0x84"], "signature": [], "gas_price": 0, "chain": "GOERLI", "pending_updates": {{}}, "pending_deployed": [], "pending_nonces": {{}}'
 
     con.execute("delete from starknet_blocks")
     con.commit()
@@ -364,9 +483,9 @@ def test_no_such_block():
         (
             # there's only block 1
             # it is important that none of these have pending_updates or pending_deployed
-            f'{{ "command": "call", "at_block": 99999999999, "contract_address": {contract_address}, "entry_point_selector": "get_value", "calldata": [132], "gas_price": null, "chain": "GOERLI" }}',
-            f'{{ "command": "call", "at_block": "0x{(b"no such block").hex()}", "contract_address": {contract_address}, "entry_point_selector": "get_value", "calldata": [132], "gas_price": null, "chain": "GOERLI" }}',
-            f'{{ "command": "call", "at_block": "latest", "contract_address": {contract_address}, "entry_point_selector": "get_value", "calldata": [132], "gas_price": null, "chain": "GOERLI" }}',
+            f'{{ "verb": "CALL", "at_block": "99999999999", {common_command_data} }}',
+            f'{{ "verb": "CALL", "at_block": "0x{(b"no such block").hex()}", {common_command_data} }}',
+            f'{{ "verb": "CALL", "at_block": "latest", {common_command_data} }}',
         ),
     )
 
@@ -386,23 +505,28 @@ def test_check_cairolang_version():
 
 
 def test_fee_estimate_on_positive_directly():
-    # fee estimation is a new thing on top of a call, but returning only the estimated fee
     con = inmemory_with_tables()
     contract_address = populate_test_contract_with_132_on_3(con)
 
     con.execute("BEGIN")
 
-    # f'{{ "command": "estimate_fee", "at_block": "latest", "contract_address": {contract_address}, "entry_point_selector": "get_value", "calldata": [132], "gas_price": null }}'
-    command = {
-        "command": "estimate_fee",
-        "at_block": "latest",
-        "contract_address": contract_address,
-        "entry_point_selector": "get_value",
-        "calldata": [132],
-        # gas_price is None for null => use block's (zero)
-        "gas_price": None,
-        "chain": StarknetChainId.TESTNET,
-    }
+    command = EstimateFee(
+        at_block="latest",
+        chain=call.Chain.GOERLI,
+        gas_price=0,
+        pending_updates={},
+        pending_deployed=[],
+        pending_nonces={},
+        transaction=InvokeFunction(
+            version=0x100000000000000000000000000000000,
+            contract_address=contract_address,
+            calldata=[132],
+            entry_point_selector=get_selector_from_name("get_value"),
+            nonce=None,
+            max_fee=0,
+            signature=[],
+        ),
+    )
 
     (verb, output, _timings) = loop_inner(con, command)
 
@@ -413,16 +537,94 @@ def test_fee_estimate_on_positive_directly():
     }
 
 
-def test_fee_estimate_on_positive():
-    # fee estimation is a new thing on top of a call, but returning only the estimated fee
+def test_fee_estimate_for_declare_transaction_directly():
     con = inmemory_with_tables()
     contract_address = populate_test_contract_with_132_on_3(con)
+
+    path = test_relative_path(
+        "../../crates/pathfinder/fixtures/contract_definition.json.zst"
+    )
+
+    with open(path, "rb") as file:
+        contract_definition = file.read()
+        contract_definition = zstandard.decompress(contract_definition)
+        contract_definition = contract_definition.decode("utf-8")
+        contract_definition = ContractClass.Schema().loads(contract_definition)
+
+    con.execute("BEGIN")
+
+    command = EstimateFee(
+        at_block="latest",
+        chain=call.Chain.GOERLI,
+        gas_price=1,
+        pending_updates={},
+        pending_deployed=[],
+        pending_nonces={},
+        transaction=Declare(
+            version=0x100000000000000000000000000000000,
+            max_fee=0,
+            signature=[],
+            nonce=0,
+            contract_class=contract_definition,
+            sender_address=contract_address,
+        ),
+    )
+
+    (verb, output, _timings) = loop_inner(con, command)
+
+    assert output == {
+        "gas_consumed": 1341,
+        "gas_price": 1,
+        "overall_fee": 1341,
+    }
+
+
+def test_fee_estimate_on_positive():
+    con = inmemory_with_tables()
+    contract_address = hex(populate_test_contract_with_132_on_3(con))
+    entry_point = hex(get_selector_from_name("get_value"))
+
+    command = """{{
+        "verb":"ESTIMATE_FEE",
+        "at_block":"latest",
+        "chain":"GOERLI",
+        "gas_price":"{gas_price}",
+        "pending_updates":{{}},
+        "pending_deployed":[],
+        "pending_nonces":{{}},
+        "transaction":{{
+            "type":"INVOKE_FUNCTION",
+            "version":"0x100000000000000000000000000000000",
+            "max_fee":"0x0",
+            "signature":[],
+            "nonce":null,
+            "contract_address":"{contract_address}",
+            "entry_point_selector":"{entry_point}",
+            "calldata":["132"]
+        }}
+    }}"""
 
     (first, second) = default_132_on_3_scenario(
         con,
         [
-            f'{{ "command": "estimate_fee", "at_block": "latest", "contract_address": {contract_address}, "entry_point_selector": "get_value", "calldata": [132], "gas_price": null, "chain": "GOERLI" }}',
-            f'{{ "command": "estimate_fee", "at_block": "latest", "contract_address": {contract_address}, "entry_point_selector": "get_value", "calldata": [132], "gas_price": "0xa", "chain": "GOERLI" }}',
+            json.dumps(
+                json.loads(
+                    command.format(
+                        gas_price="0x0",
+                        contract_address=contract_address,
+                        entry_point=entry_point,
+                    )
+                )
+            ),
+            json.dumps(
+                json.loads(
+                    command.format(
+                        gas_price="0xa",
+                        contract_address=contract_address,
+                        entry_point=entry_point,
+                    )
+                )
+            ),
         ],
     )
 
@@ -457,7 +659,7 @@ def test_starknet_version_is_resolved():
     version_id = cursor.lastrowid
 
     con.execute("UPDATE starknet_blocks SET version_id = ?", [version_id])
-    (info, _root) = resolve_block(con, "latest", None)
+    (info, _root) = resolve_block(con, "latest", 0)
 
     assert info.starknet_version == "0.9.1"
 
@@ -466,30 +668,25 @@ def test_call_on_pending_updated():
     con = inmemory_with_tables()
     contract_address = populate_test_contract_with_132_on_3(con)
     con.execute("BEGIN")
-    contract_address = "0x" + contract_address.to_bytes(32, "big").hex()
 
-    pending_updates = maybe_pending_updates(
-        {
-            contract_address: [
-                {"key": "0x84", "value": "0x99"},
-            ]
-        }
+    command = Call(
+        at_block="latest",
+        chain=call.Chain.MAINNET,
+        contract_address=contract_address,
+        entry_point_selector=get_selector_from_name("get_value"),
+        calldata=[132],
+        max_fee=0,
+        signature=[],
+        nonce=None,
+        pending_updates={contract_address: [call.StorageDiff(key=0x84, value=0x99)]},
+        pending_deployed=[],
+        pending_nonces={},
     )
-
-    command = {
-        "command": "call",
-        "at_block": "latest",
-        "contract_address": int_param(contract_address),
-        "entry_point_selector": "get_value",
-        "calldata": [132],
-        "chain": StarknetChainId.MAINNET,
-        "pending_updates": pending_updates,
-    }
 
     (verb, output, _timings) = loop_inner(con, command)
     assert output == [0x99]
 
-    del command["pending_updates"]
+    command = dataclasses.replace(command, pending_updates={})
     (verb, output, _timings) = loop_inner(con, command)
     assert output == [3]
 
@@ -498,44 +695,30 @@ def test_call_on_pending_deployed():
     con = inmemory_with_tables()
     _ = populate_test_contract_with_132_on_3(con)
     con.execute("BEGIN")
-    contract_address = (
-        "0x18b2088accbd652384e5ac545fd249095cb17bdc709868d1d748094d52b9f7d"
-    )
-    contract_hash = "0x050b2148c0d782914e0b12a1a32abe5e398930b7e914f82c65cb7afce0a0ab9b"
 
-    pending_updates = maybe_pending_updates(
-        {
-            contract_address: [
-                {"key": "0x5", "value": "0x65"},
-            ]
-        }
-    )
+    contract_address = 0x18B2088ACCBD652384E5AC545FD249095CB17BDC709868D1D748094D52B9F7D
+    contract_hash = 0x050B2148C0D782914E0B12A1A32ABE5E398930B7E914F82C65CB7AFCE0A0AB9B
 
-    pending_deployed = maybe_pending_deployed(
-        [
-            {
-                "address": contract_address,
-                "contract_hash": contract_hash,
-            }
-        ]
+    command = Call(
+        at_block="latest",
+        chain=call.Chain.MAINNET,
+        contract_address=contract_address,
+        entry_point_selector=get_selector_from_name("get_value"),
+        calldata=[5],
+        max_fee=0,
+        signature=[],
+        nonce=None,
+        pending_updates={contract_address: [call.StorageDiff(key=0x5, value=0x65)]},
+        pending_deployed=[
+            call.DeployedContract(address=contract_address, contract_hash=contract_hash)
+        ],
+        pending_nonces={},
     )
-
-    command = {
-        "command": "call",
-        "at_block": "latest",
-        "contract_address": int_param(contract_address),
-        "entry_point_selector": "get_value",
-        "calldata": [5],
-        "gas_price": None,
-        "chain": StarknetChainId.MAINNET,
-        "pending_updates": pending_updates,
-        "pending_deployed": pending_deployed,
-    }
 
     (verb, output, _timings) = loop_inner(con, command)
     assert output == [0x65]
 
-    del command["pending_updates"]
+    command = dataclasses.replace(command, pending_updates={})
     (verb, output, _timings) = loop_inner(con, command)
     assert output == [0]
 
@@ -544,46 +727,32 @@ def test_call_on_pending_deployed_through_existing():
     con = inmemory_with_tables()
     orig_contract_address = populate_test_contract_with_132_on_3(con)
     con.execute("BEGIN")
-    contract_address = (
-        "0x18b2088accbd652384e5ac545fd249095cb17bdc709868d1d748094d52b9f7d"
-    )
-    contract_hash = "0x050b2148c0d782914e0b12a1a32abe5e398930b7e914f82c65cb7afce0a0ab9b"
 
-    pending_updates = maybe_pending_updates(
-        {
-            contract_address: [
-                {"key": "0x5", "value": "0x65"},
-            ]
-        }
-    )
+    contract_address = 0x18B2088ACCBD652384E5AC545FD249095CB17BDC709868D1D748094D52B9F7D
+    contract_hash = 0x050B2148C0D782914E0B12A1A32ABE5E398930B7E914F82C65CB7AFCE0A0AB9B
 
-    pending_deployed = maybe_pending_deployed(
-        [
-            {
-                "address": contract_address,
-                "contract_hash": contract_hash,
-            }
-        ]
-    )
-
-    command = {
-        "command": "call",
-        "at_block": "latest",
-        "contract_address": orig_contract_address,
-        "entry_point_selector": "call_increase_value",
-        "calldata": [
+    command = Call(
+        at_block="latest",
+        chain=call.Chain.MAINNET,
+        contract_address=orig_contract_address,
+        entry_point_selector=get_selector_from_name("call_increase_value"),
+        calldata=[
             # target contract
-            int_param(contract_address),
+            contract_address,
             # address
             5,
             # increment by
             4,
         ],
-        "gas_price": None,
-        "chain": StarknetChainId.MAINNET,
-        "pending_updates": pending_updates,
-        "pending_deployed": pending_deployed,
-    }
+        max_fee=0,
+        signature=[],
+        nonce=None,
+        pending_updates={contract_address: [call.StorageDiff(key=0x5, value=0x65)]},
+        pending_deployed=[
+            call.DeployedContract(address=contract_address, contract_hash=contract_hash)
+        ],
+        pending_nonces={},
+    )
 
     # the call_increase_value doesn't return anything, which is a bit unfortunate.
     # the reason why this works is probably because the contract is already
@@ -592,7 +761,7 @@ def test_call_on_pending_deployed_through_existing():
     # FIXME: add a test case for calling from existing to a new deployed contract.
     # It'll probably be easy to just modify the existing test.cairo thing we
     # already have, add a method or a return value to call_increase_value.
-    (verb, output, _timings) = loop_inner(con, command)
+    (_verb, output, _timings) = loop_inner(con, command)
     assert output == []
 
 
@@ -612,122 +781,94 @@ def test_call_on_reorgged_pending_block():
     con = inmemory_with_tables()
     contract_address = populate_test_contract_with_132_on_3(con)
 
-    existing_block = int_hash_or_latest(f'0x{(b"some blockhash somewhere").hex()}')
-    reorgged_block = int_hash_or_latest(f'0x{(b"this block got reorgged").hex()}')
+    existing_block = f'0x{(b"some blockhash somewhere").hex()}'
+    reorgged_block = f'0x{(b"this block got reorgged").hex()}'
 
-    commands = []
-
-    commands.append(
+    commands = [
         (
-            {
-                "command": "call",
-                "at_block": existing_block,
-                "contract_address": contract_address,
-                "entry_point_selector": "get_value",
-                "calldata": [132],
-                "gas_price": None,
-                "chain": StarknetChainId.MAINNET,
-                "pending_updates": maybe_pending_updates(
-                    {
-                        contract_address: [
-                            {"key": 132, "value": 5},
-                        ]
-                    }
-                ),
-                "pending_deployed": maybe_pending_deployed([]),
-            },
+            Call(
+                at_block=existing_block,
+                chain=call.Chain.MAINNET,
+                contract_address=contract_address,
+                entry_point_selector=get_selector_from_name("get_value"),
+                calldata=[132],
+                max_fee=0,
+                signature=[],
+                nonce=None,
+                pending_updates={
+                    contract_address: [call.StorageDiff(key=132, value=5)]
+                },
+                pending_deployed=[],
+                pending_nonces={},
+            ),
             [5],
-        )
-    )
-
-    commands.append(
+        ),
         (
-            {
-                "command": "call",
+            Call(
                 # this block is not found
-                "at_block": reorgged_block,
-                "contract_address": contract_address,
-                "entry_point_selector": "get_value",
-                "calldata": [132],
-                "gas_price": None,
-                "chain": StarknetChainId.MAINNET,
+                at_block=reorgged_block,
+                chain=call.Chain.MAINNET,
+                contract_address=contract_address,
+                entry_point_selector=get_selector_from_name("get_value"),
+                calldata=[132],
+                max_fee=0,
+                signature=[],
+                nonce=None,
                 # because the block is not found, the updates are not used
-                "pending_updates": maybe_pending_updates(
-                    {
-                        contract_address: [
-                            {"key": 132, "value": 5},
-                        ]
-                    }
-                ),
-                "pending_deployed": maybe_pending_deployed([]),
-            },
+                pending_updates={
+                    contract_address: [call.StorageDiff(key=132, value=5)]
+                },
+                pending_deployed=[],
+                pending_nonces={},
+            ),
             [3],
-        )
-    )
-
-    # similar to above cases, but this time call on pending_deployed address.
-
-    commands.append(
+        ),
+        # similar to above cases, but this time call on pending_deployed address.
         (
-            {
-                "command": "call",
-                "at_block": existing_block,
-                "contract_address": 1234567,
-                "entry_point_selector": "get_value",
-                "calldata": [132],
-                "gas_price": None,
-                "chain": StarknetChainId.MAINNET,
-                "pending_updates": maybe_pending_updates(
-                    {
-                        1234567: [
-                            {"key": 132, "value": 5},
-                        ]
-                    }
-                ),
-                "pending_deployed": maybe_pending_deployed(
-                    [
-                        {
-                            "address": 1234567,
-                            "contract_hash": "0x050b2148c0d782914e0b12a1a32abe5e398930b7e914f82c65cb7afce0a0ab9b",
-                        }
-                    ]
-                ),
-            },
+            Call(
+                at_block=existing_block,
+                chain=call.Chain.MAINNET,
+                contract_address=1234567,
+                entry_point_selector=get_selector_from_name("get_value"),
+                calldata=[132],
+                max_fee=0,
+                signature=[],
+                nonce=None,
+                pending_updates={1234567: [call.StorageDiff(key=132, value=5)]},
+                pending_deployed=[
+                    call.DeployedContract(
+                        address=1234567,
+                        contract_hash=0x050B2148C0D782914E0B12A1A32ABE5E398930B7E914F82C65CB7AFCE0A0AB9B,
+                    )
+                ],
+                pending_nonces={},
+            ),
             [5],
-        )
-    )
-
-    commands.append(
+        ),
         (
-            {
-                "command": "call",
+            Call(
                 # this block is not found
-                "at_block": reorgged_block,
-                "contract_address": 1234567,
-                "entry_point_selector": "get_value",
-                "calldata": [132],
-                "gas_price": None,
-                "chain": StarknetChainId.MAINNET,
+                at_block=reorgged_block,
+                chain=call.Chain.MAINNET,
+                contract_address=1234567,
+                entry_point_selector=get_selector_from_name("get_value"),
+                calldata=[132],
+                max_fee=0,
+                signature=[],
+                nonce=None,
                 # because the block is not found, the updates are not used
-                "pending_updates": maybe_pending_updates(
-                    {
-                        1234567: [
-                            {"key": 132, "value": 5},
-                        ]
-                    }
-                ),
-                "pending_deployed": maybe_pending_deployed(
-                    [
-                        {
-                            "address": 1234567,
-                            "contract_hash": "0x050b2148c0d782914e0b12a1a32abe5e398930b7e914f82c65cb7afce0a0ab9b",
-                        }
-                    ]
-                ),
-            },
+                pending_updates={1234567: [call.StorageDiff(key=132, value=5)]},
+                pending_deployed=[
+                    call.DeployedContract(
+                        address=1234567,
+                        contract_hash=0x050B2148C0D782914E0B12A1A32ABE5E398930B7E914F82C65CB7AFCE0A0AB9B,
+                    )
+                ],
+                pending_nonces={},
+            ),
             "StarknetErrorCode.UNINITIALIZED_CONTRACT",
-        )
-    )
+        ),
+    ]
 
     # existing test cases calling on non-existing blocks should work as they have been,
     # because they don't define any value for pending stuffs
@@ -743,11 +884,11 @@ def test_call_on_reorgged_pending_block():
 
 def test_static_returned_not_found_contract_state():
     # this is quite silly that we need to communicate serialized default values instead of None for not found values
-    from starkware.starkware_utils.commitment_tree.patricia_tree.patricia_tree import (
-        PatriciaTree,
-    )
     from starkware.starknet.business_logic.fact_state.contract_state_objects import (
         ContractState,
+    )
+    from starkware.starkware_utils.commitment_tree.patricia_tree.patricia_tree import (
+        PatriciaTree,
     )
 
     dumped = (
@@ -757,24 +898,6 @@ def test_static_returned_not_found_contract_state():
     )
     # test is to make sure the static value is up to date between versions
     assert dumped == NOT_FOUND_CONTRACT_STATE
-
-
-def test_maybe_pending_updates():
-    example = {"0x123": [{"key": 1, "value": 2}]}
-    expected = {291: [(1, 2)]}
-    assert expected == maybe_pending_updates(example)
-
-
-def test_maybe_pending_deployed():
-    example = [{"address": "0x123", "contract_hash": "0x12345"}]
-    expected = {291: bytes.fromhex("012345")}
-    assert expected == maybe_pending_deployed(example)
-
-
-def test_maybe_pending_nonces():
-    example = {"0x123": "0x12345"}
-    expected = {291: 74565}
-    assert expected == maybe_pending_nonces(example)
 
 
 def test_nonce_with_dummy():
@@ -921,102 +1044,109 @@ def test_nonce_with_dummy():
     # second and third block with a new account at two different nonces
 
     # this will be used as a basis for the other commands with the `dict(base, **updates)` signature
-    base_command = {
-        "command": "estimate_fee",
-        "at_block": b"some blockhash somewhere",
-        "contract_address": 0x123,
-        # cairo-lang asserts that this is None
-        # "entry_point_selector": "__execute__",
+    base_transaction = InvokeFunction(
+        version=0x100000000000000000000000000000001,
+        contract_address=0x123,
         # this should be: target address, target selector, input len, input..
-        "calldata": [test_contract, get_selector_from_name("get_value"), 1, 132],
-        "gas_price": 0x1,
-        "chain": StarknetChainId.MAINNET,
-        "nonce": 0,
-        "version": 1,
-    }
+        calldata=[test_contract, get_selector_from_name("get_value"), 1, 132],
+        entry_point_selector=None,
+        nonce=0,
+        max_fee=0,
+        signature=[],
+    )
+    base_command = EstimateFee(
+        at_block=f'0x{(b"some blockhash somewhere").hex()}',
+        chain=call.Chain.MAINNET,
+        gas_price=0x1,
+        pending_updates={},
+        pending_deployed=[],
+        pending_nonces={},
+        transaction=base_transaction,
+    )
 
-    commands = []
-    commands.append(
+    commands = [
         (
             # on the first block there is no contract by that address
             base_command,
             "StarknetErrorCode.UNINITIALIZED_CONTRACT",
-        )
-    )
-    commands.append(
+        ),
         (
             # in this block the acct contract has been deployed, so it has nonce=0
-            dict(base_command, at_block=b"another block"),
+            dataclasses.replace(base_command, at_block=f'0x{(b"another block").hex()}'),
             {"gas_consumed": 1400, "gas_price": 1, "overall_fee": 1400},
-        )
-    )
-    commands.append(
+        ),
         (
-            dict(base_command, at_block=b"another block", nonce=1),
+            dataclasses.replace(
+                base_command,
+                at_block=f'0x{(b"another block").hex()}',
+                transaction=dataclasses.replace(base_transaction, nonce=1),
+            ),
             "StarknetErrorCode.INVALID_TRANSACTION_NONCE",
-        )
-    )
-    commands.append(
+        ),
         (
-            dict(base_command, at_block=b"another block", nonce=2),
+            dataclasses.replace(
+                base_command,
+                at_block=f'0x{(b"another block").hex()}',
+                transaction=dataclasses.replace(base_transaction, nonce=2),
+            ),
             "StarknetErrorCode.INVALID_TRANSACTION_NONCE",
-        )
-    )
-    commands.append(
+        ),
         (
             # in this block the stored nonce is 1
-            dict(base_command, at_block=b"third block", nonce=1),
+            dataclasses.replace(
+                base_command,
+                at_block=f'0x{(b"third block").hex()}',
+                transaction=dataclasses.replace(base_transaction, nonce=1),
+            ),
             {"gas_consumed": 1400, "gas_price": 1, "overall_fee": 1400},
-        )
-    )
-    commands.append(
+        ),
         (
-            dict(base_command, at_block=b"third block", nonce=2),
+            dataclasses.replace(
+                base_command,
+                at_block=f'0x{(b"third block").hex()}',
+                transaction=dataclasses.replace(base_transaction, nonce=2),
+            ),
             "StarknetErrorCode.INVALID_TRANSACTION_NONCE",
-        )
-    )
-    commands.append(
+        ),
         (
             # in this block the stored nonce is 1
-            dict(base_command, at_block=b"third block", nonce=3),
+            dataclasses.replace(
+                base_command,
+                at_block=f'0x{(b"third block").hex()}',
+                transaction=dataclasses.replace(base_transaction, nonce=3),
+            ),
             "StarknetErrorCode.INVALID_TRANSACTION_NONCE",
-        )
-    )
-    commands.append(
+        ),
         (
             # now the nonce requirement should had been advanced to 2
-            dict(
+            dataclasses.replace(
                 base_command,
-                at_block=b"third block",
-                nonce=1,
+                at_block=f'0x{(b"third block").hex()}',
+                transaction=dataclasses.replace(base_transaction, nonce=1),
                 pending_nonces={0x123: 2},
             ),
             "StarknetErrorCode.INVALID_TRANSACTION_NONCE",
-        )
-    )
-    commands.append(
+        ),
         (
             # now the nonce requirement should had been advanced to 2
-            dict(
+            dataclasses.replace(
                 base_command,
-                at_block=b"third block",
-                nonce=2,
+                at_block=f'0x{(b"third block").hex()}',
+                transaction=dataclasses.replace(base_transaction, nonce=2),
                 pending_nonces={0x123: 2},
             ),
             {"gas_consumed": 1400, "gas_price": 1, "overall_fee": 1400},
-        )
-    )
-    commands.append(
+        ),
         (
-            dict(
+            dataclasses.replace(
                 base_command,
-                at_block=b"third block",
-                nonce=3,
+                at_block=f'0x{(b"third block").hex()}',
+                transaction=dataclasses.replace(base_transaction, nonce=3),
                 pending_nonces={0x123: 2},
             ),
             "StarknetErrorCode.INVALID_TRANSACTION_NONCE",
-        )
-    )
+        ),
+    ]
 
     con.execute("BEGIN")
     for nth, (command, expected) in enumerate(commands):
@@ -1024,8 +1154,8 @@ def test_nonce_with_dummy():
             print(command)
             (verb, output, _timings) = loop_inner(con, command)
             assert expected == output, f"{nth + 1}th example"
-        except WebFriendlyException as e:
-            assert expected == str(e.code), f"{nth + 1}th example"
+        except WebFriendlyException as exc:
+            assert expected == str(exc.code), f"{nth + 1}th example"
 
 
 # Rest of the test cases require a mainnet or goerli database in some path.
@@ -1042,31 +1172,37 @@ def test_failing_mainnet_tx2():
     # easiest way to find this command is to add logging into the call.py::loop_inner:
     #    print(f"{command}", file=sys.stderr, flush=True)
     # then reproduce it in a test case like this, let automatic formatting do it's job.
-    command = {
-        "command": "estimate_fee",
-        "contract_address": 45915111574649954983606422480229741823594314537836586888051448850027079668,
-        "calldata": [
-            1,
-            2087021424722619777119509474943472645767659996348769578120564519014510906823,
-            232670485425082704932579856502088130646006032362877466777181098476241604910,
-            0,
-            3,
-            3,
-            1993141595574381281542654435135626980310393893133465032682864365884756205412,
-            8235300000000000,
-            0,
-            1,
-        ],
-        "entry_point_selector": 617075754465154585683856897856256838130216341506379215893724690153393808813,
-        "at_block": b"\x01G\xc4\xb0\xf7\x02\x07\x93\x84\xe2m\x9d4\xa1^wX\x88\x1e2\xb2\x19\xfch\xc0v\xb0\x9d\x0b\xe1?\x8c",
-        "gas_price": 21367239423,
-        "signature": [
-            0x10E400D046147777C2AC5645024E1EE81C86D90B52D76AB8A8125E5F49612F9,
-            0xADB92739205B4626FEFB533B38D0071EB018E6FF096C98C17A6826B536817B,
-        ],
-        "max_fee": 0x12C72866EFA9B,
-        "chain": StarknetChainId.MAINNET,
-    }
+    command = EstimateFee(
+        at_block="0x0147c4b0f702079384e26d9d34a15e7758881e32b219fc68c076b09d0be13f8c",
+        chain=call.Chain.MAINNET,
+        gas_price=21367239423,
+        pending_updates={},
+        pending_deployed=[],
+        pending_nonces={},
+        transaction=InvokeFunction(
+            version=0,
+            contract_address=45915111574649954983606422480229741823594314537836586888051448850027079668,
+            calldata=[
+                1,
+                2087021424722619777119509474943472645767659996348769578120564519014510906823,
+                232670485425082704932579856502088130646006032362877466777181098476241604910,
+                0,
+                3,
+                3,
+                1993141595574381281542654435135626980310393893133465032682864365884756205412,
+                8235300000000000,
+                0,
+                1,
+            ],
+            entry_point_selector=617075754465154585683856897856256838130216341506379215893724690153393808813,
+            nonce=None,
+            max_fee=0x12C72866EFA9B,
+            signature=[
+                0x10E400D046147777C2AC5645024E1EE81C86D90B52D76AB8A8125E5F49612F9,
+                0xADB92739205B4626FEFB533B38D0071EB018E6FF096C98C17A6826B536817B,
+            ],
+        ),
+    )
 
     (verb, output, _timings) = loop_inner(con, command)
 
@@ -1085,44 +1221,41 @@ def test_positive_streamed_on_early_goerli_block_without_deployed():
     con = sqlite3.connect(test_relative_path("../../goerli.sqlite"))
     con.execute("BEGIN")
 
-    # this is copypasted from the get_state_update
-    pending_updates = {
-        "0x7c38021eb1f890c5d572125302fe4a0d2f79d38b018d68a9fcd102145d4e451": [
-            {"key": "0x5", "value": "0x0"}
-        ],
-        # this is the one we care about, it was written at block 5 to 0x64
-        "0x543e54f26ae33686f57da2ceebed98b340c3a78e9390931bd84fb711d5caabc": [
-            {"key": "0x5", "value": "0x22b"}
-        ],
-        # leave this out since it was deployed, which we should list as well, but not yet
-        # "0x18b2088accbd652384e5ac545fd249095cb17bdc709868d1d748094d52b9f7d": [
-        #     {"key": "0x5", "value": "0x65"},
-        #     {
-        #         "key": "0x2199e6fee3564246f851c45e8268c79fe073caff90420878b3fb11458d77139",
-        #         "value": "0x563e7b33aef472392dfb1a491f739295bad7105e669a6183c6f1a76124bafd1",
-        #     },
-        # ],
-        "0x2fb7ff5b1b474e8e691f5bebad9aa7aa3009f6ef22ccc2816f96cdfe217604d": [
-            {"key": "0x5", "value": "0x64"}
-        ],
-    }
+    with_updates = Call(
+        at_block="6",
+        chain=call.Chain.GOERLI,
+        contract_address=0x543E54F26AE33686F57DA2CEEBED98B340C3A78E9390931BD84FB711D5CAABC,
+        entry_point_selector=get_selector_from_name("get_value"),
+        calldata=[5],
+        max_fee=0,
+        signature=[],
+        nonce=None,
+        # this is from the corresponding state update for block 6
+        pending_updates={
+            0x7C38021EB1F890C5D572125302FE4A0D2F79D38B018D68A9FCD102145D4E451: [
+                call.StorageDiff(key=0x5, value=0x0)
+            ],
+            # this is the one we care about, it was written at block 5 to 0x64
+            0x543E54F26AE33686F57DA2CEEBED98B340C3A78E9390931BD84FB711D5CAABC: [
+                call.StorageDiff(key=0x5, value=0x22B)
+            ],
+            # leave this out since it was deployed, which we should list as well, but not yet
+            # 0x18B2088ACCBD652384E5AC545FD249095CB17BDC709868D1D748094D52B9F7D: [
+            #     call.StorageDiff(key=0x5, value=0x65),
+            #     call.StorageDiff(
+            #         key=0x2199E6FEE3564246F851C45E8268C79FE073CAFF90420878B3FB11458D77139,
+            #         value=0x563E7B33AEF472392DFB1A491F739295BAD7105E669A6183C6F1A76124BAFD1,
+            #     ),
+            # ],
+            0x2FB7FF5B1B474E8E691F5BEBAD9AA7AA3009F6EF22CCC2816F96CDFE217604D: [
+                call.StorageDiff(key=0x5, value=0x64),
+            ],
+        },
+        pending_deployed=[],
+        pending_nonces={},
+    )
 
-    pending_updates = maybe_pending_updates(pending_updates)
-
-    without_updates = {
-        "command": "call",
-        "at_block": 6,
-        "contract_address": int_param(
-            "0x543e54f26ae33686f57da2ceebed98b340c3a78e9390931bd84fb711d5caabc"
-        ),
-        "entry_point_selector": "get_value",
-        "calldata": [5],
-        "gas_price": None,
-        "chain": StarknetChainId.TESTNET,
-    }
-
-    with_updates = copy.deepcopy(without_updates)
-    with_updates["pending_updates"] = pending_updates
+    without_updates = dataclasses.replace(with_updates, pending_updates={})
 
     (verb, output, _timings) = loop_inner(con, without_updates)
     assert output == [0x64]
@@ -1136,55 +1269,51 @@ def test_positive_streamed_on_early_goerli_block_with_deployed():
     con = sqlite3.connect(test_relative_path("../../goerli.sqlite"))
     con.execute("BEGIN")
 
-    # this is copypasted from the get_state_update
+    # this is from the corresponding state update for block 6
     pending_updates = {
-        "0x7c38021eb1f890c5d572125302fe4a0d2f79d38b018d68a9fcd102145d4e451": [
-            {"key": "0x5", "value": "0x0"}
+        0x7C38021EB1F890C5D572125302FE4A0D2F79D38B018D68A9FCD102145D4E451: [
+            call.StorageDiff(key=0x5, value=0x0)
         ],
         # this is the one we care about, it was written at block 5 to 0x64
-        "0x543e54f26ae33686f57da2ceebed98b340c3a78e9390931bd84fb711d5caabc": [
-            {"key": "0x5", "value": "0x22b"}
+        0x543E54F26AE33686F57DA2CEEBED98B340C3A78E9390931BD84FB711D5CAABC: [
+            call.StorageDiff(key=0x5, value=0x22B)
         ],
-        "0x18b2088accbd652384e5ac545fd249095cb17bdc709868d1d748094d52b9f7d": [
-            {"key": "0x5", "value": "0x65"},
-            {
-                "key": "0x2199e6fee3564246f851c45e8268c79fe073caff90420878b3fb11458d77139",
-                "value": "0x563e7b33aef472392dfb1a491f739295bad7105e669a6183c6f1a76124bafd1",
-            },
+        0x18B2088ACCBD652384E5AC545FD249095CB17BDC709868D1D748094D52B9F7D: [
+            call.StorageDiff(key=0x5, value=0x65),
+            call.StorageDiff(
+                key=0x2199E6FEE3564246F851C45E8268C79FE073CAFF90420878B3FB11458D77139,
+                value=0x563E7B33AEF472392DFB1A491F739295BAD7105E669A6183C6F1A76124BAFD1,
+            ),
         ],
-        "0x2fb7ff5b1b474e8e691f5bebad9aa7aa3009f6ef22ccc2816f96cdfe217604d": [
-            {"key": "0x5", "value": "0x64"}
+        0x2FB7FF5B1B474E8E691F5BEBAD9AA7AA3009F6EF22CCC2816F96CDFE217604D: [
+            call.StorageDiff(key=0x5, value=0x64),
         ],
     }
 
-    pending_updates = maybe_pending_updates(pending_updates)
-
-    # this matches sequencer state update
     pending_deployed = [
-        {
-            "address": "0x18b2088accbd652384e5ac545fd249095cb17bdc709868d1d748094d52b9f7d",
-            "contract_hash": "0x010455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8",
-        }
+        call.DeployedContract(
+            address=0x18B2088ACCBD652384E5AC545FD249095CB17BDC709868D1D748094D52B9F7D,
+            contract_hash=0x010455C752B86932CE552F2B0FE81A880746649B9AEE7E0D842BF3F52378F9F8,
+        )
     ]
 
-    # pending deployed contracts need to be included because otherwise the contract => class mapping could not be resolved.
-    pending_deployed = maybe_pending_deployed(pending_deployed)
+    with_updates = Call(
+        at_block="6",
+        chain=call.Chain.GOERLI,
+        contract_address=0x543E54F26AE33686F57DA2CEEBED98B340C3A78E9390931BD84FB711D5CAABC,
+        entry_point_selector=get_selector_from_name("get_value"),
+        calldata=[5],
+        max_fee=0,
+        signature=[],
+        nonce=None,
+        pending_updates=pending_updates,
+        pending_deployed=pending_deployed,
+        pending_nonces={},
+    )
 
-    without_updates = {
-        "command": "call",
-        "at_block": 6,
-        "contract_address": int_param(
-            "0x543e54f26ae33686f57da2ceebed98b340c3a78e9390931bd84fb711d5caabc"
-        ),
-        "entry_point_selector": "get_value",
-        "calldata": [5],
-        "gas_price": None,
-        "chain": StarknetChainId.TESTNET,
-    }
-
-    with_updates = copy.deepcopy(without_updates)
-    with_updates["pending_updates"] = pending_updates
-    with_updates["pending_deployed"] = pending_deployed
+    without_updates = dataclasses.replace(
+        with_updates, pending_updates={}, pending_deployed=[]
+    )
 
     (verb, output, _timings) = loop_inner(con, without_updates)
     assert output == [0x64]
@@ -1200,25 +1329,24 @@ def test_positive_streamed_on_early_goerli_block_with_deployed():
     # the reason must be that other pending_updates had prompted fetching of
     # the required (and shared) contract_hash so this didn't seem to require
     # it.
-
-    on_newly_deployed = {
-        "command": "call",
-        "at_block": 6,
-        "contract_address": int_param(
-            "0x18b2088accbd652384e5ac545fd249095cb17bdc709868d1d748094d52b9f7d"
-        ),
-        "entry_point_selector": "get_value",
-        "calldata": [5],
-        "gas_price": None,
-        "chain": StarknetChainId.MAINNET,
-        "pending_updates": pending_updates,
-        "pending_deployed": pending_deployed,
-    }
+    on_newly_deployed = Call(
+        at_block="6",
+        chain=call.Chain.GOERLI,
+        contract_address=pending_deployed[0].address,
+        entry_point_selector=get_selector_from_name("get_value"),
+        calldata=[5],
+        max_fee=0,
+        signature=[],
+        nonce=None,
+        pending_updates=pending_updates,
+        pending_deployed=pending_deployed,
+        pending_nonces={},
+    )
 
     (verb, output, _timings) = loop_inner(con, on_newly_deployed)
     assert output == [0x65]
 
-    del on_newly_deployed["pending_updates"][on_newly_deployed["contract_address"]]
+    del on_newly_deployed.pending_updates[on_newly_deployed.contract_address]
 
     (verb, output, _timings) = loop_inner(con, on_newly_deployed)
     assert output == [0]


### PR DESCRIPTION
And change the Rust layer to use `BroadcastedTransaction` as the input to `estimate_fee`.

This PR doesn't _yet_ add support for estimating non-invoke transactions (although it has a single test case in the Python code). Functionally this refactor is still equivalent to our previous code, but it adds the infrastructure required to represent broadcasted transactions as an input to fee estimation both in the Rust and the Python code.