### PR TITLE
fix: nethermind L1 node spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- pathfinder can spam nethermind L1 nodes
+
 ## [0.5.0] - 2023-03-20
 
 ### Added


### PR DESCRIPTION
This is a bandaid fix for a bug in how we fetch L1 logs. This is an edgecase / papercut in the current algorithm which will pretty much only occur for nethermind nodes - because they don't allow querying past latest block.

### Bug rundown

Once we are in sync for L1, nethermind does not allow us to query past the `latest` block. Our algorithm handles this well, and this means that `stride_cap = 1` i.e. our max query range is 1. Which makes sense as essentially we have to query block by block.

If there is then a block with no logs, then we should query by at least two blocks. However, the stride calculation is:
```
self.stride = (self.stride.saturating_add(max + 1)) / 2
```
and if both `stride` and `max` are `1`, then `stride` remains `1` and we hit an infinite loop.

### Bandaid

I opted to special case the `stride_cap = 1` situation and to force `stride = latest - current`. There are probably more general solutions, but I'm scared to change what was working.

In the long-term its probably best to rethink and rework this entirely.