### PR TITLE
refactor(Dockerfile): use cargo-chef for build-dependency caching

### DIFF
--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -3,21 +3,9 @@
 //! Just sets up `vergen` to query our git information for the build.
 
 pub fn main() {
-    // Our Dockerfile is set up to a dependency only run, to cache a layer with all of the
-    // dependencies downloaded. during that "DEPENDENCY_LAYER" environment variable is set,
-    // and we shouldn't ask vergen to setup anything on that run to avoid this adding additional
-    // cache-miss reasons.
-
-    if std::env::var_os("DEPENDENCY_LAYER").is_some() {
-        return;
-    }
-
-    {
-        // at 7.0.0 default enables everything compiled in, selected with feature-flags
-        let mut config = vergen::Config::default();
-        *config.git_mut().semver_kind_mut() = vergen::SemverKind::Lightweight;
-        *config.git_mut().semver_dirty_mut() = Some("-dirty");
-        vergen::vergen(config)
-            .expect("vergen failed; this is probably due to missing .git directory");
-    }
+    // at 7.0.0 default enables everything compiled in, selected with feature-flags
+    let mut config = vergen::Config::default();
+    *config.git_mut().semver_kind_mut() = vergen::SemverKind::Lightweight;
+    *config.git_mut().semver_dirty_mut() = Some("-dirty");
+    vergen::vergen(config).expect("vergen failed; this is probably due to missing .git directory");
 }

--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -7,5 +7,11 @@ pub fn main() {
     let mut config = vergen::Config::default();
     *config.git_mut().semver_kind_mut() = vergen::SemverKind::Lightweight;
     *config.git_mut().semver_dirty_mut() = Some("-dirty");
+    *config.git_mut().branch_mut() = false;
+    *config.git_mut().commit_author_mut() = false;
+    *config.git_mut().commit_count_mut() = false;
+    *config.git_mut().commit_message_mut() = false;
+    *config.git_mut().commit_timestamp_mut() = false;
+    *config.git_mut().sha_mut() = false;
     vergen::vergen(config).expect("vergen failed; this is probably due to missing .git directory");
 }


### PR DESCRIPTION
Our own hack tried to mimic what cargo-chef does: creating a fake project that has the exact same dependencies as our main one, compiling those dependencies and then compiling the pathfinder binary using those pre-compiled deps as a separate step. This is to allow the dependencies to be cached as a layer so that those are not re-compiled every time.

This change modifies the Dockerfile to just use cargo-chef that does all this in a maintanable manner.