### PR TITLE
chore: minor usage improvements

### DIFF
--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -59,6 +59,8 @@ Examples:
     #[arg(
         long = "rpc.cors-domains",
         long_help = r"Comma separated list of domains from which Cross-Origin requests will be accepted by the RPC server.
+
+Use '*' to indicate any domain and an empty list to disable CORS.
         
 Examples:
     single: http://one.io
@@ -66,6 +68,7 @@ Examples:
     any:    *",
         value_name = "DOMAIN-LIST",
         value_delimiter = ',',
+        default_value = "Empty list i.e. CORS disabled",
         env = "PATHFINDER_RPC_CORS_DOMAINS"
     )]
     rpc_cors_domains: Vec<String>,

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -28,7 +28,7 @@ mod update;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "info");
+        std::env::set_var("RUST_LOG", "warn, pathfinder=info");
     }
 
     setup_tracing();


### PR DESCRIPTION
Defaults the tracing level to `warn` for dependencies. `jsonrpsee_server` has started logging connection events at the `info` level, so this change silences those.

Also attempted to improve the CORS description, however I'm unsure if its correct as is.