### PR TITLE
refactor(rpc): specialize `Felt` serde for RPC

### DIFF
--- a/crates/rpc/src/felt.rs
+++ b/crates/rpc/src/felt.rs
@@ -18,6 +18,7 @@ use pathfinder_common::{
     L2ToL1MessagePayloadElem, SequencerAddress, StarknetBlockHash, StarknetTransactionHash,
     StateCommitment, StorageAddress, StorageValue, TransactionNonce, TransactionSignatureElem,
 };
+use stark_hash::Felt;
 
 /// An RPC specific wrapper around [Felt] which implements
 /// [serde::Serialize] in accordance with RPC specifications.
@@ -25,9 +26,19 @@ use pathfinder_common::{
 /// RPC output types should use this type for serialization instead of [Felt].
 ///
 /// This can be easily accomplished by marking a field with `#[serde_as(as = "RpcFelt")]`.
-///
-/// [Felt]: stark_hash::Felt
-pub struct RpcFelt(stark_hash::Felt);
+pub struct RpcFelt(pub Felt);
+
+impl From<Felt> for RpcFelt {
+    fn from(value: Felt) -> Self {
+        Self(value)
+    }
+}
+
+impl From<RpcFelt> for Felt {
+    fn from(value: RpcFelt) -> Self {
+        value.0
+    }
+}
 
 /// An RPC specific wrapper around [Felt] for types which are restricted to 251 bits. It implements
 /// [serde::Serialize] in accordance with RPC specifications.
@@ -35,8 +46,6 @@ pub struct RpcFelt(stark_hash::Felt);
 /// RPC output types should use this type for serialization instead of [Felt].
 ///
 /// This can be easily accomplished by marking a field with `#[serde_as(as = "RpcFelt251")]`.
-///
-/// [Felt]: stark_hash::Felt
 #[derive(serde::Serialize)]
 pub struct RpcFelt251(RpcFelt);
 
@@ -148,7 +157,6 @@ rpc_felt_serde!(
 
 rpc_felt_251_serde!(ContractAddress, StorageAddress);
 
-#[cfg(any(test, feature = "rpc-full-serde"))]
 mod deserialization {
     use super::*;
 

--- a/crates/rpc/src/felt.rs
+++ b/crates/rpc/src/felt.rs
@@ -14,8 +14,8 @@
 
 use pathfinder_common::{
     CallParam, ChainId, ClassHash, ConstructorParam, ContractAddress, ContractAddressSalt,
-    EntryPoint, StarknetBlockHash, StarknetTransactionHash, TransactionNonce,
-    TransactionSignatureElem,
+    EntryPoint, EventData, EventKey, L1ToL2MessagePayloadElem, L2ToL1MessagePayloadElem,
+    StarknetBlockHash, StarknetTransactionHash, TransactionNonce, TransactionSignatureElem,
 };
 
 /// An RPC specific wrapper around [Felt] which implements
@@ -130,6 +130,10 @@ rpc_felt_serde!(
     ContractAddressSalt,
     ConstructorParam,
     EntryPoint,
+    EventKey,
+    EventData,
+    L1ToL2MessagePayloadElem,
+    L2ToL1MessagePayloadElem,
     StarknetBlockHash,
     StarknetTransactionHash,
     TransactionNonce,

--- a/crates/rpc/src/felt.rs
+++ b/crates/rpc/src/felt.rs
@@ -15,8 +15,8 @@
 use pathfinder_common::{
     CallParam, ChainId, ClassHash, ConstructorParam, ContractAddress, ContractAddressSalt,
     ContractNonce, EntryPoint, EventData, EventKey, L1ToL2MessagePayloadElem,
-    L2ToL1MessagePayloadElem, StarknetBlockHash, StarknetTransactionHash, StorageValue,
-    TransactionNonce, TransactionSignatureElem,
+    L2ToL1MessagePayloadElem, StarknetBlockHash, StarknetTransactionHash, StateCommitment,
+    StorageAddress, StorageValue, TransactionNonce, TransactionSignatureElem,
 };
 
 /// An RPC specific wrapper around [Felt] which implements
@@ -138,12 +138,13 @@ rpc_felt_serde!(
     L2ToL1MessagePayloadElem,
     StarknetBlockHash,
     StarknetTransactionHash,
+    StateCommitment,
     StorageValue,
     TransactionNonce,
     TransactionSignatureElem,
 );
 
-rpc_felt_251_serde!(ContractAddress);
+rpc_felt_251_serde!(ContractAddress, StorageAddress,);
 
 #[cfg(any(test, feature = "rpc-full-serde"))]
 mod deserialization {

--- a/crates/rpc/src/felt.rs
+++ b/crates/rpc/src/felt.rs
@@ -15,8 +15,8 @@
 use pathfinder_common::{
     CallParam, ChainId, ClassHash, ConstructorParam, ContractAddress, ContractAddressSalt,
     ContractNonce, EntryPoint, EventData, EventKey, L1ToL2MessagePayloadElem,
-    L2ToL1MessagePayloadElem, StarknetBlockHash, StarknetTransactionHash, StateCommitment,
-    StorageAddress, StorageValue, TransactionNonce, TransactionSignatureElem,
+    L2ToL1MessagePayloadElem, SequencerAddress, StarknetBlockHash, StarknetTransactionHash,
+    StateCommitment, StorageAddress, StorageValue, TransactionNonce, TransactionSignatureElem,
 };
 
 /// An RPC specific wrapper around [Felt] which implements
@@ -139,12 +139,13 @@ rpc_felt_serde!(
     StarknetBlockHash,
     StarknetTransactionHash,
     StateCommitment,
+    SequencerAddress,
     StorageValue,
     TransactionNonce,
     TransactionSignatureElem,
 );
 
-rpc_felt_251_serde!(ContractAddress, StorageAddress,);
+rpc_felt_251_serde!(ContractAddress, StorageAddress);
 
 #[cfg(any(test, feature = "rpc-full-serde"))]
 mod deserialization {

--- a/crates/rpc/src/felt.rs
+++ b/crates/rpc/src/felt.rs
@@ -1,9 +1,9 @@
-//! Contains the [RpcFelt] and [RpcFelt251] wrappers around [Felt](stark_hash::Felt) which 
+//! Contains the [RpcFelt] and [RpcFelt251] wrappers around [Felt](stark_hash::Felt) which
 //! implement RPC compliant serialization.
 //!
 //! The wrappers implement [serde_with::SerializeAs] which allows annotating
 //! struct fields `serde_as(as = "RpcFelt")`to use the RPC compliant serialization.
-//! 
+//!
 //! ```rust
 //! #[serde_with::serde_as]
 //! struct RpcOutput {
@@ -13,8 +13,9 @@
 //! ```
 
 use pathfinder_common::{
-    ChainId, ClassHash, ContractAddress, StarknetBlockHash, StarknetTransactionHash,
-    TransactionNonce, TransactionSignatureElem,
+    CallParam, ChainId, ClassHash, ConstructorParam, ContractAddress, ContractAddressSalt,
+    EntryPoint, StarknetBlockHash, StarknetTransactionHash, TransactionNonce,
+    TransactionSignatureElem,
 };
 
 /// An RPC specific wrapper around [Felt] which implements
@@ -123,8 +124,12 @@ macro_rules! rpc_felt_251_serde {
 }
 
 rpc_felt_serde!(
+    CallParam,
     ChainId,
     ClassHash,
+    ContractAddressSalt,
+    ConstructorParam,
+    EntryPoint,
     StarknetBlockHash,
     StarknetTransactionHash,
     TransactionNonce,

--- a/crates/rpc/src/felt.rs
+++ b/crates/rpc/src/felt.rs
@@ -14,8 +14,9 @@
 
 use pathfinder_common::{
     CallParam, ChainId, ClassHash, ConstructorParam, ContractAddress, ContractAddressSalt,
-    EntryPoint, EventData, EventKey, L1ToL2MessagePayloadElem, L2ToL1MessagePayloadElem,
-    StarknetBlockHash, StarknetTransactionHash, TransactionNonce, TransactionSignatureElem,
+    ContractNonce, EntryPoint, EventData, EventKey, L1ToL2MessagePayloadElem,
+    L2ToL1MessagePayloadElem, StarknetBlockHash, StarknetTransactionHash, TransactionNonce,
+    TransactionSignatureElem,
 };
 
 /// An RPC specific wrapper around [Felt] which implements
@@ -127,8 +128,9 @@ rpc_felt_serde!(
     CallParam,
     ChainId,
     ClassHash,
-    ContractAddressSalt,
     ConstructorParam,
+    ContractAddressSalt,
+    ContractNonce,
     EntryPoint,
     EventKey,
     EventData,

--- a/crates/rpc/src/felt.rs
+++ b/crates/rpc/src/felt.rs
@@ -15,8 +15,8 @@
 use pathfinder_common::{
     CallParam, ChainId, ClassHash, ConstructorParam, ContractAddress, ContractAddressSalt,
     ContractNonce, EntryPoint, EventData, EventKey, L1ToL2MessagePayloadElem,
-    L2ToL1MessagePayloadElem, StarknetBlockHash, StarknetTransactionHash, TransactionNonce,
-    TransactionSignatureElem,
+    L2ToL1MessagePayloadElem, StarknetBlockHash, StarknetTransactionHash, StorageValue,
+    TransactionNonce, TransactionSignatureElem,
 };
 
 /// An RPC specific wrapper around [Felt] which implements
@@ -138,6 +138,7 @@ rpc_felt_serde!(
     L2ToL1MessagePayloadElem,
     StarknetBlockHash,
     StarknetTransactionHash,
+    StorageValue,
     TransactionNonce,
     TransactionSignatureElem,
 );

--- a/crates/rpc/src/felt.rs
+++ b/crates/rpc/src/felt.rs
@@ -1,0 +1,216 @@
+//! Contains the [RpcFelt] and [RpcFelt251] wrappers around [Felt](stark_hash::Felt) which 
+//! implement RPC compliant serialization.
+//!
+//! The wrappers implement [serde_with::SerializeAs] which allows annotating
+//! struct fields `serde_as(as = "RpcFelt")`to use the RPC compliant serialization.
+//! 
+//! ```rust
+//! #[serde_with::serde_as]
+//! struct RpcOutput {
+//!     serde_as(as = "RpcFelt")`
+//!     hash: StarknetTransactionHash,
+//! }
+//! ```
+
+use pathfinder_common::{
+    ChainId, ClassHash, ContractAddress, StarknetBlockHash, StarknetTransactionHash,
+    TransactionNonce, TransactionSignatureElem,
+};
+
+/// An RPC specific wrapper around [Felt] which implements
+/// [serde::Serialize] in accordance with RPC specifications.
+///
+/// RPC output types should use this type for serialization instead of [Felt].
+///
+/// This can be easily accomplished by marking a field with `#[serde_as(as = "RpcFelt")]`.
+///
+/// [Felt]: stark_hash::Felt
+pub struct RpcFelt(stark_hash::Felt);
+
+/// An RPC specific wrapper around [Felt] for types which are restricted to 251 bits. It implements
+/// [serde::Serialize] in accordance with RPC specifications.
+///
+/// RPC output types should use this type for serialization instead of [Felt].
+///
+/// This can be easily accomplished by marking a field with `#[serde_as(as = "RpcFelt251")]`.
+///
+/// [Felt]: stark_hash::Felt
+#[derive(serde::Serialize)]
+pub struct RpcFelt251(RpcFelt);
+
+impl serde::Serialize for RpcFelt {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // StarkHash has a leading "0x" and at most 64 digits
+        let mut buf = [0u8; 2 + 64];
+        let s = self.0.as_hex_str(&mut buf);
+        serializer.serialize_str(s)
+    }
+}
+
+impl<T> serde_with::SerializeAs<T> for RpcFelt
+where
+    T: Into<RpcFelt> + Clone,
+{
+    fn serialize_as<S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+
+        RpcFelt::serialize(&value.clone().into(), serializer)
+    }
+}
+
+impl<T> serde_with::SerializeAs<T> for RpcFelt251
+where
+    T: Into<RpcFelt251> + Clone,
+{
+    fn serialize_as<S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+
+        RpcFelt251::serialize(&value.clone().into(), serializer)
+    }
+}
+
+macro_rules! rpc_felt_serde {
+    ($target:ident) => {
+        impl From<$target> for RpcFelt {
+            fn from(value: $target) -> Self {
+                RpcFelt(value.0)
+            }
+        }
+
+        #[cfg(any(test, feature = "rpc-full-serde"))]
+        impl From<RpcFelt> for $target {
+            fn from(value: RpcFelt) -> Self {
+                $target(value.0)
+            }
+        }
+    };
+
+    ($head:ident, $($tail:ident),+ $(,)?) => {
+        rpc_felt_serde!($head);
+        rpc_felt_serde!($($tail),+);
+    };
+}
+
+macro_rules! rpc_felt_251_serde {
+    ($target:ident) => {
+        impl From<$target> for RpcFelt251 {
+            fn from(value: $target) -> Self {
+                RpcFelt251(RpcFelt(value.get().clone()))
+            }
+        }
+
+        #[cfg(any(test, feature = "rpc-full-serde"))]
+        impl From<RpcFelt251> for $target {
+            fn from(value: RpcFelt251) -> Self {
+                $target::new_or_panic(value.0.0)
+            }
+        }
+    };
+
+    ($head:ident, $($tail:ident),+ $(,)?) => {
+        rpc_felt_251_serde!($head);
+        rpc_felt_251_serde!($($tail),+);
+    };
+}
+
+rpc_felt_serde!(
+    ChainId,
+    ClassHash,
+    StarknetBlockHash,
+    StarknetTransactionHash,
+    TransactionNonce,
+    TransactionSignatureElem,
+);
+
+rpc_felt_251_serde!(ContractAddress);
+
+#[cfg(any(test, feature = "rpc-full-serde"))]
+mod deserialization {
+    use super::*;
+
+    impl<'de, T> serde_with::DeserializeAs<'de, T> for RpcFelt
+    where
+        T: From<RpcFelt>,
+    {
+        fn deserialize_as<D>(deserializer: D) -> Result<T, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            use serde::Deserialize;
+
+            let rpc_felt: RpcFelt = Deserialize::deserialize(deserializer)?;
+
+            Ok(T::from(rpc_felt))
+        }
+    }
+
+    impl<'de> serde::Deserialize<'de> for RpcFelt {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            struct FeltVisitor;
+
+            impl<'de> serde::de::Visitor<'de> for FeltVisitor {
+                type Value = RpcFelt;
+
+                fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    formatter
+                        .write_str("a hex string of up to 64 digits with an optional '0x' prefix")
+                }
+
+                fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    stark_hash::Felt::from_hex_str(v)
+                        .map_err(|e| serde::de::Error::custom(e))
+                        .map(RpcFelt)
+                }
+            }
+
+            deserializer.deserialize_str(FeltVisitor)
+        }
+    }
+
+    impl<'de, T> serde_with::DeserializeAs<'de, T> for RpcFelt251
+    where
+        T: From<RpcFelt251>,
+    {
+        fn deserialize_as<D>(deserializer: D) -> Result<T, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            use serde::Deserialize;
+
+            let rpc_felt: RpcFelt251 = Deserialize::deserialize(deserializer)?;
+
+            Ok(T::from(rpc_felt))
+        }
+    }
+
+    impl<'de> serde::Deserialize<'de> for RpcFelt251 {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            use serde::de::Error;
+            let felt: RpcFelt = serde::Deserialize::deserialize(deserializer)?;
+
+            if felt.0.has_more_than_251_bits() {
+                return Err(D::Error::custom("Value exceeded 251 bits"));
+            }
+
+            Ok(RpcFelt251(felt))
+        }
+    }
+}

