### PR TITLE
feat: release github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: "release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "x.y.z format"
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: branch verification
+        if: github.ref_name != 'main' || github.ref_type != 'branch'
+        run: |
+          echo "::error This action may only be run on 'main' branch"
+          exit 1
+
+      - uses: actions/checkout@v3
+
+      - name: Update pathfinder package version
+        run: |
+          sed -i -e 's/version = ".*"/version = "${{ github.event.inputs.version }}"/' crates/pathfinder/Cargo.toml
+
+      - name: Create PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config --local user.email "${{ github.actor }}@users.noreply.github.com"
+          git config --local user.name "${{ github.actor }}"
+          git switch -c release-${{ github.event.inputs.version }}
+          git commit -a -m "feat: update package version to ${{ github.event.inputs.version }}"
+          git push --set-upstream origin release-${{ github.event.inputs.version }}
+
+          gh pr create --base main --fill
+
+      - name: Approve PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          gh pr review --approve
+          gh pr merge --delete-branch --merge
+            
+      - name: Tag & release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git switch main
+          git pull
+          git tag v${{ github.event.inputs.version }}
+          git push origin v${{ github.event.inputs.version }}
+
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+              /repos/eqlabs/pathfinder/releases \
+            -f tag_name='v${{ github.event.inputs.version }}' \
+            -f target_commitish='main' \
+            -f name='v${{ github.event.inputs.version }}' \
+            -f body='Description of the release' \
+            -F draft=true \
+            -F prerelease=false \
+            -F generate_release_notes=true 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: branch verification
+      - name: Branch verification
         if: github.ref_name != 'main' || github.ref_type != 'branch'
         run: |
           echo "::error This action may only be run on 'main' branch"


### PR DESCRIPTION
This PR attempts to add a release workflow which can only be triggered manually on the `main` branch.

It does the following:

1. Update the pathfinder crate version
2. Tag that commit as `vx.y.z`
3. Push that tag & commit to `main`
4. Create draft release notes

The flow is as follows:

1. provide release version (`x.y.z` format)
2. disable `main` branch protections (so we can push to `main`)
3. make changes, commit, tag and push
4. restore `main` branch protections

Some caveats:

1. This can only be fully tested once its on main..
    1. I've tested it on a private repo and it works
    2. But that's a personal repo and not an org repo so the token may work differently.
2. The version is not validated as semver. Could be added but its a bit of pita.
3. This requires a personal access token (normal `GITHUB_TOKEN` does not have enough access). I've created one and set its value in the repo secrets. It will expire and require replacing. I'm also unsure if it will work as this is an org repo.
4. Alternate solutions are:
    1. Remove branch protections 👎 
    2. Create a bot user with more privelages (requires removing our admin privelages which is weird)

