### PR TITLE
fix: add missing tokio `macros` feature to dev-dependencies

### DIFF
--- a/crates/gateway-client/Cargo.toml
+++ b/crates/gateway-client/Cargo.toml
@@ -39,6 +39,6 @@ serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value
 stark_hash = { path = "../stark_hash" }
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
-tokio = { version = "1.23.0", features = ["test-util"] }
+tokio = { version = "1.23.0", features = ["macros", "test-util"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 warp = "0.3.3"

--- a/crates/gateway-types/Cargo.toml
+++ b/crates/gateway-types/Cargo.toml
@@ -24,5 +24,5 @@ tokio = { version = "1.23.0" }
 # Due to pathfinder_common::starkhash!() usage
 hex-literal = "0.3"
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
-tokio = { version = "1.23.0", features = ["test-util"] }
+tokio = { version = "1.23.0", features = ["macros", "test-util"] }
 zstd = "0.12"


### PR DESCRIPTION
For crates that use `#[tokio::test]` this is required to be able to build the tests.