### PR TITLE
feat(py): implement storage adapter for flattened state

### DIFF
--- a/crates/storage/src/state_update.rs
+++ b/crates/storage/src/state_update.rs
@@ -11,17 +11,17 @@ pub fn insert_canonical_state_diff(
     state_diff: &StateDiff,
 ) -> anyhow::Result<()> {
     let mut insert_nonce = tx
-        .prepare(
+        .prepare_cached(
             "INSERT INTO nonce_updates (block_number, contract_address, nonce) VALUES (?, ?, ?)",
         )
         .context("Preparing nonce insert statement")?;
 
     let mut insert_storage = tx
-        .prepare("INSERT INTO storage_updates (block_number, contract_address, storage_address, storage_value) VALUES (?, ?, ?, ?)")
+        .prepare_cached("INSERT INTO storage_updates (block_number, contract_address, storage_address, storage_value) VALUES (?, ?, ?, ?)")
         .context("Preparing nonce insert statement")?;
 
     let mut insert_contract = tx
-        .prepare("INSERT INTO contract_updates (block_number, contract_address, class_hash) VALUES (?, ?, ?)")
+        .prepare_cached("INSERT INTO contract_updates (block_number, contract_address, class_hash) VALUES (?, ?, ?)")
         .context("Preparing contract insert statement")?;
 
     // Insert contract deployments. Doing this first ensures that subsequent sections will be

--- a/py/src/pathfinder_worker/call.py
+++ b/py/src/pathfinder_worker/call.py
@@ -2,7 +2,6 @@ import asyncio
 import dataclasses
 import json
 import os
-import pkg_resources
 import re
 import sqlite3
 import sys
@@ -13,10 +12,12 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import ClassVar, Dict, List, Optional, Tuple, Type
 
+import pkg_resources
+
 try:
     import starknet_pathfinder_crypto
-    import starkware.crypto.signature.fast_pedersen_hash
     import starkware.cairo.common.poseidon_hash
+    import starkware.crypto.signature.fast_pedersen_hash
 
     starkware.crypto.signature.fast_pedersen_hash.pedersen_hash_func = (
         starknet_pathfinder_crypto.pedersen_hash_func
@@ -46,7 +47,6 @@ try:
     import marshmallow.exceptions
     import marshmallow_dataclass
     import marshmallow_oneofschema
-    import zstandard
     from cachetools import LRUCache
     from marshmallow import Schema
     from marshmallow import fields as mfields
@@ -58,23 +58,34 @@ try:
         ExecutionResourcesManager,
     )
     from starkware.starknet.business_logic.state.state import BlockInfo, CachedState
-    from starkware.starknet.definitions import fields, constants
+    from starkware.starknet.core.os.contract_class.utils import (
+        ClassHashType,
+        class_hash_cache_ctx_var,
+        set_class_hash_cache,
+    )
+    from starkware.starknet.definitions import constants, fields
     from starkware.starknet.definitions.constants import GasCost
     from starkware.starknet.definitions.error_codes import StarknetErrorCode
     from starkware.starknet.definitions.general_config import (
-        DEFAULT_MAX_STEPS,
         DEFAULT_GAS_PRICE,
+        DEFAULT_MAX_STEPS,
         DEFAULT_SEQUENCER_ADDRESS,
         DEFAULT_VALIDATE_MAX_STEPS,
         StarknetChainId,
         StarknetGeneralConfig,
         build_general_config,
     )
+    from starkware.starknet.public.abi import starknet_keccak
     from starkware.starknet.services.api.contract_class.contract_class import (
         EntryPointType,
     )
     from starkware.starknet.services.api.contract_class.contract_class_utils import (
         compile_contract_class,
+    )
+    from starkware.starknet.services.api.feeder_gateway.response_objects import (
+        BaseResponseObject,
+        FunctionInvocation,
+        TransactionTrace,
     )
     from starkware.starknet.services.api.gateway.transaction import (
         AccountTransaction,
@@ -85,18 +96,6 @@ try:
         InternalAccountTransactionForSimulate,
     )
     from starkware.starkware_utils.error_handling import StarkException
-    from starkware.starknet.core.os.contract_class.utils import (
-        ClassHashType,
-        class_hash_cache_ctx_var,
-        set_class_hash_cache,
-    )
-    from starkware.starknet.public.abi import starknet_keccak
-
-    from starkware.starknet.services.api.feeder_gateway.response_objects import (
-        BaseResponseObject,
-        FunctionInvocation,
-        TransactionTrace,
-    )
 
     from .storage import SqliteStateReader
 

--- a/py/src/pathfinder_worker/storage.py
+++ b/py/src/pathfinder_worker/storage.py
@@ -1,0 +1,204 @@
+import json
+import sqlite3
+from typing import Optional
+
+import zstandard
+from starkware.starknet.business_logic.state.state_api import StateReader
+from starkware.starknet.definitions import fields
+from starkware.starknet.definitions.error_codes import StarknetErrorCode
+from starkware.starknet.services.api.contract_class.contract_class import (
+    CompiledClass,
+    CompiledClassBase,
+    DeprecatedCompiledClass,
+)
+from starkware.starkware_utils.error_handling import StarkException
+
+
+class SqliteStateReader(StateReader):
+    """
+    A StateReader implementation that reads from the SQLite database of pathfinder.
+    """
+
+    def __init__(self, connection: sqlite3.Connection, block_number: int):
+        assert (
+            connection.in_transaction
+        ), "first query should have started a transaction"
+        self.connection = connection
+        self.block_number = block_number
+
+    # StateReader API
+    async def get_compiled_class(self, compiled_class_hash: int) -> CompiledClassBase:
+        # Compiled_class_hash is either the hash of a compiled CASM _or_ the class hash
+        # of a Cairo 0.x class. The order matters here, because if there is no CASM
+        # definition the class is guaranteed to be a deprecated class (if exists).
+        class_definition = self._get_compiled_class(
+            compiled_class_hash
+        ) or self._get_deprecated_class(compiled_class_hash)
+
+        if class_definition is None:
+            formatted_class_hash = fields.ClassHashIntField.format(compiled_class_hash)
+            raise StarkException(
+                code=StarknetErrorCode.UNDECLARED_CLASS,
+                message=f"Class with hash {formatted_class_hash} is not declared.",
+            )
+
+        return class_definition
+
+    async def get_compiled_class_hash(self, class_hash: int) -> int:
+        cursor = self.connection.cursor()
+        res = cursor.execute(
+            """
+            SELECT
+                compiled_class_hash
+            FROM
+                casm_definitions
+            WHERE
+                hash = ?
+            """,
+            [felt_to_bytes(class_hash)],
+        )
+        row = res.fetchone()
+        if row is None:
+            return 0
+
+        compiled_class_hash = row[0]
+        compiled_class_hash = int.from_bytes(compiled_class_hash, byteorder="big")
+
+        return compiled_class_hash
+
+    async def get_class_hash_at(self, contract_address: int) -> int:
+        cursor = self.connection.cursor()
+        res = cursor.execute(
+            """
+            SELECT
+                class_hash
+            FROM
+                contract_updates
+            WHERE
+                contract_address = ?
+                AND
+                block_number <= ?
+            ORDER BY block_number
+            DESC
+            LIMIT 1
+            """,
+            [felt_to_bytes(contract_address), self.block_number],
+        )
+        row = res.fetchone()
+        if row is None:
+            return 0
+
+        class_hash = row[0]
+        class_hash = int.from_bytes(class_hash, byteorder="big")
+
+        return class_hash
+
+    async def get_nonce_at(self, contract_address: int) -> int:
+        cursor = self.connection.cursor()
+        res = cursor.execute(
+            """
+            SELECT
+                nonce
+            FROM
+                nonce_updates
+            WHERE
+                contract_address = ?
+                AND
+                block_number <= ?
+            ORDER BY block_number
+            DESC
+            LIMIT 1
+            """,
+            [felt_to_bytes(contract_address), self.block_number],
+        )
+        row = res.fetchone()
+        if row is None:
+            return 0
+
+        nonce = row[0]
+        nonce = int.from_bytes(nonce, byteorder="big")
+
+        return nonce
+
+    async def get_storage_at(self, contract_address: int, key: int) -> int:
+        cursor = self.connection.cursor()
+        res = cursor.execute(
+            """
+            SELECT
+                storage_value
+            FROM
+                storage_updates
+            WHERE
+                contract_address = ?
+                AND
+                storage_address = ?
+                AND
+                block_number <= ?
+            ORDER BY block_number
+            DESC
+            LIMIT 1
+            """,
+            [felt_to_bytes(contract_address), felt_to_bytes(key), self.block_number],
+        )
+        row = res.fetchone()
+        if row is None:
+            return 0
+
+        value = row[0]
+        value = int.from_bytes(value, byteorder="big")
+
+        return value
+
+    def _get_deprecated_class(
+        self, class_hash: int
+    ) -> Optional[DeprecatedCompiledClass]:
+        cursor = self.connection.cursor()
+        res = cursor.execute(
+            """
+            SELECT
+                definition
+            FROM
+                class_definitions
+            WHERE
+                hash = ?
+            """,
+            [felt_to_bytes(class_hash)],
+        )
+        row = res.fetchone()
+        if row is None:
+            return None
+
+        class_definition = row[0]
+        class_definition = zstandard.decompress(class_definition)
+        class_definition = json.loads(class_definition)
+        class_definition = DeprecatedCompiledClass.load(class_definition)
+
+        return class_definition
+
+    def _get_compiled_class(self, class_hash: int) -> Optional[CompiledClass]:
+        cursor = self.connection.cursor()
+        res = cursor.execute(
+            """
+            SELECT
+                definition
+            FROM
+                casm_definitions
+            WHERE
+                compiled_class_hash = ?
+            """,
+            [felt_to_bytes(class_hash)],
+        )
+        row = res.fetchone()
+        if row is None:
+            return None
+
+        class_definition = row[0]
+        class_definition = zstandard.decompress(class_definition)
+        class_definition = json.loads(class_definition)
+        class_definition = CompiledClass.load(class_definition)
+
+        return class_definition
+
+
+def felt_to_bytes(v: int) -> bytes:
+    return v.to_bytes(length=32, byteorder="big")


### PR DESCRIPTION
This PR implements a `StateReader` using the flattened state data from our database for the Python execution layer.

Most of the state set-up code in tests (setting up the global and contract Merkle trees) is not strictly needed but I've still left it as is. We can get rid of that code if we think it's not required.