### PR TITLE
feat: implement JSON-RPC API v0.3 `starknet_estimateFee`

### DIFF
--- a/crates/rpc/src/cairo/ext_py.rs
+++ b/crates/rpc/src/cairo/ext_py.rs
@@ -166,7 +166,7 @@ impl Handle {
         self.command_tx
             .send((
                 Command::EstimateFee {
-                    transaction,
+                    transactions: vec![transaction],
                     at_block,
                     gas_price,
                     chain: self.chain,
@@ -261,7 +261,7 @@ enum Command {
         response: oneshot::Sender<Result<Vec<CallResultValue>, CallFailure>>,
     },
     EstimateFee {
-        transaction: add_transaction::AddTransaction,
+        transactions: Vec<add_transaction::AddTransaction>,
         at_block: BlockHashNumberOrLatest,
         /// Price input for the fee estimation, also communicated back in response
         gas_price: GasPriceSource,

--- a/crates/rpc/src/cairo/ext_py.rs
+++ b/crates/rpc/src/cairo/ext_py.rs
@@ -86,87 +86,94 @@ impl Handle {
     /// Returns the fee as a three components.
     pub async fn estimate_fee(
         &self,
-        transaction: BroadcastedTransaction,
+        transactions: Vec<BroadcastedTransaction>,
         at_block: BlockHashNumberOrLatest,
         gas_price: GasPriceSource,
         diffs: Option<Arc<PendingStateUpdate>>,
         block_timestamp: Option<StarknetBlockTimestamp>,
-    ) -> Result<FeeEstimate, CallFailure> {
+    ) -> Result<Vec<FeeEstimate>, CallFailure> {
         use tracing::field::Empty;
         let (response, rx) = oneshot::channel();
 
         let continued_span = tracing::info_span!("ext_py_est_fee", pid = Empty);
 
-        let transaction = match transaction {
-            BroadcastedTransaction::DeployAccount(tx) => {
-                add_transaction::AddTransaction::DeployAccount(add_transaction::DeployAccount {
-                    version: tx.version,
-                    max_fee: tx.max_fee,
-                    signature: tx.signature,
-                    nonce: tx.nonce,
-                    class_hash: tx.class_hash,
-                    contract_address_salt: tx.contract_address_salt,
-                    constructor_calldata: tx.constructor_calldata,
+        let transactions = transactions
+            .into_iter()
+            .map(|transaction| {
+                Ok(match transaction {
+                    BroadcastedTransaction::DeployAccount(tx) => {
+                        add_transaction::AddTransaction::DeployAccount(
+                            add_transaction::DeployAccount {
+                                version: tx.version,
+                                max_fee: tx.max_fee,
+                                signature: tx.signature,
+                                nonce: tx.nonce,
+                                class_hash: tx.class_hash,
+                                contract_address_salt: tx.contract_address_salt,
+                                constructor_calldata: tx.constructor_calldata,
+                            },
+                        )
+                    }
+                    BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V0V1(tx)) => {
+                        add_transaction::AddTransaction::Declare(add_transaction::Declare {
+                            version: tx.version,
+                            max_fee: tx.max_fee,
+                            signature: tx.signature,
+                            contract_class: add_transaction::ContractDefinition::Cairo(
+                                tx.contract_class.try_into().map_err(|_| {
+                                    CallFailure::Internal("contract class serialization failure")
+                                })?,
+                            ),
+                            sender_address: tx.sender_address,
+                            nonce: tx.nonce,
+                            compiled_class_hash: None,
+                        })
+                    }
+                    BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V2(tx)) => {
+                        add_transaction::AddTransaction::Declare(add_transaction::Declare {
+                            version: tx.version,
+                            max_fee: tx.max_fee,
+                            signature: tx.signature,
+                            contract_class: add_transaction::ContractDefinition::Sierra(
+                                tx.contract_class.try_into().map_err(|_| {
+                                    CallFailure::Internal("contract class serialization failure")
+                                })?,
+                            ),
+                            sender_address: tx.sender_address,
+                            nonce: tx.nonce,
+                            compiled_class_hash: Some(tx.compiled_class_hash),
+                        })
+                    }
+                    BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V0(tx)) => {
+                        add_transaction::AddTransaction::Invoke(add_transaction::InvokeFunction {
+                            version: tx.version,
+                            max_fee: tx.max_fee,
+                            signature: tx.signature,
+                            nonce: None,
+                            contract_address: tx.contract_address,
+                            entry_point_selector: Some(tx.entry_point_selector),
+                            calldata: tx.calldata,
+                        })
+                    }
+                    BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(tx)) => {
+                        add_transaction::AddTransaction::Invoke(add_transaction::InvokeFunction {
+                            version: tx.version,
+                            max_fee: tx.max_fee,
+                            signature: tx.signature,
+                            nonce: Some(tx.nonce),
+                            contract_address: tx.sender_address,
+                            entry_point_selector: None,
+                            calldata: tx.calldata,
+                        })
+                    }
                 })
-            }
-            BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V0V1(tx)) => {
-                add_transaction::AddTransaction::Declare(add_transaction::Declare {
-                    version: tx.version,
-                    max_fee: tx.max_fee,
-                    signature: tx.signature,
-                    contract_class: add_transaction::ContractDefinition::Cairo(
-                        tx.contract_class.try_into().map_err(|_| {
-                            CallFailure::Internal("contract class serialization failure")
-                        })?,
-                    ),
-                    sender_address: tx.sender_address,
-                    nonce: tx.nonce,
-                    compiled_class_hash: None,
-                })
-            }
-            BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V2(tx)) => {
-                add_transaction::AddTransaction::Declare(add_transaction::Declare {
-                    version: tx.version,
-                    max_fee: tx.max_fee,
-                    signature: tx.signature,
-                    contract_class: add_transaction::ContractDefinition::Sierra(
-                        tx.contract_class.try_into().map_err(|_| {
-                            CallFailure::Internal("contract class serialization failure")
-                        })?,
-                    ),
-                    sender_address: tx.sender_address,
-                    nonce: tx.nonce,
-                    compiled_class_hash: Some(tx.compiled_class_hash),
-                })
-            }
-            BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V0(tx)) => {
-                add_transaction::AddTransaction::Invoke(add_transaction::InvokeFunction {
-                    version: tx.version,
-                    max_fee: tx.max_fee,
-                    signature: tx.signature,
-                    nonce: None,
-                    contract_address: tx.contract_address,
-                    entry_point_selector: Some(tx.entry_point_selector),
-                    calldata: tx.calldata,
-                })
-            }
-            BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(tx)) => {
-                add_transaction::AddTransaction::Invoke(add_transaction::InvokeFunction {
-                    version: tx.version,
-                    max_fee: tx.max_fee,
-                    signature: tx.signature,
-                    nonce: Some(tx.nonce),
-                    contract_address: tx.sender_address,
-                    entry_point_selector: None,
-                    calldata: tx.calldata,
-                })
-            }
-        };
+            })
+            .collect::<Result<Vec<_>, CallFailure>>()?;
 
         self.command_tx
             .send((
                 Command::EstimateFee {
-                    transactions: vec![transaction],
+                    transactions,
                     at_block,
                     gas_price,
                     chain: self.chain,
@@ -268,7 +275,7 @@ enum Command {
         chain: UsedChain,
         diffs: Option<Arc<PendingStateUpdate>>,
         block_timestamp: Option<StarknetBlockTimestamp>,
-        response: oneshot::Sender<Result<FeeEstimate, CallFailure>>,
+        response: oneshot::Sender<Result<Vec<FeeEstimate>, CallFailure>>,
     },
 }
 
@@ -505,8 +512,8 @@ mod tests {
         .await
         .unwrap();
 
-        let transaction = BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V0(
-            BroadcastedInvokeTransactionV0 {
+        let transactions = vec![BroadcastedTransaction::Invoke(
+            BroadcastedInvokeTransaction::V0(BroadcastedInvokeTransactionV0 {
                 version: TransactionVersion::ZERO_WITH_QUERY_VERSION,
                 max_fee: super::Call::DEFAULT_MAX_FEE,
                 signature: Default::default(),
@@ -516,12 +523,12 @@ mod tests {
                 )),
                 entry_point_selector: EntryPoint::hashed(&b"get_value"[..]),
                 calldata: vec![CallParam(felt!("0x84"))],
-            },
-        ));
+            }),
+        )];
 
         let at_block_fee = handle
             .estimate_fee(
-                transaction.clone(),
+                transactions.clone(),
                 StarknetBlockNumber::new_or_panic(1).into(),
                 super::GasPriceSource::PastBlock,
                 None,
@@ -534,16 +541,16 @@ mod tests {
 
         assert_eq!(
             at_block_fee,
-            crate::v02::types::reply::FeeEstimate {
+            vec![crate::v02::types::reply::FeeEstimate {
                 gas_consumed: H256::from_low_u64_be(0x4ea),
                 gas_price: H256::from_low_u64_be(1),
                 overall_fee: H256::from_low_u64_be(0x4ea),
-            }
+            }]
         );
 
         let current_fee = handle
             .estimate_fee(
-                transaction,
+                transactions.clone(),
                 StarknetBlockHash(Felt::from_be_slice(&b"some blockhash somewhere"[..]).unwrap())
                     .into(),
                 super::GasPriceSource::Current(H256::from_low_u64_be(10)),
@@ -555,11 +562,11 @@ mod tests {
 
         assert_eq!(
             current_fee,
-            crate::v02::types::reply::FeeEstimate {
+            vec![crate::v02::types::reply::FeeEstimate {
                 gas_consumed: H256::from_low_u64_be(0x4ea),
                 gas_price: H256::from_low_u64_be(10),
                 overall_fee: H256::from_low_u64_be(0x3124),
-            }
+            }]
         );
 
         shutdown_tx.send(()).unwrap();
@@ -597,8 +604,8 @@ mod tests {
         .await
         .unwrap();
 
-        let transaction =
-            BroadcastedTransaction::DeployAccount(BroadcastedDeployAccountTransaction {
+        let transactions = vec![BroadcastedTransaction::DeployAccount(
+            BroadcastedDeployAccountTransaction {
                 version: TransactionVersion::ONE_WITH_QUERY_VERSION,
                 max_fee: super::Call::DEFAULT_MAX_FEE,
                 signature: Default::default(),
@@ -606,11 +613,12 @@ mod tests {
                 contract_address_salt: ContractAddressSalt(Felt::ZERO),
                 class_hash: account_contract_class_hash,
                 constructor_calldata: vec![],
-            });
+            },
+        )];
 
         let at_block_fee = handle
             .estimate_fee(
-                transaction.clone(),
+                transactions.clone(),
                 StarknetBlockNumber::new_or_panic(1).into(),
                 super::GasPriceSource::PastBlock,
                 None,
@@ -623,11 +631,11 @@ mod tests {
 
         assert_eq!(
             at_block_fee,
-            crate::v02::types::reply::FeeEstimate {
+            vec![crate::v02::types::reply::FeeEstimate {
                 gas_consumed: H256::from_low_u64_be(0xc18),
                 gas_price: H256::from_low_u64_be(1),
                 overall_fee: H256::from_low_u64_be(0xc18),
-            }
+            }]
         );
 
         shutdown_tx.send(()).unwrap();

--- a/crates/rpc/src/cairo/ext_py/de.rs
+++ b/crates/rpc/src/cairo/ext_py/de.rs
@@ -28,7 +28,7 @@ pub(crate) struct ChildResponse<'a> {
 #[serde(untagged)]
 pub(crate) enum OutputValue {
     Call(Vec<CallResultValue>),
-    Fee(FeeEstimate),
+    Fee(Vec<FeeEstimate>),
 }
 
 impl<'a> ChildResponse<'a> {

--- a/crates/rpc/src/cairo/ext_py/ser.rs
+++ b/crates/rpc/src/cairo/ext_py/ser.rs
@@ -33,7 +33,7 @@ pub(crate) enum ChildCommand<'a> {
         // zero means use the gas price from the block.
         #[serde_as(as = "&pathfinder_serde::H256AsHexStr")]
         gas_price: &'a ethers::types::H256,
-        transaction: &'a AddTransaction,
+        transactions: &'a [AddTransaction],
     },
 }
 

--- a/crates/rpc/src/cairo/ext_py/sub_process.rs
+++ b/crates/rpc/src/cairo/ext_py/sub_process.rs
@@ -351,7 +351,7 @@ async fn process(
             entry_point_selector: call.entry_point_selector.as_ref(),
         },
         Command::EstimateFee {
-            transaction,
+            transactions,
             at_block,
             gas_price,
             chain,
@@ -368,7 +368,7 @@ async fn process(
                 pending_timestamp: block_timestamp.map(|t| t.get()).unwrap_or_default(),
             },
             gas_price: gas_price.as_price(),
-            transaction,
+            transactions,
         },
     };
 

--- a/crates/rpc/src/v02/method/estimate_fee.rs
+++ b/crates/rpc/src/v02/method/estimate_fee.rs
@@ -68,15 +68,23 @@ pub async fn estimate_fee(
     let (when, pending_timestamp, pending_update) =
         base_block_and_pending_for_call(input.block_id, &context.pending_data).await?;
 
-    let result = handle
+    let mut result = handle
         .estimate_fee(
-            input.request,
+            vec![input.request],
             when,
             gas_price,
             pending_update,
             pending_timestamp,
         )
         .await?;
+
+    if result.len() != 1 {
+        return Err(
+            anyhow::anyhow!("Internal error: expected exactly one fee estimation result").into(),
+        );
+    }
+
+    let result = result.pop().unwrap();
 
     Ok(result)
 }

--- a/crates/rpc/src/v03.rs
+++ b/crates/rpc/src/v03.rs
@@ -27,6 +27,7 @@ pub fn register_methods(module: Module) -> anyhow::Result<Module> {
         .register_method_with_no_input("v0.3_starknet_blockNumber", v02_method::block_number)?
         .register_method("v0.3_starknet_call", v02_method::call)?
         .register_method_with_no_input("v0.3_starknet_chainId", v02_method::chain_id)?
+        .register_method("v0.3_starknet_estimateFee", method::estimate_fee)?
         .register_method(
             "v0.3_starknet_getBlockWithTxHashes",
             v02_method::get_block_with_tx_hashes,

--- a/crates/rpc/src/v03/method.rs
+++ b/crates/rpc/src/v03/method.rs
@@ -1,5 +1,7 @@
+mod estimate_fee;
 mod get_events;
 mod get_state_update;
 
+pub(super) use estimate_fee::estimate_fee;
 pub(super) use get_events::get_events;
 pub(super) use get_state_update::get_state_update;

--- a/crates/rpc/src/v03/method/estimate_fee.rs
+++ b/crates/rpc/src/v03/method/estimate_fee.rs
@@ -1,0 +1,409 @@
+use crate::{
+    cairo::ext_py::{BlockHashNumberOrLatest, GasPriceSource},
+    context::RpcContext,
+    v02::types::{reply::FeeEstimate, request::BroadcastedTransaction},
+};
+use pathfinder_common::{BlockId, StarknetBlockTimestamp};
+use starknet_gateway_types::pending::PendingData;
+use std::sync::Arc;
+
+#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+pub struct EstimateFeeInput {
+    request: Vec<BroadcastedTransaction>,
+    block_id: BlockId,
+}
+
+crate::error::generate_rpc_error_subset!(
+    EstimateFeeError: BlockNotFound,
+    ContractNotFound,
+    ContractError,
+    InvalidMessageSelector,
+    InvalidCallData
+);
+
+impl From<crate::cairo::ext_py::CallFailure> for EstimateFeeError {
+    fn from(c: crate::cairo::ext_py::CallFailure) -> Self {
+        use crate::cairo::ext_py::CallFailure::*;
+        match c {
+            NoSuchBlock => Self::BlockNotFound,
+            NoSuchContract => Self::ContractNotFound,
+            InvalidEntryPoint => Self::InvalidMessageSelector,
+            ExecutionFailed(e) => Self::Internal(anyhow::anyhow!("Internal error: {}", e)),
+            // Intentionally hide the message under Internal
+            Internal(_) | Shutdown => Self::Internal(anyhow::anyhow!("Internal error")),
+        }
+    }
+}
+
+pub async fn estimate_fee(
+    context: RpcContext,
+    input: EstimateFeeInput,
+) -> Result<Vec<FeeEstimate>, EstimateFeeError> {
+    let handle = context
+        .call_handle
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("Unsupported configuration"))?;
+
+    // discussed during estimateFee work: when user is requesting using block_hash use the
+    // gasPrice from the starknet_blocks::gas_price column, otherwise (tags) get the latest
+    // eth_gasPrice.
+    //
+    // the fact that [`base_block_and_pending_for_call`] transforms pending cases to use
+    // actual parent blocks by hash is an internal transformation we do for correctness,
+    // unrelated to this consideration.
+    let gas_price = if matches!(input.block_id, BlockId::Pending | BlockId::Latest) {
+        let gas_price = match context.eth_gas_price.as_ref() {
+            Some(cached) => cached.get().await,
+            None => None,
+        };
+
+        let gas_price =
+            gas_price.ok_or_else(|| anyhow::anyhow!("Current eth_gasPrice is unavailable"))?;
+
+        GasPriceSource::Current(gas_price)
+    } else {
+        GasPriceSource::PastBlock
+    };
+
+    let (when, pending_timestamp, pending_update) =
+        base_block_and_pending_for_call(input.block_id, &context.pending_data).await?;
+
+    let result = handle
+        .estimate_fee(
+            input.request,
+            when,
+            gas_price,
+            pending_update,
+            pending_timestamp,
+        )
+        .await?;
+
+    Ok(result)
+}
+
+/// Transforms the request to call or estimate fee at some point in time to the type expected
+/// by [`crate::cairo::ext_py`] with the optional, latest pending data.
+async fn base_block_and_pending_for_call(
+    at_block: BlockId,
+    pending_data: &Option<PendingData>,
+) -> Result<
+    (
+        BlockHashNumberOrLatest,
+        Option<StarknetBlockTimestamp>,
+        Option<Arc<starknet_gateway_types::reply::PendingStateUpdate>>,
+    ),
+    anyhow::Error,
+> {
+    use crate::cairo::ext_py::Pending;
+
+    match BlockHashNumberOrLatest::try_from(at_block) {
+        Ok(when) => Ok((when, None, None)),
+        Err(Pending) => {
+            // we must have pending_data configured for pending requests, otherwise we fail
+            // fast.
+            match pending_data {
+                Some(pending) => {
+                    // call on this particular parent block hash; if it's not found at query time over
+                    // at python, it should fall back to latest and **disregard** the pending data.
+                    let pending_on_top_of_a_block = pending
+                        .state_update_on_parent_block()
+                        .await
+                        .map(|(parent_block, timestamp, data)| {
+                            (parent_block.into(), Some(timestamp), Some(data))
+                        });
+
+                    // if there is no pending data available, just execute on whatever latest.
+                    Ok(pending_on_top_of_a_block.unwrap_or((
+                        BlockHashNumberOrLatest::Latest,
+                        None,
+                        None,
+                    )))
+                }
+                None => Err(anyhow::anyhow!(
+                    "Pending data not supported in this configuration"
+                )),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::v02::types::request::BroadcastedInvokeTransaction;
+    use pathfinder_common::{
+        felt, CallParam, ContractAddress, EntryPoint, Fee, StarknetBlockHash, TransactionNonce,
+        TransactionSignatureElem, TransactionVersion,
+    };
+
+    mod parsing {
+        use super::*;
+
+        fn test_invoke_txn() -> BroadcastedTransaction {
+            BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V0(
+                crate::v02::types::request::BroadcastedInvokeTransactionV0 {
+                    version: TransactionVersion::ZERO_WITH_QUERY_VERSION,
+                    max_fee: Fee(ethers::types::H128::from_low_u64_be(0x6)),
+                    signature: vec![TransactionSignatureElem(felt!("0x7"))],
+                    nonce: Some(TransactionNonce(felt!("0x8"))),
+                    contract_address: ContractAddress::new_or_panic(felt!("0xaaa")),
+                    entry_point_selector: EntryPoint(felt!("0xe")),
+                    calldata: vec![CallParam(felt!("0xff"))],
+                },
+            ))
+        }
+
+        #[test]
+        fn positional_args() {
+            use jsonrpsee::types::Params;
+
+            let positional = r#"[
+                [
+                    {
+                        "type": "INVOKE",
+                        "version": "0x100000000000000000000000000000000",
+                        "max_fee": "0x6",
+                        "signature": [
+                            "0x7"
+                        ],
+                        "nonce": "0x8",
+                        "contract_address": "0xaaa",
+                        "entry_point_selector": "0xe",
+                        "calldata": [
+                            "0xff"
+                        ]
+                    }
+                ],
+                { "block_hash": "0xabcde" }
+            ]"#;
+            let positional = Params::new(Some(positional));
+
+            let input = positional.parse::<EstimateFeeInput>().unwrap();
+            let expected = EstimateFeeInput {
+                request: vec![test_invoke_txn()],
+                block_id: BlockId::Hash(StarknetBlockHash(felt!("0xabcde"))),
+            };
+            assert_eq!(input, expected);
+        }
+
+        #[test]
+        fn named_args() {
+            use jsonrpsee::types::Params;
+
+            let named_args = r#"{
+                "request": [
+                    {
+                        "type": "INVOKE",
+                        "version": "0x100000000000000000000000000000000",
+                        "max_fee": "0x6",
+                        "signature": [
+                            "0x7"
+                        ],
+                        "nonce": "0x8",
+                        "contract_address": "0xaaa",
+                        "entry_point_selector": "0xe",
+                        "calldata": [
+                            "0xff"
+                        ]
+                    }
+                ],
+                "block_id": { "block_hash": "0xabcde" }
+            }"#;
+            let named_args = Params::new(Some(named_args));
+
+            let input = named_args.parse::<EstimateFeeInput>().unwrap();
+            let expected = EstimateFeeInput {
+                request: vec![test_invoke_txn()],
+                block_id: BlockId::Hash(StarknetBlockHash(felt!("0xabcde"))),
+            };
+            assert_eq!(input, expected);
+        }
+    }
+
+    // These tests require a Python environment properly set up _and_ a mainnet database with the first six blocks.
+    mod ext_py {
+        use std::path::PathBuf;
+
+        use super::*;
+        use crate::v02::types::request::{
+            BroadcastedDeclareTransaction, BroadcastedDeclareTransactionV0V1,
+            BroadcastedInvokeTransactionV0,
+        };
+        use crate::v02::types::{CairoContractClass, ContractClass};
+        use pathfinder_common::{felt_bytes, Chain};
+        use pathfinder_storage::JournalMode;
+
+        // Mainnet block number 5
+        const BLOCK_5: BlockId = BlockId::Hash(StarknetBlockHash(felt!(
+            "00dcbd2a4b597d051073f40a0329e585bb94b26d73df69f8d72798924fd097d3"
+        )));
+
+        // Data from transaction 0xc52079f33dcb44a58904fac3803fd908ac28d6632b67179ee06f2daccb4b5.
+        fn valid_mainnet_invoke_v0() -> BroadcastedInvokeTransactionV0 {
+            BroadcastedInvokeTransactionV0 {
+                version: TransactionVersion::ZERO_WITH_QUERY_VERSION,
+                max_fee: Fee(Default::default()),
+                signature: vec![],
+                nonce: Some(TransactionNonce(Default::default())),
+                contract_address: ContractAddress::new_or_panic(felt!(
+                    "020cfa74ee3564b4cd5435cdace0f9c4d43b939620e4a0bb5076105df0a626c6"
+                )),
+                entry_point_selector: EntryPoint(felt!(
+                    "03d7905601c217734671143d457f0db37f7f8883112abd34b92c4abfeafde0c3"
+                )),
+                calldata: vec![
+                    CallParam(felt!(
+                        "e150b6c2db6ed644483b01685571de46d2045f267d437632b508c19f3eb877"
+                    )),
+                    CallParam(felt!(
+                        "0494196e88ce16bff11180d59f3c75e4ba3475d9fba76249ab5f044bcd25add6"
+                    )),
+                ],
+            }
+        }
+
+        fn valid_broadcasted_transaction() -> BroadcastedTransaction {
+            BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V0(
+                valid_mainnet_invoke_v0(),
+            ))
+        }
+
+        async fn test_context_with_call_handling() -> (RpcContext, tokio::task::JoinHandle<()>) {
+            use pathfinder_common::ChainId;
+
+            let mut database_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            database_path.push("fixtures/mainnet.sqlite");
+            let storage =
+                pathfinder_storage::Storage::migrate(database_path.clone(), JournalMode::WAL)
+                    .unwrap();
+            let sync_state = Arc::new(crate::SyncState::default());
+            let (call_handle, cairo_handle) = crate::cairo::ext_py::start(
+                storage.path().into(),
+                std::num::NonZeroUsize::try_from(2).unwrap(),
+                futures::future::pending(),
+                Chain::Mainnet,
+            )
+            .await
+            .unwrap();
+
+            let sequencer = starknet_gateway_client::Client::new(Chain::Mainnet).unwrap();
+            let context = RpcContext::new(storage, sync_state, ChainId::MAINNET, sequencer);
+            (context.with_call_handling(call_handle), cairo_handle)
+        }
+
+        #[tokio::test]
+        async fn no_such_block() {
+            let (context, _join_handle) = test_context_with_call_handling().await;
+
+            let input = EstimateFeeInput {
+                request: vec![valid_broadcasted_transaction()],
+                block_id: BlockId::Hash(StarknetBlockHash(felt_bytes!(b"nonexistent"))),
+            };
+            let error = estimate_fee(context, input).await;
+            assert_matches::assert_matches!(error, Err(EstimateFeeError::BlockNotFound));
+        }
+
+        #[tokio::test]
+        async fn no_such_contract() {
+            let (context, _join_handle) = test_context_with_call_handling().await;
+
+            let mainnet_invoke = valid_mainnet_invoke_v0();
+            let input = EstimateFeeInput {
+                request: vec![BroadcastedTransaction::Invoke(
+                    BroadcastedInvokeTransaction::V0(BroadcastedInvokeTransactionV0 {
+                        contract_address: ContractAddress::new_or_panic(felt!("0xdeadbeef")),
+                        ..mainnet_invoke
+                    }),
+                )],
+                block_id: BLOCK_5,
+            };
+            let error = estimate_fee(context, input).await;
+            assert_matches::assert_matches!(error, Err(EstimateFeeError::ContractNotFound));
+        }
+
+        #[tokio::test]
+        async fn invalid_message_selector() {
+            let (context, _join_handle) = test_context_with_call_handling().await;
+
+            let mainnet_invoke = valid_mainnet_invoke_v0();
+            let input = EstimateFeeInput {
+                request: vec![BroadcastedTransaction::Invoke(
+                    BroadcastedInvokeTransaction::V0(BroadcastedInvokeTransactionV0 {
+                        entry_point_selector: EntryPoint(Default::default()),
+                        ..mainnet_invoke
+                    }),
+                )],
+                block_id: BLOCK_5,
+            };
+            let error = estimate_fee(context, input).await;
+            assert_matches::assert_matches!(error, Err(EstimateFeeError::InvalidMessageSelector));
+        }
+
+        #[tokio::test]
+        async fn successful_invoke_v0() {
+            let (context, _join_handle) = test_context_with_call_handling().await;
+
+            let input = EstimateFeeInput {
+                request: vec![
+                    valid_broadcasted_transaction(),
+                    valid_broadcasted_transaction(),
+                ],
+                block_id: BLOCK_5,
+            };
+            let result = estimate_fee(context, input).await.unwrap();
+            assert_eq!(
+                result,
+                vec![
+                    FeeEstimate {
+                        gas_consumed: Default::default(),
+                        gas_price: Default::default(),
+                        overall_fee: Default::default()
+                    },
+                    FeeEstimate {
+                        gas_consumed: Default::default(),
+                        gas_price: Default::default(),
+                        overall_fee: Default::default()
+                    }
+                ]
+            );
+        }
+
+        lazy_static::lazy_static! {
+            pub static ref CONTRACT_CLASS: CairoContractClass = {
+                let compressed_json = starknet_gateway_test_fixtures::zstd_compressed_contracts::CONTRACT_DEFINITION;
+                let json = zstd::decode_all(compressed_json).unwrap();
+                ContractClass::from_definition_bytes(&json).unwrap().as_cairo().unwrap()
+            };
+        }
+
+        #[test_log::test(tokio::test)]
+        async fn successful_declare_v0() {
+            let (context, _join_handle) = test_context_with_call_handling().await;
+
+            let declare_transaction = BroadcastedTransaction::Declare(
+                BroadcastedDeclareTransaction::V0V1(BroadcastedDeclareTransactionV0V1 {
+                    version: TransactionVersion::ZERO_WITH_QUERY_VERSION,
+                    max_fee: Fee(Default::default()),
+                    signature: vec![],
+                    nonce: TransactionNonce(Default::default()),
+                    contract_class: CONTRACT_CLASS.clone(),
+                    sender_address: ContractAddress::new_or_panic(felt!("01")),
+                }),
+            );
+
+            let input = EstimateFeeInput {
+                request: vec![declare_transaction],
+                block_id: BLOCK_5,
+            };
+            let result = estimate_fee(context, input).await.unwrap();
+            assert_eq!(
+                result,
+                vec![FeeEstimate {
+                    gas_consumed: Default::default(),
+                    gas_price: Default::default(),
+                    overall_fee: Default::default()
+                }]
+            );
+        }
+    }
+}

--- a/py/src/pathfinder_worker/call.py
+++ b/py/src/pathfinder_worker/call.py
@@ -950,17 +950,20 @@ def apply_pending(
     nonces: Dict[int, int],
 ):
     for deployed_contract in deployed:
+        # pylint: disable=protected-access
         state.cache._class_hash_initial_values[
             deployed_contract.address
         ] = deployed_contract.contract_hash
 
     for addr, updates in updates.items():
         for update in updates:
+            # pylint: disable=protected-access
             state.cache._storage_initial_values[(addr, update.key)] = update.value
 
     for addr, nonce in nonces.items():
         # bypass the CachedState.increment_nonce which would give extra queries
         # per each, and only single step at a time
+        # pylint: disable=protected-access
         state.cache._nonce_initial_values[addr] = nonce
 
 

--- a/py/src/pathfinder_worker/call.py
+++ b/py/src/pathfinder_worker/call.py
@@ -507,13 +507,15 @@ def render(verb, vals):
         return list(map(prefixed_hex, vals))
     else:
         assert verb == Verb.ESTIMATE_FEE
-        # FIXME: temporarily use only the first element of the fee list
-        vals = vals[0]
-        return {
-            "gas_consumed": prefixed_hex(vals["gas_consumed"]),
-            "gas_price": prefixed_hex(vals["gas_price"]),
-            "overall_fee": prefixed_hex(vals["overall_fee"]),
-        }
+
+        return [
+            {
+                "gas_consumed": prefixed_hex(val["gas_consumed"]),
+                "gas_price": prefixed_hex(val["gas_price"]),
+                "overall_fee": prefixed_hex(val["overall_fee"]),
+            }
+            for val in vals
+        ]
 
 
 def int_hash_or_latest(s: str):

--- a/py/src/pathfinder_worker/call.py
+++ b/py/src/pathfinder_worker/call.py
@@ -216,7 +216,7 @@ class EstimateFee(Command):
     # zero means to use the gas price from the current block.
     gas_price: int = field(metadata=fields.gas_price_metadata)
 
-    transaction: AccountTransaction
+    transactions: List[AccountTransaction]
 
     def has_pending_data(self):
         return (
@@ -484,7 +484,7 @@ def loop_inner(
                 async_state,
                 general_config,
                 block_info,
-                [command.transaction],
+                command.transactions,
             )
         )
         ret = (command.verb, fees, timings)

--- a/py/tests/pathfinder_worker/test_call.py
+++ b/py/tests/pathfinder_worker/test_call.py
@@ -742,20 +742,24 @@ def test_fee_estimate_on_positive():
 
     assert first == {
         "status": "ok",
-        "output": {
-            "gas_consumed": "0x" + (0).to_bytes(32, "big").hex(),
-            "gas_price": "0x" + (0).to_bytes(32, "big").hex(),
-            "overall_fee": "0x" + (0).to_bytes(32, "big").hex(),
-        },
+        "output": [
+            {
+                "gas_consumed": "0x" + (0).to_bytes(32, "big").hex(),
+                "gas_price": "0x" + (0).to_bytes(32, "big").hex(),
+                "overall_fee": "0x" + (0).to_bytes(32, "big").hex(),
+            }
+        ],
     }
 
     assert second == {
         "status": "ok",
-        "output": {
-            "gas_consumed": "0x" + (0x04EA).to_bytes(32, "big").hex(),
-            "gas_price": "0x" + (10).to_bytes(32, "big").hex(),
-            "overall_fee": "0x" + (0x3124).to_bytes(32, "big").hex(),
-        },
+        "output": [
+            {
+                "gas_consumed": "0x" + (0x04EA).to_bytes(32, "big").hex(),
+                "gas_price": "0x" + (10).to_bytes(32, "big").hex(),
+                "overall_fee": "0x" + (0x3124).to_bytes(32, "big").hex(),
+            },
+        ],
     }
 
 

--- a/py/tests/pathfinder_worker/test_call.py
+++ b/py/tests/pathfinder_worker/test_call.py
@@ -52,7 +52,7 @@ def test_command_parsing_estimate_fee():
         ],
         "pending_nonces":{"0x123":"0x1"},
         "pending_timestamp": 0,
-        "transaction":{
+        "transactions":[{
             "type":"INVOKE_FUNCTION",
             "version":"0x100000000000000000000000000000000",
             "max_fee":"0x0",
@@ -60,7 +60,7 @@ def test_command_parsing_estimate_fee():
             "nonce":null,
             "contract_address":"0x57dde83c18c0efe7123c36a52d704cf27d5c38cdf0b1e1edc3b0dae3ee4e374",
             "entry_point_selector":"0x26813d396fdb198e9ead934e4f7a592a8b88a059e45ab0eb6ee53494e8d45b0",
-            "calldata":["132"]}
+            "calldata":["132"]}]
     }"""
     command = Command.Schema().loads(input)
     assert command == EstimateFee(
@@ -80,15 +80,17 @@ def test_command_parsing_estimate_fee():
         ],
         pending_nonces={0x123: 1},
         pending_timestamp=0,
-        transaction=InvokeFunction(
-            version=0x100000000000000000000000000000000,
-            sender_address=0x57DDE83C18C0EFE7123C36A52D704CF27D5C38CDF0B1E1EDC3B0DAE3EE4E374,
-            calldata=[132],
-            entry_point_selector=0x26813D396FDB198E9EAD934E4F7A592A8B88A059E45AB0EB6EE53494E8D45B0,
-            nonce=None,
-            max_fee=0,
-            signature=[],
-        ),
+        transactions=[
+            InvokeFunction(
+                version=0x100000000000000000000000000000000,
+                sender_address=0x57DDE83C18C0EFE7123C36A52D704CF27D5C38CDF0B1E1EDC3B0DAE3EE4E374,
+                calldata=[132],
+                entry_point_selector=0x26813D396FDB198E9EAD934E4F7A592A8B88A059E45AB0EB6EE53494E8D45B0,
+                nonce=None,
+                max_fee=0,
+                signature=[],
+            )
+        ],
     )
     assert command.has_pending_data()
 
@@ -613,15 +615,17 @@ def test_fee_estimate_on_positive_directly():
         pending_deployed=[],
         pending_nonces={},
         pending_timestamp=0,
-        transaction=InvokeFunction(
-            version=0x100000000000000000000000000000000,
-            sender_address=contract_address,
-            calldata=[132],
-            entry_point_selector=get_selector_from_name("get_value"),
-            nonce=None,
-            max_fee=0,
-            signature=[],
-        ),
+        transactions=[
+            InvokeFunction(
+                version=0x100000000000000000000000000000000,
+                sender_address=contract_address,
+                calldata=[132],
+                entry_point_selector=get_selector_from_name("get_value"),
+                nonce=None,
+                max_fee=0,
+                signature=[],
+            )
+        ],
     )
 
     (verb, output, _timings) = loop_inner(con, command)
@@ -661,14 +665,16 @@ def test_fee_estimate_for_declare_transaction_directly():
         pending_deployed=[],
         pending_nonces={},
         pending_timestamp=0,
-        transaction=DeprecatedDeclare(
-            version=0x100000000000000000000000000000000,
-            max_fee=0,
-            signature=[],
-            nonce=0,
-            contract_class=contract_definition,
-            sender_address=1,
-        ),
+        transactions=[
+            DeprecatedDeclare(
+                version=0x100000000000000000000000000000000,
+                max_fee=0,
+                signature=[],
+                nonce=0,
+                contract_class=contract_definition,
+                sender_address=1,
+            )
+        ],
     )
 
     (verb, output, _timings) = loop_inner(con, command)
@@ -697,7 +703,7 @@ def test_fee_estimate_on_positive():
         "pending_deployed":[],
         "pending_nonces":{{}},
         "pending_timestamp":0,
-        "transaction":{{
+        "transactions":[{{
             "type":"INVOKE_FUNCTION",
             "version":"0x100000000000000000000000000000000",
             "max_fee":"0x0",
@@ -706,7 +712,7 @@ def test_fee_estimate_on_positive():
             "contract_address":"{contract_address}",
             "entry_point_selector":"{entry_point}",
             "calldata":["132"]
-        }}
+        }}]
     }}"""
 
     (first, second) = default_132_on_3_scenario(
@@ -1143,7 +1149,7 @@ def test_nonce_with_dummy():
         pending_deployed=[],
         pending_nonces={},
         pending_timestamp=0,
-        transaction=base_transaction,
+        transactions=[base_transaction],
     )
 
     commands = [
@@ -1161,7 +1167,7 @@ def test_nonce_with_dummy():
             dataclasses.replace(
                 base_command,
                 at_block=f'0x{(b"another block").hex()}',
-                transaction=dataclasses.replace(base_transaction, nonce=1),
+                transactions=[dataclasses.replace(base_transaction, nonce=1)],
             ),
             "StarknetErrorCode.INVALID_TRANSACTION_NONCE",
         ),
@@ -1169,7 +1175,7 @@ def test_nonce_with_dummy():
             dataclasses.replace(
                 base_command,
                 at_block=f'0x{(b"another block").hex()}',
-                transaction=dataclasses.replace(base_transaction, nonce=2),
+                transactions=[dataclasses.replace(base_transaction, nonce=2)],
             ),
             "StarknetErrorCode.INVALID_TRANSACTION_NONCE",
         ),
@@ -1178,7 +1184,7 @@ def test_nonce_with_dummy():
             dataclasses.replace(
                 base_command,
                 at_block=f'0x{(b"third block").hex()}',
-                transaction=dataclasses.replace(base_transaction, nonce=1),
+                transactions=[dataclasses.replace(base_transaction, nonce=1)],
             ),
             [{"gas_consumed": 1266, "gas_price": 1, "overall_fee": 1266}],
         ),
@@ -1186,7 +1192,7 @@ def test_nonce_with_dummy():
             dataclasses.replace(
                 base_command,
                 at_block=f'0x{(b"third block").hex()}',
-                transaction=dataclasses.replace(base_transaction, nonce=2),
+                transactions=[dataclasses.replace(base_transaction, nonce=2)],
             ),
             "StarknetErrorCode.INVALID_TRANSACTION_NONCE",
         ),
@@ -1195,7 +1201,7 @@ def test_nonce_with_dummy():
             dataclasses.replace(
                 base_command,
                 at_block=f'0x{(b"third block").hex()}',
-                transaction=dataclasses.replace(base_transaction, nonce=3),
+                transactions=[dataclasses.replace(base_transaction, nonce=3)],
             ),
             "StarknetErrorCode.INVALID_TRANSACTION_NONCE",
         ),
@@ -1204,7 +1210,7 @@ def test_nonce_with_dummy():
             dataclasses.replace(
                 base_command,
                 at_block=f'0x{(b"third block").hex()}',
-                transaction=dataclasses.replace(base_transaction, nonce=1),
+                transactions=[dataclasses.replace(base_transaction, nonce=1)],
                 pending_nonces={0x123: 2},
             ),
             "StarknetErrorCode.INVALID_TRANSACTION_NONCE",
@@ -1214,7 +1220,7 @@ def test_nonce_with_dummy():
             dataclasses.replace(
                 base_command,
                 at_block=f'0x{(b"third block").hex()}',
-                transaction=dataclasses.replace(base_transaction, nonce=2),
+                transactions=[dataclasses.replace(base_transaction, nonce=2)],
                 pending_nonces={0x123: 2},
             ),
             [{"gas_consumed": 1266, "gas_price": 1, "overall_fee": 1266}],
@@ -1223,7 +1229,7 @@ def test_nonce_with_dummy():
             dataclasses.replace(
                 base_command,
                 at_block=f'0x{(b"third block").hex()}',
-                transaction=dataclasses.replace(base_transaction, nonce=3),
+                transactions=[dataclasses.replace(base_transaction, nonce=3)],
                 pending_nonces={0x123: 2},
             ),
             "StarknetErrorCode.INVALID_TRANSACTION_NONCE",
@@ -1438,21 +1444,23 @@ def test_sierra_invoke_function_through_account():
         pending_deployed=[],
         pending_nonces={},
         pending_timestamp=0,
-        transaction=InvokeFunction(
-            version=2**128 + 1,
-            sender_address=dummy_account_contract_address,
-            calldata=[
-                sierra_contract_address,
-                get_selector_from_name("test"),
-                3,
-                1,
-                2,
-                3,
-            ],
-            nonce=0,
-            max_fee=0,
-            signature=[],
-        ),
+        transactions=[
+            InvokeFunction(
+                version=2**128 + 1,
+                sender_address=dummy_account_contract_address,
+                calldata=[
+                    sierra_contract_address,
+                    get_selector_from_name("test"),
+                    3,
+                    1,
+                    2,
+                    3,
+                ],
+                nonce=0,
+                max_fee=0,
+                signature=[],
+            )
+        ],
     )
 
     (verb, output, _timings) = loop_inner(con, command)
