### PR TITLE
feat: pathfinder_getTransactionStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - support `starknet_estimateFee` in the JSON-RPC v0.3 API
   - supports estimating multiple transactions
   - this includes declaring and immediately using a class (not currently possible via the gateway)
+- support `pathfinder_getTransactionStatus` which is exposed on all RPC routes
+  - this enables querying a transactions current status, including whether the gateway has received or rejected it
 
 ### Fixed
 
 - RPC rejects Fee values with more than 32 digits
+- RPC does not expose `pathfinder_getProof` on v0.2 and v0.3 routes
 
 ## [0.5.1] - 2023-23-23
 

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -168,6 +168,8 @@ pub struct Transaction {
     pub transaction: Option<transaction::Transaction>,
     #[serde(default)]
     pub transaction_index: Option<u64>,
+    #[serde(default)]
+    pub transaction_failure_reason: Option<transaction::Failure>,
 }
 
 /// Used to deserialize replies to StarkNet transaction status requests.
@@ -627,7 +629,6 @@ pub mod transaction {
     pub struct Failure {
         pub code: String,
         pub error_message: String,
-        pub tx_id: u64,
     }
 }
 

--- a/crates/rpc/src/pathfinder.rs
+++ b/crates/rpc/src/pathfinder.rs
@@ -9,7 +9,8 @@ pub fn register_methods(module: Module) -> anyhow::Result<Module> {
         .register_method_with_no_input("v0.1_pathfinder_version", |_| async {
             Result::<_, RpcError>::Ok(pathfinder_common::consts::VERGEN_GIT_SEMVER_LIGHTWEIGHT)
         })?
-        .register_method("v0.1_pathfinder_getProof", methods::get_proof)?;
+        .register_method("v0.1_pathfinder_getProof", methods::get_proof)?
+        .register_method("v0.1_pathfinder_getTransactionStatus", methods::get_transaction_status)?;
 
     Ok(module)
 }

--- a/crates/rpc/src/pathfinder.rs
+++ b/crates/rpc/src/pathfinder.rs
@@ -9,7 +9,7 @@ pub fn register_methods(module: Module) -> anyhow::Result<Module> {
         .register_method_with_no_input("v0.1_pathfinder_version", |_| async {
             Result::<_, RpcError>::Ok(pathfinder_common::consts::VERGEN_GIT_SEMVER_LIGHTWEIGHT)
         })?
-        .register_method("v0.1_pathfinder_getProof", methods::get_proof::get_proof)?;
+        .register_method("v0.1_pathfinder_getProof", methods::get_proof)?;
 
     Ok(module)
 }

--- a/crates/rpc/src/pathfinder/methods.rs
+++ b/crates/rpc/src/pathfinder/methods.rs
@@ -1,3 +1,5 @@
+mod get_transaction_status;
 mod get_proof;
 
+pub(crate) use get_transaction_status::get_transaction_status;
 pub(crate) use get_proof::get_proof;

--- a/crates/rpc/src/pathfinder/methods.rs
+++ b/crates/rpc/src/pathfinder/methods.rs
@@ -1,1 +1,3 @@
-pub(crate) mod get_proof;
+mod get_proof;
+
+pub(crate) use get_proof::get_proof;

