### PR TITLE
fix(gateway-types/error): handle unknown Starknet error codes

### DIFF
--- a/crates/gateway-client/src/builder.rs
+++ b/crates/gateway-client/src/builder.rs
@@ -490,7 +490,7 @@ mod tests {
         #[test_log::test(tokio::test)]
         async fn stop_on_fatal() {
             use crate::builder;
-            use starknet_gateway_types::error::{SequencerError, StarknetErrorCode};
+            use starknet_gateway_types::error::{KnownStarknetErrorCode, SequencerError};
 
             tokio::time::pause();
 
@@ -522,7 +522,7 @@ mod tests {
             .unwrap_err();
             assert_matches!(
                 error,
-                SequencerError::StarknetError(se) => assert_eq!(se.code, StarknetErrorCode::BlockNotFound)
+                SequencerError::StarknetError(se) => assert_eq!(se.code, KnownStarknetErrorCode::BlockNotFound.into())
             );
         }
 

--- a/crates/gateway-client/tests/metrics.rs
+++ b/crates/gateway-client/tests/metrics.rs
@@ -9,7 +9,7 @@ use pretty_assertions::assert_eq;
 use starknet_gateway_client::test_utils::{response_from, setup_with_varied_responses};
 use starknet_gateway_client::{Client, GatewayApi};
 use starknet_gateway_test_fixtures::{v0_11_0, v0_9_0};
-use starknet_gateway_types::error::StarknetErrorCode;
+use starknet_gateway_types::error::KnownStarknetErrorCode;
 use std::future::Future;
 
 #[tokio::test]
@@ -49,7 +49,7 @@ where
         // Any valid fixture
         response,
         // 1 Starknet error
-        response_from(StarknetErrorCode::BlockNotFound),
+        response_from(KnownStarknetErrorCode::BlockNotFound),
         // 2 decode errors
         (r#"{"not":"valid"}"#.to_owned(), 200),
         (r#"{"not":"valid, again"}"#.to_owned(), 200),

--- a/crates/gateway-types/src/error.rs
+++ b/crates/gateway-types/src/error.rs
@@ -96,4 +96,6 @@ pub enum KnownStarknetErrorCode {
     CompilationFailed,
     #[serde(rename = "StarknetErrorCode.UNAUTHORIZED_ENTRY_POINT_FOR_INVOKE")]
     UnauthorizedEntryPointForInvoke,
+    #[serde(rename = "StarknetErrorCode.INVALID_CONTRACT_CLASS")]
+    InvalidContractClass,
 }

--- a/crates/gateway-types/src/error.rs
+++ b/crates/gateway-types/src/error.rs
@@ -99,3 +99,27 @@ pub enum KnownStarknetErrorCode {
     #[serde(rename = "StarknetErrorCode.INVALID_CONTRACT_CLASS")]
     InvalidContractClass,
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::error::KnownStarknetErrorCode;
+
+    use super::StarknetErrorCode;
+
+    #[test]
+    fn test_known_error_code() {
+        let e = serde_json::from_str::<StarknetErrorCode>(r#""StarknetErrorCode.BLOCK_NOT_FOUND""#)
+            .unwrap();
+        assert_eq!(e, KnownStarknetErrorCode::BlockNotFound.into())
+    }
+
+    #[test]
+    fn test_unknown_error_code() {
+        let e = serde_json::from_str::<StarknetErrorCode>(r#""StarknetErrorCode.UNKNOWN_ERROR""#)
+            .unwrap();
+        assert_eq!(
+            e,
+            StarknetErrorCode::Unknown("StarknetErrorCode.UNKNOWN_ERROR".to_owned())
+        )
+    }
+}

--- a/crates/gateway-types/src/error.rs
+++ b/crates/gateway-types/src/error.rs
@@ -33,10 +33,24 @@ impl std::fmt::Display for StarknetError {
     }
 }
 
-/// Represents starknet specific error codes reported by the sequencer.
+/// Represents a starknet error code reported by the sequencer.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum StarknetErrorCode {
+    Known(KnownStarknetErrorCode),
+    Unknown(String),
+}
+
+impl From<KnownStarknetErrorCode> for StarknetErrorCode {
+    fn from(value: KnownStarknetErrorCode) -> Self {
+        Self::Known(value)
+    }
+}
+
+/// Represents well-known starknet specific error codes reported by the sequencer.
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
-pub enum StarknetErrorCode {
+pub enum KnownStarknetErrorCode {
     #[serde(rename = "StarknetErrorCode.BLOCK_NOT_FOUND")]
     BlockNotFound,
     #[serde(rename = "StarknetErrorCode.ENTRY_POINT_NOT_FOUND_IN_CONTRACT")]

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -439,7 +439,7 @@ async fn download_block(
 ) -> anyhow::Result<DownloadBlock> {
     use pathfinder_common::BlockId;
     use starknet_gateway_types::{
-        error::StarknetErrorCode::BlockNotFound, reply::MaybePendingBlock,
+        error::KnownStarknetErrorCode::BlockNotFound, reply::MaybePendingBlock,
     };
 
     let result = match next_block {
@@ -484,7 +484,7 @@ async fn download_block(
             }
         }
         Ok(MaybePendingBlock::Pending(_)) => anyhow::bail!("Sequencer returned `pending` block"),
-        Err(SequencerError::StarknetError(err)) if err.code == BlockNotFound => {
+        Err(SequencerError::StarknetError(err)) if err.code == BlockNotFound.into() => {
             // This would occur if we queried past the head of the chain. We now need to check that
             // a reorg hasn't put us too far in the future. This does run into race conditions with
             // the sequencer but this is the best we can do I think.
@@ -610,7 +610,7 @@ mod tests {
         use stark_hash::Felt;
         use starknet_gateway_client::MockGatewayApi;
         use starknet_gateway_types::{
-            error::{SequencerError, StarknetError, StarknetErrorCode},
+            error::{KnownStarknetErrorCode, SequencerError, StarknetError},
             reply,
         };
         use std::collections::HashMap;
@@ -935,7 +935,7 @@ mod tests {
         /// Convenience wrapper
         fn block_not_found() -> SequencerError {
             SequencerError::StarknetError(StarknetError {
-                code: StarknetErrorCode::BlockNotFound,
+                code: KnownStarknetErrorCode::BlockNotFound.into(),
                 message: String::new(),
             })
         }

--- a/crates/rpc/src/v02/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v02/method/add_declare_transaction.rs
@@ -12,9 +12,9 @@ crate::error::generate_rpc_error_subset!(AddDeclareTransactionError: InvalidCont
 
 impl From<SequencerError> for AddDeclareTransactionError {
     fn from(e: SequencerError) -> Self {
-        use starknet_gateway_types::error::StarknetErrorCode::InvalidProgram;
+        use starknet_gateway_types::error::KnownStarknetErrorCode::InvalidProgram;
         match e {
-            SequencerError::StarknetError(e) if e.code == InvalidProgram => {
+            SequencerError::StarknetError(e) if e.code == InvalidProgram.into() => {
                 Self::InvalidContractClass
             }
             _ => Self::Internal(e.into()),
@@ -120,7 +120,7 @@ mod tests {
     use starknet_gateway_test_fixtures::class_definitions::{
         CAIRO_1_0_0_ALPHA6_SIERRA, CONTRACT_DEFINITION,
     };
-    use starknet_gateway_types::error::StarknetErrorCode;
+    use starknet_gateway_types::error::KnownStarknetErrorCode;
 
     lazy_static::lazy_static! {
         pub static ref CONTRACT_CLASS: CairoContractClass = {
@@ -360,7 +360,7 @@ mod tests {
         assert_matches::assert_matches!(error, AddDeclareTransactionError::Internal(error) => {
             let error = error.downcast::<SequencerError>().unwrap();
             assert_matches::assert_matches!(error, SequencerError::StarknetError(error) => {
-                assert_eq!(error.code, StarknetErrorCode::CompilationFailed);
+                assert_eq!(error.code, KnownStarknetErrorCode::CompilationFailed.into());
             })
         });
     }


### PR DESCRIPTION
Instead of handling unknown error codes as de-serialization errors this PR adds a catch-all error variant that just stores the code we've received as a string -- this helps because then we include this string representation in the internal error we're returning over JSON-RPC.

We also add the INVALID_CONTRACT_CLASS error code as a known error so that we can return the proper JSON-RPC response code in `starknet_addDeclareTransaction`.

Fixes #1122 