### PR TITLE
fix(pathfinder/block_hash): update block hash verification for Starknet 0.11.1

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -511,10 +511,6 @@ impl StarknetVersion {
         StarknetVersion(Some(format!("{major}.{minor}.{patch}")))
     }
 
-    pub fn new_from_string(version: Option<String>) -> Self {
-        Self(version)
-    }
-
     /// Parses the version string.
     ///
     /// Note: there are known deviations from semver such as version 0.11.0.2, which
@@ -537,6 +533,12 @@ impl StarknetVersion {
 
     pub fn as_str(&self) -> Option<&str> {
         self.0.as_deref()
+    }
+}
+
+impl From<Option<String>> for StarknetVersion {
+    fn from(value: Option<String>) -> Self {
+        Self(value)
     }
 }
 

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -511,6 +511,10 @@ impl StarknetVersion {
         StarknetVersion(Some(format!("{major}.{minor}.{patch}")))
     }
 
+    pub fn new_from_string(version: Option<String>) -> Self {
+        Self(version)
+    }
+
     /// Parses the version string.
     ///
     /// Note: there are known deviations from semver such as version 0.11.0.2, which

--- a/crates/gateway-test-fixtures/fixtures/integration/block/285915.json
+++ b/crates/gateway-test-fixtures/fixtures/integration/block/285915.json
@@ -1,0 +1,52 @@
+{
+    "block_hash": "0x26b5f94cc65f6290d3429fb74aa6d1213a6fc6bc5de879bb7f5929c6e10f65",
+    "parent_block_hash": "0x469c1abdae5a55e6a857cbbcd173be9c79678b5db241c9a2630937d4202570b",
+    "block_number": 285915,
+    "state_root": "03f62e058b75962fc4dc5469e43c210515e04ace567fed4dfa1585e2200b07b5",
+    "status": "ACCEPTED_ON_L2",
+    "gas_price": "0x4095a3c9d94",
+    "transactions": [
+        {
+            "transaction_hash": "0x554a65bb9f00cb95ccb87e1bda805e2722fe997cad3947600eaa46d9d2fce05",
+            "version": "0x1",
+            "max_fee": "0x2386f26fc10000",
+            "signature": [
+                "0x295a4016f3b7a8c2321114d3a4baf76d4189dde0c9741fb47810f1b75741fff",
+                "0x43fc9670848ad76f4d129a1d4fe8d00dc4e6641425ef604ee64965c4f74fe3b"
+            ],
+            "nonce": "0x1685",
+            "class_hash": "0x484c163658bcce5f9916f486171ac60143a92897533aa7ff7ac800b16c63311",
+            "sender_address": "0x733dead6027a46717d7e79be28bf059bb8f5b02db2854c742ff652392d94506",
+            "type": "DECLARE"
+        },
+        {
+            "transaction_hash": "0x6fdbb914cef884eac2d47eeee11b0de823e404ede92b782c14b6c15c3a35bb9",
+            "version": "0x0",
+            "max_fee": "0x0",
+            "signature": [],
+            "nonce": "0x0",
+            "class_hash": "0x5a9941d0cc16b8619a3325055472da709a66113afcc6a8ab86055da7d29c5f8",
+            "sender_address": "0x1",
+            "type": "DECLARE"
+        }
+    ],
+    "timestamp": 1683444772,
+    "sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+    "transaction_receipts": [
+        {
+            "transaction_index": 0,
+            "transaction_hash": "0x554a65bb9f00cb95ccb87e1bda805e2722fe997cad3947600eaa46d9d2fce05",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "actual_fee": "0x13c1c6aaaf4564"
+        },
+        {
+            "transaction_index": 1,
+            "transaction_hash": "0x6fdbb914cef884eac2d47eeee11b0de823e404ede92b782c14b6c15c3a35bb9",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "actual_fee": "0x0"
+        }
+    ],
+    "starknet_version": "0.11.1"
+}

