### PR TITLE
fix(py/test_call): fix some FIXMEs that were left in tests

### DIFF
--- a/py/tests/pathfinder_worker/test_call.py
+++ b/py/tests/pathfinder_worker/test_call.py
@@ -660,9 +660,7 @@ def test_fee_estimate_for_declare_transaction_directly():
         pending_nonces={},
         pending_timestamp=0,
         transaction=DeprecatedDeclare(
-            # FIXME: query version should work
-            # version=0x100000000000000000000000000000000,
-            version=0,
+            version=0x100000000000000000000000000000000,
             max_fee=0,
             signature=[],
             nonce=0,
@@ -1124,8 +1122,7 @@ def test_nonce_with_dummy():
 
     # this will be used as a basis for the other commands with the `dict(base, **updates)` signature
     base_transaction = InvokeFunction(
-        # FIXME: query version should work
-        version=0x1,
+        version=2**128 + 1,
         sender_address=0x123,
         # this should be: target address, target selector, input len, input..
         calldata=[test_contract_address, get_selector_from_name("get_value"), 1, 132],

--- a/py/tests/pathfinder_worker/test_call.py
+++ b/py/tests/pathfinder_worker/test_call.py
@@ -1483,7 +1483,7 @@ def test_sierra_declare_through_account():
     command = EstimateFee(
         at_block="latest",
         chain=call.Chain.TESTNET,
-        gas_price=0,
+        gas_price=1,
         pending_updates={},
         pending_deployed=[],
         pending_nonces={},
@@ -1501,11 +1501,10 @@ def test_sierra_declare_through_account():
 
     (verb, output, _timings) = loop_inner(con, command)
 
-    # FIXME: correct gas consumed
     assert output == {
-        "gas_consumed": 0,
-        "gas_price": 0,
-        "overall_fee": 0,
+        "gas_consumed": 1251,
+        "gas_price": 1,
+        "overall_fee": 1251,
     }
 
 


### PR DESCRIPTION
Due to issues with the previous pre-release of cairo-lang 0.11.0 we couldn't properly use query versions in transactions and estimating Declare v2 was broken too.

This PR fixes all of these remaining test issues.