### PR TITLE
fix(retry): set retry backoff saturation to 10 minutes

### DIFF
--- a/crates/ethereum/src/provider.rs
+++ b/crates/ethereum/src/provider.rs
@@ -36,9 +36,9 @@ pub trait EthereumTransport {
 
 /// An implementation of [`EthereumTransport`] wrapped with a [exponential backoff retry utility](Retry).
 ///
-/// Initial backoff time is 30 seconds and saturates at 1 hour:
+/// Initial backoff time is 30 seconds and saturates at 10 minutes:
 ///
-/// `backoff [secs] = min((2 ^ N) * 15, 3600) [secs]`
+/// `backoff [secs] = min((2 ^ N) * 15, 600) [secs]`
 ///
 /// where `N` is the consecutive retry iteration number `{1, 2, ...}`.
 #[derive(Clone, Debug)]
@@ -193,7 +193,7 @@ where
 {
     Retry::exponential(future_factory, NonZeroU64::new(2).unwrap())
         .factor(NonZeroU64::new(15).unwrap())
-        .max_delay(Duration::from_secs(60 * 60))
+        .max_delay(Duration::from_secs(10 * 60))
         .when(retry_condition)
         .await
 }

--- a/crates/gateway-client/src/builder.rs
+++ b/crates/gateway-client/src/builder.rs
@@ -387,7 +387,7 @@ where
 
     Retry::exponential(future_factory, NonZeroU64::new(2).unwrap())
         .factor(NonZeroU64::new(15).unwrap())
-        .max_delay(std::time::Duration::from_secs(60 * 60))
+        .max_delay(std::time::Duration::from_secs(10 * 60))
         .when(retry_condition)
         .await
 }

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -101,9 +101,9 @@ pub trait ClientApi {
 /// Retry is performed on __all__ types of errors __except for__
 /// [StarkNet specific errors](starknet_gateway_types::error::StarknetError).
 ///
-/// Initial backoff time is 30 seconds and saturates at 1 hour:
+/// Initial backoff time is 30 seconds and saturates at 10 minutes:
 ///
-/// `backoff [secs] = min((2 ^ N) * 15, 3600) [secs]`
+/// `backoff [secs] = min((2 ^ N) * 15, 600) [secs]`
 ///
 /// where `N` is the consecutive retry iteration number `{1, 2, ...}`.
 #[derive(Debug, Clone)]

--- a/crates/pathfinder/src/state/sync/l1.rs
+++ b/crates/pathfinder/src/state/sync/l1.rs
@@ -79,7 +79,7 @@ where
 {
     Retry::exponential(future_factory, NonZeroU64::new(2).unwrap())
         .factor(NonZeroU64::new(15).unwrap())
-        .max_delay(Duration::from_secs(60 * 60))
+        .max_delay(Duration::from_secs(10 * 60))
         .when(retry_condition)
         .await
 }


### PR DESCRIPTION
Don't wait more than 10 minutes before retrying an HTTP request again.

Block time is ~10 minutes on mainnet now so this change tries to make sure that we don't fall too much behind even if a request to the feeder gateway failed.

Closes #893.