### PR TITLE
Add `BlockValidationMode` switch

### DIFF
--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -263,6 +263,7 @@ If you are trying to setup a custom StarkNet please use '--network custom',
         state::l2::sync,
         pending_state.clone(),
         pending_interval,
+        state::l2::BlockValidationMode::Strict,
     ));
 
     let shared = pathfinder_rpc::gas_price::Cached::new(Arc::new(eth_transport));


### PR DESCRIPTION
Add `BlockValidationMode` enum (default: `Strict` check for hash match)
Avoid `#[cfg(not(test))]` in `state::l2::download_block` and use `BlockValidationMode::AllowMismatch` for testing explicitly.