### PR TITLE
fix: load test

### DIFF
--- a/crates/load-test/src/requests/v01.rs
+++ b/crates/load-test/src/requests/v01.rs
@@ -127,6 +127,8 @@ pub async fn get_events(
             "to_block": to_block,
             "address": filter.address,
             "keys": filter.keys,
+            "page_size": 1000,
+            "page_number": 0,
         }}),
     )
     .await

--- a/crates/load-test/src/requests/v02.rs
+++ b/crates/load-test/src/requests/v02.rs
@@ -180,6 +180,7 @@ pub async fn get_events(
             "to_block": to_block,
             "address": filter.address,
             "keys": filter.keys,
+            "chunk_size": 1000,
         }}),
     )
     .await
@@ -197,8 +198,7 @@ pub struct EventFilter {
 #[derive(Clone, Debug, serde::Deserialize, PartialEq, Eq)]
 pub struct GetEventsResult {
     pub events: Vec<serde_json::Value>,
-    pub page_number: usize,
-    pub is_last_page: bool,
+    pub continuation_token: Option<String>,
 }
 
 fn block_number_to_block_id(number: Option<u64>) -> serde_json::Value {


### PR DESCRIPTION
This PR fixes load-test parsing issues for both v0.1 and v0.2 `get_events`.

These were the only failures when running this locally.