### PR TITLE
fix(sync): fix fetching new class definitions for the pending block

### DIFF
--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -27,6 +27,11 @@ pub trait ClientApi {
 
     async fn class_by_hash(&self, class_hash: ClassHash) -> Result<bytes::Bytes, SequencerError>;
 
+    async fn pending_class_by_hash(
+        &self,
+        class_hash: ClassHash,
+    ) -> Result<bytes::Bytes, SequencerError>;
+
     async fn compiled_class(&self, class_hash: SierraHash) -> Result<bytes::Bytes, SequencerError>;
 
     async fn storage(
@@ -228,6 +233,21 @@ impl ClientApi for Client {
         self.feeder_gateway_request()
             .get_class_by_hash()
             .with_class_hash(class_hash)
+            .with_retry(Self::RETRY)
+            .get_as_bytes()
+            .await
+    }
+
+    /// Gets class for a particular class hash.
+    #[tracing::instrument(skip(self))]
+    async fn pending_class_by_hash(
+        &self,
+        class_hash: ClassHash,
+    ) -> Result<bytes::Bytes, SequencerError> {
+        self.feeder_gateway_request()
+            .get_class_by_hash()
+            .with_class_hash(class_hash)
+            .with_block(BlockId::Pending)
             .with_retry(Self::RETRY)
             .get_as_bytes()
             .await

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -945,7 +945,7 @@ async fn download_class<SequencerClient: ClientApi>(
     use starknet_gateway_types::class_hash::compute_class_hash;
 
     let definition = sequencer
-        .class_by_hash(class_hash)
+        .pending_class_by_hash(class_hash)
         .await
         .with_context(|| format!("Downloading class {}", class_hash.0))?;
 
@@ -1140,6 +1140,13 @@ mod tests {
         }
 
         async fn class_by_hash(&self, _: ClassHash) -> Result<bytes::Bytes, SequencerError> {
+            unimplemented!()
+        }
+
+        async fn pending_class_by_hash(
+            &self,
+            _: ClassHash,
+        ) -> Result<bytes::Bytes, SequencerError> {
             unimplemented!()
         }
 


### PR DESCRIPTION
With Starknet 0.11 classes declared in the pending block are available through the `get_class_by_hash` feeder gateway endpoint _only_ if we explicitly request the pending block.