### PR TITLE
ci: add MSRV check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,16 @@ jobs:
           cargo install cargo-sort
           cargo sort --check --workspace
 
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: |
+          cargo install cargo-msrv
+          cargo msrv --path crates/pathfinder verify
+
   python:
     runs-on: ubuntu-latest
     needs: python-starkhash

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ sudo apt install curl git
 
 ### Install Rust
 
-`pathfinder` requires Rust version `1.63` or later.
+`pathfinder` requires Rust version `1.64` or later.
 The easiest way to install Rust is by following the [official instructions](https://www.rust-lang.org/tools/install).
 
 If you already have Rust installed, verify the version:

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -3,7 +3,7 @@ name = "pathfinder"
 version = "0.4.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-rust-version = "1.62"
+rust-version = "1.64"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]


### PR DESCRIPTION
This PR adds a CI check for pathfinder's minimum support rust version.

Since we usually are at the latest Rust version, we very often invalidate the MSRV specified in the pathfinder `Cargo.toml`.

Case in point, `package.rust-version = "1.62"` but in reality MSRV is `1.64.0`.

The `cargo-msrv` tool is used to verify the MSRV. It does this by installing the rust version specified and ensuring the project is compilable with `cargo check`. Installing the MSRV version of course takes a while, but once cached its very fast.

This tool can also be used to determine the actual MSRV, which it does by installing a rust version and checking it until it finds the MSRV. By default this is done using a bisect method so its not as terrible as it seems. This should be run locally and not on CI of course.

A clean (no cache) build of everything takes ~13 minutes including compiling `cargo-msrv` and downloading the msrv version. A cached check takes ~30s. We should however keep an eye on it; mayube source code changes make this a lot worse? I don't think it should though.