### PR TITLE
feat(Dockerfile): upgrade cargo-chef and Rust to 1.69

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,8 @@
 # Note that we're explicitly using the Debian bullseye image to make sure we're
 # compatible with the Python container we'll be copying the pathfinder
 # executable to.
-FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:0.1.52-rust-1.68-bullseye AS cargo-chef
+FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:0.1.59-rust-1.69-slim-bullseye AS cargo-chef
 WORKDIR /usr/src/pathfinder
-
-# Use Cargo's sparse protocol: downloading the full crate registry index takes
-# a _lot_ of time so we just use the new sparse protocol which became available
-# in Rust 1.68.
-ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 FROM --platform=$BUILDPLATFORM cargo-chef AS rust-planner
 COPY . .

--- a/build/prepare-stark_hash_python.sh
+++ b/build/prepare-stark_hash_python.sh
@@ -1,10 +1,11 @@
 #!/bin/bash -e
 if [[ "${TARGETARCH}" == "amd64" ]]; then
-    echo "nothing to do"
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y python3 libpython3-dev
 elif [[ "${TARGETARCH}" == "arm64" ]]; then
     echo "deb [arch=arm64] http://deb.debian.org/debian bullseye main" >>/etc/apt/sources.list
     apt-get update
-    DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross
+    DEBIAN_FRONTEND=noninteractive apt-get install -y python3 gcc-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross
     apt-get download libpython3.9-dev:arm64 libpython3.9:arm64 libpython3.9-minimal:arm64 python3.9:arm64 python3-dev:arm64 libpython3.9-stdlib:arm64
     mkdir -p /build/sysroot
     dpkg -x python3.9_*.deb /build/sysroot/

--- a/build/prepare.sh
+++ b/build/prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 if [[ "${TARGETARCH}" == "amd64" ]]; then
     apt-get update
-    DEBIAN_FRONTEND=noninteractive apt-get install -y libssl-dev protobuf-compiler
+    DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config libssl-dev protobuf-compiler
 elif [[ "${TARGETARCH}" == "arm64" ]]; then
     echo "deb [arch=arm64] http://deb.debian.org/debian bullseye main" >>/etc/apt/sources.list
     apt-get update


### PR DESCRIPTION
The cargo-chef base image seems to be missing Python 3.9 and pkg-config now so we have to install those in our prepare scripts.

I've also removed setting CARGO_REGISTRIES_CRATES_IO_PROTOCOL to `sparse` since the cargo-chef base image already has that.