### PR TITLE
Verify transaction hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - CORS support for the RPC server, enabled via the `rpc.cors-domains` command line argument
+- transaction hash verification, excluding older L1 handler transactions, i.e. in blocks older than
+  - 4400 for mainnet
+  - 306008 for testnet
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7317,6 +7317,7 @@ dependencies = [
  "lazy_static",
  "pathfinder-common",
  "pathfinder-serde",
+ "pathfinder-storage",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7328,7 +7328,6 @@ dependencies = [
  "starknet-gateway-test-fixtures",
  "thiserror",
  "tokio",
- "tracing",
  "zstd",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7314,6 +7314,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ethers",
+ "lazy_static",
  "pathfinder-common",
  "pathfinder-serde",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7317,7 +7317,6 @@ dependencies = [
  "lazy_static",
  "pathfinder-common",
  "pathfinder-serde",
- "pathfinder-storage",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7328,6 +7328,7 @@ dependencies = [
  "starknet-gateway-test-fixtures",
  "thiserror",
  "tokio",
+ "tracing",
  "zstd",
 ]
 

--- a/crates/ethereum/src/contract.rs
+++ b/crates/ethereum/src/contract.rs
@@ -179,7 +179,7 @@ mod tests {
                 // update the address and more importantly, the ABI once it reaches testnet.
 
                 // The current address of Starknet's core contract implementation.
-                const CORE_IMPL_ADDR: &str = "0xc95b2435c3e0c9a4674c1060ea2d2494487babae";
+                const CORE_IMPL_ADDR: &str = "0x3cecee6b359fac09c79ca4032826894f7e660b33";
                 let expect_addr = H160::from_str(CORE_IMPL_ADDR).unwrap();
                 let provider = HttpProvider::test_provider(Chain::Integration);
                 let provider = std::sync::Arc::new(&*provider);

--- a/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/declare_v1_block_463319.json
+++ b/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/declare_v1_block_463319.json
@@ -1,0 +1,19 @@
+{
+    "status": "ACCEPTED_ON_L1",
+    "block_hash": "0x3a67a0902cd2e9e0f7afa181a005f682a0284b68a150fd4f1aaa61b5c1d8169",
+    "block_number": 463319,
+    "transaction_index": 3,
+    "transaction": {
+        "transaction_hash": "0xaed69c218b07fdce54cc5bbed3346b76c236d4ce851ffe5742f967e4390ea6",
+        "version": "0x1",
+        "max_fee": "0x2386f26fc10000",
+        "signature": [
+            "0x7c26c6f2ff39d1e778af9f121752678d2f17590dacf594b2e81e2930b72d9db",
+            "0x51efa12ef543d34273955a48f21704d50e21c5e1ba1ccc65d46ed4db6515d04"
+        ],
+        "nonce": "0x234",
+        "class_hash": "0x1e77e6a83dc4d6fb9cc698b0493f40795ec95595971f61750643a85afc99bcc",
+        "sender_address": "0x223a8d916acd673717bb514decf82218cd590b9b82d467f6588ecf179970445",
+        "type": "DECLARE"
+    }
+}

--- a/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/declare_v1_block_797215.json
+++ b/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/declare_v1_block_797215.json
@@ -1,0 +1,19 @@
+{
+    "status": "ACCEPTED_ON_L2",
+    "block_hash": "0x7f4b31498098ae4e7c931e006788517d531bcda93f53512c2d181e9f6f13170",
+    "block_number": 797215,
+    "transaction_index": 36,
+    "transaction": {
+        "transaction_hash": "0x2eaa60a2b1a7964941d4948144a9d9c9bd4866ea700048841fd7eb92036659e",
+        "version": "0x1",
+        "max_fee": "0x1ed09bead87c0378d8e6400000000",
+        "signature": [
+            "0x1125afd7eac1bd98732f3f00522e567c819fe25c9779735795cb88d500ecee3",
+            "0x3bb118383a97dc16a693eb6005a53f90a55d7eac76c1b5f876067b0052e7d72"
+        ],
+        "nonce": "0x20",
+        "class_hash": "0x462c186c8b1a5f1c282543d96ef0f99f70b3eedb321069da5846ee1e3046845",
+        "sender_address": "0x4a17c3c500a8249fc29f5bbe96a6e5a93dfde7c4b75ec7bedd030e0e4f29bc7",
+        "type": "DECLARE"
+    }
+}

--- a/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/declare_v2_block_797220.json
+++ b/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/declare_v2_block_797220.json
@@ -1,0 +1,20 @@
+{
+    "status": "ACCEPTED_ON_L2",
+    "block_hash": "0x42d3be49c69b6bfa7bfd23c295101276f47db20610a2ac0bcc6483238b7818f",
+    "block_number": 797220,
+    "transaction_index": 37,
+    "transaction": {
+        "transaction_hash": "0x4cc334c670486d286f38dc7ffcee2059d5db7f96d60fe64130e4e5a31acc9d3",
+        "version": "0x2",
+        "max_fee": "0x9a045fc50b3e",
+        "signature": [
+            "0x6ea8e4e33be3ce5056a949c680469f4bd1d01a3dca4ca5d96954639a0939612",
+            "0x75fc2e8e402a1896966258381b53f32610b7df5546f8201fa1966f2272705f6"
+        ],
+        "nonce": "0x3",
+        "class_hash": "0x43d1ec664972001e26c51c4632354a0dc32e0b13bdbea04fb019fbee6e4c118",
+        "compiled_class_hash": "0x13f6700f794ccf04bac0f8d1c33b13f8153930e0dbd5c9c6659ffe89b0bc2c3",
+        "sender_address": "0x33ba85da43392459a9bd85e1d3094be8a08cf575ab32a384741c061f8c467e2",
+        "type": "DECLARE"
+    }
+}

--- a/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/deploy_account_v1_block_375919.json
+++ b/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/deploy_account_v1_block_375919.json
@@ -1,0 +1,23 @@
+{
+    "status": "ACCEPTED_ON_L1",
+    "block_hash": "0x5a8c7eb8b8fbe5c6ee76591fe093fe906d93805e9cf1a82d55410b17977e373",
+    "block_number": 375919,
+    "transaction_index": 43,
+    "transaction": {
+        "transaction_hash": "0x750beaa89b45ddc7da0cbf145421b623ab61e7043d87ccefd9cd5572ff464d5",
+        "version": "0x1",
+        "max_fee": "0x13a44c00f09",
+        "signature": [
+            "0x55d73fd0b3e9c03ee2cb612f39263435591641c78cd0a33d55e3685ec2b0541",
+            "0x25ad93a9a270142129c2e11e4a452f6c9fad8955f9934a1bde18ba14111f425"
+        ],
+        "nonce": "0x0",
+        "contract_address": "0x576f2f671483dbd3a98201a677015317dc508f4092dba1110292b65020570e2",
+        "contract_address_salt": "0x7a41671d0912dbcea3a95f79350bbe8ab61f2ab12c6e8bbfbf477a4a1121bdd",
+        "class_hash": "0x1fac3074c9d5282f0acc5c69a4781a1c711efea5e73c550c5d9fb253cf7fd3d",
+        "constructor_calldata": [
+            "0x7d9b388e8ae71307ead5e71d2739ad6d29071f0a0e7bee7391421cc33c7e802"
+        ],
+        "type": "DEPLOY_ACCOUNT"
+    }
+}

--- a/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/deploy_account_v1_block_797k.json
+++ b/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/deploy_account_v1_block_797k.json
@@ -1,0 +1,27 @@
+{
+    "status": "ACCEPTED_ON_L1",
+    "block_hash": "0x7e920cfd7ba535746b8ab75562826d897e6d1ab65c0a6586651bcf09c77f30e",
+    "block_number": 797000,
+    "transaction_index": 11,
+    "transaction": {
+        "transaction_hash": "0x1708e522240968ec8283e6bb13c3628ed126fd0e82ec6716ddbc074c3c4119a",
+        "version": "0x1",
+        "max_fee": "0xb8d9ee8ad2",
+        "signature": [
+            "0x7d12a1a4abe296fd5e0260757b5ba98b3223c7bb85eda93f8df7e01d74dbc3e",
+            "0x18cc1d216f7f61f3b8afd5ef681e1911a405339dabb8590a10ee6bcd3a6a1c6"
+        ],
+        "nonce": "0x0",
+        "contract_address": "0x3c54ffa250b748560d17beab705ac51aa9ac59c57f069d571a1f738d8e4eea",
+        "contract_address_salt": "0x57f53aa8354a085d28b36fed3b24e8934fcb2ba889c68e910e1f357345fb747",
+        "class_hash": "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+        "constructor_calldata": [
+            "0x33434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2",
+            "0x79dc0da7c54b95f10aa182ad0a46400db63156920adb65eca2654c0945a463",
+            "0x2",
+            "0x57f53aa8354a085d28b36fed3b24e8934fcb2ba889c68e910e1f357345fb747",
+            "0x0"
+        ],
+        "type": "DEPLOY_ACCOUNT"
+    }
+}

--- a/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/deploy_v0_genesis.json
+++ b/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/deploy_v0_genesis.json
@@ -1,0 +1,18 @@
+{
+    "status": "ACCEPTED_ON_L1",
+    "block_hash": "0x7d328a71faf48c5c3857e99f20a77b18522480956d1cd5bff1ff2df3c8b427b",
+    "block_number": 0,
+    "transaction_index": 0,
+    "transaction": {
+        "transaction_hash": "0x45c61314be4da85f0e13df53d18062e002c04803218f08061e4b274d4b38537",
+        "version": "0x0",
+        "contract_address": "0x2f40faa63fdd5871415b2dcfb1a5e3e1ca06435b3dda6e2ba9df3f726fd3251",
+        "contract_address_salt": "0x7284a0367fdd636434f76da25532785690d5f27db40ba38b0cfcbc89a472507",
+        "class_hash": "0x10455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8",
+        "constructor_calldata": [
+            "0x635b73abaa9efff71570cb08f3e5014424788470c3b972b952368fb3fc27cc3",
+            "0x7e92479a573a24241ee6f3e4ade742ff37bae4a60bacef5be1caaff5e7e04f3"
+        ],
+        "type": "DEPLOY"
+    }
+}

--- a/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/deploy_v1_block_485004.json
+++ b/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/deploy_v1_block_485004.json
@@ -1,0 +1,18 @@
+{
+    "status": "ACCEPTED_ON_L1",
+    "block_hash": "0x7f9413a02d787cb52046925414b4f4f4cfde93b4a96f92fa7c57eb0ac302f3",
+    "block_number": 485004,
+    "transaction_index": 10,
+    "transaction": {
+        "transaction_hash": "0x790cc8b131a58a28d8f30a96a12dc37bdccd7b9a9d830f28cae713f0f8a3ac2",
+        "version": "0x1",
+        "contract_address": "0x690a73743f30f534d960e8dcec36c40e4648427a9669d7cac2924d5be29cee9",
+        "contract_address_salt": "0x1f0c06480fbbcf9df67a9780fb13265a26f9a428bb38719375f714f61f7d7cb",
+        "class_hash": "0x1e77e6a83dc4d6fb9cc698b0493f40795ec95595971f61750643a85afc99bcc",
+        "constructor_calldata": [
+            "0x618b4d6a27e6a97ebb43ddb825c78c5306409658779b6e920e7a00d493e18c",
+            "0x3147ce71f170b879ab4890f52698317d2cd697443e32cca3f1dfc521f473380"
+        ],
+        "type": "DEPLOY"
+    }
+}

--- a/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/deploy_v1_genesis_testnet2.json
+++ b/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/deploy_v1_genesis_testnet2.json
@@ -1,0 +1,11 @@
+{
+    "type": "DEPLOY",
+    "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+    "contract_address_salt": "0x322c2610264639f6b2cee681ac53fa65c37e187ea24292d1b21d859c55e1a78",
+    "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+    "constructor_calldata": [
+        "0"
+    ],
+    "transaction_hash": "0x356893f6716b2817ebb7b817ef8d5d6bfa0e10b14ad1bac654119f09f5b892c",
+    "version": "0x1"
+}

--- a/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/invoke_v0_block_854_idx_96.json
+++ b/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/invoke_v0_block_854_idx_96.json
@@ -1,0 +1,16 @@
+{
+    "type": "INVOKE_FUNCTION",
+    "version": "0x0",
+    "calldata": [
+        "7184257680882984759486662715103668781242208776",
+        "917789154208678215885349831600092172101398039978",
+        "2",
+        "1957115730347262841245066474128500922180113325335838466518362100423532002451"
+    ],
+    "sender_address": "0xda8054260ec00606197a4103eb2ef08d6c8af0b6a808b610152d1ce498f8c3",
+    "entry_point_selector": "0xe3f5e9e1456ffa52a3fbc7e8c296631d4cc2120c0be1e2829301c0d8fa026b",
+    "entry_point_type": "L1_HANDLER",
+    "max_fee": "0x0",
+    "signature": [],
+    "transaction_hash": "0x61b518bb1f97c49244b8a7a1a984798b4c2876d42920eca2b6ba8dfb1bddc54"
+}

--- a/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/invoke_v0_genesis.json
+++ b/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/invoke_v0_genesis.json
@@ -1,0 +1,19 @@
+{
+    "status": "ACCEPTED_ON_L1",
+    "block_hash": "0x7d328a71faf48c5c3857e99f20a77b18522480956d1cd5bff1ff2df3c8b427b",
+    "block_number": 0,
+    "transaction_index": 2,
+    "transaction": {
+        "transaction_hash": "0x58fdd84faf17d323a0de3bc53e837ec1f7f61f3172c6ecf174248b7e51168db",
+        "version": "0x0",
+        "max_fee": "0x0",
+        "signature": [],
+        "entry_point_selector": "0x19a35a6e95cb7a3318dbb244f20975a1cd8587cc6b5259f15f61d7beb7ee43b",
+        "calldata": [
+            "0x2f40faa63fdd5871415b2dcfb1a5e3e1ca06435b3dda6e2ba9df3f726fd3251",
+            "0x3c75c20765d020b0ec41b48bb8c5338ac4b619fc950d59994e844e1e1b9d2a9"
+        ],
+        "contract_address": "0x2adb4393384c09f049c06bc0070b7a2f72c9cbdcbe841fa7e109a520466cd66",
+        "type": "INVOKE_FUNCTION"
+    }
+}

--- a/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/invoke_v1_block_420k.json
+++ b/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/invoke_v1_block_420k.json
@@ -1,0 +1,31 @@
+{
+    "status": "ACCEPTED_ON_L1",
+    "block_hash": "0x3191ac3e71785613c3aaa806a927cd2b986df7570b160a7db649a99001c8d94",
+    "block_number": 420000,
+    "transaction_index": 0,
+    "transaction": {
+        "transaction_hash": "0x2a52c8972c79da4fbb9ae07da6d40ca28962d797b63b7d82525032d1f72b27d",
+        "version": "0x1",
+        "max_fee": "0x407b643f408d0",
+        "signature": [
+            "0x75eef430357cd669ca4ae358264ca05b3f2dd2a6e04af72a6e60bead9465d53",
+            "0x48a9b01a8d88dbc121d030b78a9a35ea39cf624ef4229cc96a0a850bb12bb6a"
+        ],
+        "nonce": "0x6",
+        "sender_address": "0x41dacf31e2230499a7ea5b0682a29bf5ffc2cc33ef0a4e065b8a16f473633d8",
+        "calldata": [
+            "0x1",
+            "0x68c6b0cab1423338dd3ee6affb14a8e53ec0c64c27075d6137f6b8d2b4ccc73",
+            "0x152cd4b259505a6a714c2ad0327f82b18084b3bc5e264451a52193d972c2a5a",
+            "0x0",
+            "0x5",
+            "0x5",
+            "0x8",
+            "0xf0bf",
+            "0x0",
+            "0x9d411086ae32c1958679ba3c9b9ab2c6574f5645ea4aedeff74f2a2303388b",
+            "0x7819cfb8d24994a3aa1cec1f5b16ee52fee35c169e363875ffd6f3c83c88d3a"
+        ],
+        "type": "INVOKE_FUNCTION"
+    }
+}

--- a/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/invoke_v1_block_790k.json
+++ b/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/invoke_v1_block_790k.json
@@ -14,7 +14,17 @@
         "nonce": "0x2",
         "sender_address": "0x44d8599d9b7dc4b2fa66058bf24e5d45435544012da62d325536a366bda8846",
         "calldata": [
-            "0x1"
+            "0x1",
+            "0x5dc687af554664861727c909269dbc339e876bc70352efd64b8d057ddfb285",
+            "0x152cd4b259505a6a714c2ad0327f82b18084b3bc5e264451a52193d972c2a5a",
+            "0x0",
+            "0x5",
+            "0x5",
+            "0x2",
+            "0x7f56",
+            "0x0",
+            "0x2c7e1c11e984ff9b10bdc0b04c73b29a0adb687318a36b9977deec5019b70cf",
+            "0x756fc30ab00c3afd4cfd3d9cf6e70ea3428a17667f248c3aa03dbff5ac0a2f5"
         ],
         "type": "INVOKE_FUNCTION"
     }

--- a/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/invoke_v1_block_790k.json
+++ b/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/invoke_v1_block_790k.json
@@ -1,0 +1,21 @@
+{
+    "status": "ACCEPTED_ON_L1",
+    "block_hash": "0x4edeaad096487ce06187cff8ce1379d58089216bdad902760969f3fe67e9f",
+    "block_number": 790000,
+    "transaction_index": 5,
+    "transaction": {
+        "transaction_hash": "0x760ee8357ed0145d7b024132168232218ac4e8c1c0fb619ca94ce382df01702",
+        "version": "0x1",
+        "max_fee": "0x1694359ae09a4",
+        "signature": [
+            "0x5cc77c1d7b985df6071cf4b73be98f9299af0b9d63036d8a02f953981b353e1",
+            "0x1a20acc7cdb55e32294b1a6b8fafac2059803dcfe42e65e68a76881ec0480e2"
+        ],
+        "nonce": "0x2",
+        "sender_address": "0x44d8599d9b7dc4b2fa66058bf24e5d45435544012da62d325536a366bda8846",
+        "calldata": [
+            "0x1"
+        ],
+        "type": "INVOKE_FUNCTION"
+    }
+}

--- a/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/l1_handler_v0_block_1564.json
+++ b/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/l1_handler_v0_block_1564.json
@@ -1,0 +1,18 @@
+{
+    "status": "ACCEPTED_ON_L1",
+    "block_hash": "0x333e2ed0da16224c62c50e6807975779496448844e608736695c99d5ed5cc48",
+    "block_number": 1564,
+    "transaction_index": 2,
+    "transaction": {
+        "transaction_hash": "0xfb118dc1d4a4141b7718da4b7fa98980b11caf5aa5d6e1e35e9b050aae788b",
+        "version": "0x0",
+        "contract_address": "0x55a46448decca3b138edf0104b7a47d41365b8293bdfd59b03b806c102b12b7",
+        "entry_point_selector": "0xc73f681176fc7b3f9693986fd7b14581e8d540519e27400e88b8713932be01",
+        "calldata": [
+            "0x2db8c2615db39a5ed8750b87ac8f217485be11ec",
+            "0xbc614e",
+            "0x258"
+        ],
+        "type": "L1_HANDLER"
+    }
+}

--- a/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/l1_handler_v0_block_272866.json
+++ b/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/l1_handler_v0_block_272866.json
@@ -1,0 +1,20 @@
+{
+    "status": "ACCEPTED_ON_L1",
+    "block_hash": "0x2c2a6ff3fc40f719ca064a0d34b0c88cab4147a7585054b05c4701693a08902",
+    "block_number": 272866,
+    "transaction_index": 67,
+    "transaction": {
+        "transaction_hash": "0x13535b7541375c487d294e27d523e2cf649b0852dc5b1d9363fec17afb97357",
+        "version": "0x0",
+        "contract_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+        "entry_point_selector": "0x2d757788a8d8d6f21d1cd40bce38a8222d70654214e96ff95d8086e684fbee5",
+        "nonce": "0x261cb",
+        "calldata": [
+            "0xc3511006c04ef1d78af4c8e0e74ec18a6e64ff9e",
+            "0x4585926fba29ab0096d26204ffd2f59a22198b399d915a9fbc25bcc6bd45e05",
+            "0x470de4df820000",
+            "0x0"
+        ],
+        "type": "L1_HANDLER"
+    }
+}

--- a/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/l1_handler_v0_block_790k.json
+++ b/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/l1_handler_v0_block_790k.json
@@ -1,0 +1,20 @@
+{
+    "status": "ACCEPTED_ON_L1",
+    "block_hash": "0x4edeaad096487ce06187cff8ce1379d58089216bdad902760969f3fe67e9f",
+    "block_number": 790000,
+    "transaction_index": 2,
+    "transaction": {
+        "transaction_hash": "0x1dc975af72dbce6e135a0651453099765ba9cc1e59956b2f9ab442f1cad14fd",
+        "version": "0x0",
+        "contract_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+        "entry_point_selector": "0x2d757788a8d8d6f21d1cd40bce38a8222d70654214e96ff95d8086e684fbee5",
+        "nonce": "0xa9b5d",
+        "calldata": [
+            "0xc3511006c04ef1d78af4c8e0e74ec18a6e64ff9e",
+            "0x1e98434f62fc4e8aa288d2cf63c369c6ce4898a30b3b3972b91ee38d74293a4",
+            "0x53444835ec580000",
+            "0x0"
+        ],
+        "type": "L1_HANDLER"
+    }
+}

--- a/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/l1_handler_v0_block_854_idx_96.json
+++ b/crates/gateway-test-fixtures/fixtures/0.11.0/transaction/l1_handler_v0_block_854_idx_96.json
@@ -1,0 +1,14 @@
+{
+    "transaction_hash": "0x61b518bb1f97c49244b8a7a1a984798b4c2876d42920eca2b6ba8dfb1bddc54",
+    "version": "0x0",
+    "contract_address": "0xda8054260ec00606197a4103eb2ef08d6c8af0b6a808b610152d1ce498f8c3",
+    "entry_point_selector": "0xe3f5e9e1456ffa52a3fbc7e8c296631d4cc2120c0be1e2829301c0d8fa026b",
+    "nonce": "0x0",
+    "calldata": [
+        "0x142273bcbfca76512b2a05aed21f134c4495208",
+        "0xa0c316cb0bb0c9632315ddc8f49c7921f2c80daa",
+        "0x2",
+        "0x453b0310bcdfa50d3c2e7f757e284ac6cd4171933a4e67d1bdcfdbc7f3cbc93"
+    ],
+    "type": "L1_HANDLER"
+}

--- a/crates/gateway-test-fixtures/src/lib.rs
+++ b/crates/gateway-test-fixtures/src/lib.rs
@@ -77,6 +77,19 @@ pub mod v0_11_0 {
             }
         }
 
