### PR TITLE
ci: run tests for all the new crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,8 @@ jobs:
       - name: Execute tests
         run: ./pathfinder
 
-  test_pathfinder_ethereum:
-    name: pathfinder-ethereum tests
+  test_pathfinder_ethereum_alchemy:
+    name: pathfinder-ethereum tests (alchemy)
     needs: compile_tests
     runs-on: ubuntu-latest
     steps:       
@@ -109,7 +109,33 @@ jobs:
         run: chmod +x pathfinder_ethereum
 
       - name: Execute tests
-        run: ./pathfinder_ethereum
+        run: |
+          PATHFINDER_ETHEREUM_HTTP_GOERLI_URL=${{ secrets.ALCHEMY_GOERLI_URL }} \
+            PATHFINDER_ETHEREUM_HTTP_GOERLI_PASSWORD=${{ secrets.ALCHEMY_GOERLI_PASSWORD }} \
+            PATHFINDER_ETHEREUM_HTTP_MAINNET_URL=${{ secrets.ALCHEMY_MAINNET_URL }} \
+            PATHFINDER_ETHEREUM_HTTP_MAINNET_PASSWORD=${{ secrets.ALCHEMY_MAINNET_PASSWORD }} \
+            timeout 3m ./pathfinder_ethereum
+
+  test_pathfinder_ethereum_infura:
+    name: pathfinder-ethereum tests (infura)
+    needs: compile_tests
+    runs-on: ubuntu-latest
+    steps:       
+      # Fetch the test binary artifact
+      - uses: actions/download-artifact@v3
+        with:
+          name: test-binary-pathfinder-ethereum
+      # Archiving removes the file permissions
+      - name: Fix file permissions
+        run: chmod +x pathfinder_ethereum
+
+      - name: Execute tests
+        run: |
+          PATHFINDER_ETHEREUM_HTTP_GOERLI_URL=${{ secrets.INFURA_GOERLI_URL }} \
+            PATHFINDER_ETHEREUM_HTTP_GOERLI_PASSWORD=${{ secrets.INFURA_GOERLI_PASSWORD }} \
+            PATHFINDER_ETHEREUM_HTTP_MAINNET_URL=${{ secrets.INFURA_MAINNET_URL }} \
+            PATHFINDER_ETHEREUM_HTTP_MAINNET_PASSWORD=${{ secrets.INFURA_MAINNET_PASSWORD }} \
+            timeout 3m ./pathfinder_ethereum
 
   test_pathfinder_lib:
     name: pathfinder_lib tests (excludes L1)
@@ -142,49 +168,7 @@ jobs:
       - run: pip install -e py/.
 
       - name: Execute tests
-        run: "./pathfinder_lib --skip ethereum::"
-
-  test_alchemy:
-    name: pathfinder_lib tests (alchemy)
-    needs: compile_tests
-    runs-on: ubuntu-latest
-    steps:       
-      # Fetch the test binary artifact
-      - uses: actions/download-artifact@v3
-        with:
-          name: test-binary-pathfinder-lib
-      # Archiving removes the file permissions
-      - name: Fix file permissions
-        run: chmod +x pathfinder_lib
-
-      - name: Execute tests
-        run: |
-          PATHFINDER_ETHEREUM_HTTP_GOERLI_URL=${{ secrets.ALCHEMY_GOERLI_URL }} \
-            PATHFINDER_ETHEREUM_HTTP_GOERLI_PASSWORD=${{ secrets.ALCHEMY_GOERLI_PASSWORD }} \
-            PATHFINDER_ETHEREUM_HTTP_MAINNET_URL=${{ secrets.ALCHEMY_MAINNET_URL }} \
-            PATHFINDER_ETHEREUM_HTTP_MAINNET_PASSWORD=${{ secrets.ALCHEMY_MAINNET_PASSWORD }} \
-            timeout 3m ./pathfinder_lib ethereum::
-
-  test_infura:
-    name: pathfinder_lib tests (infura)
-    needs: compile_tests
-    runs-on: ubuntu-latest
-    steps:       
-      # Fetch the test binary artifact
-      - uses: actions/download-artifact@v3
-        with:
-          name: test-binary-pathfinder-lib
-      # Archiving removes the file permissions
-      - name: Fix file permissions
-        run: chmod +x pathfinder_lib
-
-      - name: Execute tests
-        run: |
-          PATHFINDER_ETHEREUM_HTTP_GOERLI_URL=${{ secrets.INFURA_GOERLI_URL }} \
-            PATHFINDER_ETHEREUM_HTTP_GOERLI_PASSWORD=${{ secrets.INFURA_GOERLI_PASSWORD }} \
-            PATHFINDER_ETHEREUM_HTTP_MAINNET_URL=${{ secrets.INFURA_MAINNET_URL }} \
-            PATHFINDER_ETHEREUM_HTTP_MAINNET_PASSWORD=${{ secrets.INFURA_MAINNET_PASSWORD }} \
-            timeout 3m ./pathfinder_lib ethereum::
+        run: ./pathfinder_lib
 
   test_pathfinder_serde:
     name: pathfinder-serde tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
             timeout 3m ./pathfinder_ethereum
 
   test_pathfinder_lib:
