### PR TITLE
fix: rpc felt decoding does not enforce 0x prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- RPC accepts hex inputs for Felt without '0x' prefix. This led to confusion especially when passing in a decimal string which would get silently interpretted as hex.
 - Using a Nethermind Ethereum endpoint occasionally causes errors such as `<block-number> could not be found` to be logged. 
 
 ### Removed


### PR DESCRIPTION
~~This PR changes `Felt::from_hex_str` to only accept `0x` prefix'd hex strings. Without this, we erroneously accepted non-prefixed felt strings in RPC, including interpretting decimal inputs silently as hex values.~~

~~In addition, this PR also adds a deserialisation exception for the gateway's `Block.state_commitment` property which unfortunately sends the value without the prefix (which was the reason for the lax felt deserialisation in the 1st place).~~

I've very much simplified the PR to only apply the "fix" to the RPC felt decoding. Initially I tried to fix it in general, but it had too many cascading effects.

This leverages the previous solution with the `RpcFelt` wrapper type - which certainly has been convenient as a quick fix. The time I sunk into this PR originally still highlights the mismatch between serde, our heavy usage of newtypes and inability to specify different serde formats for the same base type. I've added some more thoughts to #884 regarding using a proc macro to annotate these instead. A solution for further down the road.

Fixes #936.