### PR TITLE
refactor: separate newtypes and serde impls

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -33,7 +33,7 @@ pub struct ContractAddressSalt(pub Felt);
 
 /// The hash of a StarkNet contract. This is a hash over a class'
 /// deployment properties e.g. code and ABI.
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ClassHash(pub Felt);
 
 /// The hash of a StarkNet Sierra class.

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -190,7 +190,7 @@ pub mod transaction {
     };
     use pathfinder_serde::{
         CallParamAsDecimalStr, ConstructorParamAsDecimalStr, EthereumAddressAsHexStr,
-        EventDataAsDecimalStr, EventKeyAsDecimalStr, FeeAsHexStr,
+        EventDataAsDecimalStr, EventKeyAsDecimalStr, FeeAsHexStr, HexFelt,
         L1ToL2MessagePayloadElemAsDecimalStr, L2ToL1MessagePayloadElemAsDecimalStr,
         TransactionSignatureElemAsDecimalStr, TransactionVersionAsHexStr,
     };
@@ -408,6 +408,7 @@ pub mod transaction {
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
     #[serde(deny_unknown_fields)]
     pub struct DeclareTransactionV0V1 {
+        #[serde_as(as = "HexFelt")]
         pub class_hash: ClassHash,
         #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
@@ -424,6 +425,7 @@ pub mod transaction {
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
     #[serde(deny_unknown_fields)]
     pub struct DeclareTransactionV2 {
+        #[serde_as(as = "HexFelt")]
         pub class_hash: ClassHash,
         #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
@@ -447,6 +449,7 @@ pub mod transaction {
     pub struct DeployTransaction {
         pub contract_address: ContractAddress,
         pub contract_address_salt: ContractAddressSalt,
+        #[serde_as(as = "HexFelt")]
         pub class_hash: ClassHash,
         #[serde_as(as = "Vec<ConstructorParamAsDecimalStr>")]
         pub constructor_calldata: Vec<ConstructorParam>,
@@ -473,6 +476,7 @@ pub mod transaction {
         pub contract_address_salt: ContractAddressSalt,
         #[serde_as(as = "Vec<CallParamAsDecimalStr>")]
         pub constructor_calldata: Vec<CallParam>,
+        #[serde_as(as = "HexFelt")]
         pub class_hash: ClassHash,
     }
 
@@ -698,6 +702,7 @@ pub mod state_update {
         CasmHash, ClassHash, ContractAddress, ContractNonce, SierraHash, StorageAddress,
         StorageValue,
     };
+    use pathfinder_serde::HexFelt;
     use serde::Deserialize;
     use serde_with::serde_as;
     use std::collections::HashMap;
@@ -715,6 +720,7 @@ pub mod state_update {
         pub storage_diffs: HashMap<ContractAddress, Vec<StorageDiff>>,
         pub deployed_contracts: Vec<DeployedContract>,
         #[serde(alias = "declared_contracts")]
+        #[serde_as(as = "Vec<HexFelt>")]
         pub old_declared_contracts: Vec<ClassHash>,
         /// Not present in StarkNet versions < v0.11.0.
         #[serde(default)]
@@ -735,6 +741,7 @@ pub mod state_update {
     }
 
     /// L2 contract data within state diff.
+    #[serde_as]
     #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
     #[serde(deny_unknown_fields)]
     pub struct DeployedContract {
@@ -742,6 +749,7 @@ pub mod state_update {
         /// `class_hash` is the field name from cairo 0.9.0 onwards
         /// `contract_hash` is the name from cairo before 0.9.0
         #[serde(alias = "contract_hash")]
+        #[serde_as(as = "HexFelt")]
         pub class_hash: ClassHash,
     }
 
@@ -754,10 +762,12 @@ pub mod state_update {
     }
 
     /// Describes a newly replaced class. Maps contract address to a new class.
+    #[serde_as]
     #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
     #[serde(deny_unknown_fields)]
     pub struct ReplacedClass {
         pub address: ContractAddress,
+        #[serde_as(as = "HexFelt")]
         pub class_hash: ClassHash,
     }
 
@@ -808,6 +818,7 @@ pub struct EthContractAddresses {
 
 pub mod add_transaction {
     use pathfinder_common::{ClassHash, ContractAddress, StarknetTransactionHash};
+    use pathfinder_serde::HexFelt;
 
     /// API response for an INVOKE_FUNCTION transaction
     #[derive(Clone, Debug, serde::Deserialize, PartialEq, Eq)]
@@ -818,11 +829,13 @@ pub mod add_transaction {
     }
 
     /// API response for a DECLARE transaction
+    #[serde_with::serde_as]
     #[derive(Clone, Debug, serde::Deserialize, PartialEq, Eq)]
     #[serde(deny_unknown_fields)]
     pub struct DeclareResponse {
         pub code: String, // TRANSACTION_RECEIVED
         pub transaction_hash: StarknetTransactionHash,
+        #[serde_as(as = "HexFelt")]
         pub class_hash: ClassHash,
     }
 

--- a/crates/gateway-types/src/request.rs
+++ b/crates/gateway-types/src/request.rs
@@ -159,7 +159,7 @@ pub mod add_transaction {
         CasmHash, ClassHash, ContractAddressSalt, TransactionNonce, TransactionVersion,
     };
     use pathfinder_serde::{
-        CallParamAsDecimalStr, FeeAsHexStr, TransactionSignatureElemAsDecimalStr,
+        CallParamAsDecimalStr, FeeAsHexStr, HexFelt, TransactionSignatureElemAsDecimalStr,
         TransactionVersionAsHexStr,
     };
     use serde_with::serde_as;
@@ -213,6 +213,7 @@ pub mod add_transaction {
         pub signature: Vec<TransactionSignatureElem>,
         pub nonce: TransactionNonce,
 
+        #[serde_as(as = "HexFelt")]
         pub class_hash: ClassHash,
         pub contract_address_salt: ContractAddressSalt,
         #[serde_as(as = "Vec<CallParamAsDecimalStr>")]

--- a/crates/pathfinder/examples/estimate_past_transactions.rs
+++ b/crates/pathfinder/examples/estimate_past_transactions.rs
@@ -363,6 +363,7 @@ struct SimpleDeployAccount {
     contract_address_salt: pathfinder_common::ContractAddressSalt,
     #[serde_as(as = "Vec<pathfinder_serde::CallParamAsDecimalStr>")]
     pub constructor_calldata: Vec<pathfinder_common::CallParam>,
+    #[serde_as(as = "pathfinder_serde::HexFelt")]
     pub class_hash: pathfinder_common::ClassHash,
 }
 

--- a/crates/rpc/src/cairo/ext_py/ser.rs
+++ b/crates/rpc/src/cairo/ext_py/ser.rs
@@ -4,6 +4,7 @@ use pathfinder_common::{
     BlockId, CallParam, Chain, ContractAddress, ContractNonce, EntryPoint, StarknetBlockHash,
     StarknetBlockNumber,
 };
+use pathfinder_serde::HexFelt;
 use starknet_gateway_types::{
     reply::{
         state_update::{DeployedContract, StorageDiff},
@@ -181,7 +182,7 @@ impl<'a> serde::Serialize for DeployedContractElement<'a> {
         // there is no need from python side to use this huge construction,
         // could be just addr => hash
         map.serialize_entry("address", &self.0.address)?;
-        map.serialize_entry("contract_hash", &self.0.class_hash)?;
+        map.serialize_entry("contract_hash", &HexFelt(self.0.class_hash.0))?;
         map.end()
     }
 }

--- a/crates/rpc/src/felt.rs
+++ b/crates/rpc/src/felt.rs
@@ -21,7 +21,7 @@
 //! ```
 
 use pathfinder_common::{
-    CallParam, CallResultValue, CasmHash, ChainId, ClassHash, ConstructorParam, ContractAddress,
+    CallParam, CallResultValue, CasmHash, ChainId, ConstructorParam, ContractAddress,
     ContractAddressSalt, ContractNonce, EntryPoint, EventData, EventKey, L1ToL2MessagePayloadElem,
     L2ToL1MessagePayloadElem, SequencerAddress, SierraHash, StarknetBlockHash,
     StarknetTransactionHash, StateCommitment, StorageAddress, StorageValue, TransactionNonce,
@@ -171,7 +171,6 @@ rpc_felt_serde!(
     CallResultValue,
     CasmHash,
     ChainId,
-    ClassHash,
     ConstructorParam,
     ContractAddressSalt,
     ContractNonce,

--- a/crates/rpc/src/pathfinder/methods/get_proof.rs
+++ b/crates/rpc/src/pathfinder/methods/get_proof.rs
@@ -107,9 +107,11 @@ impl Serialize for Proof {
 }
 
 /// Holds the data and proofs for a specific contract.
+#[serde_with::serde_as]
 #[derive(Debug, Serialize)]
 pub struct ContractData {
     /// Required to verify the contract state hash to contract root calculation.
+    #[serde_as(as = "pathfinder_serde::HexFelt")]
     class_hash: ClassHash,
     /// Required to verify the contract state hash to contract root calculation.
     nonce: ContractNonce,

--- a/crates/rpc/src/v02/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v02/method/add_declare_transaction.rs
@@ -1,7 +1,9 @@
 use crate::felt::RpcFelt;
 use crate::v02::types::request::BroadcastedDeclareTransaction;
 use crate::v02::RpcContext;
+
 use pathfinder_common::{ClassHash, StarknetTransactionHash};
+use pathfinder_serde::HexFelt;
 use starknet_gateway_client::ClientApi;
 use starknet_gateway_types::error::SequencerError;
 use starknet_gateway_types::request::add_transaction::{
@@ -43,7 +45,7 @@ pub struct AddDeclareTransactionInput {
 pub struct AddDeclareTransactionOutput {
     #[serde_as(as = "RpcFelt")]
     transaction_hash: StarknetTransactionHash,
-    #[serde_as(as = "RpcFelt")]
+    #[serde_as(as = "HexFelt")]
     class_hash: ClassHash,
 }
 

--- a/crates/rpc/src/v02/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/v02/method/add_deploy_account_transaction.rs
@@ -64,15 +64,15 @@ mod tests {
         "max_fee": "0xbf391377813",
         "version": "0x1",
         "constructor_calldata": [
-            "0677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1"
+            "0x0677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1"
         ],
         "signature": [
-            "07dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5",
-            "071456dded17015d1234779889d78f3e7c763ddcfd2662b19e7843c7542614f8"
+            "0x07dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5",
+            "0x071456dded17015d1234779889d78f3e7c763ddcfd2662b19e7843c7542614f8"
         ],
         "nonce": "0x0",
-        "class_hash": "01fac3074c9d5282f0acc5c69a4781a1c711efea5e73c550c5d9fb253cf7fd3d",
-        "contract_address_salt": "06d44a6aecb4339e23a9619355f101cf3cb9baec289fcd9fd51486655c1bb8a8",
+        "class_hash": "0x01fac3074c9d5282f0acc5c69a4781a1c711efea5e73c550c5d9fb253cf7fd3d",
+        "contract_address_salt": "0x06d44a6aecb4339e23a9619355f101cf3cb9baec289fcd9fd51486655c1bb8a8",
         "type": "DEPLOY_ACCOUNT"
     }"#;
 
@@ -106,22 +106,22 @@ mod tests {
                     .into()),
                     signature: vec![
                         TransactionSignatureElem(felt!(
-                            "07dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5"
+                            "0x07dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5"
                         )),
                         TransactionSignatureElem(felt!(
-                            "071456dded17015d1234779889d78f3e7c763ddcfd2662b19e7843c7542614f8"
+                            "0x071456dded17015d1234779889d78f3e7c763ddcfd2662b19e7843c7542614f8"
                         )),
                     ],
                     nonce: TransactionNonce::ZERO,
 
                     contract_address_salt: ContractAddressSalt(felt!(
-                        "06d44a6aecb4339e23a9619355f101cf3cb9baec289fcd9fd51486655c1bb8a8"
+                        "0x06d44a6aecb4339e23a9619355f101cf3cb9baec289fcd9fd51486655c1bb8a8"
                     )),
                     constructor_calldata: vec![CallParam(felt!(
-                        "0677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1"
+                        "0x0677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1"
                     ))],
                     class_hash: ClassHash(felt!(
-                        "01fac3074c9d5282f0acc5c69a4781a1c711efea5e73c550c5d9fb253cf7fd3d"
+                        "0x01fac3074c9d5282f0acc5c69a4781a1c711efea5e73c550c5d9fb253cf7fd3d"
                     )),
                 },
             ),
@@ -137,10 +137,10 @@ mod tests {
 
         let expected = AddDeployAccountTransactionOutput {
             transaction_hash: StarknetTransactionHash(felt!(
-                "0273FB3C38B20037839D6BAD8811CD0AFD82F2BC3C95C061EB8F30CE5CEDC377"
+                "0x0273FB3C38B20037839D6BAD8811CD0AFD82F2BC3C95C061EB8F30CE5CEDC377"
             )),
             contract_address: ContractAddress::new_or_panic(felt!(
-                "042AE26AB2B8236242BB384C23E74C69AF7204BB2FC711A99DA63E0DD6ADF33F"
+                "0x042AE26AB2B8236242BB384C23E74C69AF7204BB2FC711A99DA63E0DD6ADF33F"
             )),
         };
 

--- a/crates/rpc/src/v02/method/get_class.rs
+++ b/crates/rpc/src/v02/method/get_class.rs
@@ -7,9 +7,11 @@ use starknet_gateway_types::pending::PendingData;
 
 crate::error::generate_rpc_error_subset!(GetClassError: BlockNotFound, ClassHashNotFound);
 
+#[serde_with::serde_as]
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
 pub struct GetClassInput {
     block_id: BlockId,
+    #[serde_as(as = "pathfinder_serde::HexFelt")]
     class_hash: ClassHash,
 }
 

--- a/crates/rpc/src/v02/method/get_class_hash_at.rs
+++ b/crates/rpc/src/v02/method/get_class_hash_at.rs
@@ -1,8 +1,8 @@
-use crate::felt::RpcFelt;
 use crate::v02::RpcContext;
 use anyhow::Context;
 use pathfinder_common::{BlockId, ClassHash, ContractAddress, ContractStateHash};
 use pathfinder_merkle_tree::state_tree::StorageCommitmentTree;
+use pathfinder_serde::HexFelt;
 use pathfinder_storage::{StarknetBlocksBlockId, StarknetBlocksTable};
 use starknet_gateway_types::pending::PendingData;
 
@@ -16,7 +16,7 @@ pub struct GetClassHashAtInput {
 
 #[serde_with::serde_as]
 #[derive(serde::Serialize, Debug)]
-pub struct GetClassHashOutput(#[serde_as(as = "RpcFelt")] ClassHash);
+pub struct GetClassHashOutput(#[serde_as(as = "HexFelt")] ClassHash);
 
 pub async fn get_class_hash_at(
     context: RpcContext,

--- a/crates/rpc/src/v02/method/get_state_update.rs
+++ b/crates/rpc/src/v02/method/get_state_update.rs
@@ -69,6 +69,8 @@ pub async fn get_state_update(
 
 mod types {
     use crate::felt::{RpcFelt, RpcFelt251};
+    use pathfinder_serde::HexFelt;
+
     use pathfinder_common::{
         ClassHash, ContractAddress, ContractNonce, StarknetBlockHash, StateCommitment,
         StorageAddress, StorageValue,
@@ -125,7 +127,7 @@ mod types {
     #[serde(deny_unknown_fields)]
     pub struct StateDiff {
         pub storage_diffs: Vec<StorageDiff>,
-        #[serde_as(as = "Vec<RpcFelt>")]
+        #[serde_as(as = "Vec<HexFelt>")]
         pub declared_contract_hashes: Vec<ClassHash>,
         pub deployed_contracts: Vec<DeployedContract>,
         pub nonces: Vec<Nonce>,
@@ -251,7 +253,7 @@ mod types {
     pub struct DeployedContract {
         #[serde_as(as = "RpcFelt251")]
         pub address: ContractAddress,
-        #[serde_as(as = "RpcFelt")]
+        #[serde_as(as = "HexFelt")]
         pub class_hash: ClassHash,
     }
 

--- a/crates/rpc/src/v02/types.rs
+++ b/crates/rpc/src/v02/types.rs
@@ -129,6 +129,7 @@ pub mod request {
         // Fields from DEPLOY_ACCOUNT_TXN_PROPERTIES
         pub contract_address_salt: ContractAddressSalt,
         pub constructor_calldata: Vec<CallParam>,
+        #[serde_as(as = "pathfinder_serde::HexFelt")]
         pub class_hash: ClassHash,
     }
 
@@ -398,7 +399,7 @@ pub mod reply {
         EntryPoint, Fee, StarknetTransactionHash, TransactionNonce, TransactionSignatureElem,
         TransactionVersion,
     };
-    use pathfinder_serde::{FeeAsHexStr, TransactionVersionAsHexStr};
+    use pathfinder_serde::{FeeAsHexStr, HexFelt, TransactionVersionAsHexStr};
     use serde::{Deserialize, Serialize};
     use serde_with::serde_as;
     use starknet_gateway_types::reply::transaction::Transaction as GatewayTransaction;
@@ -518,7 +519,7 @@ pub mod reply {
 
         // DECLARE_TXN_V0
         // DECLARE_TXN_V1
-        #[serde_as(as = "RpcFelt")]
+        #[serde_as(as = "HexFelt")]
         pub class_hash: ClassHash,
         #[serde_as(as = "RpcFelt251")]
         pub sender_address: ContractAddress,
@@ -532,7 +533,7 @@ pub mod reply {
         pub common: CommonDeclareInvokeTransactionProperties,
 
         // DECLARE_TXN_V2
-        #[serde_as(as = "RpcFelt")]
+        #[serde_as(as = "HexFelt")]
         pub class_hash: ClassHash,
         #[serde_as(as = "RpcFelt251")]
         pub sender_address: ContractAddress,
@@ -552,7 +553,7 @@ pub mod reply {
         pub contract_address_salt: ContractAddressSalt,
         #[serde_as(as = "Vec<RpcFelt>")]
         pub constructor_calldata: Vec<CallParam>,
-        #[serde_as(as = "RpcFelt")]
+        #[serde_as(as = "HexFelt")]
         pub class_hash: ClassHash,
     }
 
@@ -661,7 +662,7 @@ pub mod reply {
         #[serde(rename = "transaction_hash")]
         #[serde_as(as = "RpcFelt")]
         pub hash: StarknetTransactionHash,
-        #[serde_as(as = "RpcFelt")]
+        #[serde_as(as = "HexFelt")]
         pub class_hash: ClassHash,
 
         // DEPLOY_TXN_PROPERTIES

--- a/crates/rpc/src/v03/method/get_state_update.rs
+++ b/crates/rpc/src/v03/method/get_state_update.rs
@@ -73,6 +73,7 @@ mod types {
         CasmHash, ClassHash, ContractAddress, ContractNonce, SierraHash, StarknetBlockHash,
         StateCommitment, StorageAddress, StorageValue,
     };
+    use pathfinder_serde::HexFelt;
     use serde::Serialize;
     use serde_with::skip_serializing_none;
     use std::collections::HashMap;
@@ -125,7 +126,7 @@ mod types {
     #[serde(deny_unknown_fields)]
     pub struct StateDiff {
         pub storage_diffs: Vec<StorageDiff>,
-        #[serde_as(as = "Vec<RpcFelt>")]
+        #[serde_as(as = "Vec<HexFelt>")]
         pub deprecated_declared_classes: Vec<ClassHash>,
         pub declared_classes: Vec<DeclaredSierraClass>,
         pub deployed_contracts: Vec<DeployedContract>,
@@ -301,7 +302,7 @@ mod types {
     pub struct DeployedContract {
         #[serde_as(as = "RpcFelt251")]
         pub address: ContractAddress,
-        #[serde_as(as = "RpcFelt")]
+        #[serde_as(as = "HexFelt")]
         pub class_hash: ClassHash,
     }
 
@@ -331,7 +332,7 @@ mod types {
     pub struct ReplacedClass {
         #[serde_as(as = "RpcFelt251")]
         pub contract_address: ContractAddress,
-        #[serde_as(as = "RpcFelt")]
+        #[serde_as(as = "HexFelt")]
         pub class_hash: ClassHash,
     }
 

--- a/crates/serde/src/hex.rs
+++ b/crates/serde/src/hex.rs
@@ -1,0 +1,80 @@
+use stark_hash::Felt;
+
+use crate::newtype::NewType;
+
+pub struct HexFelt(pub Felt);
+
+impl<'de, T> serde_with::DeserializeAs<'de, T> for HexFelt
+where
+    T: NewType<Felt>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<T, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::Deserialize;
+
+        let rpc_felt: HexFelt = Deserialize::deserialize(deserializer)?;
+
+        Ok(T::from_inner(rpc_felt.0))
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for HexFelt {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct FeltVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for FeltVisitor {
+            type Value = HexFelt;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("'0x' prefix followed by a hex string of up to 64 digits")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                // Felt::from_hex_str currently does not enforce `0x` prefix, add it here to prevent
+                // breaking other serde related code.
+                match v.as_bytes() {
+                    &[b'0', b'x', ..] => stark_hash::Felt::from_hex_str(v)
+                        .map_err(|e| serde::de::Error::custom(e))
+                        .map(HexFelt),
+                    _missing_prefix => Err(serde::de::Error::custom("Missing '0x' prefix")),
+                }
+            }
+        }
+
+        deserializer.deserialize_str(FeltVisitor)
+    }
+}
+
+impl serde::Serialize for HexFelt {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // StarkHash has a leading "0x" and at most 64 digits
+        let mut buf = [0u8; 2 + 64];
+        let s = self.0.as_hex_str(&mut buf);
+        serializer.serialize_str(s)
+    }
+}
+
+impl<T> serde_with::SerializeAs<T> for HexFelt
+where
+    T: NewType<Felt> + Clone,
+{
+    fn serialize_as<S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+
+        HexFelt::serialize(&HexFelt(value.clone().into_inner()), serializer)
+    }
+}

--- a/crates/serde/src/lib.rs
+++ b/crates/serde/src/lib.rs
@@ -1,5 +1,10 @@
 //! Utilities used for serializing/deserializing sequencer REST API related data.
 
+mod hex;
+mod newtype;
+
+pub use hex::HexFelt;
+
 use ethers::types::{H128, H160, H256};
 use num_bigint::BigUint;
 use pathfinder_common::{

--- a/crates/serde/src/newtype.rs
+++ b/crates/serde/src/newtype.rs
@@ -1,0 +1,26 @@
+pub trait NewType<T> {
+    fn into_inner(self) -> T;
+    fn from_inner(inner: T) -> Self;
+}
+
+newtype!(pathfinder_common::ClassHash: stark_hash::Felt,);
+
+macro_rules! newtype {
+    ($target:ty: $inner:ty $(,)?) => {
+        impl NewType<$inner> for $target {
+            fn into_inner(self) -> $inner {
+                self.0
+            }
+
+            fn from_inner(inner: $inner) -> Self {
+                Self(inner)
+            }
+        }
+    };
+    ($head:ty, $($tail:ty),+ $(,)?) => {
+        newtype!($head);
+        newtype!($($tail),+);
+    };
+}
+
+use newtype;

--- a/crates/storage/src/schema/revision_0013.rs
+++ b/crates/storage/src/schema/revision_0013.rs
@@ -172,10 +172,12 @@ pub enum TransactionType {
     Declare,
 }
 
+#[serde_with::serde_as]
 #[derive(serde::Deserialize)]
 struct SlimTransaction {
     r#type: TransactionType,
     #[serde(default)]
+    #[serde_as(as = "Option<pathfinder_serde::HexFelt>")]
     class_hash: Option<ClassHash>,
 }
 

--- a/crates/storage/src/schema/revision_0015.rs
+++ b/crates/storage/src/schema/revision_0015.rs
@@ -49,6 +49,7 @@ mod transaction {
     #[serde_as]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
     pub struct DeclareTransaction {
+        #[serde_as(as = "pathfinder_serde::HexFelt")]
         pub class_hash: ClassHash,
         #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
@@ -70,6 +71,7 @@ mod transaction {
         pub contract_address_salt: ContractAddressSalt,
         // This is optional because there are old transactions in the DB which don't have it.
         // We fix up missing class hash before serializing the data.
+        #[serde_as(as = "Option<pathfinder_serde::HexFelt>")]
         pub class_hash: Option<ClassHash>,
         #[serde_as(as = "Vec<ConstructorParamAsDecimalStr>")]
         pub constructor_calldata: Vec<ConstructorParam>,

--- a/crates/storage/src/schema/revision_0020.rs
+++ b/crates/storage/src/schema/revision_0020.rs
@@ -409,6 +409,7 @@ mod types {
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
     #[serde(deny_unknown_fields)]
     pub struct DeclareTransaction {
+        #[serde_as(as = "pathfinder_serde::HexFelt")]
         pub class_hash: ClassHash,
         #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
@@ -433,6 +434,7 @@ mod types {
     pub struct DeployTransaction {
         pub contract_address: ContractAddress,
         pub contract_address_salt: ContractAddressSalt,
+        #[serde_as(as = "pathfinder_serde::HexFelt")]
         pub class_hash: ClassHash,
         #[serde_as(as = "Vec<ConstructorParamAsDecimalStr>")]
         pub constructor_calldata: Vec<ConstructorParam>,

--- a/crates/storage/src/schema/revision_0021.rs
+++ b/crates/storage/src/schema/revision_0021.rs
@@ -97,13 +97,17 @@ mod types {
     }
 
     /// L2 state diff declared contract item.
+    #[serde_with::serde_as]
     #[derive(Deserialize, Debug)]
     pub struct DeclaredContract {
+        #[serde_as(as = "pathfinder_serde::HexFelt")]
         pub class_hash: ClassHash,
     }
 
+    #[serde_with::serde_as]
     #[derive(Deserialize)]
     pub struct DeployedContract {
+        #[serde_as(as = "pathfinder_serde::HexFelt")]
         pub class_hash: ClassHash,
     }
 }

--- a/crates/storage/src/types.rs
+++ b/crates/storage/src/types.rs
@@ -74,6 +74,7 @@ pub mod state_update {
         CasmHash, ClassHash, ContractAddress, ContractNonce, SierraHash, StorageAddress,
         StorageValue,
     };
+    use pathfinder_serde::HexFelt;
     use serde::{Deserialize, Serialize};
 
     /// L2 state diff.
@@ -145,17 +146,21 @@ pub mod state_update {
     }
 
     /// L2 state diff Declared V1 class item.
+    #[serde_with::serde_as]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
     #[serde(deny_unknown_fields)]
     pub struct DeclaredCairoClass {
+        #[serde_as(as = "HexFelt")]
         pub class_hash: ClassHash,
     }
 
     /// L2 state diff deployed contract item.
+    #[serde_with::serde_as]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
     #[serde(deny_unknown_fields)]
     pub struct DeployedContract {
         pub address: ContractAddress,
+        #[serde_as(as = "HexFelt")]
         pub class_hash: ClassHash,
     }
 
@@ -187,10 +192,12 @@ pub mod state_update {
     }
 
     /// L2 state diff replaced class item. Maps contract address to a new class.
+    #[serde_with::serde_as]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
     #[serde(deny_unknown_fields)]
     pub struct ReplacedClass {
         pub address: ContractAddress,
+        #[serde_as(as = "HexFelt")]
         pub class_hash: ClassHash,
     }
 


### PR DESCRIPTION
Another attempt at separating serde from the actual types.

The principle is similar to how `RpcFelt` works - except the idea is to be a little more flexible, and to keep the majoprity of the serde code in a workspace crate and not in each applicable crate (RPC, gateway, storage etc). Each crate can then selectively decide which format to use.

In this demo a new `HexFelt` type is created which can then be used with `serde_as`:

```rust
struct Example {
    #[serde_as(as = "HexFelt")]
    pub class_hash: ClassHash,
}
```

Similar `serde` types would be created for `HexFelt251`, `HexNoPrefixFelt`, `DecimalFelt`, `DecimalH256`, `HexH256` etc as required. It would actually be nice to `HexFmt<T>` somehow, but I haven't tried that out yet.

The `serde` code also includes a private `NewType` and `newtype!` macro which make it trivial to add `pathfinder_common` newtypes serde derivations. Because `HexFelt` implements `DeserializeAs` for all `NewType<Felt>`, adding `serde_as(as = "HexFelt")` support for a type is as simple as adding it to the `newtype!` macro in the serde crate.

Included in this demo PR is the refactoring of `ClassHash` to use `HexFelt` - note that `ClassHash` no longer has any `serde` related derives.

A downside to this approach is that more complex structs must always have serde self-defined, and that often requires specifying `serde_as` on every single field.. 

To be clear, this is meant to generate discussion, and not to be merged as is.