-    name: pathfinder_lib tests (excludes L1)
+    name: pathfinder_lib tests
     needs: compile_tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,6 @@ jobs:
             | jq -r 'select(.reason=="compiler-artifact" and .target.test==true and .executable) | .executable' \
             | xargs -I '{}' bash -c 'file={}; mv ${file} $(basename ${file::(-17)})'
 
-      - name: Archive test binary pathfinder
-        uses: actions/upload-artifact@v3
-        with:
-          name: test-binary-pathfinder
-          path: pathfinder
-          if-no-files-found: error
-
       - name: Archive test binary pathfinder_ethereum
         uses: actions/upload-artifact@v3
         with:
@@ -120,8 +113,7 @@ jobs:
 
       # We want to strip the debug info as some of these test binaries are 100MB+ and pathfinder_lib is 1GB+
       - name: Execute tests
-        run: cargo test --all-targets --workspace --locked --profile stripdebuginfo \
-          --exclude pathfinder-ethereum
+        run: cargo test --all-targets --workspace --locked --profile stripdebuginfo --exclude pathfinder-ethereum
 
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,8 @@ jobs:
     steps:
       # Required for the python environment
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
 
       - uses: actions/setup-python@v4
         id: setup_python
@@ -113,7 +115,7 @@ jobs:
 
       # We want to strip the debug info as some of these test binaries are 100MB+ and pathfinder_lib is 1GB+
       - name: Execute tests
-        run: cargo test --all-targets --workspace --locked --profile stripdebuginfo --exclude pathfinder-ethereum
+        run: timeout 15m cargo test --all-targets --workspace --locked --profile stripdebuginfo --exclude pathfinder-ethereum
 
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,27 +34,85 @@ jobs:
 
       - name: Compile tests
         id: compile-tests
-        # Note: profile changed because otherwise test binary is 1GB+ in size..
+        # Note:
+        # - profile changed because otherwise some test binaries are 100MB+ in size with pathfinder_lib over 1GB
+        # - package pathfinder produces two test binaries: pathfinder & pathfinder_lib
         run: |
-          cargo test --no-run --lib pathfinder -p pathfinder --locked --profile stripdebuginfo --message-format=json > /tmp/cargo-output.json
-          echo -n "TEST_EXECUTABLE=" >> $GITHUB_OUTPUT
-          jq -r 'select(.reason=="compiler-artifact" and .target.name=="pathfinder_lib") | .executable' /tmp/cargo-output.json >> $GITHUB_OUTPUT
+          cargo test --no-run --locked --profile stripdebuginfo --message-format=json \
+            -p pathfinder -p pathfinder-ethereum -p pathfinder-serde -p starknet-gateway-types \
+            | jq -r 'select(.reason=="compiler-artifact" and .target.test==true and .executable) | .executable' \
+            | xargs -I '{}' bash -c 'file={}; mv ${file} $(basename ${file::(-17)})'
 
