### PR TITLE
fix(rpc): simulate input has a type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- `starknet_simulateTransaction` requires `transactions` instead of `transaction` as input field.
+
 ## [0.5.6] - 2023-05-25
 
 ### Added

--- a/crates/rpc/src/v03/method/simulate_transaction.rs
+++ b/crates/rpc/src/v03/method/simulate_transaction.rs
@@ -20,7 +20,7 @@ use super::common::prepare_handle_and_block;
 #[derive(Deserialize, Debug)]
 pub struct SimulateTrasactionInput {
     block_id: BlockId,
-    transactions: Vec<BroadcastedTransaction>,
+    transaction: Vec<BroadcastedTransaction>,
     simulation_flags: dto::SimulationFlags,
 }
 
@@ -65,7 +65,7 @@ pub async fn simulate_transaction(
             gas_price,
             pending_update,
             pending_timestamp,
-            input.transactions,
+            input.transaction,
             skip_validate,
         )
         .await?;
@@ -363,7 +363,7 @@ mod tests {
 
         let input_json = serde_json::json!({
             "block_id": {"block_number": 1},
-            "transactions": [
+            "transaction": [
                 {
                     "contract_address_salt": "0x46c0d4abf0192a788aca261e58d7031576f7d8ea5229f452b0f23e691dd5971",
                     "max_fee": "0x0",


### PR DESCRIPTION
Main issue is that the RPC spec uses poor wording tbh :)

[Link](https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_trace_api_openrpc.json#L53) to the spec line.