### PR TITLE
ci: split test commands into separate steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@v1
         with:
@@ -66,7 +66,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -76,7 +76,7 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -88,7 +88,7 @@ jobs:
     env:
       RUSTDOCFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v1
       - run: cargo doc --no-deps --document-private-items
@@ -96,7 +96,7 @@ jobs:
   dep-sort:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v1
       - run: |
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Prepare py/
         run: |
@@ -163,7 +163,7 @@ jobs:
   fuzz_targets:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,8 @@ on:
     branches: [ main ]
 
 jobs:
-  test:
+  compile_tests:
+    name: Compile pathfinder tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -30,6 +31,45 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: "mold"
+
+      - name: Compile tests
+        # Note: profile changed because otherwise test binary is 1GB+ in size..
+        run: cargo test --no-run --lib pathfinder -p pathfinder --locked --profile stripdebuginfo
+
+      # Finds the pathfinder_lib- test binary, and renames it and the .d file to something simpler to use.
+      # Essentially removing the hash to make running the file simpler (as it is used in other jobs).
+      - name: Rename test binary
+        run: |
+          filepath=`find target/stripdebuginfo/deps/ -type f -name pathfinder_lib-* | head -n 1`; \
+          filepathd="${filepath}.d"; \
+          mv $filepath pathfinder_test; \
+          mv $filepathd pathfinder_test.d;
+
+      - name: Archive test binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-binary
+          path: |
+            pathfinder_test
+            pathfinder_test.d
+          if-no-files-found: error
+
+  test_pathfinder:
+    name: pathfinder tests (excludes L1)
+    needs: compile_tests
+    runs-on: ubuntu-latest
+    steps:
+      # Required for the python environment
+      - uses: actions/checkout@v3
+
+      # Fetch the test binary artifact
+      - uses: actions/download-artifact@v3
+        with:
+          name: test-binary
+      # Archiving removes the file permissions
+      - name: Fix file permissions
+        run: chmod +x pathfinder_test
+
       - uses: actions/setup-python@v4
         id: setup_python
         with:
@@ -43,26 +83,72 @@ jobs:
           path: ${{ env.pythonLocation }}/**/site-packages
           key: site-packages-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('py/requirements*.txt') }}
       - run: pip install -e py/.
-      - run: |
-          cargo test --no-run --workspace --locked
-          timeout 5m cargo test -p pathfinder -- --skip ethereum::
 
-          # Run Ethereum tests using Infura endpoint
-          PATHFINDER_ETHEREUM_HTTP_GOERLI_URL=${{ secrets.INFURA_GOERLI_URL }} \
-            PATHFINDER_ETHEREUM_HTTP_GOERLI_PASSWORD=${{ secrets.INFURA_GOERLI_PASSWORD }} \
-            PATHFINDER_ETHEREUM_HTTP_MAINNET_URL=${{ secrets.INFURA_MAINNET_URL }} \
-            PATHFINDER_ETHEREUM_HTTP_MAINNET_PASSWORD=${{ secrets.INFURA_MAINNET_PASSWORD }} \
-            timeout 3m cargo test -p pathfinder --locked -- ethereum::
+      - name: Execute tests
+        run: "./pathfinder_test --skip ethereum::"
 
-          # Run Ethereum tests using Alchemy endpoint
+  test_alchemy:
+    name: pathfinder tests (alchemy)
+    needs: compile_tests
+    runs-on: ubuntu-latest
+    steps:       
+      # Fetch the test binary artifact
+      - uses: actions/download-artifact@v3
+        with:
+          name: test-binary
+      # Archiving removes the file permissions
+      - name: Fix file permissions
+        run: chmod +x pathfinder_test
+
+      - name: Execute tests
+        run: |
           PATHFINDER_ETHEREUM_HTTP_GOERLI_URL=${{ secrets.ALCHEMY_GOERLI_URL }} \
             PATHFINDER_ETHEREUM_HTTP_GOERLI_PASSWORD=${{ secrets.ALCHEMY_GOERLI_PASSWORD }} \
             PATHFINDER_ETHEREUM_HTTP_MAINNET_URL=${{ secrets.ALCHEMY_MAINNET_URL }} \
             PATHFINDER_ETHEREUM_HTTP_MAINNET_PASSWORD=${{ secrets.ALCHEMY_MAINNET_PASSWORD }} \
