### PR TITLE
fix(github): don't rely on wrapper scripts for black and flake8 either

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,12 +185,12 @@ jobs:
       - name: Formatting (python)
         run: |
           cd py
-          black --check .
+          python -m black --check .
 
       - name: Lints (python)
         run: |
           cd py
-          flake8 src/ tests/ tools/
+          python -m flake8 src/ tests/ tools/
 
 
   fuzz_targets:


### PR DESCRIPTION
Since we're only storing the site-packages directory in the cache the wrapper script installed to the bin subdirectory of the Python root dir might not be available.