### PR TITLE
fix(ethereum/transport): handle new Infura query limit error

### DIFF
--- a/crates/pathfinder/src/ethereum/transport.rs
+++ b/crates/pathfinder/src/ethereum/transport.rs
@@ -173,6 +173,13 @@ impl EthereumTransport for HttpTransport {
                         LogsError::QueryLimit
                     }
                     Error::Rpc(err)
+                        if err.code.code() == InvalidParams.code()
+                            && err.message.starts_with("query returned more than") =>
+                    {
+                        // Handle Infura query limit error response.
+                        LogsError::QueryLimit
+                    }
+                    Error::Rpc(err)
                         if err.code.code() == InvalidInput.code()
                             && err.message == ALCHEMY_UNKNOWN_BLOCK_ERR =>
                     {


### PR DESCRIPTION
Previously Infura was returning LimitExceeded as the code if the log query would have returned too many responses.

This seems to have changed: Infura now returns InvalidParams and includes the cause only in the error message...

This change handles this case similarly to what we've been doing with Alchemy.