### PR TITLE
fix(rpc/estimate_fee): fix ABI serialization for estimateFee

### DIFF
--- a/crates/pathfinder/src/rpc/v02/types/class.rs
+++ b/crates/pathfinder/src/rpc/v02/types/class.rs
@@ -195,18 +195,17 @@ pub struct EventAbiEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     data: Option<Vec<TypedParameter>>,
-    // FIXME: This is not part of the spec, but is present in many ABIs.
-    // Must be confirmed by StarkWare still whether to accept it.
-    #[serde(skip_serializing)]
+    // The `inputs` and `outputs` property is not part of the JSON-RPC
+    // specification, but because we use these types to parse the
+    // `starknet_estimateFee` request and then serialize the class definition in
+    // the transaction for the Python layer we have to keep this property when
+    // serializing.
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    #[serde(rename = "inputs")]
-    _inputs: Option<Vec<TypedParameter>>,
-    // FIXME: This is not part of the spec, but is present in some ABIs.
-    // Must be confirmed by StarkWare still whether to accept it.
-    #[serde(skip_serializing)]
+    inputs: Option<Vec<TypedParameter>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    #[serde(rename = "outputs")]
-    _outputs: Option<Vec<TypedParameter>>,
+    outputs: Option<Vec<TypedParameter>>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -220,12 +219,13 @@ pub struct FunctionAbiEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     outputs: Option<Vec<TypedParameter>>,
-    // This is valid but unverifiable part of the ABI, so it is excluded from
-    // serialization for RPC (and is not part of the spec).
-    #[serde(skip_serializing)]
-    #[serde(default)]
+    // This is not part of the JSON-RPC specification, but because we use these
+    // types to parse the `starknet_estimateFee` request and then serialize the
+    // class definition in the transaction for the Python layer we have to keep
+    // this property when serializing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[serde(rename = "stateMutability")]
-    _state_mutability: Option<String>,
+    state_mutability: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]


### PR DESCRIPTION
We're using the `rpc::v02::types::class::ContractClass` type for
parsing input parameters for `starknet_estimateFee` calls. After
parsing the method parameters, the transaction param is converted into
an AddTransaction type for serialization to the Python worker.

This conversion involves serializing the class ABI to JSON. Here the same
derived `Serialize` implementation is used that we're using to serialize
replies to `starknet_getClass`. To be compliant with the JSON-RPC
specification we were omitting some ABI fields from the serialization:

- "input" and "output" for event ABI entries,
- and "stateMutability" for function ABI entries.

This leads to a slightly different class declaration to be sent to the
subprocess: it's missing these fields from the ABI.

During estimation the Python worker computes the transaction hash for
the transaction and in case of a version 1 transaction calls the account
contract to verify the signature. For declare transactions the class hash
is hashed into the transaction hash, and since the ABI is hashed into
the class hash making _any_ difference to the ABI JSON will lead to
signature mismatches.

This PR adds these fields to the JSON serialization of the ABI to fix the
class hash mismatch. Unfortunately this also has some impact on our
conformance to the JSON-RPC specification: we include these properties
in the JSON response for `starknet_getClass` that are not in the
specification.