### PR TITLE
docs: create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in Pathfinder, please report it to us through coordinated disclosure.
+
+Please do **not** report security vulnerabilities through public GitHub issues, discussions, or pull requests.
+
+Instead, please send an email to pathfinder@equilibrium.co.
+
+Please include as much of the information listed below as you can to help us better understand and resolve the issue:
+
+    The type of issue (e.g., buffer overflow, SQL injection, or cross-site scripting)
+    Full paths of source file(s) related to the manifestation of the issue
+    The location of the affected source code (tag/branch/commit or direct URL)
+    Any special configuration required to reproduce the issue
+    Step-by-step instructions to reproduce the issue
+    Proof-of-concept or exploit code (if possible)
+    Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.


### PR DESCRIPTION
This PR adds a security disclosure doc. I just used the [github template](https://github.com/github/platform-samples/security/policy) which I think is sufficient?

Closes #1148 