### PR TITLE
chore: remove hex-literal dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3100,12 +3100,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hex-literal"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
-
-[[package]]
 name = "hex_fmt"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4919,7 +4913,6 @@ dependencies = [
  "fake",
  "futures",
  "hex",
- "hex-literal",
  "libp2p",
  "p2p_proto",
  "pathfinder-common",
@@ -5120,7 +5113,6 @@ dependencies = [
  "ethers",
  "flate2",
  "futures",
- "hex-literal",
  "http",
  "lazy_static",
  "metrics",
@@ -5163,7 +5155,6 @@ version = "0.1.0"
 dependencies = [
  "bitvec 0.20.4",
  "ethers",
- "hex-literal",
  "metrics",
  "rusqlite",
  "serde",
@@ -5186,7 +5177,6 @@ dependencies = [
  "ethers",
  "futures",
  "hex",
- "hex-literal",
  "lazy_static",
  "pathfinder-common",
  "pathfinder-retry",
@@ -5204,7 +5194,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitvec 0.20.4",
- "hex-literal",
  "pathfinder-common",
  "pathfinder-storage",
  "pretty_assertions",
@@ -5236,7 +5225,6 @@ dependencies = [
  "flate2",
  "futures",
  "hex",
- "hex-literal",
  "jsonrpsee",
  "lazy_static",
  "metrics",
@@ -5291,7 +5279,6 @@ dependencies = [
  "ethers",
  "flate2",
  "hex",
- "hex-literal",
  "lazy_static",
  "pathfinder-common",
  "pathfinder-ethereum",
@@ -6829,7 +6816,6 @@ dependencies = [
  "bytes",
  "flate2",
  "futures",
- "hex-literal",
  "http",
  "lazy_static",
  "metrics",
@@ -6856,7 +6842,6 @@ dependencies = [
 name = "starknet-gateway-test-fixtures"
 version = "0.1.0"
 dependencies = [
- "hex-literal",
  "pathfinder-common",
  "stark_hash",
  "starknet-gateway-types",
@@ -6868,7 +6853,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ethers",
- "hex-literal",
  "pathfinder-common",
  "pathfinder-serde",
  "reqwest",

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -11,7 +11,6 @@ test-utils = ["dep:metrics"]
 [dependencies]
 bitvec = "0.20.4"
 ethers = "1.0.2"
-hex-literal = "0.3"
 metrics = { version = "0.20.1", optional = true }
 rusqlite = { version = "0.28.0", features = ["bundled"] }
 serde = { version = "1.0.149", features = ["derive"] }

--- a/crates/ethereum/Cargo.toml
+++ b/crates/ethereum/Cargo.toml
@@ -23,6 +23,5 @@ tracing = "0.1.37"
 [dev-dependencies]
 assert_matches = "1.5.0"
 hex = "0.4.3"
-hex-literal = "0.3"
 pretty_assertions = "1.3.0"
 tokio = { workspace = true, features = ["macros"] }

--- a/crates/gateway-client/Cargo.toml
+++ b/crates/gateway-client/Cargo.toml
@@ -28,7 +28,6 @@ tracing = "0.1.37"
 assert_matches = "1.5.0"
 base64 = "0.13.1"
 flate2 = "1.0.25"
-hex-literal = "0.3"
 http = "0.2.8"
 lazy_static = "1.4.0"
 pathfinder-common = { path = "../common", features = ["test-utils"] }

--- a/crates/gateway-test-fixtures/Cargo.toml
+++ b/crates/gateway-test-fixtures/Cargo.toml
@@ -7,7 +7,6 @@ rust-version = "1.62"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hex-literal = "0.3"
 pathfinder-common = { path = "../common" }
 stark_hash = { path = "../stark_hash" }
 starknet-gateway-types = { path = "../gateway-types" }

--- a/crates/gateway-types/Cargo.toml
+++ b/crates/gateway-types/Cargo.toml
@@ -23,7 +23,6 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 # Due to pathfinder_common::starkhash!() usage
-hex-literal = "0.3"
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 tokio = { workspace = true, features = ["macros", "test-util"] }
 zstd = "0.12"

--- a/crates/merkle-tree/Cargo.toml
+++ b/crates/merkle-tree/Cargo.toml
@@ -19,5 +19,4 @@ stark_poseidon = { path = "../stark_poseidon" }
 starknet-gateway-types = { path = "../gateway-types" }
 
 [dev-dependencies]
-hex-literal = "0.3"
 pretty_assertions = "1.3.0"

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -31,7 +31,6 @@ assert_matches = "1.5.0"
 env_logger = "0.10.0"
 fake = { workspace = true }
 hex = "0.4.3"
-hex-literal = "0.3"
 p2p_proto = { path = "../p2p_proto", features = ["test-utils"] }
 # TODO Move felt!() to stark_hash crate
 pathfinder-common = { path = "../common" }

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -25,7 +25,6 @@ console-subscriber = { version = "0.1.8", optional = true }
 enum-iterator = "1.2.0"
 ethers = "1.0.2"
 futures = { version = "0.3", default-features = false, features = ["std"] }
-hex-literal = "0.3"
 lazy_static = "1.4.0"
 metrics = "0.20.1"
 metrics-exporter-prometheus = "0.11.0"

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -12,7 +12,6 @@ base64 = "0.13.1"
 ethers = "1.0.2"
 flate2 = "1.0.25"
 futures = { version = "0.3", default-features = false, features = ["std"] }
-hex-literal = "0.3"
 jsonrpsee = { git = "https://github.com/eqlabs/jsonrpsee", branch = "start_with_paths", default-features = false, features = [
     "server",
 ] }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -17,7 +17,6 @@ data-encoding = "2.3.3"
 ethers = "1.0.2"
 flate2 = "1.0.25"
 hex = "0.4.3"
-hex-literal = "0.3"
 lazy_static = "1.4.0"
 pathfinder-common = { path = "../common" }
 pathfinder-ethereum = { path = "../ethereum" }


### PR DESCRIPTION
Purges `hex-literal` from the various `Cargo.toml` files.

No longer required after work done in #944.