### PR TITLE
feat(py): upgrade cairo-lang to 0.11.0.2

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Pathfinder Python worker subprocess"
 readme = "README.md"
 dependencies = [
-    "cairo-lang == 0.11.0",
+    "cairo-lang == 0.11.0.2",
     "zstandard == 0.20.0",
     "cachetools == 5.3.0",
     # required so that pip-compile can properly resolve dependencies

--- a/py/requirements-dev.txt
+++ b/py/requirements-dev.txt
@@ -29,7 +29,7 @@ cachetools==5.3.0
     # via
     #   cairo-lang
     #   pathfinder-worker (pyproject.toml)
-cairo-lang==0.11.0
+cairo-lang==0.11.0.2
     # via pathfinder-worker (pyproject.toml)
 certifi==2022.12.7
     # via requests
@@ -87,7 +87,7 @@ fastecdsa==2.3.0
     # via cairo-lang
 flake8==5.0.4
     # via pathfinder-worker (pyproject.toml)
-frozendict==2.3.5
+frozendict==2.3.7
     # via cairo-lang
 frozenlist==1.3.3
     # via
@@ -153,11 +153,11 @@ parsimonious==0.8.1
     # via eth-abi
 pathspec==0.11.1
     # via black
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via pathfinder-worker (pyproject.toml)
-pipdeptree==2.6.0
+pipdeptree==2.7.0
     # via cairo-lang
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via black
 pluggy==1.0.0
     # via pytest

--- a/py/src/pathfinder_worker/call.py
+++ b/py/src/pathfinder_worker/call.py
@@ -113,7 +113,7 @@ except ModuleNotFoundError:
 
 # used from tests, and the query which asserts that the schema is of expected version.
 EXPECTED_SCHEMA_REVISION = 30
-EXPECTED_CAIRO_VERSION = "0.11.0"
+EXPECTED_CAIRO_VERSION = "0.11.0.2"
 
 # used by the sqlite adapter to communicate "contract state not found, nor was the patricia tree key"
 NOT_FOUND_CONTRACT_STATE = b'{"contract_hash": "0000000000000000000000000000000000000000000000000000000000000000", "nonce": "0x0", "storage_commitment_tree": {"height": 251, "root": "0000000000000000000000000000000000000000000000000000000000000000"}}'
@@ -231,7 +231,7 @@ class Call(Command):
     verb: ClassVar[Verb] = Verb.CALL
 
     contract_address: int = field(metadata=fields.contract_address_metadata)
-    calldata: List[int] = field(metadata=fields.calldata_as_hex_metadata)
+    calldata: List[int] = field(metadata=fields.call_data_as_hex_metadata)
     entry_point_selector: Optional[int] = field(
         default=None, metadata=fields.optional_entry_point_selector_metadata
     )

--- a/py/tests/pathfinder_worker/test_call.py
+++ b/py/tests/pathfinder_worker/test_call.py
@@ -2156,8 +2156,8 @@ def test_simulate_transaction_succeeds():
                 "contract_address_salt": "0x46c0d4abf0192a788aca261e58d7031576f7d8ea5229f452b0f23e691dd5971",
                 "max_fee": "0x0",
                 "signature": [
-                    "0x296ab4b0b7cb0c6929c4fb1e04b782511dffb049f72a90efe5d53f0515eab88",
-                    "0x4e80d8bb98a9baf47f6f0459c2329a5401538576e76436acaf5f56c573c7d77"
+                    "1170834978714321566077679750967140861184150362209174632516285135242242468744",
+                    "2219253403036539770789681704965496671569485440675085228837892314921869016439"
                 ],
                 "class_hash": "0xaf5f6ee1c2ad961f0b1cd3fa4285cefad65a418dd105719faa5d47583eb0a8",
                 "nonce": "0x0",
@@ -2220,8 +2220,8 @@ def test_simulate_transaction_succeeds():
                 }
             },
             "signature": [
-                "0x296ab4b0b7cb0c6929c4fb1e04b782511dffb049f72a90efe5d53f0515eab88",
-                "0x4e80d8bb98a9baf47f6f0459c2329a5401538576e76436acaf5f56c573c7d77"
+                "1170834978714321566077679750967140861184150362209174632516285135242242468744",
+                "2219253403036539770789681704965496671569485440675085228837892314921869016439"
             ]
         },
         "fee_estimation": {


### PR DESCRIPTION
Unfortunately there were a few API changes in this release, so some follow-up changes were necessary in our Python code and tests.