### PR TITLE
feat: support sierra compiler for starknet v0.11.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,6 +896,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-lang-casm"
+version = "1.1.0-rc0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+dependencies = [
+ "cairo-lang-utils 1.1.0-rc0",
+ "indoc 2.0.1",
+ "num-bigint 0.4.3",
+ "num-traits 0.2.15",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "cairo-lang-compiler"
 version = "1.0.0-alpha.6"
 source = "git+https://github.com/starkware-libs/cairo?tag=v1.0.0-alpha.6#439da05a031c2eda263c4ce12d0b71d20f38205f"
@@ -945,6 +958,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-lang-compiler"
+version = "1.1.0-rc0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+dependencies = [
+ "anyhow",
+ "cairo-lang-defs 1.1.0-rc0",
+ "cairo-lang-diagnostics 1.1.0-rc0",
+ "cairo-lang-filesystem 1.1.0-rc0",
+ "cairo-lang-lowering 1.1.0-rc0",
+ "cairo-lang-parser 1.1.0-rc0",
+ "cairo-lang-plugins 1.1.0-rc0",
+ "cairo-lang-project 1.1.0-rc0",
+ "cairo-lang-semantic 1.1.0-rc0",
+ "cairo-lang-sierra 1.1.0-rc0",
+ "cairo-lang-sierra-generator 1.1.0-rc0",
+ "cairo-lang-syntax 1.1.0-rc0",
+ "cairo-lang-utils 1.1.0-rc0",
+ "clap 4.2.7",
+ "log",
+ "salsa",
+ "smol_str 0.2.0",
+ "thiserror",
+]
+
+[[package]]
 name = "cairo-lang-debug"
 version = "1.0.0-alpha.6"
 source = "git+https://github.com/starkware-libs/cairo?tag=v1.0.0-alpha.6#439da05a031c2eda263c4ce12d0b71d20f38205f"
@@ -953,6 +991,11 @@ source = "git+https://github.com/starkware-libs/cairo?tag=v1.0.0-alpha.6#439da05
 name = "cairo-lang-debug"
 version = "1.0.0-rc0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v1.0.0-rc0#05867c82de42d5ee5cfa953dcca1cb826402f74b"
+
+[[package]]
+name = "cairo-lang-debug"
+version = "1.1.0-rc0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
 
 [[package]]
 name = "cairo-lang-defs"
@@ -989,6 +1032,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-lang-defs"
+version = "1.1.0-rc0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+dependencies = [
+ "cairo-lang-debug 1.1.0-rc0",
+ "cairo-lang-diagnostics 1.1.0-rc0",
+ "cairo-lang-filesystem 1.1.0-rc0",
+ "cairo-lang-parser 1.1.0-rc0",
+ "cairo-lang-syntax 1.1.0-rc0",
+ "cairo-lang-utils 1.1.0-rc0",
+ "indexmap",
+ "itertools",
+ "salsa",
+ "smol_str 0.2.0",
+]
+
+[[package]]
 name = "cairo-lang-diagnostics"
 version = "1.0.0-alpha.6"
 source = "git+https://github.com/starkware-libs/cairo?tag=v1.0.0-alpha.6#439da05a031c2eda263c4ce12d0b71d20f38205f"
@@ -1011,6 +1071,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-lang-diagnostics"
+version = "1.1.0-rc0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+dependencies = [
+ "cairo-lang-filesystem 1.1.0-rc0",
+ "cairo-lang-utils 1.1.0-rc0",
+ "itertools",
+ "salsa",
+]
+
+[[package]]
 name = "cairo-lang-eq-solver"
 version = "1.0.0-alpha.6"
 source = "git+https://github.com/starkware-libs/cairo?tag=v1.0.0-alpha.6#439da05a031c2eda263c4ce12d0b71d20f38205f"
@@ -1027,6 +1098,17 @@ version = "1.0.0-rc0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v1.0.0-rc0#05867c82de42d5ee5cfa953dcca1cb826402f74b"
 dependencies = [
  "cairo-lang-utils 1.0.0-rc0",
+ "good_lp",
+ "indexmap",
+ "itertools",
+]
+
+[[package]]
+name = "cairo-lang-eq-solver"
+version = "1.1.0-rc0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+dependencies = [
+ "cairo-lang-utils 1.1.0-rc0",
  "good_lp",
  "indexmap",
  "itertools",