--- a/crates/rpc/src/felt.rs
+++ b/crates/rpc/src/felt.rs
@@ -13,8 +13,8 @@
 //! ```
 
 use pathfinder_common::{
-    CallParam, ChainId, ClassHash, ConstructorParam, ContractAddress, ContractAddressSalt,
-    ContractNonce, EntryPoint, EventData, EventKey, L1ToL2MessagePayloadElem,
+    CallParam, CallResultValue, ChainId, ClassHash, ConstructorParam, ContractAddress,
+    ContractAddressSalt, ContractNonce, EntryPoint, EventData, EventKey, L1ToL2MessagePayloadElem,
     L2ToL1MessagePayloadElem, SequencerAddress, StarknetBlockHash, StarknetTransactionHash,
     StateCommitment, StorageAddress, StorageValue, TransactionNonce, TransactionSignatureElem,
 };
@@ -126,6 +126,7 @@ macro_rules! rpc_felt_251_serde {
 
 rpc_felt_serde!(
     CallParam,
+    CallResultValue,
     ChainId,
     ClassHash,
     ConstructorParam,

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod cairo;
 mod context;
 mod error;
+mod felt;
 pub mod gas_price;
 pub mod metrics;
 mod module;

--- a/crates/rpc/src/v02/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v02/method/add_declare_transaction.rs
@@ -1,3 +1,4 @@
+use crate::felt::RpcFelt;
 use crate::v02::types::request::BroadcastedDeclareTransaction;
 use crate::v02::RpcContext;
 use pathfinder_common::{ClassHash, StarknetTransactionHash};
@@ -35,9 +36,12 @@ pub struct AddDeclareTransactionInput {
     token: Option<String>,
 }
 
+#[serde_with::serde_as]
 #[derive(serde::Serialize, Debug, PartialEq, Eq)]
 pub struct AddDeclareTransactionOutput {
+    #[serde_as(as = "RpcFelt")]
     transaction_hash: StarknetTransactionHash,
+    #[serde_as(as = "RpcFelt")]
     class_hash: ClassHash,
 }
 

--- a/crates/rpc/src/v02/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/v02/method/add_deploy_account_transaction.rs
@@ -1,3 +1,4 @@
+use crate::felt::{RpcFelt, RpcFelt251};
 use crate::v02::{types::request::BroadcastedDeployAccountTransaction, RpcContext};
 use anyhow::Context;
 use pathfinder_common::{ContractAddress, StarknetTransactionHash};
@@ -15,9 +16,12 @@ pub struct AddDeployAccountTransactionInput {
     deploy_account_transaction: Transaction,
 }
 
+#[serde_with::serde_as]
 #[derive(serde::Serialize, Debug, PartialEq, Eq)]
 pub struct AddDeployAccountTransactionOutput {
+    #[serde_as(as = "RpcFelt")]
     transaction_hash: StarknetTransactionHash,
+    #[serde_as(as = "RpcFelt251")]
     contract_address: ContractAddress,
 }
 

--- a/crates/rpc/src/v02/method/add_deploy_transaction.rs
+++ b/crates/rpc/src/v02/method/add_deploy_transaction.rs
@@ -1,3 +1,4 @@
+use crate::felt::{RpcFelt, RpcFelt251};
 use crate::v02::types::request::BroadcastedDeployTransaction;
 use crate::v02::RpcContext;
 use pathfinder_common::{ContractAddress, StarknetTransactionHash};
@@ -35,9 +36,12 @@ pub struct AddDeployTransactionInput {
     token: Option<String>,
 }
 
+#[serde_with::serde_as]
 #[derive(serde::Serialize, Debug, PartialEq, Eq)]
 pub struct AddDeployTransactionOutput {
+    #[serde_as(as = "RpcFelt")]
     transaction_hash: StarknetTransactionHash,
+    #[serde_as(as = "RpcFelt251")]
     contract_address: ContractAddress,
 }
 

--- a/crates/rpc/src/v02/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/v02/method/add_invoke_transaction.rs
@@ -1,3 +1,4 @@
+use crate::felt::RpcFelt;
 use crate::v02::types::request::BroadcastedInvokeTransaction;
 use crate::v02::RpcContext;
 use anyhow::Context;
@@ -18,8 +19,10 @@ pub struct AddInvokeTransactionInput {
     invoke_transaction: Transaction,
 }
 
+#[serde_with::serde_as]
 #[derive(serde::Serialize, Debug, PartialEq, Eq)]
 pub struct AddInvokeTransactionOutput {
+    #[serde_as(as = "RpcFelt")]
     transaction_hash: StarknetTransactionHash,
 }
 

--- a/crates/rpc/src/v02/method/block_hash_and_number.rs
+++ b/crates/rpc/src/v02/method/block_hash_and_number.rs
@@ -1,10 +1,13 @@
+use crate::felt::RpcFelt;
 use crate::v02::RpcContext;
 use anyhow::Context;
 use pathfinder_common::{StarknetBlockHash, StarknetBlockNumber};
 use pathfinder_storage::StarknetBlocksTable;
 
+#[serde_with::serde_as]
 #[derive(serde::Serialize)]
 pub struct BlockHashAndNumber {
+    #[serde_as(as = "RpcFelt")]
     pub block_hash: StarknetBlockHash,
     pub block_number: StarknetBlockNumber,
 }

--- a/crates/rpc/src/v02/method/call.rs
+++ b/crates/rpc/src/v02/method/call.rs
@@ -1,3 +1,4 @@
+use crate::felt::RpcFelt;
 use crate::v02::RpcContext;
 use pathfinder_common::{BlockId, CallParam, CallResultValue, ContractAddress, EntryPoint};
 
@@ -53,10 +54,11 @@ impl From<FunctionCall> for crate::v01::types::request::Call {
     }
 }
 
-pub async fn call(
-    context: RpcContext,
-    input: CallInput,
-) -> Result<Vec<CallResultValue>, CallError> {
+#[serde_with::serde_as]
+#[derive(serde::Serialize, Debug)]
+pub struct CallOutput(#[serde_as(as = "Vec<RpcFelt>")] Vec<CallResultValue>);
+
+pub async fn call(context: RpcContext, input: CallInput) -> Result<CallOutput, CallError> {
     let handle = context
         .call_handle
         .as_ref()
@@ -75,7 +77,7 @@ pub async fn call(
         )
         .await?;
 
-    Ok(result)
+    Ok(CallOutput(result))
 }
 
 #[cfg(test)]
@@ -237,7 +239,7 @@ mod tests {
             };
 
             let result = call(context, input).await.unwrap();
-            assert_eq!(result, vec![]);
+            assert_eq!(result.0, vec![]);
         }
     }
 }

