### PR TITLE
feat(doc): move install-from-source documentation to a separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ Our images are updated on every `pathfinder` release. This means that the `:late
 
 ### Docker compose
 
-Create the folder `pathfinder` where your `docker-compose.yaml is
+You can also use `docker-compose` if you prefer that to just using Docker.
+
+Create the folder `pathfinder` where your `docker-compose.yaml` is
 
 ```bash
 mkdir -p pathfinder

--- a/README.md
+++ b/README.md
@@ -108,15 +108,6 @@ sudo docker run \
 
 Our images are updated on every `pathfinder` release. This means that the `:latest` docker image does not track our `main` branch here, but instead matches the latest `pathfinder` [release](https://github.com/eqlabs/pathfinder/releases).
 
-### Building the container image yourself
-
-Building the container image from source code is necessary only in special cases or development.
-You can build the image by running:
-
-```bash
-docker build -t pathfinder .
-```
-
 ### Docker compose
 
 Create the folder `pathfinder` where your `docker-compose.yaml is

--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ Note that the pathfinder extension is versioned separately from the StarkNet spe
 Pathfinder supports version `v0.1.0` of the StarkNet JSON-RPC [specification](https://github.com/starkware-libs/starknet-specs/blob/v0.1.0/api/starknet_api_openrpc.json), with the following changes:
 
 - The `starknet_protocolVersion` method is not implemented. This method will be removed from the specification in its next version as its semantics and usage was questionable. We decided to not implement it.
-- To be able to represent L1 handler transactions introduced in Starknet 0.10.0, we use the `L1_HANDLER_TXN` type from `v0.2.1-rc1` of the JSON-RPC specification.
-- To be able to represent DEPLOY_ACCOUNT transactions introduced in Starknet 0.10.1, we use the `DEPLOY_ACCOUNT_TXN` type from `v0.2.1-rc1` of the JSON-RPC specification.
+- To be able to represent L1 handler transactions introduced in Starknet 0.10.0, we use the `L1_HANDLER_TXN` type from `v0.2.1` of the JSON-RPC specification.
+- To be able to represent DEPLOY_ACCOUNT transactions introduced in Starknet 0.10.1, we use the `DEPLOY_ACCOUNT_TXN` type from `v0.2.1` of the JSON-RPC specification.
 
 When browsing the specification project, please be aware of the following pitfalls:
 
@@ -222,17 +222,15 @@ Note that:
 - `starknet_addDeployTransaction` and `starknet_addDeclareTransaction` allow an optional `abi` property
   within the contract definition JSON object.
 
-### API `v0.2.1-rc1`
+### API `v0.2.1`
 
-Pathfinder supports `v0.2.1` of the Starknet JSON-RPC [specification](https://github.com/starkware-libs/starknet-specs/blob/v0.2.1-rc1/api/starknet_api_openrpc.json), with the following deviations:
+Pathfinder supports `v0.2.1` of the Starknet JSON-RPC [specification](https://github.com/starkware-libs/starknet-specs/blob/v0.2.1/api/starknet_api_openrpc.json).
 
-- `starknet_estimateFee` does not support estimating DEPLOY_ACCOUNT transactions.
+Use the [playground link](https://playground.open-rpc.org/?uiSchema[appBar][ui:splitView]=false&[appBar][ui:input]=false&uiSchema[appBar][ui:darkMode]=true&uiSchema[appBar][ui:examplesDropdown]=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/v0.2.1/api/starknet_api_openrpc.json&uiSchema) to check the list of methods and the parameters.
 
-Use the [playground link](https://playground.open-rpc.org/?uiSchema[appBar][ui:splitView]=false&[appBar][ui:input]=false&uiSchema[appBar][ui:darkMode]=true&uiSchema[appBar][ui:examplesDropdown]=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/v0.2.1-rc1/api/starknet_api_openrpc.json&uiSchema) to check the list of methods and the parameters.
+### Transaction write API `v0.2.1`
 
-### Transaction write API `v0.2.1-rc1`
-
-Here are links to the [specification](https://github.com/starkware-libs/starknet-specs/blob/v0.2.1-rc1/api/starknet_write_api.json) and the [playground](https://playground.open-rpc.org/?uiSchema[appBar][ui:splitView]=false&[appBar][ui:input]=false&uiSchema[appBar][ui:darkMode]=true&uiSchema[appBar][ui:examplesDropdown]=false&schemaUrl=https://gist.githubusercontent.com/kkovaacs/9a57bedfb5c311366c00e4881c7768dc/raw/23ed477438992c84cb59573681a7da983a0496a6/starknet_write_api-0.2.1-rc1.json).
+Here are links to the [specification](https://github.com/starkware-libs/starknet-specs/blob/v0.2.1/api/starknet_write_api.json) and the [playground](https://playground.open-rpc.org/?uiSchema[appBar][ui:splitView]=false&[appBar][ui:input]=false&uiSchema[appBar][ui:darkMode]=true&uiSchema[appBar][ui:examplesDropdown]=false&schemaUrl=https://gist.githubusercontent.com/kkovaacs/9a57bedfb5c311366c00e4881c7768dc/raw/23ed477438992c84cb59573681a7da983a0496a6/starknet_write_api-0.2.1-rc1.json).
 
 Note that:
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,15 @@ Pathfinder is currently in alpha so expect some rough edges but it is already us
 
 - access the full StarkNet state history
   - includes contract code and storage, and transactions
-- verifies state using L1
+- verifies state using Ethereum
   - calculates the StarkNet state's Patricia-Merkle Trie root on a block-by-block basis and confirms it against L1
   - this means the contract code and storage are now locally verified
-- Ethereum-like RPC API
+- implements the [StarkNet JSON-RPC API](#json-rpc-api)
+  - Starknet APIs like [starknet.js](https://www.starknetjs.com/) or [starknet.py](https://github.com/software-mansion/starknet.py)
+    fully support using our JSON-RPC API for interacting with Starknet
 - run StarkNet functions without requiring a StarkNet transaction
   - executed against the local state
+- do fee estimation for transactions
 
 ## Feedback
 
@@ -22,262 +25,29 @@ This includes any documentation issues, feature requests and bugs that you may e
 
 For help or to submit bug reports or feature requests, please open an issue or alternatively visit the StarkNet [discord channel](https://discord.com/invite/QypNMzkHbc).
 
-## Installation (from source)
-
-If you'd like to just run the node, please consider skipping ahead to [docker instructions](#running-with-docker).
-The following are instructions on how to build from source.
-
-### Prerequisites
-
-Currently only supports Linux. Windows and MacOS support is planned.
-We need access to a full Ethereum node operating on the network matching the StarkNet network you wish to run. Currently this is either Goerli or Mainnet.
-
-| :warning: | If using Infura as an L1 provider, you will need access to their archive node facilities. This is because `pathfinder` requires access to the full log history. |
-| --------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-
-
-Before you start, make sure your system is up to date with Curl and Git available:
-
-```bash
-sudo apt update
-sudo apt upgrade
-sudo apt install curl git
-```
-
-### Install Rust
-
-`pathfinder` requires Rust version `1.64` or later.
-The easiest way to install Rust is by following the [official instructions](https://www.rust-lang.org/tools/install).
-
-If you already have Rust installed, verify the version:
-
-```bash
-cargo --version # must be 1.63 or higher
-```
-
-To update your Rust version, use the `rustup` tool that came with the official instructions:
-
-```bash
-rustup update
-```
-
-### Install Python
-
-`pathfinder` requires Python version `3.8` (in particular, `cairo-lang` 0.10.2a0 seems incompatible with Python 3.10).
-
-```bash
-sudo apt install python3 python3-venv python3-dev
-```
-
-Verify the python version.
-Some Linux distributions only supply an outdated python version, in which case you will need to lookup a guide for your distribution.
-
-```bash
-python3 --version # must be 3.8
-```
-
-### Install build dependencies
-
-`pathfinder` compilation need additional libraries to be installed (C compiler, linker, other deps)
-
-```bash
-sudo apt install build-essential libgmp-dev pkg-config libssl-dev
-```
-
-### Clone `pathfinder`
-
-Checkout the latest `pathfinder` release by cloning this repo and checking out the latest version tag.
-Take care not to be on our `main` branch as we do actively develop in it.
-
-The remainder of the installation documentation assumes you are in the checkout directory.
-
-### Python setup
-
-Create a python virtual environment in the `py` folder.
-
-```bash
-# Enter the `<repo>/py` directory
-cd py
-# Create the virtual environment and activate it
-python3 -m venv .venv
-source .venv/bin/activate
-```
-
-Next install the python tooling and dependencies
-
-```bash
-PIP_REQUIRE_VIRTUALENV=true pip install --upgrade pip
-PIP_REQUIRE_VIRTUALENV=true pip install -e .[dev]
-```
-
-Finally, run our python tests to make sure you were succesful.
-
-```bash
-# This should run the tests (and they should pass).
-pytest
-```
-
-### Compiling `pathfinder`
-
-You should now be able to compile `pathfinder` by running (from within the `pathfinder` repo):
-
-```bash
-cargo build --release --bin pathfinder
-```
-
-## Updating `pathfinder`
-
-Updating a `pathfinder` node from source is fairly straight forward and is a simpler variant of the installation and compilation described above.
-
-#### `pathfinder` repository
-
-Start by updating the `pathfinder` repository to the desired version. From within your `pathfinder` folder:
-
-```bash
-git fetch
-git checkout <version-tag>
-```
-
-where `<version-tag>` is the desired pathfinder version. To display a list of all available versions, run
-
-```
-git tag
-```
-
-#### Python dependencies
-
-Next, update the python dependencies. First enable your python virtual environment (if you are using one). For our example installation this would be:
-
-```bash
-source ./py/.venv/bin/activate
-```
-
-and then update:
-
-```bash
-PIP_REQUIRE_VIRTUALENV=true pip install -e py/.[dev]
-```
-
-#### Build and run `pathfinder`
-
-Re-compile `pathfinder`:
-
-```bash
-cargo build --release --bin pathfinder
-```
-
-and you should now be able to run your `pathfinder` node as described in the [next section](#running-the-node).
-
-## Running the node
-
-Ensure you have activated the python virtual environment you created in the [python setup step](#python-setup).
-For the `pathfinder` environment this is done by running:
-
-```bash
-source py/.venv/bin/activate
-```
-
-If you are already in another virtual environment, you can exit it by running `deactivate` and then activating the `pathfinder` one.
-
-This step is always required when running `pathfinder`.
-
-Finally, you can start the node:
-
-```bash
-cargo run --release --bin pathfinder -- <pathfinder options>
-```
-
-Note the extra "`--`" which separate the Rust `cargo` command options from the options for our node.
-For more information on these options see the [Configuration](#configuration) section.
-
-It may take a while to first compile the node on the first invocation if you didn't do the [compilation step](#compiling-pathfinder).
-
-`pathfinder` runs relative to the current directory.
-This means things like the database will be created and searched for within the current directory.
-
-### Configuration
-
-The `pathfinder` node options can be configured via the command line as well as environment variables.
-
-The command line options are passed in after the after the `cargo run` options, as follows:
-
-```bash
-cargo run --release --bin pathfinder -- <pathfinder options>
-```
-
-Using `--help` will display the `pathfinder` options, including their environment variable names:
-
-```bash
-# with built from source
-cargo run --release --bin pathfinder -- --help
-
-# with docker images (0.2.0 onwards)
-docker run --rm eqlabs/pathfinder
-```
-
-### Pending Support
-
-Block times on `mainnet` can be prohibitively long for certain applications. As a work-around, StarkNet added the concept of a `pending` block which is the block currently under construction. This is supported by pathfinder, and usage is documented in the [JSON-RPC API](#json-rpc-api) with various methods accepting `"block_id"="pending"`.
-
-Note that `pending` support is disabled by default and must be enabled by setting `poll-pending=true` in the configuration options.
-
-### Logging
-
-Logging can be configured using the `RUST_LOG` environment variable.
-We recommend setting it when you invoke the run command:
-
-```bash
-RUST_LOG=<log level> cargo run --release --bin pathfinder ...
-```
-
-The following log levels are supported, from most to least verbose:
-
-```bash
-trace
-debug
-info  # default
-warn
-error
-```
-
-At the more verbose log levels (`trace`, `debug`), you may find the logs a bit noisy as our dependencies also add their own logging to the mix.
-You can restrict the logs to only `pathfinder` specific ones using `RUST_LOG=pathfinder=<level>` instead. For example:
-
-```bash
-RUST_LOG=pathfinder=<log level> cargo run --release --bin pathfinder ...
-```
-
-### Network Selection
-
-The StarkNet network can be selecting with the `--network` configuration option.
-
-If `--network` is not specified, network selection will default to match your Ethereum endpoint:
-
-- StarKNet mainnet for Ethereum mainnet,
-- StarkNet testnet for Ethereum Goerli
-
-#### Custom networks & gateway proxies
-
-You can specify a custom network with `--network custom` and specifying the `--gateway-url`, `feeder-gateway-url` and `chain-id` options. 
-Note that `chain-id` should be specified as text e.g. `SN_GOERLI`.
-
-This can be used to interact with a custom StarkNet gateway, or to use a gateway proxy.
-
 ## Running with Docker
 
 The `pathfinder` node can be run in the provided Docker image.
-Docker image is the easiest way which does not involve a lot of python setup.
-The following assumes you have [docker installed](https://docs.docker.com/get-docker/) and ready to go.
+Using the Docker image is the easiest way to start `pathfinder`. If for any reason you're interested in how to set up all the
+dependencies and the Python environment yourself please check the [Installation from source](doc/install-from-source.md) guide.
 
-The example uses `$HOME/pathfinder` as the volume directory where persistent files used by `pathfinder` will be stored.
+The following assumes you have [Docker installed](https://docs.docker.com/get-docker/) and ready to go.
+(In case of Ubuntu installing docker is as easy as running `sudo snap install docker`.)
+
+The example below uses `$HOME/pathfinder` as the data directory where persistent files used by `pathfinder` will be stored.
 It is easiest to create the volume directory as the user who is running the docker command.
 If the directory gets created by docker upon startup, it might be unusable for creating files.
 
+The following commands start the node in the background, also making sure that it starts automatically after reboot:
+
 ```bash
-# ensure the directory has been created before invoking docker
+# Ensure the directory has been created before invoking docker
 mkdir -p $HOME/pathfinder
-docker run \
-  --rm \
+# Start the pathfinder container instance running in the background
+sudo docker run \
+  --name pathfinder \
+  --restart unless-stopped \
+  --detach \
   -p 9545:9545 \
   --user "$(id -u):$(id -g)" \
   -e RUST_LOG=info \
@@ -286,21 +56,53 @@ docker run \
   eqlabs/pathfinder
 ```
 
-### Updating the docker image
+To check logs you can use:
+
+```bash
+sudo docker logs -f pathfinder
+```
+
+The node can be stopped using
+
+```bash
+sudo docker stop pathfinder
+```
+
+
+### Updating the Docker image
 
 When pathfinder detects there has been a new release, it will log a message similar to:
 
 ```
-WARN New pathfinder release available! Please consider updating your node! release=0.1.8-alpha
+WARN New pathfinder release available! Please consider updating your node! release=0.4.5
 ```
 
 You can try pulling the latest docker image to update it:
 
 ```bash
-docker pull eqlabs/pathfinder
+sudo docker pull eqlabs/pathfinder
 ```
 
-There is a chance of seeing the release notification before a new docker image is available for download, so just wait a minutes and then retry.
+After pulling the updated image you should stop and remove the `pathfinder` container then re-create it with the exact same command
+that was used above to start the node:
+
+```bash
+# This stops the running instance
+sudo docker stop pathfinder
+# This removes the current instance (using the old version of pathfinder)
+sudo docker rm pathfinder
+# This command re-createst the container instance with the latest version
+sudo docker run \
+  --name pathfinder \
+  --restart unless-stopped \
+  --detach \
+  -p 9545:9545 \
+  --user "$(id -u):$(id -g)" \
+  -e RUST_LOG=info \
+  -e PATHFINDER_ETHEREUM_API_URL="https://goerli.infura.io/v3/<project-id>" \
+  -v $HOME/pathfinder:/usr/share/pathfinder/data \
+  eqlabs/pathfinder
+```
 
 ### Available images
 
@@ -329,6 +131,63 @@ docker-compose up -d
 ```
 
 To check if it's running well use `docker-compose logs -f`.
+
+## Configuration
+
+The `pathfinder` node options can be configured via the command line as well as environment variables.
+
+The command line options are passed in after the after the `docker run` options, as follows:
+
+```bash
+sudo docker run --name pathfinder [...] eqlabs/pathfinder:latest <pathfinder options>
+```
+
+Using `--help` will display the `pathfinder` options, including their environment variable names:
+
+```bash
+sudo docker run --rm eqlabs/pathfinder:latest --help
+```
+
+### Pending Support
+
+Block times on `mainnet` can be prohibitively long for certain applications. As a work-around, StarkNet added the concept of a `pending` block which is the block currently under construction. This is supported by pathfinder, and usage is documented in the [JSON-RPC API](#json-rpc-api) with various methods accepting `"block_id"="pending"`.
+
+Note that `pending` support is disabled by default and must be enabled by setting `poll-pending=true` in the configuration options.
+
+### Logging
+
+Logging can be configured using the `RUST_LOG` environment variable.
+We recommend setting it when you start the container:
+
+```bash
+sudo docker run --name pathfinder [...] -e RUST_LOG=<log level> eqlabs/pathfinder:latest
+```
+
+The following log levels are supported, from most to least verbose:
+
+```bash
+trace
+debug
+info  # default
+warn
+error
+```
+
+### Network Selection
+
+The StarkNet network can be selecting with the `--network` configuration option.
+
+If `--network` is not specified, network selection will default to match your Ethereum endpoint:
+
+- StarkNet mainnet for Ethereum mainnet,
+- StarkNet testnet for Ethereum Goerli
+
+#### Custom networks & gateway proxies
+
+You can specify a custom network with `--network custom` and specifying the `--gateway-url`, `feeder-gateway-url` and `chain-id` options. 
+Note that `chain-id` should be specified as text e.g. `SN_GOERLI`.
+
+This can be used to interact with a custom StarkNet gateway, or to use a gateway proxy.
 
 ## JSON-RPC API
 
@@ -454,6 +313,7 @@ gateway_requests_failed_total{method="get_state_update", tag="pending"}
 gateway_requests_failed_total{method="get_state_update", tag="pending", reason="starknet"}
 gateway_requests_failed_total{method="get_state_update", reason="rate_limiting"}
 ```
+
 These __will not work__:
 - `gateway_requests_total{method="get_transaction", tag="latest"}`, `tag` is not supported for that `method`
 - `gateway_requests_total{method="get_transaction", reason="decode"}`, `reason` is only supported for failures.

--- a/doc/install-from-source.md
+++ b/doc/install-from-source.md
@@ -1,0 +1,170 @@
+# Installation from source
+
+## Prerequisites
+
+Currently only supports Linux. Windows and MacOS support is planned.
+We need access to a full Ethereum node operating on the network matching the StarkNet network you wish to run. Currently this is either Goerli or Mainnet.
+
+| :warning: | If using Infura as an L1 provider, you will need access to their archive node facilities. This is because `pathfinder` requires access to the full log history. |
+| --------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+
+
+Before you start, make sure your system is up to date with Curl and Git available:
+
+```bash
+sudo apt update
+sudo apt upgrade
+sudo apt install curl git
+```
+
+## Install Rust
+
+`pathfinder` requires Rust version `1.64` or later.
+The easiest way to install Rust is by following the [official instructions](https://www.rust-lang.org/tools/install).
+
+If you already have Rust installed, verify the version:
+
+```bash
+cargo --version # must be 1.64 or higher
+```
+
+To update your Rust version, use the `rustup` tool that came with the official instructions:
+
+```bash
+rustup update
+```
+
+## Install Python
+
+`pathfinder` requires Python version `3.8` (in particular, `cairo-lang` 0.10.2a0 seems incompatible with Python 3.10).
+
+```bash
+sudo apt install python3 python3-venv python3-dev
+```
+
+Verify the python version.
+Some Linux distributions only supply an outdated python version, in which case you will need to lookup a guide for your distribution.
+
+```bash
+python3 --version # must be 3.8
+```
+
+## Install build dependencies
+
+`pathfinder` compilation need additional libraries to be installed (C compiler, linker, other deps)
+
+```bash
+sudo apt install build-essential libgmp-dev pkg-config libssl-dev
+```
+
+## Clone `pathfinder`
+
+Checkout the latest `pathfinder` release by cloning this repo and checking out the latest version tag.
+Take care not to be on our `main` branch as we do actively develop in it.
+
+The remainder of the installation documentation assumes you are in the checkout directory.
+
+## Python setup
+
+Create a python virtual environment in the `py` folder.
+
+```bash
+# Enter the `<repo>/py` directory
+cd py
+# Create the virtual environment and activate it
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+Next install the python tooling and dependencies
+
+```bash
+PIP_REQUIRE_VIRTUALENV=true pip install --upgrade pip
+PIP_REQUIRE_VIRTUALENV=true pip install -e .[dev]
+```
+
+Finally, run our python tests to make sure you were succesful.
+
+```bash
+# This should run the tests (and they should pass).
+pytest
+```
+
+### Compiling `pathfinder`
+
+You should now be able to compile `pathfinder` by running (from within the `pathfinder` repo):
+
+```bash
+cargo build --release --bin pathfinder
+```
+
+## Updating `pathfinder`
+
+Updating a `pathfinder` node from source is fairly straight forward and is a simpler variant of the installation and compilation described above.
+
+### `pathfinder` repository
+
+Start by updating the `pathfinder` repository to the desired version. From within your `pathfinder` folder:
+
+```bash
+git fetch
+git checkout <version-tag>
+```
+
+where `<version-tag>` is the desired pathfinder version. To display a list of all available versions, run
+
+```
+git tag
+```
+
+### Python dependencies
+
+Next, update the python dependencies. First enable your python virtual environment (if you are using one). For our example installation this would be:
+
+```bash
+source ./py/.venv/bin/activate
+```
+
+and then update:
+
+```bash
+PIP_REQUIRE_VIRTUALENV=true pip install -e py/.[dev]
+```
+
+### Build and run `pathfinder`
+
+Re-compile `pathfinder`:
+
+```bash
+cargo build --release --bin pathfinder
+```
+
+and you should now be able to run your `pathfinder` node as described in the [next section](#running-the-node).
+
+
+## Running the node
+
+Ensure you have activated the python virtual environment you created in the [python setup step](#python-setup).
+For the `pathfinder` environment this is done by running:
+
+```bash
+source py/.venv/bin/activate
+```
+
+If you are already in another virtual environment, you can exit it by running `deactivate` and then activating the `pathfinder` one.
+
+This step is always required when running `pathfinder`.
+
+Finally, you can start the node:
+
+```bash
+cargo run --release --bin pathfinder -- <pathfinder options>
+```
+
+Note the extra "`--`" which separate the Rust `cargo` command options from the options for our node.
+For more information on these options see the [Configuration](#configuration) section.
+
+It may take a while to first compile the node on the first invocation if you didn't do the [compilation step](#compiling-pathfinder).
+
+`pathfinder` runs relative to the current directory.
+This means things like the database will be created and searched for within the current directory.


### PR DESCRIPTION
This PR makes the following changes to our README:

- added some stuff in "Features"
- moved "install from source" section to a new document (tucked away in the doc directory)
- README now clearly suggests using Docker
- the example docker run command starts pathfinder in the backround with automatic restart (after reboot) enabled