### PR TITLE
chore: upgrade Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,8 +502,11 @@ version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
+ "iana-time-zone",
  "num-integer",
  "num-traits",
+ "serde",
+ "winapi",
 ]
 
 [[package]]
@@ -556,6 +568,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
 ]
 
 [[package]]
@@ -827,10 +849,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.13.4"
+name = "cxx"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+checksum = "bdf07d07d6531bfcdbe9b8b739b104610c6508dcc4d63b410585faf338241daf"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2eb5b96ecdc99f72657332953d4d9c50135af1bac34277801cc3937906ebd39"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac040a39517fd1674e0f32177648334b0f4074625b5588a64519804ba0553b12"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -838,9 +904,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.4"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
 dependencies = [
  "fnv",
  "ident_case",
@@ -852,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.4"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core",
  "quote",
@@ -1917,6 +1983,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,6 +2074,7 @@ checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2197,6 +2288,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3587,6 +3687,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scratch"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
 name = "scrypt"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3715,19 +3821,25 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.14.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+checksum = "25bf4a5a814902cd1014dbccfa4d4560fb8432c779471e96e035602519f82eef"
 dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "hex",
+ "indexmap",
  "serde",
+ "serde_json",
  "serde_with_macros",
+ "time",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "1.5.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+checksum = "e3452b4c0f6c1e357f73fdb87cd1efabaa12acf328c7a528e252893baeb3f4aa"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4544,6 +4656,12 @@ name = "unicode-segmentation"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,7 +192,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "itoa 1.0.4",
+ "itoa",
  "matchit",
  "memchr",
  "mime",
@@ -389,10 +395,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
- "lazy_static",
  "memchr",
- "regex-automata",
- "serde",
 ]
 
 [[package]]
@@ -502,6 +505,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,17 +539,6 @@ checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
 dependencies = [
  "crypto-common",
  "inout",
-]
-
-[[package]]
-name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "bitflags",
- "textwrap 0.11.0",
- "unicode-width",
 ]
 
 [[package]]
@@ -534,7 +553,7 @@ dependencies = [
  "indexmap",
  "strsim",
  "termcolor",
- "textwrap 0.16.0",
+ "textwrap",
 ]
 
 [[package]]
@@ -690,15 +709,16 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
 dependencies = [
+ "anes",
  "atty",
  "cast",
- "clap 2.34.0",
+ "ciborium",
+ "clap",
  "criterion-plot",
- "csv",
  "itertools",
  "lazy_static",
  "num-traits",
@@ -707,7 +727,6 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
- "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -716,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools",
@@ -793,28 +812,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.6",
  "typenum",
-]
-
-[[package]]
-name = "csv"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
-dependencies = [
- "bstr",
- "csv-core",
- "itoa 0.4.8",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1826,7 +1823,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.4",
+ "itoa",
 ]
 
 [[package]]
