### PR TITLE
fix(ext_py): fix serialization of block numbers

### DIFF
--- a/crates/pathfinder/src/cairo/ext_py.rs
+++ b/crates/pathfinder/src/cairo/ext_py.rs
@@ -502,10 +502,7 @@ mod tests {
         let at_block_fee = handle
             .estimate_fee(
                 transaction.clone(),
-                crate::core::StarknetBlockHash(
-                    StarkHash::from_be_slice(&b"some blockhash somewhere"[..]).unwrap(),
-                )
-                .into(),
+                crate::core::StarknetBlockNumber::new_or_panic(1).into(),
                 super::GasPriceSource::PastBlock,
                 None,
             )

--- a/crates/pathfinder/src/cairo/ext_py/ser.rs
+++ b/crates/pathfinder/src/cairo/ext_py/ser.rs
@@ -217,7 +217,9 @@ impl serde::Serialize for BlockHashNumberOrLatest {
         use BlockHashNumberOrLatest::*;
         match self {
             Hash(h) => h.serialize(serializer),
-            Number(n) => n.serialize(serializer),
+            // We serialize block number as string, since the Python-side dataclass expects
+            // `at_block` to be a string (and does proper conversion on that)
+            Number(n) => n.get().to_string().serialize(serializer),
             // I failed to get this working with the derive(serde::Serialize)
             Latest => "latest".serialize(serializer),
         }

--- a/crates/pathfinder/src/cairo/ext_py/ser.rs
+++ b/crates/pathfinder/src/cairo/ext_py/ser.rs
@@ -380,7 +380,7 @@ mod tests {
 
         let data = &[
             (StarknetBlockHash(StarkHash::ZERO).into(), "\"0x0\""),
-            (StarknetBlockNumber::GENESIS.into(), "0"),
+            (StarknetBlockNumber::GENESIS.into(), "\"0\""),
             (BlockHashNumberOrLatest::Latest, "\"latest\""),
         ];
 


### PR DESCRIPTION
The Python-side dataclass expects `at_block` to be a string (so that "latest" can be properly represented).

In our custom serialization implemented for `BlockHashNumberOrLatest` we were serializing block numbers as numbers which broke command parsing on the Python-side.

Fixes #696.