### PR TITLE
Allow event subscription with websockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6131,6 +6131,7 @@ dependencies = [
  "test-log",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tower",
  "tower-http",
  "tracing",
@@ -8208,6 +8209,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util 0.7.7",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8209,7 +8209,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.7",
+ "tokio-util 0.7.8",
 ]
 
 [[package]]

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -22,7 +22,7 @@ mod metrics;
 #[allow(unused_variables)]
 #[cfg_attr(feature = "test-utils", mockall::automock)]
 #[async_trait::async_trait]
-pub trait GatewayApi: Sync {
+pub trait GatewayApi: Send + Sync {
     async fn block(&self, block: BlockId) -> Result<reply::MaybePendingBlock, SequencerError> {
         unimplemented!();
     }

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -22,7 +22,7 @@ mod metrics;
 #[allow(unused_variables)]
 #[cfg_attr(feature = "test-utils", mockall::automock)]
 #[async_trait::async_trait]
-pub trait GatewayApi: Send + Sync {
+pub trait GatewayApi: Sync {
     async fn block(&self, block: BlockId) -> Result<reply::MaybePendingBlock, SequencerError> {
         unimplemented!();
     }

--- a/crates/gateway-types/Cargo.toml
+++ b/crates/gateway-types/Cargo.toml
@@ -6,6 +6,9 @@ license = "MIT OR Apache-2.0"
 rust-version = "1.62"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+test-utils = []
+
 [dependencies]
 anyhow = { workspace = true }
 ethers = "1.0.2"

--- a/crates/gateway-types/src/lib.rs
+++ b/crates/gateway-types/src/lib.rs
@@ -4,3 +4,4 @@ pub mod pending;
 pub mod reply;
 pub mod request;
 pub mod transaction_hash;
+pub mod websocket;

--- a/crates/gateway-types/src/websocket.rs
+++ b/crates/gateway-types/src/websocket.rs
@@ -1,0 +1,35 @@
+// Types used for web socket subscription events
+use crate::reply::Block;
+use serde::Serialize;
+use tokio::sync::broadcast;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WebsocketEventSync {
+    pub block: Box<Block>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WebsocketEventNewHead {
+    pub block: Box<Block>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WebsocketSenders {
+    pub sync: broadcast::Sender<WebsocketEventSync>,
+    pub new_head: broadcast::Sender<WebsocketEventNewHead>,
+}
+
+impl WebsocketSenders {
+    pub fn new() -> WebsocketSenders {
+        WebsocketSenders {
+            sync: broadcast::channel(100).0,
+            new_head: broadcast::channel(100).0,
+        }
+    }
+}
+
+impl Default for WebsocketSenders {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/gateway-types/src/websocket.rs
+++ b/crates/gateway-types/src/websocket.rs
@@ -12,7 +12,7 @@ use tokio::sync::broadcast::{self};
 #[derive(Debug, Clone)]
 pub struct RPCSender<T>(pub broadcast::Sender<T>);
 
-impl<T> RPCSender<T> {
+impl<T> SubscriptionBroadcaster<T> {
     pub fn send_if_receiving(&self, value: T) {
         if self.0.receiver_count() > 0 {
             let _ = self.0.send(value);

--- a/crates/gateway-types/src/websocket.rs
+++ b/crates/gateway-types/src/websocket.rs
@@ -1,7 +1,7 @@
 // Types used for web socket subscription events
 use crate::reply::{Block, Status};
 use pathfinder_common::{
-    GasPrice, SequencerAddress, StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp,
+    BlockHash, BlockNumber, BlockTimestamp, GasPrice, SequencerAddress, StarknetVersion,
     StateCommitment,
 };
 use pathfinder_serde::GasPriceAsHexStr;
@@ -23,13 +23,13 @@ impl<T> RPCSender<T> {
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, serde::Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WebsocketEventNewHead {
-    pub block_hash: StarknetBlockHash,
-    pub block_number: StarknetBlockNumber,
+    pub block_hash: BlockHash,
+    pub block_number: BlockNumber,
 
     #[serde_as(as = "Option<GasPriceAsHexStr>")]
     #[serde(default)]
     pub gas_price: Option<GasPrice>,
-    pub parent_block_hash: StarknetBlockHash,
+    pub parent_block_hash: BlockHash,
 
     #[serde(default)]
     pub sequencer_address: Option<SequencerAddress>,
@@ -37,10 +37,10 @@ pub struct WebsocketEventNewHead {
     #[serde(alias = "state_root")]
     pub state_commitment: StateCommitment,
     pub status: Status,
-    pub timestamp: StarknetBlockTimestamp,
+    pub timestamp: BlockTimestamp,
 
     #[serde(default)]
-    pub starknet_version: Option<String>,
+    pub starknet_version: StarknetVersion,
 }
 
 impl WebsocketEventNewHead {

--- a/crates/gateway-types/src/websocket.rs
+++ b/crates/gateway-types/src/websocket.rs
@@ -44,7 +44,7 @@ pub struct WebsocketEventNewHead {
 }
 
 impl WebsocketEventNewHead {
-    pub fn new(mut block: Block) -> WebsocketEventNewHead {
+    pub fn new(block: Block) -> WebsocketEventNewHead {
         let Block {
             block_hash,
             block_number,

--- a/crates/gateway-types/src/websocket.rs
+++ b/crates/gateway-types/src/websocket.rs
@@ -1,35 +1,91 @@
 // Types used for web socket subscription events
-use crate::reply::Block;
-use serde::Serialize;
-use tokio::sync::broadcast;
+use crate::reply::{Block, Status};
+use pathfinder_common::{
+    GasPrice, SequencerAddress, StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp,
+    StateCommitment,
+};
+use pathfinder_serde::GasPriceAsHexStr;
+use serde::Deserialize;
+use serde_with::serde_as;
+use tokio::sync::broadcast::{self};
 
-#[derive(Debug, Clone, Serialize)]
-pub struct WebsocketEventSync {
-    pub block: Box<Block>,
+#[derive(Debug, Clone)]
+pub struct RPCSender<T>(pub broadcast::Sender<T>);
+
+impl<T> RPCSender<T> {
+    pub fn send_if_receiving(&self, value: T) {
+        if self.0.receiver_count() > 0 {
+            let _ = self.0.send(value);
+        }
+    }
+}
+#[serde_as]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WebsocketEventNewHead {
+    pub block_hash: StarknetBlockHash,
+    pub block_number: StarknetBlockNumber,
+
+    #[serde_as(as = "Option<GasPriceAsHexStr>")]
+    #[serde(default)]
+    pub gas_price: Option<GasPrice>,
+    pub parent_block_hash: StarknetBlockHash,
+
+    #[serde(default)]
+    pub sequencer_address: Option<SequencerAddress>,
+
+    #[serde(alias = "state_root")]
+    pub state_commitment: StateCommitment,
+    pub status: Status,
+    pub timestamp: StarknetBlockTimestamp,
+
+    #[serde(default)]
+    pub starknet_version: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
-pub struct WebsocketEventNewHead {
-    pub block: Box<Block>,
+impl WebsocketEventNewHead {
+    pub fn new(mut block: Block) -> WebsocketEventNewHead {
+        let Block {
+            block_hash,
+            block_number,
+            gas_price,
+            parent_block_hash,
+            sequencer_address,
+            state_commitment,
+            status,
+            timestamp,
+            starknet_version,
+            ..
+        } = block;
+        WebsocketEventNewHead {
+            block_hash,
+            block_number,
+            gas_price,
+            parent_block_hash,
+            sequencer_address,
+            state_commitment,
+            status,
+            timestamp,
+            starknet_version,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct WebsocketSenders {
-    pub sync: broadcast::Sender<WebsocketEventSync>,
-    pub new_head: broadcast::Sender<WebsocketEventNewHead>,
+    pub new_head: RPCSender<WebsocketEventNewHead>,
 }
 
 impl WebsocketSenders {
-    pub fn new() -> WebsocketSenders {
+    pub fn with_capacity(capacity: usize) -> WebsocketSenders {
         WebsocketSenders {
-            sync: broadcast::channel(100).0,
-            new_head: broadcast::channel(100).0,
+            new_head: RPCSender(broadcast::channel(capacity).0),
         }
     }
 }
 
 impl Default for WebsocketSenders {
     fn default() -> Self {
-        Self::new()
+        Self::with_capacity(100)
     }
 }

--- a/crates/gateway-types/src/websocket.rs
+++ b/crates/gateway-types/src/websocket.rs
@@ -84,8 +84,3 @@ impl WebsocketSenders {
     }
 }
 
-impl Default for WebsocketSenders {
-    fn default() -> Self {
-        Self::with_capacity(100)
-    }
-}

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -44,7 +44,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["arbitrary_precision", "raw_value"] }
 stark_hash = { path = "../stark_hash" }
 starknet-gateway-client = { path = "../gateway-client" }
-starknet-gateway-types = { path = "../gateway-types" }
+starknet-gateway-types = { path = "../gateway-types", features = ["test-utils"] }
 tempfile = "3.4"
 thiserror = "1.0.40"
 time = { version = "0.3.20", features = ["macros"] }

--- a/crates/pathfinder/examples/compute_class_hash.rs
+++ b/crates/pathfinder/examples/compute_class_hash.rs
@@ -15,6 +15,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         starknet_gateway_types::class_hash::ComputedClassHash::Cairo(h) => h.0,
         starknet_gateway_types::class_hash::ComputedClassHash::Sierra(h) => h.0,
     };
-    println!("{:x}", class_hash);
+    println!("{class_hash:x}");
     Ok(())
 }

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -363,7 +363,7 @@ mod tests {
         let not_url = "not_url".to_string();
         let with_path = "http://a.com/path".to_string();
         let with_query = "http://a.com/?query=x".to_string();
-        let with_trailing_slash = format!("{}/", valid);
+        let with_trailing_slash = format!("{valid}/");
 
         [
             (

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -66,7 +66,7 @@ Examples:
     ws: bool,
 
     #[arg(
-        long = "ws.capacity",
+        long = "rpc.websocket.capacity",
         long_help = "Maximum number of websocket subscriptions per subscription type",
         default_value = "100",
         env = "PATHFINDER_RPC_WEBSOCKET_CAPACITY"

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -56,6 +56,16 @@ Examples:
     )]
     rpc_address: SocketAddr,
 
+    #[arg(long = "ws", long_help = "Enable WebSocket transport")]
+    ws: bool,
+
+    #[arg(
+        long = "ws.capacity",
+        long_help = "Capacity for WebSocket Senders",
+        default_value = "100"
+    )]
+    ws_capacity: usize,
+
     #[arg(
         long = "rpc.cors-domains",
         long_help = r"Comma separated list of domains from which Cross-Origin requests will be accepted by the RPC server.
@@ -255,12 +265,18 @@ pub struct Config {
     pub ethereum: Ethereum,
     pub rpc_address: SocketAddr,
     pub rpc_cors_domains: Option<AllowedOrigins>,
+    pub ws: WebSocket,
     pub monitor_address: Option<SocketAddr>,
     pub network: Option<NetworkConfig>,
     pub poll_pending: bool,
     pub python_subprocesses: std::num::NonZeroUsize,
     pub sqlite_wal: JournalMode,
     pub max_rpc_connections: std::num::NonZeroU32,
+}
+
+pub struct WebSocket {
+    pub enabled: bool,
+    pub capacity: usize,
 }
 
 pub struct Ethereum {
@@ -337,6 +353,10 @@ impl Config {
             },
             rpc_address: cli.rpc_address,
             rpc_cors_domains: parse_cors_or_exit(cli.rpc_cors_domains),
+            ws: WebSocket {
+                enabled: cli.ws,
+                capacity: cli.ws_capacity,
+            },
             monitor_address: cli.monitor_address,
             network,
             poll_pending: cli.poll_pending,

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -56,12 +56,12 @@ Examples:
     )]
     rpc_address: SocketAddr,
 
-    #[arg(long = "ws", long_help = "Enable WebSocket transport")]
+    #[arg(long = "rpc.websocket", long_help = "Enable RPC WebSocket transport", default_value = "false", env = "PATHFINDER_RPC_WEBSOCKET")]
     ws: bool,
 
     #[arg(
         long = "ws.capacity",
-        long_help = "Capacity for WebSocket Senders",
+        long_help = "Maximum number of websocket subscriptions per subscription type",
         default_value = "100"
     )]
     ws_capacity: usize,

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -359,13 +359,9 @@ impl Config {
             },
             rpc_address: cli.rpc_address,
             rpc_cors_domains: parse_cors_or_exit(cli.rpc_cors_domains),
-            ws: if cli.ws {
-                Some(WebSocket {
-                    capacity: cli.ws_capacity,
-                })
-            } else {
-                None
-            },
+            ws: cli.ws.then_some(WebSocket {
+                capacity: cli.ws_capacity,
+            }),
             monitor_address: cli.monitor_address,
             network,
             poll_pending: cli.poll_pending,

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -121,9 +121,9 @@ async fn main() -> anyhow::Result<()> {
         None => rpc_server,
     };
 
-    let rpc_server = match config.ws.enabled {
-        true => rpc_server.with_ws(config.ws.capacity),
-        false => rpc_server,
+    let rpc_server = match config.ws {
+        Some(ws) => rpc_server.with_ws(ws.capacity),
+        None => rpc_server,
     };
 
     let sync_handle = tokio::spawn(state::sync(

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -121,6 +121,11 @@ async fn main() -> anyhow::Result<()> {
         None => rpc_server,
     };
 
+    let rpc_server = match config.ws.enabled {
+        true => rpc_server.with_ws(config.ws.capacity),
+        false => rpc_server,
+    };
+
     let sync_handle = tokio::spawn(state::sync(
         storage.clone(),
         ethereum.transport,
@@ -134,7 +139,7 @@ async fn main() -> anyhow::Result<()> {
         pending_state,
         pending_interval,
         state::l2::BlockValidationMode::Strict,
-        rpc_server.get_websocket_txs(),
+        rpc_server.get_ws_senders(),
     ));
 
     let (rpc_handle, local_addr) = rpc_server

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -375,7 +375,7 @@ where
 
                     let (new_tx, new_rx) = mpsc::channel(1);
 
-                    let websocket_txs = WebsocketSenders::new();
+                    let websocket_txs = WebsocketSenders::default();
                     rx_l2 = new_rx;
 
                     let fut = l2_sync(new_tx, websocket_txs, sequencer.clone(), l2_head, chain, chain_id, pending_poll_interval, block_validation_mode);
@@ -1288,7 +1288,7 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let mut connection = storage.connection().unwrap();
             let tx = connection.transaction().unwrap();
-            let websocket_txs = WebsocketSenders::new();
+            let websocket_txs = WebsocketSenders::default();
 
             state
                 .into_iter()
@@ -1393,7 +1393,7 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let mut connection = storage.connection().unwrap();
             let tx = connection.transaction().unwrap();
-            let websocket_txs = WebsocketSenders::new();
+            let websocket_txs = WebsocketSenders::default();
 
             // A simple L1 sync task
             let l1 = move |tx: mpsc::Sender<l1::Event>, _, _, _, _| async move {
@@ -1460,7 +1460,7 @@ mod tests {
         let storage = Storage::in_memory().unwrap();
         let mut connection = storage.connection().unwrap();
         let tx = connection.transaction().unwrap();
-        let websocket_txs = WebsocketSenders::new();
+        let websocket_txs = WebsocketSenders::default();
 
         // This is what we're asking for
         L1StateTable::upsert(&tx, &STATE_UPDATE_LOG0).unwrap();
@@ -1509,7 +1509,7 @@ mod tests {
         let storage = Storage::in_memory().unwrap();
 
         let (starts_tx, mut starts_rx) = tokio::sync::mpsc::channel(1);
-        let websocket_txs = WebsocketSenders::new();
+        let websocket_txs = WebsocketSenders::default();
 
         let l1 = move |_, _, _, _, _| {
             let starts_tx = starts_tx.clone();
@@ -1558,7 +1558,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn l2_update() {
         let sync_state = Arc::new(SyncState::default());
-        let websocket_txs = WebsocketSenders::new();
+        let websocket_txs = WebsocketSenders::default();
 
         // Incoming L2 update
         let block = || BLOCK0.clone();
@@ -1673,7 +1673,7 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let mut connection = storage.connection().unwrap();
             let tx = connection.transaction().unwrap();
-            let websocket_txs = WebsocketSenders::new();
+            let websocket_txs = WebsocketSenders::default();
 
             // A simple L2 sync task
             let l2 = move |tx: mpsc::Sender<l2::Event>, _, _, _, _, _, _, _| async move {
@@ -1747,7 +1747,7 @@ mod tests {
     async fn l2_new_cairo_contract() {
         let storage = Storage::in_memory().unwrap();
         let connection = storage.connection().unwrap();
-        let websocket_txs = WebsocketSenders::new();
+        let websocket_txs = WebsocketSenders::default();
 
         // A simple L2 sync task
         let l2 = |tx: mpsc::Sender<l2::Event>, _, _, _, _, _, _, _| async move {
@@ -1793,7 +1793,7 @@ mod tests {
     async fn l2_new_sierra_contract() {
         let storage = Storage::in_memory().unwrap();
         let connection = storage.connection().unwrap();
-        let websocket_txs = WebsocketSenders::new();
+        let websocket_txs = WebsocketSenders::default();
 
         // A simple L2 sync task
         let l2 = |tx: mpsc::Sender<l2::Event>, _, _, _, _, _, _, _| async move {
@@ -1851,7 +1851,7 @@ mod tests {
         let storage = Storage::in_memory().unwrap();
         let mut connection = storage.connection().unwrap();
         let tx = connection.transaction().unwrap();
-        let websocket_txs = WebsocketSenders::new();
+        let websocket_txs = WebsocketSenders::default();
 
         // This is what we're asking for
         StarknetBlocksTable::insert(
@@ -1905,7 +1905,7 @@ mod tests {
         let storage = Storage::in_memory().unwrap();
         let connection = storage.connection().unwrap();
         let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
-        let websocket_txs = WebsocketSenders::new();
+        let websocket_txs = WebsocketSenders::default();
 
         // This is what we're asking for
         ContractCodeTable::insert_compressed(
@@ -1957,7 +1957,7 @@ mod tests {
         let storage = Storage::in_memory().unwrap();
 
         static CNT: AtomicUsize = AtomicUsize::new(0);
-        let websocket_txs = WebsocketSenders::new();
+        let websocket_txs = WebsocketSenders::default();
 
         // A simple L2 sync task
         let l2 = move |_, _, _, _, _, _, _, _| async move {

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -601,7 +601,7 @@ async fn l2_update(
                 class_hash,
                 block.block_number,
             )
-            .with_context(|| format!("Setting declared_on for class={:?}", class_hash))?;
+            .with_context(|| format!("Setting declared_on for class={class_hash:?}"))?;
         }
 
         // Insert the transactions.

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -117,7 +117,7 @@ where
     ));
     let mut l2_handle = tokio::spawn(l2_sync(
         tx_l2,
-        websocket_txs,
+        websocket_txs.clone(),
         sequencer.clone(),
         l2_head,
         chain,
@@ -375,10 +375,9 @@ where
 
                     let (new_tx, new_rx) = mpsc::channel(1);
 
-                    let websocket_txs = WebsocketSenders::default();
                     rx_l2 = new_rx;
 
-                    let fut = l2_sync(new_tx, websocket_txs, sequencer.clone(), l2_head, chain, chain_id, pending_poll_interval, block_validation_mode);
+                    let fut = l2_sync(new_tx, websocket_txs.clone(), sequencer.clone(), l2_head, chain, chain_id, pending_poll_interval, block_validation_mode);
 
                     l2_handle = tokio::spawn(async move {
                         #[cfg(not(test))]
@@ -1289,7 +1288,7 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let mut connection = storage.connection().unwrap();
             let tx = connection.transaction().unwrap();
-            let websocket_txs = WebsocketSenders::default();
+            let websocket_txs = WebsocketSenders::for_test();
 
             state
                 .into_iter()
@@ -1394,7 +1393,7 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let mut connection = storage.connection().unwrap();
             let tx = connection.transaction().unwrap();
-            let websocket_txs = WebsocketSenders::default();
+            let websocket_txs = WebsocketSenders::for_test();
 
             // A simple L1 sync task
             let l1 = move |tx: mpsc::Sender<l1::Event>, _, _, _, _| async move {
@@ -1461,7 +1460,7 @@ mod tests {
         let storage = Storage::in_memory().unwrap();
         let mut connection = storage.connection().unwrap();
         let tx = connection.transaction().unwrap();
-        let websocket_txs = WebsocketSenders::default();
+        let websocket_txs = WebsocketSenders::for_test();
 
         // This is what we're asking for
         L1StateTable::upsert(&tx, &STATE_UPDATE_LOG0).unwrap();
@@ -1510,7 +1509,7 @@ mod tests {
         let storage = Storage::in_memory().unwrap();
 
         let (starts_tx, mut starts_rx) = tokio::sync::mpsc::channel(1);
-        let websocket_txs = WebsocketSenders::default();
+        let websocket_txs = WebsocketSenders::for_test();
 
         let l1 = move |_, _, _, _, _| {
             let starts_tx = starts_tx.clone();
@@ -1559,7 +1558,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn l2_update() {
         let sync_state = Arc::new(SyncState::default());
-        let websocket_txs = WebsocketSenders::default();
+        let websocket_txs = WebsocketSenders::for_test();
 
         // Incoming L2 update
         let block = || BLOCK0.clone();
@@ -1674,7 +1673,7 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let mut connection = storage.connection().unwrap();
             let tx = connection.transaction().unwrap();
-            let websocket_txs = WebsocketSenders::default();
+            let websocket_txs = WebsocketSenders::for_test();
 
             // A simple L2 sync task
             let l2 = move |tx: mpsc::Sender<l2::Event>, _, _, _, _, _, _, _| async move {
@@ -1748,7 +1747,7 @@ mod tests {
     async fn l2_new_cairo_contract() {
         let storage = Storage::in_memory().unwrap();
         let connection = storage.connection().unwrap();
-        let websocket_txs = WebsocketSenders::default();
+        let websocket_txs = WebsocketSenders::for_test();
 
         // A simple L2 sync task
         let l2 = |tx: mpsc::Sender<l2::Event>, _, _, _, _, _, _, _| async move {
@@ -1794,7 +1793,7 @@ mod tests {
     async fn l2_new_sierra_contract() {
         let storage = Storage::in_memory().unwrap();
         let connection = storage.connection().unwrap();
-        let websocket_txs = WebsocketSenders::default();
+        let websocket_txs = WebsocketSenders::for_test();
 
         // A simple L2 sync task
         let l2 = |tx: mpsc::Sender<l2::Event>, _, _, _, _, _, _, _| async move {
@@ -1852,7 +1851,7 @@ mod tests {
         let storage = Storage::in_memory().unwrap();
         let mut connection = storage.connection().unwrap();
         let tx = connection.transaction().unwrap();
-        let websocket_txs = WebsocketSenders::default();
+        let websocket_txs = WebsocketSenders::for_test();
 
         // This is what we're asking for
         StarknetBlocksTable::insert(
@@ -1906,7 +1905,7 @@ mod tests {
         let storage = Storage::in_memory().unwrap();
         let connection = storage.connection().unwrap();
         let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
-        let websocket_txs = WebsocketSenders::default();
+        let websocket_txs = WebsocketSenders::for_test();
 
         // This is what we're asking for
         ContractCodeTable::insert_compressed(
@@ -1958,7 +1957,7 @@ mod tests {
         let storage = Storage::in_memory().unwrap();
 
         static CNT: AtomicUsize = AtomicUsize::new(0);
-        let websocket_txs = WebsocketSenders::default();
+        let websocket_txs = WebsocketSenders::for_test();
 
         // A simple L2 sync task
         let l2 = move |_, _, _, _, _, _, _, _| async move {

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -33,7 +33,9 @@ use starknet_gateway_types::{
     reply::{
         state_update::DeployedContract, Block, MaybePendingBlock, PendingStateUpdate, StateUpdate,
     },
+    websocket::WebsocketSenders,
 };
+
 use std::sync::Arc;
 use std::{collections::HashMap, future::Future};
 use tokio::sync::mpsc;
@@ -53,6 +55,7 @@ pub async fn sync<Transport, SequencerClient, F1, F2, L1Sync, L2Sync>(
     pending_data: PendingData,
     pending_poll_interval: Option<std::time::Duration>,
     block_validation_mode: l2::BlockValidationMode,
+    websocket_txs: WebsocketSenders,
 ) -> anyhow::Result<()>
 where
     Transport: EthereumTransport + Clone,
@@ -62,6 +65,7 @@ where
     L1Sync: FnMut(mpsc::Sender<l1::Event>, Transport, Chain, H160, Option<StateUpdateLog>) -> F1,
     L2Sync: FnOnce(
             mpsc::Sender<l2::Event>,
+            WebsocketSenders,
             SequencerClient,
             Option<(BlockNumber, BlockHash, StateCommitment)>,
             Chain,
@@ -113,6 +117,7 @@ where
     ));
     let mut l2_handle = tokio::spawn(l2_sync(
         tx_l2,
+        websocket_txs,
         sequencer.clone(),
         l2_head,
         chain,
@@ -369,9 +374,11 @@ where
                     .map(|block| (block.number, block.hash, block.state_commmitment));
 
                     let (new_tx, new_rx) = mpsc::channel(1);
+
+                    let websocket_txs = WebsocketSenders::new();
                     rx_l2 = new_rx;
 
-                    let fut = l2_sync(new_tx, sequencer.clone(), l2_head, chain, chain_id, pending_poll_interval, block_validation_mode);
+                    let fut = l2_sync(new_tx, websocket_txs, sequencer.clone(), l2_head, chain, chain_id, pending_poll_interval, block_validation_mode);
 
                     l2_handle = tokio::spawn(async move {
                         #[cfg(not(test))]
@@ -380,7 +387,7 @@ where
                     });
                     tracing::info!("L2 sync process restarted.");
                 }
-            }
+            },
         }
     }
 }
@@ -1075,7 +1082,9 @@ mod tests {
     };
     use stark_hash::Felt;
     use starknet_gateway_client::GatewayApi;
-    use starknet_gateway_types::{error::SequencerError, pending::PendingData, reply};
+    use starknet_gateway_types::{
+        error::SequencerError, pending::PendingData, reply, websocket::WebsocketSenders,
+    };
     use std::{sync::Arc, time::Duration};
     use tokio::sync::mpsc;
 
@@ -1149,6 +1158,7 @@ mod tests {
 
     async fn l2_noop(
         _: mpsc::Sender<l2::Event>,
+        _: WebsocketSenders,
         _: impl GatewayApi,
         _: Option<(BlockNumber, BlockHash, StateCommitment)>,
         _: Chain,
@@ -1278,6 +1288,7 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let mut connection = storage.connection().unwrap();
             let tx = connection.transaction().unwrap();
+            let websocket_txs = WebsocketSenders::new();
 
             state
                 .into_iter()
@@ -1308,6 +1319,7 @@ mod tests {
                 PendingData::default(),
                 None,
                 l2::BlockValidationMode::Strict,
+                websocket_txs.clone(),
             ));
 
             // TODO Find a better way to figure out that the DB update has already been performed
@@ -1381,6 +1393,7 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let mut connection = storage.connection().unwrap();
             let tx = connection.transaction().unwrap();
+            let websocket_txs = WebsocketSenders::new();
 
             // A simple L1 sync task
             let l1 = move |tx: mpsc::Sender<l1::Event>, _, _, _, _| async move {
@@ -1413,6 +1426,7 @@ mod tests {
                 PendingData::default(),
                 None,
                 l2::BlockValidationMode::Strict,
+                websocket_txs,
             ));
 
             // TODO Find a better way to figure out that the DB update has already been performed
@@ -1446,6 +1460,7 @@ mod tests {
         let storage = Storage::in_memory().unwrap();
         let mut connection = storage.connection().unwrap();
         let tx = connection.transaction().unwrap();
+        let websocket_txs = WebsocketSenders::new();
 
         // This is what we're asking for
         L1StateTable::upsert(&tx, &STATE_UPDATE_LOG0).unwrap();
@@ -1482,6 +1497,7 @@ mod tests {
             PendingData::default(),
             None,
             l2::BlockValidationMode::Strict,
+            websocket_txs,
         ));
 
         tokio::time::sleep(Duration::from_millis(10)).await;
@@ -1493,6 +1509,7 @@ mod tests {
         let storage = Storage::in_memory().unwrap();
 
         let (starts_tx, mut starts_rx) = tokio::sync::mpsc::channel(1);
+        let websocket_txs = WebsocketSenders::new();
 
         let l1 = move |_, _, _, _, _| {
             let starts_tx = starts_tx.clone();
@@ -1520,6 +1537,7 @@ mod tests {
             PendingData::default(),
             None,
             l2::BlockValidationMode::Strict,
+            websocket_txs,
         ));
 
         let timeout = std::time::Duration::from_secs(1);
@@ -1540,6 +1558,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn l2_update() {
         let sync_state = Arc::new(SyncState::default());
+        let websocket_txs = WebsocketSenders::new();
 
         // Incoming L2 update
         let block = || BLOCK0.clone();
@@ -1551,7 +1570,7 @@ mod tests {
         };
 
         // A simple L2 sync task
-        let l2 = move |tx: mpsc::Sender<l2::Event>, _, _, _, _, _, _| async move {
+        let l2 = move |tx: mpsc::Sender<l2::Event>, _, _, _, _, _, _, _| async move {
             tx.send(l2::Event::Update(
                 (Box::new(block()), Default::default()),
                 Box::new(state_update()),
@@ -1595,6 +1614,7 @@ mod tests {
                 PendingData::default(),
                 None,
                 l2::BlockValidationMode::Strict,
+                websocket_txs.clone(),
             ));
 
             // TODO Find a better way to figure out that the DB update has already been performed
@@ -1653,9 +1673,10 @@ mod tests {
             let storage = Storage::in_memory().unwrap();
             let mut connection = storage.connection().unwrap();
             let tx = connection.transaction().unwrap();
+            let websocket_txs = WebsocketSenders::new();
 
             // A simple L2 sync task
-            let l2 = move |tx: mpsc::Sender<l2::Event>, _, _, _, _, _, _| async move {
+            let l2 = move |tx: mpsc::Sender<l2::Event>, _, _, _, _, _, _, _| async move {
                 tx.send(l2::Event::Reorg(BlockNumber::new_or_panic(reorg_on_block)))
                     .await
                     .unwrap();
@@ -1694,6 +1715,7 @@ mod tests {
                 PendingData::default(),
                 None,
                 l2::BlockValidationMode::Strict,
+                websocket_txs,
             ));
 
             // TODO Find a better way to figure out that the DB update has already been performed
@@ -1725,9 +1747,10 @@ mod tests {
     async fn l2_new_cairo_contract() {
         let storage = Storage::in_memory().unwrap();
         let connection = storage.connection().unwrap();
+        let websocket_txs = WebsocketSenders::new();
 
         // A simple L2 sync task
-        let l2 = |tx: mpsc::Sender<l2::Event>, _, _, _, _, _, _| async move {
+        let l2 = |tx: mpsc::Sender<l2::Event>, _, _, _, _, _, _, _| async move {
             let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
             tx.send(l2::Event::NewCairoContract(CompressedContract {
                 definition: zstd_magic,
@@ -1754,6 +1777,7 @@ mod tests {
             PendingData::default(),
             None,
             l2::BlockValidationMode::Strict,
+            websocket_txs,
         ));
 
         // TODO Find a better way to figure out that the DB update has already been performed
@@ -1769,9 +1793,10 @@ mod tests {
     async fn l2_new_sierra_contract() {
         let storage = Storage::in_memory().unwrap();
         let connection = storage.connection().unwrap();
+        let websocket_txs = WebsocketSenders::new();
 
         // A simple L2 sync task
-        let l2 = |tx: mpsc::Sender<l2::Event>, _, _, _, _, _, _| async move {
+        let l2 = |tx: mpsc::Sender<l2::Event>, _, _, _, _, _, _, _| async move {
             let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
             tx.send(l2::Event::NewSierraContract(
                 CompressedContract {
@@ -1805,6 +1830,7 @@ mod tests {
             PendingData::default(),
             None,
             l2::BlockValidationMode::Strict,
+            websocket_txs,
         ));
 
         // TODO Find a better way to figure out that the DB update has already been performed
@@ -1825,6 +1851,7 @@ mod tests {
         let storage = Storage::in_memory().unwrap();
         let mut connection = storage.connection().unwrap();
         let tx = connection.transaction().unwrap();
+        let websocket_txs = WebsocketSenders::new();
 
         // This is what we're asking for
         StarknetBlocksTable::insert(
@@ -1837,7 +1864,7 @@ mod tests {
         .unwrap();
 
         // A simple L2 sync task which does the request and checks he result
-        let l2 = |tx: mpsc::Sender<l2::Event>, _, _, _, _, _, _| async move {
+        let l2 = |tx: mpsc::Sender<l2::Event>, _, _, _, _, _, _, _| async move {
             let (tx1, rx1) = tokio::sync::oneshot::channel();
 
             tx.send(l2::Event::QueryBlock(BlockNumber::GENESIS, tx1))
@@ -1869,6 +1896,7 @@ mod tests {
             PendingData::default(),
             None,
             l2::BlockValidationMode::Strict,
+            websocket_txs,
         ));
     }
 
@@ -1877,6 +1905,7 @@ mod tests {
         let storage = Storage::in_memory().unwrap();
         let connection = storage.connection().unwrap();
         let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
+        let websocket_txs = WebsocketSenders::new();
 
         // This is what we're asking for
         ContractCodeTable::insert_compressed(
@@ -1889,7 +1918,7 @@ mod tests {
         .unwrap();
 
         // A simple L2 sync task which does the request and checks he result
-        let l2 = |tx: mpsc::Sender<l2::Event>, _, _, _, _, _, _| async move {
+        let l2 = |tx: mpsc::Sender<l2::Event>, _, _, _, _, _, _, _| async move {
             let (tx1, rx1) = tokio::sync::oneshot::channel::<Vec<bool>>();
 
             tx.send(l2::Event::QueryContractExistance(vec![ClassHash(*A)], tx1))
@@ -1917,6 +1946,7 @@ mod tests {
             PendingData::default(),
             None,
             l2::BlockValidationMode::Strict,
+            websocket_txs,
         ));
     }
 
@@ -1927,9 +1957,10 @@ mod tests {
         let storage = Storage::in_memory().unwrap();
 
         static CNT: AtomicUsize = AtomicUsize::new(0);
+        let websocket_txs = WebsocketSenders::new();
 
         // A simple L2 sync task
-        let l2 = move |_, _, _, _, _, _, _| async move {
+        let l2 = move |_, _, _, _, _, _, _, _| async move {
             CNT.fetch_add(1, Ordering::Relaxed);
             Ok(())
         };
@@ -1948,6 +1979,7 @@ mod tests {
             PendingData::default(),
             None,
             l2::BlockValidationMode::Strict,
+            websocket_txs,
         ));
 
         tokio::time::sleep(Duration::from_millis(5)).await;

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -1156,6 +1156,7 @@ mod tests {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn l2_noop(
         _: mpsc::Sender<l2::Event>,
         _: WebsocketSenders,

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -61,6 +61,7 @@ pub enum Event {
     Pending(Arc<PendingBlock>, Arc<PendingStateUpdate>),
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn sync(
     tx_event: mpsc::Sender<Event>,
     websocket_txs: WebsocketSenders,
@@ -628,11 +629,10 @@ mod tests {
     mod sync {
         use super::super::{sync, BlockValidationMode, Event};
         use assert_matches::assert_matches;
-        use pathfinder_common::Chain;
         use pathfinder_common::{
-            BlockHash, BlockId, BlockNumber, BlockTimestamp, ChainId, ClassHash, ContractAddress,
-            GasPrice, SequencerAddress, StarknetVersion, StateCommitment, StorageAddress,
-            StorageValue,
+            BlockHash, BlockId, BlockNumber, BlockTimestamp, Chain, ChainId, ClassHash,
+            ContractAddress, GasPrice, SequencerAddress, StarknetVersion, StateCommitment,
+            StorageAddress, StorageValue,
         };
         use stark_hash::Felt;
         use starknet_gateway_client::MockGatewayApi;

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -631,13 +631,14 @@ mod tests {
     mod sync {
         use super::super::{sync, BlockValidationMode, Event};
         use assert_matches::assert_matches;
+        use pathfinder_common::Chain;
         use pathfinder_common::{
-            BlockHash, BlockId, BlockNumber, BlockTimestamp, Chain, ChainId, ClassHash,
-            ContractAddress, GasPrice, SequencerAddress, StarknetVersion, StateCommitment,
-            StorageAddress, StorageValue,
+            BlockHash, BlockId, BlockNumber, BlockTimestamp, ChainId, ClassHash, ContractAddress,
+            GasPrice, SequencerAddress, StarknetVersion, StateCommitment, StorageAddress,
+            StorageValue,
         };
         use stark_hash::Felt;
-        use starknet_gateway_client::{GatewayApi, MockGatewayApi};
+        use starknet_gateway_client::MockGatewayApi;
         use starknet_gateway_types::{
             error::{SequencerError, StarknetError, StarknetErrorCode},
             reply,
@@ -672,7 +673,7 @@ mod tests {
 
         fn spawn_sync_default(
             tx_event: mpsc::Sender<Event>,
-            sequencer: impl GatewayApi + 'static,
+            sequencer: MockGatewayApi,
         ) -> JoinHandle<anyhow::Result<()>> {
             tokio::spawn(sync(
                 tx_event,

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -1105,7 +1105,7 @@ mod tests {
                 // Let's run the UUT
                 let _jh = tokio::spawn(sync(
                     tx_event,
-                    WebsocketSenders::default(),
+                    WebsocketSenders::for_test(),
                     mock,
                     Some((BLOCK0_NUMBER, *BLOCK0_HASH, *GLOBAL_ROOT0)),
                     Chain::Testnet,

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -15,7 +15,7 @@ use starknet_gateway_types::{
         StateUpdate, Status,
     },
     transaction_hash::verify,
-    websocket::{WebsocketEventNewHead, WebsocketSenders},
+    websocket::{BlockHeader, WebsocketSenders},
 };
 use std::time::Duration;
 use std::{collections::HashSet, sync::Arc};
@@ -222,7 +222,7 @@ pub async fn sync(
 
         websocket_txs
             .new_head
-            .send_if_receiving(WebsocketEventNewHead::new(*block.clone()))
+            .send_if_receiving(BlockHeader::new(*block.clone()))
     }
 }
 
@@ -674,7 +674,7 @@ mod tests {
         ) -> JoinHandle<anyhow::Result<()>> {
             tokio::spawn(sync(
                 tx_event,
-                WebsocketSenders::default(),
+                WebsocketSenders::for_test(),
                 sequencer,
                 None,
                 Chain::Testnet,

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -35,6 +35,7 @@ starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures", optional =
 starknet-gateway-types = { path = "../gateway-types" }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["process"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
 tower = { version = "0.4.13", default-features = false, features = ["filter", "util"] }
 tower-http = { version = "0.4.0", default-features = false, features = ["cors"] }
 tracing = "0.1.37"

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -13,12 +13,14 @@ pub mod test_client;
 mod utils;
 pub mod v02;
 pub mod v03;
+pub mod websocket;
 
 use crate::metrics::logger::{MaybeRpcMetricsLogger, RpcMetricsLogger};
 use crate::v02::types::syncing::Syncing;
 use context::RpcContext;
 use jsonrpsee::server::{ServerBuilder, ServerHandle};
 use pathfinder_common::AllowedOrigins;
+use starknet_gateway_types::websocket::WebsocketSenders;
 use std::{net::SocketAddr, result::Result};
 use tokio::sync::RwLock;
 use tower_http::cors::CorsLayer;

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -138,8 +138,11 @@ Hint: If you are looking to run two instances of pathfinder, you must configure 
     }
 
     pub fn get_ws_senders(&self) -> WebsocketSenders {
+        // For parts in code that require WebsocketSenders
         match &self.ws_senders {
             Some(txs) => txs.clone(),
+            // Returns WebsocketSenders instance for code to work as is.
+            // Nothing is actually done coz no one can subscribe.
             _ => WebsocketSenders::with_capacity(1),
         }
     }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -46,7 +46,7 @@ impl RpcServer {
             logger: MaybeRpcMetricsLogger::NoOp,
             max_connections: DEFAULT_MAX_CONNECTIONS,
             cors: None,
-            websocket_txs: WebsocketSenders::new(),
+            websocket_txs: WebsocketSenders::default(),
         }
     }
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -23,6 +23,7 @@ use hyper::Body;
 use jsonrpsee::server::{ServerBuilder, ServerHandle};
 use pathfinder_common::AllowedOrigins;
 use starknet_gateway_types::websocket::WebsocketSenders;
+use std::num::NonZeroUsize;
 use std::{net::SocketAddr, result::Result};
 use tokio::sync::RwLock;
 use tower_http::cors::CorsLayer;
@@ -57,9 +58,9 @@ impl RpcServer {
         }
     }
 
-    pub fn with_ws(self, capacity: usize) -> Self {
+    pub fn with_ws(self, capacity: NonZeroUsize) -> Self {
         Self {
-            ws_senders: Some(WebsocketSenders::with_capacity(capacity)),
+            ws_senders: Some(WebsocketSenders::with_capacity(capacity.get())),
             ..self
         }
     }

--- a/crates/rpc/src/module.rs
+++ b/crates/rpc/src/module.rs
@@ -1,6 +1,10 @@
 use std::sync::Arc;
 
 use jsonrpsee::core::server::rpc_module::Methods;
+use jsonrpsee::types::SubscriptionResult;
+use jsonrpsee::SubscriptionSink;
+
+use tokio::sync::broadcast;
 
 use crate::context::RpcContext;
 use crate::error::RpcError;
@@ -116,6 +120,46 @@ impl Module {
         self.0
             .register_async_method(method_name, method_callback)
             .with_context(|| format!("Registering {method_name}"))?;
+
+        Ok(self)
+    }
+
+    pub fn register_subscription<Subscription, WSAnySubscriptionEvent: 'static + Send>(
+        mut self,
+        subscription_name: &'static str,
+        subscription_answer_name: &'static str,
+        unsubscription_name: &'static str,
+        subscription: Subscription,
+        ws_broadcast_tx: broadcast::Sender<WSAnySubscriptionEvent>,
+    ) -> anyhow::Result<Self>
+    where
+        Subscription: (Fn(
+                RpcContext,
+                SubscriptionSink,
+                &broadcast::Sender<WSAnySubscriptionEvent>,
+            ) -> SubscriptionResult)
+            + Copy
+            + Send
+            + Sync
+            + 'static,
+    {
+        use anyhow::Context;
+        use jsonrpsee::types::Params;
+
+        metrics::register_counter!("rpc_subscription_calls_total", "subscription" => subscription_name);
+
+        let subscription_callback = move |_params: Params<'_>, sink, context: Arc<RpcContext>| {
+            subscription((*context).clone(), sink, &ws_broadcast_tx.clone())
+        };
+
+        self.0
+            .register_subscription(
+                subscription_name,
+                subscription_answer_name,
+                unsubscription_name,
+                subscription_callback,
+            )
+            .with_context(|| format!("Registering subscription {subscription_name}"))?;
 
         Ok(self)
     }

--- a/crates/rpc/src/module.rs
+++ b/crates/rpc/src/module.rs
@@ -4,7 +4,7 @@ use jsonrpsee::core::server::rpc_module::Methods;
 use jsonrpsee::types::SubscriptionResult;
 use jsonrpsee::SubscriptionSink;
 
-use tokio::sync::broadcast;
+use starknet_gateway_types::websocket::RPCSender;
 
 use crate::context::RpcContext;
 use crate::error::RpcError;
@@ -124,19 +124,19 @@ impl Module {
         Ok(self)
     }
 
-    pub fn register_subscription<Subscription, WSAnySubscriptionEvent: 'static + Send>(
+    pub fn register_subscription<Subscription, WSAnySubscriptionEvent: 'static + Send + Clone>(
         mut self,
         subscription_name: &'static str,
         subscription_answer_name: &'static str,
         unsubscription_name: &'static str,
         subscription: Subscription,
-        ws_broadcast_tx: broadcast::Sender<WSAnySubscriptionEvent>,
+        ws_broadcast_tx: RPCSender<WSAnySubscriptionEvent>,
     ) -> anyhow::Result<Self>
     where
         Subscription: (Fn(
                 RpcContext,
                 SubscriptionSink,
-                &broadcast::Sender<WSAnySubscriptionEvent>,
+                &RPCSender<WSAnySubscriptionEvent>,
             ) -> SubscriptionResult)
             + Copy
             + Send

--- a/crates/rpc/src/module.rs
+++ b/crates/rpc/src/module.rs
@@ -149,7 +149,9 @@ impl Module {
         metrics::register_counter!("rpc_subscription_calls_total", "subscription" => subscription_name);
 
         let subscription_callback = move |_params: Params<'_>, sink, context: Arc<RpcContext>| {
-            subscription((*context).clone(), sink, &ws_broadcast_tx.clone())
+            let result = subscription((*context).clone(), sink, &ws_broadcast_tx.clone());
+            metrics::increment_counter!("rpc_subscription_calls_total", "subscription" => subscription_name);
+            result
         };
 
         self.0

--- a/crates/rpc/src/module.rs
+++ b/crates/rpc/src/module.rs
@@ -4,7 +4,7 @@ use jsonrpsee::core::server::rpc_module::Methods;
 use jsonrpsee::types::SubscriptionResult;
 use jsonrpsee::SubscriptionSink;
 
-use starknet_gateway_types::websocket::RPCSender;
+use starknet_gateway_types::websocket::SubscriptionBroadcaster;
 
 use crate::context::RpcContext;
 use crate::error::RpcError;
@@ -130,13 +130,13 @@ impl Module {
         subscription_answer_name: &'static str,
         unsubscription_name: &'static str,
         subscription: Subscription,
-        ws_broadcast_tx: RPCSender<WSAnySubscriptionEvent>,
+        ws_broadcast_tx: SubscriptionBroadcaster<WSAnySubscriptionEvent>,
     ) -> anyhow::Result<Self>
     where
         Subscription: (Fn(
                 RpcContext,
                 SubscriptionSink,
-                &RPCSender<WSAnySubscriptionEvent>,
+                &SubscriptionBroadcaster<WSAnySubscriptionEvent>,
             ) -> SubscriptionResult)
             + Copy
             + Send

--- a/crates/rpc/src/module.rs
+++ b/crates/rpc/src/module.rs
@@ -124,6 +124,7 @@ impl Module {
         Ok(self)
     }
 
+    /// Registers all methods for the RPC Websocket subscription API
     pub fn register_subscription<Subscription, WSAnySubscriptionEvent: 'static + Send + Clone>(
         mut self,
         subscription_name: &'static str,

--- a/crates/rpc/src/module.rs
+++ b/crates/rpc/src/module.rs
@@ -124,7 +124,7 @@ impl Module {
         Ok(self)
     }
 
-    /// Registers all methods for the RPC Websocket subscription API
+    /// Registers RPC Websocket subscription endpoints
     pub fn register_subscription<Subscription, WSAnySubscriptionEvent: 'static + Send + Clone>(
         mut self,
         subscription_name: &'static str,

--- a/crates/rpc/src/websocket.rs
+++ b/crates/rpc/src/websocket.rs
@@ -1,0 +1,20 @@
+use crate::module::Module;
+
+use starknet_gateway_types::websocket::WebsocketSenders;
+
+pub mod subscription;
+
+pub fn register_subscriptions(
+    module: Module,
+    ws_broadcast_txs: WebsocketSenders,
+) -> anyhow::Result<Module> {
+    let module = module.register_subscription(
+        "starknet_subscribe_newHeads",
+        "s_newHeads",
+        "starknet_unsubscribe_newHeads",
+        subscription::subscribe_new_heads::subscribe_new_heads,
+        ws_broadcast_txs.new_head,
+    )?;
+
+    Ok(module)
+}

--- a/crates/rpc/src/websocket.rs
+++ b/crates/rpc/src/websocket.rs
@@ -9,9 +9,9 @@ pub fn register_subscriptions(
     ws_broadcast_txs: WebsocketSenders,
 ) -> anyhow::Result<Module> {
     let module = module.register_subscription(
-        "starknet_subscribe_newHeads",
+        "pathfinder_subscribe_newHeads",
         "s_newHeads",
-        "starknet_unsubscribe_newHeads",
+        "pathfinder_unsubscribe_newHeads",
         subscription::subscribe_new_heads::subscribe_new_heads,
         ws_broadcast_txs.new_head,
     )?;

--- a/crates/rpc/src/websocket.rs
+++ b/crates/rpc/src/websocket.rs
@@ -10,7 +10,7 @@ pub fn register_subscriptions(
 ) -> anyhow::Result<Module> {
     let module = module.register_subscription(
         "pathfinder_subscribe_newHeads",
-        "s_newHeads",
+        "pathfinder_subscription_newHead",
         "pathfinder_unsubscribe_newHeads",
         subscription::subscribe_new_heads::subscribe_new_heads,
         ws_broadcast_txs.new_head,

--- a/crates/rpc/src/websocket/subscription.rs
+++ b/crates/rpc/src/websocket/subscription.rs
@@ -1,0 +1,1 @@
+pub(super) mod subscribe_new_heads;

--- a/crates/rpc/src/websocket/subscription/subscribe_new_heads.rs
+++ b/crates/rpc/src/websocket/subscription/subscribe_new_heads.rs
@@ -1,0 +1,28 @@
+use crate::context::RpcContext;
+use jsonrpsee::core::error::SubscriptionClosed;
+use jsonrpsee::types::error::SubscriptionEmptyError;
+use jsonrpsee::SubscriptionSink;
+use starknet_gateway_types::websocket::WebsocketEventNewHead;
+use tokio::sync::broadcast;
+use tokio_stream::wrappers::BroadcastStream;
+
+pub fn subscribe_new_heads(
+    _context: RpcContext,
+    mut sink: SubscriptionSink,
+    ws_new_heads_tx: &broadcast::Sender<WebsocketEventNewHead>,
+) -> Result<(), SubscriptionEmptyError> {
+    let ws_new_heads_tx = BroadcastStream::new(ws_new_heads_tx.subscribe());
+
+    tokio::spawn(async move {
+        match sink.pipe_from_try_stream(ws_new_heads_tx).await {
+            SubscriptionClosed::Success => {
+                sink.close(SubscriptionClosed::Success);
+            }
+            SubscriptionClosed::RemotePeerAborted => (),
+            SubscriptionClosed::Failed(err) => {
+                sink.close(err);
+            }
+        };
+    });
+    Ok(())
+}

--- a/crates/rpc/src/websocket/subscription/subscribe_new_heads.rs
+++ b/crates/rpc/src/websocket/subscription/subscribe_new_heads.rs
@@ -17,9 +17,12 @@ pub fn subscribe_new_heads(
             SubscriptionClosed::Success => {
                 sink.close(SubscriptionClosed::Success);
             }
-            SubscriptionClosed::RemotePeerAborted => (),
-            SubscriptionClosed::Failed(err) => {
-                sink.close(err);
+            SubscriptionClosed::RemotePeerAborted => {
+                tracing::trace!("WS: newHeads subscription peer aborted");
+            }
+            SubscriptionClosed::Failed(error) => {
+                tracing::trace!("WS: newHeads subscription failed {error:?}");
+                sink.close(error);
             }
         };
     });

--- a/crates/rpc/src/websocket/subscription/subscribe_new_heads.rs
+++ b/crates/rpc/src/websocket/subscription/subscribe_new_heads.rs
@@ -2,16 +2,15 @@ use crate::context::RpcContext;
 use jsonrpsee::core::error::SubscriptionClosed;
 use jsonrpsee::types::error::SubscriptionEmptyError;
 use jsonrpsee::SubscriptionSink;
-use starknet_gateway_types::websocket::WebsocketEventNewHead;
-use tokio::sync::broadcast;
+use starknet_gateway_types::websocket::{RPCSender, WebsocketEventNewHead};
 use tokio_stream::wrappers::BroadcastStream;
 
 pub fn subscribe_new_heads(
     _context: RpcContext,
     mut sink: SubscriptionSink,
-    ws_new_heads_tx: &broadcast::Sender<WebsocketEventNewHead>,
+    ws_new_heads_tx: &RPCSender<WebsocketEventNewHead>,
 ) -> Result<(), SubscriptionEmptyError> {
-    let ws_new_heads_tx = BroadcastStream::new(ws_new_heads_tx.subscribe());
+    let ws_new_heads_tx = BroadcastStream::new(ws_new_heads_tx.0.subscribe());
 
     tokio::spawn(async move {
         match sink.pipe_from_try_stream(ws_new_heads_tx).await {

--- a/crates/rpc/src/websocket/subscription/subscribe_new_heads.rs
+++ b/crates/rpc/src/websocket/subscription/subscribe_new_heads.rs
@@ -2,13 +2,13 @@ use crate::context::RpcContext;
 use jsonrpsee::core::error::SubscriptionClosed;
 use jsonrpsee::types::error::SubscriptionEmptyError;
 use jsonrpsee::SubscriptionSink;
-use starknet_gateway_types::websocket::{RPCSender, WebsocketEventNewHead};
+use starknet_gateway_types::websocket::{BlockHeader, SubscriptionBroadcaster};
 use tokio_stream::wrappers::BroadcastStream;
 
 pub fn subscribe_new_heads(
     _context: RpcContext,
     mut sink: SubscriptionSink,
-    ws_new_heads_tx: &RPCSender<WebsocketEventNewHead>,
+    ws_new_heads_tx: &SubscriptionBroadcaster<BlockHeader>,
 ) -> Result<(), SubscriptionEmptyError> {
     let ws_new_heads_tx = BroadcastStream::new(ws_new_heads_tx.0.subscribe());
 

--- a/doc/rpc/pathfinder_rpc_api.json
+++ b/doc/rpc/pathfinder_rpc_api.json
@@ -332,10 +332,7 @@
                     "block_number": {
                         "type": "number"
                     },
-                    "gas_price": {
-                        "type": "string"
-                    },
-                    "parent_block_hash": {
+                    "parent_hash": {
                         "type": "string"
                     },
                     "sequencer_address": {
@@ -344,22 +341,18 @@
                     "state_commitment": {
                         "type": "string"
                     },
-                    "status": {
-                        "type": "string",
-                        "enum": [
-                            "PENDING",
-                            "ACCEPTED_ON_L2",
-                            "ACCEPTED_ON_L1",
-                            "REJECTED"
-                        ]
-                    },
                     "timestamp": {
                         "type": "number"
-                    },
-                    "starknet_version": {
-                        "type": "string"
                     }
-                }
+                },
+                "required": [
+                    "block_hash",
+                    "block_number",
+                    "parent_hash",
+                    "sequencer_address",
+                    "state_commitment",
+                    "timestamp"
+                ]
             }
         },
         "errors": {

--- a/doc/rpc/pathfinder_rpc_api.json
+++ b/doc/rpc/pathfinder_rpc_api.json
@@ -141,6 +141,33 @@
                     "$ref": "#/components/schemas/TX_GATEWAY_STATUS"
                 }
             }
+        },
+        {
+            "name": "pathfinder_subscribe_newHeads",
+            "summary": "Subscribe to new head events on WebSocket",
+            "description": "Fires a notification each time a new header is appended to the chain.",
+            "params": [],
+            "result": {
+                "name": "result",
+                "description": "The status of the transaction.",
+                "schema": {
+                    "type": "number",
+                    "description": "Subscription ID"
+                }
+            }
+        },
+        {
+            "name": "pathfinder_subscription_newHead",
+            "summary": "New header event notification",
+            "description": "Incoming notification from server when new header is appended to the chain.",
+            "params": [],
+            "result": {
+                "name": "result",
+                "description": "Newly added block header.",
+                "schema": {
+                    "$ref": "#/components/schemas/WebsocketEventNewHead"
+                }
+            }
         }
     ],
     "components": {
@@ -295,6 +322,44 @@
                     "ABORTED"
                 ],
                 "description": "The status of a transaction"
+            },
+            "WebsocketEventNewHead": {
+                "type": "object",
+                "properties": {
+                    "block_hash": {
+                        "type": "string"
+                    },
+                    "block_number": {
+                        "type": "number"
+                    },
+                    "gas_price": {
+                        "type": "string"
+                    },
+                    "parent_block_hash": {
+                        "type": "string"
+                    },
+                    "sequencer_address": {
+                        "type": "string"
+                    },
+                    "state_commitment": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "ACCEPTED_ON_L2",
+                            "ACCEPTED_ON_L1",
+                            "REJECTED"
+                        ]
+                    },
+                    "timestamp": {
+                        "type": "number"
+                    },
+                    "starknet_version": {
+                        "type": "string"
+                    }
+                }
             }
         },
         "errors": {

--- a/doc/rpc/pathfinder_rpc_api.json
+++ b/doc/rpc/pathfinder_rpc_api.json
@@ -323,7 +323,7 @@
                 ],
                 "description": "The status of a transaction"
             },
-            "WebsocketEventNewHead": {
+            "BLOCK_HEADER": {
                 "type": "object",
                 "properties": {
                     "block_hash": {


### PR DESCRIPTION
Hello pathfinder team, thanks for your patience. It's been a long journey but here we are.

This PR is a proof of concept implementation that allows event subscription with websockets. Larger objective is to discuss and get a consensus with the community on event subscription API and supported events with the publication of a [SNIP](https://github.com/matthieuauger/SNIPs/blob/main/SNIPS/snip-5.md). 

Currently code implements one event: `newHeads`.
You can subscribe to this event with function `starknet_subscribe_newHeads`.
Architecture is ready for multiple events once we defined them in the SNIP.

If current implementation is ok for you, we will update the SNIP and have interviews with Pathfinder community to understand.

PR is authored by @shramee and myself. If you want to we can plan a quick call together to discuss the PR and next steps

https://user-images.githubusercontent.com/1172099/234785862-592f53ac-3c86-4b2e-b160-64239bedd349.mp4

