### PR TITLE
fix(poseidon): update Poseidon sponge construct

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,4 @@
 # notify on these specifically
 /crates/stark_curve @mikdk
 /crates/stark_hash @mikdk
+/crates/stark_poseidon @mikdk

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -142,6 +142,11 @@ pub struct StorageValue(pub Felt);
 pub struct StateCommitment(pub Felt);
 
 impl StateCommitment {
+    /// Calculates  global state commitment by combining the storage and class commitment.
+    ///
+    /// See
+    /// <https://github.com/starkware-libs/cairo-lang/blob/12ca9e91bbdc8a423c63280949c7e34382792067/src/starkware/starknet/core/os/state.cairo#L125>
+    /// for details.
     pub fn calculate(
         storage_commitment: StorageCommitment,
         class_commitment: ClassCommitment,
@@ -149,13 +154,13 @@ impl StateCommitment {
         if class_commitment == ClassCommitment::ZERO {
             Self(storage_commitment.0)
         } else {
-            const COMMITMENT_VERSION: stark_curve::FieldElement = stark_curve::FieldElement::ZERO;
+            const GLOBAL_STATE_VERSION: Felt = felt_bytes!(b"STARKNET_STATE_V0");
 
             StateCommitment(
-                stark_poseidon::poseidon_hash(&[
+                stark_poseidon::poseidon_hash_many(&[
+                    GLOBAL_STATE_VERSION.into(),
                     storage_commitment.0.into(),
                     class_commitment.0.into(),
-                    COMMITMENT_VERSION,
                 ])
                 .into(),
             )

--- a/crates/merkle-tree/src/lib.rs
+++ b/crates/merkle-tree/src/lib.rs
@@ -24,6 +24,6 @@ impl Hash for PedersenHash {
 struct PoseidonHash;
 impl crate::Hash for PoseidonHash {
     fn hash(left: Felt, right: Felt) -> Felt {
-        stark_poseidon::poseidon_hash(&[left.into(), right.into()]).into()
+        stark_poseidon::poseidon_hash(left.into(), right.into()).into()
     }
 }

--- a/crates/rpc/src/v02/method/get_state_update.rs
+++ b/crates/rpc/src/v02/method/get_state_update.rs
@@ -516,10 +516,10 @@ mod tests {
         let expected = StateUpdate {
             block_hash: None,
             new_root: StateCommitment(felt!(
-                "06df64b357468b371e8a81e438914cd3a5fe4a6b693129149c382aa3d03f9674"
+                "0x06df64b357468b371e8a81e438914cd3a5fe4a6b693129149c382aa3d03f9674"
             )),
             old_root: StateCommitment(felt!(
-                "0786B86566E547D4F0D3DA87419C9821CC9BCF10425C466CAD298084CC2FC7A9"
+                "0x04F53E3D1AD8AE22475BF02414088FA4D1DC1A837BBA4E34461FEA4DBCBB76D8"
             )),
             state_diff: StateDiff {
                 storage_diffs: vec![StorageDiff {

--- a/crates/stark_poseidon/README.md
+++ b/crates/stark_poseidon/README.md
@@ -6,7 +6,7 @@ This crate implements the StarkWare Poseidon hash function. The chosen parameter
 Check out [Sagemath script](/crates/stark_poseidon/poseidon.ipynb) for an easy overview and computed test vectors.
 
 ### Sponge construction
-The hash function is a sponge construction as depicted below (image source, wikipedia) with rate $r=1$ and capacity $c=2$, i.e. total state width of $n=3$. Each entry is a finite field element of integers modulo $p=2^{251} + 17*2^{192} + 1$.
+The hash function is a sponge construction as depicted below (image source, wikipedia) with rate $r=2$ and capacity $c=1$, i.e. total state width of $n=3$. Each entry is a finite field element of integers modulo $p=2^{251} + 17\cdot 2^{192} + 1$.
 
 ![Sponge function](spec/sponge.png)
 

--- a/crates/stark_poseidon/poseidon.ipynb
+++ b/crates/stark_poseidon/poseidon.ipynb
@@ -588,65 +588,11 @@
    "source": [
     "poseidon_permute(parse_vector([0,0,0]))"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b4014b4e",
-   "metadata": {},
-   "source": [
-    "Finally, we can wrap it in a sponge."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "ff928c94",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def sponge(msgs):\n",
-    "    state = parse_vector([0,0,0])\n",
-    "    for msg in msgs:\n",
-    "        state[0] += msg\n",
-    "        state = poseidon_permute(state)\n",
-    "    return state[0]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1b804bed",
-   "metadata": {},
-   "source": [
-    "Let's test by hashing the first few integers"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "5221e3d2",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1376036081002274569911474664093949383789905861331924457288437526797324788374"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "sponge([0,1,2,3])"
-   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "SageMath 9.5",
+   "display_name": "SageMath 9.8",
    "language": "sage",
    "name": "sagemath"
   },
@@ -660,7 +606,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.9"
   },
   "vscode": {
    "interpreter": {

--- a/crates/stark_poseidon/src/hash.rs
+++ b/crates/stark_poseidon/src/hash.rs
@@ -1,19 +1,45 @@
 use crate::{permute_comp, PoseidonState};
 use stark_curve::FieldElement;
 
-/// Hashes a number of messages using the Poseidon hash
-pub fn poseidon_hash(msgs: &[FieldElement]) -> FieldElement {
+/// Hashes two elements using the Poseidon hash.
+///
+/// Equivalent to [`poseidon_hash`](https://github.com/starkware-libs/cairo-lang/blob/12ca9e91bbdc8a423c63280949c7e34382792067/src/starkware/cairo/common/builtin_poseidon/poseidon.cairo#L5).
+pub fn poseidon_hash(x: FieldElement, y: FieldElement) -> FieldElement {
+    let mut state = [x, y, FieldElement::TWO];
+    permute_comp(&mut state);
+
+    state[0]
+}
+
+/// Hashes a number of messages using the Poseidon hash.
+///
+/// Equivalent to [`poseidon_hash_many`](https://github.com/starkware-libs/cairo-lang/blob/12ca9e91bbdc8a423c63280949c7e34382792067/src/starkware/cairo/common/builtin_poseidon/poseidon.cairo#L28).
+pub fn poseidon_hash_many(msgs: &[FieldElement]) -> FieldElement {
     let mut state = [FieldElement::ZERO, FieldElement::ZERO, FieldElement::ZERO];
-    for msg in msgs {
-        state[0] += msg;
+    let mut iter = msgs.chunks_exact(2);
+
+    for msg in iter.by_ref() {
+        state[0] += msg[0];
+        state[1] += msg[1];
         permute_comp(&mut state);
     }
+    let r = iter.remainder();
+    if r.len() == 1 {
+        state[0] += r[0];
+    }
+    state[r.len()] += FieldElement::ONE;
+    permute_comp(&mut state);
+
     state[0]
 }
 
 /// The PoseidonHasher can build up a hash by appending to state
+///
+/// Its output is equivalent to calling [poseidon_hash_many] with the
+/// field elements.
 pub struct PoseidonHasher {
     state: PoseidonState,
+    buffer: Option<FieldElement>,
 }
 
 impl PoseidonHasher {
@@ -21,24 +47,38 @@ impl PoseidonHasher {
     pub fn new() -> PoseidonHasher {
         PoseidonHasher {
             state: [FieldElement::ZERO, FieldElement::ZERO, FieldElement::ZERO],
+            buffer: None,
         }
     }
 
     /// Absorbs message into the hash
     pub fn write(&mut self, msg: FieldElement) {
-        self.state[0] += msg;
-        permute_comp(&mut self.state);
-    }
-
-    /// Extracts a single hash output
-    pub fn extract(&mut self) -> FieldElement {
-        let hash = self.state[0];
-        permute_comp(&mut self.state);
-        hash
+        match self.buffer.take() {
+            Some(previous_message) => {
+                self.state[0] += previous_message;
+                self.state[1] += msg;
+                permute_comp(&mut self.state);
+            }
+            None => {
+                self.buffer = Some(msg);
+            }
+        }
     }
 
     /// Finish and return hash
-    pub fn finish(self) -> FieldElement {
+    pub fn finish(mut self) -> FieldElement {
+        // Apply padding
+        match self.buffer.take() {
+            Some(last_message) => {
+                self.state[0] += last_message;
+                self.state[1] += FieldElement::ONE;
+            }
+            None => {
+                self.state[0] += FieldElement::ONE;
+            }
+        }
+        permute_comp(&mut self.state);
+
         self.state[0]
     }
 }
@@ -51,14 +91,77 @@ impl Default for PoseidonHasher {
 
 #[cfg(test)]
 mod tests {
-    use super::{poseidon_hash, PoseidonHasher};
+    use super::{poseidon_hash, poseidon_hash_many, PoseidonHasher};
     use stark_curve::FieldElement;
     use stark_hash::Felt;
 
     #[test]
+    fn test_poseidon_hash() {
+        // The test vector is derived by running the Python implementation with random input.
+        let x =
+            Felt::from_hex_str("0x23a77118133287637ebdcd9e87a1613e443df789558867f5ba91faf7a024204")
+                .unwrap();
+        let y =
+            Felt::from_hex_str("0x259f432e6f4590b9a164106cf6a659eb4862b21fb97d43588561712e8e5216a")
+                .unwrap();
+        let expected_hash =
+            Felt::from_hex_str("0x4be9af45b942b4b0c9f04a15e37b7f34f8109873ef7ef20e9eef8a38a3011e1")
+                .unwrap();
+        assert_eq!(poseidon_hash(x.into(), y.into()), expected_hash.into());
+    }
+
+    #[test]
+    fn test_poseidon_hash_many_empty_input() {
+        // The test vector is derived by running the Python implementation with random input.
+        assert_eq!(
+            poseidon_hash_many(&[]),
+            Felt::from_hex_str("0x2272be0f580fd156823304800919530eaa97430e972d7213ee13f4fbf7a5dbc")
+                .unwrap()
+                .into()
+        );
+    }
+
+    #[test]
+    fn test_poseidon_hash_many_single_input() {
+        // The test vector is derived by running the Python implementation with random input.
+        assert_eq!(
+            poseidon_hash_many(&[Felt::from_hex_str(
+                "0x23a77118133287637ebdcd9e87a1613e443df789558867f5ba91faf7a024204"
+            )
+            .unwrap()
+            .into()]),
+            Felt::from_hex_str("0x7d1f569e0e898982de6515c20132703410abca88ee56100e02df737fc4bf10e")
+                .unwrap()
+                .into()
+        );
+    }
+
+    #[test]
+    fn test_poseidon_hash_many_two_inputs() {
+        // The test vector is derived by running the Python implementation with random input.
+        assert_eq!(
+            poseidon_hash_many(&[
+                Felt::from_hex_str(
+                    "0x259f432e6f4590b9a164106cf6a659eb4862b21fb97d43588561712e8e5216a"
+                )
+                .unwrap()
+                .into(),
+                Felt::from_hex_str(
+                    "0x5487ce1af19922ad9b8a714e61a441c12e0c8b2bad640fb19488dec4f65d4d9"
+                )
+                .unwrap()
+                .into(),
+            ]),
+            Felt::from_hex_str("0x70869d36570fc0b364777c9322373fb7e15452d2282ebdb5b4f3212669f2e7")
+                .unwrap()
+                .into()
+        );
+    }
+
+    #[test]
     fn test_sponge() {
-        let result = FieldElement::from(
-            Felt::from_hex_str("30ACF0EF3C4549E3684B19652015FD9EADF7BDBA2A1A46CB29B9E18E6622296")
+        let expected_result = FieldElement::from(
+            Felt::from_hex_str("07b8f30ac298ea12d170c0873f1fa631a18c00756c6e7d1fd273b9a239d0d413")
                 .unwrap(),
         );
 
@@ -78,10 +181,10 @@ mod tests {
         let hasher_result = hasher.finish();
 
         // Construct hash from hash function
-        let hash_result = poseidon_hash(&msgs);
+        let hash_result = poseidon_hash_many(&msgs);
 
         // Check they are equal
         assert_eq!(hasher_result, hash_result);
-        assert_eq!(result, hash_result);
+        assert_eq!(expected_result, hash_result);
     }
 }

--- a/crates/stark_poseidon/src/lib.rs
+++ b/crates/stark_poseidon/src/lib.rs
@@ -1,5 +1,5 @@
 mod hash;
 mod poseidon;
 
-pub use hash::{poseidon_hash, PoseidonHasher};
+pub use hash::{poseidon_hash, poseidon_hash_many, PoseidonHasher};
 pub use poseidon::{permute, permute_comp, PoseidonState};


### PR DESCRIPTION
It turned out that the sponge construction used by Starknet is different compared to what we had implemented.

This PR updates our code to match the Cairo (and Python) implementation in the pre-release of `cairo-lang` 0.11. Test vectors were added by feeding the Python implementation in `cairo-lang` random input and asserting that our result is the same as that of the Python code.

We also update state commitment computation where it was involving the Poseidon hash functions to use the proper constructs (based on code in the pre-release, again). Some constants involved in commitment calculation are also updated.