### PR TITLE
feat(storage): remove revision 35

### DIFF
--- a/crates/storage/src/schema/revision_0035.rs
+++ b/crates/storage/src/schema/revision_0035.rs
@@ -1,33 +1,5 @@
-use anyhow::Context;
-
-/// Ensures the trie reference counts are not NULL by setting these to 1.
-///
-/// The nulls came about because reference counting was stopped for a releases,
-/// during which new nodes were inserted with ref_count=NULL. Since we are now
-/// starting reference counting again, these NULLs should be an integer so they
-/// can be incremented / decremented via sql.
-///
-/// Due to this skipping of reference counting, it is not yet safe to delete / purge node
-/// data. Another migration will be requried to rewrite the trie data with accurate ref counts
-/// before it is safe to delete.
-pub(crate) fn migrate(tx: &rusqlite::Transaction<'_>) -> anyhow::Result<()> {
-    tx.execute(
-        "UPDATE tree_contracts SET ref_count=1 WHERE ref_count IS NULL;",
-        [],
-    )
-    .context("Replacing contract trie NULL reference counts")?;
-
-    tx.execute(
-        "UPDATE tree_class SET ref_count=1 WHERE ref_count IS NULL;",
-        [],
-    )
-    .context("Replacing class trie NULL reference counts")?;
-
-    tx.execute(
-        "UPDATE tree_global SET ref_count=1 WHERE ref_count IS NULL;",
-        [],
-    )
-    .context("Replacing global storage trie NULL reference counts")?;
-
+/// This migration originally replaced all trie null ref counts with 1. However this migration took long with no actual benefit
+/// so we removed it again. Whether or not this migration was run does not matter as the ref counts are already corrupt.
+pub(crate) fn migrate(_tx: &rusqlite::Transaction<'_>) -> anyhow::Result<()> {
     Ok(())
 }


### PR DESCRIPTION
This PR removes storage schema migration 35 entirely. It was slow and gave no benefit.

We'll have to revisit reference counting again when we add deleting tries.