### PR TITLE
fix(rpc/v02/get_class_at): add decompression of contract definition

### DIFF
--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -178,10 +178,12 @@ mod tests {
         // We need to set the magic bytes for zstd compression to simulate a compressed
         // contract definition, as this is asserted for internally
         let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
+        let contract_definition =
+            include_bytes!("../fixtures/contract_definition.json.zst").to_vec();
         let contract0_code = CompressedContract {
             abi: zstd_magic.clone(),
-            bytecode: zstd_magic.clone(),
-            definition: zstd_magic,
+            bytecode: zstd_magic,
+            definition: contract_definition,
             hash: class0_hash,
         };
         let mut contract1_code = contract0_code.clone();

--- a/crates/pathfinder/src/rpc/v02/method/get_class_at.rs
+++ b/crates/pathfinder/src/rpc/v02/method/get_class_at.rs
@@ -118,6 +118,15 @@ fn get_definition_at(
         .context("Reading definition from database")?
         .context("Class definition is missing")?;
 
+    let definition = zstd::decode_all(&*definition)
+        .context("Decompressing contract definition")
+        .map_err(|e| {
+            GetClassAtError::Internal(anyhow::anyhow!(
+                "Decompressing class definition failed: {}",
+                e
+            ))
+        })?;
+
     Ok(definition)
 }
 


### PR DESCRIPTION
We're storing contract definitions in a compressed form in the database.

The decompression step was missing in this method so that parsing the zstd-compressed byte stream as JSON was always failing.