--- a/crates/gateway-test-fixtures/src/lib.rs
+++ b/crates/gateway-test-fixtures/src/lib.rs
@@ -150,6 +150,7 @@ pub mod integration {
         pub const NUMBER_216171: &str = str_fixture!("integration/block/216171.json");
         pub const NUMBER_216591: &str = str_fixture!("integration/block/216591.json");
         pub const NUMBER_228457: &str = str_fixture!("integration/block/228457.json");
+        pub const NUMBER_285915: &str = str_fixture!("integration/block/285915.json");
         pub const PENDING: &str = str_fixture!("integration/block/pending.json");
     }
 

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -414,6 +414,16 @@ pub mod transaction {
         }
     }
 
+    impl DeclareTransaction {
+        pub fn signature(&self) -> &[TransactionSignatureElem] {
+            match self {
+                DeclareTransaction::V0(tx) => tx.signature.as_ref(),
+                DeclareTransaction::V1(tx) => tx.signature.as_ref(),
+                DeclareTransaction::V2(tx) => tx.signature.as_ref(),
+            }
+        }
+    }
+
     /// A version 0 or 1 declare transaction.
     #[serde_as]
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]

--- a/crates/pathfinder/examples/calculate_commitments.rs
+++ b/crates/pathfinder/examples/calculate_commitments.rs
@@ -55,7 +55,10 @@ fn main() -> anyhow::Result<()> {
 
         let now = Instant::now();
         let (transaction_commitment, event_commitment) = (
-            calculate_transaction_commitment(&transactions)?,
+            calculate_transaction_commitment(
+                &transactions,
+                pathfinder_lib::state::block_hash::FinalHashType::Normal,
+            )?,
             calculate_event_commitment(&receipts)?,
         );
         let calc_ms = now.elapsed().as_millis();

--- a/crates/pathfinder/examples/verify_block_hashes.rs
+++ b/crates/pathfinder/examples/verify_block_hashes.rs
@@ -56,7 +56,7 @@ fn main() -> anyhow::Result<()> {
             gas_price: Some(block.gas_price),
             parent_block_hash,
             sequencer_address: Some(block.sequencer_address),
-            state_commitment: block.root,
+            state_commitment: block.state_commmitment,
             status: Status::AcceptedOnL1,
             timestamp: block.timestamp,
             transaction_receipts: receipts,

--- a/crates/rpc/src/cairo/ext_py.rs
+++ b/crates/rpc/src/cairo/ext_py.rs
@@ -887,7 +887,7 @@ mod tests {
             &StarknetBlock {
                 number: StarknetBlockNumber::new_or_panic(1),
                 hash: StarknetBlockHash(felt_bytes!(b"some blockhash somewhere")),
-                root: StateCommitment::calculate(storage_commitment, class_commitment),
+                state_commmitment: StateCommitment::calculate(storage_commitment, class_commitment),
                 timestamp: StarknetBlockTimestamp::new_or_panic(1),
                 gas_price: GasPrice(1),
                 sequencer_address: SequencerAddress(Felt::ZERO),
@@ -947,7 +947,7 @@ mod tests {
             &StarknetBlock {
                 number: StarknetBlockNumber::new_or_panic(1),
                 hash: StarknetBlockHash(felt_bytes!(b"some blockhash somewhere")),
-                root: StateCommitment::calculate(storage_commitment, class_commitment),
+                state_commmitment: StateCommitment::calculate(storage_commitment, class_commitment),
                 timestamp: StarknetBlockTimestamp::new_or_panic(1),
                 gas_price: GasPrice(1),
                 sequencer_address: SequencerAddress(Felt::ZERO),

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -287,7 +287,7 @@ pub mod test_utils {
         let block0 = StarknetBlock {
             number: StarknetBlockNumber::GENESIS,
             hash: genesis_hash,
-            root: StateCommitment::calculate(storage_commitment0, class_commitment0),
+            state_commmitment: StateCommitment::calculate(storage_commitment0, class_commitment0),
             timestamp: StarknetBlockTimestamp::new_or_panic(0),
             gas_price: GasPrice::ZERO,
             sequencer_address: SequencerAddress(Felt::ZERO),
@@ -298,7 +298,7 @@ pub mod test_utils {
         let block1 = StarknetBlock {
             number: StarknetBlockNumber::new_or_panic(1),
             hash: block1_hash,
-            root: StateCommitment::calculate(storage_commitment1, class_commitment1),
+            state_commmitment: StateCommitment::calculate(storage_commitment1, class_commitment1),
             timestamp: StarknetBlockTimestamp::new_or_panic(1),
             gas_price: GasPrice::from(1),
             sequencer_address: SequencerAddress(felt_bytes!(&[1u8])),
@@ -309,7 +309,7 @@ pub mod test_utils {
         let block2 = StarknetBlock {
             number: StarknetBlockNumber::new_or_panic(2),
             hash: latest_hash,
-            root: StateCommitment::calculate(storage_commitment2, class_commitment2),
+            state_commmitment: StateCommitment::calculate(storage_commitment2, class_commitment2),
             timestamp: StarknetBlockTimestamp::new_or_panic(2),
             gas_price: GasPrice::from(2),
             sequencer_address: SequencerAddress(felt_bytes!(&[2u8])),
@@ -596,7 +596,7 @@ pub mod test_utils {
         .unwrap();
 
         let state_update = starknet_gateway_types::reply::PendingStateUpdate {
-            old_root: latest.root,
+            old_root: latest.state_commmitment,
             state_diff,
         };
 

--- a/crates/rpc/src/v02/method/estimate_fee.rs
+++ b/crates/rpc/src/v02/method/estimate_fee.rs
@@ -368,7 +368,10 @@ pub(crate) mod tests {
             let new_block = StarknetBlock {
                 number: latest_block_number + 1,
                 hash: StarknetBlockHash(felt_bytes!(b"latest block")),
-                root: StateCommitment::calculate(new_storage_commitment, ClassCommitment::ZERO),
+                state_commmitment: StateCommitment::calculate(
+                    new_storage_commitment,
+                    ClassCommitment::ZERO,
+                ),
                 timestamp: StarknetBlockTimestamp::new_or_panic(0),
                 gas_price: GasPrice::ZERO,
                 sequencer_address: SequencerAddress(Felt::ZERO),

--- a/crates/rpc/src/v02/method/get_block.rs
+++ b/crates/rpc/src/v02/method/get_block.rs
@@ -112,14 +112,14 @@ fn get_raw_block(
                 .context("Read parent block from database")?
                 .context("Parent block missing")?;
 
-            (parent_block.hash, parent_block.root)
+            (parent_block.hash, parent_block.state_commmitment)
         }
     };
 
     let block = types::RawBlock {
         number: block.number,
         hash: block.hash,
-        root: block.root,
+        root: block.state_commmitment,
         parent_hash,
         parent_root,
         timestamp: block.timestamp,

--- a/crates/storage/src/state.rs
+++ b/crates/storage/src/state.rs
@@ -316,7 +316,7 @@ impl StarknetBlocksTable {
                 let block = StarknetBlock {
                     number,
                     hash,
-                    root,
+                    state_commmitment: root,
                     timestamp,
                     gas_price,
                     sequencer_address,
@@ -1270,7 +1270,7 @@ impl StarknetEventsTable {
 pub struct StarknetBlock {
     pub number: StarknetBlockNumber,
     pub hash: StarknetBlockHash,
-    pub root: StateCommitment,
+    pub state_commmitment: StateCommitment,
     pub timestamp: StarknetBlockTimestamp,
     pub gas_price: GasPrice,
     pub sequencer_address: SequencerAddress,
@@ -1973,7 +1973,7 @@ mod tests {
                             assert_eq!(state_commitment.1, block.class_commitment);
                             assert_eq!(
                                 StateCommitment::calculate(state_commitment.0, state_commitment.1),
-                                block.block.root
+                                block.block.state_commmitment
                             );
                         }
                     })
@@ -2022,7 +2022,7 @@ mod tests {
                             assert_eq!(state_commitment.1, block.class_commitment);
                             assert_eq!(
                                 StateCommitment::calculate(state_commitment.0, state_commitment.1),
-                                block.block.root
+                                block.block.state_commmitment
                             );
                         }
                     })
@@ -2073,7 +2073,7 @@ mod tests {
                         assert_eq!(state_commitment.1, expected.class_commitment);
                         assert_eq!(
                             StateCommitment::calculate(state_commitment.0, state_commitment.1),
-                            expected.block.root
+                            expected.block.state_commmitment
                         );
                     })
                 }
@@ -2129,7 +2129,7 @@ mod tests {
                     let expected = StarknetBlock {
                         number: blocks[0].block.number,
                         hash: blocks[0].block.hash,
-                        root: blocks[0].block.root,
+                        state_commmitment: blocks[0].block.state_commmitment,
                         timestamp: blocks[0].block.timestamp,
                         gas_price: blocks[0].block.gas_price,
                         sequencer_address: blocks[0].block.sequencer_address,
@@ -2409,7 +2409,7 @@ mod tests {
             let block = StarknetBlock {
                 number: StarknetBlockNumber::GENESIS,
                 hash: StarknetBlockHash(felt!("0x1234")),
-                root: StateCommitment(felt!("0x1234")),
+                state_commmitment: StateCommitment(felt!("0x1234")),
                 timestamp: StarknetBlockTimestamp::new_or_panic(0),
                 gas_price: GasPrice(0),
                 sequencer_address: SequencerAddress(felt!("0x1234")),

--- a/crates/storage/src/state.rs
+++ b/crates/storage/src/state.rs
@@ -450,8 +450,8 @@ impl StarknetBlocksTable {
 
         match row {
             Some(row) => {
-                let version = row.get_unwrap("version");
-                Ok(StarknetVersion::new_from_string(version))
+                let version: Option<String> = row.get_unwrap("version");
+                Ok(version.into())
             }
             None => Ok(Default::default()),
         }

--- a/crates/storage/src/test_fixtures.rs
+++ b/crates/storage/src/test_fixtures.rs
@@ -96,7 +96,7 @@ impl StarknetBlock {
         Self {
             number: StarknetBlockNumber::new(n as u64).expect("block number out of range"),
             hash: StarknetBlockHash(hash!(n)),
-            root: StateCommitment(hash!(1, n)),
+            state_commmitment: StateCommitment(hash!(1, n)),
             timestamp: StarknetBlockTimestamp::new(n as u64 + 1000)
                 .expect("block timestamp out of range"),
             gas_price: GasPrice(n as u128 + 2000),

--- a/crates/storage/src/test_utils.rs
+++ b/crates/storage/src/test_utils.rs
@@ -38,7 +38,10 @@ pub(crate) fn create_blocks() -> [BlockWithCommitment; NUM_BLOCKS] {
                 block: StarknetBlock {
                     number: StarknetBlockNumber::GENESIS + i as u64,
                     hash: StarknetBlockHash(Felt::from_hex_str(&"a".repeat(i + 3)).unwrap()),
-                    root: StateCommitment::calculate(storage_commitment, class_commitment),
+                    state_commmitment: StateCommitment::calculate(
+                        storage_commitment,
+                        class_commitment,
+                    ),
                     timestamp: StarknetBlockTimestamp::new_or_panic(i as u64 + 500),
                     gas_price: GasPrice::from(i as u64),
                     sequencer_address: SequencerAddress(index_as_felt),


### PR DESCRIPTION
Starknet 0.11.1 block hash calculation contains a change that includes the transaction signature into the transaction commitment for all transaction types having a signature -- and not just invokes.

This is an incompatible change: we have to use the new commitment calculation for blocks with version >= 0.11.1, and the old one for older blocks.