### PR TITLE
fix: L1 logs update even if no change occurred

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -131,7 +131,7 @@ pub struct StorageValue(pub Felt);
 /// The commitment for the state of a Starknet block.
 ///
 /// Before Starknet v0.11.0 this was equivalent to [StorageCommitment].
-#[derive(Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Copy, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
 pub struct StateCommitment(pub Felt);
 
 impl StateCommitment {
@@ -168,7 +168,7 @@ impl StateCommitment {
 pub struct StorageCommitment(pub Felt);
 
 /// A Starknet block hash.
-#[derive(Copy, Clone, PartialEq, Eq, Deserialize, Serialize, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Deserialize, Serialize, Hash, Default)]
 pub struct BlockHash(pub Felt);
 
 /// A Starknet block number.

--- a/crates/ethereum/src/lib.rs
+++ b/crates/ethereum/src/lib.rs
@@ -12,7 +12,7 @@ pub mod core_addr {
         Decoder::Hex.decode(b"d5c325D183C592C94998000C5e0EED9e6655c020");
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct EthereumStateUpdate {
     pub state_root: StateCommitment,
     pub block_number: BlockNumber,


### PR DESCRIPTION
This PR changes the L1 producer to only emit an update if a change is detected.

Current behaviour emits an update event even if nothing has changed resulting in pretty spammy logs:
```
2023-06-12T10:29:59  INFO L1/L2 block hash match block_number=BlockNumber(817909)
2023-06-12T10:29:59  INFO L1 sync updated to block 817909
2023-06-12T10:30:29  INFO At head of chain poll_interval=30s
2023-06-12T10:30:30  INFO L1/L2 block hash match block_number=BlockNumber(817909)
2023-06-12T10:30:30  INFO L1 sync updated to block 817909
2023-06-12T10:30:59  INFO At head of chain poll_interval=30s
2023-06-12T10:31:00  INFO L1/L2 block hash match block_number=BlockNumber(817909)
2023-06-12T10:31:00  INFO L1 sync updated to block 817909
2023-06-12T10:31:29  INFO At head of chain poll_interval=30s
2023-06-12T10:31:31  INFO L1/L2 block hash match block_number=BlockNumber(817909)
2023-06-12T10:31:31  INFO L1 sync updated to block 817909
2023-06-12T10:31:59  INFO At head of chain poll_interval=30s
2023-06-12T10:32:02  INFO L1/L2 block hash match block_number=BlockNumber(817909)
2023-06-12T10:32:02  INFO L1 sync updated to block 817909
2023-06-12T10:32:29  INFO At head of chain poll_interval=30s
```

This PR also removes one instance of the L1 update logging since two are currently printed for each event.