@@ -1051,6 +1133,19 @@ source = "git+https://github.com/starkware-libs/cairo?tag=v1.0.0-rc0#05867c82de4
 dependencies = [
  "cairo-lang-debug 1.0.0-rc0",
  "cairo-lang-utils 1.0.0-rc0",
+ "path-clean",
+ "salsa",
+ "serde",
+ "smol_str 0.2.0",
+]
+
+[[package]]
+name = "cairo-lang-filesystem"
+version = "1.1.0-rc0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+dependencies = [
+ "cairo-lang-debug 1.1.0-rc0",
+ "cairo-lang-utils 1.1.0-rc0",
  "path-clean",
  "salsa",
  "serde",
@@ -1095,6 +1190,30 @@ dependencies = [
  "cairo-lang-semantic 1.0.0-rc0",
  "cairo-lang-syntax 1.0.0-rc0",
  "cairo-lang-utils 1.0.0-rc0",
+ "id-arena",
+ "indexmap",
+ "itertools",
+ "log",
+ "num-bigint 0.4.3",
+ "num-traits 0.2.15",
+ "salsa",
+ "smol_str 0.2.0",
+]
+
+[[package]]
+name = "cairo-lang-lowering"
+version = "1.1.0-rc0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+dependencies = [
+ "cairo-lang-debug 1.1.0-rc0",
+ "cairo-lang-defs 1.1.0-rc0",
+ "cairo-lang-diagnostics 1.1.0-rc0",
+ "cairo-lang-filesystem 1.1.0-rc0",
+ "cairo-lang-parser 1.1.0-rc0",
+ "cairo-lang-proc-macros 1.1.0-rc0",
+ "cairo-lang-semantic 1.1.0-rc0",
+ "cairo-lang-syntax 1.1.0-rc0",
+ "cairo-lang-utils 1.1.0-rc0",
  "id-arena",
  "indexmap",
  "itertools",
@@ -1143,6 +1262,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-lang-parser"
+version = "1.1.0-rc0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+dependencies = [
+ "cairo-lang-diagnostics 1.1.0-rc0",
+ "cairo-lang-filesystem 1.1.0-rc0",
+ "cairo-lang-syntax 1.1.0-rc0",
+ "cairo-lang-syntax-codegen 1.1.0-rc0",
+ "cairo-lang-utils 1.1.0-rc0",
+ "colored",
+ "itertools",
+ "log",
+ "num-bigint 0.4.3",
+ "num-traits 0.2.15",
+ "salsa",
+ "smol_str 0.2.0",
+ "unescaper",
+]
+
+[[package]]
 name = "cairo-lang-plugins"
 version = "1.0.0-alpha.6"
 source = "git+https://github.com/starkware-libs/cairo?tag=v1.0.0-alpha.6#439da05a031c2eda263c4ce12d0b71d20f38205f"
@@ -1180,6 +1319,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-lang-plugins"
+version = "1.1.0-rc0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+dependencies = [
+ "cairo-lang-defs 1.1.0-rc0",
+ "cairo-lang-diagnostics 1.1.0-rc0",
+ "cairo-lang-filesystem 1.1.0-rc0",
+ "cairo-lang-parser 1.1.0-rc0",
+ "cairo-lang-semantic 1.1.0-rc0",
+ "cairo-lang-syntax 1.1.0-rc0",
+ "cairo-lang-utils 1.1.0-rc0",
+ "indoc 2.0.1",
+ "itertools",
+ "salsa",
+ "smol_str 0.2.0",
+]
+
+[[package]]
 name = "cairo-lang-proc-macros"
 version = "1.0.0-alpha.6"
 source = "git+https://github.com/starkware-libs/cairo?tag=v1.0.0-alpha.6#439da05a031c2eda263c4ce12d0b71d20f38205f"
@@ -1195,6 +1352,16 @@ version = "1.0.0-rc0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v1.0.0-rc0#05867c82de42d5ee5cfa953dcca1cb826402f74b"
 dependencies = [
  "cairo-lang-debug 1.0.0-rc0",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "cairo-lang-proc-macros"
+version = "1.1.0-rc0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+dependencies = [
+ "cairo-lang-debug 1.1.0-rc0",
  "quote",
  "syn 1.0.109",
 ]
