### PR TITLE
fix(gateway-client): handle Starknet errors with HTTP status code 400

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Handle Starknet errors with HTTP status code 400. This fixes poll pending and polling
+  in general.
+
 ## [0.6.3] - 2023-06-29
 
 ### Fixed


### PR DESCRIPTION
Starknet 0.12 seems to have changed the HTTP status code for at least some Starknet errors (like BLOCK_NOT_FOUND). Up to now these errors always came with HTTP status code 500 so we weren't properly parsing them now.

This causes all kinds of unintended side effects, like sync not polling properly and not entering poll pending mode.