### PR TITLE
fix: historic L1 handler txs are identified as Invoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RPC emits connection logs and warnings
 - Fee estimate mismatch between gateway and pathfinder
   - Gateway uses a new gas price sampling algorithm which was incompatible with pathfinders.
+- Historic L1 handler transactions are served as Invoke V0
+  - Older databases contain L1 handler transactions from before L1 handler was a specific transaction type. These were
+    stored as Invoke V0. These are now correctly identified as being L1 Handler transactions.
 
 ## [0.5.4] - 2023-05-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7791,6 +7791,7 @@ name = "starknet-gateway-types"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "ethers",
  "lazy_static",
  "pathfinder-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,8 @@ exclude = [
 resolver = "2"
 
 [workspace.dependencies]
-anyhow = { version = "1.0.66" }
+anyhow = "1.0.66"
+assert_matches = "1.5.0"
 clap = { version = "4.1.13" }
 fake = { version = "2.5.0", features = ["derive"] }
 rand = "0.8.5"

--- a/crates/ethereum/Cargo.toml
+++ b/crates/ethereum/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { workspace = true }
 tracing = "0.1.37"
 
 [dev-dependencies]
-assert_matches = "1.5.0"
+assert_matches = { workspace = true }
 hex = "0.4.3"
 pretty_assertions = "1.3.0"
 tokio = { workspace = true, features = ["macros"] }

--- a/crates/gateway-client/Cargo.toml
+++ b/crates/gateway-client/Cargo.toml
@@ -29,7 +29,7 @@ tracing = "0.1.37"
 warp = { version = "0.3.3", optional = true }
 
 [dev-dependencies]
-assert_matches = "1.5.0"
+assert_matches = { workspace = true }
 base64 = "0.13.1"
 flate2 = "1.0.25"
 http = { version = "0.2.8" }

--- a/crates/gateway-types/Cargo.toml
+++ b/crates/gateway-types/Cargo.toml
@@ -23,7 +23,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
-assert_matches = "1.5.0"
+assert_matches = { workspace = true }
 # Due to pathfinder_common::starkhash!() usage
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 tokio = { workspace = true, features = ["macros", "test-util"] }

--- a/crates/gateway-types/Cargo.toml
+++ b/crates/gateway-types/Cargo.toml
@@ -23,6 +23,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
+assert_matches = "1.5.0"
 # Due to pathfinder_common::starkhash!() usage
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 tokio = { workspace = true, features = ["macros", "test-util"] }

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -412,17 +412,6 @@ pub mod transaction {
                 Transaction::L1Handler(t) => t.contract_address,
             }
         }
-
-        pub fn is_l1_handler_or_legacy_l1_handler(&self) -> bool {
-            match self {
-                Self::Invoke(InvokeTransaction::V0(i)) => match i.entry_point_type {
-                    Some(entry_point_type) if entry_point_type == EntryPointType::L1Handler => true,
-                    Some(_) | None => false,
-                },
-                Self::L1Handler(_) => true,
-                _ => false,
-            }
-        }
     }
 
     #[derive(Clone, Debug, Serialize, PartialEq, Eq)]

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -301,7 +301,7 @@ pub mod transaction {
     }
 
     /// Represents deserialized L2 transaction data.
-    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
     #[serde(tag = "type")]
     #[serde(deny_unknown_fields)]
     pub enum Transaction {
@@ -318,6 +318,65 @@ pub mod transaction {
         Invoke(InvokeTransaction),
         #[serde(rename = "L1_HANDLER")]
         L1Handler(L1HandlerTransaction),
+    }
+
+    // This manual deserializtion is a work-around for L1 handler transactions
+    // historically being served as Invoke V0. However, the gateway has retroactively
+    // changed these to L1 handlers. This means older databases will have these as Invoke
+    // but modern one's as L1 handler. This causes confusion, so we convert these old Invoke
+    // to L1 handler manually.
+    //
+    // The alternative is to do a costly database migration which involves opening every tx.
+    //
+    // This work-around may be removed once we are certain all databases no longer contain these
+    // transactions, which will likely only occur after either a migration, or regenesis.
+    impl<'de> Deserialize<'de> for Transaction {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            /// Copy of [Transaction] to deserialize into, before converting to [Transaction]
+            /// with the potential Invoke V0 -> L1 handler cast.
+            #[derive(Deserialize)]
+            #[serde(tag = "type", deny_unknown_fields)]
+            pub enum InnerTransaction {
+                #[serde(rename = "DECLARE")]
+                Declare(DeclareTransaction),
+                #[serde(rename = "DEPLOY")]
+                Deploy(DeployTransaction),
+                #[serde(rename = "DEPLOY_ACCOUNT")]
+                DeployAccount(DeployAccountTransaction),
+                #[serde(rename = "INVOKE_FUNCTION")]
+                Invoke(InvokeTransaction),
+                #[serde(rename = "L1_HANDLER")]
+                L1Handler(L1HandlerTransaction),
+            }
+
+            let tx = InnerTransaction::deserialize(deserializer)?;
+            let tx = match tx {
+                InnerTransaction::Declare(x) => Transaction::Declare(x),
+                InnerTransaction::Deploy(x) => Transaction::Deploy(x),
+                InnerTransaction::DeployAccount(x) => Transaction::DeployAccount(x),
+                InnerTransaction::Invoke(InvokeTransaction::V0(i))
+                    if i.entry_point_type == Some(EntryPointType::L1Handler) =>
+                {
+                    let l1_handler = L1HandlerTransaction {
+                        contract_address: i.sender_address,
+                        entry_point_selector: i.entry_point_selector,
+                        nonce: TransactionNonce::ZERO,
+                        calldata: i.calldata,
+                        transaction_hash: i.transaction_hash,
+                        version: TransactionVersion::ZERO,
+                    };
+
+                    Transaction::L1Handler(l1_handler)
+                }
+                InnerTransaction::Invoke(x) => Transaction::Invoke(x),
+                InnerTransaction::L1Handler(x) => Transaction::L1Handler(x),
+            };
+
+            Ok(tx)
+        }
     }
 
     impl Transaction {
@@ -923,6 +982,35 @@ mod tests {
         #[test]
         fn transaction() {
             serde_json::from_str::<Transaction>(v0_8_2::transaction::INVOKE).unwrap();
+        }
+
+        #[test]
+        fn legacy_l1_handler_is_invoke() {
+            // In the times before L1 Handler became an official tx variant,
+            // these were instead served as Invoke V0 txs. This test ensures
+            // that we correctly map these historic txs to L1 Handler.
+            use super::super::transaction::Transaction as TransactionVariant;
+
+            let json = serde_json::json!({
+                "type":"INVOKE_FUNCTION",
+                "calldata":[
+                    "580042449035822898911647251144793933582335302582",
+                    "3241583063705060367416058138609427972824194056099997457116843686898315086623",
+                    "2000000000000000000",
+                    "0",
+                    "725188533692944996190142472767755401716439215485"
+                ],
+                "contract_address":"0x1108cdbe5d82737b9057590adaf97d34e74b5452f0628161d237746b6fe69e",
+                "entry_point_selector":"0x2d757788a8d8d6f21d1cd40bce38a8222d70654214e96ff95d8086e684fbee5",
+                "entry_point_type":"L1_HANDLER",
+                "max_fee":"0x0",
+                "signature":[],
+                "transaction_hash":"0x70cad5b0d09ff2b252d3bf040708a89e6f175715f5f550e8d8161fabef01261"
+            });
+
+            let tx: TransactionVariant = serde_json::from_value(json).unwrap();
+
+            assert_matches::assert_matches!(tx, TransactionVariant::L1Handler(_));
         }
     }
 }

