### PR TITLE
feat: support nethermind L1 node in `eth_getLogs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `starknet_call` and `starknet_estimateFee` JSON-RPC methods return more detailed error messages
 
+### Fixed
+
+- Using a Nethermind Ethereum endpoint occasionally causes errors such as `<block-number> could not be found` to be logged. 
+
 ### Removed
 
 - file configuration (deprecated in [v0.4.1](https://github.com/eqlabs/pathfinder/releases/tag/v0.4.1))

--- a/crates/ethereum/src/provider.rs
+++ b/crates/ethereum/src/provider.rs
@@ -128,6 +128,7 @@ impl EthereumTransport for HttpProvider {
         const INVALID_PARAMS: i64 = -32602;
         const LIMIT_EXCEEDED: i64 = -32005;
         const INVALID_INPUT: i64 = -32000;
+        const RESOURCE_NOT_FOUND: i64 = -32001;
 
         retry(
             || {
@@ -156,6 +157,10 @@ impl EthereumTransport for HttpProvider {
                             LogsError::QueryLimit
                         }
                         (INVALID_PARAMS, msg) if msg.starts_with("query returned more than") => {
+                            LogsError::QueryLimit
+                        }
+                        // This error is emitted by the Nethermind node if `toBlock > latest`.
+                        (RESOURCE_NOT_FOUND, msg) if msg.ends_with("could not be found") => {
                             LogsError::QueryLimit
                         }
                         (INVALID_INPUT, "Query timeout exceeded. Consider reducing your block range.") => LogsError::QueryLimit,


### PR DESCRIPTION
The Ethereum Nethermind node responds with an error message if we query `eth_getLogs` with `toBlock` set a block beyond the latest known block. This PR adds support for the Nethermind specific error response, similar to what we already have for geth.

Note that this PR simply maps this error to `QueryLimit` which in turn gets handled [here](https://github.com/eqlabs/pathfinder/blob/296511628446b02195860bd3c575d6b918134423/crates/ethereum/src/state_update.rs#L124-L129). Returning `QueryLimit` is therefore sufficient because the log fetcher will respond by reducing its `toBlock` value.

Fixes #941 and fixes #689.

Complete error message format:
```
reason=(code: -32001, message: 8633830 could not be found, data: None)
```