### PR TITLE
Disalbe `merkle_tree` benchmark on every `test` run

### DIFF
--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -75,10 +75,6 @@ starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 tokio = { workspace = true, features = ["test-util"] }
 zstd = "0.12"
 
-[[bench]]
-name = "merkle_tree"
-harness = false
-
 [build-dependencies]
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["arbitrary_precision", "raw_value"] }


### PR DESCRIPTION
The `merkle_tree` benchmark is running every single time I run `cargo test ...`. Every. Single. Time.