+        pub mod deploy {
+            pub mod v0 {
+                /// First deploy on testnet
+                pub const GENESIS: &str = str_fixture!("0.11.0/transaction/deploy_v0_genesis.json");
+            }
+
+            pub mod v1 {
+                /// Last deploy on testnet
+                pub const BLOCK_485004: &str =
+                    str_fixture!("0.11.0/transaction/deploy_v1_block_485004.json");
+            }
+        }
+
         pub mod deploy_account {
             pub mod v1 {
                 pub const BLOCK_375919: &str =
@@ -102,6 +115,8 @@ pub mod v0_11_0 {
             pub mod v0 {
                 pub const BLOCK_1564: &str =
                     str_fixture!("0.11.0/transaction/l1_handler_v0_block_1564.json");
+                pub const BLOCK_272866: &str =
+                    str_fixture!("0.11.0/transaction/l1_handler_v0_block_272866.json");
                 pub const BLOCK_790K: &str =
                     str_fixture!("0.11.0/transaction/l1_handler_v0_block_790k.json");
             }

--- a/crates/gateway-test-fixtures/src/lib.rs
+++ b/crates/gateway-test-fixtures/src/lib.rs
@@ -86,6 +86,10 @@ pub mod v0_11_0 {
             }
 
             pub mod v1 {
+                /// First deploy on testnet2, hash was calculated using chain id of testnet (goerli)
+                pub const GENESIS_TESTNET2: &str =
+                    str_fixture!("0.11.0/transaction/deploy_v1_genesis_testnet2.json");
+
                 /// Last deploy on testnet
                 pub const BLOCK_485004: &str =
                     str_fixture!("0.11.0/transaction/deploy_v1_block_485004.json");
@@ -104,6 +108,10 @@ pub mod v0_11_0 {
         pub mod invoke {
             pub mod v0 {
                 pub const GENESIS: &str = str_fixture!("0.11.0/transaction/invoke_v0_genesis.json");
+                // Invoke v0 with entry point type L1 handler later served
+                // as an L1 handler transaction
+                pub const BLOCK_854_IDX_96: &str =
+                    str_fixture!("0.11.0/transaction/invoke_v0_block_854_idx_96.json");
             }
             pub mod v1 {
                 pub const BLOCK_420K: &str =
@@ -115,6 +123,10 @@ pub mod v0_11_0 {
 
         pub mod l1_handler {
             pub mod v0 {
+                // Former Invoke v0 with entry point type L1 handler later served
+                // as an L1 handler transaction
+                pub const BLOCK_854_IDX_96: &str =
+                    str_fixture!("0.11.0/transaction/l1_handler_v0_block_854_idx_96.json");
                 pub const BLOCK_1564: &str =
                     str_fixture!("0.11.0/transaction/l1_handler_v0_block_1564.json");
                 pub const BLOCK_272866: &str =

--- a/crates/gateway-test-fixtures/src/lib.rs
+++ b/crates/gateway-test-fixtures/src/lib.rs
@@ -46,20 +46,66 @@ pub mod v0_9_0 {
     }
 }
 
-pub mod v0_11_0 {
-    pub mod state_update {
-        pub const GENESIS: &str = str_fixture!("0.11.0/state-update/genesis.json");
-        pub const NUMBER_315700: &str = str_fixture!("0.11.0/state-update/315700.json");
-        pub const PENDING: &str = str_fixture!("0.11.0/state-update/pending.json");
-    }
-}
-
 pub mod v0_10_1 {
     pub mod add_transaction {
         pub const DEPLOY_ACCOUNT_REQUEST: &str =
             str_fixture!("0.10.1/add-transaction/deploy-account-request.json");
         pub const DEPLOY_ACCOUNT_RESPONSE: &str =
             str_fixture!("0.10.1/add-transaction/deploy-account-response.json");
+    }
+}
+
+pub mod v0_11_0 {
+    pub mod state_update {
+        pub const GENESIS: &str = str_fixture!("0.11.0/state-update/genesis.json");
+        pub const NUMBER_315700: &str = str_fixture!("0.11.0/state-update/315700.json");
+        pub const PENDING: &str = str_fixture!("0.11.0/state-update/pending.json");
+    }
+
+    pub mod transaction {
+        pub mod declare {
+            pub mod v1 {
+                pub const BLOCK_463319: &str =
+                    str_fixture!("0.11.0/transaction/declare_v1_block_463319.json");
+                pub const BLOCK_797215: &str =
+                    str_fixture!("0.11.0/transaction/declare_v1_block_797215.json");
+            }
+
+            pub mod v2 {
+                pub const BLOCK_797220: &str =
+                    str_fixture!("0.11.0/transaction/declare_v2_block_797220.json");
+            }
+        }
+
+        pub mod deploy_account {
+            pub mod v1 {
+                pub const BLOCK_375919: &str =
+                    str_fixture!("0.11.0/transaction/deploy_account_v1_block_375919.json");
+                pub const BLOCK_797K: &str =
+                    str_fixture!("0.11.0/transaction/deploy_account_v1_block_797k.json");
+            }
+        }
+
+        pub mod invoke {
+            pub mod v0 {
+                pub const GENESIS: &str = str_fixture!("0.11.0/transaction/invoke_v0_genesis.json");
+            }
+            pub mod v1 {
+                pub const BLOCK_420K: &str =
+                    str_fixture!("0.11.0/transaction/invoke_v1_block_420k.json");
+                pub const BLOCK_790K: &str =
+                    str_fixture!("0.11.0/transaction/invoke_v1_block_790k.json");
+            }
+        }
+
+        pub mod l1_handler {
+            pub mod v0 {
+                pub const BLOCK_1564: &str =
+                    str_fixture!("0.11.0/transaction/l1_handler_v0_block_1564.json");
+                pub const BLOCK_790K: &str =
+                    str_fixture!("0.11.0/transaction/l1_handler_v0_block_790k.json");
+            }
+        }
     }
 }
 

--- a/crates/gateway-test-fixtures/src/lib.rs
+++ b/crates/gateway-test-fixtures/src/lib.rs
@@ -62,6 +62,8 @@ pub mod v0_11_0 {
         pub const PENDING: &str = str_fixture!("0.11.0/state-update/pending.json");
     }
 
+    /// Some of the following transactions are "as of" 0.11.0 and not really
+    /// introduced in the chain in 0.11.0
     pub mod transaction {
         pub mod declare {
             pub mod v1 {

--- a/crates/gateway-types/Cargo.toml
+++ b/crates/gateway-types/Cargo.toml
@@ -9,6 +9,7 @@ rust-version = "1.62"
 [dependencies]
 anyhow = { workspace = true }
 ethers = "1.0.2"
+lazy_static = "1.4.0"
 pathfinder-common = { path = "../common" }
 pathfinder-serde = { path = "../serde" }
 reqwest = "0.11.13"

--- a/crates/gateway-types/Cargo.toml
+++ b/crates/gateway-types/Cargo.toml
@@ -23,7 +23,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
-pathfinder-storage = { path = "../storage" }
 # Due to pathfinder_common::starkhash!() usage
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 tokio = { workspace = true, features = ["macros", "test-util"] }

--- a/crates/gateway-types/Cargo.toml
+++ b/crates/gateway-types/Cargo.toml
@@ -23,6 +23,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
+pathfinder-storage = { path = "../storage" }
 # Due to pathfinder_common::starkhash!() usage
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 tokio = { workspace = true, features = ["macros", "test-util"] }

--- a/crates/gateway-types/Cargo.toml
+++ b/crates/gateway-types/Cargo.toml
@@ -21,6 +21,7 @@ stark_hash = { path = "../stark_hash" }
 stark_poseidon = { path = "../stark_poseidon" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tracing = "0.1.37"
 
 [dev-dependencies]
 pathfinder-storage = { path = "../storage" }

--- a/crates/gateway-types/Cargo.toml
+++ b/crates/gateway-types/Cargo.toml
@@ -21,7 +21,6 @@ stark_hash = { path = "../stark_hash" }
 stark_poseidon = { path = "../stark_poseidon" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-tracing = "0.1.37"
 
 [dev-dependencies]
 pathfinder-storage = { path = "../storage" }

--- a/crates/gateway-types/examples/verify_transaction_hashes.rs
+++ b/crates/gateway-types/examples/verify_transaction_hashes.rs
@@ -64,14 +64,23 @@ fn main() -> anyhow::Result<()> {
                     txn.hash()
                 )
             })?;
-            if computed_hash.hash() != txn.hash() {
-                println!(
-                    "Mismatch: {} block {block_number} idx {i} expected {} computed {} full_txn\n{}",
+            match computed_hash.hash() {
+                Some(computed_hash) => {
+                    if computed_hash != txn.hash() {
+                        println!(
+                        "Mismatch: {} block {block_number} idx {i} expected {} computed {} full_txn\n{}",
+                        transaction_type(txn),
+                        txn.hash(),
+                        computed_hash,
+                        serde_json::to_string(&txn).unwrap_or(">Failed to deserialize<".into()))
+                    }
+                }
+                None => println!(
+                    "Ignored: {} block {block_number} idx {i} hash {} full_txn\n{}",
                     transaction_type(txn),
                     txn.hash(),
-                    computed_hash.hash(),
-                    serde_json::to_string(&txn).unwrap_or("Failed to deserialize".into()),
-                )
+                    serde_json::to_string(&txn).unwrap_or(">Failed to deserialize<".into())
+                ),
             }
         }
     }

--- a/crates/gateway-types/examples/verify_transaction_hashes.rs
+++ b/crates/gateway-types/examples/verify_transaction_hashes.rs
@@ -1,0 +1,95 @@
+use anyhow::Context;
+use pathfinder_common::{ChainId, StarknetBlockNumber};
+use pathfinder_storage::{
+    JournalMode, StarknetBlocksBlockId, StarknetBlocksTable, StarknetTransactionsTable, Storage,
+};
+use starknet_gateway_types::{
+    reply::transaction::{DeclareTransaction, InvokeTransaction, Transaction},
+    transaction_hash::compute_transaction_hash,
+};
+
+/// Verify transaction hashes in a pathfinder database.
+///
+/// Iterates over all blocks in the database and verifies if the computed transaction hashes match
+/// values we store for the block.
+///
+/// Usage:
+/// `cargo run --release -p starknet-gateway-types --example verify_transaction_hashes mainnet ./mainnet.sqlite 100`
+fn main() -> anyhow::Result<()> {
+    let chain_name = std::env::args().nth(1).unwrap();
+    let chain_id = match chain_name.as_str() {
+        "mainnet" => ChainId::MAINNET,
+        "goerli" => ChainId::TESTNET,
+        "testnet2" => ChainId::TESTNET2,
+        "integration" => ChainId::INTEGRATION,
+        _ => panic!("Expected chain name: mainnet/goerli/testnet2/integration"),
+    };
+    let database_path = std::env::args().nth(2).unwrap();
+    let start_block = std::env::args().nth(3).unwrap_or("0".into());
+
+    let start_block = start_block
+        .parse::<u64>()
+        .context("Parse start block number")?;
+
+    println!("Migrating database...");
+
+    let storage = Storage::migrate(database_path.into(), JournalMode::WAL)?;
+    let mut db = storage
+        .connection()
+        .context("Opening database connection")?;
+
+    let latest_block_number = {
+        let tx = db.transaction().unwrap();
+        StarknetBlocksTable::get_latest_number(&tx)?.unwrap()
+    };
+
+    println!("Done. Verifying transactions...");
+
+    for block_number in start_block..latest_block_number.get() {
+        if block_number % 10 == 0 {
+            println!("Block: {block_number}")
+        }
+
+        let tx = db.transaction().unwrap();
+        let block_id =
+            StarknetBlocksBlockId::Number(StarknetBlockNumber::new_or_panic(block_number));
+        let transactions =
+            StarknetTransactionsTable::get_transaction_data_for_block(&tx, block_id)?;
+        drop(tx);
+
+        for (i, (txn, _)) in transactions.iter().enumerate() {
+            let computed_hash = compute_transaction_hash(txn, chain_id).with_context(|| {
+                format!(
+                    "Compute hash for transaction: block {block_number} idx {i} hash {}",
+                    txn.hash()
+                )
+            })?;
+            if computed_hash.hash() != txn.hash() {
+                println!(
+                    "Mismatch: {} block {block_number} idx {i} expected {} computed {} full_txn\n{}",
+                    transaction_type(txn),
+                    txn.hash(),
+                    computed_hash.hash(),
+                    serde_json::to_string(&txn).unwrap_or("Failed to deserialize".into()),
+                )
+            }
+        }
+    }
+
+    println!("Done.");
+
+    Ok(())
+}
+
+fn transaction_type(txn: &Transaction) -> String {
+    match txn {
+        Transaction::Declare(DeclareTransaction::V0(_)) => "          Declare v0".into(),
+        Transaction::Declare(DeclareTransaction::V1(_)) => "          Declare v1".into(),
+        Transaction::Declare(DeclareTransaction::V2(_)) => "       Declare v2".into(),
+        Transaction::Deploy(t) => format!("       Deploy v{}", t.version.0.to_low_u64_be()),
+        Transaction::DeployAccount(_) => "Deploy Account v1".into(),
+        Transaction::Invoke(InvokeTransaction::V0(_)) => "        Invoke v0".into(),
+        Transaction::Invoke(InvokeTransaction::V1(_)) => "        Invoke v1".into(),
+        Transaction::L1Handler(t) => format!("    L1 Handler v{}", t.version.0.to_low_u64_be()),
+    }
+}

--- a/crates/gateway-types/src/lib.rs
+++ b/crates/gateway-types/src/lib.rs
@@ -3,3 +3,4 @@ pub mod error;
 pub mod pending;
 pub mod reply;
 pub mod request;
+pub mod transaction_hash;

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -353,6 +353,17 @@ pub mod transaction {
                 Transaction::L1Handler(t) => t.contract_address,
             }
         }
+
+        pub fn is_l1_handler_or_legacy_l1_handler(&self) -> bool {
+            match self {
+                Self::Invoke(InvokeTransaction::V0(i)) => match i.entry_point_type {
+                    Some(entry_point_type) if entry_point_type == EntryPointType::L1Handler => true,
+                    Some(_) | None => false,
+                },
+                Self::L1Handler(_) => true,
+                _ => false,
+            }
+        }
     }
 
     #[derive(Clone, Debug, Serialize, PartialEq, Eq)]

--- a/crates/gateway-types/src/transaction_hash.rs
+++ b/crates/gateway-types/src/transaction_hash.rs
@@ -1,0 +1,99 @@
+use crate::reply::transaction::{
+    DeclareTransaction, DeclareTransactionV0V1, DeclareTransactionV2, DeployAccountTransaction,
+    DeployTransaction, InvokeTransaction, InvokeTransactionV0, InvokeTransactionV1,
+    L1HandlerTransaction, Transaction,
+};
+use pathfinder_common::StarknetTransactionHash;
+
+#[derive(Debug, PartialEq)]
+pub enum ComputedTransactionHash {
+    DeclareV0V1(StarknetTransactionHash),
+    DeclareV2(StarknetTransactionHash),
+    Deploy(StarknetTransactionHash),
+    DeployAccount(StarknetTransactionHash),
+    InvokeV0(StarknetTransactionHash),
+    InvokeV1(StarknetTransactionHash),
+    L1Handler(StarknetTransactionHash),
+}
+
+impl ComputedTransactionHash {
+    pub fn hash(&self) -> StarknetTransactionHash {
+        match self {
+            ComputedTransactionHash::DeclareV0V1(h) => *h,
+            ComputedTransactionHash::DeclareV2(h) => *h,
+            ComputedTransactionHash::Deploy(h) => *h,
+            ComputedTransactionHash::DeployAccount(h) => *h,
+            ComputedTransactionHash::InvokeV0(h) => *h,
+            ComputedTransactionHash::InvokeV1(h) => *h,
+            ComputedTransactionHash::L1Handler(h) => *h,
+        }
+    }
+}
+
+pub fn compute_transaction_hash(txn: Transaction) -> ComputedTransactionHash {
+    match txn {
+        Transaction::Declare(DeclareTransaction::V0(txn) | DeclareTransaction::V1(txn)) => {
+            compute_declare_v0v1_hash(txn)
+        }
+        Transaction::Declare(DeclareTransaction::V2(txn)) => compute_declare_v2_hash(txn),
+        Transaction::Deploy(txn) => compute_deploy_hash(txn),
+        Transaction::DeployAccount(txn) => compute_deploy_account_hash(txn),
+        Transaction::Invoke(InvokeTransaction::V0(txn)) => compute_invoke_v0_hash(txn),
+        Transaction::Invoke(InvokeTransaction::V1(txn)) => compute_invoke_v1_hash(txn),
+        Transaction::L1Handler(txn) => compute_l1_handler_hash(txn),
+    }
+}
+
+fn compute_declare_v0v1_hash(_txn: DeclareTransactionV0V1) -> ComputedTransactionHash {
+    todo!()
+}
+
+fn compute_declare_v2_hash(_txn: DeclareTransactionV2) -> ComputedTransactionHash {
+    todo!()
+}
+
+fn compute_deploy_hash(_txn: DeployTransaction) -> ComputedTransactionHash {
+    todo!()
+}
+
+fn compute_deploy_account_hash(_txn: DeployAccountTransaction) -> ComputedTransactionHash {
+    todo!()
+}
+
+fn compute_invoke_v0_hash(_txn: InvokeTransactionV0) -> ComputedTransactionHash {
+    todo!()
+}
+
+fn compute_invoke_v1_hash(_txn: InvokeTransactionV1) -> ComputedTransactionHash {
+    todo!()
+}
+
+fn compute_l1_handler_hash(_txn: L1HandlerTransaction) -> ComputedTransactionHash {
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compute_transaction_hash;
+    use crate::reply::transaction::Transaction;
+    use starknet_gateway_test_fixtures::{v0_8_2, v0_9_0};
+
+    #[test]
+    fn success() {
+        let declare_v0 = serde_json::from_str::<Transaction>(v0_9_0::transaction::DECLARE).unwrap();
+        let deploy_v0 = serde_json::from_str::<Transaction>(v0_9_0::transaction::DEPLOY).unwrap();
+        let invoke_v0_starknet_v0_8 =
+            serde_json::from_str::<Transaction>(v0_8_2::transaction::INVOKE).unwrap();
+        let invoke_v0_starknet_v0_9 =
+            serde_json::from_str::<Transaction>(v0_9_0::transaction::INVOKE).unwrap();
+
+        [
+            declare_v0,
+            deploy_v0,
+            invoke_v0_starknet_v0_8,
+            invoke_v0_starknet_v0_9,
+        ]
+        .into_iter()
+        .for_each(|txn| assert_eq!(compute_transaction_hash(txn.clone()).hash(), txn.hash()))
+    }
+}

--- a/crates/gateway-types/src/transaction_hash.rs
+++ b/crates/gateway-types/src/transaction_hash.rs
@@ -316,14 +316,6 @@ fn compute_invoke_v0_hash(
     txn: &InvokeTransactionV0,
     chain_id: ChainId,
 ) -> Result<ComputedTransactionHash> {
-    // // Some old L1 Handler txns can be marked by the entry point type, but we've no idea
-    // // how to calculate their hashes properly, so let's just ignore them
-    // if let Some(entry_point_type) = txn.entry_point_type {
-    //     if entry_point_type == EntryPointType::L1Handler {
-    //         return Ok(ComputedTransactionHash::InvokeV0(None));
-    //     }
-    // }
-
     let call_params_hash = {
         let mut hh = HashChain::default();
         hh = txn.calldata.iter().fold(hh, |mut hh, call_param| {
@@ -598,7 +590,7 @@ mod tests {
             use starknet_gateway_test_fixtures::v0_11_0;
 
             #[test]
-            fn new_version() {
+            fn rewritten_old_l1_handler() {
                 let block_854_idx_96 =
                     serde_json::from_str(v0_11_0::transaction::l1_handler::v0::BLOCK_854_IDX_96)
                         .unwrap();
@@ -612,7 +604,7 @@ mod tests {
             }
 
             #[test]
-            fn old_version() {
+            fn old_l1_handler_in_invoke_v0() {
                 let block_854_idx_96 =
                     serde_json::from_str(v0_11_0::transaction::invoke::v0::BLOCK_854_IDX_96)
                         .unwrap();

--- a/crates/gateway-types/src/transaction_hash.rs
+++ b/crates/gateway-types/src/transaction_hash.rs
@@ -546,17 +546,9 @@ mod tests {
 
     #[test]
     fn computation() {
-        // Block on testnet where starknet version was added (0.9.1)
-        // https://alpha4.starknet.io/feeder_gateway/get_block?blockNumber=272881
-
-        let testnet2_with_wrong_chain_id = r#"{"type":"DEPLOY","contract_address":"0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7","contract_address_salt":
-        "0x322c2610264639f6b2cee681ac53fa65c37e187ea24292d1b21d859c55e1a78","class_hash":"0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3","constructor_calldata":[
-        "0"],"transaction_hash":"0x356893f6716b2817ebb7b817ef8d5d6bfa0e10b14ad1bac654119f09f5b892c","version":"0x1"}"#;
-        let testnet2_with_wrong_chain_id = serde_json::from_str::<
-            crate::reply::transaction::Transaction,
-        >(testnet2_with_wrong_chain_id)
-        .unwrap();
-
+        // At the beginning testnet2 used chain id of testnet for hash calculation
+        let testnet2_with_wrong_chain_id =
+            serde_json::from_str(v0_11_0::transaction::deploy::v1::GENESIS_TESTNET2).unwrap();
         assert_eq!(
             compute_transaction_hash(&testnet2_with_wrong_chain_id, ChainId::TESTNET)
                 .unwrap()
@@ -603,31 +595,13 @@ mod tests {
         mod skipped {
             use crate::transaction_hash::verify;
             use pathfinder_common::{ChainId, StarknetBlockNumber};
+            use starknet_gateway_test_fixtures::v0_11_0;
 
             #[test]
             fn new_version() {
-                // Invoke which is in fact an old L1 Handler
-                // Dunno how to compute the hash
-                let block_854_idx_96 = r#"
-                {
-                    "transaction_hash": "0x61b518bb1f97c49244b8a7a1a984798b4c2876d42920eca2b6ba8dfb1bddc54",
-                    "version": "0x0",
-                    "contract_address": "0xda8054260ec00606197a4103eb2ef08d6c8af0b6a808b610152d1ce498f8c3",
-                    "entry_point_selector": "0xe3f5e9e1456ffa52a3fbc7e8c296631d4cc2120c0be1e2829301c0d8fa026b",
-                    "nonce": "0x0",
-                    "calldata": [
-                      "0x142273bcbfca76512b2a05aed21f134c4495208",
-                      "0xa0c316cb0bb0c9632315ddc8f49c7921f2c80daa",
-                      "0x2",
-                      "0x453b0310bcdfa50d3c2e7f757e284ac6cd4171933a4e67d1bdcfdbc7f3cbc93"
-                    ],
-                    "type": "L1_HANDLER"
-                }"#;
                 let block_854_idx_96 =
-                    serde_json::from_str::<crate::reply::transaction::Transaction>(
-                        block_854_idx_96,
-                    )
-                    .unwrap();
+                    serde_json::from_str(v0_11_0::transaction::l1_handler::v0::BLOCK_854_IDX_96)
+                        .unwrap();
 
                 assert!(verify(
                     &block_854_idx_96,
@@ -639,31 +613,9 @@ mod tests {
 
             #[test]
             fn old_version() {
-                // Invoke which is in fact an old L1 Handler
-                // Dunno how to compute the hash
-                let block_854_idx_96 = r#"
-                {
-                    "type": "INVOKE_FUNCTION",
-                    "version": "0x0",
-                    "calldata": [
-                    "7184257680882984759486662715103668781242208776",
-                    "917789154208678215885349831600092172101398039978",
-                    "2",
-                    "1957115730347262841245066474128500922180113325335838466518362100423532002451"
-                    ],
-                    "sender_address": "0xda8054260ec00606197a4103eb2ef08d6c8af0b6a808b610152d1ce498f8c3",
-                    "entry_point_selector": "0xe3f5e9e1456ffa52a3fbc7e8c296631d4cc2120c0be1e2829301c0d8fa026b",
-                    "entry_point_type": "L1_HANDLER",
-                    "max_fee": "0x0",
-                    "signature": [
-                    ],
-                    "transaction_hash": "0x61b518bb1f97c49244b8a7a1a984798b4c2876d42920eca2b6ba8dfb1bddc54"
-                }"#;
                 let block_854_idx_96 =
-                    serde_json::from_str::<crate::reply::transaction::Transaction>(
-                        block_854_idx_96,
-                    )
-                    .unwrap();
+                    serde_json::from_str(v0_11_0::transaction::invoke::v0::BLOCK_854_IDX_96)
+                        .unwrap();
 
                 assert!(verify(
                     &block_854_idx_96,

--- a/crates/gateway-types/src/transaction_hash.rs
+++ b/crates/gateway-types/src/transaction_hash.rs
@@ -483,6 +483,7 @@ fn legacy_compute_txn_hash(
 }
 
 /// _Generic_ compute transaction hash for transactions
+#[allow(clippy::too_many_arguments)]
 fn compute_txn_hash(
     prefix: &[u8],
     version: TransactionVersion,
@@ -574,8 +575,8 @@ mod tests {
         ]
         .iter()
         .for_each(|(txn, line)| {
-            let actual_hash =
-                compute_transaction_hash(txn, ChainId::TESTNET).expect(&format!("line: {line}"));
+            let actual_hash = compute_transaction_hash(txn, ChainId::TESTNET)
+                .unwrap_or_else(|_| panic!("line: {line}"));
             assert_eq!(actual_hash.hash(), txn.hash(), "line: {line}");
         });
     }

--- a/crates/gateway-types/src/transaction_hash.rs
+++ b/crates/gateway-types/src/transaction_hash.rs
@@ -2,7 +2,7 @@
 
 use crate::reply::transaction::{
     DeclareTransaction, DeclareTransactionV0V1, DeclareTransactionV2, DeployAccountTransaction,
-    DeployTransaction, EntryPointType, InvokeTransaction, InvokeTransactionV0, InvokeTransactionV1,
+    DeployTransaction, InvokeTransaction, InvokeTransactionV0, InvokeTransactionV1,
     L1HandlerTransaction, Transaction,
 };
 use pathfinder_common::{
@@ -21,54 +21,50 @@ pub fn verify(
     chain_id: ChainId,
     block_number: StarknetBlockNumber,
 ) -> Result<bool> {
-    // Earlier blocks on testnet2 used the same chain id as testnet (ie. goerli)
-    let chain_id = if chain_id == ChainId::TESTNET2 && block_number.get() <= 21086 {
-        ChainId::TESTNET
-    } else {
-        chain_id
+    let chain_id = match chain_id {
+        // We don't know how to properly compute hashes of some old L1 Handler transactions
+        // Worse still those are invokes in old snapshots but currently are served as
+        // L1 handler txns.
+        ChainId::MAINNET => {
+            if block_number.get() <= 4399 && txn.is_l1_handler_or_legacy_l1_handler() {
+                // Unable to compute, skipping
+                return Ok(true);
+            } else {
+                chain_id
+            }
+        }
+        ChainId::TESTNET => {
+            if block_number.get() <= 306007 && txn.is_l1_handler_or_legacy_l1_handler() {
+                // Unable to compute, skipping
+                return Ok(true);
+            } else {
+                chain_id
+            }
+        }
+        // Earlier blocks on testnet2 used the same chain id as testnet (ie. goerli)
+        ChainId::TESTNET2 => {
+            if block_number.get() <= 21086 {
+                ChainId::TESTNET
+            } else {
+                chain_id
+            }
+        }
+        _ => chain_id,
     };
 
-    let computed_hash =
-        compute_transaction_hash(txn, chain_id).context("Compute transaction hash")?;
-    match computed_hash.hash() {
-        Some(computed_hash) if computed_hash != txn.hash() => Err(anyhow::anyhow!(
-            "Transaction hash mismatch: expected {} computed {}",
-            txn.hash(),
-            computed_hash,
-        )),
-        Some(_) => Ok(false),
-        None => Ok(true), // Unable to compute, skipping
-    }
-}
+    let computed_hash = compute_transaction_hash(txn, chain_id)
+        .context("Compute transaction hash")?
+        .hash();
 
-pub fn verify2(
-    txn: &Transaction,
-    chain_id: ChainId,
-    block_number: StarknetBlockNumber,
-    txn_idx: usize,
-) -> Result<bool> {
-    // Earlier blocks on testnet2 used the same chain id as testnet (ie. goerli)
-    let chain_id = if chain_id == ChainId::TESTNET2 && block_number.get() <= 21086 {
-        ChainId::TESTNET
-    } else {
-        chain_id
-    };
+    anyhow::ensure!(
+        computed_hash == txn.hash(),
+        "Transaction hash mismatch: expected {} computed {}",
+        txn.hash(),
+        computed_hash
+    );
 
-    let computed_hash = compute_transaction_hash(txn, chain_id).with_context(|| {
-        format!(
-            "Compute hash for transaction: block {block_number} idx {txn_idx} hash {}",
-            txn.hash()
-        )
-    })?;
-    match computed_hash.hash() {
-        Some(computed_hash) if computed_hash == txn.hash() => Err(anyhow::anyhow!(
-            "Transaction hash mismatch: block {block_number} idx {txn_idx} expected {} computed {}",
-            txn.hash(),
-            computed_hash,
-        )),
-        Some(_) => Ok(false),
-        None => Ok(true), // Unable to compute, skipping
-    }
+    // Computation matches
+    Ok(false)
 }
 
 #[derive(Debug, PartialEq)]
@@ -78,27 +74,23 @@ pub enum ComputedTransactionHash {
     DeclareV2(StarknetTransactionHash),
     Deploy(StarknetTransactionHash),
     DeployAccount(StarknetTransactionHash),
-    InvokeV0(Option<StarknetTransactionHash>),
+    InvokeV0(StarknetTransactionHash),
     InvokeV1(StarknetTransactionHash),
     L1Handler(StarknetTransactionHash),
 }
 
 impl ComputedTransactionHash {
-    pub fn hash(&self) -> Option<StarknetTransactionHash> {
-        if let ComputedTransactionHash::InvokeV0(h) = self {
-            return *h;
-        }
-
-        Some(match self {
+    pub fn hash(&self) -> StarknetTransactionHash {
+        match self {
             ComputedTransactionHash::DeclareV0(h) => *h,
             ComputedTransactionHash::DeclareV1(h) => *h,
             ComputedTransactionHash::DeclareV2(h) => *h,
             ComputedTransactionHash::Deploy(h) => *h,
             ComputedTransactionHash::DeployAccount(h) => *h,
-            ComputedTransactionHash::InvokeV0(_) => unreachable!("already handled"),
+            ComputedTransactionHash::InvokeV0(h) => *h,
             ComputedTransactionHash::InvokeV1(h) => *h,
             ComputedTransactionHash::L1Handler(h) => *h,
-        })
+        }
     }
 }
 
@@ -324,13 +316,13 @@ fn compute_invoke_v0_hash(
     txn: &InvokeTransactionV0,
     chain_id: ChainId,
 ) -> Result<ComputedTransactionHash> {
-    // Some old L1 Handler txns can be marked by the entry point type, but we've no idea
-    // how to calculate their hashes properly, so let's just ignore them
-    if let Some(entry_point_type) = txn.entry_point_type {
-        if entry_point_type == EntryPointType::L1Handler {
-            return Ok(ComputedTransactionHash::InvokeV0(None));
-        }
-    }
+    // // Some old L1 Handler txns can be marked by the entry point type, but we've no idea
+    // // how to calculate their hashes properly, so let's just ignore them
+    // if let Some(entry_point_type) = txn.entry_point_type {
+    //     if entry_point_type == EntryPointType::L1Handler {
+    //         return Ok(ComputedTransactionHash::InvokeV0(None));
+    //     }
+    // }
 
     let call_params_hash = {
         let mut hh = HashChain::default();
@@ -365,7 +357,7 @@ fn compute_invoke_v0_hash(
         )?
     };
 
-    Ok(ComputedTransactionHash::InvokeV0(Some(h)))
+    Ok(ComputedTransactionHash::InvokeV0(h))
 }
 
 /// Computes invoke v1 transaction hash based on [this formula](https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#v1_hash_calculation):
@@ -568,8 +560,7 @@ mod tests {
         assert_eq!(
             compute_transaction_hash(&testnet2_with_wrong_chain_id, ChainId::TESTNET)
                 .unwrap()
-                .hash()
-                .unwrap(),
+                .hash(),
             testnet2_with_wrong_chain_id.hash()
         );
 
@@ -601,7 +592,7 @@ mod tests {
         .for_each(|(txn, line)| {
             let actual_hash =
                 compute_transaction_hash(txn, ChainId::TESTNET).expect(&format!("line: {line}"));
-            assert_eq!(actual_hash.hash().unwrap(), txn.hash(), "line: {line}");
+            assert_eq!(actual_hash.hash(), txn.hash(), "line: {line}");
         });
     }
 
@@ -651,23 +642,23 @@ mod tests {
                 // Invoke which is in fact an old L1 Handler
                 // Dunno how to compute the hash
                 let block_854_idx_96 = r#"
-            {
-                "type": "INVOKE_FUNCTION",
-                "version": "0x0",
-                "calldata": [
-                  "7184257680882984759486662715103668781242208776",
-                  "917789154208678215885349831600092172101398039978",
-                  "2",
-                  "1957115730347262841245066474128500922180113325335838466518362100423532002451"
-                ],
-                "sender_address": "0xda8054260ec00606197a4103eb2ef08d6c8af0b6a808b610152d1ce498f8c3",
-                "entry_point_selector": "0xe3f5e9e1456ffa52a3fbc7e8c296631d4cc2120c0be1e2829301c0d8fa026b",
-                "entry_point_type": "L1_HANDLER",
-                "max_fee": "0x0",
-                "signature": [
-                ],
-                "transaction_hash": "0x61b518bb1f97c49244b8a7a1a984798b4c2876d42920eca2b6ba8dfb1bddc54"
-            }"#;
+                {
+                    "type": "INVOKE_FUNCTION",
+                    "version": "0x0",
+                    "calldata": [
+                    "7184257680882984759486662715103668781242208776",
+                    "917789154208678215885349831600092172101398039978",
+                    "2",
+                    "1957115730347262841245066474128500922180113325335838466518362100423532002451"
+                    ],
+                    "sender_address": "0xda8054260ec00606197a4103eb2ef08d6c8af0b6a808b610152d1ce498f8c3",
+                    "entry_point_selector": "0xe3f5e9e1456ffa52a3fbc7e8c296631d4cc2120c0be1e2829301c0d8fa026b",
+                    "entry_point_type": "L1_HANDLER",
+                    "max_fee": "0x0",
+                    "signature": [
+                    ],
+                    "transaction_hash": "0x61b518bb1f97c49244b8a7a1a984798b4c2876d42920eca2b6ba8dfb1bddc54"
+                }"#;
                 let block_854_idx_96 =
                     serde_json::from_str::<crate::reply::transaction::Transaction>(
                         block_854_idx_96,

--- a/crates/gateway-types/src/transaction_hash.rs
+++ b/crates/gateway-types/src/transaction_hash.rs
@@ -75,25 +75,72 @@ fn compute_l1_handler_hash(_txn: L1HandlerTransaction) -> ComputedTransactionHas
 #[cfg(test)]
 mod tests {
     use super::compute_transaction_hash;
-    use crate::reply::transaction::Transaction;
-    use starknet_gateway_test_fixtures::{v0_8_2, v0_9_0};
+    use crate::reply::Transaction;
+    use starknet_gateway_test_fixtures::{v0_11_0, v0_8_2, v0_9_0};
 
     #[test]
     fn success() {
-        let declare_v0 = serde_json::from_str::<Transaction>(v0_9_0::transaction::DECLARE).unwrap();
-        let deploy_v0 = serde_json::from_str::<Transaction>(v0_9_0::transaction::DEPLOY).unwrap();
-        let invoke_v0_starknet_v0_8 =
+        let declare_v0_231579 =
+            serde_json::from_str::<Transaction>(v0_9_0::transaction::DECLARE).unwrap();
+        let declare_v1_463319 =
+            serde_json::from_str::<Transaction>(v0_11_0::transaction::declare::v1::BLOCK_463319)
+                .unwrap();
+        let declare_v1_797215 =
+            serde_json::from_str::<Transaction>(v0_11_0::transaction::declare::v1::BLOCK_797215)
+                .unwrap();
+        let declare_v2_797220 =
+            serde_json::from_str::<Transaction>(v0_11_0::transaction::declare::v2::BLOCK_797220)
+                .unwrap();
+        let deploy_v0_231579 =
+            serde_json::from_str::<Transaction>(v0_9_0::transaction::DEPLOY).unwrap();
+        let deploy_account_v1_375919 = serde_json::from_str::<Transaction>(
+            v0_11_0::transaction::deploy_account::v1::BLOCK_375919,
+        )
+        .unwrap();
+        let deploy_account_v1_797k = serde_json::from_str::<Transaction>(
+            v0_11_0::transaction::deploy_account::v1::BLOCK_797K,
+        )
+        .unwrap();
+        let invoke_v0_genesis =
+            serde_json::from_str::<Transaction>(v0_11_0::transaction::invoke::v0::GENESIS).unwrap();
+        let invoke_v0_21520 =
             serde_json::from_str::<Transaction>(v0_8_2::transaction::INVOKE).unwrap();
-        let invoke_v0_starknet_v0_9 =
+        let invoke_v0_231579 =
             serde_json::from_str::<Transaction>(v0_9_0::transaction::INVOKE).unwrap();
+        let invoke_v1_420k =
+            serde_json::from_str::<Transaction>(v0_11_0::transaction::invoke::v1::BLOCK_420K)
+                .unwrap();
+        let invoke_v1_790k =
+            serde_json::from_str::<Transaction>(v0_11_0::transaction::invoke::v1::BLOCK_790K)
+                .unwrap();
+        let l1_handler_v0_1564 =
+            serde_json::from_str::<Transaction>(v0_11_0::transaction::l1_handler::v0::BLOCK_1564)
+                .unwrap();
+        let l1_handler_v0_790k =
+            serde_json::from_str::<Transaction>(v0_11_0::transaction::l1_handler::v0::BLOCK_790K)
+                .unwrap();
 
         [
-            declare_v0,
-            deploy_v0,
-            invoke_v0_starknet_v0_8,
-            invoke_v0_starknet_v0_9,
+            declare_v0_231579,
+            declare_v1_463319,
+            declare_v1_797215,
+            declare_v2_797220,
+            deploy_v0_231579,
+            deploy_account_v1_375919,
+            deploy_account_v1_797k,
+            invoke_v0_genesis,
+            invoke_v0_21520,
+            invoke_v0_231579,
+            invoke_v1_420k,
+            invoke_v1_790k,
+            l1_handler_v0_1564,
+            l1_handler_v0_790k,
         ]
         .into_iter()
-        .for_each(|txn| assert_eq!(compute_transaction_hash(txn.clone()).hash(), txn.hash()))
+        .for_each(|txn| {
+            let txn = txn.transaction.unwrap();
+            eprintln!("{}", txn.hash());
+            assert_eq!(compute_transaction_hash(txn.clone()).hash(), txn.hash())
+        })
     }
 }

--- a/crates/pathfinder/examples/verify_block_hashes.rs
+++ b/crates/pathfinder/examples/verify_block_hashes.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use pathfinder_common::{Chain, StarknetBlockHash, StarknetBlockNumber, StarknetVersion};
+use pathfinder_common::{Chain, ChainId, StarknetBlockHash, StarknetBlockNumber, StarknetVersion};
 use pathfinder_lib::state::block_hash::{verify_block_hash, VerifyResult};
 use pathfinder_storage::{
     JournalMode, StarknetBlocksBlockId, StarknetBlocksTable, StarknetTransactionsTable, Storage,
@@ -14,14 +14,14 @@ use starknet_gateway_types::reply::{Block, Status};
 ///
 /// Usage:
 /// `cargo run --release -p pathfinder --example verify_block_hashes mainnet ./mainnet.sqlite`
-/// Either mainnet or goerli is accepted as the chain name.
 fn main() -> anyhow::Result<()> {
     let chain_name = std::env::args().nth(1).unwrap();
-    let chain = match chain_name.as_str() {
-        "mainnet" => Chain::Mainnet,
-        "goerli" => Chain::Testnet,
-        "integration" => Chain::Integration,
-        _ => panic!("Expected chain name: mainnet/goerli/integration"),
+    let (chain, chain_id) = match chain_name.as_str() {
+        "mainnet" => (Chain::Mainnet, ChainId::MAINNET),
+        "goerli" => (Chain::Testnet, ChainId::TESTNET),
+        "testnet2" => (Chain::Testnet2, ChainId::TESTNET2),
+        "integration" => (Chain::Integration, ChainId::INTEGRATION),
+        _ => panic!("Expected chain name: mainnet/goerli/testnet2/integration"),
     };
 
     let database_path = std::env::args().nth(2).unwrap();
@@ -65,7 +65,7 @@ fn main() -> anyhow::Result<()> {
         };
         parent_block_hash = block_hash;
 
-        let result = verify_block_hash(&block, chain, block_hash)?;
+        let result = verify_block_hash(&block, chain, chain_id, block_hash)?;
         match result {
             VerifyResult::Match(_) => {}
             VerifyResult::NotVerifiable => println!(

--- a/crates/pathfinder/examples/verify_transaction_hashes.rs
+++ b/crates/pathfinder/examples/verify_transaction_hashes.rs
@@ -60,20 +60,16 @@ fn main() -> anyhow::Result<()> {
                 chain_id,
                 StarknetBlockNumber::new_or_panic(block_number),
             ) {
-                Ok(VerifyResult::Match) => {}
-                Ok(VerifyResult::Mismatch(calculated)) => println!(
+                VerifyResult::Match => {}
+                VerifyResult::Mismatch(calculated) => println!(
                     "Mismatch: block {block_number} idx {i} expected {} calculated {} full_txn\n{}",
                     txn.hash(),
                     calculated,
                     serde_json::to_string(&txn).unwrap_or(">Failed to deserialize<".into())
                 ),
-                Ok(VerifyResult::NotVerifiable) => println!(
+                VerifyResult::NotVerifiable => println!(
                     "Skipped: block {block_number} idx {i} hash {} full_txn\n{}",
                     txn.hash(),
-                    serde_json::to_string(&txn).unwrap_or(">Failed to deserialize<".into())
-                ),
-                Err(e) => println!(
-                    "{e}, block {block_number} idx {i} full_txn {}",
                     serde_json::to_string(&txn).unwrap_or(">Failed to deserialize<".into())
                 ),
             }

--- a/crates/pathfinder/examples/verify_transaction_hashes.rs
+++ b/crates/pathfinder/examples/verify_transaction_hashes.rs
@@ -11,7 +11,7 @@ use starknet_gateway_types::transaction_hash::verify;
 /// values we store for the block.
 ///
 /// Usage:
-/// `cargo run --release -p starknet-gateway-types --example verify_transaction_hashes mainnet ./mainnet.sqlite 100`
+/// `cargo run --release -p pathfinder --example verify_transaction_hashes mainnet ./mainnet.sqlite 100`
 fn main() -> anyhow::Result<()> {
     let chain_name = std::env::args().nth(1).unwrap();
     let chain_id = match chain_name.as_str() {

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -105,6 +105,7 @@ async fn main() -> anyhow::Result<()> {
         storage.clone(),
         ethereum.transport.clone(),
         pathfinder_context.network,
+        pathfinder_context.network_id,
         pathfinder_context.l1_core_address.0,
         pathfinder_context.gateway.clone(),
         sync_state.clone(),

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -1115,7 +1115,6 @@ mod tests {
 
         mod errors {
             use super::*;
-            use pathfinder_common::Chain;
             use starknet_gateway_types::reply::Status;
 
             #[tokio::test]

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -439,7 +439,9 @@ async fn download_block(
     match result {
         Ok(DownloadBlock::Block(block, commitments)) => {
             for (i, txn) in block.transactions.iter().enumerate() {
-                let skipped = verify(txn, chain_id, block_number)?;
+                let skipped = verify(txn, chain_id, block_number).with_context(|| {
+                    format!("Transaction verification failed: block {block_number} idx {i}")
+                })?;
                 if skipped {
                     tracing::trace!(
                         "Skipping transaction verification: block {block_number} idx {i} hash {}",

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -439,10 +439,7 @@ async fn download_block(
     match result {
         Ok(DownloadBlock::Block(block, commitments)) => {
             for (i, txn) in block.transactions.iter().enumerate() {
-                let verify_result = verify(txn, chain_id, block_number).with_context(|| {
-                    format!("Transaction verification failed: block {block_number} idx {i}")
-                })?;
-                match verify_result {
+                match verify(txn, chain_id, block_number) {
                     starknet_gateway_types::transaction_hash::VerifyResult::Match => {}
                     starknet_gateway_types::transaction_hash::VerifyResult::Mismatch(actual) =>
                         anyhow::bail!("Transaction hash mismatch: block {block_number} idx {i} expected {} calculated {}",

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -65,6 +65,7 @@ pub async fn sync(
     sequencer: impl ClientApi,
     mut head: Option<(StarknetBlockNumber, StarknetBlockHash, StateCommitment)>,
     chain: Chain,
+    chain_id: ChainId,
     pending_poll_interval: Option<Duration>,
     block_validation_mode: BlockValidationMode,
 ) -> anyhow::Result<()> {
@@ -87,6 +88,7 @@ pub async fn sync(
                 // Reuse the next full block if we got it for free when polling pending
                 std::mem::take(&mut next_block),
                 chain,
+                chain_id,
                 head_meta.map(|h| h.1),
                 &sequencer,
                 block_validation_mode,
@@ -122,6 +124,7 @@ pub async fn sync(
                     head = reorg(
                         some_head,
                         chain,
+                        chain_id,
                         &tx_event,
                         &sequencer,
                         block_validation_mode,
@@ -140,6 +143,7 @@ pub async fn sync(
                 head = reorg(
                     some_head,
                     chain,
+                    chain_id,
                     &tx_event,
                     &sequencer,
                     block_validation_mode,
@@ -349,6 +353,7 @@ async fn download_block(
     // Poll pending could exit when it encountered a finalized block, so we'd like to reuse it
     next_block: Option<Block>,
     chain: Chain,
+    chain_id: ChainId,
     prev_block_hash: Option<StarknetBlockHash>,
     sequencer: &impl ClientApi,
     mode: BlockValidationMode,
@@ -372,7 +377,7 @@ async fn download_block(
             let expected_block_hash = block.block_hash;
             let verify_hash = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
                 let block_number = block.block_number;
-                let verify_result = verify_block_hash(&block, chain, expected_block_hash)
+                let verify_result = verify_block_hash(&block, chain, chain_id, expected_block_hash)
                     .with_context(move || format!("Verify block {block_number}"))?;
                 Ok((block, verify_result))
             });
@@ -435,14 +440,13 @@ async fn download_block(
     match result {
         Ok(DownloadBlock::Block(block, commitments)) => {
             for (i, txn) in block.transactions.iter().enumerate() {
-                let computed_hash =
-                    compute_transaction_hash(txn, ChainId::TESTNET).with_context(|| {
-                        format!(
-                            "Verify transaction {} block {} idx {i}",
-                            txn.hash(),
-                            block.block_number,
-                        )
-                    })?;
+                let computed_hash = compute_transaction_hash(txn, chain_id).with_context(|| {
+                    format!(
+                        "Verify transaction {} block {} idx {i}",
+                        txn.hash(),
+                        block.block_number,
+                    )
+                })?;
 
                 if computed_hash.hash() != txn.hash() {
                     return Err(anyhow!(
@@ -463,6 +467,7 @@ async fn download_block(
 async fn reorg(
     head: (StarknetBlockNumber, StarknetBlockHash, StateCommitment),
     chain: Chain,
+    chain_id: ChainId,
     tx_event: &mpsc::Sender<Event>,
     sequencer: &impl ClientApi,
     mode: BlockValidationMode,
@@ -493,6 +498,7 @@ async fn reorg(
             previous_block_number,
             None,
             chain,
+            chain_id,
             Some(previous.0),
             sequencer,
             mode,
@@ -623,9 +629,9 @@ mod tests {
         use super::super::{sync, BlockValidationMode, Event};
         use assert_matches::assert_matches;
         use pathfinder_common::{
-            BlockId, ClassHash, ContractAddress, GasPrice, SequencerAddress, StarknetBlockHash,
-            StarknetBlockNumber, StarknetBlockTimestamp, StarknetVersion, StateCommitment,
-            StorageAddress, StorageValue,
+            BlockId, Chain, ChainId, ClassHash, ContractAddress, GasPrice, SequencerAddress,
+            StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp, StarknetVersion,
+            StateCommitment, StorageAddress, StorageValue,
         };
         use stark_hash::Felt;
         use starknet_gateway_client::MockClientApi;
@@ -942,7 +948,6 @@ mod tests {
 
         mod happy_path {
             use super::*;
-            use pathfinder_common::Chain;
             use pretty_assertions::assert_eq;
 
             #[tokio::test]
@@ -1004,7 +1009,15 @@ mod tests {
                 );
 
                 // Let's run the UUT
-                let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Testnet, None, MODE));
+                let _jh = tokio::spawn(sync(
+                    tx_event,
+                    mock,
+                    None,
+                    Chain::Testnet,
+                    ChainId::TESTNET,
+                    None,
+                    MODE,
+                ));
 
                 let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
 
@@ -1084,6 +1097,7 @@ mod tests {
                     mock,
                     Some((BLOCK0_NUMBER, *BLOCK0_HASH, *GLOBAL_ROOT0)),
                     Chain::Testnet,
+                    ChainId::TESTNET,
                     None,
                     MODE,
                 ));
@@ -1123,7 +1137,15 @@ mod tests {
                 block.status = Status::Reverted;
                 expect_block(&mut mock, &mut seq, BLOCK0_NUMBER.into(), Ok(block.into()));
 
-                let jh = tokio::spawn(sync(tx_event, mock, None, Chain::Testnet, None, MODE));
+                let jh = tokio::spawn(sync(
+                    tx_event,
+                    mock,
+                    None,
+                    Chain::Testnet,
+                    ChainId::TESTNET,
+                    None,
+                    MODE,
+                ));
                 let error = jh.await.unwrap().unwrap_err();
                 assert_eq!(
                     &error.to_string(),
@@ -1226,7 +1248,15 @@ mod tests {
                 );
 
                 // Let's run the UUT
-                let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Testnet, None, MODE));
+                let _jh = tokio::spawn(sync(
+                    tx_event,
+                    mock,
+                    None,
+                    Chain::Testnet,
+                    ChainId::TESTNET,
+                    None,
+                    MODE,
+                ));
 
                 let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
 
@@ -1427,7 +1457,15 @@ mod tests {
                 );
 
                 // Run the UUT
-                let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Testnet, None, MODE));
+                let _jh = tokio::spawn(sync(
+                    tx_event,
+                    mock,
+                    None,
+                    Chain::Testnet,
+                    ChainId::TESTNET,
+                    None,
+                    MODE,
+                ));
 
                 let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
 
@@ -1701,7 +1739,15 @@ mod tests {
                 );
 
                 // Run the UUT
-                let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Testnet, None, MODE));
+                let _jh = tokio::spawn(sync(
+                    tx_event,
+                    mock,
+                    None,
+                    Chain::Testnet,
+                    ChainId::TESTNET,
+                    None,
+                    MODE,
+                ));
 
                 let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
 
@@ -1904,7 +1950,15 @@ mod tests {
                 );
 
                 // Run the UUT
-                let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Testnet, None, MODE));
+                let _jh = tokio::spawn(sync(
+                    tx_event,
+                    mock,
+                    None,
+                    Chain::Testnet,
+                    ChainId::TESTNET,
+                    None,
+                    MODE,
+                ));
 
                 let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
 
@@ -2096,7 +2150,15 @@ mod tests {
                 );
 
                 // Run the UUT
-                let _jh = tokio::spawn(sync(tx_event, mock, None, Chain::Testnet, None, MODE));
+                let _jh = tokio::spawn(sync(
+                    tx_event,
+                    mock,
+                    None,
+                    Chain::Testnet,
+                    ChainId::TESTNET,
+                    None,
+                    MODE,
+                ));
 
                 let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
 
@@ -2169,7 +2231,15 @@ mod tests {
                 );
 
                 // Run the UUT
-                let jh = tokio::spawn(sync(tx_event, mock, None, Chain::Testnet, None, MODE));
+                let jh = tokio::spawn(sync(
+                    tx_event,
+                    mock,
+                    None,
+                    Chain::Testnet,
+                    ChainId::TESTNET,
+                    None,
+                    MODE,
+                ));
 
                 // Wrap this in a timeout so we don't wait forever in case of test failure.
                 // Right now closing the channel causes an error.


### PR DESCRIPTION
Some old L1 handler transactions had to be skipped because I couldn't figure out how to properly calculate their hashes. Neither was I willing to dig through old cairo-lang commits.

So far I've verified my dbs successfully (mainnet, testnet, testnet2) and synced from scratch successfully from main beyond the last block where those unfortunate transactions had to be skipped. Those dbs of mine date back to some of those L1 handler transactions still being served as Invoke v0s.

I'm yet to verify the latest mainnet snaphot from @kkovaacs which is still being downloaded.

Fixes: #480 