### PR TITLE
fix(rpc/gas_price): fix gas price H256 conversion

### DIFF
--- a/crates/rpc/src/gas_price.rs
+++ b/crates/rpc/src/gas_price.rs
@@ -86,7 +86,11 @@ impl Cached {
 
                     let now = std::time::Instant::now();
 
-                    let gas_price = ethers::types::H256::from_slice(&gas_price.0.to_be_bytes());
+                    let gas_price = {
+                        let mut g = [0u8; 32];
+                        g[16..].copy_from_slice(&gas_price.0.to_be_bytes());
+                        ethers::types::H256::from_slice(&g)
+                    };
 
                     let mut g = inner.lock().unwrap_or_else(|e| e.into_inner());
                     g.latest.replace((now, gas_price));


### PR DESCRIPTION
Contrary to what you'd expect `H256::from_sice` succeeds _only_ if the length of the input slice is exactly 32 bytes.