### PR TITLE
feat: cleanup gateway api

### DIFF
--- a/crates/gateway-client/src/builder.rs
+++ b/crates/gateway-client/src/builder.rs
@@ -10,9 +10,7 @@
 //!   3. [Params](stage::Params) where you select the retry behavior.
 //!   4. [Final](stage::Final) where you select the REST operation type, which is then executed.
 use crate::metrics::{with_metrics, BlockTag, RequestMetadata};
-use pathfinder_common::{
-    BlockId, ClassHash, ContractAddress, StarknetTransactionHash, StorageAddress,
-};
+use pathfinder_common::{BlockId, ClassHash, StarknetTransactionHash};
 use starknet_gateway_types::error::SequencerError;
 
 /// A Sequencer Request builder.
@@ -39,8 +37,6 @@ pub mod stage {
     /// - [add_transaction](super::Request::add_transaction)
     /// - [get_block](super::Request::get_block)
     /// - [get_class_by_hash](super::Request::get_class_by_hash)
-    /// - [get_compiled_class_by_class_hash](super::Request::get_compiled_class_by_class_hash)
-    /// - [get_storage_at](super::Request::get_storage_at)
     /// - [get_transaction](super::Request::get_transaction)
     /// - [get_state_update](super::Request::get_state_update)
     /// - [get_contract_addresses](super::Request::get_contract_addresses)
@@ -48,10 +44,8 @@ pub mod stage {
 
     /// Specify the request parameters:
     /// - [at_block](super::Request::with_block)
-    /// - [with_contract_address](super::Request::with_contract_address)
     /// - [with_class_hash](super::Request::with_class_hash)
     /// - [with_optional_token](super::Request::with_optional_token)
-    /// - [with_storage_address](super::Request::with_storage_address)
     /// - [with_transaction_hash](super::Request::with_transaction_hash)
     /// - [add_param](super::Request::add_param) (allows adding custom (name, value) parameter)
     ///
@@ -138,11 +132,9 @@ impl<'a> Request<'a, stage::Method> {
         add_transaction,
         get_block,
         get_class_by_hash,
-        get_storage_at,
         get_transaction,
         get_state_update,
         get_contract_addresses,
-        get_compiled_class_by_class_hash,
     );
 
     /// Appends the given method to the request url.
@@ -182,10 +174,6 @@ impl<'a> Request<'a, stage::Params> {
         self.update_tag(tag).add_param(name, &value)
     }
 
-    pub fn with_contract_address(self, address: ContractAddress) -> Self {
-        self.add_param("contractAddress", &address.get().to_hex_str())
-    }
-
     pub fn with_class_hash(self, class_hash: ClassHash) -> Self {
         self.add_param("classHash", &class_hash.0.to_hex_str())
     }
@@ -195,11 +183,6 @@ impl<'a> Request<'a, stage::Params> {
             Some(token) => self.add_param("token", token),
             None => self,
         }
-    }
-
-    pub fn with_storage_address(self, address: StorageAddress) -> Self {
-        use pathfinder_serde::starkhash_to_dec_str;
-        self.add_param("key", &starkhash_to_dec_str(address.get()))
     }
 
     pub fn with_transaction_hash(self, hash: StarknetTransactionHash) -> Self {

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -20,7 +20,7 @@ mod metrics;
 #[allow(unused_variables)]
 #[cfg_attr(feature = "test-utils", mockall::automock)]
 #[async_trait::async_trait]
-pub trait ClientApi: Sync {
+pub trait GatewayApi: Sync {
     async fn block(&self, block: BlockId) -> Result<reply::MaybePendingBlock, SequencerError> {
         unimplemented!();
     }
@@ -210,7 +210,7 @@ impl Client {
 }
 
 #[async_trait::async_trait]
-impl ClientApi for Client {
+impl GatewayApi for Client {
     #[tracing::instrument(skip(self))]
     async fn block(&self, block: BlockId) -> Result<reply::MaybePendingBlock, SequencerError> {
         self.feeder_gateway_request()
@@ -1553,7 +1553,7 @@ mod tests {
         // The tests are kept here to prevent crate dependency cycles while keeping the macro widely available.
         use pathfinder_common::{version_check, StarknetVersion};
 
-        use crate::{Client, ClientApi};
+        use crate::{Client, GatewayApi};
         use anyhow::Context;
         use pathfinder_common::BlockId;
 

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -17,29 +17,42 @@ use std::{fmt::Debug, result::Result, time::Duration};
 mod builder;
 mod metrics;
 
+#[allow(unused_variables)]
 #[cfg_attr(feature = "test-utils", mockall::automock)]
 #[async_trait::async_trait]
-pub trait ClientApi {
-    async fn block(&self, block: BlockId) -> Result<reply::MaybePendingBlock, SequencerError>;
+pub trait ClientApi: Sync {
+    async fn block(&self, block: BlockId) -> Result<reply::MaybePendingBlock, SequencerError> {
+        unimplemented!();
+    }
 
-    async fn class_by_hash(&self, class_hash: ClassHash) -> Result<bytes::Bytes, SequencerError>;
+    async fn class_by_hash(&self, class_hash: ClassHash) -> Result<bytes::Bytes, SequencerError> {
+        unimplemented!();
+    }
 
     async fn pending_class_by_hash(
         &self,
         class_hash: ClassHash,
-    ) -> Result<bytes::Bytes, SequencerError>;
+    ) -> Result<bytes::Bytes, SequencerError> {
+        unimplemented!();
+    }
 
     async fn transaction(
         &self,
         transaction_hash: StarknetTransactionHash,
-    ) -> Result<reply::Transaction, SequencerError>;
+    ) -> Result<reply::Transaction, SequencerError> {
+        unimplemented!();
+    }
 
     async fn state_update(
         &self,
         block: BlockId,
-    ) -> Result<reply::MaybePendingStateUpdate, SequencerError>;
+    ) -> Result<reply::MaybePendingStateUpdate, SequencerError> {
+        unimplemented!();
+    }
 
-    async fn eth_contract_addresses(&self) -> Result<reply::EthContractAddresses, SequencerError>;
+    async fn eth_contract_addresses(&self) -> Result<reply::EthContractAddresses, SequencerError> {
+        unimplemented!();
+    }
 
     #[allow(clippy::too_many_arguments)]
     async fn add_invoke_transaction(
@@ -50,7 +63,9 @@ pub trait ClientApi {
         nonce: TransactionNonce,
         contract_address: ContractAddress,
         calldata: Vec<CallParam>,
-    ) -> Result<reply::add_transaction::InvokeResponse, SequencerError>;
+    ) -> Result<reply::add_transaction::InvokeResponse, SequencerError> {
+        unimplemented!();
+    }
 
     #[allow(clippy::too_many_arguments)]
     async fn add_declare_transaction(
@@ -63,7 +78,9 @@ pub trait ClientApi {
         sender_address: ContractAddress,
         compiled_class_hash: Option<CasmHash>,
         token: Option<String>,
-    ) -> Result<reply::add_transaction::DeclareResponse, SequencerError>;
+    ) -> Result<reply::add_transaction::DeclareResponse, SequencerError> {
+        unimplemented!();
+    }
 
     #[allow(clippy::too_many_arguments)]
     async fn add_deploy_account(
@@ -75,7 +92,9 @@ pub trait ClientApi {
         contract_address_salt: ContractAddressSalt,
         class_hash: ClassHash,
         calldata: Vec<CallParam>,
-    ) -> Result<reply::add_transaction::DeployAccountResponse, SequencerError>;
+    ) -> Result<reply::add_transaction::DeployAccountResponse, SequencerError> {
+        unimplemented!();
+    }
 }
 
 /// StarkNet sequencer client using REST API.

--- a/crates/gateway-client/tests/metrics.rs
+++ b/crates/gateway-client/tests/metrics.rs
@@ -7,7 +7,7 @@ use futures::stream::StreamExt;
 use pathfinder_common::{BlockId, StarknetBlockNumber};
 use pretty_assertions::assert_eq;
 use starknet_gateway_client::test_utils::{response_from, setup_with_varied_responses};
-use starknet_gateway_client::{Client, ClientApi};
+use starknet_gateway_client::{Client, GatewayApi};
 use starknet_gateway_test_fixtures::{v0_11_0, v0_9_0};
 use starknet_gateway_types::error::StarknetErrorCode;
 use std::future::Future;

--- a/crates/pathfinder/examples/download_state_updates.rs
+++ b/crates/pathfinder/examples/download_state_updates.rs
@@ -52,7 +52,7 @@ async fn main() {
 
     let downloader = std::thread::spawn(move || {
         use pathfinder_common::BlockId;
-        use starknet_gateway_client::{Client, ClientApi};
+        use starknet_gateway_client::{Client, GatewayApi};
 
         let client = match chain {
             Chain::Mainnet => Client::mainnet(),

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -13,7 +13,7 @@ use pathfinder_lib::{
 };
 use pathfinder_rpc::{cairo, metrics::logger::RpcMetricsLogger, SyncState};
 use pathfinder_storage::Storage;
-use starknet_gateway_client::ClientApi;
+use starknet_gateway_client::GatewayApi;
 use starknet_gateway_types::pending::PendingData;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -401,7 +401,7 @@ mod pathfinder_context {
             data_directory: PathBuf,
         ) -> anyhow::Result<Self> {
             use stark_hash::Felt;
-            use starknet_gateway_client::ClientApi;
+            use starknet_gateway_client::GatewayApi;
 
             let gateway =
                 GatewayClient::with_urls(gateway, feeder).context("Creating gateway client")?;

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -1064,10 +1064,9 @@ mod tests {
         BlockId, CallParam, CasmHash, Chain, ChainId, ClassCommitment, ClassHash, ContractAddress,
         ContractAddressSalt, EthereumBlockHash, EthereumBlockNumber, EthereumChain,
         EthereumLogIndex, EthereumTransactionHash, EthereumTransactionIndex, Fee, GasPrice,
-        SequencerAddress, SierraHash, StarknetBlockHash, StarknetBlockNumber,
-        StarknetBlockTimestamp, StarknetTransactionHash, StarknetVersion, StateCommitment,
-        StorageAddress, StorageCommitment, StorageValue, TransactionNonce,
-        TransactionSignatureElem, TransactionVersion,
+        SequencerAddress, StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp,
+        StarknetTransactionHash, StarknetVersion, StateCommitment, StorageCommitment,
+        TransactionNonce, TransactionSignatureElem, TransactionVersion,
     };
     use pathfinder_rpc::SyncState;
     use pathfinder_storage::{
@@ -1078,10 +1077,8 @@ mod tests {
     use stark_hash::Felt;
     use starknet_gateway_client::ClientApi;
     use starknet_gateway_types::{
-        error::SequencerError,
-        pending::PendingData,
-        reply,
-        request::{add_transaction::ContractDefinition, BlockHashOrTag},
+        error::SequencerError, pending::PendingData, reply,
+        request::add_transaction::ContractDefinition,
     };
     use std::{sync::Arc, time::Duration};
     use tokio::sync::mpsc;
@@ -1149,19 +1146,6 @@ mod tests {
             &self,
             _: ClassHash,
         ) -> Result<bytes::Bytes, SequencerError> {
-            unimplemented!()
-        }
-
-        async fn compiled_class(&self, _: SierraHash) -> Result<bytes::Bytes, SequencerError> {
-            unimplemented!()
-        }
-
-        async fn storage(
-            &self,
-            _: ContractAddress,
-            _: StorageAddress,
-            _: BlockHashOrTag,
-        ) -> Result<StorageValue, SequencerError> {
             unimplemented!()
         }
 

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -1061,12 +1061,11 @@ mod tests {
     use ethers::types::H256;
     use futures::stream::{StreamExt, TryStreamExt};
     use pathfinder_common::{
-        BlockId, CallParam, CasmHash, Chain, ChainId, ClassCommitment, ClassHash, ContractAddress,
-        ContractAddressSalt, EthereumBlockHash, EthereumBlockNumber, EthereumChain,
-        EthereumLogIndex, EthereumTransactionHash, EthereumTransactionIndex, Fee, GasPrice,
-        SequencerAddress, StarknetBlockHash, StarknetBlockNumber, StarknetBlockTimestamp,
-        StarknetTransactionHash, StarknetVersion, StateCommitment, StorageCommitment,
-        TransactionNonce, TransactionSignatureElem, TransactionVersion,
+        BlockId, CasmHash, Chain, ChainId, ClassCommitment, ClassHash, EthereumBlockHash,
+        EthereumBlockNumber, EthereumChain, EthereumLogIndex, EthereumTransactionHash,
+        EthereumTransactionIndex, GasPrice, SequencerAddress, StarknetBlockHash,
+        StarknetBlockNumber, StarknetBlockTimestamp, StarknetVersion, StateCommitment,
+        StorageCommitment,
     };
     use pathfinder_rpc::SyncState;
     use pathfinder_storage::{
@@ -1076,10 +1075,7 @@ mod tests {
     };
     use stark_hash::Felt;
     use starknet_gateway_client::ClientApi;
-    use starknet_gateway_types::{
-        error::SequencerError, pending::PendingData, reply,
-        request::add_transaction::ContractDefinition,
-    };
+    use starknet_gateway_types::{error::SequencerError, pending::PendingData, reply};
     use std::{sync::Arc, time::Duration};
     use tokio::sync::mpsc;
 
@@ -1136,76 +1132,6 @@ mod tests {
                 BlockId::Number(_) => Ok(reply::MaybePendingBlock::Block(BLOCK0.clone())),
                 _ => unimplemented!(),
             }
-        }
-
-        async fn class_by_hash(&self, _: ClassHash) -> Result<bytes::Bytes, SequencerError> {
-            unimplemented!()
-        }
-
-        async fn pending_class_by_hash(
-            &self,
-            _: ClassHash,
-        ) -> Result<bytes::Bytes, SequencerError> {
-            unimplemented!()
-        }
-
-        async fn transaction(
-            &self,
-            _: StarknetTransactionHash,
-        ) -> Result<reply::Transaction, SequencerError> {
-            unimplemented!()
-        }
-
-        async fn state_update(
-            &self,
-            _: BlockId,
-        ) -> Result<reply::MaybePendingStateUpdate, SequencerError> {
-            unimplemented!()
-        }
-
-        async fn eth_contract_addresses(
-            &self,
-        ) -> Result<reply::EthContractAddresses, SequencerError> {
-            unimplemented!()
-        }
-
-        async fn add_invoke_transaction(
-            &self,
-            _: TransactionVersion,
-            _: Fee,
-            _: Vec<TransactionSignatureElem>,
-            _: TransactionNonce,
-            _: ContractAddress,
-            _: Vec<CallParam>,
-        ) -> Result<reply::add_transaction::InvokeResponse, SequencerError> {
-            unimplemented!()
-        }
-
-        async fn add_declare_transaction(
-            &self,
-            _: TransactionVersion,
-            _: Fee,
-            _: Vec<TransactionSignatureElem>,
-            _: TransactionNonce,
-            _: ContractDefinition,
-            _: ContractAddress,
-            _: Option<CasmHash>,
-            _: Option<String>,
-        ) -> Result<reply::add_transaction::DeclareResponse, SequencerError> {
-            unimplemented!()
-        }
-
-        async fn add_deploy_account(
-            &self,
-            _: TransactionVersion,
-            _: Fee,
-            _: Vec<TransactionSignatureElem>,
-            _: TransactionNonce,
-            _: ContractAddressSalt,
-            _: ClassHash,
-            _: Vec<CallParam>,
-        ) -> Result<reply::add_transaction::DeployAccountResponse, SequencerError> {
-            unimplemented!()
         }
     }
 

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -26,7 +26,7 @@ use pathfinder_storage::{
 };
 use rusqlite::{Connection, Transaction, TransactionBehavior};
 use stark_hash::Felt;
-use starknet_gateway_client::ClientApi;
+use starknet_gateway_client::GatewayApi;
 use starknet_gateway_types::{
     pending::PendingData,
     reply::{
@@ -55,7 +55,7 @@ pub async fn sync<Transport, SequencerClient, F1, F2, L1Sync, L2Sync>(
 ) -> anyhow::Result<()>
 where
     Transport: EthereumTransport + Clone,
-    SequencerClient: ClientApi + Clone + Send + Sync + 'static,
+    SequencerClient: GatewayApi + Clone + Send + Sync + 'static,
     F1: Future<Output = anyhow::Result<()>> + Send + 'static,
     F2: Future<Output = anyhow::Result<()>> + Send + 'static,
     L1Sync: FnMut(mpsc::Sender<l1::Event>, Transport, Chain, H160, Option<StateUpdateLog>) -> F1,
@@ -387,7 +387,7 @@ where
 /// Periodically updates sync state with the latest block height.
 async fn update_sync_status_latest(
     state: Arc<SyncState>,
-    sequencer: impl ClientApi,
+    sequencer: impl GatewayApi,
     starting_block_hash: StarknetBlockHash,
     starting_block_num: StarknetBlockNumber,
     chain: Chain,
@@ -824,7 +824,7 @@ fn deploy_contract(
 
 /// Downloads and inserts class definitions for any classes in the
 /// list which are not already present in the database.
-async fn download_verify_and_insert_missing_classes<SequencerClient: ClientApi>(
+async fn download_verify_and_insert_missing_classes<SequencerClient: GatewayApi>(
     sequencer: SequencerClient,
     connection: &mut Connection,
     state_update: &PendingStateUpdate,
@@ -938,7 +938,7 @@ enum DownloadedClass {
     Sierra(CompressedContract, CompressedCasmClass),
 }
 
-async fn download_class<SequencerClient: ClientApi>(
+async fn download_class<SequencerClient: GatewayApi>(
     sequencer: &SequencerClient,
     class_hash: ClassHash,
     chain: Chain,
@@ -1074,7 +1074,7 @@ mod tests {
         StarknetBlocksBlockId, StarknetBlocksTable, Storage,
     };
     use stark_hash::Felt;
-    use starknet_gateway_client::ClientApi;
+    use starknet_gateway_client::GatewayApi;
     use starknet_gateway_types::{error::SequencerError, pending::PendingData, reply};
     use std::{sync::Arc, time::Duration};
     use tokio::sync::mpsc;
@@ -1126,7 +1126,7 @@ mod tests {
     struct FakeSequencer;
 
     #[async_trait::async_trait]
-    impl ClientApi for FakeSequencer {
+    impl GatewayApi for FakeSequencer {
         async fn block(&self, block: BlockId) -> Result<reply::MaybePendingBlock, SequencerError> {
             match block {
                 BlockId::Number(_) => Ok(reply::MaybePendingBlock::Block(BLOCK0.clone())),
@@ -1149,7 +1149,7 @@ mod tests {
 
     async fn l2_noop(
         _: mpsc::Sender<l2::Event>,
-        _: impl ClientApi,
+        _: impl GatewayApi,
         _: Option<(StarknetBlockNumber, StarknetBlockHash, StateCommitment)>,
         _: Chain,
         _: ChainId,

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -11,7 +11,7 @@ use starknet_gateway_types::reply::{Block, StateUpdate};
 /// A full block or full state update can be returned from this function if it is encountered during polling.
 pub async fn poll_pending(
     tx_event: tokio::sync::mpsc::Sender<super::l2::Event>,
-    sequencer: &impl starknet_gateway_client::ClientApi,
+    sequencer: &impl starknet_gateway_client::GatewayApi,
     head: (
         pathfinder_common::StarknetBlockHash,
         pathfinder_common::StateCommitment,
@@ -105,7 +105,7 @@ mod tests {
         felt, felt_bytes, GasPrice, SequencerAddress, StarknetBlockHash, StarknetBlockNumber,
         StarknetBlockTimestamp, StarknetVersion, StateCommitment,
     };
-    use starknet_gateway_client::MockClientApi;
+    use starknet_gateway_client::MockGatewayApi;
     use starknet_gateway_types::reply::{
         state_update::StateDiff, Block, MaybePendingBlock, MaybePendingStateUpdate, PendingBlock,
         PendingStateUpdate, StateUpdate, Status,
@@ -160,7 +160,7 @@ mod tests {
     #[tokio::test]
     async fn exits_on_full_block() {
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
-        let mut sequencer = MockClientApi::new();
+        let mut sequencer = MockGatewayApi::new();
 
         // Give a pending state update and full block.
         sequencer
@@ -192,7 +192,7 @@ mod tests {
     #[tokio::test]
     async fn exits_on_full_state_diff() {
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
-        let mut sequencer = MockClientApi::new();
+        let mut sequencer = MockGatewayApi::new();
 
         // Construct some full diff
         let pending_diff = PENDING_DIFF.clone();
@@ -233,7 +233,7 @@ mod tests {
     #[tokio::test]
     async fn exits_on_block_discontinuity() {
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
-        let mut sequencer = MockClientApi::new();
+        let mut sequencer = MockGatewayApi::new();
 
         let mut pending_block = PENDING_BLOCK.clone();
         pending_block.parent_hash = StarknetBlockHash(felt!("0xFFFFFF"));
@@ -264,7 +264,7 @@ mod tests {
     #[tokio::test]
     async fn exits_on_state_diff_discontinuity() {
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
-        let mut sequencer = MockClientApi::new();
+        let mut sequencer = MockGatewayApi::new();
 
         sequencer
             .expect_block()
@@ -296,7 +296,7 @@ mod tests {
     #[tokio::test]
     async fn success() {
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
-        let mut sequencer = MockClientApi::new();
+        let mut sequencer = MockGatewayApi::new();
 
         sequencer
             .expect_block()

--- a/crates/rpc/src/pathfinder/methods/get_transaction_status.rs
+++ b/crates/rpc/src/pathfinder/methods/get_transaction_status.rs
@@ -40,7 +40,7 @@ pub async fn get_transaction_status(
     }
 
     // Check gateway for rejected transactions.
-    use starknet_gateway_client::ClientApi;
+    use starknet_gateway_client::GatewayApi;
     context
         .sequencer
         .transaction(input.transaction_hash)

--- a/crates/rpc/src/v02/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v02/method/add_declare_transaction.rs
@@ -2,7 +2,7 @@ use crate::context::RpcContext;
 use crate::felt::RpcFelt;
 use crate::v02::types::request::BroadcastedDeclareTransaction;
 use pathfinder_common::{ClassHash, StarknetTransactionHash};
-use starknet_gateway_client::ClientApi;
+use starknet_gateway_client::GatewayApi;
 use starknet_gateway_types::error::SequencerError;
 use starknet_gateway_types::request::add_transaction::{
     CairoContractDefinition, ContractDefinition, SierraContractDefinition,

--- a/crates/rpc/src/v02/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/v02/method/add_deploy_account_transaction.rs
@@ -3,7 +3,7 @@ use crate::felt::{RpcFelt, RpcFelt251};
 use crate::v02::types::request::BroadcastedDeployAccountTransaction;
 use anyhow::Context;
 use pathfinder_common::{ContractAddress, StarknetTransactionHash};
-use starknet_gateway_client::ClientApi;
+use starknet_gateway_client::GatewayApi;
 
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
 #[serde(tag = "type")]

--- a/crates/rpc/src/v02/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/v02/method/add_invoke_transaction.rs
@@ -3,7 +3,7 @@ use crate::felt::RpcFelt;
 use crate::v02::types::request::BroadcastedInvokeTransaction;
 use anyhow::Context;
 use pathfinder_common::StarknetTransactionHash;
-use starknet_gateway_client::ClientApi;
+use starknet_gateway_client::GatewayApi;
 
 crate::error::generate_rpc_error_subset!(AddInvokeTransactionError);
 

--- a/crates/storage/src/schema/revision_0013.rs
+++ b/crates/storage/src/schema/revision_0013.rs
@@ -41,7 +41,7 @@ pub(crate) fn migrate(transaction: &Transaction<'_>) -> anyhow::Result<()> {
 
     let downloader = std::thread::spawn(move || {
         {
-            use starknet_gateway_client::{Client, ClientApi};
+            use starknet_gateway_client::{Client, GatewayApi};
 
             let client = match chain {
                 Chain::Mainnet => Client::mainnet(),


### PR DESCRIPTION
I noticed a couple of unused gateway APIs so I removed them. And then I refactored the trait a bit. 

The 2nd and 3rd commits are optional, and I'm happy to remove them if they are useless churn.