### PR TITLE
chore(py): upgrade Python deps

### DIFF
--- a/py/requirements-dev.txt
+++ b/py/requirements-dev.txt
@@ -8,7 +8,7 @@ aiohttp==3.8.3
     # via
     #   cairo-lang
     #   web3
-aiosignal==1.2.0
+aiosignal==1.3.1
     # via aiohttp
 async-timeout==4.0.2
     # via aiohttp
@@ -23,7 +23,7 @@ bitarray==2.6.0
     # via eth-account
 black==22.10.0
     # via pathfinder-worker (pyproject.toml)
-build==0.8.0
+build==0.9.0
     # via pip-tools
 cachetools==5.0.0
     # via
@@ -31,7 +31,7 @@ cachetools==5.0.0
     #   pathfinder-worker (pyproject.toml)
 cairo-lang==0.10.3
     # via pathfinder-worker (pyproject.toml)
-certifi==2022.9.24
+certifi==2022.12.7
     # via requests
 charset-normalizer==2.1.1
     # via
@@ -89,7 +89,7 @@ flake8==5.0.4
     # via pathfinder-worker (pyproject.toml)
 frozendict==1.2
     # via cairo-lang
-frozenlist==1.3.1
+frozenlist==1.3.3
     # via
     #   aiohttp
     #   aiosignal
@@ -106,19 +106,19 @@ iniconfig==1.1.1
     # via pytest
 ipfshttpclient==0.8.0a2
     # via web3
-jsonschema==4.16.0
+jsonschema==4.17.3
     # via web3
-lark==1.1.3
+lark==1.1.5
     # via cairo-lang
 lru-dict==1.1.8
     # via web3
-marshmallow==3.18.0
+marshmallow==3.19.0
     # via
     #   cairo-lang
     #   marshmallow-dataclass
     #   marshmallow-enum
     #   marshmallow-oneofschema
-marshmallow-dataclass==8.5.9
+marshmallow-dataclass==8.5.10
     # via cairo-lang
 marshmallow-enum==1.5.1
     # via cairo-lang
@@ -132,7 +132,7 @@ mpmath==1.2.1
     #   sympy
 multiaddr==0.0.9
     # via ipfshttpclient
-multidict==6.0.2
+multidict==6.0.3
     # via
     #   aiohttp
     #   yarl
@@ -142,24 +142,24 @@ mypy-extensions==0.4.3
     #   typing-inspect
 netaddr==0.8.0
     # via multiaddr
-numpy==1.23.4
+numpy==1.23.5
     # via cairo-lang
-packaging==21.3
+packaging==22.0
     # via
     #   build
     #   marshmallow
     #   pytest
 parsimonious==0.8.1
     # via eth-abi
-pathspec==0.10.1
+pathspec==0.10.3
     # via black
 pep517==0.13.0
     # via build
-pip-tools==6.9.0
+pip-tools==6.11.0
     # via pathfinder-worker (pyproject.toml)
-pipdeptree==2.3.1
+pipdeptree==2.3.3
     # via cairo-lang
-platformdirs==2.5.2
+platformdirs==2.6.0
     # via black
 pluggy==1.0.0
     # via pytest
@@ -171,22 +171,20 @@ py==1.11.0
     # via pytest
 pycodestyle==2.9.1
     # via flake8
-pycryptodome==3.15.0
+pycryptodome==3.16.0
     # via
     #   eth-hash
     #   eth-keyfile
 pyflakes==2.5.0
     # via flake8
-pyparsing==3.0.9
-    # via packaging
-pyrsistent==0.18.1
+pyrsistent==0.19.2
     # via jsonschema
 pytest==7.1.3
     # via
     #   cairo-lang
     #   pathfinder-worker (pyproject.toml)
     #   pytest-asyncio
-pytest-asyncio==0.20.0
+pytest-asyncio==0.20.3
     # via cairo-lang
 pyyaml==6.0
     # via cairo-lang
@@ -221,17 +219,17 @@ typing-extensions==4.4.0
     #   typing-inspect
 typing-inspect==0.8.0
     # via marshmallow-dataclass
-urllib3==1.26.12
+urllib3==1.26.13
     # via requests
 varint==1.0.2
     # via multiaddr
-web3==5.31.1
+web3==5.31.3
     # via cairo-lang
 websockets==9.1
     # via web3
-wheel==0.37.1
+wheel==0.38.4
     # via pip-tools
-yarl==1.8.1
+yarl==1.8.2
     # via aiohttp
 zstandard==0.18.0
     # via pathfinder-worker (pyproject.toml)


### PR DESCRIPTION
This fixes the Dependabot alert for certifi <2022.12.07. (https://github.com/eqlabs/pathfinder/security/dependabot/11)