### PR TITLE
fix(pathfinder/build.rs): fix `cargo-metadata` issues

### DIFF
--- a/crates/common/src/test_utils.rs
+++ b/crates/common/src/test_utils.rs
@@ -166,7 +166,7 @@ pub mod metrics {
         }
 
         fn is_key_used(&self, key: &Key) -> bool {
-            key.labels().into_iter().any(|label| {
+            key.labels().any(|label| {
                 label.key() == "method"
                     && self.0.methods.iter().any(|&method| method == label.value())
             })

--- a/crates/pathfinder/build.rs
+++ b/crates/pathfinder/build.rs
@@ -38,7 +38,15 @@ fn set_casm_compiler_version() {
         .output()
         .unwrap();
 
-    let metadata = serde_json::from_slice::<CargoMetadata>(&cargo_output.stdout).unwrap();
+    let metadata =
+        serde_json::from_slice::<CargoMetadata>(&cargo_output.stdout).unwrap_or_else(|_| {
+            panic!(
+                "{}",
+                std::str::from_utf8(&cargo_output.stderr)
+                    .unwrap()
+                    .to_string()
+            )
+        });
 
     let sierra_compiler_package = metadata
         .packages

--- a/crates/pathfinder/build.rs
+++ b/crates/pathfinder/build.rs
@@ -25,9 +25,7 @@ fn set_casm_compiler_version() {
 
     let cargo_args = [
         "metadata",
-        "--offline",
         "--locked",
-        "--frozen",
         "--format-version=1",
         "--manifest-path",
         manifest_path.to_str().unwrap(),

--- a/crates/storage/src/test_fixtures.rs
+++ b/crates/storage/src/test_fixtures.rs
@@ -36,7 +36,6 @@ pub mod init {
     /// Inserts `n` state updates, referring to blocks with numbers `(0..n)` and hashes `("0x0".."0xn")` respectively.
     pub fn with_n_state_updates(tx: &Transaction<'_>, n: u8) -> Vec<StateUpdate> {
         (0..n)
-            .into_iter()
             .map(|n| {
                 StarknetBlocksTable::insert(
                     tx,


### PR DESCRIPTION
When running the build script during a GitHub Actions build (like clippy) we're starting with an empty cargo cache. Unfortunately this breaks `cargo metadata` completely when using it with `--frozen` and `--offline` because some required crate data might be missing from the cache.