### PR TITLE
feat(sequencer): support v1 invoke sender_address

### DIFF
--- a/crates/pathfinder/src/rpc/v01/types.rs
+++ b/crates/pathfinder/src/rpc/v01/types.rs
@@ -741,7 +741,7 @@ pub mod reply {
                                     signature: txn.signature.clone(),
                                     nonce: txn.nonce,
                                 },
-                                contract_address: txn.contract_address,
+                                contract_address: txn.sender_address,
                                 entry_point_selector: EntryPoint(StarkHash::ZERO),
                                 calldata: txn.calldata.clone(),
                             })

--- a/crates/pathfinder/src/rpc/v02/types.rs
+++ b/crates/pathfinder/src/rpc/v02/types.rs
@@ -527,7 +527,7 @@ pub mod reply {
                                     signature: txn.signature.clone(),
                                     nonce: txn.nonce,
                                 },
-                                sender_address: txn.contract_address,
+                                sender_address: txn.sender_address,
                                 calldata: txn.calldata.clone(),
                             }))
                         }

--- a/crates/pathfinder/src/sequencer/reply.rs
+++ b/crates/pathfinder/src/sequencer/reply.rs
@@ -343,7 +343,7 @@ pub mod transaction {
                 Transaction::DeployAccount(t) => t.contract_address,
                 Transaction::Invoke(t) => match t {
                     InvokeTransaction::V0(t) => t.contract_address,
-                    InvokeTransaction::V1(t) => t.contract_address,
+                    InvokeTransaction::V1(t) => t.sender_address,
                 },
                 Transaction::L1Handler(t) => t.contract_address,
             }
@@ -496,7 +496,12 @@ pub mod transaction {
     pub struct InvokeTransactionV1 {
         #[serde_as(as = "Vec<CallParamAsDecimalStr>")]
         pub calldata: Vec<CallParam>,
-        pub contract_address: ContractAddress,
+        // contract_address is the historic name for this field. sender_address was
+        // introduced with starknet v0.11. Although the gateway no longer uses the historic
+        // name at all, this alias must be kept until a database migration fixes all historic
+        // transaction naming, or until regenesis removes them all.
+        #[serde(alias = "contract_address")]
+        pub sender_address: ContractAddress,
         #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
         #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]


### PR DESCRIPTION
This supports an upcoming change (StarkNet v0.11) in the gateway's response for V1 Invoke transactions.

Closes #727.