### PR TITLE
feat(Dockerfile): cross-compile Rust code instead of running an emulated compiler on aarch64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,37 +8,43 @@
 # Note that we're explicitly using the Debian bullseye image to make sure we're
 # compatible with the Python container we'll be copying the pathfinder
 # executable to.
-FROM lukemathwalker/cargo-chef:0.1.48-rust-1.65.0-bullseye AS cargo-chef
+FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:0.1.48-rust-1.65.0-bullseye AS cargo-chef
 WORKDIR /usr/src/pathfinder
 
 # refresh indices, do it with cli git for much better ram usage
 RUN CARGO_NET_GIT_FETCH_WITH_CLI=true cargo search --limit 0
 
-FROM cargo-chef AS rust-planner
+FROM --platform=$BUILDPLATFORM cargo-chef AS rust-planner
 COPY . .
 # carg-chef prepare examines your project and builds a recipe that captures
 # the set of information required to build your dependencies.
 RUN cargo chef prepare --recipe-path recipe.json
 
-FROM cargo-chef AS rust-builder
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libssl-dev && rm -rf /var/lib/apt/lists/*
+FROM --platform=$BUILDPLATFORM cargo-chef AS rust-builder
+ARG TARGETARCH
+COPY ./build/prepare.sh prepare.sh
+RUN TARGETARCH=${TARGETARCH} ./prepare.sh
 
 # The recipe.json is the equivalent of the Python requirements.txt file - it is the only
 # input required for cargo chef cook, the command that will build out our dependencies.
 COPY --from=rust-planner /usr/src/pathfinder/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
+COPY ./build/cargo-chef-cook.sh ./cargo-chef-cook.sh
+RUN TARGETARCH=${TARGETARCH} ./cargo-chef-cook.sh --release --recipe-path recipe.json
 
 # Compile the actual libraries and binary now
 COPY . .
-
 ARG PATHFINDER_FORCE_VERSION
+COPY ./build/cargo-build.sh ./cargo-build.sh
+RUN TARGETARCH=${TARGETARCH} \
+    PATHFINDER_FORCE_VERSION=${PATHFINDER_FORCE_VERSION} \
+    ./cargo-build.sh --locked --release -p pathfinder --bin pathfinder \
+    && cp target/*-unknown-linux-gnu/release/pathfinder pathfinder-${TARGETARCH}
 
-RUN PATHFINDER_FORCE_VERSION=${PATHFINDER_FORCE_VERSION} CARGO_INCREMENTAL=0 cargo build --release -p pathfinder --bin pathfinder
 
 #############################################
 # Stage 1.5: Build the Python Pedersen hash #
 #############################################
-FROM cargo-chef AS rust-python-starkhash-planner
+FROM --platform=$BUILDPLATFORM cargo-chef AS rust-python-starkhash-planner
 COPY crates/stark_curve crates/stark_curve
 COPY crates/stark_hash crates/stark_hash
 COPY crates/stark_hash_python crates/stark_hash_python
@@ -46,26 +52,34 @@ RUN cd crates/stark_hash_python && \
     cargo chef prepare --recipe-path recipe.json
 
 
-FROM cargo-chef AS rust-python-starkhash-builder
+FROM --platform=$BUILDPLATFORM cargo-chef AS rust-python-starkhash-builder
+ARG TARGETARCH
+COPY ./build/prepare-stark_hash_python.sh prepare-stark_hash_python.sh
+RUN TARGETARCH=${TARGETARCH} ./prepare-stark_hash_python.sh
 COPY --from=rust-python-starkhash-planner /usr/src/pathfinder/crates/stark_hash_python/recipe.json /usr/src/pathfinder/crates/stark_hash_python/recipe.json
 COPY crates/stark_curve crates/stark_curve
 COPY crates/stark_hash crates/stark_hash
-RUN cd crates/stark_hash_python && cargo chef cook --release --recipe-path recipe.json
+COPY ./build/cargo-chef-cook.sh ./crates/stark_hash_python/cargo-chef-cook.sh
+RUN cd crates/stark_hash_python && TARGETARCH=${TARGETARCH} ./cargo-chef-cook.sh --release --recipe-path recipe.json
 
 COPY crates/stark_hash_python crates/stark_hash_python
-RUN cd crates/stark_hash_python && CARGO_INCREMENTAL=0 cargo build --release
+COPY ./build/cargo-build.sh ./crates/stark_hash_python/cargo-build.sh
+RUN cd crates/stark_hash_python \
+    && TARGETARCH=${TARGETARCH} ./cargo-build.sh --locked --release \
+    && cp target/*-unknown-linux-gnu/release/libstark_hash_rust.so stark_hash_rust.so-${TARGETARCH}
 
 #######################################
 # Stage 2: Build the Python libraries #
 #######################################
 FROM python:3.9-slim-bullseye AS python-builder
+ARG TARGETARCH
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libgmp-dev gcc && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/share/pathfinder
 COPY py py
 RUN python3 -m pip --disable-pip-version-check install py/.
-COPY --from=rust-python-starkhash-builder /usr/src/pathfinder/crates/stark_hash_python/target/release/libstark_hash_rust.so /usr/local/lib/python3.9/site-packages/stark_hash_rust.so
+COPY --from=rust-python-starkhash-builder /usr/src/pathfinder/crates/stark_hash_python/stark_hash_rust.so-${TARGETARCH} /usr/local/lib/python3.9/site-packages/stark_hash_rust.so
 
 # This reduces the size of the python libs by about 50%
 ENV PY_PATH=/usr/local/lib/python3.9/
@@ -80,11 +94,12 @@ RUN find ${PY_PATH} -type d -a -name test -exec rm -rf '{}' + \
 # Note that we're explicitly using the Debian bullseye image to make sure we're
 # compatible with the Rust builder we've built the pathfinder executable in.
 FROM python:3.9-slim-bullseye AS runner
+ARG TARGETARCH
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libgmp10 tini && rm -rf /var/lib/apt/lists/*
 RUN groupadd --gid 1000 pathfinder && useradd --no-log-init --uid 1000 --gid pathfinder --no-create-home pathfinder
 
-COPY --from=rust-builder /usr/src/pathfinder/target/release/pathfinder /usr/local/bin/pathfinder
+COPY --from=rust-builder /usr/src/pathfinder/pathfinder-${TARGETARCH} /usr/local/bin/pathfinder
 COPY --from=python-builder /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
 COPY --from=python-builder /usr/local/bin/pathfinder_python_worker /usr/local/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libgmp-d
 
 WORKDIR /usr/share/pathfinder
 COPY py py
-RUN python3 -m pip --disable-pip-version-check install py/.
+RUN --mount=type=cache,target=/root/.cache/pip python3 -m pip --disable-pip-version-check install py/.
 COPY --from=rust-python-starkhash-builder /usr/src/pathfinder/crates/stark_hash_python/stark_hash_rust.so-${TARGETARCH} /usr/local/lib/python3.9/site-packages/stark_hash_rust.so
 
 # This reduces the size of the python libs by about 50%

--- a/build/cargo-build.sh
+++ b/build/cargo-build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+if [[ "${TARGETARCH}" == "amd64" ]]; then
+    CARGO_INCREMENTAL=0 cargo build --target x86_64-unknown-linux-gnu $*
+elif [[ "${TARGETARCH}" == "arm64" ]]; then
+    PKG_CONFIG_ALLOW_CROSS=1 \
+    RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -L/usr/aarch64-linux-gnu/lib -L/build/sysroot/usr/lib/aarch64-linux-gnu" \
+    C_INCLUDE_PATH=/build/sysroot/usr/include \
+    OPENSSL_LIB_DIR=/build/sysroot/usr/lib/aarch64-linux-gnu \
+    OPENSSL_INCLUDE_DIR=/build/sysroot/usr/include/aarch64-linux-gnu \
+    PYO3_CROSS_INCLUDE_DIR=/build/sysroot/usr/include \
+    PYO3_CROSS_LIB_DIR=/build/sysroot/usr/ \
+    PYO3_CROSS_PYTHON_VERSION=3.9 \
+    cargo build --target aarch64-unknown-linux-gnu $*
+fi

--- a/build/cargo-chef-cook.sh
+++ b/build/cargo-chef-cook.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+if [[ "${TARGETARCH}" == "amd64" ]]; then
+    cargo chef cook --target x86_64-unknown-linux-gnu $*
+elif [[ "${TARGETARCH}" == "arm64" ]]; then
+    PKG_CONFIG_ALLOW_CROSS=1 \
+    RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -L/usr/aarch64-linux-gnu/lib -L/build/sysroot/usr/lib/aarch64-linux-gnu" \
+    C_INCLUDE_PATH=/build/sysroot/usr/include \
+    OPENSSL_LIB_DIR=/build/sysroot/usr/lib/aarch64-linux-gnu \
+    OPENSSL_INCLUDE_DIR=/build/sysroot/usr/include/aarch64-linux-gnu \
+    PYO3_CROSS_INCLUDE_DIR=/build/sysroot/usr/include \
+    PYO3_CROSS_LIB_DIR=/build/sysroot/usr/ \
+    PYO3_CROSS_PYTHON_VERSION=3.9 \
+    cargo chef cook --target aarch64-unknown-linux-gnu $*
+fi

--- a/build/prepare-stark_hash_python.sh
+++ b/build/prepare-stark_hash_python.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+if [[ "${TARGETARCH}" == "amd64" ]]; then
+    echo "nothing to do"
+elif [[ "${TARGETARCH}" == "arm64" ]]; then
+    echo "deb [arch=arm64] http://deb.debian.org/debian bullseye main" >>/etc/apt/sources.list
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross
+    apt-get download libpython3.9-dev:arm64 libpython3.9:arm64 libpython3.9-minimal:arm64 python3.9:arm64 python3-dev:arm64 libpython3.9-stdlib:arm64
+    mkdir -p /build/sysroot
+    dpkg -x python3.9_*.deb /build/sysroot/
+    dpkg -x python3-dev_*.deb /build/sysroot/
+    dpkg -x libpython3.9_*.deb /build/sysroot/
+    dpkg -x libpython3.9-minimal_*.deb /build/sysroot/
+    dpkg -x libpython3.9-dev_*.deb /build/sysroot/
+    dpkg -x libpython3.9-stdlib_*.deb /build/sysroot/
+    cd /build/sysroot/usr/lib/aarch64-linux-gnu
+    ln -s libpython3.9.so libpython.so 
+    ln -s ../python3.9/_sysconfigdata__linux_aarch64-linux-gnu.py _sysconfigdata__linux_aarch64-linux-gnu.py
+    rustup target add aarch64-unknown-linux-gnu
+fi

--- a/build/prepare.sh
+++ b/build/prepare.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+if [[ "${TARGETARCH}" == "amd64" ]]; then
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y libssl-dev
+elif [[ "${TARGETARCH}" == "arm64" ]]; then
+    echo "deb [arch=arm64] http://deb.debian.org/debian bullseye main" >>/etc/apt/sources.list
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y libssl-dev gcc-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross
+    apt-get download libssl-dev:arm64 libssl1.1:arm64
+    mkdir -p /build/sysroot
+    dpkg -x libssl-dev_*.deb /build/sysroot/
+    dpkg -x libssl1.1_*.deb /build/sysroot/
+    rustup target add aarch64-unknown-linux-gnu
+fi


### PR DESCRIPTION
Instead of running Rust compilation steps via qemu this change adds cross-compilation both for the pathfinder binary and the stark_hash Python wrapper.

It turns out Docker has support for using layers from the build architecture instead of the target architecture. This makes it possible to use cross-compilers to produce binaries for the target architecture and use those in QEMU-emulated build layers. For more details check out this blog post:

https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/

Setting up an environment for cross-compilation is tricky though, since our Rust code depends on some native libraries (like OpenSSL  and Python) and a working C/C++ cross-compiler (for SQLite and zstd). This is taken care by manually downloading the respective packages from Debian _bullseye_ (the same distribution our Rust compiler image _and_ our runner image is based on) and extracting thos into a sysroot directory, then setting the required environment variables and Rust compiler flags to use that sysroot.
