### PR TITLE
feat: support special 0x1 contract

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -25,6 +25,15 @@ pub struct ContractAddress(Felt);
 macros::starkhash251::newtype!(ContractAddress);
 macros::starkhash251::deserialization!(ContractAddress);
 
+impl ContractAddress {
+    /// The contract at 0x1 is special. It was never deployed and therefore
+    /// has no class hash. It does however receive storage changes.
+    ///
+    /// It is used by starknet to store values for smart contracts to access
+    /// using syscalls. For example the block hash.
+    pub const ONE: ContractAddress = ContractAddress(felt!("0x1"));
+}
+
 /// A nonce that is associated with a particular deployed Starknet contract
 /// distinguishing it from other contracts that use the same contract class.
 #[derive(Copy, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]

--- a/crates/merkle-tree/src/contract_state.rs
+++ b/crates/merkle-tree/src/contract_state.rs
@@ -60,9 +60,15 @@ pub fn update_contract_state(
     };
 
     // Calculate contract state hash, update global state tree and persist pre-image.
-    let class_hash = new_class_hash
-        .or(old_class_hash)
-        .context("Class hash is unknown for new contract")?;
+    //
+    // The contract at address 0x1 is special. It was never deployed and doesn't have a class.
+    let class_hash = if contract_address == ContractAddress::ONE {
+        ClassHash::ZERO
+    } else {
+        new_class_hash
+            .or(old_class_hash)
+            .context("Class hash is unknown for new contract")?
+    };
     let contract_state_hash = calculate_contract_state_hash(class_hash, new_root, new_nonce);
 
     transaction


### PR DESCRIPTION
This PR adds support for the special contract at address 0x1 introduced in starknet v0.12.

The special contract is never deployed and always has class hash and nonce set to 0. This PR adds an exception for this special case.

The situation here isn't great, but this will work for now.