--- a/crates/gateway-types/src/transaction_hash.rs
+++ b/crates/gateway-types/src/transaction_hash.rs
@@ -28,7 +28,7 @@ pub fn verify(txn: &Transaction, chain_id: ChainId, block_number: BlockNumber) -
         // Worse still those are invokes in old snapshots but currently are served as
         // L1 handler txns.
         ChainId::MAINNET => {
-            if block_number.get() <= 4399 && txn.is_l1_handler_or_legacy_l1_handler() {
+            if block_number.get() <= 4399 && matches!(txn, Transaction::L1Handler(_)) {
                 // Unable to compute, skipping
                 return VerifyResult::NotVerifiable;
             } else {
@@ -36,7 +36,7 @@ pub fn verify(txn: &Transaction, chain_id: ChainId, block_number: BlockNumber) -
             }
         }
         ChainId::TESTNET => {
-            if block_number.get() <= 306007 && txn.is_l1_handler_or_legacy_l1_handler() {
+            if block_number.get() <= 306007 && matches!(txn, Transaction::L1Handler(_)) {
                 // Unable to compute, skipping
                 return VerifyResult::NotVerifiable;
             } else {

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -26,7 +26,7 @@ tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
 zeroize = "1.5.7"
 
 [dev-dependencies]
-assert_matches = "1.5.0"
+assert_matches = { workspace = true }
 env_logger = "0.10.0"
 fake = { workspace = true }
 hex = "0.4.3"

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -57,7 +57,7 @@ warp = "0.3.3"
 zstd = "0.12"
 
 [dev-dependencies]
-assert_matches = "1.5.0"
+assert_matches = { workspace = true }
 bytes = "1.3.0"
 criterion = "0.4"
 flate2 = "1.0.25"

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -41,7 +41,7 @@ tracing = "0.1.37"
 zstd = "0.12"
 
 [dev-dependencies]
-assert_matches = "1.5.0"
+assert_matches = { workspace = true }
 bytes = "1.3.0"
 hex = "0.4.3"
 jsonrpsee = { version = "0.16.2", default-features = false, features = ["async-client", "jsonrpsee-types", "server"] }

--- a/crates/stark_hash/Cargo.toml
+++ b/crates/stark_hash/Cargo.toml
@@ -25,7 +25,7 @@ serde = { workspace = true }
 stark_curve = { path = "../stark_curve" }
 
 [dev-dependencies]
-assert_matches = "1.5.0"
+assert_matches = { workspace = true }
 criterion = "0.4"
 hex = "0.4.3"
 pretty_assertions = "1.3.0"

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -37,7 +37,7 @@ tracing = "0.1.37"
 zstd = "0.12"
 
 [dev-dependencies]
-assert_matches = "1.5.0"
+assert_matches = { workspace = true }
 # fake = { workspace = true }
 # pretty_assertions = "1.3.0"
 # stark_hash = { path = "../stark_hash", features = ["test-utils"] }


### PR DESCRIPTION
In the times before L1 Handler was a transaction type, these were instead served as Invoke V0 transactions. This can be confusing, especially as the gateway retroactively changed these, and now serves them as L1 Handler. Really old pathfinder databases still store these as Invoke V0 which can cause pathfinder RPC output to appear different, even though they are technically equivalent.

This PR fixes that by adding a deserialization step which maps these Invoke V0 to L1 Handler.

Alternative solution is a database migration, but this would require opening every single tx which would be costly.

Note that this doesn't fix all instances, as there also exist transactions which also do not contain the `entry_points_type` but one would instead have to check the transaction's contract to match its list of L1 entry point against the transactions. Which is just way too much to do.