### PR TITLE
feat: sierra 2.0.0-rc5 compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `block_download`: time taken to download current block's data excluding classes
   - `block_processing`: time taken to process and store the current block
 - configuration for new block polling interval: `--sync.poll-interval <seconds>`
+- sierra v2.0.0 support
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-felt"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edaee21a254b549dd00ecb5db15399c8d03b663ddb5a659f7c62ea7e16a3ed85"
+dependencies = [
+ "lazy_static",
+ "num-bigint 0.4.3",
+ "num-integer",
+ "num-traits 0.2.15",
+ "serde",
+]
+
+[[package]]
 name = "cairo-lang-casm"
 version = "1.0.0-alpha.6"
 source = "git+https://github.com/starkware-libs/cairo?tag=v1.0.0-alpha.6#439da05a031c2eda263c4ce12d0b71d20f38205f"
@@ -833,13 +846,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-casm"
-version = "1.1.0-rc0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+version = "2.0.0-rc6"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.0.0-rc6#54bd0e668e92c6ae504bfa0f680e22b4c29be27d"
 dependencies = [
- "cairo-lang-utils 1.1.0-rc0",
+ "cairo-lang-utils 2.0.0-rc6",
  "indoc 2.0.1",
  "num-bigint 0.4.3",
  "num-traits 0.2.15",
+ "parity-scale-codec",
+ "parity-scale-codec-derive",
+ "schemars",
  "serde",
  "thiserror",
 ]
