### PR TITLE
Always use copy of `fixtures/mainnet.sqlite`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6096,6 +6096,7 @@ dependencies = [
  "stark_hash",
  "starknet-gateway-client",
  "starknet-gateway-types",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",

--- a/crates/rpc/src/v02/method/estimate_fee.rs
+++ b/crates/rpc/src/v02/method/estimate_fee.rs
@@ -253,7 +253,7 @@ pub(crate) mod tests {
             let mut db_path = PathBuf::from(db_dir.path());
             db_path.push("mainnet.sqlite");
 
-            std::fs::copy(source_path, db_path.clone()).unwrap();
+            std::fs::copy(&source_path, &db_path).unwrap();
 
             let storage = pathfinder_storage::Storage::migrate(db_path, JournalMode::WAL).unwrap();
 

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -38,6 +38,7 @@ zstd = "0.12"
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+tempfile = "3.4"
 # fake = { workspace = true }
 # pretty_assertions = "1.3.0"
 # stark_hash = { path = "../stark_hash", features = ["test-utils"] }


### PR DESCRIPTION
This PR isolates and fixes tests that were using `crate/rpc/fixtures/mainnet.sqlite` and causing weird side-effects in PRs (updates to the file that can slip into PR via `git add .`).