### PR TITLE
feat: support v0.11.1 L1 contract

### DIFF
--- a/crates/ethereum/resources/contracts/core_impl_0.11.1.json
+++ b/crates/ethereum/resources/contracts/core_impl_0.11.1.json
@@ -1,0 +1,883 @@
+[
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "changedBy",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "oldConfigHash",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "newConfigHash",
+                "type": "uint256"
+            }
+        ],
+        "name": "ConfigHashChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "fromAddress",
+                "type": "uint256"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "toAddress",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256[]",
+                "name": "payload",
+                "type": "uint256[]"
+            }
+        ],
+        "name": "ConsumedMessageToL1",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "fromAddress",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "toAddress",
+                "type": "uint256"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "selector",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256[]",
+                "name": "payload",
+                "type": "uint256[]"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "nonce",
+                "type": "uint256"
+            }
+        ],
+        "name": "ConsumedMessageToL2",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [],
+        "name": "Finalized",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "fromAddress",
+                "type": "uint256"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "toAddress",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256[]",
+                "name": "payload",
+                "type": "uint256[]"
+            }
+        ],
+        "name": "LogMessageToL1",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "fromAddress",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "toAddress",
+                "type": "uint256"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "selector",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256[]",
+                "name": "payload",
+                "type": "uint256[]"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "nonce",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "fee",
+                "type": "uint256"
+            }
+        ],
+        "name": "LogMessageToL2",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "acceptedGovernor",
+                "type": "address"
+            }
+        ],
+        "name": "LogNewGovernorAccepted",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "nominatedGovernor",
+                "type": "address"
+            }
+        ],
+        "name": "LogNominatedGovernor",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [],
+        "name": "LogNominationCancelled",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "operator",
+                "type": "address"
+            }
+        ],
+        "name": "LogOperatorAdded",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "operator",
+                "type": "address"
+            }
+        ],
+        "name": "LogOperatorRemoved",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "removedGovernor",
+                "type": "address"
+            }
+        ],
+        "name": "LogRemovedGovernor",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "stateTransitionFact",
+                "type": "bytes32"
+            }
+        ],
+        "name": "LogStateTransitionFact",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "globalRoot",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "int256",
+                "name": "blockNumber",
+                "type": "int256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "blockHash",
+                "type": "uint256"
+            }
+        ],
+        "name": "LogStateUpdate",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "fromAddress",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "toAddress",
+                "type": "uint256"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "selector",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256[]",
+                "name": "payload",
+                "type": "uint256[]"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "nonce",
+                "type": "uint256"
+            }
+        ],
+        "name": "MessageToL2Canceled",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "fromAddress",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "toAddress",
+                "type": "uint256"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "selector",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256[]",
+                "name": "payload",
+                "type": "uint256[]"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "nonce",
+                "type": "uint256"
+            }
+        ],
+        "name": "MessageToL2CancellationStarted",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "changedBy",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "oldProgramHash",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "newProgramHash",
+                "type": "uint256"
+            }
+        ],
+        "name": "ProgramHashChanged",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "toAddress",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "selector",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "payload",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "nonce",
+                "type": "uint256"
+            }
+        ],
+        "name": "cancelL1ToL2Message",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "configHash",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "fromAddress",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "payload",
+                "type": "uint256[]"
+            }
+        ],
+        "name": "consumeMessageFromL2",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "finalize",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getMaxL1MsgFee",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "identify",
+        "outputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "initialize",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "isFinalized",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "isFrozen",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "user",
+                "type": "address"
+            }
+        ],
+        "name": "isOperator",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "msgHash",
+                "type": "bytes32"
+            }
+        ],
+        "name": "l1ToL2MessageCancellations",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "l1ToL2MessageNonce",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "msgHash",
+                "type": "bytes32"
+            }
+        ],
+        "name": "l1ToL2Messages",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "msgHash",
+                "type": "bytes32"
+            }
+        ],
+        "name": "l2ToL1Messages",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "messageCancellationDelay",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "programHash",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newOperator",
+                "type": "address"
+            }
+        ],
+        "name": "registerOperator",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "toAddress",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "selector",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "payload",
+                "type": "uint256[]"
+            }
+        ],
+        "name": "sendMessageToL2",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "newConfigHash",
+                "type": "uint256"
+            }
+        ],
+        "name": "setConfigHash",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "delayInSeconds",
+                "type": "uint256"
+            }
+        ],
+        "name": "setMessageCancellationDelay",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "newProgramHash",
+                "type": "uint256"
+            }
+        ],
+        "name": "setProgramHash",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "starknetAcceptGovernance",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "starknetCancelNomination",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "user",
+                "type": "address"
+            }
+        ],
+        "name": "starknetIsGovernor",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newGovernor",
+                "type": "address"
+            }
+        ],
+        "name": "starknetNominateNewGovernor",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "governorForRemoval",
+                "type": "address"
+            }
+        ],
+        "name": "starknetRemoveGovernor",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "toAddress",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "selector",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "payload",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "nonce",
+                "type": "uint256"
+            }
+        ],
+        "name": "startL1ToL2MessageCancellation",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "stateBlockHash",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "stateBlockNumber",
+        "outputs": [
+            {
+                "internalType": "int256",
+                "name": "",
+                "type": "int256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "stateRoot",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "removedOperator",
+                "type": "address"
+            }
+        ],
+        "name": "unregisterOperator",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256[]",
+                "name": "programOutput",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "onchainDataHash",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "onchainDataSize",
+                "type": "uint256"
+            }
+        ],
+        "name": "updateState",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    }
+]

