### PR TITLE
remove recorder guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
   
       # We want to strip the debug info as some of these test binaries are 100MB+ and pathfinder_lib is 1GB+
       - name: Execute tests
-        run: timeout 25m cargo test --all-targets --workspace --locked --profile stripdebuginfo --exclude pathfinder-ethereum
+        run: timeout 25m cargo test --all-targets --workspace --features test-utils --locked --profile stripdebuginfo --exclude pathfinder-ethereum
 
   clippy:
     runs-on: ubuntu-latest
@@ -143,7 +143,7 @@ jobs:
       - name: Install protoc
         run: |
           sudo apt-get install -y protobuf-compiler
-      - run: cargo clippy --workspace --all-targets --locked -- -D warnings -D rust_2018_idioms
+      - run: cargo clippy --workspace --all-targets --features test-utils --locked -- -D warnings -D rust_2018_idioms
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,8 +129,11 @@ jobs:
           pip install --no-index --force-reinstall ./stark_hash_rust-*.whl
   
       # We want to strip the debug info as some of these test binaries are 100MB+ and pathfinder_lib is 1GB+
+      # Integration tests have to be called explicitly
       - name: Execute tests
-        run: timeout 25m cargo test --all-targets --workspace --features test-utils --locked --profile stripdebuginfo --exclude pathfinder-ethereum
+        run: |
+          timeout 25m cargo test --all-targets --workspace --locked --profile stripdebuginfo --exclude pathfinder-ethereum
+          timeout 3m cargo test --test integration* --features test-utils --locked --profile stripdebuginfo
 
   clippy:
     runs-on: ubuntu-latest
@@ -143,7 +146,7 @@ jobs:
       - name: Install protoc
         run: |
           sudo apt-get install -y protobuf-compiler
-      - run: cargo clippy --workspace --all-targets --features test-utils --locked -- -D warnings -D rust_2018_idioms
+      - run: cargo clippy --workspace --all-targets --locked -- -D warnings -D rust_2018_idioms
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/crates/gateway-client/Cargo.toml
+++ b/crates/gateway-client/Cargo.toml
@@ -7,13 +7,14 @@ rust-version = "1.62"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-test-utils = ["dep:mockall"]
+test-utils = ["dep:http", "dep:mockall", "dep:serde_json", "dep:tokio", "dep:warp"]
 
 [dependencies]
 anyhow = { workspace = true }
 async-trait = "0.1.59"
 bytes = "1.3.0"
 futures = { version = "0.3", default-features = false, features = ["std"] }
+http = { version = "0.2.8", optional = true }
 metrics = "0.20.1"
 mockall = { version = "0.11.3", optional = true }
 pathfinder-common = { path = "../common" }
@@ -21,24 +22,23 @@ pathfinder-retry = { path = "../retry" }
 pathfinder-serde = { path = "../serde" }
 reqwest = { version = "0.11.13", features = ["json"] }
 serde = { version = "1.0.149", features = ["derive"] }
+serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"], optional = true }
 starknet-gateway-types = { path = "../gateway-types" }
+tokio = { workspace = true, features = ["macros", "test-util"], optional = true }
 tracing = "0.1.37"
