### PR TITLE
fix(pathfinder/sierra): use experimental libfunc list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - pathfinder can spam nethermind L1 nodes
+- pathfinder stops syncing testnet2 at block 95220 due to a Sierra class compilation issue
 
 ## [0.5.0] - 2023-03-20
 

--- a/crates/pathfinder/src/sierra.rs
+++ b/crates/pathfinder/src/sierra.rs
@@ -19,7 +19,13 @@ pub fn compile_to_casm(sierra_definition: &[u8]) -> anyhow::Result<Vec<u8>> {
         .try_into()
         .context("Converting to Sierra class")?;
 
-    validate_compatible_sierra_version(&sierra_class, ListSelector::DefaultList)?;
+    validate_compatible_sierra_version(
+        &sierra_class,
+        ListSelector::ListName(
+            cairo_lang_starknet::allowed_libfuncs::DEFAULT_EXPERIMENTAL_LIBFUNCS_LIST.to_string(),
+        ),
+    )
+    .context("Validating Sierra class")?;
 
     let casm_class =
         CasmContractClass::from_contract_class(sierra_class, true).context("Compiling to CASM")?;


### PR DESCRIPTION
Looks like there are classes on testnet that use libfuncs only allowed in the experimental libfuncs list.