### PR TITLE
fix(storage): set synchronous flag to normal in WAL mode

### DIFF
--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -84,6 +84,9 @@ impl Storage {
                     (1024usize * 1024 * 1024).to_string(),
                 )
                 .context("Set journal size limit")?;
+                // According to the documentation NORMAL is a good choice for WAL mode.
+                conn.pragma_update(None, "synchronous", "normal")
+                    .context("Setting synchronous flag to NORMAL")?;
             }
         }
         migrate_database(&mut conn).context("Migrate database")?;


### PR DESCRIPTION
The SQLite documentation suggests using normal mode when in WAL mode.

Thanks to @koivunej for pointing this out. 

Closes issue #810.