### PR TITLE
fix(rpc/v02): `starknet_estimateFee` does not work for DEPLOY_ACCOUNT

### DIFF
--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -102,17 +102,11 @@ impl Handle {
                     fee: ZERO,
                 });
             }
-            BroadcastedTransaction::DeployAccount(tx) => {
+            BroadcastedTransaction::DeployAccount(_) => {
                 // TODO(0.10.1) Cairo upgrade is required for estimate_fee to support DEPLOY_ACCOUNT
-                add_transaction::AddTransaction::DeployAccount(add_transaction::DeployAccount {
-                    version: tx.version,
-                    max_fee: tx.max_fee,
-                    signature: tx.signature,
-                    nonce: tx.nonce,
-                    class_hash: tx.class_hash,
-                    contract_address_salt: tx.contract_address_salt,
-                    constructor_calldata: tx.constructor_calldata,
-                })
+                return Err(CallFailure::Internal(
+                    "DEPLOY_ACCOUNT transactions are unsupported",
+                ));
             }
             BroadcastedTransaction::Declare(tx) => {
                 add_transaction::AddTransaction::Declare(add_transaction::Declare {


### PR DESCRIPTION
cairo-lang 0.10.0 does not yet support DEPLOY_ACCOUNT transactions so estimation would fail on the Python subprocess not being able to de-serialize the transaction.

Instead of the cryptic error this leads to we should just return with a straightforward error.