### PR TITLE
fix(ci/python): run pytest with "python -m pytest"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Test (python)
         run: |
           cd py
-          pytest
+          python -m pytest
 
       - name: Formatting (python)
         run: |


### PR DESCRIPTION
We're caching our installed Python dependencies but are only storing the site-packages directory. This leads to the pytest wrapper script not being available after restoring the cache. We should use "pytest -m pytest" instead that doesn't realy on scripts being present in the "bin" directory of the Python root.