### PR TITLE
refactor: change fee to felt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - supports estimating multiple transactions
   - this includes declaring and immediately using a class (not currently possible via the gateway)
 
+### Fixed
+
+- RPC rejects Fee values with more than 32 digits
+
 ## [0.5.1] - 2023-23-23
 
 ### Fixed

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -2,7 +2,7 @@
 //! home of their own.
 //!
 //! This includes many trivial wrappers around [Felt] which help by providing additional type safety.
-use ethers::types::{H128, H160, H256};
+use ethers::types::{H160, H256};
 use serde::{Deserialize, Serialize};
 use stark_hash::Felt;
 
@@ -267,7 +267,11 @@ pub struct SequencerAddress(pub Felt);
 
 /// StarkNet fee value.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
-pub struct Fee(pub H128);
+pub struct Fee(pub Felt);
+
+impl Fee {
+    pub const ZERO: Self = Self(Felt::ZERO);
+}
 
 /// StarkNet gas price.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -1272,7 +1272,7 @@ mod tests {
             let error = client
                 .add_invoke_transaction(
                     TransactionVersion::ZERO,
-                    Fee(5444010076217u128.to_be_bytes().into()),
+                    Fee(felt!("0x4F388496839")),
                     vec![
                         TransactionSignatureElem(felt!(
                             "07dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5"
@@ -1322,7 +1322,7 @@ mod tests {
             client
                 .add_invoke_transaction(
                     TransactionVersion::ZERO,
-                    Fee(5444010076217u128.to_be_bytes().into()),
+                    Fee(felt!("0x4F388496839")),
                     vec![
                         TransactionSignatureElem(felt!(
                             "07dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5"
@@ -1374,7 +1374,7 @@ mod tests {
             client
                 .add_declare_transaction(
                     TransactionVersion::ZERO,
-                    Fee(0u128.to_be_bytes().into()),
+                    Fee::ZERO,
                     vec![],
                     TransactionNonce(Felt::ZERO),
                     ContractDefinition::Cairo(contract_class),
@@ -1517,7 +1517,7 @@ mod tests {
                 client
                     .add_declare_transaction(
                         TransactionVersion::ZERO,
-                        Fee(0u128.to_be_bytes().into()),
+                        Fee::ZERO,
                         vec![],
                         TransactionNonce::ZERO,
                         ContractDefinition::Cairo(CairoContractDefinition {
@@ -1543,7 +1543,7 @@ mod tests {
                 let err = client
                     .add_declare_transaction(
                         TransactionVersion::ZERO,
-                        Fee(0u128.to_be_bytes().into()),
+                        Fee::ZERO,
                         vec![],
                         TransactionNonce::ZERO,
                         ContractDefinition::Cairo(CairoContractDefinition {

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -190,9 +190,9 @@ pub mod transaction {
     };
     use pathfinder_serde::{
         CallParamAsDecimalStr, ConstructorParamAsDecimalStr, EthereumAddressAsHexStr,
-        EventDataAsDecimalStr, EventKeyAsDecimalStr, FeeAsHexStr,
-        L1ToL2MessagePayloadElemAsDecimalStr, L2ToL1MessagePayloadElemAsDecimalStr,
-        TransactionSignatureElemAsDecimalStr, TransactionVersionAsHexStr,
+        EventDataAsDecimalStr, EventKeyAsDecimalStr, L1ToL2MessagePayloadElemAsDecimalStr,
+        L2ToL1MessagePayloadElemAsDecimalStr, TransactionSignatureElemAsDecimalStr,
+        TransactionVersionAsHexStr,
     };
     use serde::{Deserialize, Serialize};
     use serde_with::serde_as;
@@ -272,11 +272,9 @@ pub mod transaction {
     }
 
     /// Represents deserialized L2 transaction receipt data.
-    #[serde_as]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
     #[serde(deny_unknown_fields)]
     pub struct Receipt {
-        #[serde_as(as = "Option<FeeAsHexStr>")]
         #[serde(default)]
         pub actual_fee: Option<Fee>,
         pub events: Vec<Event>,
@@ -409,7 +407,6 @@ pub mod transaction {
     #[serde(deny_unknown_fields)]
     pub struct DeclareTransactionV0V1 {
         pub class_hash: ClassHash,
-        #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
         pub nonce: TransactionNonce,
         pub sender_address: ContractAddress,
@@ -425,7 +422,6 @@ pub mod transaction {
     #[serde(deny_unknown_fields)]
     pub struct DeclareTransactionV2 {
         pub class_hash: ClassHash,
-        #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
         pub nonce: TransactionNonce,
         pub sender_address: ContractAddress,
@@ -463,7 +459,6 @@ pub mod transaction {
     pub struct DeployAccountTransaction {
         pub contract_address: ContractAddress,
         pub transaction_hash: StarknetTransactionHash,
-        #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
         #[serde_as(as = "TransactionVersionAsHexStr")]
         pub version: TransactionVersion,
@@ -544,7 +539,6 @@ pub mod transaction {
         pub entry_point_selector: EntryPoint,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub entry_point_type: Option<EntryPointType>,
-        #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
         #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
         pub signature: Vec<TransactionSignatureElem>,
@@ -564,7 +558,6 @@ pub mod transaction {
         // transaction naming, or until regenesis removes them all.
         #[serde(alias = "contract_address")]
         pub sender_address: ContractAddress,
-        #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
         #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
         pub signature: Vec<TransactionSignatureElem>,

--- a/crates/gateway-types/src/request.rs
+++ b/crates/gateway-types/src/request.rs
@@ -197,8 +197,7 @@ pub mod add_transaction {
         CasmHash, ClassHash, ContractAddressSalt, TransactionNonce, TransactionVersion,
     };
     use pathfinder_serde::{
-        CallParamAsDecimalStr, FeeAsHexStr, TransactionSignatureElemAsDecimalStr,
-        TransactionVersionAsHexStr,
+        CallParamAsDecimalStr, TransactionSignatureElemAsDecimalStr, TransactionVersionAsHexStr,
     };
     use serde_with::serde_as;
     use std::collections::HashMap;
@@ -240,7 +239,6 @@ pub mod add_transaction {
         #[serde_as(as = "TransactionVersionAsHexStr")]
         pub version: TransactionVersion,
 
-        #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
         #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
         pub signature: Vec<TransactionSignatureElem>,
@@ -261,7 +259,6 @@ pub mod add_transaction {
         pub version: TransactionVersion,
 
         // AccountTransaction properties
-        #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
         #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
         pub signature: Vec<TransactionSignatureElem>,
@@ -282,7 +279,6 @@ pub mod add_transaction {
         pub version: TransactionVersion,
 
         // AccountTransaction properties -- except for nonce which is non-optional here
-        #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
         #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
         pub signature: Vec<TransactionSignatureElem>,

--- a/crates/pathfinder/examples/estimate_past_transactions.rs
+++ b/crates/pathfinder/examples/estimate_past_transactions.rs
@@ -354,7 +354,6 @@ struct SimpleDeclare {}
 struct SimpleDeployAccount {
     #[serde_as(as = "pathfinder_serde::TransactionVersionAsHexStr")]
     pub version: pathfinder_common::TransactionVersion,
-    #[serde_as(as = "pathfinder_serde::FeeAsHexStr")]
     pub max_fee: pathfinder_common::Fee,
     #[serde_as(as = "Vec<pathfinder_serde::TransactionSignatureElemAsDecimalStr>")]
     #[serde(default)]
@@ -374,7 +373,6 @@ struct SimpleInvoke {
     #[serde(default)]
     #[serde_as(as = "Option<pathfinder_serde::TransactionVersionAsHexStr>")]
     pub version: Option<pathfinder_common::TransactionVersion>,
-    #[serde_as(as = "pathfinder_serde::FeeAsHexStr")]
     pub max_fee: pathfinder_common::Fee,
     #[serde_as(as = "Vec<pathfinder_serde::TransactionSignatureElemAsDecimalStr>")]
     #[serde(default)]

--- a/crates/pathfinder/src/state/block_hash.rs
+++ b/crates/pathfinder/src/state/block_hash.rs
@@ -485,7 +485,7 @@ mod tests {
             sender_address: ContractAddress::new_or_panic(felt!("0xdeadbeef")),
             entry_point_type: Some(EntryPointType::External),
             entry_point_selector: EntryPoint(felt!("0xe")),
-            max_fee: Fee(0u128.to_be_bytes().into()),
+            max_fee: Fee::ZERO,
             signature: vec![
                 TransactionSignatureElem(felt!("0x2")),
                 TransactionSignatureElem(felt!("0x3")),

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -137,7 +137,6 @@ mod tests {
 
     // Local test helper
     pub fn setup_storage() -> Storage {
-        use ethers::types::H128;
         use pathfinder_common::{ContractNonce, StorageValue};
         use pathfinder_merkle_tree::contract_state::update_contract_state;
 
@@ -336,7 +335,7 @@ mod tests {
             sender_address: contract0_addr,
             entry_point_type: Some(EntryPointType::External),
             entry_point_selector: EntryPoint(Felt::ZERO),
-            max_fee: pathfinder_common::Fee(H128::zero()),
+            max_fee: pathfinder_common::Fee::ZERO,
             signature: vec![],
             transaction_hash: txn0_hash,
         };

--- a/crates/rpc/src/v02/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v02/method/add_declare_transaction.rs
@@ -153,7 +153,7 @@ mod tests {
             fn test_declare_txn() -> Transaction {
                 Transaction::Declare(BroadcastedDeclareTransaction::V0V1(
                     BroadcastedDeclareTransactionV0V1 {
-                        max_fee: Fee(ethers::types::H128::from_low_u64_be(1)),
+                        max_fee: Fee(felt!("0x1")),
                         version: TransactionVersion::ONE,
                         signature: vec![],
                         nonce: TransactionNonce(Felt::ZERO),
@@ -228,7 +228,7 @@ mod tests {
             fn test_declare_txn() -> Transaction {
                 Transaction::Declare(BroadcastedDeclareTransaction::V2(
                     BroadcastedDeclareTransactionV2 {
-                        max_fee: Fee(ethers::types::H128::from_low_u64_be(1)),
+                        max_fee: Fee(felt!("0x1")),
                         version: TransactionVersion::TWO,
                         signature: vec![],
                         nonce: TransactionNonce(Felt::ZERO),
@@ -341,7 +341,7 @@ mod tests {
         let declare_transaction = Transaction::Declare(BroadcastedDeclareTransaction::V2(
             BroadcastedDeclareTransactionV2 {
                 version: TransactionVersion::TWO,
-                max_fee: Fee(ethers::types::H128::from_low_u64_be(u64::MAX)),
+                max_fee: Fee(Felt::from_be_slice(&u64::MAX.to_be_bytes()).unwrap()),
                 signature: vec![],
                 nonce: TransactionNonce(Default::default()),
                 contract_class: invalid_contract_class,
@@ -410,7 +410,7 @@ mod tests {
         let declare_transaction = Transaction::Declare(BroadcastedDeclareTransaction::V2(
             BroadcastedDeclareTransactionV2 {
                 version: TransactionVersion::TWO,
-                max_fee: Fee(ethers::types::H128::from_low_u64_be(u64::MAX)),
+                max_fee: Fee(Felt::from_be_slice(&u64::MAX.to_be_bytes()).unwrap()),
                 signature: vec![],
                 nonce: TransactionNonce(Default::default()),
                 contract_class: SIERRA_CLASS.clone(),

--- a/crates/rpc/src/v02/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/v02/method/add_deploy_account_transaction.rs
@@ -100,11 +100,7 @@ mod tests {
             deploy_account_transaction: Transaction::DeployAccount(
                 BroadcastedDeployAccountTransaction {
                     version: TransactionVersion::ONE,
-                    max_fee: Fee([
-                        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0b, 0xf3,
-                        0x91, 0x37, 0x78, 0x13,
-                    ]
-                    .into()),
+                    max_fee: Fee(felt!("0xbf391377813")),
                     signature: vec![
                         TransactionSignatureElem(felt!(
                             "07dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5"

--- a/crates/rpc/src/v02/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/v02/method/add_invoke_transaction.rs
@@ -81,7 +81,7 @@ mod tests {
         Transaction::Invoke(BroadcastedInvokeTransaction::V0(
             BroadcastedInvokeTransactionV0 {
                 version: TransactionVersion::ZERO,
-                max_fee: Fee(5444010076217u128.to_be_bytes().into()),
+                max_fee: Fee(felt!("0x4F388496839")),
                 signature: vec![
                     TransactionSignatureElem(felt!(
                         "07dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5"
@@ -218,7 +218,7 @@ mod tests {
         let context = RpcContext::for_tests();
         let input = BroadcastedInvokeTransactionV1 {
             version: TransactionVersion::ONE,
-            max_fee: Fee(ethers::types::H128::from_low_u64_be(0x630a0aff77)),
+            max_fee: Fee(felt!("0x630a0aff77")),
             signature: vec![
                 TransactionSignatureElem(felt!(
                     "07ccc81b438581c9360120e0ba0ef52c7d031bdf20a4c2bc3820391b29a8945f"

--- a/crates/rpc/src/v02/method/estimate_fee.rs
+++ b/crates/rpc/src/v02/method/estimate_fee.rs
@@ -153,7 +153,7 @@ mod tests {
             BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V0(
                 crate::v02::types::request::BroadcastedInvokeTransactionV0 {
                     version: TransactionVersion::ZERO_WITH_QUERY_VERSION,
-                    max_fee: Fee(ethers::types::H128::from_low_u64_be(0x6)),
+                    max_fee: Fee(felt!("0x6")),
                     signature: vec![TransactionSignatureElem(felt!("0x7"))],
                     nonce: Some(TransactionNonce(felt!("0x8"))),
                     contract_address: ContractAddress::new_or_panic(felt!("0xaaa")),

--- a/crates/rpc/src/v02/method/get_transaction_by_hash.rs
+++ b/crates/rpc/src/v02/method/get_transaction_by_hash.rs
@@ -130,7 +130,7 @@ mod tests {
             Transaction::Invoke(reply::InvokeTransaction::V0(reply::InvokeTransactionV0 {
                 common: reply::CommonDeclareInvokeTransactionProperties {
                     hash: StarknetTransactionHash(felt_bytes!(b"txn 0")),
-                    max_fee: Fee(ethers::types::H128::zero()),
+                    max_fee: Fee::ZERO,
                     signature: vec![],
                     nonce: TransactionNonce(Felt::ZERO),
                 },
@@ -156,7 +156,7 @@ mod tests {
             Transaction::Invoke(reply::InvokeTransaction::V0(reply::InvokeTransactionV0 {
                 common: reply::CommonDeclareInvokeTransactionProperties {
                     hash: StarknetTransactionHash(felt_bytes!(b"pending tx hash 0")),
-                    max_fee: Fee(ethers::types::H128::zero()),
+                    max_fee: Fee::ZERO,
                     signature: vec![],
                     nonce: TransactionNonce(Felt::ZERO),
                 },

--- a/crates/rpc/src/v02/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v02/method/get_transaction_receipt.rs
@@ -83,7 +83,7 @@ mod types {
         ContractAddress, EthereumAddress, EventData, EventKey, Fee, L1ToL2MessagePayloadElem,
         L2ToL1MessagePayloadElem, StarknetBlockHash, StarknetBlockNumber, StarknetTransactionHash,
     };
-    use pathfinder_serde::{EthereumAddressAsHexStr, FeeAsHexStr};
+    use pathfinder_serde::EthereumAddressAsHexStr;
     use serde::Serialize;
     use serde_with::serde_as;
     use starknet_gateway_types::reply::transaction::{L1ToL2Message, L2ToL1Message};
@@ -130,7 +130,6 @@ mod types {
     pub struct CommonTransactionReceiptProperties {
         #[serde_as(as = "RpcFelt")]
         pub transaction_hash: StarknetTransactionHash,
-        #[serde_as(as = "FeeAsHexStr")]
         pub actual_fee: Fee,
         pub status: TransactionStatus,
         #[serde_as(as = "RpcFelt")]
@@ -246,7 +245,6 @@ mod types {
     #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
     pub struct CommonPendingTransactionReceiptProperties {
         pub transaction_hash: StarknetTransactionHash,
-        #[serde_as(as = "FeeAsHexStr")]
         pub actual_fee: Fee,
         pub messages_sent: Vec<MessageToL1>,
         pub events: Vec<Event>,
@@ -424,7 +422,7 @@ mod types {
                 pub fn test_data() -> Self {
                     Self {
                         transaction_hash: StarknetTransactionHash(felt!("0xdeadbeef")),
-                        actual_fee: Fee(ethers::types::H128::from_low_u64_be(0x1)),
+                        actual_fee: Fee(felt!("0x1")),
                         status: TransactionStatus::AcceptedOnL1,
                         block_hash: StarknetBlockHash(felt!("0xaaa")),
                         block_number: StarknetBlockNumber::new_or_panic(3),
@@ -445,7 +443,7 @@ mod types {
                 pub fn test_data() -> Self {
                     Self {
                         transaction_hash: StarknetTransactionHash(felt!("0xfeedfeed")),
-                        actual_fee: Fee(ethers::types::H128::from_low_u64_be(0x2)),
+                        actual_fee: Fee(felt!("0x2")),
                         messages_sent: vec![MessageToL1 {
                             to_address: EthereumAddress(ethers::types::H160::from_low_u64_be(0x5)),
                             payload: vec![L2ToL1MessagePayloadElem(felt!("0x6"))],
@@ -620,7 +618,7 @@ mod tests {
                 InvokeTransactionReceipt {
                     common: CommonTransactionReceiptProperties {
                         transaction_hash: StarknetTransactionHash(felt_bytes!(b"txn 0")),
-                        actual_fee: Fee(ethers::types::H128::zero()),
+                        actual_fee: Fee::ZERO,
                         status: TransactionStatus::AcceptedOnL2,
                         block_hash: StarknetBlockHash(felt_bytes!(b"genesis")),
                         block_number: StarknetBlockNumber::new_or_panic(0),
@@ -652,7 +650,7 @@ mod tests {
                 PendingInvokeTransactionReceipt {
                     common: CommonPendingTransactionReceiptProperties {
                         transaction_hash,
-                        actual_fee: Fee(ethers::types::H128::zero()),
+                        actual_fee: Fee::ZERO,
                         messages_sent: vec![],
                         events: vec![
                             Event {

--- a/crates/rpc/src/v02/types.rs
+++ b/crates/rpc/src/v02/types.rs
@@ -10,9 +10,7 @@ pub mod request {
         CallParam, CasmHash, ClassHash, ContractAddress, ContractAddressSalt, EntryPoint, Fee,
         TransactionNonce, TransactionSignatureElem, TransactionVersion,
     };
-    use pathfinder_serde::{
-        FeeAsHexStr, TransactionSignatureElemAsDecimalStr, TransactionVersionAsHexStr,
-    };
+    use pathfinder_serde::{TransactionSignatureElemAsDecimalStr, TransactionVersionAsHexStr};
     use serde::Deserialize;
     use serde_with::serde_as;
 
@@ -82,7 +80,6 @@ pub mod request {
         // BROADCASTED_TXN_COMMON_PROPERTIES: ideally this should just be included
         // here in a flattened struct, but `flatten` doesn't work with
         // `deny_unknown_fields`: https://serde.rs/attr-flatten.html#struct-flattening
-        #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
         #[serde_as(as = "TransactionVersionAsHexStr")]
         pub version: TransactionVersion,
@@ -101,7 +98,6 @@ pub mod request {
         // BROADCASTED_TXN_COMMON_PROPERTIES: ideally this should just be included
         // here in a flattened struct, but `flatten` doesn't work with
         // `deny_unknown_fields`: https://serde.rs/attr-flatten.html#struct-flattening
-        #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
         #[serde_as(as = "TransactionVersionAsHexStr")]
         pub version: TransactionVersion,
@@ -121,7 +117,6 @@ pub mod request {
         // Fields from BROADCASTED_TXN_COMMON_PROPERTIES
         #[serde_as(as = "TransactionVersionAsHexStr")]
         pub version: TransactionVersion,
-        #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
         pub signature: Vec<TransactionSignatureElem>,
         pub nonce: TransactionNonce,
@@ -187,7 +182,6 @@ pub mod request {
         // BROADCASTED_TXN_COMMON_PROPERTIES: ideally this should just be included
         // here in a flattened struct, but `flatten` doesn't work with
         // `deny_unknown_fields`: https://serde.rs/attr-flatten.html#struct-flattening
-        #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
         pub signature: Vec<TransactionSignatureElem>,
         // This is a mistake in RPC specification v0.2. This field should not exist,
@@ -212,7 +206,6 @@ pub mod request {
         // BROADCASTED_TXN_COMMON_PROPERTIES: ideally this should just be included
         // here in a flattened struct, but `flatten` doesn't work with
         // `deny_unknown_fields`: https://serde.rs/attr-flatten.html#struct-flattening
-        #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
         pub signature: Vec<TransactionSignatureElem>,
         pub nonce: TransactionNonce,
@@ -235,7 +228,6 @@ pub mod request {
         #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
         pub signature: Vec<TransactionSignatureElem>,
         /// EstimateFee hurry: max fee is needed if there's a signature
-        #[serde_as(as = "FeeAsHexStr")]
         #[serde(default = "call_default_max_fee")]
         pub max_fee: Fee,
         /// EstimateFee hurry: transaction version might be interesting, might not be around for
@@ -260,7 +252,7 @@ pub mod request {
     }
 
     impl Call {
-        pub const DEFAULT_MAX_FEE: Fee = Fee(ethers::types::H128::zero());
+        pub const DEFAULT_MAX_FEE: Fee = Fee::ZERO;
         pub const DEFAULT_VERSION: TransactionVersion =
             TransactionVersion(ethers::types::H256::zero());
         pub const DEFAULT_NONCE: TransactionNonce = TransactionNonce(stark_hash::Felt::ZERO);
@@ -307,7 +299,7 @@ pub mod request {
                 let txs = vec![
                     BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V0V1(
                         BroadcastedDeclareTransactionV0V1 {
-                            max_fee: Fee(ethers::types::H128::from_low_u64_be(0x5)),
+                            max_fee: Fee(felt!("0x5")),
                             version: TransactionVersion(ethers::types::H256::from_low_u64_be(0x1)),
                             signature: vec![TransactionSignatureElem(felt!("0x7"))],
                             nonce: TransactionNonce(felt!("0x8")),
@@ -317,7 +309,7 @@ pub mod request {
                     )),
                     BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V2(
                         BroadcastedDeclareTransactionV2 {
-                            max_fee: Fee(ethers::types::H128::from_low_u64_be(0x51)),
+                            max_fee: Fee(felt!("0x51")),
                             version: TransactionVersion(ethers::types::H256::from_low_u64_be(0x2)),
                             signature: vec![TransactionSignatureElem(felt!("0x71"))],
                             nonce: TransactionNonce(felt!("0x81")),
@@ -347,7 +339,7 @@ pub mod request {
                     BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V0(
                         BroadcastedInvokeTransactionV0 {
                             version: TransactionVersion(ethers::types::H256::zero()),
-                            max_fee: Fee(ethers::types::H128::from_low_u64_be(0x6)),
+                            max_fee: Fee(felt!("0x6")),
                             signature: vec![TransactionSignatureElem(felt!("0x7"))],
                             nonce: Some(TransactionNonce(felt!("0x8"))),
                             contract_address: ContractAddress::new_or_panic(felt!("0xaaa")),
@@ -358,7 +350,7 @@ pub mod request {
                     BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(
                         BroadcastedInvokeTransactionV1 {
                             version: TransactionVersion(ethers::types::H256::from_low_u64_be(1)),
-                            max_fee: Fee(ethers::types::H128::from_low_u64_be(0x6)),
+                            max_fee: Fee(felt!("0x6")),
                             signature: vec![TransactionSignatureElem(felt!("0x7"))],
                             nonce: TransactionNonce(felt!("0x8")),
                             sender_address: ContractAddress::new_or_panic(felt!("0xaaa")),
@@ -368,7 +360,7 @@ pub mod request {
                     BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(
                         BroadcastedInvokeTransactionV1 {
                             version: TransactionVersion::ONE_WITH_QUERY_VERSION,
-                            max_fee: Fee(ethers::types::H128::from_low_u64_be(0x6)),
+                            max_fee: Fee(felt!("0x6")),
                             signature: vec![TransactionSignatureElem(felt!("0x7"))],
                             nonce: TransactionNonce(felt!("0x8")),
                             sender_address: ContractAddress::new_or_panic(felt!("0xaaa")),
@@ -398,7 +390,7 @@ pub mod reply {
         EntryPoint, Fee, StarknetTransactionHash, TransactionNonce, TransactionSignatureElem,
         TransactionVersion,
     };
-    use pathfinder_serde::{FeeAsHexStr, TransactionVersionAsHexStr};
+    use pathfinder_serde::TransactionVersionAsHexStr;
     use serde::{Deserialize, Serialize};
     use serde_with::serde_as;
     use starknet_gateway_types::reply::transaction::Transaction as GatewayTransaction;
@@ -446,7 +438,6 @@ pub mod reply {
         #[serde(rename = "transaction_hash")]
         #[serde_as(as = "RpcFelt")]
         pub hash: StarknetTransactionHash,
-        #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
         #[serde_as(as = "TransactionVersionAsHexStr")]
         pub version: TransactionVersion,
@@ -645,7 +636,6 @@ pub mod reply {
         #[serde(rename = "transaction_hash")]
         #[serde_as(as = "RpcFelt")]
         pub hash: StarknetTransactionHash,
-        #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
         #[serde_as(as = "Vec<RpcFelt>")]
         pub signature: Vec<TransactionSignatureElem>,
@@ -895,7 +885,7 @@ pub mod reply {
                     Transaction::Declare(DeclareTransaction::V1(DeclareTransactionV0V1 {
                         common: CommonDeclareInvokeTransactionProperties {
                             hash: StarknetTransactionHash(felt!("0x4")),
-                            max_fee: Fee(ethers::types::H128::from_low_u64_be(0x5)),
+                            max_fee: Fee(felt!("0x5")),
                             signature: vec![TransactionSignatureElem(felt!("0x7"))],
                             nonce: TransactionNonce(felt!("0x8")),
                         },
@@ -905,7 +895,7 @@ pub mod reply {
                     Transaction::Declare(DeclareTransaction::V2(DeclareTransactionV2 {
                         common: CommonDeclareInvokeTransactionProperties {
                             hash: StarknetTransactionHash(felt!("0x44")),
-                            max_fee: Fee(ethers::types::H128::from_low_u64_be(0x55)),
+                            max_fee: Fee(felt!("0x55")),
                             signature: vec![TransactionSignatureElem(felt!("0x77"))],
                             nonce: TransactionNonce(felt!("0x88")),
                         },
@@ -916,7 +906,7 @@ pub mod reply {
                     Transaction::Invoke(InvokeTransaction::V0(InvokeTransactionV0 {
                         common: CommonDeclareInvokeTransactionProperties {
                             hash: StarknetTransactionHash(felt!("0xb")),
-                            max_fee: Fee(ethers::types::H128::from_low_u64_be(0x999)),
+                            max_fee: Fee(felt!("0x999")),
                             signature: vec![TransactionSignatureElem(felt!("0x777"))],
                             nonce: TransactionNonce(felt!("0xdd")),
                         },
@@ -927,7 +917,7 @@ pub mod reply {
                     Transaction::Invoke(InvokeTransaction::V1(InvokeTransactionV1 {
                         common: CommonDeclareInvokeTransactionProperties {
                             hash: StarknetTransactionHash(felt!("0xbbb")),
-                            max_fee: Fee(ethers::types::H128::from_low_u64_be(0x9999)),
+                            max_fee: Fee(felt!("0x9999")),
                             signature: vec![TransactionSignatureElem(felt!("0xeee"))],
                             nonce: TransactionNonce(felt!("0xde")),
                         },

--- a/crates/rpc/src/v03/method/estimate_fee.rs
+++ b/crates/rpc/src/v03/method/estimate_fee.rs
@@ -143,7 +143,7 @@ mod tests {
             BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V0(
                 crate::v02::types::request::BroadcastedInvokeTransactionV0 {
                     version: TransactionVersion::ZERO_WITH_QUERY_VERSION,
-                    max_fee: Fee(ethers::types::H128::from_low_u64_be(0x6)),
+                    max_fee: Fee(felt!("0x6")),
                     signature: vec![TransactionSignatureElem(felt!("0x7"))],
                     nonce: Some(TransactionNonce(felt!("0x8"))),
                     contract_address: ContractAddress::new_or_panic(felt!("0xaaa")),

--- a/crates/serde/src/lib.rs
+++ b/crates/serde/src/lib.rs
@@ -1,9 +1,9 @@
 //! Utilities used for serializing/deserializing sequencer REST API related data.
 
-use ethers::types::{H128, H160, H256};
+use ethers::types::{H160, H256};
 use num_bigint::BigUint;
 use pathfinder_common::{
-    CallParam, ConstructorParam, EthereumAddress, EventData, EventKey, Fee, GasPrice,
+    CallParam, ConstructorParam, EthereumAddress, EventData, EventKey, GasPrice,
     L1ToL2MessagePayloadElem, L2ToL1MessagePayloadElem, StarknetBlockNumber,
     TransactionSignatureElem, TransactionVersion,
 };
@@ -143,48 +143,6 @@ impl<'de> DeserializeAs<'de, H256> for H256AsNoLeadingZerosHexStr {
         }
 
         deserializer.deserialize_str(H256Visitor)
-    }
-}
-
-pub struct FeeAsHexStr;
-
-impl SerializeAs<Fee> for FeeAsHexStr {
-    fn serialize_as<S>(source: &Fee, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        // Fee is "0x" + 32 digits at most
-        let mut buf = [0u8; 2 + 32];
-        let s = bytes_as_hex_str(source.0.as_bytes(), &mut buf);
-        serializer.serialize_str(s)
-    }
-}
-
-impl<'de> DeserializeAs<'de, Fee> for FeeAsHexStr {
-    fn deserialize_as<D>(deserializer: D) -> Result<Fee, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        struct FeeVisitor;
-
-        impl<'de> Visitor<'de> for FeeVisitor {
-            type Value = Fee;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                formatter.write_str("a hex string of up to 32 digits with an optional '0x' prefix")
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                bytes_from_hex_str::<{ H128::len_bytes() }>(v)
-                    .map_err(serde::de::Error::custom)
-                    .map(|b| Fee(H128::from(b)))
-            }
-        }
-
-        deserializer.deserialize_str(FeeVisitor)
     }
 }
 

--- a/crates/storage/src/schema/revision_0007.rs
+++ b/crates/storage/src/schema/revision_0007.rs
@@ -13,9 +13,8 @@ mod transaction {
     };
     use pathfinder_serde::{
         CallParamAsDecimalStr, ConstructorParamAsDecimalStr, EthereumAddressAsHexStr,
-        EventDataAsDecimalStr, EventKeyAsDecimalStr, FeeAsHexStr,
-        L1ToL2MessagePayloadElemAsDecimalStr, L2ToL1MessagePayloadElemAsDecimalStr,
-        TransactionSignatureElemAsDecimalStr,
+        EventDataAsDecimalStr, EventKeyAsDecimalStr, L1ToL2MessagePayloadElemAsDecimalStr,
+        L2ToL1MessagePayloadElemAsDecimalStr, TransactionSignatureElemAsDecimalStr,
     };
     use serde::{Deserialize, Serialize};
     use serde_with::serde_as;
@@ -146,7 +145,6 @@ mod transaction {
         pub entry_point_type: Option<EntryPointType>,
         #[serde(default)]
         pub entry_point_selector: Option<EntryPoint>,
-        #[serde_as(as = "Option<FeeAsHexStr>")]
         #[serde(default)]
         pub max_fee: Option<Fee>,
         #[serde_as(as = "Option<Vec<TransactionSignatureElemAsDecimalStr>>")]

--- a/crates/storage/src/schema/revision_0020.rs
+++ b/crates/storage/src/schema/revision_0020.rs
@@ -275,9 +275,9 @@ mod types {
     };
     use pathfinder_serde::{
         CallParamAsDecimalStr, ConstructorParamAsDecimalStr, EthereumAddressAsHexStr,
-        EventDataAsDecimalStr, EventKeyAsDecimalStr, FeeAsHexStr,
-        L1ToL2MessagePayloadElemAsDecimalStr, L2ToL1MessagePayloadElemAsDecimalStr,
-        TransactionSignatureElemAsDecimalStr, TransactionVersionAsHexStr,
+        EventDataAsDecimalStr, EventKeyAsDecimalStr, L1ToL2MessagePayloadElemAsDecimalStr,
+        L2ToL1MessagePayloadElemAsDecimalStr, TransactionSignatureElemAsDecimalStr,
+        TransactionVersionAsHexStr,
     };
     use serde::{Deserialize, Serialize};
     use serde_with::serde_as;
@@ -287,7 +287,6 @@ mod types {
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
     #[serde(deny_unknown_fields)]
     pub struct Receipt {
-        #[serde_as(as = "Option<FeeAsHexStr>")]
         #[serde(default)]
         pub actual_fee: Option<Fee>,
         pub events: Vec<Event>,
@@ -410,7 +409,6 @@ mod types {
     #[serde(deny_unknown_fields)]
     pub struct DeclareTransaction {
         pub class_hash: ClassHash,
-        #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
         pub nonce: TransactionNonce,
         pub sender_address: ContractAddress,
@@ -505,7 +503,6 @@ mod types {
         pub contract_address: ContractAddress,
         pub entry_point_selector: EntryPoint,
         pub entry_point_type: EntryPointType,
-        #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
         #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
         pub signature: Vec<TransactionSignatureElem>,
@@ -520,7 +517,6 @@ mod types {
         #[serde_as(as = "Vec<CallParamAsDecimalStr>")]
         pub calldata: Vec<CallParam>,
         pub contract_address: ContractAddress,
-        #[serde_as(as = "FeeAsHexStr")]
         pub max_fee: Fee,
         #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
         pub signature: Vec<TransactionSignatureElem>,

--- a/crates/storage/src/state.rs
+++ b/crates/storage/src/state.rs
@@ -2310,7 +2310,6 @@ mod tests {
         use super::*;
         use crate::test_utils;
         use assert_matches::assert_matches;
-        use ethers::types::H128;
         use pathfinder_common::felt;
         use pathfinder_common::{EntryPoint, EventData, Fee};
 
@@ -2426,7 +2425,7 @@ mod tests {
                         sender_address: ContractAddress::new_or_panic(Felt::ZERO),
                         entry_point_type: Some(transaction::EntryPointType::External),
                         entry_point_selector: EntryPoint(Felt::ZERO),
-                        max_fee: Fee(H128::zero()),
+                        max_fee: Fee::ZERO,
                         signature: vec![],
                         transaction_hash: StarknetTransactionHash(felt!("0xF")),
                     },
@@ -2438,7 +2437,7 @@ mod tests {
                         sender_address: ContractAddress::new_or_panic(Felt::ZERO),
                         entry_point_type: Some(transaction::EntryPointType::External),
                         entry_point_selector: EntryPoint(Felt::ZERO),
-                        max_fee: Fee(H128::zero()),
+                        max_fee: Fee::ZERO,
                         signature: vec![],
                         transaction_hash: StarknetTransactionHash(felt!("0x1")),
                     },

--- a/crates/storage/src/test_utils.rs
+++ b/crates/storage/src/test_utils.rs
@@ -1,7 +1,6 @@
 use super::{
     StarknetBlock, StarknetBlocksTable, StarknetEmittedEvent, StarknetTransactionsTable, Storage,
 };
-use ethers::types::H128;
 use pathfinder_common::{
     felt, CallParam, ClassCommitment, ClassHash, ConstructorParam, ContractAddress,
     ContractAddressSalt, EntryPoint, EventCommitment, EventData, EventKey, Fee, GasPrice,
@@ -70,7 +69,7 @@ pub(crate) fn create_transactions_and_receipts(
                 } else {
                     EntryPointType::L1Handler
                 }),
-                max_fee: Fee(H128::zero()),
+                max_fee: Fee::ZERO,
                 signature: vec![TransactionSignatureElem(
                     Felt::from_hex_str(&"3".repeat(i + 3)).unwrap(),
                 )],
@@ -102,7 +101,7 @@ pub(crate) fn create_transactions_and_receipts(
         }
         _ => transaction::Transaction::Declare(DeclareTransaction::V0(DeclareTransactionV0V1 {
             class_hash: ClassHash(Felt::from_hex_str(&"a".repeat(i + 3)).unwrap()),
-            max_fee: Fee(H128::zero()),
+            max_fee: Fee::ZERO,
             nonce: TransactionNonce(Felt::from_hex_str(&"b".repeat(i + 3)).unwrap()),
             sender_address: ContractAddress::new_or_panic(
                 Felt::from_hex_str(&"c".repeat(i + 3)).unwrap(),


### PR DESCRIPTION
This PR changes the `Fee` inner type from `H128` to `Felt`. The primary reason is to deal with #989 - the RPC specification defines `Fee` as a felt, and our deserialization restricted `Fee` to be `< 32 hex characters` - this meant it rejected `0x000000...0000000000001` for example. Which is valid and technically even more correct since the spec actually says to use 64 digits.

`H128` stems from the gateway (and cairo-lang) restriction of `max_fee = 2^128`, however considering `Felt` allows for this (and some more), we can let the cairo-lang / gateway deal with this rejection.

A side-effect of this PR is to also prettify the test constants used for `Fee`, and we also got rid of an extra `FeeAsHexStr` cast.

Please take a second to think whether this `H128 -> Felt` has any further impact beyond the cosmetic - I don't think it does?

Fixes #989.