### PR TITLE
feat(rpc): `pathfinder_version`

### DIFF
--- a/crates/pathfinder/pathfinder_rpc_api.json
+++ b/crates/pathfinder/pathfinder_rpc_api.json
@@ -1,0 +1,23 @@
+{
+    "openrpc": "1.2.6",
+    "info": {
+        "title": "Pathfinder RPC API",
+        "version": "0.1",
+        "description": "Provides additional (pathfinder specific) methods above the StarkNet RPC API"
+    },
+    "methods": [
+        {
+            "name": "version",
+            "summary": "The version of the pathfinder node hosting this API.",
+            "params": [],
+            "result": {
+                "name": "semver version",
+                "required": true,
+                "schema": {
+                    "type": "string",
+                    "description": "A semver compatible version string"
+                }
+            }
+        }
+    ]
+}

--- a/crates/pathfinder/pathfinder_rpc_api.json
+++ b/crates/pathfinder/pathfinder_rpc_api.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "Pathfinder RPC API",
         "version": "0.1",
-        "description": "Provides additional (pathfinder specific) methods above the StarkNet RPC API"
+        "description": "Provides additional (pathfinder specific) methods over and above the StarkNet RPC API"
     },
     "methods": [
         {

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -1,6 +1,7 @@
 //! StarkNet node JSON-RPC related modules.
 mod error;
 pub mod gas_price;
+mod pathfinder;
 pub mod serde;
 #[cfg(test)]
 pub mod test_client;
@@ -77,10 +78,15 @@ Hint: If you are looking to run two instances of pathfinder, you must configure 
         v02::register_all_methods(&mut module_v02)?;
         let module_v02 = module_v02.into();
 
+        let mut pathfinder_module = RpcModule::new(());
+        pathfinder::register_all_methods(&mut pathfinder_module)?;
+        let pathfinder_module = pathfinder_module.into();
+
         Ok(server
             .start_with_paths([
                 (vec!["/rpc/v0.1"], module_v01),
                 (vec!["/", "/rpc/v0.2"], module_v02),
+                (vec!["/rpc/pathfinder/v0.1"], pathfinder_module),
             ])
             .map(|handle| (handle, local_addr))?)
     }

--- a/crates/pathfinder/src/rpc/pathfinder.rs
+++ b/crates/pathfinder/src/rpc/pathfinder.rs
@@ -2,15 +2,10 @@ pub fn register_all_methods(module: &mut jsonrpsee::RpcModule<()>) -> anyhow::Re
     use anyhow::Context;
 
     module
-        .register_async_method(
-            "pathfinder_version",
-            |_, _| async move { Ok(version().await) },
-        )
+        .register_method("pathfinder_version", |_, _| {
+            Ok(env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT"))
+        })
         .with_context(|| format!("Registering pathfinder_version"))?;
 
     Ok(())
-}
-
-async fn version() -> &'static str {
-    return env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT");
 }

--- a/crates/pathfinder/src/rpc/pathfinder.rs
+++ b/crates/pathfinder/src/rpc/pathfinder.rs
@@ -1,0 +1,16 @@
+pub fn register_all_methods(module: &mut jsonrpsee::RpcModule<()>) -> anyhow::Result<()> {
+    use anyhow::Context;
+
+    module
+        .register_async_method(
+            "pathfinder_version",
+            |_, _| async move { Ok(version().await) },
+        )
+        .with_context(|| format!("Registering pathfinder_version"))?;
+
+    Ok(())
+}
+
+async fn version() -> &'static str {
+    return env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT");
+}


### PR DESCRIPTION
Adds support for querying a node's version via RPC.

To enable this, this PR adds a new RPC route: `/rpc/pathfinder/v0.1/pathfinder_version`. I've defaulted to using the version'd approach right from the start. This will also be used by any other extensions we do the rpc api.

I also want to refactor / move the existing rpc code one level deeper, something like:
```
rpc/starknet/v01.rs
rpc/starknet/v02.rs
```
to separate it from the pathfinder one's. But I'll save that for a different PR.

Closes #725.