--- a/crates/rpc/src/pathfinder/methods/get_transaction_status.rs
+++ b/crates/rpc/src/pathfinder/methods/get_transaction_status.rs
@@ -1,0 +1,182 @@
+use anyhow::Context;
+use pathfinder_common::{StarknetBlockNumber, StarknetTransactionHash};
+use pathfinder_storage::Storage;
+use rusqlite::OptionalExtension;
+use starknet_gateway_types::pending::PendingData;
+
+use crate::context::RpcContext;
+use crate::v02::common::get_block_status;
+
+#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+pub struct GetGatewayTransactionInput {
+    transaction_hash: StarknetTransactionHash,
+}
+
+crate::error::generate_rpc_error_subset!(GetGatewayTransactionError:);
+
+pub async fn get_transaction_status(
+    context: RpcContext,
+    input: GetGatewayTransactionInput,
+) -> Result<GatewayStatus, GetGatewayTransactionError> {
+    // Check in pending block.
+    if let Some(pending) = &context.pending_data {
+        if is_pending_tx(pending, &input.transaction_hash).await {
+            return Ok(GatewayStatus::Pending);
+        }
+    }
+
+    // Check database.
+    let span = tracing::Span::current();
+
+    let db_status = tokio::task::spawn_blocking(move || {
+        let _g = span.enter();
+        check_database(&context.storage, &input.transaction_hash)
+    })
+    .await
+    .context("Database read panic or shutting down")?
+    .context("Checking database for transaction")?;
+    if let Some(status) = db_status {
+        return Ok(status);
+    }
+
+    // Check gateway for rejected transactions.
+    use starknet_gateway_client::ClientApi;
+    context
+        .sequencer
+        .transaction(input.transaction_hash)
+        .await
+        .context("Fetching transaction from gateway")
+        .map(|tx| tx.status.into())
+        .map_err(GetGatewayTransactionError::Internal)
+}
+
+async fn is_pending_tx(pending: &PendingData, tx_hash: &StarknetTransactionHash) -> bool {
+    pending
+        .block()
+        .await
+        .map(|block| block.transactions.iter().any(|tx| &tx.hash() == tx_hash))
+        .unwrap_or_default()
+}
+
+fn check_database(
+    storage: &Storage,
+    transaction_hash: &StarknetTransactionHash,
+) -> anyhow::Result<Option<GatewayStatus>> {
+    let mut db = storage
+        .connection()
+        .context("Opening database connection")?;
+
+    let db_tx = db.transaction().context("Creating database transaction")?;
+
+    // Get the transaction from storage.
+    let block_number = db_tx
+        .query_row(
+            r"SELECT starknet_blocks.number FROM starknet_transactions 
+    JOIN starknet_blocks ON starknet_transactions.block_hash = starknet_blocks.hash
+    WHERE starknet_transactions.hash = ?",
+            [transaction_hash],
+            |row| {
+                let number = row.get_ref_unwrap(0).as_i64()?;
+                Ok(StarknetBlockNumber::new_or_panic(number as u64))
+            },
+        )
+        .optional()
+        .context("Fetching transaction's block number from database")?;
+
+    let block_number = match block_number {
+        Some(block_number) => block_number,
+        None => return anyhow::Ok(None),
+    };
+
+    let status =
+        get_block_status(&db_tx, block_number).context("Fetching block status from database")?;
+    use crate::v02::types::reply::BlockStatus;
+    let status = match status {
+        BlockStatus::Pending => GatewayStatus::Pending,
+        BlockStatus::AcceptedOnL2 => GatewayStatus::AcceptedOnL2,
+        BlockStatus::AcceptedOnL1 => GatewayStatus::AcceptedOnL1,
+        BlockStatus::Rejected => GatewayStatus::Rejected,
+    };
+
+    Ok(Some(status))
+}
+
+
+/// A local definition of the [gateway's status type](starknet_gateway_types::reply::Status) to decouple this from the official gateway types.
+#[derive(Copy, Clone, Debug, serde::Serialize, PartialEq)]
+pub enum GatewayStatus {
+    #[serde(rename = "NOT_RECEIVED")]
+    NotReceived,
+    #[serde(rename = "RECEIVED")]
+    Received,
+    #[serde(rename = "PENDING")]
+    Pending,
+    #[serde(rename = "REJECTED")]
+    Rejected,
+    #[serde(rename = "ACCEPTED_ON_L1")]
+    AcceptedOnL1,
+    #[serde(rename = "ACCEPTED_ON_L2")]
+    AcceptedOnL2,
+    #[serde(rename = "REVERTED")]
+    Reverted,
+    #[serde(rename = "ABORTED")]
+    Aborted,
+}
+
+impl From<starknet_gateway_types::reply::Status> for GatewayStatus {
+    fn from(value: starknet_gateway_types::reply::Status) -> Self {
+        use starknet_gateway_types::reply::Status;
+        match value {
+            Status::NotReceived => Self::NotReceived,
+            Status::Received => Self::Received,
+            Status::Pending => Self::Pending,
+            Status::Rejected => Self::Rejected,
+            Status::AcceptedOnL1 => Self::AcceptedOnL1,
+            Status::AcceptedOnL2 => Self::AcceptedOnL2,
+            Status::Reverted => Self::Reverted,
+            Status::Aborted => Self::Aborted,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pathfinder_common::{felt, felt_bytes};
+
+    use super::*;
+
+    #[test]
+    fn database() {
+        let context = RpcContext::for_tests();
+
+        let status = check_database(
+            &context.storage,
+            &StarknetTransactionHash(felt_bytes!(b"txn 0")),
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(status, GatewayStatus::AcceptedOnL2);
+    }
+
+    #[tokio::test]
+    async fn pending() {
+        let context = RpcContext::for_tests_with_pending().await;
+        let tx_hash = StarknetTransactionHash(felt_bytes!(b"pending tx hash 0"));
+        assert!(is_pending_tx(&context.pending_data.unwrap(), &tx_hash).await);
+    }
+
+    #[tokio::test]
+    async fn rejected() {
+        let input = GetGatewayTransactionInput {
+            transaction_hash: StarknetTransactionHash(felt!(
+                // Transaction hash known to be rejected by the testnet gateway.
+                "0x07c64b747bdb0831e7045925625bfa6309c422fded9527bacca91199a1c8d212"
+            )),
+        };
+        let context = RpcContext::for_tests();
+        let status = get_transaction_status(context, input).await.unwrap();
+
+        assert_eq!(status, GatewayStatus::Rejected);
+    }
+}

--- a/crates/rpc/src/v02.rs
+++ b/crates/rpc/src/v02.rs
@@ -1,6 +1,6 @@
 use crate::module::Module;
 
-mod common;
+pub mod common;
 pub mod method;
 pub mod types;
 
@@ -63,6 +63,10 @@ pub fn register_methods(module: Module) -> anyhow::Result<Module> {
         .register_method(
             "v0.2_pathfinder_getProof",
             crate::pathfinder::methods::get_proof,
+        )?
+        .register_method(
+            "v0.2_pathfinder_getTransactionStatus",
+            crate::pathfinder::methods::get_transaction_status,
         )?;
 
     Ok(module)

--- a/crates/rpc/src/v02.rs
+++ b/crates/rpc/src/v02.rs
@@ -59,6 +59,10 @@ pub fn register_methods(module: Module) -> anyhow::Result<Module> {
         .register_method(
             "v0.2_starknet_addDeployAccountTransaction",
             method::add_deploy_account_transaction,
+        )?
+        .register_method(
+            "v0.2_pathfinder_getProof",
+            crate::pathfinder::methods::get_proof,
         )?;
 
     Ok(module)

--- a/crates/rpc/src/v03.rs
+++ b/crates/rpc/src/v03.rs
@@ -75,6 +75,10 @@ pub fn register_methods(module: Module) -> anyhow::Result<Module> {
         .register_method(
             "v0.3_pathfinder_getProof",
             crate::pathfinder::methods::get_proof,
+        )?
+        .register_method(
+            "v0.3_pathfinder_getTransactionStatus",
+            crate::pathfinder::methods::get_transaction_status,
         )?;
 
     Ok(module)

--- a/crates/rpc/src/v03.rs
+++ b/crates/rpc/src/v03.rs
@@ -71,6 +71,10 @@ pub fn register_methods(module: Module) -> anyhow::Result<Module> {
         .register_method(
             "v0.3_starknet_simulateTransaction",
             method::simulate_transaction,
+        )?
+        .register_method(
+            "v0.3_pathfinder_getProof",
+            crate::pathfinder::methods::get_proof,
         )?;
 
     Ok(module)

--- a/doc/rpc/pathfinder_rpc_api.json
+++ b/doc/rpc/pathfinder_rpc_api.json
@@ -119,6 +119,28 @@
                     "$ref": "#/components/errors/PROOF_LIMIT_EXCEEDED"
                 }
             ]
+        },
+        {
+            "name": "pathfinder_getTransactionStatus",
+            "summary": "Returns the status of a transaction",
+            "description": "Returns a transaction's current status, including if it has been rejected by the sequencer.",
+            "params": [
+                {
+                    "name": "transaction_hash",
+                    "summary": "The hash of the requested transaction",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/components/schemas/TXN_HASH"
+                    }
+                }
+            ],
+            "result": {
+                "name": "result",
+                "description": "The status of the transaction.",
+                "schema": {
+                    "$ref": "#/components/schemas/TX_GATEWAY_STATUS"
+                }
+            }
         }
     ],
     "components": {
@@ -160,8 +182,8 @@
                 "type": "string",
                 "title": "Field element",
                 "$comment": "A field element, represented as a string of hex digits",
-                "description": "A field element represented as a string of hex digits with a 0x prefix",
-                "pattern": "^0x0[a-fA-F0-9]{1,63}$"
+                "description": "A field element represented as a string of hex digits with a 0x prefix and up-to 63 hex digits",
+                "pattern": "^0x(0|[a-fA-F1-9]{1}[a-fA-F0-9]{0,62})$"
             },
             "BLOCK_NUMBER": {
                 "description": "The block's number (its height)",
@@ -254,6 +276,25 @@
                 "required": [
                     "edge"
                 ]
+            },
+            "TXN_HASH": {
+                "$ref": "#/components/schemas/FELT",
+                "description": "The transaction hash, as assigned in StarkNet",
+                "title": "A transaction's hash"
+            },
+            "TX_GATEWAY_STATUS": {
+                "type": "string",
+                "enum": [
+                    "NOT_RECEIVED",
+                    "RECEIVED",
+                    "PENDING",
+                    "REJECTED",
+                    "ACCEPTED_ON_L1",
+                    "ACCEPTED_ON_L2",
+                    "REVERTED",
+                    "ABORTED"
+                ],
+                "description": "The status of a transaction"
             }
         },
         "errors": {


### PR DESCRIPTION
This PR adds an endpoint for users to track a transactions status. Importantly, this includes transactions that are rejected or only received by the gateway -- and therefore are not a part of any blocks pathfinder is traditionally aware of.

To get the information about rejected or received-but-unprocessed transactions, pathfinder will reach out to the gateway.

Fixes #1000.