### PR TITLE
feat(rpc/v02): add `starknet_call`

### DIFF
--- a/crates/pathfinder/src/cairo/ext_py/ser.rs
+++ b/crates/pathfinder/src/cairo/ext_py/ser.rs
@@ -1,9 +1,6 @@
 //! The json serializable types
 
-use crate::core::{
-    CallParam, ContractAddress, ContractNonce, EntryPoint, TransactionNonce,
-    TransactionSignatureElem,
-};
+use crate::core::{CallParam, ContractAddress, ContractNonce, EntryPoint};
 use crate::rpc::v01::types::BlockHashOrTag;
 use crate::sequencer::reply::state_update::{DeployedContract, StorageDiff};
 use std::collections::HashMap;
@@ -19,9 +16,6 @@ pub(crate) enum ChildCommand<'a> {
 
         contract_address: &'a ContractAddress,
         calldata: &'a [CallParam],
-        max_fee: &'a crate::core::Fee,
-        signature: &'a [TransactionSignatureElem],
-        nonce: Option<&'a TransactionNonce>,
         entry_point_selector: Option<&'a EntryPoint>,
     },
     EstimateFee {

--- a/crates/pathfinder/src/cairo/ext_py/sub_process.rs
+++ b/crates/pathfinder/src/cairo/ext_py/sub_process.rs
@@ -360,13 +360,6 @@ async fn process(
             },
             contract_address: &call.contract_address,
             calldata: &call.calldata,
-            max_fee: &call.max_fee,
-            signature: &call.signature,
-            nonce: if call.version.is_zero() {
-                None
-            } else {
-                Some(&call.nonce)
-            },
             entry_point_selector: call.entry_point_selector.as_ref(),
         },
         Command::EstimateFee {

--- a/crates/pathfinder/src/rpc/v02.rs
+++ b/crates/pathfinder/src/rpc/v02.rs
@@ -184,6 +184,7 @@ where
 
 // Registers all methods for the v0.2 API
 pub fn register_all_methods(module: &mut jsonrpsee::RpcModule<RpcContext>) -> anyhow::Result<()> {
+    register_method(module, "starknet_call", method::call::call)?;
     register_method_with_no_input(module, "starknet_chainId", method::chain_id::chain_id)?;
     register_method(
         module,

--- a/crates/pathfinder/src/rpc/v02/method.rs
+++ b/crates/pathfinder/src/rpc/v02/method.rs
@@ -1,6 +1,7 @@
 pub(super) mod add_declare_transaction;
 pub(super) mod add_invoke_transaction;
 pub(super) mod block_hash_and_number;
+pub(super) mod call;
 pub(super) mod chain_id;
 pub(super) mod estimate_fee;
 pub(super) mod get_block;

--- a/crates/pathfinder/src/rpc/v02/method/call.rs
+++ b/crates/pathfinder/src/rpc/v02/method/call.rs
@@ -1,0 +1,243 @@
+use crate::{
+    core::{BlockId, CallParam, CallResultValue, ContractAddress, EntryPoint},
+    rpc::v02::RpcContext,
+};
+
+crate::rpc::error::generate_rpc_error_subset!(
+    CallError: BlockNotFound,
+    ContractNotFound,
+    InvalidMessageSelector,
+    InvalidCallData,
+    ContractError
+);
+
+impl From<crate::cairo::ext_py::CallFailure> for CallError {
+    fn from(c: crate::cairo::ext_py::CallFailure) -> Self {
+        use crate::cairo::ext_py::CallFailure::*;
+        match c {
+            NoSuchBlock => Self::BlockNotFound,
+            NoSuchContract => Self::ContractNotFound,
+            InvalidEntryPoint => Self::InvalidMessageSelector,
+            ExecutionFailed(e) => Self::Internal(anyhow::anyhow!("Internal error: {}", e)),
+            // Intentionally hide the message under Internal
+            Internal(_) | Shutdown => Self::Internal(anyhow::anyhow!("Internal error")),
+        }
+    }
+}
+
+#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+pub struct CallInput {
+    request: FunctionCall,
+    block_id: BlockId,
+}
+
+#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+pub struct FunctionCall {
+    pub contract_address: ContractAddress,
+    pub entry_point_selector: EntryPoint,
+    pub calldata: Vec<CallParam>,
+}
+
+impl From<FunctionCall> for crate::rpc::v01::types::request::Call {
+    fn from(call: FunctionCall) -> Self {
+        Self {
+            contract_address: call.contract_address,
+            calldata: call.calldata,
+            entry_point_selector: Some(call.entry_point_selector),
+            // TODO: these fields are estimateFee-only and effectively ignored
+            // by the underlying implementation. We can remove these once
+            // JSON-RPC v0.1.0 is removed.
+            signature: vec![],
+            max_fee: Self::DEFAULT_MAX_FEE,
+            version: Self::DEFAULT_VERSION,
+            nonce: Self::DEFAULT_NONCE,
+        }
+    }
+}
+
+pub async fn call(
+    context: RpcContext,
+    input: CallInput,
+) -> Result<Vec<CallResultValue>, CallError> {
+    let handle = context
+        .call_handle
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("Unsupported configuration"))?;
+
+    let (when, pending_update) =
+        super::estimate_fee::base_block_and_pending_for_call(input.block_id, &context.pending_data)
+            .await?;
+
+    let result = handle
+        .call(input.request.into(), when, pending_update)
+        .await?;
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::starkhash;
+
+    mod parsing {
+        use crate::core::StarknetBlockHash;
+
+        use super::*;
+
+        use jsonrpsee::types::Params;
+
+        #[test]
+        fn positional_args() {
+            let positional = r#"[
+                { "contract_address": "0xabcde", "entry_point_selector": "0xee", "calldata": ["0x1234", "0x2345"] },
+                { "block_hash": "0xbbbbbbbb" }
+            ]"#;
+            let positional = Params::new(Some(positional));
+
+            let input = positional.parse::<CallInput>().unwrap();
+            let expected = CallInput {
+                request: FunctionCall {
+                    contract_address: ContractAddress::new_or_panic(starkhash!("0abcde")),
+                    entry_point_selector: EntryPoint(starkhash!("ee")),
+                    calldata: vec![CallParam(starkhash!("1234")), CallParam(starkhash!("2345"))],
+                },
+                block_id: StarknetBlockHash(starkhash!("bbbbbbbb")).into(),
+            };
+            assert_eq!(input, expected);
+        }
+
+        #[test]
+        fn named_args() {
+            let named = r#"{
+                "request": { "contract_address": "0xabcde", "entry_point_selector": "0xee", "calldata": ["0x1234", "0x2345"] },
+                "block_id": { "block_hash": "0xbbbbbbbb" }
+            }"#;
+            let named = Params::new(Some(named));
+
+            let input = named.parse::<CallInput>().unwrap();
+            let expected = CallInput {
+                request: FunctionCall {
+                    contract_address: ContractAddress::new_or_panic(starkhash!("0abcde")),
+                    entry_point_selector: EntryPoint(starkhash!("ee")),
+                    calldata: vec![CallParam(starkhash!("1234")), CallParam(starkhash!("2345"))],
+                },
+                block_id: StarknetBlockHash(starkhash!("bbbbbbbb")).into(),
+            };
+            assert_eq!(input, expected);
+        }
+    }
+
+    mod ext_py {
+        use std::path::PathBuf;
+        use std::sync::Arc;
+
+        use crate::core::{Chain, StarknetBlockHash};
+        use crate::starkhash_bytes;
+        use crate::storage::JournalMode;
+
+        use super::*;
+
+        // Mainnet block number 5
+        const BLOCK_5: BlockId = BlockId::Hash(StarknetBlockHash(starkhash!(
+            "00dcbd2a4b597d051073f40a0329e585bb94b26d73df69f8d72798924fd097d3"
+        )));
+
+        // Data from transaction 0xc52079f33dcb44a58904fac3803fd908ac28d6632b67179ee06f2daccb4b5.
+        fn valid_mainnet_call() -> FunctionCall {
+            FunctionCall {
+                contract_address: ContractAddress::new_or_panic(starkhash!(
+                    "020cfa74ee3564b4cd5435cdace0f9c4d43b939620e4a0bb5076105df0a626c6"
+                )),
+                entry_point_selector: EntryPoint(starkhash!(
+                    "03d7905601c217734671143d457f0db37f7f8883112abd34b92c4abfeafde0c3"
+                )),
+                calldata: vec![
+                    CallParam(starkhash!(
+                        "e150b6c2db6ed644483b01685571de46d2045f267d437632b508c19f3eb877"
+                    )),
+                    CallParam(starkhash!(
+                        "0494196e88ce16bff11180d59f3c75e4ba3475d9fba76249ab5f044bcd25add6"
+                    )),
+                ],
+            }
+        }
+
+        async fn test_context_with_call_handling() -> (RpcContext, tokio::task::JoinHandle<()>) {
+            let mut database_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            database_path.push("fixtures/mainnet.sqlite");
+            let storage =
+                crate::storage::Storage::migrate(database_path.clone(), JournalMode::WAL).unwrap();
+            let sync_state = Arc::new(crate::state::SyncState::default());
+            let (call_handle, cairo_handle) = crate::cairo::ext_py::start(
+                storage.path().into(),
+                std::num::NonZeroUsize::try_from(2).unwrap(),
+                futures::future::pending(),
+                Chain::Mainnet,
+            )
+            .await
+            .unwrap();
+
+            let chain = Chain::Mainnet;
+            let sequencer = crate::sequencer::Client::new(chain).unwrap();
+
+            let context = RpcContext::new(storage, sync_state, chain, sequencer);
+            (context.with_call_handling(call_handle), cairo_handle)
+        }
+
+        #[tokio::test]
+        async fn no_such_block() {
+            let (context, _join_handle) = test_context_with_call_handling().await;
+
+            let input = CallInput {
+                request: valid_mainnet_call(),
+                block_id: BlockId::Hash(StarknetBlockHash(starkhash_bytes!(b"nonexistent"))),
+            };
+            let error = call(context, input).await;
+            assert_matches::assert_matches!(error, Err(CallError::BlockNotFound));
+        }
+
+        #[tokio::test]
+        async fn no_such_contract() {
+            let (context, _join_handle) = test_context_with_call_handling().await;
+
+            let input = CallInput {
+                request: FunctionCall {
+                    contract_address: ContractAddress::new_or_panic(starkhash!("deadbeef")),
+                    ..valid_mainnet_call()
+                },
+                block_id: BLOCK_5,
+            };
+            let error = call(context, input).await;
+            assert_matches::assert_matches!(error, Err(CallError::ContractNotFound));
+        }
+
+        #[tokio::test]
+        async fn invalid_message_selector() {
+            let (context, _join_handle) = test_context_with_call_handling().await;
+
+            let input = CallInput {
+                request: FunctionCall {
+                    entry_point_selector: EntryPoint(Default::default()),
+                    ..valid_mainnet_call()
+                },
+                block_id: BLOCK_5,
+            };
+            let error = call(context, input).await;
+            assert_matches::assert_matches!(error, Err(CallError::InvalidMessageSelector));
+        }
+
+        #[tokio::test]
+        async fn successful_call() {
+            let (context, _join_handle) = test_context_with_call_handling().await;
+
+            let input = CallInput {
+                request: valid_mainnet_call(),
+                block_id: BLOCK_5,
+            };
+
+            let result = call(context, input).await.unwrap();
+            assert_eq!(result, vec![]);
+        }
+    }
+}

