### PR TITLE
fix(rpc/v0.3): add `from_address` to `MSG_TO_L1`

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -23,7 +23,7 @@ pub use header::{BlockHeader, BlockHeaderBuilder};
 
 /// The address of a Starknet contract.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize, PartialOrd, Ord)]
-pub struct ContractAddress(Felt);
+pub struct ContractAddress(pub Felt);
 
 macros::starkhash251::newtype!(ContractAddress);
 macros::starkhash251::deserialization!(ContractAddress);

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -23,7 +23,7 @@ pub use header::{BlockHeader, BlockHeaderBuilder};
 
 /// The address of a Starknet contract.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize, PartialOrd, Ord)]
-pub struct ContractAddress(pub Felt);
+pub struct ContractAddress(Felt);
 
 macros::starkhash251::newtype!(ContractAddress);
 macros::starkhash251::deserialization!(ContractAddress);

--- a/crates/rpc/src/context.rs
+++ b/crates/rpc/src/context.rs
@@ -8,6 +8,26 @@ use std::sync::Arc;
 
 type SequencerClient = starknet_gateway_client::Client;
 
+#[derive(Copy, Clone, Default)]
+pub enum RpcVersion {
+    #[default]
+    Undefined,
+    V01,
+    V02,
+    V03,
+}
+
+impl RpcVersion {
+    fn parse(s: &str) -> Self {
+        match s {
+            "v0.1" => Self::V01,
+            "v0.2" => Self::V02,
+            "v0.3" => Self::V03,
+            _ => Self::default(),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct RpcContext {
     pub storage: Storage,
@@ -17,6 +37,7 @@ pub struct RpcContext {
     pub call_handle: Option<ext_py::Handle>,
     pub eth_gas_price: Option<gas_price::Cached>,
     pub sequencer: SequencerClient,
+    pub version: RpcVersion,
 }
 
 impl RpcContext {
@@ -34,6 +55,14 @@ impl RpcContext {
             call_handle: None,
             eth_gas_price: None,
             sequencer,
+            version: RpcVersion::default(),
+        }
+    }
+
+    pub(crate) fn with_version(self, version: &str) -> Self {
+        Self {
+            version: RpcVersion::parse(version),
+            ..self
         }
     }
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -438,17 +438,15 @@ pub mod test_utils {
         let mut receipt4 = receipt0.clone();
         let mut receipt5 = receipt0.clone();
         let mut receipt6 = Receipt {
-            l2_to_l1_messages: vec![
-                L2ToL1Message { 
-                    from_address: ContractAddress(felt!("0xcafebabe")), 
-                    payload: vec![
-                        L2ToL1MessagePayloadElem(felt!("0x1")),
-                        L2ToL1MessagePayloadElem(felt!("0x2")),
-                        L2ToL1MessagePayloadElem(felt!("0x3")),
-                    ], 
-                    to_address: EthereumAddress(H160::zero()),
-                }
-            ],
+            l2_to_l1_messages: vec![L2ToL1Message {
+                from_address: ContractAddress(felt!("0xcafebabe")),
+                payload: vec![
+                    L2ToL1MessagePayloadElem(felt!("0x1")),
+                    L2ToL1MessagePayloadElem(felt!("0x2")),
+                    L2ToL1MessagePayloadElem(felt!("0x3")),
+                ],
+                to_address: EthereumAddress(H160::zero()),
+            }],
             ..receipt0.clone()
         };
         receipt0.events = vec![Event {
@@ -464,7 +462,12 @@ pub mod test_utils {
         receipt6.transaction_hash = txn6_hash;
         let transaction_data0 = [(txn0, receipt0)];
         let transaction_data1 = [(txn1, receipt1), (txn2, receipt2)];
-        let transaction_data2 = [(txn3, receipt3), (txn4, receipt4), (txn5, receipt5), (txn6, receipt6)];
+        let transaction_data2 = [
+            (txn3, receipt3),
+            (txn4, receipt4),
+            (txn5, receipt5),
+            (txn6, receipt6),
+        ];
         db_txn
             .insert_transaction_data(header0.hash, header0.number, &transaction_data0)
             .unwrap();

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -164,9 +164,10 @@ pub mod test_utils {
     use pathfinder_common::event::Event;
     use pathfinder_common::{
         felt, felt_bytes, BlockHash, BlockHeader, BlockNumber, BlockTimestamp, CasmHash,
-        ClassCommitment, ClassHash, ContractAddress, ContractAddressSalt, EntryPoint, EventData,
-        EventKey, GasPrice, SequencerAddress, SierraHash, StarknetVersion, StateUpdate,
-        StorageAddress, StorageCommitment, TransactionHash, TransactionIndex, TransactionVersion,
+        ClassCommitment, ClassHash, ContractAddress, ContractAddressSalt, EntryPoint,
+        EthereumAddress, EventData, EventKey, GasPrice, L2ToL1MessagePayloadElem, SequencerAddress,
+        SierraHash, StarknetVersion, StateUpdate, StorageAddress, StorageCommitment,
+        TransactionHash, TransactionIndex, TransactionVersion,
     };
     use pathfinder_merkle_tree::StorageCommitmentTree;
     use pathfinder_storage::{BlockId, Storage};

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -170,8 +170,9 @@ pub mod test_utils {
     };
     use pathfinder_merkle_tree::StorageCommitmentTree;
     use pathfinder_storage::{BlockId, Storage};
-    use primitive_types::H256;
+    use primitive_types::{H160, H256};
     use stark_hash::Felt;
+    use starknet_gateway_types::reply::transaction::L2ToL1Message;
     use starknet_gateway_types::{
         pending::PendingData,
         reply::transaction::{
@@ -405,10 +406,12 @@ pub mod test_utils {
         let txn3_hash = TransactionHash(felt_bytes!(b"txn 3"));
         let txn4_hash = TransactionHash(felt_bytes!(b"txn 4 "));
         let txn5_hash = TransactionHash(felt_bytes!(b"txn 5"));
+        let txn6_hash = TransactionHash(felt_bytes!(b"txn 6"));
         let mut txn1 = txn0.clone();
         let mut txn2 = txn0.clone();
         let mut txn3 = txn0.clone();
         let mut txn4 = txn0.clone();
+        let mut txn6 = txn0.clone();
         txn1.transaction_hash = txn1_hash;
         txn1.sender_address = contract1_addr;
         txn2.transaction_hash = txn2_hash;
@@ -416,6 +419,8 @@ pub mod test_utils {
         txn3.transaction_hash = txn3_hash;
         txn3.sender_address = contract1_addr;
         txn4.transaction_hash = txn4_hash;
+        txn6.sender_address = contract1_addr;
+        txn6.transaction_hash = txn6_hash;
 
         txn4.sender_address = ContractAddress::new_or_panic(Felt::ZERO);
         let mut txn5 = txn4.clone();
@@ -426,11 +431,26 @@ pub mod test_utils {
         let txn3 = Transaction::Invoke(txn3.into());
         let txn4 = Transaction::Invoke(txn4.into());
         let txn5 = Transaction::Invoke(txn5.into());
+        let txn6 = Transaction::Invoke(txn6.into());
         let mut receipt1 = receipt0.clone();
         let mut receipt2 = receipt0.clone();
         let mut receipt3 = receipt0.clone();
         let mut receipt4 = receipt0.clone();
         let mut receipt5 = receipt0.clone();
+        let mut receipt6 = Receipt {
+            l2_to_l1_messages: vec![
+                L2ToL1Message { 
+                    from_address: ContractAddress(felt!("0xcafebabe")), 
+                    payload: vec![
+                        L2ToL1MessagePayloadElem(felt!("0x1")),
+                        L2ToL1MessagePayloadElem(felt!("0x2")),
+                        L2ToL1MessagePayloadElem(felt!("0x3")),
+                    ], 
+                    to_address: EthereumAddress(H160::zero()),
+                }
+            ],
+            ..receipt0.clone()
+        };
         receipt0.events = vec![Event {
             data: vec![EventData(felt_bytes!(b"event 0 data"))],
             from_address: ContractAddress::new_or_panic(felt_bytes!(b"event 0 from addr")),
@@ -441,9 +461,10 @@ pub mod test_utils {
         receipt3.transaction_hash = txn3_hash;
         receipt4.transaction_hash = txn4_hash;
         receipt5.transaction_hash = txn5_hash;
+        receipt6.transaction_hash = txn6_hash;
         let transaction_data0 = [(txn0, receipt0)];
         let transaction_data1 = [(txn1, receipt1), (txn2, receipt2)];
-        let transaction_data2 = [(txn3, receipt3), (txn4, receipt4), (txn5, receipt5)];
+        let transaction_data2 = [(txn3, receipt3), (txn4, receipt4), (txn5, receipt5), (txn6, receipt6)];
         db_txn
             .insert_transaction_data(header0.hash, header0.number, &transaction_data0)
             .unwrap();

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -439,7 +439,7 @@ pub mod test_utils {
         let mut receipt5 = receipt0.clone();
         let mut receipt6 = Receipt {
             l2_to_l1_messages: vec![L2ToL1Message {
-                from_address: ContractAddress(felt!("0xcafebabe")),
+                from_address: ContractAddress::new_or_panic(felt!("0xcafebabe")),
                 payload: vec![
                     L2ToL1MessagePayloadElem(felt!("0x1")),
                     L2ToL1MessagePayloadElem(felt!("0x2")),

--- a/crates/rpc/src/v02/method/get_block_transaction_count.rs
+++ b/crates/rpc/src/v02/method/get_block_transaction_count.rs
@@ -137,7 +137,7 @@ mod tests {
     async fn test_latest() {
         let context = RpcContext::for_tests();
         let block_id = BlockId::Latest;
-        check_count(context, block_id, 3).await;
+        check_count(context, block_id, 4).await;
     }
 
     #[tokio::test]

--- a/crates/rpc/src/v02/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v02/method/get_transaction_receipt.rs
@@ -28,7 +28,8 @@ pub async fn get_transaction_receipt(
         });
 
         if let Some((receipt, transaction)) = receipt_transaction {
-            let pending = types::PendingTransactionReceipt::from(receipt, &transaction, context.version);
+            let pending =
+                types::PendingTransactionReceipt::from(receipt, &transaction, context.version);
             return Ok(types::MaybePendingTransactionReceipt::Pending(pending));
         };
     }
@@ -559,7 +560,10 @@ mod types {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pathfinder_common::{BlockHash, BlockNumber, ContractAddress, EthereumAddress, EventData, EventKey, Fee, L2ToL1MessagePayloadElem, TransactionHash, felt, felt_bytes};
+    use pathfinder_common::{
+        felt, felt_bytes, BlockHash, BlockNumber, ContractAddress, EthereumAddress, EventData,
+        EventKey, Fee, L2ToL1MessagePayloadElem, TransactionHash,
+    };
     use primitive_types::H160;
 
     mod parsing {
@@ -671,17 +675,15 @@ mod tests {
                         status: TransactionStatus::AcceptedOnL2,
                         block_hash: BlockHash(felt_bytes!(b"latest")),
                         block_number: BlockNumber::new_or_panic(2),
-                        messages_sent: vec![
-                            MessageToL1 { 
-                                from_address: None, // RPC v0.2 does not have this field 
-                                to_address: EthereumAddress(H160::zero()), 
-                                payload: vec![
-                                    L2ToL1MessagePayloadElem(felt!("0x1")),
-                                    L2ToL1MessagePayloadElem(felt!("0x2")),
-                                    L2ToL1MessagePayloadElem(felt!("0x3")),
-                                ],
-                            }
-                        ],
+                        messages_sent: vec![MessageToL1 {
+                            from_address: None, // RPC v0.2 does not have this field
+                            to_address: EthereumAddress(H160::zero()),
+                            payload: vec![
+                                L2ToL1MessagePayloadElem(felt!("0x1")),
+                                L2ToL1MessagePayloadElem(felt!("0x2")),
+                                L2ToL1MessagePayloadElem(felt!("0x3")),
+                            ],
+                        }],
                         events: vec![],
                     }
                 }
@@ -708,17 +710,15 @@ mod tests {
                         status: TransactionStatus::AcceptedOnL2,
                         block_hash: BlockHash(felt_bytes!(b"latest")),
                         block_number: BlockNumber::new_or_panic(2),
-                        messages_sent: vec![
-                            MessageToL1 { 
-                                from_address: Some(ContractAddress(felt!("0xcafebabe"))), 
-                                to_address: EthereumAddress(H160::zero()), 
-                                payload: vec![
-                                    L2ToL1MessagePayloadElem(felt!("0x1")),
-                                    L2ToL1MessagePayloadElem(felt!("0x2")),
-                                    L2ToL1MessagePayloadElem(felt!("0x3")),
-                                ],
-                            }
-                        ],
+                        messages_sent: vec![MessageToL1 {
+                            from_address: Some(ContractAddress(felt!("0xcafebabe"))),
+                            to_address: EthereumAddress(H160::zero()),
+                            payload: vec![
+                                L2ToL1MessagePayloadElem(felt!("0x1")),
+                                L2ToL1MessagePayloadElem(felt!("0x2")),
+                                L2ToL1MessagePayloadElem(felt!("0x3")),
+                            ],
+                        }],
                         events: vec![],
                     }
                 }

--- a/crates/rpc/src/v02/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v02/method/get_transaction_receipt.rs
@@ -90,7 +90,6 @@ mod types {
     use pathfinder_serde::EthereumAddressAsHexStr;
     use serde::Serialize;
     use serde_with::serde_as;
-    use stark_hash::Felt;
     use starknet_gateway_types::reply::transaction::{L1ToL2Message, L2ToL1Message};
 
     /// L2 transaction receipt as returned by the RPC API.
@@ -328,12 +327,12 @@ mod types {
     #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
     #[serde(deny_unknown_fields)]
     pub struct MessageToL1 {
-        // In RPC spec v0.3 MSG_TO_L1 has mandatory `from_address` field.
-        // This way it can be supported for both v0.2 and v0.3 versions.
-        #[serde_as(as = "Option<RpcFelt>")]
+        // RPC spec v0.3: `MSG_TO_L1` has a new mandatory `from_address` field.
+        // This way it works for both versions without copying much code around.
+        #[serde_as(as = "Option<RpcFelt251>")]
         #[serde(default)]
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub from_address: Option<Felt>,
+        pub from_address: Option<ContractAddress>,
         #[serde_as(as = "EthereumAddressAsHexStr")]
         pub to_address: EthereumAddress,
         #[serde_as(as = "Vec<RpcFelt>")]
@@ -343,7 +342,7 @@ mod types {
     impl From<L2ToL1Message> for MessageToL1 {
         fn from(msg: L2ToL1Message) -> Self {
             Self {
-                from_address: Some(msg.from_address.0),
+                from_address: Some(msg.from_address),
                 to_address: msg.to_address,
                 payload: msg.payload,
             }

--- a/crates/rpc/src/v02/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v02/method/get_transaction_receipt.rs
@@ -711,7 +711,7 @@ mod tests {
                         block_hash: BlockHash(felt_bytes!(b"latest")),
                         block_number: BlockNumber::new_or_panic(2),
                         messages_sent: vec![MessageToL1 {
-                            from_address: Some(ContractAddress(felt!("0xcafebabe"))),
+                            from_address: Some(ContractAddress::new_or_panic(felt!("0xcafebabe"))),
                             to_address: EthereumAddress(H160::zero()),
                             payload: vec![
                                 L2ToL1MessagePayloadElem(felt!("0x1")),

--- a/crates/rpc/src/v03/method/simulate_transaction.rs
+++ b/crates/rpc/src/v03/method/simulate_transaction.rs
@@ -245,6 +245,8 @@ pub mod dto {
         pub payload: Vec<Felt>,
         #[serde_as(as = "RpcFelt")]
         pub to_address: Felt,
+        #[serde_as(as = "RpcFelt")]
+        pub from_address: Felt,
     }
 
     #[serde_with::serde_as]


### PR DESCRIPTION
Closes https://github.com/eqlabs/pathfinder/issues/1180

`RpcContext` becomes version-aware, which is necessary to fit both v0.2 and v0.3 versions of the spec:
- In v0.3 a mandatory field `from_address` is added to `MSG_TO_L1` entity
- For v0.2 method, the response is patched effectively removing `from_address`
- AFAICT for v0.2 only `get_transaction_receipt` method is affected

It is an ugly but tiny & working solution which avoids copying lots of code from v02 to v03.