### PR TITLE
cors support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- CORS support for the RPC server, enabled via the `rpc.cors-domains` command line argument
+
+### Fixed
+
+- rpc server panic for unprefixed unregistered method names
+
 ## [0.5.3] - 2023-04-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,6 +3176,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5286,6 +5292,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "zstd",
@@ -7411,6 +7418,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,42 +177,51 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
+checksum = "9e579a7752471abc2a8268df8b20005e3eadd975f585398f17efcfd8d4927371"
 dependencies = [
  "anstyle",
  "anstyle-parse",
+ "anstyle-query",
  "anstyle-wincon",
- "concolor-override",
- "concolor-query",
+ "colorchoice",
  "is-terminal",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "0.3.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
-name = "anstyle-wincon"
-version = "0.2.0"
+name = "anstyle-query"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcd8291a340dd8ac70e18878bc4501dd7b4ff970cfa21c207d36ece51ea88fd"
 dependencies = [
  "anstyle",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -375,7 +384,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -386,7 +395,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -793,7 +802,7 @@ dependencies = [
  "cairo-lang-sierra-generator",
  "cairo-lang-syntax",
  "cairo-lang-utils",
- "clap 4.2.1",
+ "clap 4.2.2",
  "log",
  "salsa",
  "thiserror",
@@ -1045,7 +1054,7 @@ dependencies = [
  "cairo-lang-sierra-ap-change",
  "cairo-lang-sierra-gas",
  "cairo-lang-utils",
- "clap 4.2.1",
+ "clap 4.2.2",
  "indoc",
  "itertools",
  "log",
@@ -1076,7 +1085,7 @@ dependencies = [
  "cairo-lang-sierra-to-casm",
  "cairo-lang-syntax",
  "cairo-lang-utils",
- "clap 4.2.1",
+ "clap 4.2.2",
  "convert_case",
  "genco",
  "indoc",
@@ -1306,9 +1315,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ae530c528f252094e4a77886ee1374437744b2bff1497aa898bbddbbb29b3"
+checksum = "9b802d85aaf3a1cdb02b224ba472ebdea62014fccfcb269b95a4d76443b5ee5a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1317,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223163f58c9a40c3b0a43e1c4b50a9ce09f007ea2cb1ec258a687945b4b7929f"
+checksum = "14a1a858f532119338887a4b8e1af9c60de8249cd7bafd68036a489e261e37b6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1338,7 +1347,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1424,6 +1433,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "colored"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1432,21 +1447,6 @@ dependencies = [
  "atty",
  "lazy_static",
  "winapi",
-]
-
-[[package]]
-name = "concolor-override"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a855d4a1978dc52fb0536a04d384c2c0c1aa273597f08b77c8c4d3b2eec6037f"
-
-[[package]]
-name = "concolor-query"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
-dependencies = [
- "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1770,7 +1770,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1787,7 +1787,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -2795,7 +2795,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -2975,9 +2975,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b91535aa35fea1523ad1b86cb6b53c28e0ae566ba4a460f4457e936cad7c6f"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
  "bytes",
  "fnv",
@@ -3195,9 +3195,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.25"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -4881,7 +4881,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -4942,7 +4942,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "base64 0.13.1",
- "clap 4.2.1",
+ "clap 4.2.2",
  "delay_map",
  "env_logger 0.10.0",
  "fake",
@@ -4970,7 +4970,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
- "clap 4.2.1",
+ "clap 4.2.2",
  "futures",
  "libp2p",
  "serde",
@@ -5139,7 +5139,7 @@ dependencies = [
  "bitvec 0.20.4",
  "bytes",
  "cairo-lang-starknet",
- "clap 4.2.1",
+ "clap 4.2.2",
  "console-subscriber",
  "criterion",
  "enum-iterator",
@@ -5174,10 +5174,12 @@ dependencies = [
  "starknet-gateway-types",
  "tempfile",
  "test-log",
+ "thiserror",
  "tokio",
  "toml 0.5.11",
  "tracing",
  "tracing-subscriber",
+ "url",
  "warp",
  "zstd",
 ]
@@ -5692,9 +5694,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -5702,9 +5704,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c828f93f5ca4826f97fedcbd3f9a536c16b12cff3dbbb4a007f932bbad95b12"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck 0.4.1",
@@ -5737,9 +5739,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
  "itertools",
@@ -5750,9 +5752,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379119666929a1afd7a043aa6cf96fa67a6dce9af60c88095a4686dbce4c9c88"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
  "prost",
 ]
@@ -6541,7 +6543,7 @@ checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -6994,9 +6996,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.14"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf316d5356ed6847742d036f8a39c3b8435cac10bd528a4bd461928a6ab34d5"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7131,7 +7133,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -7253,7 +7255,7 @@ checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -8602,7 +8604,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -548,6 +548,21 @@ pub enum AllowedOrigins {
     List(Vec<String>),
 }
 
+impl<S> From<S> for AllowedOrigins
+where
+    S: ToString,
+{
+    fn from(value: S) -> Self {
+        let s = value.to_string();
+
+        if s == "*" {
+            Self::Any
+        } else {
+            Self::List(vec![s])
+        }
+    }
+}
+
 /// See:
 /// <https://github.com/starkware-libs/cairo-lang/blob/64a7f6aed9757d3d8d6c28bd972df73272b0cb0a/src/starkware/starknet/public/abi.py#L21-L26>
 pub fn truncated_keccak(mut plain: [u8; 32]) -> Felt {

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -542,6 +542,12 @@ macros::starkhash::common_newtype!(
 macros::fmt::thin_display!(StarknetBlockNumber);
 macros::fmt::thin_display!(StarknetBlockTimestamp);
 
+#[derive(Clone, Debug, PartialEq)]
+pub enum AllowedOrigins {
+    Any,
+    List(Vec<String>),
+}
+
 /// See:
 /// <https://github.com/starkware-libs/cairo-lang/blob/64a7f6aed9757d3d8d6c28bd972df73272b0cb0a/src/starkware/starknet/public/abi.py#L21-L26>
 pub fn truncated_keccak(mut plain: [u8; 32]) -> Felt {

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -46,10 +46,12 @@ stark_hash = { path = "../stark_hash" }
 starknet-gateway-client = { path = "../gateway-client" }
 starknet-gateway-types = { path = "../gateway-types" }
 tempfile = "3.4"
+thiserror = "1.0.40"
 tokio = { workspace = true, features = ["process"] }
 toml = "0.5.9"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+url = "2.3.1"
 warp = "0.3.3"
 zstd = "0.12"
 

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -57,8 +57,8 @@ Examples:
     rpc_address: SocketAddr,
 
     #[arg(
-        long = "http-rpc.cors-domains",
-        long_help = r"Comma separated list of domains from which Cross-Origin requests will be accepted by the HTTP-RPC server.
+        long = "rpc.cors-domains",
+        long_help = r"Comma separated list of domains from which Cross-Origin requests will be accepted by the RPC server.
         
 Examples:
     single: http://one.io
@@ -66,7 +66,7 @@ Examples:
     any:    *",
         value_name = "DOMAIN-LIST",
         value_delimiter = ',',
-        env = "PATHFINDER_HTTP_RPC_CORS_DOMAINS"
+        env = "PATHFINDER_RPC_CORS_DOMAINS"
     )]
     rpc_cors_domains: Vec<String>,
 

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -203,9 +203,7 @@ fn parse_cors(inputs: Vec<String>) -> Result<Option<AllowedOrigins>, RpcCorsDoma
                     return Err(RpcCorsDomainsParseError::InvalidDomain(input));
                 }
 
-                let origin_str = origin.ascii_serialization();
-
-                if origin_str == input {
+                if origin.ascii_serialization() == input {
                     Ok(input)
                 } else {
                     // Valid URL but not a valid origin

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -371,7 +371,7 @@ mod tests {
                 RpcCorsDomainsParseError::InvalidDomain(empty.clone()),
             ),
             (
-                vec![empty.clone(), wildcard.clone()],
+                vec![empty, wildcard.clone()],
                 RpcCorsDomainsParseError::WildcardAmongOtherValues,
             ),
             (
@@ -392,7 +392,7 @@ mod tests {
             ),
             (
                 vec![valid.clone(), with_path.clone()],
-                RpcCorsDomainsParseError::InvalidDomain(with_path.clone()),
+                RpcCorsDomainsParseError::InvalidDomain(with_path),
             ),
             (
                 vec![valid.clone(), with_query.clone()],

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -130,7 +130,13 @@ async fn main() -> anyhow::Result<()> {
         false => context,
     };
 
-    let (rpc_handle, local_addr) = pathfinder_rpc::RpcServer::new(config.rpc_address, context)
+    let rpc_server = pathfinder_rpc::RpcServer::new(config.rpc_address, context);
+    let rpc_server = match config.rpc_cors_domains {
+        Some(allowed_origins) => rpc_server.with_cors(allowed_origins),
+        None => rpc_server,
+    };
+
+    let (rpc_handle, local_addr) = rpc_server
         .with_logger(RpcMetricsLogger)
         .with_max_connections(config.max_rpc_connections.get())
         .run()

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -36,6 +36,7 @@ starknet-gateway-types = { path = "../gateway-types" }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["process"] }
 tower = { version = "0.4.13", default-features = false, features = ["filter", "util"] }
+tower-http = { version = "0.4.0", default-features = false, features = ["cors"] }
 tracing = "0.1.37"
 zstd = "0.12"
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -73,11 +73,11 @@ impl RpcServer {
             .set_host_filtering(AllowHosts::Any)
             .set_logger(self.logger)
             .set_middleware(tower::ServiceBuilder::new()
+                .option_layer(self.cors)
                 .map_result(middleware::versioning::try_map_errors_to_responses)
                 .filter_async(|result| async move {
                     middleware::versioning::prefix_rpc_method_names_with_version(result, TEN_MB).await
                 })
-                .option_layer(self.cors)
             )
             .build(self.addr)
             .await

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -16,7 +16,6 @@ pub mod v03;
 use crate::metrics::logger::{MaybeRpcMetricsLogger, RpcMetricsLogger};
 use crate::v02::types::syncing::Syncing;
 use context::RpcContext;
-use jsonrpsee::core::server::host_filtering::AllowHosts;
 use jsonrpsee::server::{ServerBuilder, ServerHandle};
 use pathfinder_common::AllowedOrigins;
 use std::{net::SocketAddr, result::Result};
@@ -70,7 +69,6 @@ impl RpcServer {
         let server = ServerBuilder::default()
             .max_connections(self.max_connections)
             .max_request_body_size(TEN_MB)
-            .set_host_filtering(AllowHosts::Any)
             .set_logger(self.logger)
             .set_middleware(tower::ServiceBuilder::new()
                 .option_layer(self.cors)

--- a/crates/rpc/src/metrics.rs
+++ b/crates/rpc/src/metrics.rs
@@ -29,8 +29,14 @@ pub mod logger {
             _kind: jsonrpsee::server::logger::MethodKind,
             _transport: jsonrpsee::server::logger::TransportProtocol,
         ) {
-            let (version, method_name) = split_version_prefix(method_name);
-            metrics::increment_counter!("rpc_method_calls_total", "method" => method_name, "version" => version);
+            match split_version_prefix(method_name) {
+                Some((version, method_name)) => {
+                    metrics::increment_counter!("rpc_method_calls_total", "method" => method_name, "version" => version)
+                }
+                None => {
+                    metrics::increment_counter!("rpc_method_calls_total", "method" => method_name.to_owned())
+                }
+            }
         }
 
         fn on_result(
@@ -41,8 +47,14 @@ pub mod logger {
             _transport: jsonrpsee::server::logger::TransportProtocol,
         ) {
             if !success {
-                let (version, method_name) = split_version_prefix(method_name);
-                metrics::increment_counter!("rpc_method_calls_failed_total", "method" => method_name, "version" => version);
+                match split_version_prefix(method_name) {
+                    Some((version, method_name)) => {
+                        metrics::increment_counter!("rpc_method_calls_failed_total", "method" => method_name, "version" => version)
+                    }
+                    None => {
+                        metrics::increment_counter!("rpc_method_calls_failed_total", "method" => method_name.to_owned())
+                    }
+                }
             }
         }
 

--- a/crates/rpc/src/middleware.rs
+++ b/crates/rpc/src/middleware.rs
@@ -1,0 +1,2 @@
+pub mod cors;
+pub mod versioning;

--- a/crates/rpc/src/middleware/cors.rs
+++ b/crates/rpc/src/middleware/cors.rs
@@ -19,8 +19,56 @@ pub fn with_allowed_origins(allowed_origins: AllowedOrigins) -> CorsLayer {
 
 #[cfg(test)]
 mod tests {
+    use crate::{context::RpcContext, RpcServer};
+    use http::HeaderValue;
+
     #[tokio::test]
-    async fn cors_works() {
-        // unimplemented!();
+    async fn preflight() {
+        for (allowed, expected, line) in [
+            // Successful
+            (Some("*"), Some("*"), line!()),
+            (Some("http://a.com"), Some("http://a.com"), line!()),
+            // Not on the list
+            (Some("http://b.com"), None, line!()),
+            // Disabled
+            (None, None, line!()),
+        ] {
+            let context = RpcContext::for_tests();
+            let server = RpcServer::new("127.0.0.1:0".parse().unwrap(), context);
+            let server = match allowed {
+                Some(allowed) => server.with_cors(allowed.into()),
+                None => server,
+            };
+
+            let (_server_handle, address) = server.run().await.unwrap();
+
+            let resp = reqwest::Client::new()
+                .request(reqwest::Method::OPTIONS, format!("http://{address}"))
+                .header("Access-Control-Request-Headers", "content-type")
+                .header("Access-Control-Request-Method", "POST")
+                .header("Origin", "http://a.com")
+                .body("")
+                .send()
+                .await
+                .unwrap();
+
+            let h = resp.headers();
+
+            assert_eq!(
+                h.get("access-control-allow-headers"),
+                allowed.and(Some(&HeaderValue::from_static("content-type"))),
+                "line: {line}"
+            );
+            assert_eq!(
+                h.get("access-control-allow-methods"),
+                allowed.and(Some(&HeaderValue::from_static("POST"))),
+                "line: {line}"
+            );
+            assert_eq!(
+                h.get("access-control-allow-origin"),
+                expected.map(HeaderValue::from_static).as_ref(),
+                "line: {line}"
+            );
+        }
     }
 }

--- a/crates/rpc/src/middleware/cors.rs
+++ b/crates/rpc/src/middleware/cors.rs
@@ -1,0 +1,26 @@
+use http::HeaderValue;
+use pathfinder_common::AllowedOrigins;
+use tower_http::cors::{AllowOrigin, CorsLayer};
+
+pub fn with_allowed_origins(allowed_origins: AllowedOrigins) -> CorsLayer {
+    let allowed_origins = match allowed_origins {
+        AllowedOrigins::Any => AllowOrigin::any(),
+        AllowedOrigins::List(x) => AllowOrigin::list(x.into_iter().map(|s| {
+            HeaderValue::from_maybe_shared(s.into_bytes())
+                .expect("passed type is 'shared' (i.e. owned byte buffer)")
+        })),
+    };
+
+    CorsLayer::new()
+        .allow_methods([hyper::Method::POST])
+        .allow_origin(allowed_origins)
+        .allow_headers([hyper::header::CONTENT_TYPE])
+}
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    async fn cors_works() {
+        // unimplemented!();
+    }
+}

--- a/crates/rpc/src/middleware/versioning.rs
+++ b/crates/rpc/src/middleware/versioning.rs
@@ -175,6 +175,7 @@ mod response {
     }
 }
 
+#[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils {
     pub mod method_names {
         pub const COMMON_FOR_V02_V03: [&str; 23] = [

--- a/crates/rpc/src/middleware/versioning.rs
+++ b/crates/rpc/src/middleware/versioning.rs
@@ -220,15 +220,16 @@ pub mod test_utils {
 mod tests {
 
     use super::test_utils::{method_names, paths};
+    use crate::test_client::TestClientBuilder;
+    use crate::{RpcContext, RpcServer};
+    use jsonrpsee::core::error::Error;
+    use jsonrpsee::types::error::{CallError, METHOD_NOT_FOUND_CODE};
+    use serde_json::json;
 
     // In an unintentional way OFC: if a method is INTENDED to be available
     // on many paths then this is absolutely allowed.
     #[tokio::test]
     async fn api_versions_dont_leak_between_each_other() {
-        use crate::test_client::TestClientBuilder;
-        use crate::{RpcContext, RpcServer};
-        use serde_json::json;
-
         let context = RpcContext::for_tests();
         let (_server_handle, address) = RpcServer::new("127.0.0.1:0".parse().unwrap(), context)
             .run()
@@ -266,9 +267,9 @@ mod tests {
                     let res = client.request::<serde_json::Value>(method, json!([])).await;
 
                     match res {
-                        Err(jsonrpsee::core::Error::Call(
-                            jsonrpsee::types::error::CallError::Custom(e),
-                        )) if e.code() == jsonrpsee::types::error::METHOD_NOT_FOUND_CODE => {
+                        Err(Error::Call(CallError::Custom(e)))
+                            if e.code() == METHOD_NOT_FOUND_CODE =>
+                        {
                             // Hurray, this method is not supposed to be available on this path
                         }
                         Ok(_) | Err(_) => {
@@ -282,8 +283,6 @@ mod tests {
 
     #[tokio::test]
     async fn invalid_path() {
-        use crate::{RpcContext, RpcServer};
-
         let context = RpcContext::for_tests();
         let (_server_handle, address) = RpcServer::new("127.0.0.1:0".parse().unwrap(), context)
             .run()

--- a/crates/rpc/tests/versioning.rs
+++ b/crates/rpc/tests/versioning.rs
@@ -6,8 +6,8 @@
 #[tokio::test]
 async fn api_versions_are_routed_correctly_for_all_methods() {
     use pathfinder_common::test_utils::metrics::{FakeRecorder, ScopedRecorderGuard};
+    use pathfinder_rpc::middleware::versioning::test_utils::{method_names, paths};
     use pathfinder_rpc::test_client::TestClientBuilder;
-    use pathfinder_rpc::versioning::test_utils::{method_names, paths};
     use pathfinder_rpc::{context::RpcContext, metrics::logger::RpcMetricsLogger, RpcServer};
     use serde_json::json;
 


### PR DESCRIPTION
Fixes: #784 

- new command line option: `http-rpc.cors-domains` (cors domains instead of imo more intuitive "cors-allowed-origins" because this seems to be the convention followed by geth), maybe the latter is better though, wdyt?
- btw I noticed a peculiar bug with metrics and the unfortunate way we now version the api, so I fixed it,
- I also did a manual "live" test with a more proper setup: a simple server serving a simple page with a script that fetches from the rpc server which is of different origin, preflight requests are auto generated by the browser, and it works for me :shrug: 
- as for proper integration tests there's a simple preflight test