### PR TITLE
Update state commitment code for Starknet 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5335,7 +5335,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
+ "stark_curve",
  "stark_hash",
+ "stark_poseidon",
  "thiserror",
  "vergen",
 ]
@@ -5374,7 +5376,9 @@ dependencies = [
  "pretty_assertions",
  "rand 0.8.5",
  "rusqlite",
+ "stark_curve",
  "stark_hash",
+ "stark_poseidon",
  "starknet-gateway-types",
 ]
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -17,7 +17,9 @@ rusqlite = { version = "0.28.0", features = ["bundled"] }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
 sha3 = "0.10"
+stark_curve = { path = "../stark_curve" }
 stark_hash = { path = "../stark_hash" }
+stark_poseidon = { path = "../stark_poseidon" }
 thiserror = "1.0.37"
 
 [build-dependencies]

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -153,11 +153,16 @@ impl StateCommitment {
         if class_commitment == ClassCommitment::ZERO {
             Self(storage_commitment.0)
         } else {
-            // FIXME 0.11.0 make sure which hash to use Pedersen or Poseidon
-            StateCommitment(stark_hash::stark_hash(
-                storage_commitment.0,
-                class_commitment.0,
-            ))
+            const COMMITMENT_VERSION: stark_curve::FieldElement = stark_curve::FieldElement::ZERO;
+
+            StateCommitment(
+                stark_poseidon::poseidon_hash(&[
+                    storage_commitment.0.into(),
+                    class_commitment.0.into(),
+                    COMMITMENT_VERSION,
+                ])
+                .into(),
+            )
         }
     }
 }

--- a/crates/merkle-tree/Cargo.toml
+++ b/crates/merkle-tree/Cargo.toml
@@ -13,7 +13,9 @@ pathfinder-common = { path = "../common" }
 pathfinder-storage = { path = "../storage" }
 rand = "0.8"
 rusqlite = { version = "0.28.0", features = ["bundled"] }
+stark_curve = { path = "../stark_curve" }
 stark_hash = { path = "../stark_hash" }
+stark_poseidon = { path = "../stark_poseidon" }
 starknet-gateway-types = { path = "../gateway-types" }
 
 [dev-dependencies]

--- a/crates/merkle-tree/src/lib.rs
+++ b/crates/merkle-tree/src/lib.rs
@@ -20,12 +20,10 @@ impl Hash for PedersenHash {
     }
 }
 
-/// Implements [Hash] for the StarkNet Poseidon hash.
-///
-/// TODO: add once hash is implemented.
+/// Implements [Hash] for the [StarkNet Poseidon hash](stark_poseidon::poseidon_hash).
 struct PoseidonHash;
 impl crate::Hash for PoseidonHash {
-    fn hash(_left: stark_hash::Felt, _right: stark_hash::Felt) -> stark_hash::Felt {
-        unimplemented!("Hash function still needs to be implemented");
+    fn hash(left: Felt, right: Felt) -> Felt {
+        stark_poseidon::poseidon_hash(&[left.into(), right.into()]).into()
     }
 }

--- a/crates/rpc/src/v02/method/get_state_update.rs
+++ b/crates/rpc/src/v02/method/get_state_update.rs
@@ -519,7 +519,7 @@ mod tests {
                 "06df64b357468b371e8a81e438914cd3a5fe4a6b693129149c382aa3d03f9674"
             )),
             old_root: StateCommitment(felt!(
-                "0712DA727C748FC3B118B7DE7A50EECD50693203CBA42973755AF13AB729684D"
+                "0786B86566E547D4F0D3DA87419C9821CC9BCF10425C466CAD298084CC2FC7A9"
             )),
             state_diff: StateDiff {
                 storage_diffs: vec![StorageDiff {


### PR DESCRIPTION
This PR implements changes in the state commitment scheme for Starknet 0.11. In particular:

- The classes tree will be computed with the Poseidon hash function, while the global state tree will continue to use Pedersen

- The leaves in the classes tree will be h(compiled_class_hash, leaf_version) where leaf_version is a field added to allow forward compatability and is currently set to 0

-  If the classes tree is none empty, the state commitment will be computed by h(global_tree_root, classes_root, commitment_version) where h is the Poseidon hash function and commitment_version is a field added to allow forward compatability and is currently set to 0

Source: https://docs.starknet.io/documentation/starknet_versions/upcoming_versions/#state_commitment

Closes #895 