### PR TITLE
fix(rpc/v03/simulate_tranasction): add "transactions" alias

### DIFF
--- a/crates/rpc/src/v03/method/simulate_transaction.rs
+++ b/crates/rpc/src/v03/method/simulate_transaction.rs
@@ -20,7 +20,9 @@ use super::common::prepare_handle_and_block;
 #[derive(Deserialize, Debug)]
 pub struct SimulateTrasactionInput {
     block_id: BlockId,
-    transaction: Vec<BroadcastedTransaction>,
+    // `transactions` used to be called `transaction` in the JSON-RPC 0.3.0 specification.
+    #[serde(alias = "transaction")]
+    transactions: Vec<BroadcastedTransaction>,
     simulation_flags: dto::SimulationFlags,
 }
 
@@ -65,7 +67,7 @@ pub async fn simulate_transaction(
             gas_price,
             pending_update,
             pending_timestamp,
-            input.transaction,
+            input.transactions,
             skip_validate,
         )
         .await?;


### PR DESCRIPTION
So that we allow naming the argument "transaction" and "transactions" too.

Version 0.3.0 of the specification requires "transaction", but this will be fixed in a future version because "transactions" makes more sense.