### PR TITLE
feat(stark_hash_python): add Poseidon hash function implementations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
   test_all_except_pathfinder_ethereum:
     name: all tests w/o l1
     runs-on: ubuntu-latest
+    needs: python-starkhash
     steps:
       # Required for the python environment
       - uses: actions/checkout@v3
@@ -119,6 +120,14 @@ jobs:
       - run: |
           pip install -r py/requirements-dev.txt
           pip install -e py/.
+      # Install fresh stark_hash_rust
+      - uses: actions/download-artifact@v3
+        with:
+          name: pathfinder-starkhash-wheels
+      - name: Install Pedersen hash Python wrapper
+        run: |
+          pip install --no-index --force-reinstall ./stark_hash_rust-*.whl
+  
       # We want to strip the debug info as some of these test binaries are 100MB+ and pathfinder_lib is 1GB+
       - name: Execute tests
         run: timeout 25m cargo test --all-targets --workspace --locked --profile stripdebuginfo --exclude pathfinder-ethereum

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
           name: pathfinder-starkhash-wheels
       - name: Install Pedersen hash Python wrapper
         run: |
-          pip install --no-index ./stark_hash_rust-*.whl
+          pip install --no-index --force-reinstall ./stark_hash_rust-*.whl
 
       - name: Test (python)
         run: |

--- a/crates/stark_hash_python/Cargo.lock
+++ b/crates/stark_hash_python/Cargo.lock
@@ -324,6 +324,17 @@ version = "0.1.0"
 dependencies = [
  "num-bigint 0.4.3",
  "pyo3",
+ "stark_curve",
+ "stark_hash",
+ "stark_poseidon",
+]
+
+[[package]]
+name = "stark_poseidon"
+version = "0.1.0"
+dependencies = [
+ "num-bigint 0.4.3",
+ "stark_curve",
  "stark_hash",
 ]
 

--- a/crates/stark_hash_python/Cargo.toml
+++ b/crates/stark_hash_python/Cargo.toml
@@ -11,4 +11,6 @@ crate-type = ["cdylib"]
 [dependencies]
 num-bigint = "0.4.3"
 pyo3 = { version = "0.17.1", features = ["extension-module", "num-bigint"] }
+stark_curve = { path = "../stark_curve" }
 stark_hash = { path = "../stark_hash" }
+stark_poseidon = { path = "../stark_poseidon" }

--- a/crates/stark_hash_python/src/lib.rs
+++ b/crates/stark_hash_python/src/lib.rs
@@ -2,6 +2,7 @@ use num_bigint::BigUint;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
+use stark_curve::FieldElement;
 use stark_hash::{stark_hash, Felt};
 
 /// Computes the Pedersen hash.
@@ -32,9 +33,91 @@ fn pedersen_hash(a: BigUint, b: BigUint) -> PyResult<BigUint> {
     Ok(BigUint::from_bytes_be(&hash.to_be_bytes()))
 }
 
