### PR TITLE
chore(docker): inject version number explicitly and don't rely on Git

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
-# Don't ignore this, because it being missing would interfere with -dirty in `git describe`.
-# Dockerfile
+Dockerfile
+.git
 # rust temporary files
 target/
 crates/load-test/target/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,6 +35,13 @@ jobs:
           swap-size-gb: 10
       - name: Checkout sources
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Generate version
+        id: generate_version
+        run: |
+          echo -n "pathfinder_version=" >> $GITHUB_OUTPUT
+          git describe --tags --dirty >> $GITHUB_OUTPUT
       - name: Set up QEMU
         id: qemu
         uses: docker/setup-qemu-action@v2
@@ -62,6 +69,8 @@ jobs:
             linux/amd64
             linux/arm64
           file: ./Dockerfile
+          build-args: |
+            PATHFINDER_FORCE_VERSION=${{ steps.generate_version.outputs.pathfinder_version }}
           builder: ${{ steps.buildx.outputs.name }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,6 @@
-# when developing this file, you might want to start by creating a copy of this
-# file away from the source tree and then editing that, finally committing a
-# changed version of this file. editing this file will render most of the
-# layers unusable.
-#
-# our build process requires that all files are copied for the rust build,
-# which uses `git describe --tags` to determine the build identifier.
-# Dockerfile cannot be .dockerignore'd because of this as it would produce a
-# false dirty flag.
+# Our Dockerfile relies on the PATHFINDER_FORCE_VERSION build-time variable being set.
+# This is required so that we don't have to copy the .git directory into the layer which
+# might cause caches to be invalidated even if that's unnecessary.
 
 ########################################
 # Stage 1: Build the pathfinder binary #
@@ -36,9 +30,10 @@ RUN cargo chef cook --release --recipe-path recipe.json
 
 # Compile the actual libraries and binary now
 COPY . .
-COPY ./.git /usr/src/pathfinder/.git
 
-RUN CARGO_INCREMENTAL=0 cargo build --release -p pathfinder --bin pathfinder
+ARG PATHFINDER_FORCE_VERSION
+
+RUN PATHFINDER_FORCE_VERSION=${PATHFINDER_FORCE_VERSION} CARGO_INCREMENTAL=0 cargo build --release -p pathfinder --bin pathfinder
 
 #######################################
 # Stage 2: Build the Python libraries #

--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -3,6 +3,17 @@
 //! Just sets up `vergen` to query our git information for the build.
 
 pub fn main() {
+    let force_version_env_var_name = "PATHFINDER_FORCE_VERSION";
+
+    println!("cargo:rerun-if-env-changed={}", force_version_env_var_name);
+
+    if let Ok(version) = std::env::var(force_version_env_var_name) {
+        if !version.is_empty() {
+            println!("cargo:rustc-env=VERGEN_GIT_SEMVER_LIGHTWEIGHT={}", version);
+            return;
+        }
+    }
+
     // at 7.0.0 default enables everything compiled in, selected with feature-flags
     let mut config = vergen::Config::default();
     *config.git_mut().semver_kind_mut() = vergen::SemverKind::Lightweight;


### PR DESCRIPTION
Copying the .git directory in the Dockerfile results in cache layer invalidation even for changes that have no effect at all on the source code we're building.

We needed the .git directory just so that we can generate a version number. Instead of copying that into the container we can just generate the version number first and pass that as a build argument into the build process.