@@ -1217,6 +1384,18 @@ version = "1.0.0-rc0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v1.0.0-rc0#05867c82de42d5ee5cfa953dcca1cb826402f74b"
 dependencies = [
  "cairo-lang-filesystem 1.0.0-rc0",
+ "serde",
+ "smol_str 0.2.0",
+ "thiserror",
+ "toml 0.4.10",
+]
+
+[[package]]
+name = "cairo-lang-project"
+version = "1.1.0-rc0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+dependencies = [
+ "cairo-lang-filesystem 1.1.0-rc0",
  "serde",
  "smol_str 0.2.0",
  "thiserror",
@@ -1270,6 +1449,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-lang-semantic"
+version = "1.1.0-rc0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+dependencies = [
+ "cairo-lang-debug 1.1.0-rc0",
+ "cairo-lang-defs 1.1.0-rc0",
+ "cairo-lang-diagnostics 1.1.0-rc0",
+ "cairo-lang-filesystem 1.1.0-rc0",
+ "cairo-lang-parser 1.1.0-rc0",
+ "cairo-lang-proc-macros 1.1.0-rc0",
+ "cairo-lang-syntax 1.1.0-rc0",
+ "cairo-lang-utils 1.1.0-rc0",
+ "id-arena",
+ "itertools",
+ "log",
+ "num-bigint 0.4.3",
+ "num-traits 0.2.15",
+ "salsa",
+ "smol_str 0.2.0",
+]
+
+[[package]]
 name = "cairo-lang-sierra"
 version = "1.0.0-alpha.6"
 source = "git+https://github.com/starkware-libs/cairo?tag=v1.0.0-alpha.6#439da05a031c2eda263c4ce12d0b71d20f38205f"
@@ -1314,6 +1515,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-lang-sierra"
+version = "1.1.0-rc0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+dependencies = [
+ "cairo-lang-utils 1.1.0-rc0",
+ "const-fnv1a-hash",
+ "convert_case",
+ "derivative",
+ "itertools",
+ "lalrpop",
+ "lalrpop-util",
+ "num-bigint 0.4.3",
+ "num-traits 0.2.15",
+ "regex",
+ "salsa",
+ "serde",
+ "sha3",
+ "smol_str 0.2.0",
+ "thiserror",
+]
+
+[[package]]
 name = "cairo-lang-sierra-ap-change"
 version = "1.0.0-alpha.6"
 source = "git+https://github.com/starkware-libs/cairo?tag=v1.0.0-alpha.6#439da05a031c2eda263c4ce12d0b71d20f38205f"
@@ -1338,6 +1561,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-lang-sierra-ap-change"
+version = "1.1.0-rc0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+dependencies = [
+ "cairo-lang-eq-solver 1.1.0-rc0",
+ "cairo-lang-sierra 1.1.0-rc0",
+ "cairo-lang-utils 1.1.0-rc0",
+ "itertools",
+ "thiserror",
+]
+
+[[package]]
 name = "cairo-lang-sierra-gas"
 version = "1.0.0-alpha.6"
 source = "git+https://github.com/starkware-libs/cairo?tag=v1.0.0-alpha.6#439da05a031c2eda263c4ce12d0b71d20f38205f"
@@ -1357,6 +1592,18 @@ dependencies = [
  "cairo-lang-eq-solver 1.0.0-rc0",
  "cairo-lang-sierra 1.0.0-rc0",
  "cairo-lang-utils 1.0.0-rc0",
+ "itertools",
+ "thiserror",
+]
+
+[[package]]
+name = "cairo-lang-sierra-gas"
+version = "1.1.0-rc0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+dependencies = [
+ "cairo-lang-eq-solver 1.1.0-rc0",
+ "cairo-lang-sierra 1.1.0-rc0",
+ "cairo-lang-utils 1.1.0-rc0",
  "itertools",
  "thiserror",
 ]
