### PR TITLE
feat(rpc): limit getProof to 100 storage keys

### DIFF
--- a/pathfinder_rpc_api.json
+++ b/pathfinder_rpc_api.json
@@ -104,7 +104,12 @@
                         "contract_proof"
                     ]
                 }
-            }
+            },
+            "errors": [
+                {
+                    "$ref": "#/components/errors/PROOF_LIMIT_EXCEEDED"
+                }
+            ]
         }
     ],
     "components": {
@@ -246,6 +251,27 @@
             "BLOCK_NOT_FOUND": {
                 "code": 24,
                 "message": "Block not found"
+            },
+            "PROOF_LIMIT_EXCEEDED": {
+                "code": 10000,
+                "message": "Too many storage keys requested",
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "limit": {
+                            "description": "The maximum number of storage keys a request may have",
+                            "type": "integer"
+                        },
+                        "requested": {
+                            "description": "The number of storage keys this request had",
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "limit",
+                        "requested"
+                    ]
+                }
             }
         }
     }


### PR DESCRIPTION
This addresses a potential DoS vector by restricting the number of storage addresses a single `pathfinder_getProof` query can have. The current limit is set to 100 (no scientific method applied here, just seems like a reasonable number).

Unfortunately this new error type contains state and is therefore incompatible with our RPC macro. I've spent / wasted some time on getting this to work, but its quite complex. For the time being I think this is fine as is.