### PR TITLE
chore(py): upgrade cairo-lang to 0.10.3

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Pathfinder Python worker subprocess"
 readme = "README.md"
 dependencies = [
-    "cairo-lang == 0.10.2",
+    "cairo-lang == 0.10.3",
     "zstandard == 0.18.0",
     "cachetools == 5.0.0",
 ]

--- a/py/requirements-dev.txt
+++ b/py/requirements-dev.txt
@@ -29,7 +29,7 @@ cachetools==5.0.0
     # via
     #   cairo-lang
     #   pathfinder-worker (pyproject.toml)
-cairo-lang==0.10.2
+cairo-lang==0.10.3
     # via pathfinder-worker (pyproject.toml)
 certifi==2022.9.24
     # via requests

--- a/py/src/pathfinder_worker/call.py
+++ b/py/src/pathfinder_worker/call.py
@@ -49,7 +49,7 @@ except ModuleNotFoundError:
 
 # used from tests, and the query which asserts that the schema is of expected version.
 EXPECTED_SCHEMA_REVISION = 22
-EXPECTED_CAIRO_VERSION = "0.10.2"
+EXPECTED_CAIRO_VERSION = "0.10.3"
 
 # used by the sqlite adapter to communicate "contract state not found, nor was the patricia tree key"
 NOT_FOUND_CONTRACT_STATE = b'{"contract_hash": "0000000000000000000000000000000000000000000000000000000000000000", "nonce": "0x0", "storage_commitment_tree": {"height": 251, "root": "0000000000000000000000000000000000000000000000000000000000000000"}}'


### PR DESCRIPTION
This PR upgrades cairo-lang to the latest version available.

The upgrade seems trivial: it's really just bumping the version number this time. (I know, famous last words...)