### PR TITLE
fix: slow rpc queries can exhaust db connection pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- reorgs fail if a class declaration is included in the reorg
+- sync can fail if db connection pool is held saturated by rpc queries
+
+## Changed
+
+- dropped upgrade support for pathfinder v0.4 and earlier
+- separate db connection pools rpc, sync and storage
+
+## [0.6.1] - 2023-06-18
+
+### Fixed
+
+- class hash mismatch for cairo 0 classes with non-ascii text
+
 ## [0.6.0] - 2023-06-14
 
 ### Fixed

--- a/crates/pathfinder/examples/feeder_gateway.rs
+++ b/crates/pathfinder/examples/feeder_gateway.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::num::NonZeroU32;
 
 use anyhow::Context;
 use pathfinder_common::{BlockHash, BlockNumber, Chain, ClassHash, StateCommitment};
@@ -46,7 +47,9 @@ async fn serve() -> anyhow::Result<()> {
     let storage = pathfinder_storage::Storage::migrate(
         database_path.into(),
         pathfinder_storage::JournalMode::WAL,
-    )?;
+    )?
+    .create_pool(NonZeroU32::new(10).unwrap())
+    .unwrap();
 
     let chain = {
         let mut connection = storage.connection()?;

--- a/crates/pathfinder/examples/verify_block_hashes.rs
+++ b/crates/pathfinder/examples/verify_block_hashes.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU32;
+
 use anyhow::Context;
 use pathfinder_common::{BlockHash, BlockNumber, Chain, ChainId, StarknetVersion};
 use pathfinder_lib::state::block_hash::{verify_block_hash, VerifyResult};
@@ -23,7 +25,9 @@ fn main() -> anyhow::Result<()> {
     };
 
     let database_path = std::env::args().nth(2).unwrap();
-    let storage = Storage::migrate(database_path.into(), JournalMode::WAL)?;
+    let storage = Storage::migrate(database_path.into(), JournalMode::WAL)?
+        .create_pool(NonZeroU32::new(1).unwrap())
+        .unwrap();
     let mut db = storage
         .connection()
         .context("Opening database connection")?;

--- a/crates/pathfinder/examples/verify_transaction_hashes.rs
+++ b/crates/pathfinder/examples/verify_transaction_hashes.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU32;
+
 use anyhow::Context;
 use pathfinder_common::{BlockNumber, ChainId};
 use pathfinder_storage::{JournalMode, Storage};
@@ -28,7 +30,9 @@ fn main() -> anyhow::Result<()> {
 
     println!("Migrating database...");
 
-    let storage = Storage::migrate(database_path.into(), JournalMode::WAL)?;
+    let storage = Storage::migrate(database_path.into(), JournalMode::WAL)?
+        .create_pool(NonZeroU32::new(1).unwrap())
+        .unwrap();
     let mut db = storage
         .connection()
         .context("Opening database connection")?;

--- a/crates/rpc/src/cairo/ext_py.rs
+++ b/crates/rpc/src/cairo/ext_py.rs
@@ -466,6 +466,7 @@ mod tests {
         JournalMode, Storage, Transaction,
     };
     use stark_hash::Felt;
+    use std::num::NonZeroU32;
     use std::path::PathBuf;
     use tokio::sync::oneshot;
 
@@ -475,7 +476,10 @@ mod tests {
 
         let db_file = tempfile::NamedTempFile::new().unwrap();
 
-        let s = Storage::migrate(PathBuf::from(db_file.path()), JournalMode::WAL).unwrap();
+        let s = Storage::migrate(PathBuf::from(db_file.path()), JournalMode::WAL)
+            .unwrap()
+            .create_pool(NonZeroU32::new(1).unwrap())
+            .unwrap();
 
         let mut conn = s.connection().unwrap();
 
@@ -613,7 +617,10 @@ mod tests {
         // TODO: refactor the outer parts to a with_test_env or similar?
         let db_file = tempfile::NamedTempFile::new().unwrap();
 
-        let s = Storage::migrate(PathBuf::from(db_file.path()), JournalMode::WAL).unwrap();
+        let s = Storage::migrate(PathBuf::from(db_file.path()), JournalMode::WAL)
+            .unwrap()
+            .create_pool(NonZeroU32::new(1).unwrap())
+            .unwrap();
 
         let mut conn = s.connection().unwrap();
 
@@ -680,7 +687,10 @@ mod tests {
     async fn call_with_unknown_contract() {
         let db_file = tempfile::NamedTempFile::new().unwrap();
 
-        let s = Storage::migrate(PathBuf::from(db_file.path()), JournalMode::WAL).unwrap();
+        let s = Storage::migrate(PathBuf::from(db_file.path()), JournalMode::WAL)
+            .unwrap()
+            .create_pool(NonZeroU32::new(1).unwrap())
+            .unwrap();
 
         let mut conn = s.connection().unwrap();
 
@@ -738,7 +748,10 @@ mod tests {
 
         let db_file = tempfile::NamedTempFile::new().unwrap();
 
-        let s = Storage::migrate(PathBuf::from(db_file.path()), JournalMode::WAL).unwrap();
+        let s = Storage::migrate(PathBuf::from(db_file.path()), JournalMode::WAL)
+            .unwrap()
+            .create_pool(NonZeroU32::new(1).unwrap())
+            .unwrap();
 
         let mut conn = s.connection().unwrap();
 

--- a/crates/rpc/src/v02/method/call.rs
+++ b/crates/rpc/src/v02/method/call.rs
@@ -134,6 +134,7 @@ mod tests {
         use super::*;
         use pathfinder_common::{felt_bytes, BlockHash, Chain};
         use pathfinder_storage::JournalMode;
+        use std::num::NonZeroU32;
         use std::path::PathBuf;
         use std::sync::Arc;
 
@@ -175,7 +176,10 @@ mod tests {
 
             std::fs::copy(&source_path, &db_path).unwrap();
 
-            let storage = pathfinder_storage::Storage::migrate(db_path, JournalMode::WAL).unwrap();
+            let storage = pathfinder_storage::Storage::migrate(db_path, JournalMode::WAL)
+                .unwrap()
+                .create_pool(NonZeroU32::new(1).unwrap())
+                .unwrap();
             let sync_state = Arc::new(crate::SyncState::default());
             let (call_handle, cairo_handle) = crate::cairo::ext_py::start(
                 storage.path().into(),

--- a/crates/rpc/src/v02/method/estimate_fee.rs
+++ b/crates/rpc/src/v02/method/estimate_fee.rs
@@ -149,6 +149,7 @@ pub(crate) mod tests {
 
     // These tests require a Python environment properly set up _and_ a mainnet database with the first six blocks.
     pub(crate) mod ext_py {
+        use std::num::NonZeroU32;
         use std::sync::Arc;
 
         use super::*;
@@ -253,7 +254,10 @@ pub(crate) mod tests {
 
             std::fs::copy(&source_path, &db_path).unwrap();
 
-            let storage = pathfinder_storage::Storage::migrate(db_path, JournalMode::WAL).unwrap();
+            let storage = pathfinder_storage::Storage::migrate(db_path, JournalMode::WAL)
+                .unwrap()
+                .create_pool(NonZeroU32::new(1).unwrap())
+                .unwrap();
 
             let (account_address, latest_block_hash, latest_block_number) =
                 add_dummy_account(storage.clone(), gas_price);

--- a/crates/rpc/src/v03/method/simulate_transaction.rs
+++ b/crates/rpc/src/v03/method/simulate_transaction.rs
@@ -315,6 +315,8 @@ pub mod dto {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU32;
+
     use pathfinder_common::{
         felt, BlockHash, BlockHeader, BlockNumber, BlockTimestamp, Chain, ContractAddress,
         GasPrice, TransactionVersion,
@@ -335,10 +337,13 @@ mod tests {
         let mut db_path = dir.path().to_path_buf();
         db_path.push("db.sqlite");
 
-        let storage = Storage::migrate(db_path, JournalMode::WAL).expect("storage");
+        let storage = Storage::migrate(db_path, JournalMode::WAL)
+            .expect("storage")
+            .create_pool(NonZeroU32::new(1).unwrap())
+            .unwrap();
 
         {
-            let mut db = storage.connection().expect("db connection");
+            let mut db = storage.connection().unwrap();
             let tx = db.transaction().expect("tx");
 
             tx.insert_cairo_class(DUMMY_ACCOUNT_CLASS_HASH, DUMMY_ACCOUNT)

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -14,6 +14,7 @@ pub mod test_fixtures;
 pub mod test_utils;
 pub mod types;
 
+use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -92,36 +93,44 @@ struct Inner {
     pool: Pool<SqliteConnectionManager>,
 }
 
+pub struct StorageManager(PathBuf);
+
+impl StorageManager {
+    pub fn create_pool(&self, capacity: NonZeroU32) -> anyhow::Result<Storage> {
+        let pool_manager = SqliteConnectionManager::file(&self.0).with_init(setup_connection);
+        let pool = Pool::builder()
+            .max_size(capacity.get())
+            .build(pool_manager)?;
+
+        Ok(Storage(Inner {
+            database_path: Arc::new(self.0.clone()),
+            pool,
+        }))
+    }
+}
+
 impl Storage {
-    /// Performs database schema migration and returns a new [Storage].
+    /// Performs the database schema migration and returns two new connection pools with the given capacity.
     ///
     /// This should be called __once__ at the start of the application,
     /// and passed to the various components which require access to the database.
     ///
-    /// May be cloned safely.
-    pub fn migrate(database_path: PathBuf, journal_mode: JournalMode) -> anyhow::Result<Self> {
+    /// Panics if u32
+    pub fn migrate(
+        database_path: PathBuf,
+        journal_mode: JournalMode,
+    ) -> anyhow::Result<StorageManager> {
         let mut connection = rusqlite::Connection::open(&database_path)
             .context("Opening DB for setting journal mode")?;
+        setup_connection(&mut connection).context("Setting up database connection")?;
         setup_journal_mode(&mut connection, journal_mode).context("Setting journal mode")?;
+        migrate_database(&mut connection).context("Migrate database")?;
         connection
             .close()
             .map_err(|(_connection, error)| error)
             .context("Closing DB after setting journal mode")?;
 
-        let manager = SqliteConnectionManager::file(&database_path).with_init(setup_connection);
-        let pool = Pool::builder().build(manager)?;
-
-        let mut conn = pool.get()?;
-        migrate_database(&mut conn).context("Migrate database")?;
-
-        let inner = Inner {
-            database_path: Arc::new(database_path),
-            pool,
-        };
-
-        let storage = Storage(inner);
-
-        Ok(storage)
+        Ok(StorageManager(database_path))
     }
 
     /// Returns a new Sqlite [Connection] to the database.
@@ -149,7 +158,9 @@ impl Storage {
 
         let database_path = PathBuf::from(unique_mem_db);
 
-        Self::migrate(database_path, JournalMode::Rollback)
+        let storage = Self::migrate(database_path, JournalMode::Rollback)?;
+
+        storage.create_pool(NonZeroU32::new(5).unwrap())
     }
 
     pub fn path(&self) -> &Path {

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -157,6 +157,10 @@ impl Storage {
         };
 
         let database_path = PathBuf::from(unique_mem_db);
+        // This connection must be held until a pool has been created, since an
+        // in-memory database is dropped once all its connections are. This connection
+        // therefore holds the database in-place until the pool is established.
+        let _conn = rusqlite::Connection::open(&database_path)?;
 
         let storage = Self::migrate(database_path, JournalMode::Rollback)?;
 

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -110,7 +110,7 @@ impl StorageManager {
 }
 
 impl Storage {
-    /// Performs the database schema migration and returns two new connection pools with the given capacity.
+    /// Performs the database schema migration and returns a [storage manager](StorageManager).
     ///
     /// This should be called __once__ at the start of the application,
     /// and passed to the various components which require access to the database.


### PR DESCRIPTION
This PR creates separate database connection pools for sync, rpc and p2p.

Currently there is only a single shared connection pool. Slow RPC queries can therefore exhaust the connection pool, causing the sync process to halt as no connection can be obtained.
