### PR TITLE
fix(storage/events): improve events query

### DIFF
--- a/crates/storage/src/state.rs
+++ b/crates/storage/src/state.rs
@@ -914,7 +914,7 @@ impl KeyFilter for V02KeyFilter {
             );
 
             Some(KeyFilterResult {
-                base_query: " INNER JOIN starknet_events_keys ON starknet_events.rowid = starknet_events_keys.rowid",
+                base_query: " CROSS JOIN starknet_events_keys ON starknet_events.rowid = starknet_events_keys.rowid",
                 where_statement: "starknet_events_keys.keys MATCH :events_match",
                 param: (":events_match", key_fts_expression),
             })
@@ -963,7 +963,7 @@ impl KeyFilter for V03KeyFilter {
                 }
             });
             Some(KeyFilterResult {
-                base_query: " INNER JOIN starknet_events_keys_03 ON starknet_events.rowid = starknet_events_keys_03.rowid",
+                base_query: " CROSS JOIN starknet_events_keys_03 ON starknet_events.rowid = starknet_events_keys_03.rowid",
                 where_statement: "starknet_events_keys_03.keys MATCH :events_match",
                 param: (":events_match", key_fts_expression),
             })
@@ -3001,7 +3001,7 @@ mod tests {
             match expected_fts_expression {
                 Some(expected_fts_expression) => assert_matches!(
                     result,
-                    Some(result) => {assert_eq!(result, KeyFilterResult { base_query: " INNER JOIN starknet_events_keys_03 ON starknet_events.rowid = starknet_events_keys_03.rowid",
+                    Some(result) => {assert_eq!(result, KeyFilterResult { base_query: " CROSS JOIN starknet_events_keys_03 ON starknet_events.rowid = starknet_events_keys_03.rowid",
                      where_statement: "starknet_events_keys_03.keys MATCH :events_match", param: (":events_match", expected_fts_expression) })}
                 ),
                 None => assert_eq!(result, None),


### PR DESCRIPTION
The events query using the following SELECT was found to take a lot of time to execute (using mainnet database):

```
SELECT
    block_number,
    starknet_blocks.hash as block_hash,
    transaction_hash,
    starknet_transactions.idx as transaction_idx,
    from_address,
    data,
    starknet_events.keys as keys
FROM starknet_events
INNER JOIN starknet_events_keys ON starknet_events.rowid = starknet_events_keys.rowid
INNER JOIN starknet_transactions ON (starknet_transactions.hash = starknet_events.transaction_hash)
INNER JOIN starknet_blocks ON (starknet_blocks.number = starknet_events.block_number)
WHERE
    block_number BETWEEN 10000 AND 10300
    AND from_address = X'04c6fe73a62e5b8970959520b5a2fc9c1572ed2df55d4d955212680cace46f0f'
    AND starknet_events_keys.keys MATCH '"AOMW8NnSo6/6l94dmbsqrAU44mZtDYVFVF6tJB7wzKs="'
ORDER BY block_number, transaction_idx, starknet_events.idx
LIMIT 20
OFFSET 0;
```

The order which SQLite executes joins on has a huge effect on the time it takes to execute the events query. If statistics are missing (no ANALYZE or PRAGMA optimize was run) it seems that SQLite chooses a query plan that is very unoptimal if the key filter results in too many matches:

```
QUERY PLAN
|--SCAN starknet_events_keys VIRTUAL TABLE INDEX 0:M0
|--SEARCH starknet_events USING INTEGER PRIMARY KEY (rowid=?)
|--SEARCH starknet_transactions USING INDEX sqlite_autoindex_starknet_transactions_1 (hash=?)
|--SEARCH starknet_blocks USING INDEX starknet_blocks_block_number (number=?)
`--USE TEMP B-TREE FOR ORDER BY
```

In an example query the first scan results in ~2.9 million row ids, which are then looked up in the starknet_events table and evaluated if they match the specified block range.

We can force SQLite not to re-order the joins by using CROSS JOIN instead of INNER JOIN for the starknet_events_keys table -- this leads to a much better query plan (and quick execution):

```
QUERY PLAN
|--SEARCH starknet_events USING INDEX starknet_events_from_address_block_number (from_address=? AND block_number>? AND block_number<?)
|--SEARCH starknet_transactions USING INDEX sqlite_autoindex_starknet_transactions_1 (hash=?)
|--SEARCH starknet_blocks USING INDEX starknet_blocks_block_number (number=?)
|--SCAN starknet_events_keys VIRTUAL TABLE INDEX 0:=M0
`--USE TEMP B-TREE FOR RIGHT PART OF ORDER BY
```