-      # Finds the pathfinder_lib- test binary, and renames it and the .d file to something simpler to use.
-      # Essentially removing the hash to make running the file simpler (as it is used in other jobs).
-      - name: Rename test binary
-        run: mv ${{ steps.compile-tests.outputs.TEST_EXECUTABLE}} pathfinder_test
-
-      - name: Archive test binary
+      - name: Archive test binary pathfinder
         uses: actions/upload-artifact@v3
         with:
-          name: test-binary
-          path: |
-            pathfinder_test
+          name: test-binary-pathfinder
+          path: pathfinder
           if-no-files-found: error
 
+      - name: Archive test binary pathfinder_ethereum
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-binary-pathfinder-ethereum
+          path: pathfinder_ethereum
+          if-no-files-found: error
+
+      - name: Archive test binary pathfinder_lib
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-binary-pathfinder-lib
+          path: pathfinder_lib
+          if-no-files-found: error
+
+      - name: Archive test binary pathfinder_serde
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-binary-pathfinder-serde
+          path: pathfinder_serde
+          if-no-files-found: error
+
+      - name: Archive test binary starknet_gateway_types
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-binary-starknet-gateway-types
+          path: starknet_gateway_types
+          if-no-files-found: error
+
+  # Tests with stripped test binaries
   test_pathfinder:
-    name: pathfinder tests (excludes L1)
+    name: pathfinder (binary) tests
+    needs: compile_tests
+    runs-on: ubuntu-latest
+    steps:       
+      # Fetch the test binary artifact
+      - uses: actions/download-artifact@v3
+        with:
+          name: test-binary-pathfinder
+      # Archiving removes the file permissions
+      - name: Fix file permissions
+        run: chmod +x pathfinder
+
+      - name: Execute tests
+        run: ./pathfinder
+
+  test_pathfinder_ethereum:
+    name: pathfinder-ethereum tests
+    needs: compile_tests
+    runs-on: ubuntu-latest
+    steps:       
+      # Fetch the test binary artifact
+      - uses: actions/download-artifact@v3
+        with:
+          name: test-binary-pathfinder-ethereum
+      # Archiving removes the file permissions
+      - name: Fix file permissions
+        run: chmod +x pathfinder_ethereum
+
+      - name: Execute tests
+        run: ./pathfinder_ethereum
+
+  test_pathfinder_lib:
+    name: pathfinder_lib tests (excludes L1)
     needs: compile_tests
     runs-on: ubuntu-latest
     steps:
@@ -64,10 +122,10 @@ jobs:
       # Fetch the test binary artifact
       - uses: actions/download-artifact@v3
         with:
-          name: test-binary
+          name: test-binary-pathfinder-lib
       # Archiving removes the file permissions
       - name: Fix file permissions
-        run: chmod +x pathfinder_test
+        run: chmod +x pathfinder_lib
 
       - uses: actions/setup-python@v4
         id: setup_python
@@ -84,20 +142,20 @@ jobs:
       - run: pip install -e py/.
 
       - name: Execute tests
-        run: "./pathfinder_test --skip ethereum::"
+        run: "./pathfinder_lib --skip ethereum::"
 
   test_alchemy:
-    name: pathfinder tests (alchemy)
+    name: pathfinder_lib tests (alchemy)
     needs: compile_tests
     runs-on: ubuntu-latest
     steps:       
       # Fetch the test binary artifact
       - uses: actions/download-artifact@v3
         with:
-          name: test-binary
+          name: test-binary-pathfinder-lib
       # Archiving removes the file permissions
       - name: Fix file permissions
-        run: chmod +x pathfinder_test
+        run: chmod +x pathfinder_lib
 
       - name: Execute tests
         run: |
@@ -105,20 +163,20 @@ jobs:
             PATHFINDER_ETHEREUM_HTTP_GOERLI_PASSWORD=${{ secrets.ALCHEMY_GOERLI_PASSWORD }} \
             PATHFINDER_ETHEREUM_HTTP_MAINNET_URL=${{ secrets.ALCHEMY_MAINNET_URL }} \
             PATHFINDER_ETHEREUM_HTTP_MAINNET_PASSWORD=${{ secrets.ALCHEMY_MAINNET_PASSWORD }} \
