### PR TITLE
Select query strategy for `starknet_getEvents` dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - reorgs fail if a class declaration is included in the reorg
 - sync can fail if db connection pool is held saturated by rpc queries
 - uses `finalized` (reorg-safe) L1 state instead of `latest`
+- `starknet_getEvents` times out for queries involving a large block range
 
 ## Changed
 

--- a/crates/rpc/src/v02/method/get_events.rs
+++ b/crates/rpc/src/v02/method/get_events.rs
@@ -123,7 +123,7 @@ pub async fn get_events(
     }
 
     let storage = context.storage.clone();
-    let keys = V02KeyFilter(request.keys.clone());
+    let keys = V02KeyFilter::new(request.keys.clone());
 
     // blocking task to perform database event query and optionally, the event count
     // required for (4d).

--- a/crates/rpc/src/v03/method/get_events.rs
+++ b/crates/rpc/src/v03/method/get_events.rs
@@ -189,8 +189,11 @@ pub async fn get_events(
         // own context to the errors. This way we get meaningful error information
         // for errors related to query parameters.
         let page = transaction.events(&filter).map_err(|e| {
-            if e.downcast_ref::<EventFilterError>().is_some() {
-                GetEventsError::PageSizeTooBig
+            if let Some(event_filter_error) = e.downcast_ref::<EventFilterError>() {
+                match event_filter_error {
+                    EventFilterError::PageSizeTooBig(_) => GetEventsError::PageSizeTooBig,
+                    EventFilterError::TooManyMatches => GetEventsError::from(e),
+                }
             } else {
                 GetEventsError::from(e)
             }

--- a/crates/rpc/src/v03/method/get_events.rs
+++ b/crates/rpc/src/v03/method/get_events.rs
@@ -159,7 +159,7 @@ pub async fn get_events(
     }
 
     let storage = context.storage.clone();
-    let keys = V03KeyFilter(request.keys.clone());
+    let keys = V03KeyFilter::new(request.keys.clone());
 
     // blocking task to perform database event query and optionally, the event count
     // required for (4d).

--- a/crates/storage/src/connection/event.rs
+++ b/crates/storage/src/connection/event.rs
@@ -548,13 +548,18 @@ fn select_query_strategy(
     let weighted_events_by_key_filter =
         events_by_key_filter.map(|n| n.saturating_mul(KEY_FILTER_WEIGHT));
 
-    let cost = std::cmp::min(
-        events_in_block_range.unwrap_or(usize::MAX),
-        weighted_events_by_key_filter.unwrap_or(usize::MAX),
-    );
+    if events_in_block_range
+        .or(weighted_events_by_key_filter)
+        .is_some()
+    {
+        let cost = std::cmp::min(
+            events_in_block_range.unwrap_or(usize::MAX),
+            weighted_events_by_key_filter.unwrap_or(usize::MAX),
+        );
 
-    if cost > KEY_FILTER_COST_LIMIT {
-        return Err(EventFilterError::TooManyMatches.into());
+        if cost > KEY_FILTER_COST_LIMIT {
+            return Err(EventFilterError::TooManyMatches.into());
+        }
     }
 
     let strategy = match (events_in_block_range, events_by_key_filter) {

--- a/crates/storage/src/connection/event.rs
+++ b/crates/storage/src/connection/event.rs
@@ -564,12 +564,16 @@ fn number_of_events_in_block_range(
             query.push_str("block_number <= :to_block ");
             params.push((":to_block", to_block.to_sql()));
         }
-        (None, None) => return Ok(None),
+        (None, None) => {}
     };
 
     // on contract address
     if let Some(contract_address) = contract_address {
-        query.push_str("AND from_address = :contract_address");
+        if params.is_empty() {
+            query.push_str("from_address = :contract_address");
+        } else {
+            query.push_str("AND from_address = :contract_address");
+        }
         params.push((":contract_address", contract_address.to_sql()));
     }
 
@@ -577,6 +581,10 @@ fn number_of_events_in_block_range(
         .iter()
         .map(|(s, x)| (*s, x as &dyn rusqlite::ToSql))
         .collect::<Vec<_>>();
+
+    if params.is_empty() {
+        return Ok(None);
+    }
 
     let count: usize = tx
         .inner()


### PR DESCRIPTION
We seem to have performance issues with `starknet_getEvents`. The issue is that we need different query strategies for different cases but unfortunately the SQLite query optimizer does not have all the information it would need to select the best query plan...

---------------------------

Previously we queried the key FTS table first, but this has been changed in https://github.com/eqlabs/pathfinder/pull/1132 to always do the range-based lookup first and _then_ filter the result set with the key filter. Unfortunately this caused a regression for some queries that were working before...

There are two main cases we would like to optimize for:

-  The block range (and optionally `address`) present in the filter is quite narrow, but the key filter would return at least an order of magnitude more event IDs. In this case we would like to use a query plan where events are looked up using their respective index for the `starknet_events` table and then filtered using the data in the keys FTS table.
- The block range is large, but the key filter is very specific. In this case we want to do the keys lookup first and then filter that using data looked up from the `starknet_events` table.

This PR adds two additional queries that return:
- The number of events covered by the (from_block, to_block, from_address) filters.
- The number of events covered by the key filter.

These queries are fairly quick, since we're using a single index to determine the event count (without contents). We then use these to select the query strategy that matches the smaller of these counts.

Having these counts also makes it possible for us to reject requests with an event filter that would be too costly to evaluate. We no reject these queries with an internal error suggesting that the filter is too broad.

Fixes #1155 