### PR TITLE
test(common): add benchmark for sierra to cairo compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3759,6 +3759,7 @@ version = "0.1.0"
 dependencies = [
  "bitvec 0.20.4",
  "cairo-lang-starknet",
+ "criterion",
  "ethers",
  "hex-literal",
  "metrics",

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -30,4 +30,9 @@ vergen = { version = "7", default-features = false, features = ["git"] }
 # cairo-lang-starknet is fixed to depend on cairo-vm "=0.1.0"
 # cairo-lang-starknet = "0.1.0"
 cairo-lang-starknet = { git = "https://github.com/eqlabs/cairo", branch = "force-cairo-vm-0.1.0" }
+criterion = "0.4"
 pretty_assertions = "1.3.0"
+
+[[bench]]
+name = "sierra_to_casm"
+harness = false

--- a/crates/common/benches/sierra_to_casm.rs
+++ b/crates/common/benches/sierra_to_casm.rs
@@ -1,0 +1,28 @@
+use cairo_lang_starknet::{casm_contract_class::CasmContractClass, contract_class::ContractClass};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+
+#[inline]
+fn sierra_to_casm(sierra: ContractClass) -> CasmContractClass {
+    CasmContractClass::from_contract_class(sierra).unwrap()
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("sierra_to_casm", |b| {
+        // ContractClass is neither Copy nor Clone :(
+        b.iter_batched(
+            || {
+                serde_json::from_slice::<ContractClass>(include_bytes!(
+                    "../fixtures/test_contract.json"
+                ))
+                .unwrap()
+            },
+            |sierra| {
+                black_box(sierra_to_casm(sierra));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
Not sure if we need it in main, nevertheless opening a draft pr to allow easy access during discussion.

On my PC it roughly takes 1.9-2.0 ms to compile the test contract into casm, serde excluded:
```
sierra_to_casm          time:   [1.9262 ms 1.9314 ms 1.9374 ms]
```
On the contrary when I run the load test, the average timings are as follows:
- `v02_get_class` 46.91 ~ 47 ms
- `v02_get_class_at` 47.06 ~ 47 ms

Imo this indicates that we could do compilation on the fly.