### PR TITLE
chore: bump deps for security advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,7 +878,7 @@ dependencies = [
  "cairo-lang-sierra-generator 1.0.0-alpha.6",
  "cairo-lang-syntax 1.0.0-alpha.6",
  "cairo-lang-utils 1.0.0-alpha.6",
- "clap 4.2.7",
+ "clap",
  "log",
  "salsa",
  "thiserror",
@@ -902,7 +902,7 @@ dependencies = [
  "cairo-lang-sierra-generator 1.0.0-rc0",
  "cairo-lang-syntax 1.0.0-rc0",
  "cairo-lang-utils 1.0.0-rc0",
- "clap 4.2.7",
+ "clap",
  "log",
  "salsa",
  "smol_str 0.2.0",
@@ -1651,7 +1651,7 @@ dependencies = [
  "cairo-lang-sierra-ap-change 1.0.0-alpha.6",
  "cairo-lang-sierra-gas 1.0.0-alpha.6",
  "cairo-lang-utils 1.0.0-alpha.6",
- "clap 4.2.7",
+ "clap",
  "indoc 1.0.9",
  "itertools",
  "log",
@@ -1673,7 +1673,7 @@ dependencies = [
  "cairo-lang-sierra-ap-change 1.0.0-rc0",
  "cairo-lang-sierra-gas 1.0.0-rc0",
  "cairo-lang-utils 1.0.0-rc0",
- "clap 4.2.7",
+ "clap",
  "indoc 2.0.1",
  "itertools",
  "log",
@@ -1724,7 +1724,7 @@ dependencies = [
  "cairo-lang-sierra-to-casm 1.0.0-alpha.6",
  "cairo-lang-syntax 1.0.0-alpha.6",
  "cairo-lang-utils 1.0.0-alpha.6",
- "clap 4.2.7",
+ "clap",
  "convert_case",
  "genco",
  "indoc 1.0.9",
@@ -1764,7 +1764,7 @@ dependencies = [
  "cairo-lang-sierra-to-casm 1.0.0-rc0",
  "cairo-lang-syntax 1.0.0-rc0",
  "cairo-lang-utils 1.0.0-rc0",
- "clap 4.2.7",
+ "clap",
  "convert_case",
  "genco",
  "indoc 2.0.1",
@@ -2078,18 +2078,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "bitflags",
- "clap_lex 0.2.4",
- "indexmap",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
 version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
@@ -2108,7 +2096,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "bitflags",
- "clap_lex 0.4.1",
+ "clap_lex",
  "strsim",
  "terminal_size",
 ]
@@ -2123,15 +2111,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.15",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -2299,19 +2278,19 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
 dependencies = [
  "anes",
- "atty",
  "cast",
  "ciborium",
- "clap 3.2.25",
+ "clap",
  "criterion-plot",
+ "is-terminal",
  "itertools",
- "lazy_static",
  "num-traits 0.2.15",
+ "once_cell",
  "oorandom",
  "plotters",
  "rayon",
@@ -5687,12 +5666,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
-
-[[package]]
 name = "output_vt100"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5726,7 +5699,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "base64 0.13.1",
- "clap 4.2.7",
+ "clap",
  "delay_map",
  "env_logger 0.10.0",
  "fake",
@@ -5754,7 +5727,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
- "clap 4.2.7",
+ "clap",
  "futures",
  "libp2p 0.50.0",
  "serde",
@@ -5914,7 +5887,7 @@ dependencies = [
  "cairo-lang-starknet 1.0.0-alpha.6",
  "cairo-lang-starknet 1.0.0-rc0",
  "cairo-lang-starknet 2.0.0-rc6",
- "clap 4.2.7",
+ "clap",
  "console-subscriber",
  "const-decoder",
  "criterion",
@@ -7860,12 +7833,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5623,9 +5623,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.52"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -5655,9 +5655,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.87"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,8 @@ resolver = "2"
 [workspace.dependencies]
 anyhow = "1.0.66"
 assert_matches = "1.5.0"
-clap = { version = "4.1.13" }
+clap =  "4.1.13"
+criterion = "0.5.1"
 fake = { version = "2.5.0", features = ["derive"] }
 rand = "0.8.5"
 semver = "1.0.14"

--- a/crates/load-test/Cargo.lock
+++ b/crates/load-test/Cargo.lock
@@ -985,9 +985,9 @@ checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "openssl"
-version = "0.10.48"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1017,11 +1017,10 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.83"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
- "autocfg",
  "cc",
  "libc",
  "pkg-config",

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -59,7 +59,7 @@ warp = "0.3.3"
 assert_matches = { workspace = true }
 bytes = "1.3.0"
 const-decoder = "0.3.0"
-criterion = "0.4"
+criterion = { workspace = true }
 flate2 = "1.0.25"
 http = "0.2.8"
 mockall = "0.11.3"

--- a/crates/stark_hash/Cargo.toml
+++ b/crates/stark_hash/Cargo.toml
@@ -26,7 +26,7 @@ stark_curve = { path = "../stark_curve" }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-criterion = "0.4"
+criterion = { workspace = true }
 hex = "0.4.3"
 pretty_assertions = "1.3.0"
 rand = "0.8"

--- a/crates/stark_poseidon/Cargo.toml
+++ b/crates/stark_poseidon/Cargo.toml
@@ -19,7 +19,7 @@ stark_curve = { path = "../stark_curve" }
 stark_hash = { path = "../stark_hash" }
 
 [dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }
 rand = "0.8"
 
 [[bench]]


### PR DESCRIPTION
This PR bumps criterion and openssl to fix security advisories.

The criterion bump addresses our own dependency on `atty` but unfortunately it still remains due to the sierra compiler.