### PR TITLE
chore: bump deps for security fixes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,6 +60,9 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      # Required for git security reasons. See https://github.com/rustyhorde/vergen/pull/126#issuecomment-1201088162
+      - name: Vergen git safe directory
+        run: git config --global --add safe.directory /workspace
       - name: Build
         id: docker_build
         uses: docker/build-push-action@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3000,9 +3000,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+checksum = "66b91535aa35fea1523ad1b86cb6b53c28e0ae566ba4a460f4457e936cad7c6f"
 dependencies = [
  "bytes",
  "fnv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,7 +478,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
- "percent-encoding 2.2.0",
+ "percent-encoding",
  "pin-project-lite",
  "rustversion",
  "serde",
@@ -2387,7 +2387,7 @@ dependencies = [
  "serde_json",
  "syn 1.0.109",
  "toml 0.5.11",
- "url 2.3.1",
+ "url",
  "walkdir",
 ]
 
@@ -2477,7 +2477,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "url 2.3.1",
+ "url",
 ]
 
 [[package]]
@@ -2507,7 +2507,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "url 2.3.1",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-timer",
@@ -2692,7 +2692,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "percent-encoding 2.2.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -2920,18 +2920,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getset"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "ghash"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2949,19 +2937,6 @@ checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
 dependencies = [
  "opaque-debug 0.3.0",
  "polyval 0.6.0",
-]
-
-[[package]]
-name = "git2"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "910a2df52d2354e4eb27aa12f3803ea86bf461a93e17028908ec0e356572aa7b"
-dependencies = [
- "bitflags",
- "libc",
- "libgit2-sys",
- "log",
- "url 1.7.2",
 ]
 
 [[package]]
@@ -3315,17 +3290,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "idna"
@@ -3692,18 +3656,6 @@ name = "libc"
 version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
-
-[[package]]
-name = "libgit2-sys"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48441cb35dc255da8ae72825689a95368bf510659ae1ad55dc4aa88cb1789bf1"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
 
 [[package]]
 name = "libm"
@@ -4226,18 +4178,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-sys"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "link-cplusplus"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4522,11 +4462,11 @@ dependencies = [
  "data-encoding",
  "multibase",
  "multihash 0.16.3",
- "percent-encoding 2.2.0",
+ "percent-encoding",
  "serde",
  "static_assertions",
  "unsigned-varint",
- "url 2.3.1",
+ "url",
 ]
 
 [[package]]
@@ -4541,11 +4481,11 @@ dependencies = [
  "log",
  "multibase",
  "multihash 0.17.0",
- "percent-encoding 2.2.0",
+ "percent-encoding",
  "serde",
  "static_assertions",
  "unsigned-varint",
- "url 2.3.1",
+ "url",
 ]
 
 [[package]]
