### PR TITLE
chore:  rpc db connections to 1/8 network limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - dropped upgrade support for pathfinder v0.4 and earlier
 - separate db connection pools rpc, sync and storage
-- rpc db connection limit now matches the max rpc connection limit
+- increased the number of rpc db connections
 
 ## [0.6.1] - 2023-06-18
 

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -79,8 +79,13 @@ async fn main() -> anyhow::Result<()> {
     let sync_storage = storage_manager
         .create_pool(NonZeroU32::new(5).unwrap())
         .context("Creating database connection pool for sync")?;
+    // Set the rpc file connection limit to a fraction of the RPC connections.
+    // Having this be too large is counter productive as disk IO will then slow down
+    // all queries.
+    let rpc_storage = std::cmp::max(10, config.max_rpc_connections.get() / 8);
+    let rpc_storage = NonZeroU32::new(rpc_storage).expect("A non-zero minimum is set");
     let rpc_storage = storage_manager
-        .create_pool(config.max_rpc_connections)
+        .create_pool(rpc_storage)
         .context("Creating database connection pool for sync")?;
     let p2p_storage = storage_manager
         .create_pool(NonZeroU32::new(1).unwrap())


### PR DESCRIPTION
Change the rpc db pool size from rpc network pool size to 1/8th thereof.

Having it match the network limit would set the default to 1024 which would likely fail since that is often the file handle limit on unix. In addition, having too many open is counter-productive as all queries would become slower instead of only a few that idle.