+warp = { version = "0.3.3", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
 base64 = "0.13.1"
 flate2 = "1.0.25"
-http = "0.2.8"
 lazy_static = "1.4.0"
 pathfinder-common = { path = "../common", features = ["test-utils"] }
 pathfinder-serde = { path = "../serde" }
 pretty_assertions = "1.3.0"
 reqwest = { version = "0.11.13", features = ["json"] }
-serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
 stark_hash = { path = "../stark_hash" }
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
-tokio = { workspace = true, features = ["macros", "test-util"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
-warp = "0.3.3"
 zstd = "0.12"

--- a/crates/gateway-client/Cargo.toml
+++ b/crates/gateway-client/Cargo.toml
@@ -32,13 +32,23 @@ warp = { version = "0.3.3", optional = true }
 assert_matches = "1.5.0"
 base64 = "0.13.1"
 flate2 = "1.0.25"
+http = { version = "0.2.8" }
 lazy_static = "1.4.0"
+mockall = { version = "0.11.3" }
 pathfinder-common = { path = "../common", features = ["test-utils"] }
 pathfinder-serde = { path = "../serde" }
 pretty_assertions = "1.3.0"
 reqwest = { version = "0.11.13", features = ["json"] }
+serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
 stark_hash = { path = "../stark_hash" }
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
+tokio = { workspace = true, features = ["macros", "test-util"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+warp = { version = "0.3.3" }
 zstd = "0.12"
+
+[[test]]
+name = "integration-metrics"
+path = "tests/metrics.rs"
+required-features = ["test-utils"]

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -591,15 +591,11 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn client_user_agent() {
-        use pathfinder_common::{
-            consts::VERGEN_GIT_SEMVER_LIGHTWEIGHT, test_utils::metrics::RecorderGuard,
-            StarknetBlockTimestamp,
-        };
+        use pathfinder_common::{consts::VERGEN_GIT_SEMVER_LIGHTWEIGHT, StarknetBlockTimestamp};
         use starknet_gateway_types::reply::{Block, Status};
         use std::convert::Infallible;
         use warp::Filter;
 
-        let _guard = RecorderGuard::lock_as_noop();
         let filter = warp::header::optional("user-agent").and_then(
             |user_agent: Option<String>| async move {
                 let user_agent = user_agent.expect("user-agent set");
@@ -642,11 +638,10 @@ mod tests {
 
     mod block_matches_by_hash_on {
         use super::*;
-        use pathfinder_common::{felt, test_utils::metrics::RecorderGuard};
+        use pathfinder_common::felt;
 
         #[tokio::test]
         async fn genesis() {
-            let _guard = RecorderGuard::lock_as_noop();
             let (_jh, client) = setup([
                 (
                     format!("/feeder_gateway/get_block?blockHash={GENESIS_BLOCK_HASH}"),
@@ -670,7 +665,6 @@ mod tests {
 
         #[tokio::test]
         async fn specific_block() {
-            let _guard = RecorderGuard::lock_as_noop();
             let (_jh, client) = setup([
                 (
                     "/feeder_gateway/get_block?blockHash=0x40ffdbd9abbc4fc64652c50db94a29bce65c183316f304a95df624de708e746",
@@ -700,12 +694,11 @@ mod tests {
 
     mod block {
         use super::*;
-        use pathfinder_common::{test_utils::metrics::RecorderGuard, BlockId};
+        use pathfinder_common::BlockId;
         use pretty_assertions::assert_eq;
 
         #[tokio::test]
         async fn latest() {
-            let _guard = RecorderGuard::lock_as_noop();
             let (_jh, client) = setup([(
                 "/feeder_gateway/get_block?blockNumber=latest",
                 (v0_9_0::block::NUMBER_231579, 200),
@@ -715,7 +708,6 @@ mod tests {
 
         #[tokio::test]
         async fn pending() {
-            let _guard = RecorderGuard::lock_as_noop();
             let (_jh, client) = setup([(
                 "/feeder_gateway/get_block?blockNumber=pending",
                 (v0_9_0::block::PENDING, 200),
@@ -725,7 +717,6 @@ mod tests {
 
         #[test_log::test(tokio::test)]
         async fn invalid_hash() {
-            let _guard = RecorderGuard::lock_as_noop();
             let (_jh, client) = setup([(
                 format!("/feeder_gateway/get_block?blockHash={INVALID_BLOCK_HASH}"),
                 response_from(StarknetErrorCode::BlockNotFound),
@@ -742,7 +733,6 @@ mod tests {
 
         #[test_log::test(tokio::test)]
         async fn invalid_number() {
-            let _guard = RecorderGuard::lock_as_noop();
             let (_jh, client) = setup([(
                 format!("/feeder_gateway/get_block?blockNumber={INVALID_BLOCK_NUMBER}"),
                 response_from(StarknetErrorCode::BlockNotFound),
@@ -759,7 +749,6 @@ mod tests {
 
         #[tokio::test]
         async fn with_starknet_version_added_in_0_9_1() {
-            let _guard = RecorderGuard::lock_as_noop();
             use starknet_gateway_types::reply::MaybePendingBlock;
             let (_jh, client) = setup([
                 (
@@ -1075,9 +1064,7 @@ mod tests {
             reply::state_update::{DeployedContract, StorageDiff},
             *,
         };
-        use pathfinder_common::{
-            felt, test_utils::metrics::RecorderGuard, ContractAddress, StateCommitment,
-        };
+        use pathfinder_common::{felt, ContractAddress, StateCommitment};
         use pretty_assertions::assert_eq;
         use starknet_gateway_types::reply::MaybePendingStateUpdate;
         use std::collections::{BTreeSet, HashMap};
@@ -1124,7 +1111,6 @@ mod tests {
 
         #[tokio::test]
         async fn genesis() {
-            let _guard = RecorderGuard::lock_as_noop();
             let (_jh, client) = setup([
                 (
                     "/feeder_gateway/get_state_update?blockNumber=0".to_string(),
@@ -1151,7 +1137,6 @@ mod tests {
 
         #[tokio::test]
         async fn specific_block() {
-            let _guard = RecorderGuard::lock_as_noop();
             let (_jh, client) = setup([
                 (
                     "/feeder_gateway/get_state_update?blockNumber=315700",
@@ -1184,11 +1169,9 @@ mod tests {
 
     mod state_update {
         use super::*;
-        use pathfinder_common::test_utils::metrics::RecorderGuard;
 
         #[test_log::test(tokio::test)]
         async fn invalid_number() {
-            let _guard = RecorderGuard::lock_as_noop();
             let (_jh, client) = setup([(
                 format!("/feeder_gateway/get_state_update?blockNumber={INVALID_BLOCK_NUMBER}"),
                 response_from(StarknetErrorCode::BlockNotFound),
@@ -1205,7 +1188,6 @@ mod tests {
 
         #[tokio::test]
         async fn invalid_hash() {
-            let _guard = RecorderGuard::lock_as_noop();
             let (_jh, client) = setup([(
                 format!("/feeder_gateway/get_state_update?blockHash={INVALID_BLOCK_HASH}"),
                 response_from(StarknetErrorCode::BlockNotFound),
@@ -1222,7 +1204,6 @@ mod tests {
 
         #[tokio::test]
         async fn latest() {
-            let _guard = RecorderGuard::lock_as_noop();
             let (_jh, client) = setup([(
                 "/feeder_gateway/get_state_update?blockNumber=latest",
                 (v0_11_0::state_update::NUMBER_315700, 200),
@@ -1232,7 +1213,6 @@ mod tests {
 
         #[tokio::test]
         async fn pending() {
-            let _guard = RecorderGuard::lock_as_noop();
             let (_jh, client) = setup([(
                 "/feeder_gateway/get_state_update?blockNumber=pending",
                 (v0_11_0::state_update::PENDING, 200),
@@ -1767,14 +1747,13 @@ mod tests {
         // Ensures the versions in the pathfinder_common::version_check! macro are kept in sync with reality.
         //
         // The tests are kept here to prevent crate dependency cycles while keeping the macro widely available.
-        use pathfinder_common::{test_utils::metrics::RecorderGuard, version_check};
+        use pathfinder_common::version_check;
 
         use crate::{Client, ClientApi};
         use anyhow::Context;
         use pathfinder_common::BlockId;
 
         async fn get_latest_version(client: &Client) -> anyhow::Result<(u64, u64, u64)> {
-            let _guard = RecorderGuard::lock_as_noop();
             let version = client
                 .block(BlockId::Latest)
                 .await?

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -111,9 +111,9 @@ pub struct Client {
 }
 
 impl Client {
-    #[cfg(not(test))]
+    #[cfg(not(any(test, feature = "test-utils")))]
     const RETRY: builder::Retry = builder::Retry::Enabled;
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-utils"))]
     const RETRY: builder::Retry = builder::Retry::Disabled;
 
     /// Creates a new Sequencer client for the given chain.
@@ -408,16 +408,11 @@ impl ClientApi for Client {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use assert_matches::assert_matches;
-    use pathfinder_common::{Chain, StarknetBlockHash, StarknetBlockNumber};
-    use stark_hash::Felt;
-    use starknet_gateway_test_fixtures::{testnet::*, *};
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils {
+    use super::Client;
+    use pathfinder_common::Chain;
     use starknet_gateway_types::error::StarknetErrorCode;
-    use starknet_gateway_types::request::Tag;
-    use std::collections::VecDeque;
 
     /// Helper funtion which allows for easy creation of a response tuple
     /// that contains a [StarknetError] for a given [StarknetErrorCode].
@@ -426,7 +421,7 @@ mod tests {
     ///
     /// The `message` field is always an empty string.
     /// The HTTP status code for this response is always `500` (`Internal Server Error`).
-    fn response_from(code: StarknetErrorCode) -> (String, u16) {
+    pub fn response_from(code: StarknetErrorCode) -> (String, u16) {
         use starknet_gateway_types::error::StarknetError;
 
         let e = StarknetError {
@@ -449,7 +444,7 @@ mod tests {
     ///      url paths & queries and respective fixtures for replies
     ///    - creates a [sequencer::Client] instance which connects to the mock server
     ///
-    fn setup<S1, S2, const N: usize>(
+    pub fn setup<S1, S2, const N: usize>(
         url_paths_queries_and_response_fixtures: [(S1, (S2, u16)); N],
     ) -> (Option<tokio::task::JoinHandle<()>>, Client)
     where
@@ -522,12 +517,17 @@ mod tests {
     /// Panics if replies for a particular path & query have been exhausted and the
     /// client still attempts to query the very same path.
     ///
-    fn setup_with_varied_responses<const M: usize, const N: usize>(
+    pub fn setup_with_varied_responses<const M: usize, const N: usize>(
         url_paths_queries_and_response_fixtures: [(String, [(String, u16); M]); N],
     ) -> (Option<tokio::task::JoinHandle<()>>, Client) {
         let url_paths_queries_and_response_fixtures = url_paths_queries_and_response_fixtures
             .into_iter()
-            .map(|x| (x.0.clone(), x.1.into_iter().collect::<VecDeque<_>>()))
+            .map(|x| {
+                (
+                    x.0.clone(),
+                    x.1.into_iter().collect::<std::collections::VecDeque<_>>(),
+                )
+            })
             .collect::<Vec<_>>();
         use std::sync::{Arc, Mutex};
 
@@ -577,6 +577,17 @@ mod tests {
             Client::with_base_url(reqwest::Url::parse(&format!("http://{addr}")).unwrap()).unwrap();
         (Some(server_handle), client)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{test_utils::*, *};
+    use assert_matches::assert_matches;
+    use pathfinder_common::{StarknetBlockHash, StarknetBlockNumber};
+    use stark_hash::Felt;
+    use starknet_gateway_test_fixtures::{testnet::*, *};
+    use starknet_gateway_types::error::StarknetErrorCode;
+    use starknet_gateway_types::request::Tag;
 
     #[test_log::test(tokio::test)]
     async fn client_user_agent() {
@@ -1749,185 +1760,6 @@ mod tests {
         async fn invalid() {
             let (_server_handle, sequencer) = setup_server(TargetChain::Invalid);
             sequencer.chain().await.unwrap_err();
-        }
-    }
-
-    mod metrics {
-        use super::*;
-        use futures::stream::StreamExt;
-        use pathfinder_common::BlockId;
-        use pretty_assertions::assert_eq;
-        use std::future::Future;
-
-        #[tokio::test]
-        async fn all_counter_types_including_tags() {
-            use super::ClientApi;
-
-            with_method(
-                "get_block",
-                |client, x| async move {
-                    let _ = client.block(x).await;
-                },
-                (v0_9_0::block::GENESIS.to_owned(), 200),
-            )
-            .await;
-            with_method(
-                "get_state_update",
-                |client, x| async move {
-                    let _ = client.state_update(x).await;
-                },
-                (v0_11_0::state_update::GENESIS.to_owned(), 200),
-            )
-            .await;
-        }
-
-        async fn with_method<F, Fut, T>(method_name: &'static str, f: F, response: (String, u16))
-        where
-            F: Fn(Client, BlockId) -> Fut,
-            Fut: Future<Output = T>,
-        {
-            use pathfinder_common::test_utils::metrics::{FakeRecorder, RecorderGuard};
-
-            let recorder = FakeRecorder::new_for(&["get_block", "get_state_update"]);
-            let handle = recorder.handle();
-
-            let guard = RecorderGuard::lock(recorder);
-
-            let responses = [
-                // Any valid fixture
-                response,
-                // 1 StarkNet error
-                response_from(StarknetErrorCode::BlockNotFound),
-                // 2 decode errors
-                (r#"{"not":"valid"}"#.to_owned(), 200),
-                (r#"{"not":"valid, again"}"#.to_owned(), 200),
-                // 3 of rate limiting
-                ("you're being rate limited".to_owned(), 429),
-                ("".to_owned(), 429),
-                ("".to_owned(), 429),
-            ];
-
-            let (_jh, client) = setup_with_varied_responses([
-                (
-                    format!("/feeder_gateway/{method_name}?blockNumber=123"),
-                    responses.clone(),
-                ),
-                (
-                    format!("/feeder_gateway/{method_name}?blockNumber=latest"),
-                    responses.clone(),
-                ),
-                (
-                    format!("/feeder_gateway/{method_name}?blockNumber=pending"),
-                    responses,
-                ),
-            ]);
-            [BlockId::Number(StarknetBlockNumber::new_or_panic(123)); 7]
-                .into_iter()
-                .chain([BlockId::Latest; 7].into_iter())
-                .chain([BlockId::Pending; 7].into_iter())
-                .map(|x| f(client.clone(), x))
-                .collect::<futures::stream::FuturesUnordered<_>>()
-                .collect::<Vec<_>>()
-                .await;
-
-            // Drop the global recorder guard to avoid poisoning its internal lock if
-            // the following asserts fail which would fail other tests using the `RecorderGuard`
-            // at the same time.
-            //
-            // The recorder itself still exists since dropping the guard only unregisters the recorder
-            // and leaks it making the handle still valid past this point.
-            drop(guard);
-
-            // IMPORTANT
-            //
-            // We're not using any crate::sequencer::metrics consts here, because this is public API
-            // and we'd like to catch if/when it changed (apparently due to a bug)
-            [
-                ("gateway_requests_total", None, None, 21),
-                ("gateway_requests_total", Some("latest"), None, 7),
-                ("gateway_requests_total", Some("pending"), None, 7),
-                ("gateway_requests_failed_total", None, None, 18),
-                ("gateway_requests_failed_total", Some("latest"), None, 6),
-                ("gateway_requests_failed_total", Some("pending"), None, 6),
-                ("gateway_requests_failed_total", None, Some("starknet"), 3),
-                (
-                    "gateway_requests_failed_total",
-                    Some("latest"),
-                    Some("starknet"),
-                    1,
-                ),
-                (
-                    "gateway_requests_failed_total",
-                    Some("pending"),
-                    Some("starknet"),
-                    1,
-                ),
-                ("gateway_requests_failed_total", None, Some("decode"), 6),
-                (
-                    "gateway_requests_failed_total",
-                    Some("latest"),
-                    Some("decode"),
-                    2,
-                ),
-                (
-                    "gateway_requests_failed_total",
-                    Some("pending"),
-                    Some("decode"),
-                    2,
-                ),
-                (
-                    "gateway_requests_failed_total",
-                    None,
-                    Some("rate_limiting"),
-                    9,
-                ),
-                (
-                    "gateway_requests_failed_total",
-                    Some("latest"),
-                    Some("rate_limiting"),
-                    3,
-                ),
-                (
-                    "gateway_requests_failed_total",
-                    Some("pending"),
-                    Some("rate_limiting"),
-                    3,
-                ),
-            ]
-            .into_iter()
-            .for_each(|(counter_name, tag, failure_reason, expected_count)| {
-                match (tag, failure_reason) {
-                    (None, None) => assert_eq!(
-                        handle.get_counter_value(counter_name, method_name),
-                        expected_count,
-                        "counter: {counter_name}, method: {method_name}"
-                    ),
-                    (None, Some(reason)) => assert_eq!(
-                        handle.get_counter_value_by_label(
-                            counter_name,
-                            [("method", method_name), ("reason", reason)]
-                        ),
-                        expected_count,
-                        "counter: {counter_name}, method: {method_name}, reason: {reason}"
-                    ),
-                    (Some(tag), None) => assert_eq!(
-                        handle.get_counter_value_by_label(
-                            counter_name,
-                            [("method", method_name), ("tag", tag)]
-                        ),
-                        expected_count,
-                        "counter: {counter_name}, method: {method_name}, tag: {tag}"
-                    ),
-                    (Some(tag), Some(reason)) => assert_eq!(
-                        handle.get_counter_value_by_label(
-                            counter_name,
-                            [("method", method_name), ("tag", tag), ("reason", reason)]
-                        ),
-                        expected_count,
-                        "counter: {counter_name}, method: {method_name}, tag: {tag}, reason: {reason}"
-                    ),
-                }
-            });
         }
     }
 

--- a/crates/gateway-client/tests/metrics.rs
+++ b/crates/gateway-client/tests/metrics.rs
@@ -1,0 +1,183 @@
+//! This test was separated because the `metrics` crate uses a singleton recorder, so keeping a test
+//! that relies on metric values in a separate binary makes more sense than using an inter-test
+//! locking mechanism which can cause weird test failures without any obvious clue to what might
+//! have caused those failures in the first place.
+
+use futures::stream::StreamExt;
+use pathfinder_common::{BlockId, StarknetBlockNumber};
+use pretty_assertions::assert_eq;
+use starknet_gateway_client::test_utils::{response_from, setup_with_varied_responses};
+use starknet_gateway_client::{Client, ClientApi};
+use starknet_gateway_test_fixtures::{v0_11_0, v0_9_0};
+use starknet_gateway_types::error::StarknetErrorCode;
+use std::future::Future;
+
+#[tokio::test]
+async fn all_counter_types_including_tags() {
+    with_method(
+        "get_block",
+        |client, x| async move {
+            let _ = client.block(x).await;
+        },
+        (v0_9_0::block::GENESIS.to_owned(), 200),
+    )
+    .await;
+    with_method(
+        "get_state_update",
+        |client, x| async move {
+            let _ = client.state_update(x).await;
+        },
+        (v0_11_0::state_update::GENESIS.to_owned(), 200),
+    )
+    .await;
+}
+
+async fn with_method<F, Fut, T>(method_name: &'static str, f: F, response: (String, u16))
+where
+    F: Fn(Client, BlockId) -> Fut,
+    Fut: Future<Output = T>,
+{
+    use pathfinder_common::test_utils::metrics::{FakeRecorder, RecorderGuard};
+
+    let recorder = FakeRecorder::new_for(&["get_block", "get_state_update"]);
+    let handle = recorder.handle();
+
+    let guard = RecorderGuard::lock(recorder);
+
+    let responses = [
+        // Any valid fixture
+        response,
+        // 1 StarkNet error
+        response_from(StarknetErrorCode::BlockNotFound),
+        // 2 decode errors
+        (r#"{"not":"valid"}"#.to_owned(), 200),
+        (r#"{"not":"valid, again"}"#.to_owned(), 200),
+        // 3 of rate limiting
+        ("you're being rate limited".to_owned(), 429),
+        ("".to_owned(), 429),
+        ("".to_owned(), 429),
+    ];
+
+    let (_jh, client) = setup_with_varied_responses([
+        (
+            format!("/feeder_gateway/{method_name}?blockNumber=123"),
+            responses.clone(),
+        ),
+        (
+            format!("/feeder_gateway/{method_name}?blockNumber=latest"),
+            responses.clone(),
+        ),
+        (
+            format!("/feeder_gateway/{method_name}?blockNumber=pending"),
+            responses,
+        ),
+    ]);
+
+    [BlockId::Number(StarknetBlockNumber::new_or_panic(123)); 7]
+        .into_iter()
+        .chain([BlockId::Latest; 7].into_iter())
+        .chain([BlockId::Pending; 7].into_iter())
+        .map(|x| f(client.clone(), x))
+        .collect::<futures::stream::FuturesUnordered<_>>()
+        .collect::<Vec<_>>()
+        .await;
+
+    // Drop the global recorder guard to avoid poisoning its internal lock if
+    // the following asserts fail which would fail other tests using the `RecorderGuard`
+    // at the same time.
+    //
+    // The recorder itself still exists since dropping the guard only unregisters the recorder
+    // and leaks it making the handle still valid past this point.
+    drop(guard);
+
+    // IMPORTANT
+    //
+    // We're not using any crate::sequencer::metrics consts here, because this is public API
+    // and we'd like to catch if/when it changed (apparently due to a bug)
+    [
+        ("gateway_requests_total", None, None, 21),
+        ("gateway_requests_total", Some("latest"), None, 7),
+        ("gateway_requests_total", Some("pending"), None, 7),
+        ("gateway_requests_failed_total", None, None, 18),
+        ("gateway_requests_failed_total", Some("latest"), None, 6),
+        ("gateway_requests_failed_total", Some("pending"), None, 6),
+        ("gateway_requests_failed_total", None, Some("starknet"), 3),
+        (
+            "gateway_requests_failed_total",
+            Some("latest"),
+            Some("starknet"),
+            1,
+        ),
+        (
+            "gateway_requests_failed_total",
+            Some("pending"),
+            Some("starknet"),
+            1,
+        ),
+        ("gateway_requests_failed_total", None, Some("decode"), 6),
+        (
+            "gateway_requests_failed_total",
+            Some("latest"),
+            Some("decode"),
+            2,
+        ),
+        (
+            "gateway_requests_failed_total",
+            Some("pending"),
+            Some("decode"),
+            2,
+        ),
+        (
+            "gateway_requests_failed_total",
+            None,
+            Some("rate_limiting"),
+            9,
+        ),
+        (
+            "gateway_requests_failed_total",
+            Some("latest"),
+            Some("rate_limiting"),
+            3,
+        ),
+        (
+            "gateway_requests_failed_total",
+            Some("pending"),
+            Some("rate_limiting"),
+            3,
+        ),
+    ]
+    .into_iter()
+    .for_each(
+        |(counter_name, tag, failure_reason, expected_count)| match (tag, failure_reason) {
+            (None, None) => assert_eq!(
+                handle.get_counter_value(counter_name, method_name),
+                expected_count,
+                "counter: {counter_name}, method: {method_name}"
+            ),
+            (None, Some(reason)) => assert_eq!(
+                handle.get_counter_value_by_label(
+                    counter_name,
+                    [("method", method_name), ("reason", reason)]
+                ),
+                expected_count,
+                "counter: {counter_name}, method: {method_name}, reason: {reason}"
+            ),
+            (Some(tag), None) => assert_eq!(
+                handle.get_counter_value_by_label(
+                    counter_name,
+                    [("method", method_name), ("tag", tag)]
+                ),
+                expected_count,
+                "counter: {counter_name}, method: {method_name}, tag: {tag}"
+            ),
+            (Some(tag), Some(reason)) => assert_eq!(
+                handle.get_counter_value_by_label(
+                    counter_name,
+                    [("method", method_name), ("tag", tag), ("reason", reason)]
+                ),
+                expected_count,
+                "counter: {counter_name}, method: {method_name}, tag: {tag}, reason: {reason}"
+            ),
+        },
+    );
+}

--- a/crates/pathfinder/src/monitoring.rs
+++ b/crates/pathfinder/src/monitoring.rs
@@ -96,6 +96,8 @@ mod tests {
         // Other concurrent tests could be setting their own recorders
         let guard = RecorderGuard::lock(recorder);
 
+        // We don't care about the recorder being a singleton as the counter name here does not
+        // interfere with any other "real" counter registered in pathfinder or other tests
         let counter = metrics::register_counter!("x");
         counter.increment(123);
 

--- a/crates/pathfinder/src/monitoring.rs
+++ b/crates/pathfinder/src/monitoring.rs
@@ -89,12 +89,12 @@ mod tests {
 
     #[tokio::test]
     async fn metrics() {
-        use pathfinder_common::test_utils::metrics::RecorderGuard;
+        use pathfinder_common::test_utils::metrics::ScopedRecorderGuard;
 
         let recorder = PrometheusBuilder::new().build_recorder();
         let handle = recorder.handle();
-        // Other concurrent tests could be setting their own recorders
-        let guard = RecorderGuard::lock(recorder);
+        // Automatically deregister the recorder
+        let _guard = ScopedRecorderGuard::new(recorder);
 
         // We don't care about the recorder being a singleton as the counter name here does not
         // interfere with any other "real" counter registered in pathfinder or other tests
@@ -104,10 +104,6 @@ mod tests {
         let readiness = Arc::new(AtomicBool::new(false));
         let filter = super::routes(readiness.clone(), handle);
         let response = warp::test::request().path("/metrics").reply(&filter).await;
-
-        // Drop to avoid poisoning the internal lock if the following asserts fail
-        // which would fail other tests using the `RecorderGuard`.
-        drop(guard);
 
         assert_eq!(response.status(), http::StatusCode::OK);
         assert_eq!(response.body(), "# TYPE x counter\nx 123\n\n");

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -7,7 +7,7 @@ rust-version = "1.62"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-test-utils = ["dep:reqwest", "dep:starknet-gateway-test-fixtures"]
+test-utils = ["dep:reqwest", "dep:starknet-gateway-test-fixtures", "tokio/test-util"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -48,11 +48,18 @@ lazy_static = "1.4.0"
 pathfinder-common = { path = "../common", features = ["full-serde", "test-utils"] }
 pathfinder-storage = { path = "../storage", features = ["test-utils"] }
 pretty_assertions = "1.3.0"
+reqwest = { version = "0.11.13", features = ["json"] }
 rusqlite = { version = "0.28.0", features = ["bundled"] }
 serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
 stark_hash = { path = "../stark_hash" }
 starknet-gateway-client = { path = "../gateway-client", features = ["test-utils"] }
+starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 tempfile = "3.4"
 test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
 tokio = { workspace = true, features = ["test-util", "process"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+
+[[test]]
+name = "integration-versioning"
+path = "tests/versioning.rs"
+required-features = ["test-utils"]

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -6,6 +6,9 @@ license = "MIT OR Apache-2.0"
 rust-version = "1.62"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+test-utils = ["dep:reqwest", "dep:starknet-gateway-test-fixtures"]
+
 [dependencies]
 anyhow = { workspace = true }
 base64 = "0.13.1"
@@ -21,12 +24,14 @@ pathfinder-ethereum = { path = "../ethereum" }
 pathfinder-merkle-tree = { path = "../merkle-tree" }
 pathfinder-serde = { path = "../serde" }
 pathfinder-storage = { path = "../storage" }
+reqwest = { version = "0.11.13", features = ["json"], optional = true }
 rusqlite = { version = "0.28.0", features = ["bundled"] }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
 serde_with = "2.1.0"
 stark_hash = { path = "../stark_hash" }
 starknet-gateway-client = { path = "../gateway-client" }
+starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures", optional = true }
 starknet-gateway-types = { path = "../gateway-types" }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["process"] }
@@ -43,12 +48,10 @@ lazy_static = "1.4.0"
 pathfinder-common = { path = "../common", features = ["full-serde", "test-utils"] }
 pathfinder-storage = { path = "../storage", features = ["test-utils"] }
 pretty_assertions = "1.3.0"
-reqwest = { version = "0.11.13", features = ["json"] }
 rusqlite = { version = "0.28.0", features = ["bundled"] }
 serde_json = { version = "1.0.89", features = ["arbitrary_precision", "raw_value"] }
 stark_hash = { path = "../stark_hash" }
 starknet-gateway-client = { path = "../gateway-client", features = ["test-utils"] }
-starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 tempfile = "3.4"
 test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
 tokio = { workspace = true, features = ["test-util", "process"] }

--- a/crates/rpc/src/context.rs
+++ b/crates/rpc/src/context.rs
@@ -37,12 +37,12 @@ impl RpcContext {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-utils"))]
     pub fn for_tests() -> Self {
         Self::for_tests_on(pathfinder_common::Chain::Testnet)
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-utils"))]
     pub fn for_tests_on(chain: pathfinder_common::Chain) -> Self {
         assert_ne!(chain, Chain::Mainnet, "Testing on MainNet?");
 
@@ -55,13 +55,13 @@ impl RpcContext {
             Chain::Custom => unreachable!("Should not be testing with custom chain"),
         };
 
-        let storage = super::tests::setup_storage();
+        let storage = super::test_utils::setup_storage();
         let sync_state = Arc::new(SyncState::default());
         let sequencer = SequencerClient::new(chain).unwrap();
         Self::new(storage, sync_state, chain_id, sequencer)
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-utils"))]
     pub fn with_storage(self, storage: Storage) -> Self {
         Self { storage, ..self }
     }
@@ -73,12 +73,12 @@ impl RpcContext {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-utils"))]
     pub async fn for_tests_with_pending() -> Self {
         // This is a bit silly with the arc in and out, but since its for tests the ergonomics of
         // having Arc also constructed is nice.
         let context = Self::for_tests();
-        let pending_data = super::tests::create_pending_data(context.storage.clone()).await;
+        let pending_data = super::test_utils::create_pending_data(context.storage.clone()).await;
         context.with_pending_data(pending_data)
     }
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -7,11 +7,11 @@ pub mod gas_price;
 pub mod metrics;
 mod module;
 mod pathfinder;
-#[cfg(test)]
+#[cfg(any(test, feature = "test-utils"))]
 pub mod test_client;
 pub mod v02;
 pub mod v03;
-mod versioning;
+pub mod versioning;
 
 use crate::metrics::logger::{MaybeRpcMetricsLogger, RpcMetricsLogger};
 use crate::v02::types::syncing::Syncing;
@@ -109,8 +109,8 @@ impl Default for SyncState {
     }
 }
 
-#[cfg(test)]
-mod tests {
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils {
     use ethers::types::H256;
     use pathfinder_common::{
         felt, felt_bytes, ClassCommitment, ClassHash, ContractAddress, ContractAddressSalt,
@@ -136,16 +136,9 @@ mod tests {
             },
         },
     };
-    use std::{
-        net::{Ipv4Addr, SocketAddr, SocketAddrV4},
-        sync::Arc,
-    };
+    use std::sync::Arc;
 
-    lazy_static::lazy_static! {
-        pub static ref LOCALHOST: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0));
-    }
-
-    // Local test helper
+    // Creates storage for tests
     pub fn setup_storage() -> Storage {
         use pathfinder_common::{ContractNonce, StorageValue};
         use pathfinder_merkle_tree::contract_state::update_contract_state;
@@ -600,6 +593,10 @@ mod tests {
             .await;
         pending_data
     }
+}
+
+#[cfg(test)]
+mod tests {
 
     #[test]
     fn roundtrip_syncing() {

--- a/crates/rpc/src/test_client.rs
+++ b/crates/rpc/src/test_client.rs
@@ -60,7 +60,7 @@ impl Default for TestClientBuilder {
     fn default() -> Self {
         Self {
             request_timeout: Duration::from_secs(120),
-            address: *super::tests::LOCALHOST,
+            address: ([127, 0, 0, 1], 0).into(),
             endpoint: None,
         }
     }

--- a/crates/rpc/src/versioning.rs
+++ b/crates/rpc/src/versioning.rs
@@ -308,12 +308,11 @@ mod tests {
     #[tokio::test]
     async fn api_versions_dont_leak_between_each_other() {
         use crate::test_client::TestClientBuilder;
-        use crate::{RpcContext, RpcMetricsLogger, RpcServer};
+        use crate::{RpcContext, RpcServer};
         use serde_json::json;
 
         let context = RpcContext::for_tests();
         let (_server_handle, address) = RpcServer::new("127.0.0.1:0".parse().unwrap(), context)
-            .with_logger(RpcMetricsLogger)
             .run()
             .await
             .unwrap();

--- a/crates/rpc/src/versioning.rs
+++ b/crates/rpc/src/versioning.rs
@@ -9,7 +9,7 @@ use jsonrpsee::types::Id;
 use tower::BoxError;
 
 #[derive(thiserror::Error, Debug)]
-pub enum VersioningError {
+enum VersioningError {
     #[error("Invalid path")]
     InvalidPath,
     #[error("Too large: {0}")]
@@ -31,7 +31,7 @@ impl VersioningError {
     }
 }
 
-pub async fn prefix_rpc_method_names_with_version(
+pub(crate) async fn prefix_rpc_method_names_with_version(
     request: Request<Body>,
     max_request_body_size: u32,
 ) -> Result<Request<Body>, BoxError> {
@@ -101,7 +101,7 @@ pub async fn prefix_rpc_method_names_with_version(
     Ok(request)
 }
 
-pub fn try_map_errors_to_responses(
+pub(crate) fn try_map_errors_to_responses(
     result: Result<Response<Body>, BoxError>,
 ) -> Result<Response<Body>, BoxError> {
     match result {
@@ -175,133 +175,50 @@ mod response {
     }
 }
 
+pub mod test_utils {
+    pub mod method_names {
+        pub const COMMON_FOR_V02_V03: [&str; 23] = [
+            "starknet_addDeclareTransaction",
+            "starknet_addDeployAccountTransaction",
+            "starknet_addInvokeTransaction",
+            "starknet_blockHashAndNumber",
+            "starknet_blockNumber",
+            "starknet_call",
+            "starknet_chainId",
+            "starknet_estimateFee",
+            "starknet_getBlockWithTxHashes",
+            "starknet_getBlockWithTxs",
+            "starknet_getBlockTransactionCount",
+            "starknet_getClass",
+            "starknet_getClassAt",
+            "starknet_getClassHashAt",
+            "starknet_getEvents",
+            "starknet_getNonce",
+            "starknet_getStateUpdate",
+            "starknet_getStorageAt",
+            "starknet_getTransactionByBlockIdAndIndex",
+            "starknet_getTransactionByHash",
+            "starknet_getTransactionReceipt",
+            "starknet_pendingTransactions",
+            "starknet_syncing",
+        ];
+        pub const COMMON_FOR_ALL: [&str; 2] =
+            ["pathfinder_getProof", "pathfinder_getTransactionStatus"];
+        pub const V03_ONLY: [&str; 1] = ["starknet_simulateTransaction"];
+        pub const PATHFINDER_ONLY: [&str; 1] = ["pathfinder_version"];
+    }
+
+    pub mod paths {
+        pub const V02: &[&str] = &["", "/", "/rpc/v0.2", "/rpc/v0.2/"];
+        pub const V03: &[&str] = &["/rpc/v0.3", "/rpc/v0.3/"];
+        pub const PATHFINDER: &[&str] = &["/rpc/pathfinder/v0.1", "/rpc/pathfinder/v0.1/"];
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
-    const COMMON_FOR_V02_V03: [&str; 23] = [
-        "starknet_addDeclareTransaction",
-        "starknet_addDeployAccountTransaction",
-        "starknet_addInvokeTransaction",
-        "starknet_blockHashAndNumber",
-        "starknet_blockNumber",
-        "starknet_call",
-        "starknet_chainId",
-        "starknet_estimateFee",
-        "starknet_getBlockWithTxHashes",
-        "starknet_getBlockWithTxs",
-        "starknet_getBlockTransactionCount",
-        "starknet_getClass",
-        "starknet_getClassAt",
-        "starknet_getClassHashAt",
-        "starknet_getEvents",
-        "starknet_getNonce",
-        "starknet_getStateUpdate",
-        "starknet_getStorageAt",
-        "starknet_getTransactionByBlockIdAndIndex",
-        "starknet_getTransactionByHash",
-        "starknet_getTransactionReceipt",
-        "starknet_pendingTransactions",
-        "starknet_syncing",
-    ];
-    const COMMON_FOR_ALL: [&str; 2] = ["pathfinder_getProof", "pathfinder_getTransactionStatus"];
-    const V03_ONLY: [&str; 1] = ["starknet_simulateTransaction"];
-    const PATHFINDER_ONLY: [&str; 1] = ["pathfinder_version"];
-
-    const V02_PATHS: &[&str] = &["", "/", "/rpc/v0.2", "/rpc/v0.2/"];
-    const V03_PATHS: &[&str] = &["/rpc/v0.3", "/rpc/v0.3/"];
-    const PATHFINDER_PATHS: &[&str] = &["/rpc/pathfinder/v0.1", "/rpc/pathfinder/v0.1/"];
-
-    #[tokio::test]
-    async fn api_versions_are_routed_correctly_for_all_methods() {
-        use crate::test_client::TestClientBuilder;
-        use crate::{RpcContext, RpcMetricsLogger, RpcServer};
-        use pathfinder_common::test_utils::metrics::{FakeRecorder, RecorderGuard};
-        use serde_json::json;
-
-        let context = RpcContext::for_tests();
-        let (_server_handle, address) = RpcServer::new("127.0.0.1:0".parse().unwrap(), context)
-            .with_logger(RpcMetricsLogger)
-            .run()
-            .await
-            .unwrap();
-
-        let v02_methods = COMMON_FOR_V02_V03
-            .into_iter()
-            .chain(COMMON_FOR_ALL.into_iter())
-            .collect::<Vec<_>>();
-        let v03_methods = v02_methods
-            .clone()
-            .into_iter()
-            .chain(V03_ONLY.into_iter())
-            .collect::<Vec<_>>();
-        let pathfinder_methods = COMMON_FOR_ALL
-            .into_iter()
-            .chain(PATHFINDER_ONLY.into_iter())
-            .collect();
-
-        for (paths, version, methods) in vec![
-            (V02_PATHS, "v0.2", v02_methods),
-            (V03_PATHS, "v0.3", v03_methods),
-            (PATHFINDER_PATHS, "v0.1", pathfinder_methods),
-        ]
-        .into_iter()
-        {
-            let recorder = FakeRecorder::default();
-            let handle = recorder.handle();
-            // Other concurrent tests could be setting their own recorders
-            let guard = RecorderGuard::lock(recorder);
-
-            let paths_len = paths.len();
-            let paths_iter = paths.iter();
-
-            // Perform all the calls but don't assert the results just yet
-            for path in paths_iter.clone().map(ToOwned::to_owned) {
-                let client = TestClientBuilder::default()
-                    .address(address)
-                    .endpoint(path.into())
-                    .build()
-                    .unwrap();
-
-                for method in methods.iter() {
-                    let res = client.request::<serde_json::Value>(method, json!([])).await;
-
-                    match res {
-                        Err(jsonrpsee::core::Error::Call(
-                            jsonrpsee::types::error::CallError::Custom(e),
-                        )) if e.code() == jsonrpsee::types::error::METHOD_NOT_FOUND_CODE => {
-                            // Don't poison the internal lock
-                            drop(guard);
-                            panic!("Unregistered method called, path: {path}, method: {method}")
-                        }
-                        Ok(_) | Err(_) => {}
-                    }
-                }
-            }
-
-            // Drop the global recorder guard to avoid poisoning its internal lock if
-            // the following asserts fail which would fail other tests using the `RecorderGuard`
-            // at the same time.
-            //
-            // The recorder itself still exists since dropping the guard only unregisters the recorder
-            // and leaks it making the handle still valid past this point.
-            drop(guard);
-
-            // Now we can safely assert all results
-            for path in paths_iter.clone() {
-                for method in methods.iter() {
-                    let expected_counter = paths_len as u64;
-                    let actual_counter = handle.get_counter_value_by_label(
-                        "rpc_method_calls_total",
-                        [("method", method), ("version", version)],
-                    );
-                    assert_eq!(
-                        actual_counter, expected_counter,
-                        "path: {path}, method: {method}"
-                    );
-                }
-            }
-        }
-    }
+    use super::test_utils::{method_names, paths};
 
     // In an unintentional way OFC: if a method is INTENDED to be available
     // on many paths then this is absolutely allowed.
@@ -317,21 +234,23 @@ mod tests {
             .await
             .unwrap();
 
-        let not_in_v02 = V03_ONLY
+        let not_in_v02 = method_names::V03_ONLY
             .into_iter()
             .clone()
-            .chain(PATHFINDER_ONLY.into_iter())
+            .chain(method_names::PATHFINDER_ONLY.into_iter())
             .collect::<Vec<_>>();
-        let not_in_v03 = PATHFINDER_ONLY.into_iter().collect::<Vec<_>>();
-        let not_in_pathfinder = COMMON_FOR_V02_V03
+        let not_in_v03 = method_names::PATHFINDER_ONLY
             .into_iter()
-            .chain(V03_ONLY.into_iter())
+            .collect::<Vec<_>>();
+        let not_in_pathfinder = method_names::COMMON_FOR_V02_V03
+            .into_iter()
+            .chain(method_names::V03_ONLY.into_iter())
             .collect::<Vec<_>>();
 
         for (paths, methods) in vec![
-            (V02_PATHS, not_in_v02),
-            (V03_PATHS, not_in_v03),
-            (PATHFINDER_PATHS, not_in_pathfinder),
+            (paths::V02, not_in_v02),
+            (paths::V03, not_in_v03),
+            (paths::PATHFINDER, not_in_pathfinder),
         ]
         .into_iter()
         {

--- a/crates/rpc/tests/versioning.rs
+++ b/crates/rpc/tests/versioning.rs
@@ -1,0 +1,97 @@
+//! This test was separated because the `metrics` crate uses a singleton recorder, so keeping a test
+//! that relies on metric values in a separate binary makes more sense than using an inter-test
+//! locking mechanism which can cause weird test failures without any obvious clue to what might
+//! have caused those failures in the first place.
+
+#[tokio::test]
+async fn api_versions_are_routed_correctly_for_all_methods() {
+    use pathfinder_common::test_utils::metrics::{FakeRecorder, RecorderGuard};
+    use pathfinder_rpc::test_client::TestClientBuilder;
+    use pathfinder_rpc::versioning::test_utils::{method_names, paths};
+    use pathfinder_rpc::{context::RpcContext, metrics::logger::RpcMetricsLogger, RpcServer};
+    use serde_json::json;
+
+    let context = RpcContext::for_tests();
+    let (_server_handle, address) = RpcServer::new("127.0.0.1:0".parse().unwrap(), context)
+        .with_logger(RpcMetricsLogger)
+        .run()
+        .await
+        .unwrap();
+
+    let v02_methods = method_names::COMMON_FOR_V02_V03
+        .into_iter()
+        .chain(method_names::COMMON_FOR_ALL.into_iter())
+        .collect::<Vec<_>>();
+    let v03_methods = v02_methods
+        .clone()
+        .into_iter()
+        .chain(method_names::V03_ONLY.into_iter())
+        .collect::<Vec<_>>();
+    let pathfinder_methods = method_names::COMMON_FOR_ALL
+        .into_iter()
+        .chain(method_names::PATHFINDER_ONLY.into_iter())
+        .collect();
+
+    for (paths, version, methods) in vec![
+        (paths::V02, "v0.2", v02_methods),
+        (paths::V03, "v0.3", v03_methods),
+        (paths::PATHFINDER, "v0.1", pathfinder_methods),
+    ]
+    .into_iter()
+    {
+        let recorder = FakeRecorder::default();
+        let handle = recorder.handle();
+        // Other concurrent tests could be setting their own recorders
+        let guard = RecorderGuard::lock(recorder);
+
+        let paths_len = paths.len();
+        let paths_iter = paths.iter();
+
+        // Perform all the calls but don't assert the results just yet
+        for path in paths_iter.clone().map(ToOwned::to_owned) {
+            let client = TestClientBuilder::default()
+                .address(address)
+                .endpoint(path.into())
+                .build()
+                .unwrap();
+
+            for method in methods.iter() {
+                let res = client.request::<serde_json::Value>(method, json!([])).await;
+
+                match res {
+                    Err(jsonrpsee::core::Error::Call(
+                        jsonrpsee::types::error::CallError::Custom(e),
+                    )) if e.code() == jsonrpsee::types::error::METHOD_NOT_FOUND_CODE => {
+                        // Don't poison the internal lock
+                        drop(guard);
+                        panic!("Unregistered method called, path: {path}, method: {method}")
+                    }
+                    Ok(_) | Err(_) => {}
+                }
+            }
+        }
+
+        // Drop the global recorder guard to avoid poisoning its internal lock if
+        // the following asserts fail which would fail other tests using the `RecorderGuard`
+        // at the same time.
+        //
+        // The recorder itself still exists since dropping the guard only unregisters the recorder
+        // and leaks it making the handle still valid past this point.
+        drop(guard);
+
+        // Now we can safely assert all results
+        for path in paths_iter.clone() {
+            for method in methods.iter() {
+                let expected_counter = paths_len as u64;
+                let actual_counter = handle.get_counter_value_by_label(
+                    "rpc_method_calls_total",
+                    [("method", method), ("version", version)],
+                );
+                assert_eq!(
+                    actual_counter, expected_counter,
+                    "path: {path}, method: {method}"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
1. Remove RecorderGuard. A Scoped guard remains but just as a mean to deregister the global recorder.
2. Tests that fiddle with metrics and rely on them are in separate binaries, which makes the locking unnecessary. Test inter-dependencies are removed.
3. Integration tests are made explicitly callable __intentionally__. This is because they require respective crates to provide a feature `test-utils` and otherwise without explicitly marking those integration test targets one would have to specify `--features test-utils` for clippy :facepalm: and other non-integration tests. Essentially I chose the lesser evil, plus I think integration tests should be easily "spot-able", which in this case means that you need to invoke `cargo test` with `--test integration*` as all of them should be named `integration-something` (tbh. one also has to add `--features test-utils` to run the integration tests on their own but that's a small price imo). :left_right_arrow: I was also partially inspired here by this [post](https://joshleeb.com/posts/rust-integration-tests.html). And as far as I can see `autotests = false` does not work (?) or it's at least not required if a test target is specified explicitly :shrug:.