### PR TITLE
feat(rpc): remove pending tx status

### DIFF
--- a/crates/rpc/src/v02/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v02/method/get_transaction_receipt.rs
@@ -392,8 +392,6 @@ mod types {
     #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
     #[serde(deny_unknown_fields)]
     pub enum TransactionStatus {
-        #[serde(rename = "PENDING")]
-        Pending,
         #[serde(rename = "ACCEPTED_ON_L2")]
         AcceptedOnL2,
         #[serde(rename = "ACCEPTED_ON_L1")]
@@ -405,7 +403,7 @@ mod types {
     impl From<BlockStatus> for TransactionStatus {
         fn from(status: BlockStatus) -> Self {
             match status {
-                BlockStatus::Pending => TransactionStatus::Pending,
+                BlockStatus::Pending => TransactionStatus::AcceptedOnL2,
                 BlockStatus::AcceptedOnL2 => TransactionStatus::AcceptedOnL2,
                 BlockStatus::AcceptedOnL1 => TransactionStatus::AcceptedOnL1,
                 BlockStatus::Rejected => TransactionStatus::Rejected,


### PR DESCRIPTION
This PR changes the status of a pending transaction to L2 accepted in accordance with v0.12 starknet.

Closes #1166 