+/// Computes the Poseidon hash of two felts.
+///
+/// Inputs are expected to be big-endian 32 byte slices.
+#[pyfunction]
+fn poseidon_hash_func(a: &[u8], b: &[u8]) -> PyResult<Vec<u8>> {
+    let a = Felt::from_be_slice(a).map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let b = Felt::from_be_slice(b).map_err(|e| PyValueError::new_err(e.to_string()))?;
+
+    let hash: Felt = stark_poseidon::poseidon_hash(a.into(), b.into()).into();
+
+    Ok(hash.to_be_bytes().to_vec())
+}
+
+/// Computes the Poseidon hash of two felts.
+///
+/// Inputs are expected to be Python integers.
+#[pyfunction]
+fn poseidon_hash(a: BigUint, b: BigUint, poseidon_params: Option<PyObject>) -> PyResult<BigUint> {
+    assert!(
+        poseidon_params.is_none(),
+        "Non-default Poseidon parameters are not supported"
+    );
+
+    let a =
+        Felt::from_be_slice(&a.to_bytes_be()).map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let b =
+        Felt::from_be_slice(&b.to_bytes_be()).map_err(|e| PyValueError::new_err(e.to_string()))?;
+
+    let hash: Felt = stark_poseidon::poseidon_hash(a.into(), b.into()).into();
+
+    Ok(BigUint::from_bytes_be(&hash.to_be_bytes()))
+}
+
+/// Computes the Poseidon hash of a sequence of felts.
+///
+/// Input is expected to be a sequence of Python integers.
+#[pyfunction]
+fn poseidon_hash_many(array: Vec<BigUint>, poseidon_params: Option<PyObject>) -> PyResult<BigUint> {
+    assert!(
+        poseidon_params.is_none(),
+        "Non-default Poseidon parameters are not supported"
+    );
+
+    let array = array
+        .into_iter()
+        .map(|a| {
+            Felt::from_be_slice(&a.to_bytes_be())
+                .map(Into::into)
+                .map_err(|e| PyValueError::new_err(e.to_string()))
+        })
+        .collect::<Result<Vec<FieldElement>, PyErr>>()?;
+
+    let hash: Felt = stark_poseidon::poseidon_hash_many(&array).into();
+
+    Ok(BigUint::from_bytes_be(&hash.to_be_bytes()))
+}
+
+#[pyfunction]
+fn poseidon_perm(a: BigUint, b: BigUint, c: BigUint) -> PyResult<Vec<BigUint>> {
+    let a =
+        Felt::from_be_slice(&a.to_bytes_be()).map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let b =
+        Felt::from_be_slice(&b.to_bytes_be()).map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let c =
+        Felt::from_be_slice(&c.to_bytes_be()).map_err(|e| PyValueError::new_err(e.to_string()))?;
+
+    let mut state: stark_poseidon::PoseidonState = [a.into(), b.into(), c.into()];
+
+    stark_poseidon::permute_comp(&mut state);
+
+    let output = state
+        .into_iter()
+        .map(|e| BigUint::from_bytes_be(&Felt::from(e).to_be_bytes()))
+        .collect();
+
+    Ok(output)
+}
+
 #[pymodule]
-fn stark_hash_rust(_py: Python, m: &PyModule) -> PyResult<()> {
+fn stark_hash_rust(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(pedersen_hash, m)?)?;
     m.add_function(wrap_pyfunction!(pedersen_hash_func, m)?)?;
+    m.add_function(wrap_pyfunction!(poseidon_hash, m)?)?;
+    m.add_function(wrap_pyfunction!(poseidon_hash_func, m)?)?;
+    m.add_function(wrap_pyfunction!(poseidon_hash_many, m)?)?;
+    m.add_function(wrap_pyfunction!(poseidon_perm, m)?)?;
     Ok(())
 }

--- a/py/src/pathfinder_worker/call.py
+++ b/py/src/pathfinder_worker/call.py
@@ -17,6 +17,7 @@ from typing import ClassVar, Dict, List, Optional, Tuple, Type
 try:
     import stark_hash_rust
     import starkware.crypto.signature.fast_pedersen_hash
+    import starkware.cairo.common.poseidon_hash
 
     starkware.crypto.signature.fast_pedersen_hash.pedersen_hash_func = (
         stark_hash_rust.pedersen_hash_func
@@ -24,6 +25,14 @@ try:
     starkware.crypto.signature.fast_pedersen_hash.pedersen_hash = (
         stark_hash_rust.pedersen_hash
     )
+    starkware.cairo.common.poseidon_hash.poseidon_hash = stark_hash_rust.poseidon_hash
+    starkware.cairo.common.poseidon_hash.poseidon_hash_func = (
+        stark_hash_rust.poseidon_hash_func
+    )
+    starkware.cairo.common.poseidon_hash.poseidon_hash_many = (
+        stark_hash_rust.poseidon_hash_many
+    )
+    starkware.cairo.common.poseidon_hash.poseidon_perm = stark_hash_rust.poseidon_perm
 except ModuleNotFoundError:
     # Monkey-patching with our fast implementation of the Pedersen hash failed.
     # This is not fatal, some operations will be slower this way.


### PR DESCRIPTION
This change exports our Poseidon implementation functions into Python via the stark_hash_rust Python module and then monkey-patches the cairo-lang module to use our Rust impls instead of the default Python implementation.

This leads to significantly faster execution of some operations, like computing the class hash of a Sierra class: in one test case this has gone down from 17s to 3s.