### PR TITLE
fix(pathfinder): `poll-pending` should default to false

### DIFF
--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -70,7 +70,7 @@ Examples:
         long = "poll-pending",
         long_help = "Enable polling pending block",
         action = clap::ArgAction::Set,
-        default_value = "true",
+        default_value = "false",
         env = "PATHFINDER_POLL_PENDING", 
     )]
     poll_pending: bool,


### PR DESCRIPTION
This was an accidental change introduced when moving to using clap derives for our command line argument parsing.