### PR TITLE
fix(p2p): fix compile errors in the disabled-by-default P2P integration code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
       # Integration tests have to be called explicitly
       - name: Execute tests
         run: |
-          timeout 25m cargo test --all-targets --workspace --locked --profile stripdebuginfo --exclude pathfinder-ethereum
+          timeout 25m cargo test --all-targets --all-features --workspace --locked --profile stripdebuginfo --exclude pathfinder-ethereum
           timeout 3m cargo test --test integration* --features test-utils --locked --profile stripdebuginfo
 
   clippy:
@@ -146,7 +146,7 @@ jobs:
       - name: Install protoc
         run: |
           sudo apt-get install -y protobuf-compiler
-      - run: cargo clippy --workspace --all-targets --locked -- -D warnings -D rust_2018_idioms
+      - run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings -D rust_2018_idioms
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/crates/pathfinder/src/p2p_network.rs
+++ b/crates/pathfinder/src/p2p_network.rs
@@ -22,7 +22,7 @@ pub async fn start(
     listen_on: Multiaddr,
     bootstrap_addresses: &[Multiaddr],
 ) -> anyhow::Result<(Arc<RwLock<Peers>>, p2p::Client, tokio::task::JoinHandle<()>)> {
-    let keypair = Keypair::Ed25519(p2p::libp2p::identity::ed25519::Keypair::generate());
+    let keypair = Keypair::generate_ed25519();
 
     let peer_id = keypair.public().to_peer_id();
     tracing::info!(%peer_id, "Starting P2P");

--- a/crates/pathfinder/src/p2p_network/sync_handlers.rs
+++ b/crates/pathfinder/src/p2p_network/sync_handlers.rs
@@ -70,7 +70,7 @@ fn fetch_block_headers(
         headers.push(p2p_proto::common::BlockHeader {
             parent_block_hash: parent_block_hash.unwrap_or(BlockHash(Felt::ZERO)).0,
             block_number: block.number.get(),
-            global_state_root: block.root.0,
+            global_state_root: block.state_commmitment.0,
             sequencer_address: block.sequencer_address.0,
             block_timestamp: block.timestamp.get(),
             transaction_count: transaction_count


### PR DESCRIPTION
And modify CI job to run clippy and `cargo test` with `--all-features` so that we catch these issues on CI.