### PR TITLE
feat: use starknet gas price instead of ethereum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - RPC emits connection logs and warnings
+- Fee estimate mismatch between gateway and pathfinder
+  - Gateway uses a new gas price sampling algorithm which was incompatible with pathfinders.
 
 ## [0.5.4] - 2023-05-09
 

--- a/crates/gateway-client/src/builder.rs
+++ b/crates/gateway-client/src/builder.rs
@@ -20,9 +20,8 @@ pub struct Request<'a, S: RequestState> {
     client: &'a reqwest::Client,
 }
 
-/// Describes the retry behavior of a request.
+/// Describes the retry behavior of a [Request].
 #[allow(dead_code)]
-#[derive(Debug, Clone, Copy)]
 pub enum Retry {
     Enabled,
     Disabled,

--- a/crates/gateway-client/src/builder.rs
+++ b/crates/gateway-client/src/builder.rs
@@ -20,8 +20,9 @@ pub struct Request<'a, S: RequestState> {
     client: &'a reqwest::Client,
 }
 
-/// Describes the retry behavior of a [Request] and is specified using
+/// Describes the retry behavior of a request.
 #[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
 pub enum Retry {
     Enabled,
     Disabled,

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -14,7 +14,7 @@ use starknet_gateway_types::{
 };
 use std::{fmt::Debug, result::Result, time::Duration};
 
-pub use crate::builder::Retry;
+use crate::builder::Retry;
 
 mod builder;
 mod metrics;
@@ -27,10 +27,9 @@ pub trait GatewayApi: Sync {
         unimplemented!();
     }
 
-    async fn block_with_retry(
+    async fn block_without_retry(
         &self,
         block: BlockId,
-        retry: Retry,
     ) -> Result<reply::MaybePendingBlock, SequencerError> {
         unimplemented!()
     }
@@ -195,6 +194,19 @@ impl Client {
         builder::Request::builder(&self.inner, self.feeder_gateway.clone())
     }
 
+    async fn block_with_retry_behaviour(
+        &self,
+        block: BlockId,
+        retry: Retry,
+    ) -> Result<reply::MaybePendingBlock, SequencerError> {
+        self.feeder_gateway_request()
+            .get_block()
+            .with_block(block)
+            .with_retry(retry)
+            .get()
+            .await
+    }
+
     /// Returns the [network chain](Chain) this client is operating on.
     pub async fn chain(&self) -> anyhow::Result<Chain> {
         use pathfinder_common::consts::{
@@ -223,20 +235,15 @@ impl Client {
 impl GatewayApi for Client {
     #[tracing::instrument(skip(self))]
     async fn block(&self, block: BlockId) -> Result<reply::MaybePendingBlock, SequencerError> {
-        self.block_with_retry(block, Self::RETRY).await
+        self.block_with_retry_behaviour(block, Self::RETRY).await
     }
 
     #[tracing::instrument(skip(self))]
-    async fn block_with_retry(
+    async fn block_without_retry(
         &self,
         block: BlockId,
-        retry: Retry,
     ) -> Result<reply::MaybePendingBlock, SequencerError> {
-        self.feeder_gateway_request()
-            .get_block()
-            .with_block(block)
-            .with_retry(retry)
-            .get()
+        self.block_with_retry_behaviour(block, Retry::Disabled)
             .await
     }
 

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -115,7 +115,7 @@ async fn main() -> anyhow::Result<()> {
         state::l2::BlockValidationMode::Strict,
     ));
 
-    let shared = pathfinder_rpc::gas_price::Cached::new(Arc::new(ethereum.transport));
+    let shared = pathfinder_rpc::gas_price::Cached::new(pathfinder_context.gateway.clone());
 
     let context = pathfinder_rpc::context::RpcContext::new(
         storage.clone(),

--- a/crates/rpc/src/gas_price.rs
+++ b/crates/rpc/src/gas_price.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use starknet_gateway_client::{GatewayApi, Retry};
+use starknet_gateway_client::GatewayApi;
 
 /// Caching of starknet's gas price with single request at a time refreshing.
 ///
@@ -63,7 +63,7 @@ impl Cached {
                     use starknet_gateway_types::reply::MaybePendingBlock;
                     let gas_price = match gateway
                         // Don't indefinitely retry as this could block the RPC request.
-                        .block_with_retry(pathfinder_common::BlockId::Pending, Retry::Disabled)
+                        .block_without_retry(pathfinder_common::BlockId::Pending)
                         .await
                     {
                         Ok(b) => match b {


### PR DESCRIPTION
This PR fixes pathfinder estimate fee gas price being considerably off compared to the sequencers estimate. The sequencer has changed its gas estimation algorithm to compensate for strange gas prices in particular on Goerli. Since we use `eth_gasPrice` directly, this now means we are using different numbers to the sequencer.

Instead of querying gas price directly from ethereum, we instead rely on the sequencers own gas price estimate. This data is fetched from the pending block.

I'm not wholly convinced of the robustness of this approach given the gateway's proclivity for rate-limiting. In particular, this will be prone to breaking especially during sync, where the node is likely to hit rate-limiting.

Fixes #1082.