@@ -1879,7 +1876,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.4",
+ "itoa",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2031,12 +2028,6 @@ checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
-
-[[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -2730,7 +2721,7 @@ dependencies = [
  "async-trait",
  "bitvec 0.20.4",
  "bytes",
- "clap 3.2.23",
+ "clap",
  "console-subscriber",
  "criterion",
  "enum-iterator 0.7.0",
@@ -3696,16 +3687,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3722,7 +3703,7 @@ version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
- "itoa 1.0.4",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -3734,7 +3715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.4",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -4125,15 +4106,6 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
-name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
@@ -4173,7 +4145,7 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
- "itoa 1.0.4",
+ "itoa",
  "serde",
  "time-core",
  "time-macros",
@@ -4591,12 +4563,6 @@ name = "unicode-segmentation"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -174,9 +174,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.17"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
+checksum = "08b108ad2665fa3f6e6a517c3d80ec3e77d224c47d605167aefaa5d7ef97fa48"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -192,9 +192,9 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
+ "rustversion",
  "serde",
  "sync_wrapper",
- "tokio",
  "tower",
  "tower-http",
  "tower-layer",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
+checksum = "79b8558f5a0581152dc94dcd289132a1d377494bdeafcd41869b3258e3e2ad92"
 dependencies = [
  "async-trait",
  "bytes",
@@ -213,6 +213,7 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+ "rustversion",
  "tower-layer",
  "tower-service",
 ]
@@ -2018,9 +2019,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.5.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
+checksum = "ec947b7a4ce12e3b87e353abae7ce124d025b6c7d6c5aea5cc0bcf92e9510ded"
 
 [[package]]
 name = "itertools"
@@ -2175,9 +2176,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "libgit2-sys"
@@ -2253,9 +2254,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "memchr"
@@ -2565,9 +2566,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.43"
+version = "0.10.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020433887e44c27ff16365eaa2d380547a94544ad509aff6eb5b6e3e0b27b376"
+checksum = "29d971fd5722fec23977260f6e81aa67d2f22cadbdc2aa049f1022d9a3be1566"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2597,9 +2598,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.78"
+version = "0.9.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d5c8cb6e57b3a3612064d7b18b117912b4ce70955c2504d4b741c9e244b132"
+checksum = "5454462c0eced1e97f2ec09036abc8da362e66802f66fd20f86854d9d8cbcbc4"
 dependencies = [
  "autocfg",
  "cc",
@@ -2679,7 +2680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.4",
+ "parking_lot_core 0.9.5",
 ]
 
 [[package]]
@@ -2698,9 +2699,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3039,9 +3040,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "predicates"
-version = "2.1.3"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6bd09a7f7e68f3f0bf710fb7ab9c4615a488b58b5f653382a687701e458c92"
+checksum = "f54fc5dc63ed3bbf19494623db4f3af16842c0d975818e469022d09e53f0aa05"
 dependencies = [
  "difflib",
  "float-cmp",
@@ -3139,9 +3140,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0841812012b2d4a6145fae9a6af1534873c32aa67fff26bd09f8fa42c83f95a"
+checksum = "c0b18e655c21ff5ac2084a5ad0611e827b3f92badf79f4910b5a5c58f4d87ff0"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3677,9 +3678,9 @@ checksum = "930c0acf610d3fdb5e2ab6213019aaa04e227ebe9547b0649ba599b16d788bd7"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
 dependencies = [
  "serde_derive",
 ]
@@ -3706,9 +3707,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3775,9 +3776,9 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -4061,9 +4062,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4259,9 +4260,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4325,9 +4326,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
+checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4349,9 +4350,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b9af819e54b8f33d453655bef9b9acc171568fb49523078d0cc4e7484200ec"
+checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4522,7 +4523,7 @@ dependencies = [
  "httparse",
  "log",
  "rand",
- "sha-1 0.10.0",
+ "sha-1 0.10.1",
  "thiserror",
  "url",
  "utf-8",
@@ -4539,15 +4540,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "uint"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45526d29728d135c2900b0d30573fe3ee79fceb12ef534c7bb30e810a91b601"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
  "byteorder",
  "crunchy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,31 +1050,11 @@ dependencies = [
 
 [[package]]
 name = "enum-iterator"
-version = "0.7.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+checksum = "91a4ec26efacf4aeff80887a175a419493cb6f8b5480d26387eb0bd038976187"
 dependencies = [
- "enum-iterator-derive 0.7.0",
-]
-
-[[package]]
-name = "enum-iterator"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a0ac4aeb3a18f92eaf09c6bb9b3ac30ff61ca95514fc58cbead1c9a6bf5401"
-dependencies = [
- "enum-iterator-derive 1.1.0",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "enum-iterator-derive",
 ]
 
 [[package]]
@@ -2817,7 +2797,7 @@ dependencies = [
  "clap",
  "console-subscriber",
  "criterion",
- "enum-iterator 0.7.0",
+ "enum-iterator",
  "ethers",
  "flate2",
  "futures",
@@ -4716,13 +4696,13 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "7.4.2"
+version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ba753d713ec3844652ad2cb7eb56bc71e34213a14faddac7852a10ba88f61e"
+checksum = "1ffa80ed519f45995741e70664d4abcf147d2a47b8c7ea0a4aa495548ef9474f"
 dependencies = [
  "anyhow",
  "cfg-if",
- "enum-iterator 1.1.3",
+ "enum-iterator",
  "getset",
  "git2",
  "rustversion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5038,18 +5038,18 @@ checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 
 [[package]]
 name = "zstd"
-version = "0.10.2+zstd.1.5.2"
+version = "0.12.1+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4a6bd64f22b5e3e94b4e238669ff9f10815c27a5180108b849d24174a83847"
+checksum = "5c947d2adc84ff9a59f2e3c03b81aa4128acf28d6ad7d56273f7e8af14e47bea"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "4.1.6+zstd.1.5.2"
+version = "6.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b61c51bb270702d6167b8ce67340d2754b088d0c091b06e593aa772c3ee9bb"
+checksum = "a6cf39f730b440bab43da8fb5faf5f254574462f73f260f85f7987f32154ff17"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -5057,9 +5057,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.6.3+zstd.1.5.2"
+version = "2.0.4+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
+checksum = "4fa202f2ef00074143e219d15b62ffc317d17cc33909feac471c044087cad7b0"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1746,15 +1746,6 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -1773,11 +1764,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
 dependencies = [
- "hashbrown 0.11.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2053,7 +2044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.3",
+ "hashbrown",
  "serde",
 ]
 
@@ -2249,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.24.2"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
+checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2386,7 +2377,7 @@ checksum = "f7d24dc2dbae22bff6f1f9326ffce828c9f07ef9cc1e8002e5279f845432a30a"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.12.3",
+ "hashbrown",
  "metrics",
  "num_cpus",
  "parking_lot 0.12.1",
@@ -3279,9 +3270,9 @@ dependencies = [
 
 [[package]]
 name = "r2d2_sqlite"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fdc8e4da70586127893be32b7adf21326a4c6b1aba907611edf467d13ffe895"
+checksum = "b4f5d0337e99cd5cacd91ffc326c6cc9d8078def459df560c4f9bf9ba4a51034"
 dependencies = [
  "r2d2",
  "rusqlite",
@@ -3511,16 +3502,15 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85127183a999f7db96d1a976a309eebbfb6ea3b0b400ddd8340190129de6eb7a"
+checksum = "01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a"
 dependencies = [
  "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
- "memchr",
  "smallvec",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,7 +343,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding 0.1.5",
+ "block-padding",
  "byte-tools",
  "byteorder",
  "generic-array 0.12.4",
@@ -355,7 +355,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding 0.2.1",
  "generic-array 0.14.6",
 ]
 
@@ -376,12 +375,6 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bs58"
@@ -618,7 +611,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2 0.10.6",
- "sha3 0.10.6",
+ "sha3",
  "thiserror",
 ]
 
@@ -1046,7 +1039,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.6",
- "sha3 0.10.6",
+ "sha3",
  "thiserror",
  "uuid",
 ]
@@ -1063,7 +1056,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha3 0.10.6",
+ "sha3",
  "thiserror",
  "uint",
 ]
@@ -2147,7 +2140,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "sha2 0.10.6",
- "sha3 0.10.6",
+ "sha3",
 ]
 
 [[package]]
@@ -2774,7 +2767,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "sha3 0.9.1",
+ "sha3",
  "stark_hash",
  "thiserror",
  "vergen",
@@ -2903,7 +2896,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sha3 0.9.1",
+ "sha3",
  "stark_hash",
  "starknet-gateway-client",
  "starknet-gateway-types",
@@ -3802,18 +3795,6 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "sha3"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
@@ -3993,7 +3974,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sha3 0.9.1",
+ "sha3",
  "stark_hash",
  "starknet-gateway-test-fixtures",
  "thiserror",

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -10,15 +10,15 @@ test-utils = ["dep:metrics"]
 
 [dependencies]
 bitvec = "0.20.4"
-ethers = "1.0.0"
+ethers = "1.0.2"
 hex-literal = "0.3"
 metrics = { version = "0.20.1", optional = true }
 rusqlite = { version = "0.27.0", features = ["bundled"] }
-serde = { version = "1.0.130", features = ["derive"] }
-serde_json = { version = "1.0.68", features = ["arbitrary_precision", "raw_value"] }
+serde = { version = "1.0.149", features = ["derive"] }
+serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
 sha3 = "0.9"
 stark_hash = { path = "../stark_hash" }
-thiserror = "1.0.30"
+thiserror = "1.0.37"
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["git"] }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -13,7 +13,7 @@ bitvec = "0.20.4"
 ethers = "1.0.2"
 hex-literal = "0.3"
 metrics = { version = "0.20.1", optional = true }
-rusqlite = { version = "0.27.0", features = ["bundled"] }
+rusqlite = { version = "0.28.0", features = ["bundled"] }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
 sha3 = "0.10"

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -16,7 +16,7 @@ metrics = { version = "0.20.1", optional = true }
 rusqlite = { version = "0.27.0", features = ["bundled"] }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
-sha3 = "0.9"
+sha3 = "0.10"
 stark_hash = { path = "../stark_hash" }
 thiserror = "1.0.37"
 

--- a/crates/ethereum/Cargo.toml
+++ b/crates/ethereum/Cargo.toml
@@ -7,22 +7,22 @@ rust-version = "1.62"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.44"
-async-trait = "0.1.52"
-ethers = "1.0.0"
+anyhow = "1.0.66"
+async-trait = "0.1.59"
+ethers = "1.0.2"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 lazy_static = "1.4.0"
 pathfinder-common = { path = "../common" }
 pathfinder-retry = { path = "../retry" }
-reqwest = { version = "0.11.4", features = ["json"] }
+reqwest = { version = "0.11.13", features = ["json"] }
 stark_hash = { path = "../stark_hash" }
-thiserror = "1.0.30"
-tokio = "1.11.0"
-tracing = "0.1.31"
+thiserror = "1.0.37"
+tokio = "1.23.0"
+tracing = "0.1.37"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
 hex = "0.4.3"
 hex-literal = "0.3"
-pretty_assertions = "1.0.0"
-tokio = { version = "1.11.0", features = ["macros"] }
+pretty_assertions = "1.3.0"
+tokio = { version = "1.23.0", features = ["macros"] }

--- a/crates/gateway-client/Cargo.toml
+++ b/crates/gateway-client/Cargo.toml
@@ -10,35 +10,35 @@ rust-version = "1.62"
 test-utils = ["dep:mockall"]
 
 [dependencies]
-anyhow = "1.0.44"
-async-trait = "0.1.52"
-bytes = "1.1.0"
+anyhow = "1.0.66"
+async-trait = "0.1.59"
+bytes = "1.3.0"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 metrics = "0.20.1"
-mockall = { version = "0.11.0", optional = true }
+mockall = { version = "0.11.3", optional = true }
 pathfinder-common = { path = "../common" }
 pathfinder-retry = { path = "../retry" }
 pathfinder-serde = { path = "../serde" }
-reqwest = { version = "0.11.4", features = ["json"] }
-serde = { version = "1.0.130", features = ["derive"] }
+reqwest = { version = "0.11.13", features = ["json"] }
+serde = { version = "1.0.149", features = ["derive"] }
 starknet-gateway-types = { path = "../gateway-types" }
-tracing = "0.1.31"
+tracing = "0.1.37"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-base64 = "0.13.0"
-flate2 = "1.0.23"
+base64 = "0.13.1"
+flate2 = "1.0.25"
 hex-literal = "0.3"
-http = "0.2.6"
+http = "0.2.8"
 lazy_static = "1.4.0"
 pathfinder-common = { path = "../common", features = ["test-utils"] }
 pathfinder-serde = { path = "../serde" }
-pretty_assertions = "1.0.0"
-reqwest = { version = "0.11.4", features = ["json"] }
-serde_json = { version = "1.0.68", features = ["arbitrary_precision", "raw_value"] }
+pretty_assertions = "1.3.0"
+reqwest = { version = "0.11.13", features = ["json"] }
+serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
 stark_hash = { path = "../stark_hash" }
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
-test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
-tokio = { version = "1.11.0", features = ["test-util"] }
-tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
-warp = "0.3.2"
+test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
+tokio = { version = "1.23.0", features = ["test-util"] }
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+warp = "0.3.3"

--- a/crates/gateway-types/Cargo.toml
+++ b/crates/gateway-types/Cargo.toml
@@ -15,7 +15,7 @@ reqwest = "0.11.13"
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
 serde_with = "1.14.0"
-sha3 = "0.9"
+sha3 = "0.10"
 stark_hash = { path = "../stark_hash" }
 thiserror = "1.0.37"
 tokio = { version = "1.23.0" }

--- a/crates/gateway-types/Cargo.toml
+++ b/crates/gateway-types/Cargo.toml
@@ -7,22 +7,22 @@ rust-version = "1.62"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.44"
-ethers = "1.0.0"
+anyhow = "1.0.66"
+ethers = "1.0.2"
 pathfinder-common = { path = "../common" }
 pathfinder-serde = { path = "../serde" }
-reqwest = "0.11.4"
-serde = { version = "1.0.130", features = ["derive"] }
-serde_json = { version = "1.0.68", features = ["arbitrary_precision", "raw_value"] }
-serde_with = "1.9.4"
+reqwest = "0.11.13"
+serde = { version = "1.0.149", features = ["derive"] }
+serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
+serde_with = "1.14.0"
 sha3 = "0.9"
 stark_hash = { path = "../stark_hash" }
-thiserror = "1.0.30"
-tokio = { version = "1.11.0" }
+thiserror = "1.0.37"
+tokio = { version = "1.23.0" }
 
 [dev-dependencies]
 # Due to pathfinder_common::starkhash!() usage
 hex-literal = "0.3"
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
-tokio = { version = "1.11.0", features = ["test-util"] }
+tokio = { version = "1.23.0", features = ["test-util"] }
 zstd = "0.10"

--- a/crates/gateway-types/Cargo.toml
+++ b/crates/gateway-types/Cargo.toml
@@ -25,4 +25,4 @@ tokio = { version = "1.23.0" }
 hex-literal = "0.3"
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 tokio = { version = "1.23.0", features = ["test-util"] }
-zstd = "0.10"
+zstd = "0.12"

--- a/crates/gateway-types/Cargo.toml
+++ b/crates/gateway-types/Cargo.toml
@@ -14,7 +14,7 @@ pathfinder-serde = { path = "../serde" }
 reqwest = "0.11.13"
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
-serde_with = "1.14.0"
+serde_with = "2.1.0"
 sha3 = "0.10"
 stark_hash = { path = "../stark_hash" }
 thiserror = "1.0.37"

--- a/crates/gateway-types/src/class_hash.rs
+++ b/crates/gateway-types/src/class_hash.rs
@@ -556,7 +556,7 @@ mod tests {
         use super::truncated_keccak;
         use pathfinder_common::starkhash;
         use sha3::{Digest, Keccak256};
-        let all_set = Keccak256::digest(&[0xffu8; 32]);
+        let all_set = Keccak256::digest([0xffu8; 32]);
         assert!(all_set[0] > 0xf);
         let truncated = truncated_keccak(all_set.into());
         assert_eq!(

--- a/crates/merkle-tree/Cargo.toml
+++ b/crates/merkle-tree/Cargo.toml
@@ -7,7 +7,7 @@ rust-version = "1.62"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.44"
+anyhow = "1.0.66"
 bitvec = "0.20.4"
 pathfinder-common = { path = "../common" }
 pathfinder-storage = { path = "../storage" }
@@ -18,4 +18,4 @@ starknet-gateway-types = { path = "../gateway-types" }
 
 [dev-dependencies]
 hex-literal = "0.3"
-pretty_assertions = "1.0.0"
+pretty_assertions = "1.3.0"

--- a/crates/merkle-tree/Cargo.toml
+++ b/crates/merkle-tree/Cargo.toml
@@ -12,7 +12,7 @@ bitvec = "0.20.4"
 pathfinder-common = { path = "../common" }
 pathfinder-storage = { path = "../storage" }
 rand = "0.8"
-rusqlite = { version = "0.27.0", features = ["bundled"] }
+rusqlite = { version = "0.28.0", features = ["bundled"] }
 stark_hash = { path = "../stark_hash" }
 starknet-gateway-types = { path = "../gateway-types" }
 

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -35,7 +35,7 @@ pathfinder-rpc = { path = "../rpc" }
 pathfinder-serde = { path = "../serde" }
 pathfinder-storage = { path = "../storage" }
 reqwest = { version = "0.11.13", features = ["json"] }
-rusqlite = { version = "0.27.0", features = ["bundled"] }
+rusqlite = { version = "0.28.0", features = ["bundled"] }
 semver = "1.0.14"
 serde = { version = "1.0.149", features = ["derive"] }
 stark_hash = { path = "../stark_hash" }

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -15,13 +15,13 @@ tokio-console = ["console-subscriber", "tokio/tracing"]
 rpc-full-serde = []
 
 [dependencies]
-anyhow = "1.0.44"
-async-trait = "0.1.52"
+anyhow = "1.0.66"
+async-trait = "0.1.59"
 bitvec = "0.20.4"
-clap = { version = "3.1.6", features = ["env"] }
-console-subscriber = { version = "0.1.3", optional = true }
+clap = { version = "3.2.23", features = ["env"] }
+console-subscriber = { version = "0.1.8", optional = true }
 enum-iterator = "0.7.0"
-ethers = "1.0.0"
+ethers = "1.0.2"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 hex-literal = "0.3"
 lazy_static = "1.4.0"
@@ -34,38 +34,38 @@ pathfinder-retry = { path = "../retry" }
 pathfinder-rpc = { path = "../rpc" }
 pathfinder-serde = { path = "../serde" }
 pathfinder-storage = { path = "../storage" }
-reqwest = { version = "0.11.4", features = ["json"] }
+reqwest = { version = "0.11.13", features = ["json"] }
 rusqlite = { version = "0.27.0", features = ["bundled"] }
-semver = "1.0.7"
-serde = { version = "1.0.130", features = ["derive"] }
+semver = "1.0.14"
+serde = { version = "1.0.149", features = ["derive"] }
 stark_hash = { path = "../stark_hash" }
 starknet-gateway-client = { path = "../gateway-client" }
 starknet-gateway-types = { path = "../gateway-types" }
 tempfile = "3"
-tokio = { version = "1.11.0", features = ["process"] }
-toml = "0.5.8"
-tracing = "0.1.31"
-tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
-warp = "0.3.2"
+tokio = { version = "1.23.0", features = ["process"] }
+toml = "0.5.9"
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+warp = "0.3.3"
 zstd = "0.10"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-bytes = "1.1.0"
+bytes = "1.3.0"
 criterion = "0.3"
-flate2 = "1.0.23"
-http = "0.2.6"
-mockall = "0.11.0"
+flate2 = "1.0.25"
+http = "0.2.8"
+mockall = "0.11.3"
 pathfinder-common = { path = "../common", features = ["full-serde", "test-utils"] }
 pathfinder-storage = { path = "../storage", features = ["test-utils"] }
-pretty_assertions = "1.0.0"
+pretty_assertions = "1.3.0"
 rand = "0.8"
-serde_json = { version = "1.0.68", features = ["arbitrary_precision", "raw_value"] }
-serde_with = "1.9.4"
+serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
+serde_with = "1.14.0"
 starknet-gateway-client = { path = "../gateway-client", features = ["test-utils"] }
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
-test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
-tokio = { version = "1.11.0", features = ["test-util"] }
+test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
+tokio = { version = "1.23.0", features = ["test-util"] }
 
 [[bench]]
 name = "merkle_tree"

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -61,7 +61,7 @@ pathfinder-storage = { path = "../storage", features = ["test-utils"] }
 pretty_assertions = "1.3.0"
 rand = "0.8"
 serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
-serde_with = "1.14.0"
+serde_with = "2.1.0"
 starknet-gateway-client = { path = "../gateway-client", features = ["test-utils"] }
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 test-log = { version = "0.2.11", default-features = false, features = ["trace"] }

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -52,7 +52,7 @@ zstd = "0.12"
 [dev-dependencies]
 assert_matches = "1.5.0"
 bytes = "1.3.0"
-criterion = "0.3"
+criterion = "0.4"
 flate2 = "1.0.25"
 http = "0.2.8"
 mockall = "0.11.3"

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -47,7 +47,7 @@ toml = "0.5.9"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 warp = "0.3.3"
-zstd = "0.10"
+zstd = "0.12"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -20,7 +20,7 @@ async-trait = "0.1.59"
 bitvec = "0.20.4"
 clap = { version = "3.2.23", features = ["env"] }
 console-subscriber = { version = "0.1.8", optional = true }
-enum-iterator = "0.7.0"
+enum-iterator = "1.2.0"
 ethers = "1.0.2"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 hex-literal = "0.3"

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -6,13 +6,13 @@ mod file;
 use std::{fmt::Display, net::SocketAddr, path::PathBuf, str::FromStr};
 
 use anyhow::Context;
-use enum_iterator::IntoEnumIterator;
+use enum_iterator::Sequence;
 use reqwest::Url;
 
 const DEFAULT_HTTP_RPC_ADDR: &str = "127.0.0.1:9545";
 
 /// Possible configuration options.
-#[derive(Debug, PartialEq, Clone, Copy, Hash, Eq, IntoEnumIterator)]
+#[derive(Debug, PartialEq, Clone, Copy, Hash, Eq, Sequence)]
 pub enum ConfigOption {
     /// The Ethereum URL.
     EthereumHttpUrl,

--- a/crates/pathfinder/src/bin/pathfinder/config/builder.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config/builder.rs
@@ -254,15 +254,13 @@ Hint: Register your own account or run your own Ethereum node and put the real U
 
 #[cfg(test)]
 mod tests {
-    use enum_iterator::IntoEnumIterator;
-
     use super::*;
 
     #[test]
     fn with_take() {
         let value = Some("Value".to_owned());
         let mut builder = ConfigBuilder::default();
-        for option in ConfigOption::into_enum_iter() {
+        for option in enum_iterator::all::<ConfigOption>() {
             builder = builder.with(option, value.clone());
             assert_eq!(builder.take(option), value);
             assert_eq!(builder.take(option), None);
@@ -273,7 +271,7 @@ mod tests {
     fn default_is_none() {
         // Quite a few tests rely on the default value being None, so we enforce this with a test.
         let mut builder = ConfigBuilder::default();
-        for option in ConfigOption::into_enum_iter() {
+        for option in enum_iterator::all::<ConfigOption>() {
             assert_eq!(builder.take(option), None);
         }
     }
@@ -294,7 +292,7 @@ mod tests {
             let mut builder = ConfigBuilder::default();
             let mut values = HashMap::new();
 
-            for (idx, option) in ConfigOption::into_enum_iter().enumerate() {
+            for (idx, option) in enum_iterator::all::<ConfigOption>().enumerate() {
                 let value = Some(format!("{} {}", prefix, idx));
 
                 builder = builder.with(option, value.clone());
@@ -311,7 +309,7 @@ mod tests {
 
             let mut merged = some_1.merge(some_2);
 
-            for option in ConfigOption::into_enum_iter() {
+            for option in enum_iterator::all::<ConfigOption>() {
                 assert_eq!(merged.take(option), values_1.remove(&option).unwrap());
             }
         }
@@ -323,7 +321,7 @@ mod tests {
 
             let mut merged = some.merge(none);
 
-            for option in ConfigOption::into_enum_iter() {
+            for option in enum_iterator::all::<ConfigOption>() {
                 assert_eq!(merged.take(option), values.remove(&option).unwrap());
             }
         }
@@ -335,7 +333,7 @@ mod tests {
 
             let mut merged = none.merge(some);
 
-            for option in ConfigOption::into_enum_iter() {
+            for option in enum_iterator::all::<ConfigOption>() {
                 assert_eq!(merged.take(option), values.remove(&option).unwrap());
             }
         }

--- a/crates/retry/Cargo.toml
+++ b/crates/retry/Cargo.toml
@@ -7,8 +7,8 @@ rust-version = "1.62"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = "1.11.0"
+tokio = "1.23.0"
 tokio-retry = "0.3.0"
 
 [dev-dependencies]
-tokio = { version = "1.11.0", features = ["macros", "test-util"] }
+tokio = { version = "1.23.0", features = ["macros", "test-util"] }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -25,7 +25,7 @@ pathfinder-storage = { path = "../storage" }
 rusqlite = { version = "0.27.0", features = ["bundled"] }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
-serde_with = "1.14.0"
+serde_with = "2.1.0"
 stark_hash = { path = "../stark_hash" }
 starknet-gateway-client = { path = "../gateway-client" }
 starknet-gateway-types = { path = "../gateway-types" }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -7,10 +7,10 @@ rust-version = "1.62"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.44"
-base64 = "0.13.0"
-ethers = "1.0.0"
-flate2 = "1.0.23"
+anyhow = "1.0.66"
+base64 = "0.13.1"
+ethers = "1.0.2"
+flate2 = "1.0.25"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 hex-literal = "0.3"
 jsonrpsee = { git = "https://github.com/eqlabs/jsonrpsee", branch = "start_with_paths", default-features = false, features = [
@@ -23,20 +23,20 @@ pathfinder-merkle-tree = { path = "../merkle-tree" }
 pathfinder-serde = { path = "../serde" }
 pathfinder-storage = { path = "../storage" }
 rusqlite = { version = "0.27.0", features = ["bundled"] }
-serde = { version = "1.0.130", features = ["derive"] }
-serde_json = { version = "1.0.68", features = ["arbitrary_precision", "raw_value"] }
-serde_with = "1.9.4"
+serde = { version = "1.0.149", features = ["derive"] }
+serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
+serde_with = "1.14.0"
 stark_hash = { path = "../stark_hash" }
 starknet-gateway-client = { path = "../gateway-client" }
 starknet-gateway-types = { path = "../gateway-types" }
-thiserror = "1.0.30"
-tokio = "1.11.0"
-tracing = "0.1.31"
+thiserror = "1.0.37"
+tokio = "1.23.0"
+tracing = "0.1.37"
 zstd = "0.10"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-bytes = "1.1.0"
+bytes = "1.3.0"
 hex = "0.4.3"
 jsonrpsee = { git = "https://github.com/eqlabs/jsonrpsee", branch = "start_with_paths", default-features = false, features = [
     "server",
@@ -45,14 +45,14 @@ jsonrpsee = { git = "https://github.com/eqlabs/jsonrpsee", branch = "start_with_
 lazy_static = "1.4.0"
 pathfinder-common = { path = "../common", features = ["full-serde", "test-utils"] }
 pathfinder-storage = { path = "../storage", features = ["test-utils"] }
-pretty_assertions = "1.0.0"
-reqwest = { version = "0.11.4", features = ["json"] }
+pretty_assertions = "1.3.0"
+reqwest = { version = "0.11.13", features = ["json"] }
 rusqlite = { version = "0.27.0", features = ["bundled"] }
-serde_json = { version = "1.0.68", features = ["arbitrary_precision", "raw_value"] }
+serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
 stark_hash = { path = "../stark_hash" }
 starknet-gateway-client = { path = "../gateway-client", features = ["test-utils"] }
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 tempfile = "3"
-test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
-tokio = { version = "1.11.0", features = ["test-util"] }
-tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
+test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
+tokio = { version = "1.23.0", features = ["test-util"] }
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -32,7 +32,7 @@ starknet-gateway-types = { path = "../gateway-types" }
 thiserror = "1.0.37"
 tokio = "1.23.0"
 tracing = "0.1.37"
-zstd = "0.10"
+zstd = "0.12"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -22,7 +22,7 @@ pathfinder-ethereum = { path = "../ethereum" }
 pathfinder-merkle-tree = { path = "../merkle-tree" }
 pathfinder-serde = { path = "../serde" }
 pathfinder-storage = { path = "../storage" }
-rusqlite = { version = "0.27.0", features = ["bundled"] }
+rusqlite = { version = "0.28.0", features = ["bundled"] }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
 serde_with = "2.1.0"
@@ -47,7 +47,7 @@ pathfinder-common = { path = "../common", features = ["full-serde", "test-utils"
 pathfinder-storage = { path = "../storage", features = ["test-utils"] }
 pretty_assertions = "1.3.0"
 reqwest = { version = "0.11.13", features = ["json"] }
-rusqlite = { version = "0.27.0", features = ["bundled"] }
+rusqlite = { version = "0.28.0", features = ["bundled"] }
 serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
 stark_hash = { path = "../stark_hash" }
 starknet-gateway-client = { path = "../gateway-client", features = ["test-utils"] }

--- a/crates/serde/Cargo.toml
+++ b/crates/serde/Cargo.toml
@@ -7,14 +7,14 @@ rust-version = "1.62"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.44"
-ethers = "1.0.0"
+anyhow = "1.0.66"
+ethers = "1.0.2"
 num-bigint = { version = "0.4.3", features = ["serde"] }
 pathfinder-common = { path = "../common" }
-serde = { version = "1.0.130", features = ["derive"] }
-serde_json = "1.0.68"
-serde_with = "1.9.4"
+serde = { version = "1.0.149", features = ["derive"] }
+serde_json = "1.0.89"
+serde_with = "1.14.0"
 stark_hash = { path = "../stark_hash" }
 
 [dev-dependencies]
-pretty_assertions = "1.0.0"
+pretty_assertions = "1.3.0"

--- a/crates/serde/Cargo.toml
+++ b/crates/serde/Cargo.toml
@@ -13,7 +13,7 @@ num-bigint = { version = "0.4.3", features = ["serde"] }
 pathfinder-common = { path = "../common" }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.89"
-serde_with = "1.14.0"
+serde_with = "2.1.0"
 stark_hash = { path = "../stark_hash" }
 
 [dev-dependencies]

--- a/crates/stark_curve/Cargo.toml
+++ b/crates/stark_curve/Cargo.toml
@@ -18,4 +18,4 @@ ff = { git = "https://github.com/eqlabs/ff", branch = "var_time_eq", default-fea
 ] }
 
 [dev-dependencies]
-pretty_assertions = "1.0.0"
+pretty_assertions = "1.3.0"

--- a/crates/stark_hash/Cargo.toml
+++ b/crates/stark_hash/Cargo.toml
@@ -15,17 +15,17 @@ stark_curve = { path = "../stark_curve" }
 [dependencies]
 # paritys scale codec locks us here
 bitvec = "0.20.4"
-rand_core = "0.6.3"
-serde = "1.0.134"
+rand_core = "0.6.4"
+serde = "1.0.149"
 stark_curve = { path = "../stark_curve" }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
 criterion = "0.3"
 hex = "0.4.3"
-pretty_assertions = "1.0.0"
+pretty_assertions = "1.3.0"
 rand = "0.8"
-serde_json = "1.0.75"
+serde_json = "1.0.89"
 
 [[bench]]
 name = "stark_hash"

--- a/crates/stark_hash/Cargo.toml
+++ b/crates/stark_hash/Cargo.toml
@@ -21,7 +21,7 @@ stark_curve = { path = "../stark_curve" }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-criterion = "0.3"
+criterion = "0.4"
 hex = "0.4.3"
 pretty_assertions = "1.3.0"
 rand = "0.8"

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -27,7 +27,7 @@ rusqlite = { version = "0.27.0", features = ["bundled"] }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
 serde_with = "1.14.0"
-sha3 = "0.9"
+sha3 = "0.10"
 stark_hash = { path = "../stark_hash" }
 starknet-gateway-client = { path = "../gateway-client" }
 starknet-gateway-types = { path = "../gateway-types" }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -26,7 +26,7 @@ r2d2_sqlite = "0.20.0"
 rusqlite = { version = "0.27.0", features = ["bundled"] }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
-serde_with = "1.14.0"
+serde_with = "2.1.0"
 sha3 = "0.10"
 stark_hash = { path = "../stark_hash" }
 starknet-gateway-client = { path = "../gateway-client" }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -22,8 +22,8 @@ pathfinder-common = { path = "../common" }
 pathfinder-ethereum = { path = "../ethereum" }
 pathfinder-serde = { path = "../serde" }
 r2d2 = "0.8.10"
-r2d2_sqlite = "0.20.0"
-rusqlite = { version = "0.27.0", features = ["bundled"] }
+r2d2_sqlite = "0.21.0"
+rusqlite = { version = "0.28.0", features = ["bundled"] }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
 serde_with = "2.1.0"

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -10,30 +10,30 @@ rust-version = "1.62"
 test-utils = []
 
 [dependencies]
-anyhow = "1.0.44"
-base64 = "0.13.0"
+anyhow = "1.0.66"
+base64 = "0.13.1"
 bitvec = "0.20.4"
-ethers = "1.0.0"
-flate2 = "1.0.23"
+ethers = "1.0.2"
+flate2 = "1.0.25"
 hex = "0.4.3"
 hex-literal = "0.3"
 lazy_static = "1.4.0"
 pathfinder-common = { path = "../common" }
 pathfinder-ethereum = { path = "../ethereum" }
 pathfinder-serde = { path = "../serde" }
-r2d2 = "0.8.9"
+r2d2 = "0.8.10"
 r2d2_sqlite = "0.20.0"
 rusqlite = { version = "0.27.0", features = ["bundled"] }
-serde = { version = "1.0.130", features = ["derive"] }
-serde_json = { version = "1.0.68", features = ["arbitrary_precision", "raw_value"] }
-serde_with = "1.9.4"
+serde = { version = "1.0.149", features = ["derive"] }
+serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
+serde_with = "1.14.0"
 sha3 = "0.9"
 stark_hash = { path = "../stark_hash" }
 starknet-gateway-client = { path = "../gateway-client" }
 starknet-gateway-types = { path = "../gateway-types" }
-thiserror = "1.0.30"
-tokio = "1.11.0"
-tracing = "0.1.31"
+thiserror = "1.0.37"
+tokio = "1.23.0"
+tracing = "0.1.37"
 zstd = "0.10"
 
 [dev-dependencies]

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -34,7 +34,7 @@ starknet-gateway-types = { path = "../gateway-types" }
 thiserror = "1.0.37"
 tokio = "1.23.0"
 tracing = "0.1.37"
-zstd = "0.10"
+zstd = "0.12"
 
 [dev-dependencies]
 assert_matches = "1.5.0"


### PR DESCRIPTION
This PR upgrades all of our Rust dependencies except `clap` and `bitvec` to the latest version in the main workspace.