--- a/crates/ethereum/src/contract.rs
+++ b/crates/ethereum/src/contract.rs
@@ -70,13 +70,25 @@ const CORE_IMPL_ABI: &[u8] = include_bytes!(concat!(
     "/resources/contracts/core_impl.json"
 ));
 
+const CORE_IMPL_0_11_1_ABI: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/resources/contracts/core_impl_0.11.1.json"
+));
+
 lazy_static::lazy_static!(
     pub static ref STATE_UPDATE_EVENT: Event = core_contract().event("LogStateUpdate")
+            .expect("LogStateUpdate event not found in core contract ABI").to_owned();
+
+    pub static ref STATE_UPDATE_EVENT_0_11_1: Event = core_contract_0_11_1().event("LogStateUpdate")
             .expect("LogStateUpdate event not found in core contract ABI").to_owned();
 );
 
 fn core_contract() -> Contract {
     Contract::load(CORE_IMPL_ABI).expect("Core contract ABI is invalid")
+}
+
+fn core_contract_0_11_1() -> Contract {
+    Contract::load(CORE_IMPL_0_11_1_ABI).expect("Core contract ABI is invalid")
 }
 
 #[cfg(test)]

--- a/crates/ethereum/src/contract.rs
+++ b/crates/ethereum/src/contract.rs
@@ -1,5 +1,5 @@
 use ethers::abi::{Contract, Event};