--- a/crates/pathfinder/src/rpc/v02/method/estimate_fee.rs
+++ b/crates/pathfinder/src/rpc/v02/method/estimate_fee.rs
@@ -81,7 +81,7 @@ pub async fn estimate_fee(
 
 /// Transforms the request to call or estimate fee at some point in time to the type expected
 /// by [`crate::cairo::ext_py`] with the optional, latest pending data.
-async fn base_block_and_pending_for_call(
+pub(super) async fn base_block_and_pending_for_call(
     at_block: BlockId,
     pending_data: &Option<PendingData>,
 ) -> Result<

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -128,9 +128,6 @@ class Call(Command):
 
     contract_address: int = field(metadata=fields.contract_address_metadata)
     calldata: List[int] = field(metadata=fields.call_data_as_hex_metadata)
-    max_fee: int = field(metadata=fields.fee_metadata)
-    signature: List[int] = field(metadata=fields.signature_metadata)
-    nonce: Optional[int] = field(metadata=fields.optional_nonce_metadata)
     entry_point_selector: Optional[int] = field(
         default=None, metadata=fields.optional_entry_point_selector_metadata
     )
@@ -375,11 +372,7 @@ def loop_inner(connection, command: Command):
                 command.contract_address,
                 command.entry_point_selector,
                 command.calldata,
-                command.signature,
-                command.nonce,
-                command.max_fee,
                 block_info,
-                0,
                 pending_updates,
                 pending_deployed,
                 pending_nonces,
@@ -723,11 +716,7 @@ async def do_call(
     contract_address,
     selector,
     calldata,
-    signature,
-    nonce,
-    max_fee,
     block_info,
-    version,
     pending_updates,
     pending_deployed,
     pending_nonces,

--- a/py/src/test_call.py
+++ b/py/src/test_call.py
@@ -92,9 +92,6 @@ def test_command_parsing_call():
         "pending_nonces":{},
         "contract_address":"0x57dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374",
         "calldata":["0x84"],
-        "max_fee":"0x00000000000000000000000000000000",
-        "signature":[],
-        "nonce":null,
         "entry_point_selector":"0x26813d396fdb198e9ead934e4f7a592a8b88a059e45ab0eb6ee53494e8d45b0"
     }"""
     command = Command.Schema().loads(input)
@@ -110,9 +107,6 @@ def test_command_parsing_call():
         pending_nonces={},
         contract_address=0x57DDE83C18C0EFE7123C36A52D704CF27D5C38CDF0B1E1EDC3B0DAE3EE4E374,
         calldata=[0x84],
-        max_fee=0,
-        signature=[],
-        nonce=None,
         entry_point_selector=0x26813D396FDB198E9EAD934E4F7A592A8B88A059E45AB0EB6EE53494E8D45B0,
     )
     assert command.has_pending_data()
@@ -346,7 +340,7 @@ def test_success():
     contract_address = hex(populate_test_contract_with_132_on_3(con))
     entry_point = hex(get_selector_from_name("get_value"))
 
-    common_command_data = f'"contract_address": "{contract_address}", "entry_point_selector": "{entry_point}", "calldata": ["0x84"], "signature": [], "gas_price": 0, "chain": "GOERLI", "pending_updates": {{}}, "pending_deployed": [], "pending_nonces": {{}}'
+    common_command_data = f'"contract_address": "{contract_address}", "entry_point_selector": "{entry_point}", "calldata": ["0x84"], "gas_price": 0, "chain": "GOERLI", "pending_updates": {{}}, "pending_deployed": [], "pending_nonces": {{}}'
 
     output = default_132_on_3_scenario(
         con,
@@ -377,9 +371,6 @@ def test_positive_directly():
         contract_address=contract_address,
         entry_point_selector=get_selector_from_name("get_value"),
         calldata=[132],
-        max_fee=0,
-        signature=[],
-        nonce=None,
         pending_updates={},
         pending_deployed=[],
         pending_nonces={},
@@ -397,7 +388,7 @@ def test_called_contract_not_found():
     contract_address = populate_test_contract_with_132_on_3(con)
     entry_point = hex(get_selector_from_name("get_value"))
 
-    common_command_data = f'"entry_point_selector": "{entry_point}", "calldata": ["0x84"], "signature": [], "gas_price": 0, "chain": "GOERLI", "pending_updates": {{}}, "pending_deployed": [], "pending_nonces": {{}}'
+    common_command_data = f'"entry_point_selector": "{entry_point}", "calldata": ["0x84"], "gas_price": 0, "chain": "GOERLI", "pending_updates": {{}}, "pending_deployed": [], "pending_nonces": {{}}'
 
     output = default_132_on_3_scenario(
         con,
@@ -414,7 +405,7 @@ def test_nested_called_contract_not_found():
     contract_address = populate_test_contract_with_132_on_3(con)
     entry_point = hex(get_selector_from_name("call_increase_value"))
 
-    common_command_data = '"signature": [], "gas_price": 0, "chain": "GOERLI", "pending_updates": {}, "pending_deployed": [], "pending_nonces": {}'
+    common_command_data = '"gas_price": 0, "chain": "GOERLI", "pending_updates": {}, "pending_deployed": [], "pending_nonces": {}'
 
     output = default_132_on_3_scenario(
         con,
@@ -433,7 +424,7 @@ def test_invalid_entry_point():
     contract_address = populate_test_contract_with_132_on_3(con)
     entry_point = hex(get_selector_from_name("call_increase_value2"))
 
-    common_command_data = '"signature": [], "gas_price": 0, "chain": "GOERLI", "pending_updates": {}, "pending_deployed": [], "pending_nonces": {}'
+    common_command_data = '"gas_price": 0, "chain": "GOERLI", "pending_updates": {}, "pending_deployed": [], "pending_nonces": {}'
     output = default_132_on_3_scenario(
         con,
         [
@@ -453,7 +444,7 @@ def test_invalid_schema_version():
     contract_address = hex(populate_test_contract_with_132_on_3(con))
     entry_point = hex(get_selector_from_name("get_value"))
 
-    common_command_data = f'"entry_point_selector": "{entry_point}", "calldata": ["0x84"], "signature": [], "gas_price": 0, "chain": "GOERLI", "pending_updates": {{}}, "pending_deployed": [], "pending_nonces": {{}}'
+    common_command_data = f'"entry_point_selector": "{entry_point}", "calldata": ["0x84"], "gas_price": 0, "chain": "GOERLI", "pending_updates": {{}}, "pending_deployed": [], "pending_nonces": {{}}'
 
     con.execute("pragma user_version = 0")
     con.commit()
@@ -473,7 +464,7 @@ def test_no_such_block():
     contract_address = hex(populate_test_contract_with_132_on_3(con))
     entry_point = hex(get_selector_from_name("get_value"))
 
-    common_command_data = f'"contract_address": "{contract_address}", "entry_point_selector": "{entry_point}", "calldata": ["0x84"], "signature": [], "gas_price": 0, "chain": "GOERLI", "pending_updates": {{}}, "pending_deployed": [], "pending_nonces": {{}}'
+    common_command_data = f'"contract_address": "{contract_address}", "entry_point_selector": "{entry_point}", "calldata": ["0x84"], "gas_price": 0, "chain": "GOERLI", "pending_updates": {{}}, "pending_deployed": [], "pending_nonces": {{}}'
 
     con.execute("delete from starknet_blocks")
     con.commit()
@@ -675,9 +666,6 @@ def test_call_on_pending_updated():
         contract_address=contract_address,
         entry_point_selector=get_selector_from_name("get_value"),
         calldata=[132],
-        max_fee=0,
-        signature=[],
-        nonce=None,
         pending_updates={contract_address: [call.StorageDiff(key=0x84, value=0x99)]},
         pending_deployed=[],
         pending_nonces={},
@@ -705,9 +693,6 @@ def test_call_on_pending_deployed():
         contract_address=contract_address,
         entry_point_selector=get_selector_from_name("get_value"),
         calldata=[5],
-        max_fee=0,
-        signature=[],
-        nonce=None,
         pending_updates={contract_address: [call.StorageDiff(key=0x5, value=0x65)]},
         pending_deployed=[
             call.DeployedContract(address=contract_address, contract_hash=contract_hash)
@@ -744,9 +729,6 @@ def test_call_on_pending_deployed_through_existing():
             # increment by
             4,
         ],
-        max_fee=0,
-        signature=[],
-        nonce=None,
         pending_updates={contract_address: [call.StorageDiff(key=0x5, value=0x65)]},
         pending_deployed=[
             call.DeployedContract(address=contract_address, contract_hash=contract_hash)
@@ -792,9 +774,6 @@ def test_call_on_reorgged_pending_block():
                 contract_address=contract_address,
                 entry_point_selector=get_selector_from_name("get_value"),
                 calldata=[132],
-                max_fee=0,
-                signature=[],
-                nonce=None,
                 pending_updates={
                     contract_address: [call.StorageDiff(key=132, value=5)]
                 },
@@ -811,9 +790,6 @@ def test_call_on_reorgged_pending_block():
                 contract_address=contract_address,
                 entry_point_selector=get_selector_from_name("get_value"),
                 calldata=[132],
-                max_fee=0,
-                signature=[],
-                nonce=None,
                 # because the block is not found, the updates are not used
                 pending_updates={
                     contract_address: [call.StorageDiff(key=132, value=5)]
@@ -831,9 +807,6 @@ def test_call_on_reorgged_pending_block():
                 contract_address=1234567,
                 entry_point_selector=get_selector_from_name("get_value"),
                 calldata=[132],
-                max_fee=0,
-                signature=[],
-                nonce=None,
                 pending_updates={1234567: [call.StorageDiff(key=132, value=5)]},
                 pending_deployed=[
                     call.DeployedContract(
@@ -853,9 +826,6 @@ def test_call_on_reorgged_pending_block():
                 contract_address=1234567,
                 entry_point_selector=get_selector_from_name("get_value"),
                 calldata=[132],
-                max_fee=0,
-                signature=[],
-                nonce=None,
                 # because the block is not found, the updates are not used
                 pending_updates={1234567: [call.StorageDiff(key=132, value=5)]},
                 pending_deployed=[
@@ -1227,9 +1197,6 @@ def test_positive_streamed_on_early_goerli_block_without_deployed():
         contract_address=0x543E54F26AE33686F57DA2CEEBED98B340C3A78E9390931BD84FB711D5CAABC,
         entry_point_selector=get_selector_from_name("get_value"),
         calldata=[5],
-        max_fee=0,
-        signature=[],
-        nonce=None,
         # this is from the corresponding state update for block 6
         pending_updates={
             0x7C38021EB1F890C5D572125302FE4A0D2F79D38B018D68A9FCD102145D4E451: [
@@ -1303,9 +1270,6 @@ def test_positive_streamed_on_early_goerli_block_with_deployed():
         contract_address=0x543E54F26AE33686F57DA2CEEBED98B340C3A78E9390931BD84FB711D5CAABC,
         entry_point_selector=get_selector_from_name("get_value"),
         calldata=[5],
-        max_fee=0,
-        signature=[],
-        nonce=None,
         pending_updates=pending_updates,
         pending_deployed=pending_deployed,
         pending_nonces={},
@@ -1335,9 +1299,6 @@ def test_positive_streamed_on_early_goerli_block_with_deployed():
         contract_address=pending_deployed[0].address,
         entry_point_selector=get_selector_from_name("get_value"),
         calldata=[5],
-        max_fee=0,
-        signature=[],
-        nonce=None,
         pending_updates=pending_updates,
         pending_deployed=pending_deployed,
         pending_nonces={},


### PR DESCRIPTION
This is the same underlying code as we use for v01.

I've made a refactor (in a separate commit) that removes some unused arguments from the Python `do_call` implementation.

Closes #599.