@@ -895,23 +911,22 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "1.1.0-rc0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+version = "2.0.0-rc6"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.0.0-rc6#54bd0e668e92c6ae504bfa0f680e22b4c29be27d"
 dependencies = [
  "anyhow",
- "cairo-lang-defs 1.1.0-rc0",
- "cairo-lang-diagnostics 1.1.0-rc0",
- "cairo-lang-filesystem 1.1.0-rc0",
- "cairo-lang-lowering 1.1.0-rc0",
- "cairo-lang-parser 1.1.0-rc0",
- "cairo-lang-plugins 1.1.0-rc0",
- "cairo-lang-project 1.1.0-rc0",
- "cairo-lang-semantic 1.1.0-rc0",
- "cairo-lang-sierra 1.1.0-rc0",
- "cairo-lang-sierra-generator 1.1.0-rc0",
- "cairo-lang-syntax 1.1.0-rc0",
- "cairo-lang-utils 1.1.0-rc0",
- "clap 4.2.7",
+ "cairo-lang-defs 2.0.0-rc6",
+ "cairo-lang-diagnostics 2.0.0-rc6",
+ "cairo-lang-filesystem 2.0.0-rc6",
+ "cairo-lang-lowering 2.0.0-rc6",
+ "cairo-lang-parser 2.0.0-rc6",
+ "cairo-lang-plugins 2.0.0-rc6",
+ "cairo-lang-project 2.0.0-rc6",
+ "cairo-lang-semantic 2.0.0-rc6",
+ "cairo-lang-sierra 2.0.0-rc6",
+ "cairo-lang-sierra-generator 2.0.0-rc6",
+ "cairo-lang-syntax 2.0.0-rc6",
+ "cairo-lang-utils 2.0.0-rc6",
  "log",
  "salsa",
  "smol_str 0.2.0",
@@ -930,8 +945,11 @@ source = "git+https://github.com/starkware-libs/cairo?tag=v1.0.0-rc0#05867c82de4
 
 [[package]]
 name = "cairo-lang-debug"
-version = "1.1.0-rc0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+version = "2.0.0-rc6"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.0.0-rc6#54bd0e668e92c6ae504bfa0f680e22b4c29be27d"
+dependencies = [
+ "cairo-lang-utils 2.0.0-rc6",
+]
 
 [[package]]
 name = "cairo-lang-defs"
@@ -969,15 +987,15 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-defs"
-version = "1.1.0-rc0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+version = "2.0.0-rc6"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.0.0-rc6#54bd0e668e92c6ae504bfa0f680e22b4c29be27d"
 dependencies = [
- "cairo-lang-debug 1.1.0-rc0",
- "cairo-lang-diagnostics 1.1.0-rc0",
- "cairo-lang-filesystem 1.1.0-rc0",
- "cairo-lang-parser 1.1.0-rc0",
- "cairo-lang-syntax 1.1.0-rc0",
- "cairo-lang-utils 1.1.0-rc0",
+ "cairo-lang-debug 2.0.0-rc6",
+ "cairo-lang-diagnostics 2.0.0-rc6",
+ "cairo-lang-filesystem 2.0.0-rc6",
+ "cairo-lang-parser 2.0.0-rc6",
+ "cairo-lang-syntax 2.0.0-rc6",
+ "cairo-lang-utils 2.0.0-rc6",
  "indexmap",
  "itertools",
  "salsa",
@@ -1008,11 +1026,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "1.1.0-rc0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+version = "2.0.0-rc6"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.0.0-rc6#54bd0e668e92c6ae504bfa0f680e22b4c29be27d"
 dependencies = [
- "cairo-lang-filesystem 1.1.0-rc0",
- "cairo-lang-utils 1.1.0-rc0",
+ "cairo-lang-filesystem 2.0.0-rc6",
+ "cairo-lang-utils 2.0.0-rc6",
  "itertools",
  "salsa",
 ]
@@ -1041,10 +1059,10 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "1.1.0-rc0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+version = "2.0.0-rc6"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.0.0-rc6#54bd0e668e92c6ae504bfa0f680e22b4c29be27d"
 dependencies = [
- "cairo-lang-utils 1.1.0-rc0",
+ "cairo-lang-utils 2.0.0-rc6",
  "good_lp",
  "indexmap",
  "itertools",
@@ -1077,11 +1095,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "1.1.0-rc0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+version = "2.0.0-rc6"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.0.0-rc6#54bd0e668e92c6ae504bfa0f680e22b4c29be27d"
 dependencies = [
- "cairo-lang-debug 1.1.0-rc0",
- "cairo-lang-utils 1.1.0-rc0",
+ "cairo-lang-debug 2.0.0-rc6",
+ "cairo-lang-utils 2.0.0-rc6",
  "path-clean",
  "salsa",
  "serde",
@@ -1138,18 +1156,18 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "1.1.0-rc0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+version = "2.0.0-rc6"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.0.0-rc6#54bd0e668e92c6ae504bfa0f680e22b4c29be27d"
 dependencies = [
- "cairo-lang-debug 1.1.0-rc0",
- "cairo-lang-defs 1.1.0-rc0",
- "cairo-lang-diagnostics 1.1.0-rc0",
- "cairo-lang-filesystem 1.1.0-rc0",
- "cairo-lang-parser 1.1.0-rc0",
- "cairo-lang-proc-macros 1.1.0-rc0",
- "cairo-lang-semantic 1.1.0-rc0",
- "cairo-lang-syntax 1.1.0-rc0",
- "cairo-lang-utils 1.1.0-rc0",
+ "cairo-lang-debug 2.0.0-rc6",
+ "cairo-lang-defs 2.0.0-rc6",
+ "cairo-lang-diagnostics 2.0.0-rc6",
+ "cairo-lang-filesystem 2.0.0-rc6",
+ "cairo-lang-parser 2.0.0-rc6",
+ "cairo-lang-proc-macros 2.0.0-rc6",
+ "cairo-lang-semantic 2.0.0-rc6",
+ "cairo-lang-syntax 2.0.0-rc6",
+ "cairo-lang-utils 2.0.0-rc6",
  "id-arena",
  "indexmap",
  "itertools",
@@ -1199,14 +1217,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-parser"
-version = "1.1.0-rc0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+version = "2.0.0-rc6"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.0.0-rc6#54bd0e668e92c6ae504bfa0f680e22b4c29be27d"
 dependencies = [
- "cairo-lang-diagnostics 1.1.0-rc0",
- "cairo-lang-filesystem 1.1.0-rc0",
- "cairo-lang-syntax 1.1.0-rc0",
- "cairo-lang-syntax-codegen 1.1.0-rc0",
- "cairo-lang-utils 1.1.0-rc0",
+ "cairo-lang-diagnostics 2.0.0-rc6",
+ "cairo-lang-filesystem 2.0.0-rc6",
+ "cairo-lang-syntax 2.0.0-rc6",
+ "cairo-lang-syntax-codegen 2.0.0-rc6",
+ "cairo-lang-utils 2.0.0-rc6",
  "colored",
  "itertools",
  "log",
@@ -1256,16 +1274,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "1.1.0-rc0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+version = "2.0.0-rc6"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.0.0-rc6#54bd0e668e92c6ae504bfa0f680e22b4c29be27d"
 dependencies = [
- "cairo-lang-defs 1.1.0-rc0",
- "cairo-lang-diagnostics 1.1.0-rc0",
- "cairo-lang-filesystem 1.1.0-rc0",
- "cairo-lang-parser 1.1.0-rc0",
- "cairo-lang-semantic 1.1.0-rc0",
- "cairo-lang-syntax 1.1.0-rc0",
- "cairo-lang-utils 1.1.0-rc0",
+ "cairo-lang-defs 2.0.0-rc6",
+ "cairo-lang-diagnostics 2.0.0-rc6",
+ "cairo-lang-filesystem 2.0.0-rc6",
+ "cairo-lang-parser 2.0.0-rc6",
+ "cairo-lang-semantic 2.0.0-rc6",
+ "cairo-lang-syntax 2.0.0-rc6",
+ "cairo-lang-utils 2.0.0-rc6",
  "indoc 2.0.1",
  "itertools",
  "salsa",
@@ -1294,10 +1312,10 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "1.1.0-rc0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+version = "2.0.0-rc6"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.0.0-rc6#54bd0e668e92c6ae504bfa0f680e22b4c29be27d"
 dependencies = [
- "cairo-lang-debug 1.1.0-rc0",
+ "cairo-lang-debug 2.0.0-rc6",
  "quote",
  "syn 1.0.109",
 ]
@@ -1328,10 +1346,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "1.1.0-rc0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+version = "2.0.0-rc6"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.0.0-rc6#54bd0e668e92c6ae504bfa0f680e22b4c29be27d"
 dependencies = [
- "cairo-lang-filesystem 1.1.0-rc0",
+ "cairo-lang-filesystem 2.0.0-rc6",
+ "cairo-lang-utils 2.0.0-rc6",
  "serde",
  "smol_str 0.2.0",
  "thiserror",
@@ -1386,17 +1405,17 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "1.1.0-rc0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+version = "2.0.0-rc6"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.0.0-rc6#54bd0e668e92c6ae504bfa0f680e22b4c29be27d"
 dependencies = [
- "cairo-lang-debug 1.1.0-rc0",
- "cairo-lang-defs 1.1.0-rc0",
- "cairo-lang-diagnostics 1.1.0-rc0",
- "cairo-lang-filesystem 1.1.0-rc0",
- "cairo-lang-parser 1.1.0-rc0",
- "cairo-lang-proc-macros 1.1.0-rc0",
- "cairo-lang-syntax 1.1.0-rc0",
- "cairo-lang-utils 1.1.0-rc0",
+ "cairo-lang-debug 2.0.0-rc6",
+ "cairo-lang-defs 2.0.0-rc6",
+ "cairo-lang-diagnostics 2.0.0-rc6",
+ "cairo-lang-filesystem 2.0.0-rc6",
+ "cairo-lang-parser 2.0.0-rc6",
+ "cairo-lang-proc-macros 2.0.0-rc6",
+ "cairo-lang-syntax 2.0.0-rc6",
+ "cairo-lang-utils 2.0.0-rc6",
  "id-arena",
  "itertools",
  "log",
@@ -1452,10 +1471,10 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "1.1.0-rc0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+version = "2.0.0-rc6"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.0.0-rc6#54bd0e668e92c6ae504bfa0f680e22b4c29be27d"
 dependencies = [
- "cairo-lang-utils 1.1.0-rc0",
+ "cairo-lang-utils 2.0.0-rc6",
  "const-fnv1a-hash",
  "convert_case",
  "derivative",
@@ -1498,12 +1517,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "1.1.0-rc0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+version = "2.0.0-rc6"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.0.0-rc6#54bd0e668e92c6ae504bfa0f680e22b4c29be27d"
 dependencies = [
- "cairo-lang-eq-solver 1.1.0-rc0",
- "cairo-lang-sierra 1.1.0-rc0",
- "cairo-lang-utils 1.1.0-rc0",
+ "cairo-lang-eq-solver 2.0.0-rc6",
+ "cairo-lang-sierra 2.0.0-rc6",
+ "cairo-lang-utils 2.0.0-rc6",
  "itertools",
  "thiserror",
 ]
@@ -1534,12 +1553,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "1.1.0-rc0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+version = "2.0.0-rc6"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.0.0-rc6#54bd0e668e92c6ae504bfa0f680e22b4c29be27d"
 dependencies = [
- "cairo-lang-eq-solver 1.1.0-rc0",
- "cairo-lang-sierra 1.1.0-rc0",
- "cairo-lang-utils 1.1.0-rc0",
+ "cairo-lang-eq-solver 2.0.0-rc6",
+ "cairo-lang-sierra 2.0.0-rc6",
+ "cairo-lang-utils 2.0.0-rc6",
  "itertools",
  "thiserror",
 ]
@@ -1596,21 +1615,21 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "1.1.0-rc0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+version = "2.0.0-rc6"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.0.0-rc6#54bd0e668e92c6ae504bfa0f680e22b4c29be27d"
 dependencies = [
- "cairo-lang-debug 1.1.0-rc0",
- "cairo-lang-defs 1.1.0-rc0",
- "cairo-lang-diagnostics 1.1.0-rc0",
- "cairo-lang-filesystem 1.1.0-rc0",
- "cairo-lang-lowering 1.1.0-rc0",
- "cairo-lang-parser 1.1.0-rc0",
- "cairo-lang-plugins 1.1.0-rc0",
- "cairo-lang-proc-macros 1.1.0-rc0",
- "cairo-lang-semantic 1.1.0-rc0",
- "cairo-lang-sierra 1.1.0-rc0",
- "cairo-lang-syntax 1.1.0-rc0",
- "cairo-lang-utils 1.1.0-rc0",
+ "cairo-lang-debug 2.0.0-rc6",
+ "cairo-lang-defs 2.0.0-rc6",
+ "cairo-lang-diagnostics 2.0.0-rc6",
+ "cairo-lang-filesystem 2.0.0-rc6",
+ "cairo-lang-lowering 2.0.0-rc6",
+ "cairo-lang-parser 2.0.0-rc6",
+ "cairo-lang-plugins 2.0.0-rc6",
+ "cairo-lang-proc-macros 2.0.0-rc6",
+ "cairo-lang-semantic 2.0.0-rc6",
+ "cairo-lang-sierra 2.0.0-rc6",
+ "cairo-lang-syntax 2.0.0-rc6",
+ "cairo-lang-utils 2.0.0-rc6",
  "id-arena",
  "indexmap",
  "itertools",
@@ -1665,18 +1684,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "1.1.0-rc0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+version = "2.0.0-rc6"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.0.0-rc6#54bd0e668e92c6ae504bfa0f680e22b4c29be27d"
 dependencies = [
- "anyhow",
  "assert_matches",
- "cairo-felt 0.3.0-rc1",
- "cairo-lang-casm 1.1.0-rc0",
- "cairo-lang-sierra 1.1.0-rc0",
- "cairo-lang-sierra-ap-change 1.1.0-rc0",
- "cairo-lang-sierra-gas 1.1.0-rc0",
- "cairo-lang-utils 1.1.0-rc0",
- "clap 4.2.7",
+ "cairo-felt 0.6.1",
+ "cairo-lang-casm 2.0.0-rc6",
+ "cairo-lang-sierra 2.0.0-rc6",
+ "cairo-lang-sierra-ap-change 2.0.0-rc6",
+ "cairo-lang-sierra-gas 2.0.0-rc6",
+ "cairo-lang-utils 2.0.0-rc6",
  "indoc 2.0.1",
  "itertools",
  "log",
@@ -1766,28 +1783,27 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "1.1.0-rc0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+version = "2.0.0-rc6"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.0.0-rc6#54bd0e668e92c6ae504bfa0f680e22b4c29be27d"
 dependencies = [
  "anyhow",
- "cairo-felt 0.3.0-rc1",
- "cairo-lang-casm 1.1.0-rc0",
- "cairo-lang-compiler 1.1.0-rc0",
- "cairo-lang-defs 1.1.0-rc0",
- "cairo-lang-diagnostics 1.1.0-rc0",
- "cairo-lang-filesystem 1.1.0-rc0",
- "cairo-lang-lowering 1.1.0-rc0",
- "cairo-lang-parser 1.1.0-rc0",
- "cairo-lang-plugins 1.1.0-rc0",
- "cairo-lang-semantic 1.1.0-rc0",
- "cairo-lang-sierra 1.1.0-rc0",
- "cairo-lang-sierra-ap-change 1.1.0-rc0",
- "cairo-lang-sierra-gas 1.1.0-rc0",
- "cairo-lang-sierra-generator 1.1.0-rc0",
- "cairo-lang-sierra-to-casm 1.1.0-rc0",
- "cairo-lang-syntax 1.1.0-rc0",
- "cairo-lang-utils 1.1.0-rc0",
- "clap 4.2.7",
+ "cairo-felt 0.6.1",
+ "cairo-lang-casm 2.0.0-rc6",
+ "cairo-lang-compiler 2.0.0-rc6",
+ "cairo-lang-defs 2.0.0-rc6",
+ "cairo-lang-diagnostics 2.0.0-rc6",
+ "cairo-lang-filesystem 2.0.0-rc6",
+ "cairo-lang-lowering 2.0.0-rc6",
+ "cairo-lang-parser 2.0.0-rc6",
+ "cairo-lang-plugins 2.0.0-rc6",
+ "cairo-lang-semantic 2.0.0-rc6",
+ "cairo-lang-sierra 2.0.0-rc6",
+ "cairo-lang-sierra-ap-change 2.0.0-rc6",
+ "cairo-lang-sierra-gas 2.0.0-rc6",
+ "cairo-lang-sierra-generator 2.0.0-rc6",
+ "cairo-lang-sierra-to-casm 2.0.0-rc6",
+ "cairo-lang-syntax 2.0.0-rc6",
+ "cairo-lang-utils 2.0.0-rc6",
  "convert_case",
  "genco",
  "indoc 2.0.1",
@@ -1834,12 +1850,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "1.1.0-rc0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+version = "2.0.0-rc6"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.0.0-rc6#54bd0e668e92c6ae504bfa0f680e22b4c29be27d"
 dependencies = [
- "cairo-lang-debug 1.1.0-rc0",
- "cairo-lang-filesystem 1.1.0-rc0",
- "cairo-lang-utils 1.1.0-rc0",
+ "cairo-lang-debug 2.0.0-rc6",
+ "cairo-lang-filesystem 2.0.0-rc6",
+ "cairo-lang-utils 2.0.0-rc6",
  "num-bigint 0.4.3",
  "num-traits 0.2.15",
  "salsa",
@@ -1872,12 +1888,10 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "1.1.0-rc0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+version = "2.0.0-rc6"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.0.0-rc6#54bd0e668e92c6ae504bfa0f680e22b4c29be27d"
 dependencies = [
- "cairo-lang-utils 1.1.0-rc0",
  "genco",
- "log",
  "xshell",
 ]
 
@@ -1915,18 +1929,17 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "1.1.0-rc0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v1.1.0-rc0#82f8c2b13a32f39061c99a88498ee05fcfe6bd19"
+version = "2.0.0-rc6"
+source = "git+https://github.com/starkware-libs/cairo?tag=v2.0.0-rc6#54bd0e668e92c6ae504bfa0f680e22b4c29be27d"
 dependencies = [
- "env_logger 0.9.3",
  "indexmap",
  "itertools",
- "log",
  "num-bigint 0.4.3",
  "num-integer",
  "num-traits 0.2.15",
+ "parity-scale-codec",
+ "schemars",
  "serde",
- "time 0.3.21",
 ]
 
 [[package]]
@@ -2806,6 +2819,12 @@ dependencies = [
  "quote",
  "syn 2.0.15",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
 name = "ecdsa"
@@ -5894,7 +5913,7 @@ dependencies = [
  "bytes",
  "cairo-lang-starknet 1.0.0-alpha.6",
  "cairo-lang-starknet 1.0.0-rc0",
- "cairo-lang-starknet 1.1.0-rc0",
+ "cairo-lang-starknet 2.0.0-rc6",
  "clap 4.2.7",
  "console-subscriber",
  "const-decoder",
@@ -7114,6 +7133,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
+dependencies = [
+ "dyn-clone",
+ "indexmap",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7224,6 +7268,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.15",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1.59"
 bitvec = "0.20.4"
 casm-compiler-v1_0_0-alpha6 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-alpha.6" }
 casm-compiler-v1_0_0-rc0 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-rc0" }
-casm-compiler-v1_1_0-rc0 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.1.0-rc0" }
+casm-compiler-v2_0_0-rc6 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v2.0.0-rc6" }
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
 console-subscriber = { version = "0.1.8", optional = true }
 futures = { version = "0.3", default-features = false, features = ["std"] }

--- a/crates/pathfinder/src/sierra.rs
+++ b/crates/pathfinder/src/sierra.rs
@@ -24,7 +24,7 @@ pub fn compile_to_casm(
         .parse_as_semver()
         .context("Deciding on compiler version")?
     {
-        Some(v) if v >= V_0_11_2 => v1_1_0_rc0::compile(definition),
+        Some(v) if v >= V_0_11_2 => v2_0_0_rc6::compile(definition),
         Some(v) if v >= V_0_11_1 => v1_0_0_rc0::compile(definition),
         _ => v1_0_0_alpha6::compile(definition),
     }
@@ -122,13 +122,14 @@ mod v1_0_0_rc0 {
     }
 }
 
-mod v1_1_0_rc0 {
+// This compiler is backwards compatible with v1.1.
+mod v2_0_0_rc6 {
     use anyhow::Context;
-    use casm_compiler_v1_1_0_rc0::allowed_libfuncs::{
+    use casm_compiler_v2_0_0_rc6::allowed_libfuncs::{
         validate_compatible_sierra_version, ListSelector,
     };
-    use casm_compiler_v1_1_0_rc0::casm_contract_class::CasmContractClass;
-    use casm_compiler_v1_1_0_rc0::contract_class::ContractClass;
+    use casm_compiler_v2_0_0_rc6::casm_contract_class::CasmContractClass;
+    use casm_compiler_v2_0_0_rc6::contract_class::ContractClass;
 
     use crate::sierra::FeederGatewayContractClass;
 
@@ -154,7 +155,7 @@ mod v1_1_0_rc0 {
         validate_compatible_sierra_version(
             &sierra_class,
             ListSelector::ListName(
-                casm_compiler_v1_0_0_rc0::allowed_libfuncs::DEFAULT_EXPERIMENTAL_LIBFUNCS_LIST
+                casm_compiler_v2_0_0_rc6::allowed_libfuncs::BUILTIN_EXPERIMENTAL_LIBFUNCS_LIST
                     .to_string(),
             ),
         )


### PR DESCRIPTION
This PR replaces the v1.1 sierra compiler with ~~v2.0.0-rc5~~ v2.0.0-rc6.

The compiler is backwards compatible. ~~We still need confirmation on whether this is the final release candidate; will keep the PR unmerged until then.~~

Closes #1168 
