### PR TITLE
fix: testnet and testnet2 chain_id

### DIFF
--- a/crates/pathfinder/src/core.rs
+++ b/crates/pathfinder/src/core.rs
@@ -416,10 +416,8 @@ impl Chain {
         match self {
             // SN_MAIN
             Chain::Mainnet => StarkHash::from_u128(0x534e5f4d41494eu128),
-            // SN_GOERLI
-            Chain::Testnet => StarkHash::from_u128(0x534e5f474f45524c49u128),
-            // SN_GOERLI2
-            Chain::Testnet2 => StarkHash::from_u128(0x534e5f474f45524c4932),
+            // Both testnets have the same ID: SN_GOERLI
+            Chain::Testnet | Chain::Testnet2 => StarkHash::from_u128(0x534e5f474f45524c49u128),
             // SN_INTEGRATION
             Chain::Integration => StarkHash::from_u128(0x534E5F494E544547524154494F4E),
         }

--- a/crates/pathfinder/src/rpc/v02/method/chain_id.rs
+++ b/crates/pathfinder/src/rpc/v02/method/chain_id.rs
@@ -15,22 +15,21 @@ mod tests {
     use super::chain_id;
 
     #[tokio::test]
-    async fn mainnet() {
-        let mut context = RpcContext::for_tests();
-        context.chain = Chain::Mainnet;
+    async fn test_chain_id() {
+        let cases = vec![
+            (Chain::Mainnet, "SN_MAIN"),
+            (Chain::Testnet, "SN_GOERLI"),
+            (Chain::Testnet2, "SN_GOERLI"),
+            (Chain::Integration, "SN_INTEGRATION"),
+        ];
 
-        let result = chain_id(context).await.unwrap();
-        let expected = format!("0x{}", hex::encode("SN_MAIN"));
-        assert_eq!(result, expected);
-    }
+        for (chain, label) in cases {
+            let mut context = RpcContext::for_tests();
+            context.chain = chain;
 
-    #[tokio::test]
-    async fn testnet() {
-        let mut context = RpcContext::for_tests();
-        context.chain = Chain::Testnet;
-
-        let result = chain_id(context).await.unwrap();
-        let expected = format!("0x{}", hex::encode("SN_GOERLI"));
-        assert_eq!(result, expected);
+            let returned = chain_id(context).await.unwrap();
+            let expected = format!("0x{}", hex::encode(label));
+            assert_eq!(returned, expected, "{}", label);
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/eqlabs/pathfinder/issues/711