### PR TITLE
feat(ext_py): speed up fee estimation for declare transactions

### DIFF
--- a/crates/rpc/src/cairo/ext_py/ser.rs
+++ b/crates/rpc/src/cairo/ext_py/ser.rs
@@ -9,9 +9,11 @@ use starknet_gateway_types::{
         state_update::{DeployedContract, StorageDiff},
         PendingStateUpdate,
     },
-    request::{add_transaction::AddTransaction, BlockHashOrTag, BlockNumberOrTag, Tag},
+    request::{BlockHashOrTag, BlockNumberOrTag, Tag},
 };
 use std::collections::HashMap;
+
+use super::TransactionAndClassHashHint;
 
 /// The command we send to the Python loop.
 #[serde_with::serde_as]
@@ -33,7 +35,7 @@ pub(crate) enum ChildCommand<'a> {
         // zero means use the gas price from the block.
         #[serde_as(as = "&pathfinder_serde::H256AsHexStr")]
         gas_price: &'a ethers::types::H256,
-        transactions: &'a [AddTransaction],
+        transactions: &'a [TransactionAndClassHashHint],
     },
     SimulateTx {
         #[serde(flatten)]
@@ -42,7 +44,7 @@ pub(crate) enum ChildCommand<'a> {
         // zero means use the gas price from the block.
         #[serde_as(as = "&pathfinder_serde::H256AsHexStr")]
         gas_price: &'a ethers::types::H256,
-        transactions: &'a [AddTransaction],
+        transactions: &'a [TransactionAndClassHashHint],
         skip_validate: &'a bool,
     },
 }

--- a/py/src/pathfinder_worker/call.py
+++ b/py/src/pathfinder_worker/call.py
@@ -215,13 +215,15 @@ class Command:
         Returns the verb
         """
 
-    @abstractmethod
     def has_pending_data(self):
-        pass
+        return (
+            len(self.pending_updates) > 0
+            or len(self.pending_deployed) > 0
+            or len(self.pending_nonces) > 0
+        )
 
-    @abstractmethod
     def get_pending_timestamp(self) -> int:
-        pass
+        return self.pending_timestamp
 
 
 @marshmallow_dataclass.dataclass(frozen=True)
@@ -236,16 +238,6 @@ class Call(Command):
 
     gas_price: int = 0
 
-    def has_pending_data(self):
-        return (
-            len(self.pending_updates) > 0
-            or len(self.pending_deployed) > 0
-            or len(self.pending_nonces) > 0
-        )
-
-    def get_pending_timestamp(self) -> int:
-        return self.pending_timestamp
-
 
 @marshmallow_dataclass.dataclass(frozen=True)
 class EstimateFee(Command):
@@ -254,16 +246,6 @@ class EstimateFee(Command):
     # zero means to use the gas price from the current block.
     gas_price: int = field(metadata=fields.gas_price_metadata)
 
-
-    def has_pending_data(self):
-        return (
-            len(self.pending_updates) > 0
-            or len(self.pending_deployed) > 0
-            or len(self.pending_nonces) > 0
-        )
-
-    def get_pending_timestamp(self) -> int:
-        return self.pending_timestamp
     transactions: List[TransactionAndClassHashHint]
 
 


### PR DESCRIPTION
Instead of re-computing class hashes in Python (which is in fact just calling the Cairo implementation) this PR pre-computes class hashes for all `BroadcastedDeclareTransaction`s in Rust and sends that as a class hash hint to the transaction to the Python worker.

The worker then injects these class hash values for the classes in declare transactions into a class hash cache so that we avoid actually calling the Cairo class hash calculation.

This leads to a very significant speed-up, especially with Sierra classes. Estimating a Declare v2 declaring a standard ERC20 token contract went from 17s to 0.8s.