-            timeout 3m ./pathfinder_test ethereum::
+            timeout 3m ./pathfinder_lib ethereum::
 
   test_infura:
-    name: pathfinder tests (infura)
+    name: pathfinder_lib tests (infura)
     needs: compile_tests
     runs-on: ubuntu-latest
     steps:       
       # Fetch the test binary artifact
       - uses: actions/download-artifact@v3
         with:
-          name: test-binary
+          name: test-binary-pathfinder-lib
       # Archiving removes the file permissions
       - name: Fix file permissions
-        run: chmod +x pathfinder_test
+        run: chmod +x pathfinder_lib
 
       - name: Execute tests
         run: |
@@ -126,7 +184,60 @@ jobs:
             PATHFINDER_ETHEREUM_HTTP_GOERLI_PASSWORD=${{ secrets.INFURA_GOERLI_PASSWORD }} \
             PATHFINDER_ETHEREUM_HTTP_MAINNET_URL=${{ secrets.INFURA_MAINNET_URL }} \
             PATHFINDER_ETHEREUM_HTTP_MAINNET_PASSWORD=${{ secrets.INFURA_MAINNET_PASSWORD }} \
-            timeout 3m ./pathfinder_test ethereum::
+            timeout 3m ./pathfinder_lib ethereum::
+
+  test_pathfinder_serde:
+    name: pathfinder-serde tests
+    needs: compile_tests
+    runs-on: ubuntu-latest
+    steps:       
+      # Fetch the test binary artifact
+      - uses: actions/download-artifact@v3
+        with:
+          name: test-binary-pathfinder-serde
+      # Archiving removes the file permissions
+      - name: Fix file permissions
+        run: chmod +x pathfinder_serde
+
+      - name: Execute tests
+        run: ./pathfinder_serde
+
+  test_starknet_gateway_types:
+    name: starknet-gateway-types tests
+    needs: compile_tests
+    runs-on: ubuntu-latest
+    steps:       
+      # Fetch the test binary artifact
+      - uses: actions/download-artifact@v3
+        with:
+          name: test-binary-starknet-gateway-types
+      # Archiving removes the file permissions
+      - name: Fix file permissions
+        run: chmod +x starknet_gateway_types
+
+      - name: Execute tests
+        run: ./starknet_gateway_types
+
+  # Tests with unstripped test binaries
+  test_pathfinder_common:
+    name: pathfinder-common tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: tests
+        run: cargo test -p pathfinder-common --all-targets --locked
+
+  test_pathfinder_retry:
+    name: pathfinder-retry tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: tests
+        run: cargo test -p pathfinder-retry --all-targets --locked
 
   test_stark_curve:
     name: stark_curve tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
     branches: [ main ]
 
 jobs:
-  compile_tests:
-    name: Compile pathfinder tests
+  compile_pathfinder_ethereum_tests:
+    name: Compile pathfinder-ethereum tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -34,12 +34,10 @@ jobs:
 
       - name: Compile tests
         id: compile-tests
-        # Note:
-        # - profile changed because otherwise some test binaries are 100MB+ in size with pathfinder_lib over 1GB
-        # - package pathfinder produces two test binaries: pathfinder & pathfinder_lib
+        # Note: profile changed because otherwise the test binary is 100MB+
         run: |
           cargo test --no-run --locked --profile stripdebuginfo --message-format=json \
-            -p pathfinder -p pathfinder-ethereum -p pathfinder-serde -p starknet-gateway-types \
+            -p pathfinder-ethereum \
             | jq -r 'select(.reason=="compiler-artifact" and .target.test==true and .executable) | .executable' \
             | xargs -I '{}' bash -c 'file={}; mv ${file} $(basename ${file::(-17)})'
 
@@ -57,47 +55,9 @@ jobs:
           path: pathfinder_ethereum
           if-no-files-found: error
 