@@ -5428,12 +5368,6 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-
-[[package]]
-name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
@@ -6137,7 +6071,7 @@ dependencies = [
  "mime",
  "native-tls",
  "once_cell",
- "percent-encoding 2.2.0",
+ "percent-encoding",
  "pin-project-lite",
  "rustls 0.20.8",
  "rustls-pemfile",
@@ -6148,7 +6082,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls",
  "tower-service",
- "url 2.3.1",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -6525,7 +6459,7 @@ dependencies = [
  "rand 0.8.5",
  "substring",
  "thiserror",
- "url 2.3.1",
+ "url",
 ]
 
 [[package]]
@@ -7028,7 +6962,7 @@ dependencies = [
  "subtle",
  "thiserror",
  "tokio",
- "url 2.3.1",
+ "url",
  "webrtc-util",
 ]
 
@@ -7443,7 +7377,7 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-timeout",
- "percent-encoding 2.2.0",
+ "percent-encoding",
  "pin-project",
  "prost",
  "prost-derive",
@@ -7585,7 +7519,7 @@ dependencies = [
  "tinyvec",
  "tokio",
  "tracing",
- "url 2.3.1",
+ "url",
 ]
 
 [[package]]
@@ -7629,7 +7563,7 @@ dependencies = [
  "rand 0.8.5",
  "sha1",
  "thiserror",
- "url 2.3.1",
+ "url",
  "utf-8",
 ]
 
@@ -7767,24 +7701,13 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-dependencies = [
- "idna 0.1.5",
- "matches",
- "percent-encoding 1.0.1",
-]
-
-[[package]]
-name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna 0.3.0",
- "percent-encoding 2.2.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -7832,17 +7755,12 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "7.3.1"
+version = "8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f10de320f0fe3f21913dabbfcbced6867bbe47a6b1a5db830e37df3a50279bd0"
+checksum = "c1b86a8af1dedf089b1c78338678e4c7492b6045649042d94faf19690499d236"
 dependencies = [
  "anyhow",
- "cfg-if",
- "enum-iterator",
- "getset",
- "git2",
  "rustversion",
- "thiserror",
  "time 0.3.20",
 ]
 
@@ -7909,7 +7827,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "multiparty",
- "percent-encoding 2.2.0",
+ "percent-encoding",
  "pin-project",
  "rustls-pemfile",
  "scoped-tls",
@@ -8091,7 +8009,7 @@ dependencies = [
  "time 0.3.20",
  "tokio",
  "turn",
- "url 2.3.1",
+ "url",
  "waitgroup",
  "webrtc-data",
  "webrtc-dtls",
@@ -8176,7 +8094,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "turn",
- "url 2.3.1",
+ "url",
  "uuid 1.3.1",
  "waitgroup",
  "webrtc-mdns",

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -22,4 +22,4 @@ stark_poseidon = { path = "../stark_poseidon" }
 thiserror = { workspace = true }
 
 [build-dependencies]
-vergen = { version = "7", default-features = false, features = ["git"] }
+vergen = { version = "8", default-features = false, features = ["git", "gitcl"] }

--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -9,20 +9,17 @@ pub fn main() {
 
     if let Ok(version) = std::env::var(force_version_env_var_name) {
         if !version.is_empty() {
-            println!("cargo:rustc-env=VERGEN_GIT_SEMVER_LIGHTWEIGHT={version}");
+            println!("cargo:rustc-env=VERGEN_GIT_DESCRIBE={version}");
             return;
         }
     }
 
     // at 7.0.0 default enables everything compiled in, selected with feature-flags
-    let mut config = vergen::Config::default();
-    *config.git_mut().semver_kind_mut() = vergen::SemverKind::Lightweight;
-    *config.git_mut().semver_dirty_mut() = Some("-dirty");
-    *config.git_mut().branch_mut() = false;
-    *config.git_mut().commit_author_mut() = false;
-    *config.git_mut().commit_count_mut() = false;
-    *config.git_mut().commit_message_mut() = false;
-    *config.git_mut().commit_timestamp_mut() = false;
-    *config.git_mut().sha_mut() = false;
-    vergen::vergen(config).expect("vergen failed; this is probably due to missing .git directory");
+    const ENABLE_DIRTY: bool = true;
+    const ENABLE_TAGS: bool = true;
+    vergen::EmitBuilder::builder()
+        .fail_on_error()
+        .git_describe(ENABLE_DIRTY, ENABLE_TAGS, None)
+        .emit()
+        .expect("vergen failed; this is probably due to missing .git directory");
 }

--- a/crates/common/src/consts.rs
+++ b/crates/common/src/consts.rs
@@ -3,13 +3,10 @@
 use crate::{felt, StarknetBlockHash};
 
 /// Vergen string
-pub const VERGEN_GIT_SEMVER_LIGHTWEIGHT: &str = env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT");
+pub const VERGEN_GIT_DESCRIBE: &str = env!("VERGEN_GIT_DESCRIBE");
 
 /// User agent used in http clients
-pub const USER_AGENT: &str = concat!(
-    "starknet-pathfinder/",
-    env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT")
-);
+pub const USER_AGENT: &str = concat!("starknet-pathfinder/", env!("VERGEN_GIT_DESCRIBE"));
 
 pub const TESTNET_GENESIS_HASH: StarknetBlockHash = StarknetBlockHash(felt!(
     "07d328a71faf48c5c3857e99f20a77b18522480956d1cd5bff1ff2df3c8b427b"

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -591,7 +591,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn client_user_agent() {
-        use pathfinder_common::{consts::VERGEN_GIT_SEMVER_LIGHTWEIGHT, StarknetBlockTimestamp};
+        use pathfinder_common::{consts::VERGEN_GIT_DESCRIBE, StarknetBlockTimestamp};
         use starknet_gateway_types::reply::{Block, Status};
         use std::convert::Infallible;
         use warp::Filter;
@@ -602,7 +602,7 @@ mod tests {
                 let (name, version) = user_agent.split_once('/').unwrap();
 
                 assert_eq!(name, "starknet-pathfinder");
-                assert_eq!(version, VERGEN_GIT_SEMVER_LIGHTWEIGHT);
+                assert_eq!(version, VERGEN_GIT_DESCRIBE);
 
                 Ok::<_, Infallible>(warp::reply::json(&Block {
                     block_hash: StarknetBlockHash(Felt::ZERO),

--- a/crates/load-test/Cargo.lock
+++ b/crates/load-test/Cargo.lock
@@ -1384,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.4"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]

--- a/crates/load-test/Cargo.lock
+++ b/crates/load-test/Cargo.lock
@@ -64,7 +64,7 @@ checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -266,7 +266,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -283,7 +283,7 @@ checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -349,7 +349,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -467,7 +467,7 @@ checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -574,14 +574,14 @@ checksum = "729f9bd3449d77e7831a18abfb7ba2f99ee813dfd15b8c2167c9a54ba20aa99d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
 name = "h2"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "66b91535aa35fea1523ad1b86cb6b53c28e0ae566ba4a460f4457e936cad7c6f"
 dependencies = [
  "bytes",
  "fnv",
@@ -1006,7 +1006,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1051,7 +1051,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1086,9 +1086,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -1111,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1290,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.149"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
@@ -1309,20 +1309,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.149"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.89"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -1425,7 +1425,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1439,6 +1439,17 @@ name = "syn"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1491,7 +1502,7 @@ checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1575,7 +1586,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1770,7 +1781,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
  "wasm-bindgen-shared",
 ]
 
@@ -1804,7 +1815,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -4,12 +4,12 @@ use reqwest::Url;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
-use pathfinder_common::consts::VERGEN_GIT_SEMVER_LIGHTWEIGHT;
+use pathfinder_common::consts::VERGEN_GIT_DESCRIBE;
 
 #[derive(Parser)]
 #[command(name = "Pathfinder")]
 #[command(author = "Equilibrium Labs")]
-#[command(version = VERGEN_GIT_SEMVER_LIGHTWEIGHT)]
+#[command(version = VERGEN_GIT_DESCRIBE)]
 #[command(
     about = "A StarkNet node implemented by Equilibrium Labs. Submit bug reports and issues at https://github.com/eqlabs/pathfinder."
 )]

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -13,7 +13,6 @@ use pathfinder_common::consts::VERGEN_GIT_SEMVER_LIGHTWEIGHT;
 #[command(
     about = "A StarkNet node implemented by Equilibrium Labs. Submit bug reports and issues at https://github.com/eqlabs/pathfinder."
 )]
-#[command(author, version, about, long_about = None)]
 struct Cli {
     #[arg(
         long,

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use pathfinder_common::EthereumAddress;
 use pathfinder_common::{
-    consts::VERGEN_GIT_SEMVER_LIGHTWEIGHT, Chain, ChainId, EthereumChain, StarknetBlockNumber,
+    consts::VERGEN_GIT_DESCRIBE, Chain, ChainId, EthereumChain, StarknetBlockNumber,
 };
 use pathfinder_ethereum::provider::{EthereumTransport, HttpProvider};
 use pathfinder_lib::{
@@ -37,7 +37,7 @@ async fn main() -> anyhow::Result<()> {
 
     info!(
         // this is expected to be $(last_git_tag)-$(commits_since)-$(commit_hash)
-        version = VERGEN_GIT_SEMVER_LIGHTWEIGHT,
+        version = VERGEN_GIT_DESCRIBE,
         "🏁 Starting node."
     );
 

--- a/crates/pathfinder/src/bin/pathfinder/update.rs
+++ b/crates/pathfinder/src/bin/pathfinder/update.rs
@@ -6,7 +6,7 @@
 /// has a better chance of spotting it.
 pub async fn poll_github_for_releases() -> anyhow::Result<()> {
     use anyhow::Context;
-    let current_version = pathfinder_common::consts::VERGEN_GIT_SEMVER_LIGHTWEIGHT;
+    let current_version = pathfinder_common::consts::VERGEN_GIT_DESCRIBE;
     let current_version = current_version.strip_prefix('v').unwrap_or(current_version);
     let local_version = semver::Version::parse(current_version)
         .context("Semver parsing of local version failed")?;

--- a/crates/rpc/src/pathfinder.rs
+++ b/crates/rpc/src/pathfinder.rs
@@ -7,7 +7,7 @@ pub(crate) mod methods;
 pub fn register_methods(module: Module) -> anyhow::Result<Module> {
     let module = module
         .register_method_with_no_input("v0.1_pathfinder_version", |_| async {
-            Result::<_, RpcError>::Ok(pathfinder_common::consts::VERGEN_GIT_SEMVER_LIGHTWEIGHT)
+            Result::<_, RpcError>::Ok(pathfinder_common::consts::VERGEN_GIT_DESCRIBE)
         })?
         .register_method("v0.1_pathfinder_getProof", methods::get_proof)?
         .register_method(


### PR DESCRIPTION
This PR does minor patch bumps for `h2` and `spin` depedencies and a major bump for `vergen` to fix security issues.

Also fixes an issue with `pathfinder --version` which was displaying the crate version and not the more informative `git describe`.

Closes dependabot alerts [#28](https://github.com/eqlabs/pathfinder/security/dependabot/28), [#33](https://github.com/eqlabs/pathfinder/security/dependabot/33), [#34](https://github.com/eqlabs/pathfinder/security/dependabot/34), [#35](https://github.com/eqlabs/pathfinder/security/dependabot/35).

Unfortunately I'm not able to close the remaining `time` related warnings at this time. This comes in via `chrono` (which is unmaintained), which in turn comes in via `ethers` and `cairo-lang-utils`. Technically `serde_with` also pulls in `chrono` -- but it seems this is an optional depedency that only gets pulled in if its already in the tree.. weird I think but whatever.

Since we are removing `ethers` in #1017, we should also poke SW into removing the dep from `cairo-lang`.