### PR TITLE
fix: spammy rpc connection logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- RPC emits connection logs and warnings
+
 ## [0.5.4] - 2023-05-09
 
 ### Added

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -26,7 +26,8 @@ mod update;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "warn,pathfinder=info");
+        // Disable all dependency logs by default.
+        std::env::set_var("RUST_LOG", "pathfinder=info");
     }
 
     setup_tracing();


### PR DESCRIPTION
Some dependencies are rather chatty even at `warn` level. For example, [jsonrpsee](https://github.com/paritytech/jsonrpsee/issues/1120)currently emits `warn` when a client disconnects during the connection process which can happen rather frequently for public facing services.

We should consider re-enabling dependency logs once it is fixed and we have upgraded jsonrpsee.