-      - name: Archive test binary pathfinder_lib
-        uses: actions/upload-artifact@v3
-        with:
-          name: test-binary-pathfinder-lib
-          path: pathfinder_lib
-          if-no-files-found: error
-
-      - name: Archive test binary pathfinder_serde
-        uses: actions/upload-artifact@v3
-        with:
-          name: test-binary-pathfinder-serde
-          path: pathfinder_serde
-          if-no-files-found: error
-
-      - name: Archive test binary starknet_gateway_types
-        uses: actions/upload-artifact@v3
-        with:
-          name: test-binary-starknet-gateway-types
-          path: starknet_gateway_types
-          if-no-files-found: error
-
-  # Tests with stripped test binaries
-  test_pathfinder:
-    name: pathfinder (binary) tests
-    needs: compile_tests
-    runs-on: ubuntu-latest
-    steps:       
-      # Fetch the test binary artifact
-      - uses: actions/download-artifact@v3
-        with:
-          name: test-binary-pathfinder
-      # Archiving removes the file permissions
-      - name: Fix file permissions
-        run: chmod +x pathfinder
-
-      - name: Execute tests
-        run: ./pathfinder
-
   test_pathfinder_ethereum_alchemy:
     name: pathfinder-ethereum tests (alchemy)
-    needs: compile_tests
+    needs: compile_pathfinder_ethereum_tests
     runs-on: ubuntu-latest
     steps:       
       # Fetch the test binary artifact
@@ -118,7 +78,7 @@ jobs:
 
   test_pathfinder_ethereum_infura:
     name: pathfinder-ethereum tests (infura)
-    needs: compile_tests
+    needs: compile_pathfinder_ethereum_tests
     runs-on: ubuntu-latest
     steps:       
       # Fetch the test binary artifact
@@ -137,21 +97,12 @@ jobs:
             PATHFINDER_ETHEREUM_HTTP_MAINNET_PASSWORD=${{ secrets.INFURA_MAINNET_PASSWORD }} \
             timeout 3m ./pathfinder_ethereum
 
-  test_pathfinder_lib:
-    name: pathfinder_lib tests
-    needs: compile_tests
+  test_all_except_pathfinder_ethereum:
+    name: all tests w/o pathfinder-ethereum
     runs-on: ubuntu-latest
     steps:
       # Required for the python environment
       - uses: actions/checkout@v3
-
-      # Fetch the test binary artifact
-      - uses: actions/download-artifact@v3
-        with:
-          name: test-binary-pathfinder-lib
-      # Archiving removes the file permissions
-      - name: Fix file permissions
-        run: chmod +x pathfinder_lib
 
       - uses: actions/setup-python@v4
         id: setup_python
@@ -167,81 +118,10 @@ jobs:
           key: site-packages-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('py/requirements*.txt') }}
       - run: pip install -e py/.
 
+      # We want to strip the debug info as some of these test binaries are 100MB+ and pathfinder_lib is 1GB+
       - name: Execute tests
-        run: ./pathfinder_lib
-
-  test_pathfinder_serde:
-    name: pathfinder-serde tests
-    needs: compile_tests
-    runs-on: ubuntu-latest
-    steps:       
-      # Fetch the test binary artifact
-      - uses: actions/download-artifact@v3
-        with:
-          name: test-binary-pathfinder-serde
-      # Archiving removes the file permissions
-      - name: Fix file permissions
-        run: chmod +x pathfinder_serde
-
-      - name: Execute tests
-        run: ./pathfinder_serde
-
-  test_starknet_gateway_types:
-    name: starknet-gateway-types tests
-    needs: compile_tests
-    runs-on: ubuntu-latest
-    steps:       
-      # Fetch the test binary artifact
-      - uses: actions/download-artifact@v3
-        with:
-          name: test-binary-starknet-gateway-types
-      # Archiving removes the file permissions
-      - name: Fix file permissions
-        run: chmod +x starknet_gateway_types
-
-      - name: Execute tests
-        run: ./starknet_gateway_types
-
-  # Tests with unstripped test binaries
-  test_pathfinder_common:
-    name: pathfinder-common tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: tests
-        run: cargo test -p pathfinder-common --all-targets --locked
-
-  test_pathfinder_retry:
-    name: pathfinder-retry tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: tests
-        run: cargo test -p pathfinder-retry --all-targets --locked
-
-  test_stark_curve:
-    name: stark_curve tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: tests
-        run: cargo test -p stark_curve --all-targets --locked
-
-  test_stark_hash:
-    name: stark_hash tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: tests
-        run: cargo test -p stark_hash --all-targets --locked
+        run: cargo test --all-targets --workspace --locked --profile stripdebuginfo \
+          --exclude pathfinder-ethereum
 
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   compile_pathfinder_ethereum_tests:
-    name: Compile pathfinder-ethereum tests
+    name: Compile l1 tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -49,7 +49,7 @@ jobs:
           if-no-files-found: error
 
   test_pathfinder_ethereum_alchemy:
