### PR TITLE
feat(v02/rpc/estimate_fee): add support for estimating declare transactions

### DIFF
--- a/crates/pathfinder/src/rpc/v02/types/class.rs
+++ b/crates/pathfinder/src/rpc/v02/types/class.rs
@@ -28,8 +28,7 @@ impl ContractClass {
 
         let program = json_obj
             .get_mut("program")
-            .context("program property is missing")?
-            .to_string();
+            .context("program property is missing")?;
 
         // Program is expected to be a gzip-compressed then base64 encoded representation of the JSON.
         let mut gzip_encoder =

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -276,7 +276,8 @@ def do_loop(connection, input_gen, output_file):
             out = {"status": "error", "kind": "NO_SUCH_BLOCK"}
         except UnexpectedSchemaVersion:
             out = {"status": "error", "kind": "INVALID_SCHEMA_VERSION"}
-        except marshmallow.exceptions.MarshmallowError:
+        except marshmallow.exceptions.MarshmallowError as exc:
+            logger.error(f"Failed to parse command: {exc}")
             out = {"status": "error", "kind": "INVALID_INPUT"}
         except WebFriendlyException as exc:
             if str(exc.code) == "StarknetErrorCode.UNINITIALIZED_CONTRACT":

--- a/py/src/call.py
+++ b/py/src/call.py
@@ -22,7 +22,7 @@ try:
     from starkware.starknet.definitions import fields
     from starkware.starknet.definitions.general_config import StarknetChainId
     from starkware.starknet.services.api.gateway.transaction import (
-        Transaction,
+        AccountTransaction,
     )
     from starkware.storage.storage import Storage
 except ModuleNotFoundError:
@@ -158,7 +158,7 @@ class EstimateFee(Command):
     # zero means to use the gas price from the current block.
     gas_price: int = field(metadata=fields.gas_price_metadata)
 
-    transaction: Transaction
+    transaction: AccountTransaction
 
     def has_pending_data(self):
         return (
@@ -781,7 +781,7 @@ async def do_estimate_fee(
     general_config,
     root,
     block_info,
-    transaction,
+    transaction: AccountTransaction,
     pending_updates,
     pending_deployed,
     pending_nonces,


### PR DESCRIPTION
Deploys are not supported (no support in the underlying Python layer).

This also fixes a serialization issue in the `ContractClass` type: previously we did an extra string conversion so the gzip-encoded program definition was represented as _string_ containing the JSON representation (instead of the JSON itself).

Closes #600.