--- a/crates/rpc/src/v02/method/chain_id.rs
+++ b/crates/rpc/src/v02/method/chain_id.rs
@@ -1,12 +1,16 @@
 use pathfinder_common::ChainId;
 
+use crate::felt::RpcFelt;
 use crate::v02::RpcContext;
 
 crate::error::generate_rpc_error_subset!(ChainIdError);
 
-#[allow(dead_code)]
-pub async fn chain_id(context: RpcContext) -> Result<ChainId, ChainIdError> {
-    Ok(context.chain_id)
+#[serde_with::serde_as]
+#[derive(serde::Serialize)]
+pub struct ChainIdOutput(#[serde_as(as = "RpcFelt")] ChainId);
+
+pub async fn chain_id(context: RpcContext) -> Result<ChainIdOutput, ChainIdError> {
+    Ok(ChainIdOutput(context.chain_id))
 }
 
 #[cfg(test)]

--- a/crates/rpc/src/v02/method/get_events.rs
+++ b/crates/rpc/src/v02/method/get_events.rs
@@ -369,6 +369,7 @@ fn next_continuation_token(
 }
 
 mod types {
+    use crate::felt::{RpcFelt, RpcFelt251};
     use pathfinder_common::{
         ContractAddress, EventData, EventKey, StarknetBlockHash, StarknetBlockNumber,
         StarknetTransactionHash,
@@ -377,16 +378,22 @@ mod types {
     use serde::Serialize;
 
     /// Describes an emitted event returned by starknet_getEvents
+    #[serde_with::serde_as]
     #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
     #[serde(deny_unknown_fields)]
     pub struct EmittedEvent {
+        #[serde_as(as = "Vec<RpcFelt>")]
         pub data: Vec<EventData>,
+        #[serde_as(as = "Vec<RpcFelt>")]
         pub keys: Vec<EventKey>,
+        #[serde_as(as = "RpcFelt251")]
         pub from_address: ContractAddress,
         /// [None] for pending events.
+        #[serde_as(as = "Option<RpcFelt>")]
         pub block_hash: Option<StarknetBlockHash>,
         /// [None] for pending events.
         pub block_number: Option<StarknetBlockNumber>,
+        #[serde_as(as = "RpcFelt")]
         pub transaction_hash: StarknetTransactionHash,
     }
 

--- a/crates/rpc/src/v02/method/get_state_update.rs
+++ b/crates/rpc/src/v02/method/get_state_update.rs
@@ -68,6 +68,7 @@ pub async fn get_state_update(
 }
 
 mod types {
+    use crate::felt::{RpcFelt, RpcFelt251};
     use pathfinder_common::{
         ClassHash, ContractAddress, ContractNonce, StarknetBlockHash, StateCommitment,
         StorageAddress, StorageValue,
@@ -76,6 +77,7 @@ mod types {
     use serde_with::skip_serializing_none;
     use std::collections::HashMap;
 
+    #[serde_with::serde_as]
     #[skip_serializing_none]
     #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
     #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
@@ -83,8 +85,11 @@ mod types {
     pub struct StateUpdate {
         /// None for `pending`
         #[serde(default)]
+        #[serde_as(as = "Option<RpcFelt>")]
         pub block_hash: Option<StarknetBlockHash>,
+        #[serde_as(as = "RpcFelt")]
         pub new_root: StateCommitment,
+        #[serde_as(as = "RpcFelt")]
         pub old_root: StateCommitment,
         pub state_diff: StateDiff,
     }
@@ -112,11 +117,13 @@ mod types {
     }
 
     /// L2 state diff.
+    #[serde_with::serde_as]
     #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
     #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
     #[serde(deny_unknown_fields)]
     pub struct StateDiff {
         pub storage_diffs: Vec<StorageDiff>,
+        #[serde_as(as = "Vec<RpcFelt>")]
         pub declared_contract_hashes: Vec<ClassHash>,
         pub deployed_contracts: Vec<DeployedContract>,
         pub nonces: Vec<Nonce>,
@@ -203,20 +210,25 @@ mod types {
     }
 
     /// L2 storage diff of a contract.
+    #[serde_with::serde_as]
     #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
     #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
     #[serde(deny_unknown_fields)]
     pub struct StorageDiff {
+        #[serde_as(as = "RpcFelt251")]
         pub address: ContractAddress,
         pub storage_entries: Vec<StorageEntry>,
     }
 
     /// A key-value entry of a storage diff.
+    #[serde_with::serde_as]
     #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
     #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
     #[serde(deny_unknown_fields)]
     pub struct StorageEntry {
+        #[serde_as(as = "RpcFelt251")]
         pub key: StorageAddress,
+        #[serde_as(as = "RpcFelt")]
         pub value: StorageValue,
     }
 
@@ -230,11 +242,14 @@ mod types {
     }
 
     /// L2 state diff deployed contract item.
+    #[serde_with::serde_as]
     #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
     #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
     #[serde(deny_unknown_fields)]
     pub struct DeployedContract {
+        #[serde_as(as = "RpcFelt251")]
         pub address: ContractAddress,
+        #[serde_as(as = "RpcFelt")]
         pub class_hash: ClassHash,
     }
 
@@ -257,11 +272,14 @@ mod types {
     }
 
     /// L2 state diff nonce item.
+    #[serde_with::serde_as]
     #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
     #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
     #[serde(deny_unknown_fields)]
     pub struct Nonce {
+        #[serde_as(as = "RpcFelt251")]
         pub contract_address: ContractAddress,
+        #[serde_as(as = "RpcFelt")]
         pub nonce: ContractNonce,
     }
 

--- a/crates/rpc/src/v02/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v02/method/get_transaction_receipt.rs
@@ -78,6 +78,7 @@ pub async fn get_transaction_receipt(
 }
 
 mod types {
+    use crate::felt::{RpcFelt, RpcFelt251};
     use crate::v02::types::reply::BlockStatus;
     use pathfinder_common::{
         ContractAddress, EthereumAddress, EventData, EventKey, Fee, L1ToL2MessagePayloadElem,
@@ -125,10 +126,12 @@ mod types {
     #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
     #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
     pub struct CommonTransactionReceiptProperties {
+        #[serde_as(as = "RpcFelt")]
         pub transaction_hash: StarknetTransactionHash,
         #[serde_as(as = "FeeAsHexStr")]
         pub actual_fee: Fee,
         pub status: TransactionStatus,
+        #[serde_as(as = "RpcFelt")]
         pub block_hash: StarknetBlockHash,
         pub block_number: StarknetBlockNumber,
         pub messages_sent: Vec<MessageToL1>,
@@ -142,21 +145,23 @@ mod types {
         pub common: CommonTransactionReceiptProperties,
     }
 
+    #[serde_as]
     #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
     #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
     pub struct DeployTransactionReceipt {
         #[serde(flatten)]
         pub common: CommonTransactionReceiptProperties,
-
+        #[serde_as(as = "RpcFelt251")]
         pub contract_address: ContractAddress,
     }
 
+    #[serde_as]
     #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
     #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
     pub struct DeployAccountTransactionReceipt {
         #[serde(flatten)]
         pub common: CommonTransactionReceiptProperties,
-
+        #[serde_as(as = "RpcFelt251")]
         pub contract_address: ContractAddress,
     }
 
@@ -320,6 +325,7 @@ mod types {
     pub struct MessageToL1 {
         #[serde_as(as = "EthereumAddressAsHexStr")]
         pub to_address: EthereumAddress,
+        #[serde_as(as = "Vec<RpcFelt>")]
         pub payload: Vec<L2ToL1MessagePayloadElem>,
     }
 
@@ -340,6 +346,7 @@ mod types {
     pub struct MessageToL2 {
         #[serde_as(as = "EthereumAddressAsHexStr")]
         pub from_address: EthereumAddress,
+        #[serde_as(as = "Vec<RpcFelt>")]
         pub payload: Vec<L1ToL2MessagePayloadElem>,
     }
 
@@ -353,12 +360,16 @@ mod types {
     }
 
     /// Event emitted as a part of a transaction.
+    #[serde_as]
     #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
     #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
     #[serde(deny_unknown_fields)]
     pub struct Event {
+        #[serde_as(as = "RpcFelt251")]
         pub from_address: ContractAddress,
+        #[serde_as(as = "Vec<RpcFelt>")]
         pub keys: Vec<EventKey>,
+        #[serde_as(as = "Vec<RpcFelt>")]
         pub data: Vec<EventData>,
     }
 

--- a/crates/rpc/src/v02/method/syncing.rs
+++ b/crates/rpc/src/v02/method/syncing.rs
@@ -1,3 +1,4 @@
+use crate::felt::RpcFelt;
 use crate::v02::RpcContext;
 use pathfinder_common::{StarknetBlockHash, StarknetBlockNumber};
 use pathfinder_serde::StarknetBlockNumberAsHexStr;
@@ -57,8 +58,11 @@ pub struct SyncingStatus {
     current_block_num: StarknetBlockNumber,
     #[serde_as(as = "StarknetBlockNumberAsHexStr")]
     highest_block_num: StarknetBlockNumber,
+    #[serde_as(as = "RpcFelt")]
     starting_block_hash: StarknetBlockHash,
+    #[serde_as(as = "RpcFelt")]
     current_block_hash: StarknetBlockHash,
+    #[serde_as(as = "RpcFelt")]
     highest_block_hash: StarknetBlockHash,
 }
 

--- a/crates/rpc/src/v02/types.rs
+++ b/crates/rpc/src/v02/types.rs
@@ -273,6 +273,7 @@ pub mod request {
 /// Groups all strictly output types of the RPC API.
 pub mod reply {
     // At the moment both reply types are the same for get_code, hence the re-export
+    use crate::felt::{RpcFelt, RpcFelt251};
     use pathfinder_common::{
         CallParam, ClassHash, ConstructorParam, ContractAddress, ContractAddressSalt, EntryPoint,
         Fee, StarknetTransactionHash, TransactionNonce, TransactionSignatureElem,
@@ -286,7 +287,6 @@ pub mod reply {
     use starknet_gateway_types::reply::transaction::Transaction as GatewayTransaction;
 
     /// L2 transaction as returned by the RPC API.
-    ///
     #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
     #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
     #[serde(tag = "type")]
@@ -321,12 +321,15 @@ pub mod reply {
     #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
     pub struct CommonTransactionProperties {
         #[serde(rename = "transaction_hash")]
+        #[serde_as(as = "RpcFelt")]
         pub hash: StarknetTransactionHash,
         #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
         #[serde_as(as = "TransactionVersionAsHexStr")]
         pub version: TransactionVersion,
+        #[serde_as(as = "Vec<RpcFelt>")]
         pub signature: Vec<TransactionSignatureElem>,
+        #[serde_as(as = "RpcFelt")]
         pub nonce: TransactionNonce,
     }
 
@@ -338,7 +341,9 @@ pub mod reply {
         pub common: CommonTransactionProperties,
 
         // DECLARE_TXN
+        #[serde_as(as = "RpcFelt")]
         pub class_hash: ClassHash,
+        #[serde_as(as = "RpcFelt251")]
         pub sender_address: ContractAddress,
     }
 
@@ -350,8 +355,11 @@ pub mod reply {
         pub common: CommonTransactionProperties,
 
         // DEPLOY_ACCOUNT_TXN
+        #[serde_as(as = "RpcFelt")]
         pub contract_address_salt: ContractAddressSalt,
+        #[serde_as(as = "Vec<RpcFelt>")]
         pub constructor_calldata: Vec<CallParam>,
+        #[serde_as(as = "RpcFelt")]
         pub class_hash: ClassHash,
     }
 
@@ -412,8 +420,11 @@ pub mod reply {
         pub common: CommonInvokeTransactionProperties,
 
         // INVOKE_TXN_V0
+        #[serde_as(as = "RpcFelt251")]
         pub contract_address: ContractAddress,
+        #[serde_as(as = "RpcFelt")]
         pub entry_point_selector: EntryPoint,
+        #[serde_as(as = "Vec<RpcFelt>")]
         pub calldata: Vec<CallParam>,
     }
 
@@ -425,7 +436,9 @@ pub mod reply {
         pub common: CommonInvokeTransactionProperties,
 
         // INVOKE_TXN_V1
+        #[serde_as(as = "RpcFelt251")]
         pub sender_address: ContractAddress,
+        #[serde_as(as = "Vec<RpcFelt>")]
         pub calldata: Vec<CallParam>,
     }
 
@@ -437,10 +450,13 @@ pub mod reply {
     // Version is now a property of the type embedding common properties.
     pub struct CommonInvokeTransactionProperties {
         #[serde(rename = "transaction_hash")]
+        #[serde_as(as = "RpcFelt")]
         pub hash: StarknetTransactionHash,
         #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
+        #[serde_as(as = "Vec<RpcFelt>")]
         pub signature: Vec<TransactionSignatureElem>,
+        #[serde_as(as = "RpcFelt")]
         pub nonce: TransactionNonce,
     }
 
@@ -450,13 +466,17 @@ pub mod reply {
     pub struct DeployTransaction {
         // DEPLOY_TXN
         #[serde(rename = "transaction_hash")]
+        #[serde_as(as = "RpcFelt")]
         pub hash: StarknetTransactionHash,
+        #[serde_as(as = "RpcFelt")]
         pub class_hash: ClassHash,
 
         // DEPLOY_TXN_PROPERTIES
         #[serde_as(as = "TransactionVersionAsHexStr")]
         pub version: TransactionVersion,
+        #[serde_as(as = "RpcFelt")]
         pub contract_address_salt: ContractAddressSalt,
+        #[serde_as(as = "Vec<RpcFelt>")]
         pub constructor_calldata: Vec<ConstructorParam>,
     }
 
@@ -466,14 +486,19 @@ pub mod reply {
     pub struct L1HandlerTransaction {
         // This part is a subset of CommonTransactionProperties
         #[serde(rename = "transaction_hash")]
+        #[serde_as(as = "RpcFelt")]
         pub hash: StarknetTransactionHash,
         #[serde_as(as = "TransactionVersionAsHexStr")]
         pub version: TransactionVersion,
+        #[serde_as(as = "RpcFelt")]
         pub nonce: TransactionNonce,
 
         // FUNCTION_CALL
+        #[serde_as(as = "RpcFelt251")]
         pub contract_address: ContractAddress,
+        #[serde_as(as = "RpcFelt")]
         pub entry_point_selector: EntryPoint,
+        #[serde_as(as = "Vec<RpcFelt>")]
         pub calldata: Vec<CallParam>,
     }
 

--- a/crates/rpc/src/v02/types/class.rs
+++ b/crates/rpc/src/v02/types/class.rs
@@ -116,6 +116,7 @@ pub struct ContractEntryPoints {
 pub struct ContractEntryPoint {
     #[serde_as(as = "U64AsHexStr")]
     pub offset: u64,
+    #[serde_as(as = "crate::felt::RpcFelt")]
     pub selector: Felt,
 }
 


### PR DESCRIPTION
This PR allows us to separately encode / decode `Felt`s in the RPC setting. This is required by the RPC specification, where the serde may diverge from both the gateway and our storage implementations.

In general this is also a positive in that it decouples our RPC implementation from our other components. It would be good to perform similar surgery on other components where possible.

### How

This PR adds `RpcFelt` and `RpcFelt251` types which implement custom serde - currently these are just the original, but can be trivially changed. We could also expand on this if we need more types or if we need different encodings for different RPC versions.

The `serde_with::SerializeAs` trait also allows specifying container types which is really nice:
```rust
#[serde_with::serde_as]
#[derive(serde::Serialize)]
struct Example {
    #[serde_as(as = "RpcFelt")]
    hash: StarknetTransactionHash,

    #[serde_as(as = "Option<RpcFelt>")]
    maybe_hash: Option<StarknetTransactionHash>,

    #[serde_as(as = "Vec<RpcFelt>")]
    many_hashes: Vec<StarknetTransactionHash>,
}
```

### What

`RpcFelt` and `RpcFelt251` are used to (de)serialize all applicable v0.2 RPC outputs i.e. in all elements which are `Felt` or `Felt` newtype wrappers.

I did not bother with v0.1 because we are due to delete it any day now..

v0.3 has no unique code; it is so far only re-using v0.2 methods. If we need to distinguish between v0.2 and v0.3 then we will have to make things more complicated / copy some stuff around.

### Caveats

It is possible that I missed some conversions - it will only be possible to be certain once we remove `serde` from `Felt` and its common newtype wrappers entirely. This is currently not trivially possible as storage and gateway still rely on this.

I think it would be beneficial to strive for this as it decouples our components. It is especially difficult to currently know what changes may impact other parts of the system in certain cases - usually serde related as these are not strongly typed (always derived).

Ideally, the common newtypes would implement no serde at all, and each component would wrap / convert to perform this independently from other components. i.e. each component only depends on common, and implements its own serde.

If we reach consensus on this approach then I'll add some issues for similar work on the other components.

**It would be great if you can eyeball the PR locally to make sure I didn't miss any conversions or methods that require it**