### PR TITLE
Make head & pending poll intervals configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `block_download`: time taken to download current block's data excluding classes
   - `block_processing`: time taken to process and store the current block
 - Optional CLI args `head-poll-interval-seconds` & `pending-poll-interval-seconds` to make head and pending poll intervals configurable, while preservin existing values as defaults.
+- configuration for new block polling interval
+- configuration for sync pending block polling interval
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `block_latency`: delay between current block being published and sync'd locally
   - `block_download`: time taken to download current block's data excluding classes
   - `block_processing`: time taken to process and store the current block
-- Optional CLI args `head-poll-interval-seconds` & `pending-poll-interval-seconds` to make head and pending poll intervals configurable, while preservin existing values as defaults.
-- configuration for new block polling interval
-- configuration for sync pending block polling interval
+- configuration for new block polling interval: `--sync.poll-interval <seconds>`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `block_latency`: delay between current block being published and sync'd locally
   - `block_download`: time taken to download current block's data excluding classes
   - `block_processing`: time taken to process and store the current block
+- Optional CLI args `head-poll-interval-seconds` & `pending-poll-interval-seconds` to make head and pending poll intervals configurable, while preservin existing values as defaults.
 
 ### Fixed
 

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -307,7 +307,6 @@ pub struct Ethereum {
     pub password: Option<String>,
 }
 
-#[derive(Clone)]
 pub enum NetworkConfig {
     Mainnet,
     Testnet,
@@ -381,7 +380,7 @@ impl Config {
                 capacity: cli.ws_capacity,
             }),
             monitor_address: cli.monitor_address,
-            network: network.clone(),
+            network,
             poll_pending: cli.poll_pending,
             python_subprocesses: cli.python_subprocesses,
             sqlite_wal: match cli.sqlite_wal {

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -140,14 +140,7 @@ Examples:
         default_value = "30",
         env = "PATHFINDER_HEAD_POLL_INTERVAL_SECONDS"
     )]
-    head_poll_interval: std::num::NonZeroU64,
-
-    #[arg(
-        long = "sync.pending-poll-interval",
-        long_help = "Pending block poll interval in seconds",
-        env = "PATHFINDER_PENDING_POLL_INTERVAL_SECONDS"
-    )]
-    pending_poll_interval: Option<std::num::NonZeroU64>,
+    poll_interval: std::num::NonZeroU64,
 }
 
 #[derive(clap::Args)]
@@ -294,8 +287,7 @@ pub struct Config {
     pub python_subprocesses: std::num::NonZeroUsize,
     pub sqlite_wal: JournalMode,
     pub max_rpc_connections: std::num::NonZeroU32,
-    pub head_poll_interval: std::time::Duration,
-    pub pending_poll_interval: Option<std::time::Duration>,
+    pub poll_interval: std::time::Duration,
 }
 
 pub struct WebSocket {
@@ -388,11 +380,7 @@ impl Config {
                 false => JournalMode::Rollback,
             },
             max_rpc_connections: cli.max_rpc_connections,
-            head_poll_interval: std::time::Duration::from_secs(cli.head_poll_interval.get()),
-            pending_poll_interval: cli
-                .pending_poll_interval
-                .map(|non_zero| non_zero.get())
-                .map(std::time::Duration::from_secs),
+            poll_interval: std::time::Duration::from_secs(cli.poll_interval.get()),
         }
     }
 }

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -135,15 +135,16 @@ Examples:
     max_rpc_connections: std::num::NonZeroU32,
 
     #[arg(
-        long = "head-poll-interval-seconds",
-        long_help = "Selected chain head poll interval in seconds",
+        long = "sync.poll-interval",
+        long_help = "New block poll interval in seconds",
+        default_value = "30",
         env = "PATHFINDER_HEAD_POLL_INTERVAL_SECONDS"
     )]
-    head_poll_interval: Option<std::num::NonZeroU64>,
+    head_poll_interval: std::num::NonZeroU64,
 
     #[arg(
-        long = "pending-poll-interval-seconds",
-        long_help = "Pending block poll interval in seconds (if enabled)",
+        long = "sync.pending-poll-interval",
+        long_help = "Pending block poll interval in seconds",
         env = "PATHFINDER_PENDING_POLL_INTERVAL_SECONDS"
     )]
     pending_poll_interval: Option<std::num::NonZeroU64>,
