### PR TITLE
feat: block timing metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `starknet_estimateMessageFee` for JSON-RPC v0.3.1 to estimate message fee from L1 handler.
+- sync-related metrics
+  - `current_block`: the currently sync'd block height of the node
+  - `highest_block`: the height of the block chain
+  - `block_time`: timestamp difference between the current block and its parent
+  - `block_latency`: delay between current block being published and sync'd locally
+  - `block_download`: time taken to download current block's data excluding classes
+  - `block_processing`: time taken to process and store the current block
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -293,6 +293,15 @@ These __will not work__:
 - `gateway_requests_total{method="get_transaction", tag="latest"}`, `tag` is not supported for that `method`
 - `gateway_requests_total{method="get_transaction", reason="decode"}`, `reason` is only supported for failures.
 
+### Sync related metrics
+
+- `current_block` currently sync'd block height of the node
+- `highest_block` height of the block chain
+- `block_time` timestamp difference between the current block and its parent
+- `block_latency` delay between current block being published and sync'd locally
+- `block_download` time taken to download current block's data excluding classes
+- `block_prxocessing` time taken to process and store the current block
+
 ## License
 
 Licensed under either of

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -391,6 +391,10 @@ async fn consumer(mut events: Receiver<SyncEvent>, context: ConsumerContext) -> 
                     }
                 }
 
+                let now_timestamp = time::OffsetDateTime::now_utc().unix_timestamp() as u64;
+                let latency = now_timestamp.saturating_sub(block_timestamp.get());
+
+                metrics::gauge!("block_latency", latency as f64, "number" => format!("{}", block_number));
                 metrics::gauge!("block_time", (block_timestamp.get() - latest_timestamp.get()) as f64, "number" => format!("{}", block_number));
                 latest_timestamp = block_timestamp;
 

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -385,8 +385,11 @@ async fn consumer(mut events: Receiver<SyncEvent>, context: ConsumerContext) -> 
                     Syncing::Status(status) => {
                         status.current = NumberedBlock::from((block_hash, block_number));
 
+                        metrics::counter!("current_block", block_number.get());
+
                         if status.highest.number <= block_number {
                             status.highest = status.current;
+                            metrics::counter!("highest_block", block_number.get());
                         }
                     }
                 }
@@ -564,6 +567,9 @@ async fn update_sync_status_latest(
                             highest: latest,
                         });
 
+                        metrics::counter!("current_block", starting.number.get());
+                        metrics::counter!("highest_block", latest.number.get());
+
                         tracing::debug!(
                             status=%sync_status,
                             "Updated sync status",
@@ -572,6 +578,7 @@ async fn update_sync_status_latest(
                     Syncing::Status(status) => {
                         if status.highest.hash != latest.hash {
                             status.highest = latest;
+                            metrics::counter!("highest_block", latest.number.get());
 
                             tracing::debug!(
                                 %status,


### PR DESCRIPTION
This PR adds several new metrics related to time spent processing a block.

Fairly sure I've done the metrics wrong - can one even add meta-data like block number? Naming is also poor.. suggestions welcome. 

I would also like to add more fine grained metrics, e.g. trie mutation, trie hash calcs, trie db writing, but that requires separating out those parts properly - another day.

I'll update the changelog once we've settled on naming.

New metrics:
```
block_download             // time taken to download block data excl classes
block_processing
block_latency              // diff between block timestamp and local time i.e. delay between block publish and us inserting it
block_time                 // timestamp diff between this block and previous one on chain
```

Any better ideas for naming the last two?