### PR TITLE
chore: bump tokio version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4265,9 +4265,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.23.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ exclude = [
     "crates/stark_hash_python",
 ]
 resolver = "2"
+
+[workspace.dependencies]
+tokio = "1.24.0"

--- a/crates/ethereum/Cargo.toml
+++ b/crates/ethereum/Cargo.toml
@@ -17,7 +17,7 @@ pathfinder-retry = { path = "../retry" }
 reqwest = { version = "0.11.13", features = ["json"] }
 stark_hash = { path = "../stark_hash" }
 thiserror = "1.0.37"
-tokio = "1.23.0"
+tokio = { workspace = true }
 tracing = "0.1.37"
 
 [dev-dependencies]
@@ -25,4 +25,4 @@ assert_matches = "1.5.0"
 hex = "0.4.3"
 hex-literal = "0.3"
 pretty_assertions = "1.3.0"
-tokio = { version = "1.23.0", features = ["macros"] }
+tokio = { workspace = true, features = ["macros"] }

--- a/crates/gateway-client/Cargo.toml
+++ b/crates/gateway-client/Cargo.toml
@@ -39,6 +39,6 @@ serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value
 stark_hash = { path = "../stark_hash" }
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
-tokio = { version = "1.23.0", features = ["macros", "test-util"] }
+tokio = { workspace = true, features = ["macros", "test-util"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 warp = "0.3.3"

--- a/crates/gateway-types/Cargo.toml
+++ b/crates/gateway-types/Cargo.toml
@@ -18,11 +18,11 @@ serde_with = "2.1.0"
 sha3 = "0.10"
 stark_hash = { path = "../stark_hash" }
 thiserror = "1.0.37"
-tokio = { version = "1.23.0" }
+tokio = { workspace = true }
 
 [dev-dependencies]
 # Due to pathfinder_common::starkhash!() usage
 hex-literal = "0.3"
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
-tokio = { version = "1.23.0", features = ["macros", "test-util"] }
+tokio = { workspace = true, features = ["macros", "test-util"] }
 zstd = "0.12"

--- a/crates/load-test/Cargo.lock
+++ b/crates/load-test/Cargo.lock
@@ -1551,9 +1551,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.23.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",

--- a/crates/load-test/Cargo.toml
+++ b/crates/load-test/Cargo.toml
@@ -12,4 +12,4 @@ rand = "0.8.5"
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
 stark_hash = { path = "../stark_hash" }
-tokio = "1.23.0"
+tokio = "1.24.0"

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -42,7 +42,7 @@ stark_hash = { path = "../stark_hash" }
 starknet-gateway-client = { path = "../gateway-client" }
 starknet-gateway-types = { path = "../gateway-types" }
 tempfile = "3"
-tokio = { version = "1.23.0", features = ["process"] }
+tokio = { workspace = true, features = ["process"] }
 toml = "0.5.9"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
@@ -65,7 +65,7 @@ serde_with = "2.1.0"
 starknet-gateway-client = { path = "../gateway-client", features = ["test-utils"] }
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
-tokio = { version = "1.23.0", features = ["test-util"] }
+tokio = { workspace = true, features = ["test-util"] }
 
 [[bench]]
 name = "merkle_tree"

--- a/crates/retry/Cargo.toml
+++ b/crates/retry/Cargo.toml
@@ -7,8 +7,8 @@ rust-version = "1.62"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = "1.23.0"
+tokio = { workspace = true }
 tokio-retry = "0.3.0"
 
 [dev-dependencies]
-tokio = { version = "1.23.0", features = ["macros", "test-util"] }
+tokio = { workspace = true, features = ["macros", "test-util"] }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -30,7 +30,7 @@ stark_hash = { path = "../stark_hash" }
 starknet-gateway-client = { path = "../gateway-client" }
 starknet-gateway-types = { path = "../gateway-types" }
 thiserror = "1.0.37"
-tokio = "1.23.0"
+tokio = "1.24.0"
 tracing = "0.1.37"
 zstd = "0.12"
 
@@ -54,5 +54,5 @@ starknet-gateway-client = { path = "../gateway-client", features = ["test-utils"
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 tempfile = "3"
 test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
-tokio = { version = "1.23.0", features = ["test-util", "process"] }
+tokio = { workspace = true, features = ["test-util", "process"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -32,7 +32,7 @@ stark_hash = { path = "../stark_hash" }
 starknet-gateway-client = { path = "../gateway-client" }
 starknet-gateway-types = { path = "../gateway-types" }
 thiserror = "1.0.37"
-tokio = "1.23.0"
+tokio = { workspace = true }
 tracing = "0.1.37"
 zstd = "0.12"
 


### PR DESCRIPTION
This closes [dependabot #12](https://github.com/eqlabs/pathfinder/security/dependabot/12) and [dependabot #13](https://github.com/eqlabs/pathfinder/security/dependabot/13). While these issues did not actually affect pathfinder directly (because we don't run on Windows), the fix was simpler than dismissing them.

In addition, [tokio 1.24](https://github.com/tokio-rs/tokio/releases/tag/tokio-1.24.0) comes with a nice performance boost to IO tasks which made upgrading desireable.

I've also changed to using a workspace dependency for tokio - we can / should do this for all major deps imo.