-use ethers::types::H160;
+use ethers::types::{H160, H256};
 
 /// Groups the Starknet contract addresses for a specific chain.
 pub struct ContractAddresses {
@@ -81,6 +81,9 @@ lazy_static::lazy_static!(
 
     pub static ref STATE_UPDATE_EVENT_0_11_1: Event = core_contract_0_11_1().event("LogStateUpdate")
             .expect("LogStateUpdate event not found in core contract ABI").to_owned();
+
+    pub static ref STATE_UPDATE_SIGNATURE: H256 = STATE_UPDATE_EVENT.signature();
+    pub static ref STATE_UPDATE_SIGNATURE_0_11_1: H256 = STATE_UPDATE_EVENT_0_11_1.signature();
 );
 
 fn core_contract() -> Contract {

--- a/crates/ethereum/src/log.rs
+++ b/crates/ethereum/src/log.rs
@@ -1,3 +1,4 @@
+use crate::contract::STATE_UPDATE_EVENT_0_11_1;
 use crate::{contract::STATE_UPDATE_EVENT, EthOrigin};
 use anyhow::Context;
 use ethers::abi::{LogParam, RawLog};
@@ -26,7 +27,13 @@ impl TryFrom<ethers::types::Log> for StateUpdateLog {
     fn try_from(value: ethers::types::Log) -> Result<Self, Self::Error> {
         let (origin, raw_log) = parse_web3_log(value)?;
 
-        let log = STATE_UPDATE_EVENT.parse_log(raw_log)?;
+        // As of starknet v0.11.1 we now have two state update event ABIs on L1.
+        let log = match raw_log.topics.first() {
+            Some(topic) if topic == &STATE_UPDATE_EVENT_0_11_1.signature() => {
+                STATE_UPDATE_EVENT_0_11_1.parse_log(raw_log)
+            }
+            _ => STATE_UPDATE_EVENT.parse_log(raw_log),
+        }?;
 
         let global_root = get_log_param(&log, "globalRoot")?
             .value

--- a/crates/ethereum/src/log.rs
+++ b/crates/ethereum/src/log.rs
@@ -1,4 +1,4 @@
-use crate::contract::STATE_UPDATE_EVENT_0_11_1;
+use crate::contract::{STATE_UPDATE_EVENT_0_11_1, STATE_UPDATE_SIGNATURE_0_11_1};
 use crate::{contract::STATE_UPDATE_EVENT, EthOrigin};
 use anyhow::Context;
 use ethers::abi::{LogParam, RawLog};
@@ -29,7 +29,7 @@ impl TryFrom<ethers::types::Log> for StateUpdateLog {
 
         // As of starknet v0.11.1 we now have two state update event ABIs on L1.
         let log = match raw_log.topics.first() {
-            Some(topic) if topic == &STATE_UPDATE_EVENT_0_11_1.signature() => {
+            Some(topic) if topic == &*STATE_UPDATE_SIGNATURE_0_11_1 => {
                 STATE_UPDATE_EVENT_0_11_1.parse_log(raw_log)
             }
             _ => STATE_UPDATE_EVENT.parse_log(raw_log),

--- a/crates/ethereum/src/state_update.rs
+++ b/crates/ethereum/src/state_update.rs
@@ -1,6 +1,7 @@
 use ethers::types::{Filter, H160};
 use pathfinder_common::{Chain, EthereumBlockNumber};
 
+use crate::contract::{STATE_UPDATE_EVENT, STATE_UPDATE_EVENT_0_11_1};
 use crate::log::StateUpdateLog;
 
 use anyhow::Context;
@@ -48,12 +49,12 @@ impl StateRootFetcher {
             Chain::Custom => EthereumBlockNumber(0),
         };
 
-        let signature = StateUpdateLog::signature();
-        let signature: ethers::types::H256 = signature.0.into();
-
         let base_filter = Filter::default()
             .address(vec![contract_address])
-            .topic0(signature);
+            .topic0(vec![
+                STATE_UPDATE_EVENT.signature(),
+                STATE_UPDATE_EVENT_0_11_1.signature(),
+            ]);
 
         Self {
             head,

--- a/crates/ethereum/src/state_update.rs
+++ b/crates/ethereum/src/state_update.rs
@@ -1,7 +1,7 @@
 use ethers::types::{Filter, H160};
 use pathfinder_common::{Chain, EthereumBlockNumber};
 
-use crate::contract::{STATE_UPDATE_EVENT, STATE_UPDATE_EVENT_0_11_1};
+use crate::contract::{STATE_UPDATE_SIGNATURE, STATE_UPDATE_SIGNATURE_0_11_1};
 use crate::log::StateUpdateLog;
 
 use anyhow::Context;
@@ -52,8 +52,8 @@ impl StateRootFetcher {
         let base_filter = Filter::default()
             .address(vec![contract_address])
             .topic0(vec![
-                STATE_UPDATE_EVENT.signature(),
-                STATE_UPDATE_EVENT_0_11_1.signature(),
+                *STATE_UPDATE_SIGNATURE,
+                *STATE_UPDATE_SIGNATURE_0_11_1,
             ]);
 
         Self {


### PR DESCRIPTION
This PR adds support for the new L1 starknet contract ABI introduced with v0.11.1. This ABI change is not backwards compatible ito the state update event, which we (currently) use to fetch starknet state on L1.

As of starknet v0.11.1 we have two incompatible state update log ABIs. This means they have different topics, and are decoded differently.

Note: I didn't spend too much time on naming etc, in anticipation of this code getting removed in the short term future.

Closes #1053.