-    name: pathfinder-ethereum tests (alchemy)
+    name: l1 tests (alchemy)
     needs: compile_pathfinder_ethereum_tests
     runs-on: ubuntu-latest
     steps:       
@@ -70,7 +70,7 @@ jobs:
             timeout 3m ./pathfinder_ethereum
 
   test_pathfinder_ethereum_infura:
-    name: pathfinder-ethereum tests (infura)
+    name: l1 tests (infura)
     needs: compile_pathfinder_ethereum_tests
     runs-on: ubuntu-latest
     steps:       
@@ -91,7 +91,7 @@ jobs:
             timeout 3m ./pathfinder_ethereum
 
   test_all_except_pathfinder_ethereum:
-    name: all tests w/o pathfinder-ethereum
+    name: all tests w/o l1
     runs-on: ubuntu-latest
     steps:
       # Required for the python environment

--- a/crates/gateway-types/src/error.rs
+++ b/crates/gateway-types/src/error.rs
@@ -74,4 +74,6 @@ pub enum StarknetErrorCode {
     InvalidTransactionVersion,
     #[serde(rename = "StarknetErrorCode.INVALID_PROGRAM")]
     InvalidProgram,
+    #[serde(rename = "StarknetErrorCode.DEPRECATED_TRANSACTION")]
+    DeprecatedTransaction,
 }