@@ -363,8 +364,6 @@ impl NetworkConfig {
 }
 
 impl Config {
-    const DEFAULT_HEAD_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
-
     pub fn parse() -> Self {
         let cli = Cli::parse();
 
@@ -390,15 +389,7 @@ impl Config {
                 false => JournalMode::Rollback,
             },
             max_rpc_connections: cli.max_rpc_connections,
-            head_poll_interval: cli
-                .head_poll_interval
-                .map(|non_zero| non_zero.get())
-                .or(network.map(|net| match net {
-                    NetworkConfig::Mainnet => 300,
-                    _ => 30,
-                }))
-                .map(std::time::Duration::from_secs)
-                .unwrap_or(Self::DEFAULT_HEAD_POLL_INTERVAL),
+            head_poll_interval: std::time::Duration::from_secs(cli.head_poll_interval.get()),
             pending_poll_interval: cli
                 .pending_poll_interval
                 .map(|non_zero| non_zero.get())

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -97,10 +97,6 @@ async fn main() -> anyhow::Result<()> {
 
     let sync_state = Arc::new(SyncState::default());
     let pending_state = PendingData::default();
-    let pending_interval = match config.poll_pending {
-        true => Some(std::time::Duration::from_secs(5)),
-        false => None,
-    };
 
     let (call_handle, cairo_handle) = cairo::ext_py::start(
         rpc_storage.path().into(),
@@ -147,8 +143,9 @@ async fn main() -> anyhow::Result<()> {
         core_address: pathfinder_context.l1_core_address,
         sequencer: pathfinder_context.gateway,
         state: sync_state.clone(),
+        head_poll_interval: config.head_poll_interval,
         pending_data: pending_state,
-        pending_poll_interval: pending_interval,
+        pending_poll_interval: config.pending_poll_interval,
         block_validation_mode: state::l2::BlockValidationMode::Strict,
         websocket_txs: rpc_server.get_ws_senders(),
         block_cache_size: 1_000,

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -97,6 +97,11 @@ async fn main() -> anyhow::Result<()> {
 
     let sync_state = Arc::new(SyncState::default());
     let pending_state = PendingData::default();
+    let pending_interval = if config.poll_pending {
+        Some(std::time::Duration::from_secs(5))
+    } else {
+        None
+    };
 
     let (call_handle, cairo_handle) = cairo::ext_py::start(
         rpc_storage.path().into(),
@@ -143,9 +148,9 @@ async fn main() -> anyhow::Result<()> {
         core_address: pathfinder_context.l1_core_address,
         sequencer: pathfinder_context.gateway,
         state: sync_state.clone(),
-        head_poll_interval: config.head_poll_interval,
+        head_poll_interval: config.poll_interval,
         pending_data: pending_state,
-        pending_poll_interval: config.pending_poll_interval,
+        pending_poll_interval: pending_interval,
         block_validation_mode: state::l2::BlockValidationMode::Strict,
         websocket_txs: rpc_server.get_ws_senders(),
         block_cache_size: 1_000,

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -97,11 +97,6 @@ async fn main() -> anyhow::Result<()> {
 
     let sync_state = Arc::new(SyncState::default());
     let pending_state = PendingData::default();
-    let pending_interval = if config.poll_pending {
-        Some(std::time::Duration::from_secs(5))
-    } else {
-        None
-    };
 
     let (call_handle, cairo_handle) = cairo::ext_py::start(
         rpc_storage.path().into(),
@@ -150,7 +145,9 @@ async fn main() -> anyhow::Result<()> {
         state: sync_state.clone(),
         head_poll_interval: config.poll_interval,
         pending_data: pending_state,
-        pending_poll_interval: pending_interval,
+        pending_poll_interval: config
+            .poll_pending
+            .then_some(std::time::Duration::from_secs(5)),
         block_validation_mode: state::l2::BlockValidationMode::Strict,
         websocket_txs: rpc_server.get_ws_senders(),
         block_cache_size: 1_000,


### PR DESCRIPTION
This PR makes head and pending poll intervals configurable.

---------------------------

I decided to stick to static CLI config and not to add endpoints to overwrite "live" values.
To change the poll intervals, respective parameter (or env variable) must be changed and Pathfinder restarted.
