### PR TITLE
chore: log ignored compile errors

### DIFF
--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -996,7 +996,10 @@ async fn download_class<SequencerClient: ClientApi>(
                 crate::sierra::compile_to_casm(&definition).context("Compiling Sierra class");
             let casm_definition = match (casm_definition, chain) {
                 (Ok(casm_definition), _) => casm_definition,
-                (Err(_), Chain::Integration) => Vec::new(),
+                (Err(_), Chain::Integration) => {
+                    tracing::info!(class_hash=%hash, "Ignored CASM compilation failure integration network");
+                    Vec::new()
+                }
                 (Err(e), _) => return Err(e),
             };
 

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -522,7 +522,10 @@ async fn download_and_compress_class(
                 crate::sierra::compile_to_casm(&definition).context("Compiling Sierra class");
             let casm_definition = match (casm_definition, chain) {
                 (Ok(casm_definition), _) => casm_definition,
-                (Err(_), Chain::Integration) => Vec::new(),
+                (Err(_), Chain::Integration) => {
+                    tracing::info!(class_hash=%hash, "Ignored CASM compilation failure integration network");
+                    Vec::new()
+                }
                 (Err(e), _) => return Err(e),
             };
 


### PR DESCRIPTION
Adds an `INFO` log when ignoring sierra -> casm compilation failure on integration