@@ -1412,6 +1659,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-lang-sierra-generator"
+version = "1.1.0-rc0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+dependencies = [
+ "cairo-lang-debug 1.1.0-rc0",
+ "cairo-lang-defs 1.1.0-rc0",
+ "cairo-lang-diagnostics 1.1.0-rc0",
+ "cairo-lang-filesystem 1.1.0-rc0",
+ "cairo-lang-lowering 1.1.0-rc0",
+ "cairo-lang-parser 1.1.0-rc0",
+ "cairo-lang-plugins 1.1.0-rc0",
+ "cairo-lang-proc-macros 1.1.0-rc0",
+ "cairo-lang-semantic 1.1.0-rc0",
+ "cairo-lang-sierra 1.1.0-rc0",
+ "cairo-lang-syntax 1.1.0-rc0",
+ "cairo-lang-utils 1.1.0-rc0",
+ "id-arena",
+ "indexmap",
+ "itertools",
+ "num-bigint 0.4.3",
+ "salsa",
+ "smol_str 0.2.0",
+]
+
+[[package]]
 name = "cairo-lang-sierra-to-casm"
 version = "1.0.0-alpha.6"
 source = "git+https://github.com/starkware-libs/cairo?tag=v1.0.0-alpha.6#439da05a031c2eda263c4ce12d0b71d20f38205f"
@@ -1446,6 +1718,28 @@ dependencies = [
  "cairo-lang-sierra-ap-change 1.0.0-rc0",
  "cairo-lang-sierra-gas 1.0.0-rc0",
  "cairo-lang-utils 1.0.0-rc0",
+ "clap 4.2.7",
+ "indoc 2.0.1",
+ "itertools",
+ "log",
+ "num-bigint 0.4.3",
+ "num-traits 0.2.15",
+ "thiserror",
+]
+
+[[package]]
+name = "cairo-lang-sierra-to-casm"
+version = "1.1.0-rc0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+dependencies = [
+ "anyhow",
+ "assert_matches",
+ "cairo-felt 0.3.0-rc1",
+ "cairo-lang-casm 1.1.0-rc0",
+ "cairo-lang-sierra 1.1.0-rc0",
+ "cairo-lang-sierra-ap-change 1.1.0-rc0",
+ "cairo-lang-sierra-gas 1.1.0-rc0",
+ "cairo-lang-utils 1.1.0-rc0",
  "clap 4.2.7",
  "indoc 2.0.1",
  "itertools",
@@ -1535,6 +1829,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-lang-starknet"
+version = "1.1.0-rc0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+dependencies = [
+ "anyhow",
+ "cairo-felt 0.3.0-rc1",
+ "cairo-lang-casm 1.1.0-rc0",
+ "cairo-lang-compiler 1.1.0-rc0",
+ "cairo-lang-defs 1.1.0-rc0",
+ "cairo-lang-diagnostics 1.1.0-rc0",
+ "cairo-lang-filesystem 1.1.0-rc0",
+ "cairo-lang-lowering 1.1.0-rc0",
+ "cairo-lang-parser 1.1.0-rc0",
+ "cairo-lang-plugins 1.1.0-rc0",
+ "cairo-lang-semantic 1.1.0-rc0",
+ "cairo-lang-sierra 1.1.0-rc0",
+ "cairo-lang-sierra-ap-change 1.1.0-rc0",
+ "cairo-lang-sierra-gas 1.1.0-rc0",
+ "cairo-lang-sierra-generator 1.1.0-rc0",
+ "cairo-lang-sierra-to-casm 1.1.0-rc0",
+ "cairo-lang-syntax 1.1.0-rc0",
+ "cairo-lang-utils 1.1.0-rc0",
+ "clap 4.2.7",
+ "convert_case",
+ "genco",
+ "indoc 2.0.1",
+ "itertools",
+ "log",
+ "num-bigint 0.4.3",
+ "num-integer",
+ "num-traits 0.2.15",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "sha3",
+ "smol_str 0.2.0",
+ "thiserror",
+]
+
+[[package]]
 name = "cairo-lang-syntax"
 version = "1.0.0-alpha.6"
 source = "git+https://github.com/starkware-libs/cairo?tag=v1.0.0-alpha.6#439da05a031c2eda263c4ce12d0b71d20f38205f"
@@ -1554,6 +1888,22 @@ dependencies = [
  "cairo-lang-debug 1.0.0-rc0",
  "cairo-lang-filesystem 1.0.0-rc0",
  "cairo-lang-utils 1.0.0-rc0",
+ "num-bigint 0.4.3",
+ "num-traits 0.2.15",
+ "salsa",
+ "smol_str 0.2.0",
+ "thiserror",
+ "unescaper",
+]
+
+[[package]]
+name = "cairo-lang-syntax"
+version = "1.1.0-rc0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+dependencies = [
+ "cairo-lang-debug 1.1.0-rc0",
+ "cairo-lang-filesystem 1.1.0-rc0",
+ "cairo-lang-utils 1.1.0-rc0",
  "num-bigint 0.4.3",
  "num-traits 0.2.15",
  "salsa",
