### PR TITLE
fix: pending state update never gives up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - RPC accepts hex inputs for Felt without '0x' prefix. This led to confusion especially when passing in a decimal string which would get silently interpretted as hex.
-- Using a Nethermind Ethereum endpoint occasionally causes errors such as `<block-number> could not be found` to be logged. 
+- Using a Nethermind Ethereum endpoint occasionally causes errors such as `<block-number> could not be found` to be logged.
+- Sync can miss new block events by getting stuck waiting for pending data.
 
 ### Removed
 


### PR DESCRIPTION
This PR adds a 3 minute time-cap to `gateway::state_update(pending)`.

We've previously reduced our maximum backoff time for retries, however this is not enough to ensure that pathfinder won't fall quite far behind ito actual blocks.

What can occur is that the gateway never replies `Ok(200)` to our query, but instead always 502/503s. This will cause us to sit and loop infitenitely until we get an Ok response. This PR fixes this.