### PR TITLE
fix(storage): properly initialize connections from the pool

### DIFF
--- a/py/src/pathfinder_worker/call.py
+++ b/py/src/pathfinder_worker/call.py
@@ -268,7 +268,9 @@ def main():
         )
         sys.exit(1)
 
-    with sqlite3.connect(database_path) as connection:
+    connection_string = f"file:{database_path}?mode=ro"
+
+    with sqlite3.connect(connection_string, uri=True) as connection:
         # this is not a sort of "usual" isolation_level switch with sqlite like
         # read_uncommited or anything like that. instead this asks that the
         # python side doesn't inspect the queries and try to manage autocommit


### PR DESCRIPTION
SQLite requires some pragmas and configuration options to be set on each and every connection we're having to the database.

Previously we've only set up these flags during migrating the databse, that is, on one single connection we might have in our connection pool.

This change fixes that by moving setup steps into a function and setting up SqliteConnectionManager to call that as an initialization step for each connection it's creating.

As an additional change this also makes sure the Python worker process opens the SQLite database as read-only.