--- a/crates/pathfinder/src/rpc/v01.rs
+++ b/crates/pathfinder/src/rpc/v01.rs
@@ -2559,9 +2559,7 @@ mod tests {
 
     mod add_transaction {
         use super::*;
-        use crate::rpc::v01::types::reply::{
-            DeclareTransactionResult, DeployTransactionResult, InvokeTransactionResult,
-        };
+        use crate::rpc::v01::types::reply::{DeclareTransactionResult, InvokeTransactionResult};
 
         lazy_static::lazy_static! {
             pub static ref CONTRACT_DEFINITION_JSON: serde_json::Value = {
@@ -2575,8 +2573,8 @@ mod tests {
             use super::*;
             use crate::rpc::v01::types::request::ContractCall;
             use pathfinder_common::{
-                starkhash, ByteCodeOffset, CallParam, ClassHash, ConstructorParam,
-                ContractAddressSalt, EntryPoint, Fee, TransactionSignatureElem, TransactionVersion,
+                starkhash, ByteCodeOffset, CallParam, ClassHash, EntryPoint, Fee,
+                TransactionSignatureElem, TransactionVersion,
             };
             use pretty_assertions::assert_eq;
             use starknet_gateway_types::request::{
@@ -2751,44 +2749,6 @@ mod tests {
                     }
                 );
             }
-
-            #[tokio::test]
-            async fn deploy_transaction() {
-                let storage = setup_storage();
-                let sequencer = Client::new(Chain::Testnet).unwrap();
-                let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, ChainId::TESTNET, sync_state);
-                let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
-
-                let contract_definition = CONTRACT_DEFINITION.clone();
-                let contract_address_salt = ContractAddressSalt(starkhash!(
-                    "05864b5e296c05028ac2bbc4a4c1378f56a3489d13e581f21d566bb94580f76d"
-                ));
-                let constructor_calldata: Vec<ConstructorParam> = vec![];
-
-                let params = rpc_params!(
-                    contract_address_salt,
-                    constructor_calldata,
-                    contract_definition
-                );
-
-                let rpc_result = TestClient::v01(addr)
-                    .request::<DeployTransactionResult>("starknet_addDeployTransaction", params)
-                    .await
-                    .unwrap();
-
-                assert_eq!(
-                    rpc_result,
-                    DeployTransactionResult {
-                        transaction_hash: StarknetTransactionHash(starkhash!(
-                            "057ed4b4c76a1ca0ba044a654dd3ee2d0d3e550343d739350a22aacdd524110d"
-                        )),
-                        contract_address: ContractAddress::new_or_panic(starkhash!(
-                            "03926aea98213ec34fe9783d803237d221c54c52344422e1f4942a5b340fa6ad"
-                        )),
-                    }
-                );
-            }
         }
 
         mod named_args {
@@ -2874,41 +2834,6 @@ mod tests {
                         )),
                         class_hash: ClassHash(starkhash!(
                             "0711941b11a8236b8cca42b664e19342ac7300abb1dc44957763cb65877c2708"
-                        )),
-                    }
-                );
-            }
-
-            #[tokio::test]
-            async fn deploy_transaction() {
-                let storage = setup_storage();
-                let sequencer = Client::new(Chain::Testnet).unwrap();
-                let sync_state = Arc::new(SyncState::default());
-                let api = RpcApi::new(storage, sequencer, ChainId::TESTNET, sync_state);
-                let (__handle, addr) = run_server(*LOCALHOST, api).await.unwrap();
-
-                let params = by_name([
-                    (
-                        "contract_address_salt",
-                        json!("0x5864b5e296c05028ac2bbc4a4c1378f56a3489d13e581f21d566bb94580f76d"),
-                    ),
-                    ("constructor_calldata", json!([])),
-                    ("contract_definition", CONTRACT_DEFINITION_JSON.clone()),
-                ]);
-
-                let rpc_result = TestClient::v01(addr)
-                    .request::<DeployTransactionResult>("starknet_addDeployTransaction", params)
-                    .await
-                    .unwrap();
-
-                assert_eq!(
-                    rpc_result,
-                    DeployTransactionResult {
-                        transaction_hash: StarknetTransactionHash(starkhash!(
-                            "057ed4b4c76a1ca0ba044a654dd3ee2d0d3e550343d739350a22aacdd524110d"
-                        )),
-                        contract_address: ContractAddress::new_or_panic(starkhash!(
-                            "03926aea98213ec34fe9783d803237d221c54c52344422e1f4942a5b340fa6ad"
                         )),
                     }
                 );

--- a/crates/pathfinder/src/rpc/v01/api.rs
+++ b/crates/pathfinder/src/rpc/v01/api.rs
@@ -1586,7 +1586,8 @@ fn into_rpc_error(e: starknet_gateway_types::error::SequencerError) -> Error {
             | InvalidTransactionNonce
             | OutOfRangeFee
             | InvalidTransactionVersion
-            | InvalidProgram => Error::Call(CallError::Failed(e.into())),
+            | InvalidProgram
+            | DeprecatedTransaction => Error::Call(CallError::Failed(e.into())),
             UndeclaredClass => ErrorCode::InvalidContractClassHash.into(),
         },
     }


### PR DESCRIPTION
This PR fixes the workflow so that it runs all the tests that used to be run before the pathfinder crate was split into more crates. As there are more big test binaries all of those that were above ~25MB are also stripped. The archive download action does not allow to download a single file from the archived set, so I decided to introduce separate actions for each stripped binary.

Tests are grouped in the yml file in the following order:
1. alphabetically, stripped test binaries
2. alphabetically, non-stripped test binaries

The file itself got a bit big but from my perspective this is not a big inconvenience whilst having the ability to see test actions for different crates being executed in parallel.