-            timeout 3m cargo test -p pathfinder --locked -- ethereum::
+            timeout 3m ./pathfinder_test ethereum::
 
-          timeout 3m cargo test -p stark_hash --all-targets --locked
-          timeout 1m cargo test -p stark_curve --all-targets --locked
+  test_infura:
+    name: pathfinder tests (infura)
+    needs: compile_tests
+    runs-on: ubuntu-latest
+    steps:       
+      # Fetch the test binary artifact
+      - uses: actions/download-artifact@v3
+        with:
+          name: test-binary
+      # Archiving removes the file permissions
+      - name: Fix file permissions
+        run: chmod +x pathfinder_test
+
+      - name: Execute tests
+        run: |
+          PATHFINDER_ETHEREUM_HTTP_GOERLI_URL=${{ secrets.INFURA_GOERLI_URL }} \
+            PATHFINDER_ETHEREUM_HTTP_GOERLI_PASSWORD=${{ secrets.INFURA_GOERLI_PASSWORD }} \
+            PATHFINDER_ETHEREUM_HTTP_MAINNET_URL=${{ secrets.INFURA_MAINNET_URL }} \
+            PATHFINDER_ETHEREUM_HTTP_MAINNET_PASSWORD=${{ secrets.INFURA_MAINNET_PASSWORD }} \
+            timeout 3m ./pathfinder_test ethereum::
+
+  test_stark_curve:
+    name: stark_curve tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: tests
+        run: cargo test -p stark_curve --all-targets --locked
+
+  test_stark_hash:
+    name: stark_hash tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: tests
+        run: cargo test -p stark_hash --all-targets --locked
+
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           EOF
 
           cat $HOME/.cargo/config.toml
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           key: "mold"
       - uses: actions/setup-python@v4
@@ -70,7 +70,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace --all-targets --locked -- -D warnings -D rust_2018_idioms
 
   rustfmt:
@@ -80,7 +80,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all -- --check
 
   doc:
@@ -90,7 +90,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - run: cargo doc --no-deps --document-private-items
 
   dep-sort:
@@ -98,7 +98,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - run: |
           cargo install cargo-sort
           cargo sort --check --workspace
@@ -151,7 +151,7 @@ jobs:
 
           cat $HOME/.cargo/config.toml
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           key: "mold"
       - name: Integration (rust)
@@ -181,7 +181,7 @@ jobs:
           EOF
 
           cat $HOME/.cargo/config.toml
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           key: "mold"
       - run: cargo install cargo-fuzz

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,7 +49,7 @@ jobs:
             [worker.oci]
               max-parallelism = 4
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           swap-size-gb: 10
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up QEMU
         id: qemu
         uses: docker/setup-qemu-action@v1
@@ -64,7 +64,7 @@ jobs:
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true
-          tags:  ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           image: tonistiigi/binfmt:latest
           platforms: all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
+[profile.stripdebuginfo]
+# Used by CI to lower binary size for test artifacts.
+inherits = "test"
+strip = "debuginfo"
+
 [workspace]
 members = [
     "crates/load-test",


### PR DESCRIPTION
This PR splits the test CI into separate jobs that can be executed in parallel. This has the dual benefit of speeding it up, as well as increasing the visibility into which test failed.

This is achieved by doing a single test compilation job, which archives the test binary. This is then downloaded by each test job to use.

Also version updates for some github actions (this removes the deprecation warnings in our actions).