@@ -1585,6 +1935,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-lang-syntax-codegen"
+version = "1.1.0-rc0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+dependencies = [
+ "cairo-lang-utils 1.1.0-rc0",
+ "genco",
+ "log",
+ "xshell",
+]
+
+[[package]]
 name = "cairo-lang-utils"
 version = "1.0.0-alpha.6"
 source = "git+https://github.com/starkware-libs/cairo?tag=v1.0.0-alpha.6#439da05a031c2eda263c4ce12d0b71d20f38205f"
@@ -1604,6 +1965,22 @@ dependencies = [
 name = "cairo-lang-utils"
 version = "1.0.0-rc0"
 source = "git+https://github.com/starkware-libs/cairo?tag=v1.0.0-rc0#05867c82de42d5ee5cfa953dcca1cb826402f74b"
+dependencies = [
+ "env_logger 0.9.3",
+ "indexmap",
+ "itertools",
+ "log",
+ "num-bigint 0.4.3",
+ "num-integer",
+ "num-traits 0.2.15",
+ "serde",
+ "time 0.3.21",
+]
+
+[[package]]
+name = "cairo-lang-utils"
+version = "1.1.0-rc0"
+source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
 dependencies = [
  "env_logger 0.9.3",
  "indexmap",
@@ -5984,6 +6361,7 @@ dependencies = [
  "bytes",
  "cairo-lang-starknet 1.0.0-alpha.6",
  "cairo-lang-starknet 1.0.0-rc0",
+ "cairo-lang-starknet 1.1.0-rc0",
  "clap 4.2.7",
  "console-subscriber",
  "criterion",

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -19,8 +19,8 @@ p2p = ["dep:p2p", "dep:p2p_proto"]
 anyhow = { workspace = true }
 async-trait = "0.1.59"
 bitvec = "0.20.4"
-casm-compiler = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-rc0" }
-casm-compiler-historic = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-alpha.6" }
+casm-compiler-v1_0_0-rc0 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-rc0" }
+casm-compiler-v1_0_0-alpha6 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-alpha.6" }
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
 console-subscriber = { version = "0.1.8", optional = true }
 ethers = "1.0.2"

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -19,8 +19,9 @@ p2p = ["dep:p2p", "dep:p2p_proto"]
 anyhow = { workspace = true }
 async-trait = "0.1.59"
 bitvec = "0.20.4"
-casm-compiler-v1_0_0-rc0 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-rc0" }
 casm-compiler-v1_0_0-alpha6 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-alpha.6" }
+casm-compiler-v1_0_0-rc0 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-rc0" }
+casm-compiler-v1_1_0-rc0 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.1.0-rc0" }
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
 console-subscriber = { version = "0.1.8", optional = true }
 ethers = "1.0.2"

--- a/crates/pathfinder/src/sierra.rs
+++ b/crates/pathfinder/src/sierra.rs
@@ -30,11 +30,11 @@ pub fn compile_to_casm(
 
 mod pre_0_11_1 {
     use anyhow::Context;
-    use casm_compiler_historic::allowed_libfuncs::{
+    use casm_compiler_v1_0_0_alpha6::allowed_libfuncs::{
         validate_compatible_sierra_version, ListSelector,
     };
-    use casm_compiler_historic::casm_contract_class::CasmContractClass;
-    use casm_compiler_historic::contract_class::ContractClass;
+    use casm_compiler_v1_0_0_alpha6::casm_contract_class::CasmContractClass;
+    use casm_compiler_v1_0_0_alpha6::contract_class::ContractClass;
 
     use crate::sierra::FeederGatewayContractClass;
 
@@ -60,7 +60,7 @@ mod pre_0_11_1 {
         validate_compatible_sierra_version(
             &sierra_class,
             ListSelector::ListName(
-                casm_compiler_historic::allowed_libfuncs::DEFAULT_EXPERIMENTAL_LIBFUNCS_LIST
+                casm_compiler_v1_0_0_alpha6::allowed_libfuncs::DEFAULT_EXPERIMENTAL_LIBFUNCS_LIST
                     .to_string(),
             ),
         )
@@ -76,9 +76,11 @@ mod pre_0_11_1 {
 
 mod post_0_11_1 {
     use anyhow::Context;
-    use casm_compiler::allowed_libfuncs::{validate_compatible_sierra_version, ListSelector};
-    use casm_compiler::casm_contract_class::CasmContractClass;
-    use casm_compiler::contract_class::ContractClass;
+    use casm_compiler_v1_0_0_rc0::allowed_libfuncs::{
+        validate_compatible_sierra_version, ListSelector,
+    };
+    use casm_compiler_v1_0_0_rc0::casm_contract_class::CasmContractClass;
+    use casm_compiler_v1_0_0_rc0::contract_class::ContractClass;
 
     use crate::sierra::FeederGatewayContractClass;
 
@@ -104,7 +106,7 @@ mod post_0_11_1 {
         validate_compatible_sierra_version(
             &sierra_class,
             ListSelector::ListName(
-                casm_compiler_historic::allowed_libfuncs::DEFAULT_EXPERIMENTAL_LIBFUNCS_LIST
+                casm_compiler_v1_0_0_rc0::allowed_libfuncs::DEFAULT_EXPERIMENTAL_LIBFUNCS_LIST
                     .to_string(),
             ),
         )
@@ -152,7 +154,7 @@ mod tests {
                 serde_json::from_slice::<FeederGatewayContractClass<'_>>(&contract_definition)
                     .unwrap();
 
-            let _: casm_compiler_historic::contract_class::ContractClass =
+            let _: casm_compiler_v1_0_0_rc0::contract_class::ContractClass =
                 class.try_into().unwrap();
         }
 
@@ -175,7 +177,8 @@ mod tests {
                 serde_json::from_slice::<FeederGatewayContractClass<'_>>(&contract_definition)
                     .unwrap();
 
-            let _: casm_compiler::contract_class::ContractClass = class.try_into().unwrap();
+            let _: casm_compiler_v1_0_0_rc0::contract_class::ContractClass =
+                class.try_into().unwrap();
         }
 
         #[test]

--- a/crates/pathfinder/src/sierra.rs
+++ b/crates/pathfinder/src/sierra.rs
@@ -23,12 +23,12 @@ pub fn compile_to_casm(
         .parse_as_semver()
         .context("Deciding on compiler version")?
     {
-        Some(v) if v > V_0_11_0 => post_0_11_1::compile(definition),
-        _ => pre_0_11_1::compile(definition),
+        Some(v) if v > V_0_11_0 => v1_0_0_rc0::compile(definition),
+        _ => v1_0_0_alpha6::compile(definition),
     }
 }
 
-mod pre_0_11_1 {
+mod v1_0_0_alpha6 {
     use anyhow::Context;
     use casm_compiler_v1_0_0_alpha6::allowed_libfuncs::{
         validate_compatible_sierra_version, ListSelector,
@@ -74,7 +74,7 @@ mod pre_0_11_1 {
     }
 }
 
-mod post_0_11_1 {
+mod v1_0_0_rc0 {
     use anyhow::Context;
     use casm_compiler_v1_0_0_rc0::allowed_libfuncs::{
         validate_compatible_sierra_version, ListSelector,

--- a/crates/pathfinder/src/sierra.rs
+++ b/crates/pathfinder/src/sierra.rs
@@ -17,13 +17,15 @@ pub fn compile_to_casm(
     let definition = serde_json::from_slice::<FeederGatewayContractClass<'_>>(sierra_definition)
         .context("Parsing Sierra class")?;
 
-    const V_0_11_0: semver::Version = semver::Version::new(0, 11, 0);
+    const V_0_11_1: semver::Version = semver::Version::new(0, 11, 1);
+    const V_0_11_2: semver::Version = semver::Version::new(0, 11, 2);
 
     match version
         .parse_as_semver()
         .context("Deciding on compiler version")?
     {
-        Some(v) if v > V_0_11_0 => v1_0_0_rc0::compile(definition),
+        Some(v) if v >= V_0_11_2 => v1_1_0_rc0::compile(definition),
+        Some(v) if v >= V_0_11_1 => v1_0_0_rc0::compile(definition),
         _ => v1_0_0_alpha6::compile(definition),
     }
 }
@@ -120,6 +122,52 @@ mod v1_0_0_rc0 {
     }
 }
 
+mod v1_1_0_rc0 {
+    use anyhow::Context;
+    use casm_compiler_v1_1_0_rc0::allowed_libfuncs::{
+        validate_compatible_sierra_version, ListSelector,
+    };
+    use casm_compiler_v1_1_0_rc0::casm_contract_class::CasmContractClass;
+    use casm_compiler_v1_1_0_rc0::contract_class::ContractClass;
+
+    use crate::sierra::FeederGatewayContractClass;
+
+    impl<'a> TryFrom<FeederGatewayContractClass<'a>> for ContractClass {
+        type Error = serde_json::Error;
+
+        fn try_from(value: FeederGatewayContractClass<'a>) -> Result<Self, Self::Error> {
+            let json = serde_json::json!({
+                "abi": [],
+                "sierra_program": value.sierra_program,
+                "contract_class_version": value.contract_class_version,
+                "entry_points_by_type": value.entry_points_by_type,
+            });
+            serde_json::from_value::<ContractClass>(json)
+        }
+    }
+
+    pub(super) fn compile(definition: FeederGatewayContractClass<'_>) -> anyhow::Result<Vec<u8>> {
+        let sierra_class: ContractClass = definition
+            .try_into()
+            .context("Converting to Sierra class")?;
+
+        validate_compatible_sierra_version(
+            &sierra_class,
+            ListSelector::ListName(
+                casm_compiler_v1_0_0_rc0::allowed_libfuncs::DEFAULT_EXPERIMENTAL_LIBFUNCS_LIST
+                    .to_string(),
+            ),
+        )
+        .context("Validating Sierra class")?;
+
+        let casm_class = CasmContractClass::from_contract_class(sierra_class, true)
+            .context("Compiling to CASM")?;
+        let casm_definition = serde_json::to_vec(&casm_class)?;
+
+        Ok(casm_definition)
+    }
+}
+
 #[derive(serde::Deserialize, serde::Serialize)]
 #[serde(deny_unknown_fields)]
 struct FeederGatewayContractClass<'a> {
@@ -142,7 +190,7 @@ mod tests {
 
     use pathfinder_common::StarknetVersion;
 
-    mod pre_v0_11_0 {
+    mod starknet_v0_11_0 {
         use super::*;
         use starknet_gateway_test_fixtures::zstd_compressed_contracts::CAIRO_1_0_0_ALPHA5_SIERRA;
 
@@ -165,7 +213,7 @@ mod tests {
         }
     }
 
-    mod post_v0_11_0 {
+    mod starknet_v0_11_1 {
         use super::*;
         use starknet_gateway_test_fixtures::zstd_compressed_contracts::CAIRO_1_0_0_RC0_SIERRA;
 
@@ -186,5 +234,29 @@ mod tests {
             let contract_definition = zstd::decode_all(CAIRO_1_0_0_RC0_SIERRA).unwrap();
             compile_to_casm(&contract_definition, &StarknetVersion::new(0, 11, 1)).unwrap();
         }
+    }
+
+    mod starknet_v0_11_2_onwards {
+        // TODO: replace test class with v0.11.2 compiler class.
+        // use super::*;
+        // use starknet_gateway_test_fixtures::zstd_compressed_contracts::CAIRO_1_0_0_RC0_SIERRA;
+
+        // #[test]
+        // fn test_feeder_gateway_contract_conversion() {
+        //     let contract_definition = zstd::decode_all(CAIRO_1_0_0_RC0_SIERRA).unwrap();
+
+        //     let class =
+        //         serde_json::from_slice::<FeederGatewayContractClass<'_>>(&contract_definition)
+        //             .unwrap();
+
+        //     let _: casm_compiler_v1_0_0_rc0::contract_class::ContractClass =
+        //         class.try_into().unwrap();
+        // }
+
+        // #[test]
+        // fn test_compile() {
+        //     let contract_definition = zstd::decode_all(CAIRO_1_0_0_RC0_SIERRA).unwrap();
+        //     compile_to_casm(&contract_definition, &StarknetVersion::new(0, 11, 2)).unwrap();
+        // }
     }
 }


### PR DESCRIPTION
This PR adds support for the new Sierra compiler required for starknet v0.11.2.

Compiler selection relies on the block's starknet version, which means this PR is safe to release already i.e. is backwards compatible.

I also renamed things a bit, as its getting awkward with 3 compilers in the mix now.

Closes #1099 