@@ -1494,15 +1502,17 @@ def test_sierra_declare_through_account():
         pending_deployed=[],
         pending_nonces={},
         pending_timestamp=0,
-        transaction=Declare(
-            version=0x100000000000000000000000000000002,
-            sender_address=dummy_account_contract_address,
-            contract_class=class_definition,
-            compiled_class_hash=0x05BBE92A11E8C31CAD885C72877F12E6EDFB5250AF54430DFA8ED7504C548417,
-            nonce=0,
-            max_fee=0,
-            signature=[],
-        ),
+        transactions=[
+            Declare(
+                version=0x100000000000000000000000000000002,
+                sender_address=dummy_account_contract_address,
+                contract_class=class_definition,
+                compiled_class_hash=0x05BBE92A11E8C31CAD885C72877F12E6EDFB5250AF54430DFA8ED7504C548417,
+                nonce=0,
+                max_fee=0,
+                signature=[],
+            )
+        ],
     )
 
     (verb, output, _timings) = loop_inner(con, command)

--- a/py/tests/pathfinder_worker/test_call.py
+++ b/py/tests/pathfinder_worker/test_call.py
@@ -626,11 +626,13 @@ def test_fee_estimate_on_positive_directly():
 
     (verb, output, _timings) = loop_inner(con, command)
 
