### PR TITLE
docs: keepachangelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,83 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+No unreleased changes yet.
+
+## [0.4.5] - 2022-12-21
+
+### Added
+
+- added Newton FAQ links to readme (thanks @SecurityQQ)
+
+### Fixed
+
+- node fails to sync really old blocks
+
+## [0.4.4] - 2022-12-20
+
+### Added
+
+- storage proofs via pathfinder_getProof by @pscott
+
+### Changed
+
+- improved performance for starknet_call and starknet_estimateFee by caching classes
+- improved performance for starknet_call and starknet_estimateFee by using Rust for hashing
+
+### Fixed
+
+- starknet_getEvents returns all events when from_block="latest"
+- v0.1 starknet_getStateUpdate does not contain nonces
+
+## [0.4.3] - 2022-12-7
+
+### Changed
+
+- updated to cairo-lang 0.10.3
+
+### Fixed
+
+- testnet2 and integration flags are ignored
+- starknet_estimateFee uses wrong chain ID for testnet2
+
+## [0.4.2] - 2022-12-2
+
+### Added
+
+- document that --chain-id expects text as input
+
+### Fixed
+
+- testnet2 and integration L1 addresses are swopped (bug introduced in v0.4.1)
+- proxy network setups can't sync historical blocks (bug introduced in v0.4.1)
+- ABI serialization for starknet_estimateFee for declare transactions
+
+## [0.4.1] - 2022-11-30
+
+### Added
+
+- custom StarkNet support (see above for details)
+- pathfinder specific RPC extensions hosted at <rpc-url>/rpc/pathfinder/v0.1. Currently this only contains pathfinder_version which returns the pathfinder version of the node.
+
+### Changed
+
+- The following configuration options are now marked as deprecated: --testnet2, --integration, --config, --sequencer-url
+- Optimised starknet_events for queries with both a block range and a from address
+
+### Fixed
+
+- block timestamps for pending in starknet_call and starknet_estimateFee were using the latest timestamp instead of the pending one. This meant contracts relying on accurate timestamps could sometimes fail unexpectedly.
+
+## [0.4.0] - 2022-11-30
+
+### Added
+
+- support for StarkNet v0.10.2
+
+### Changed
+
+- default RPC API version changed from v0.1 to v0.2
+
 ## Ancient History
 
 Older history may be found in the [pathfinder release notes](https://github.com/eqlabs/pathfinder/releases).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+More expansive patch notes and explanations may be found in the specific [pathfinder release notes](https://github.com/eqlabs/pathfinder/releases).
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## Ancient History
+
+Older history may be found in the [pathfinder release notes](https://github.com/eqlabs/pathfinder/releases).


### PR DESCRIPTION
Adds `CHANGELOG.md` according to [keepachangelog](https://keepachangelog.com/en/1.0.0/).

Hopefully this makes compiling release notes easier, and also gives users a place to spot unreleased features.

I've only added historical release notes up to `v0.4.0` because I'm lazy.