### PR TITLE
chore: v0.5.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.5.2] - 2023-03-28
+
 ### Added
 
 - support `starknet_estimateFee` in the JSON-RPC v0.3 API
@@ -23,7 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RPC does not expose `pathfinder_getProof` on v0.3 route
 - RPC exposes `pathfinder_version` on v0.2 route
 
-## [0.5.1] - 2023-23-23
+#### Fixed
+
+- RPC returns int for entrypoint offsets instead of hex
+
+## [0.5.1] - 2023-03-23
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,18 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - support `starknet_estimateFee` in the JSON-RPC v0.3 API
   - supports estimating multiple transactions
   - this includes declaring and immediately using a class (not currently possible via the gateway)
+- support `starknet_simulateTransaction` for JSON-RPC v0.3
+  - supports simulating multiple transactions
+  - this includes declaring and immediately using a class (not currently possible via the gateway)
 - support `pathfinder_getTransactionStatus` which is exposed on all RPC routes
   - this enables querying a transactions current status, including whether the gateway has received or rejected it
 
 ### Fixed
 
+- RPC returns int for entrypoint offsets instead of hex
 - RPC rejects Fee values with more than 32 digits
 - RPC does not expose `pathfinder_getProof` on v0.3 route
-- RPC exposes `pathfinder_version` on v0.2 route
-
-#### Fixed
-
-- RPC returns int for entrypoint offsets instead of hex
 
 ## [0.5.1] - 2023-03-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5081,7 +5081,7 @@ checksum = "ecba01bf2678719532c5e3059e0b5f0811273d94b397088b82e3bd0a78c78fdd"
 
 [[package]]
 name = "pathfinder"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pathfinder"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.65"


### PR DESCRIPTION
We can also wait for #977 and #987 before making this release. That way we have complete v0.3 RPC support.