-    assert output == {
-        "gas_consumed": 1258,
-        "gas_price": 1,
-        "overall_fee": 1258,
-    }
+    assert output == [
+        {
+            "gas_consumed": 1258,
+            "gas_price": 1,
+            "overall_fee": 1258,
+        }
+    ]
 
 
 def test_fee_estimate_for_declare_transaction_directly():
@@ -671,11 +673,13 @@ def test_fee_estimate_for_declare_transaction_directly():
 
     (verb, output, _timings) = loop_inner(con, command)
 
-    assert output == {
-        "gas_consumed": 1251,
-        "gas_price": 1,
-        "overall_fee": 1251,
-    }
+    assert output == [
+        {
+            "gas_consumed": 1251,
+            "gas_price": 1,
+            "overall_fee": 1251,
+        }
+    ]
 
 
 def test_fee_estimate_on_positive():
@@ -1151,7 +1155,7 @@ def test_nonce_with_dummy():
         (
             # in this block the acct contract has been deployed, so it has nonce=0
             dataclasses.replace(base_command, at_block=f'0x{(b"another block").hex()}'),
-            {"gas_consumed": 1266, "gas_price": 1, "overall_fee": 1266},
+            [{"gas_consumed": 1266, "gas_price": 1, "overall_fee": 1266}],
         ),
         (
             dataclasses.replace(
@@ -1176,7 +1180,7 @@ def test_nonce_with_dummy():
                 at_block=f'0x{(b"third block").hex()}',
                 transaction=dataclasses.replace(base_transaction, nonce=1),
             ),
-            {"gas_consumed": 1266, "gas_price": 1, "overall_fee": 1266},
+            [{"gas_consumed": 1266, "gas_price": 1, "overall_fee": 1266}],
         ),
         (
             dataclasses.replace(
@@ -1213,7 +1217,7 @@ def test_nonce_with_dummy():
                 transaction=dataclasses.replace(base_transaction, nonce=2),
                 pending_nonces={0x123: 2},
             ),
-            {"gas_consumed": 1266, "gas_price": 1, "overall_fee": 1266},
+            [{"gas_consumed": 1266, "gas_price": 1, "overall_fee": 1266}],
         ),
         (
             dataclasses.replace(
@@ -1453,11 +1457,13 @@ def test_sierra_invoke_function_through_account():
 
     (verb, output, _timings) = loop_inner(con, command)
 
-    assert output == {
-        "gas_consumed": 3715,
-        "gas_price": 1,
-        "overall_fee": 3715,
-    }
+    assert output == [
+        {
+            "gas_consumed": 3715,
+            "gas_price": 1,
+            "overall_fee": 3715,
+        }
+    ]
 
 
 def test_sierra_declare_through_account():
@@ -1501,11 +1507,13 @@ def test_sierra_declare_through_account():
 
     (verb, output, _timings) = loop_inner(con, command)
 
-    assert output == {
-        "gas_consumed": 1251,
-        "gas_price": 1,
-        "overall_fee": 1251,
-    }
+    assert output == [
+        {
+            "gas_consumed": 1251,
+            "gas_price": 1,
+            "overall_fee": 1251,
+        }
+    ]
 
 
 def declare_class(cur: sqlite3.Cursor, class_hash: int, class_definition_path: str):

--- a/py/tools/compute_class_hash.py
+++ b/py/tools/compute_class_hash.py
@@ -1,13 +1,15 @@
 # reads stdin for a contract_definition json blob, writes a class hash to stdout
 # example: python py/src/compute_class_hash.py < class_definition.json
 
-from starkware.starknet.business_logic.fact_state.contract_state_objects import (
-    ContractClassFact,
-)
-from starkware.starknet.services.api.contract_class import ContractClass
-from starkware.cairo.lang.vm.crypto import pedersen_hash
-
 import sys
+
+from starkware.cairo.lang.vm.crypto import pedersen_hash
+from starkware.starknet.business_logic.fact_state.contract_class_objects import (
+    DeprecatedCompiledClassFact,
+)
+from starkware.starknet.services.api.contract_class.contract_class import (
+    DeprecatedCompiledClass,
+)
 
 
 def main():
@@ -22,7 +24,7 @@ def main():
     sys.stdin.reconfigure(encoding="utf-8")
     contents = sys.stdin.read()
 
-    cdf = ContractClassFact(ContractClass.loads(contents))
+    cdf = DeprecatedCompiledClassFact(DeprecatedCompiledClass.loads(contents))
 
     print(cdf._hash(pedersen_hash).hex())
     sys.exit(0)


### PR DESCRIPTION
This includes adding the ability to estimate a list of transactions to the underlying Python worker process, and the inter-process communication too.

Closes #862 