### PR TITLE
feat: config updates for starknet v0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - dropped upgrade support for pathfinder v0.4 and earlier
 - separate db connection pools rpc, sync and storage
+- rpc db connection limit now matches the max rpc connection limit
 
 ## [0.6.1] - 2023-06-18
 

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -137,7 +137,7 @@ Examples:
     #[arg(
         long = "sync.poll-interval",
         long_help = "New block poll interval in seconds",
-        default_value = "30",
+        default_value = "5",
         env = "PATHFINDER_HEAD_POLL_INTERVAL_SECONDS"
     )]
     poll_interval: std::num::NonZeroU64,

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -147,7 +147,7 @@ async fn main() -> anyhow::Result<()> {
         pending_data: pending_state,
         pending_poll_interval: config
             .poll_pending
-            .then_some(std::time::Duration::from_secs(5)),
+            .then_some(std::time::Duration::from_secs(2)),
         block_validation_mode: state::l2::BlockValidationMode::Strict,
         websocket_txs: rpc_server.get_ws_senders(),
         block_cache_size: 1_000,

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -80,7 +80,7 @@ async fn main() -> anyhow::Result<()> {
         .create_pool(NonZeroU32::new(5).unwrap())
         .context("Creating database connection pool for sync")?;
     let rpc_storage = storage_manager
-        .create_pool(NonZeroU32::new(20).unwrap())
+        .create_pool(config.max_rpc_connections)
         .context("Creating database connection pool for sync")?;
     let p2p_storage = storage_manager
         .create_pool(NonZeroU32::new(1).unwrap())


### PR DESCRIPTION
This PR reduces the sync poll rates and matches the rpc db and network connection pools.

The default sync poll rates are reduced from 30s to 5s and the pending poll rate from 5s to 3s. This is in anticipation of much shorter v0.12 block times.

I've also matched the RPC db connection limit to the network connection limit. I'm sure this is overkill, but its not clear to me if this is actually costly?

These changes are not ideal, but time is in short supply.
