### PR TITLE
feat(sync): ensure pending data is consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- pending data from the gateway is inconsistent
+  - this could exhibit as RPC data changing status between `pending | L2 accepted | not found`, especially noticeable for transactions.
+
 ## [0.6.4] - 2023-07-05
 
 ### Fixed

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -103,6 +103,118 @@ pub trait GatewayApi: Sync {
     }
 }
 
+#[async_trait::async_trait]
+impl<T: GatewayApi + Sync + Send> GatewayApi for std::sync::Arc<T> {
+    async fn block(&self, block: BlockId) -> Result<reply::MaybePendingBlock, SequencerError> {
+        self.as_ref().block(block).await
+    }
+
+    async fn block_without_retry(
+        &self,
+        block: BlockId,
+    ) -> Result<reply::MaybePendingBlock, SequencerError> {
+        self.as_ref().block_without_retry(block).await
+    }
+
+    async fn class_by_hash(&self, class_hash: ClassHash) -> Result<bytes::Bytes, SequencerError> {
+        self.as_ref().class_by_hash(class_hash).await
+    }
+
+    async fn pending_class_by_hash(
+        &self,
+        class_hash: ClassHash,
+    ) -> Result<bytes::Bytes, SequencerError> {
+        self.as_ref().pending_class_by_hash(class_hash).await
+    }
+
+    async fn transaction(
+        &self,
+        transaction_hash: TransactionHash,
+    ) -> Result<reply::Transaction, SequencerError> {
+        self.as_ref().transaction(transaction_hash).await
+    }
+
+    async fn state_update(&self, block: BlockId) -> Result<StateUpdate, SequencerError> {
+        self.as_ref().state_update(block).await
+    }
+
+    async fn eth_contract_addresses(&self) -> Result<reply::EthContractAddresses, SequencerError> {
+        self.as_ref().eth_contract_addresses().await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn add_invoke_transaction(
+        &self,
+        version: TransactionVersion,
+        max_fee: Fee,
+        signature: Vec<TransactionSignatureElem>,
+        nonce: TransactionNonce,
+        contract_address: ContractAddress,
+        calldata: Vec<CallParam>,
+    ) -> Result<reply::add_transaction::InvokeResponse, SequencerError> {
+        self.as_ref()
+            .add_invoke_transaction(
+                version,
+                max_fee,
+                signature,
+                nonce,
+                contract_address,
+                calldata,
+            )
+            .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn add_declare_transaction(
+        &self,
+        version: TransactionVersion,
+        max_fee: Fee,
+        signature: Vec<TransactionSignatureElem>,
+        nonce: TransactionNonce,
+        contract_definition: ContractDefinition,
+        sender_address: ContractAddress,
+        compiled_class_hash: Option<CasmHash>,
+        token: Option<String>,
+    ) -> Result<reply::add_transaction::DeclareResponse, SequencerError> {
+        self.as_ref()
+            .add_declare_transaction(
+                version,
+                max_fee,
+                signature,
+                nonce,
+                contract_definition,
+                sender_address,
+                compiled_class_hash,
+                token,
+            )
+            .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn add_deploy_account(
+        &self,
+        version: TransactionVersion,
+        max_fee: Fee,
+        signature: Vec<TransactionSignatureElem>,
+        nonce: TransactionNonce,
+        contract_address_salt: ContractAddressSalt,
+        class_hash: ClassHash,
+        calldata: Vec<CallParam>,
+    ) -> Result<reply::add_transaction::DeployAccountResponse, SequencerError> {
+        self.as_ref()
+            .add_deploy_account(
+                version,
+                max_fee,
+                signature,
+                nonce,
+                contract_address_salt,
+                class_hash,
+                calldata,
+            )
+            .await
+    }
+}
+
 /// Starknet sequencer client using REST API.
 ///
 /// Retry is performed on __all__ types of errors __except for__

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -128,7 +128,7 @@ pub async fn poll_pending(
                     gateway_copy
                         .state_update(BlockId::Pending)
                         .await
-                        .context("Downloading pending block")
+                        .context("Downloading state update block")
                 });
             }
         }

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -178,7 +178,18 @@ mod tests {
             status: Status::Pending,
             timestamp: BlockTimestamp::new_or_panic(20),
             transaction_receipts: Vec::new(),
-            transactions: Vec::new(),
+            transactions: vec![
+                starknet_gateway_types::reply::transaction::Transaction::L1Handler(
+                    L1HandlerTransaction {
+                        contract_address: ContractAddress::new_or_panic(felt!("0x1")),
+                        entry_point_selector: EntryPoint(felt!("0x55")),
+                        nonce: TransactionNonce(felt!("0x2")),
+                        calldata: Vec::new(),
+                        transaction_hash: TransactionHash(felt!("0x22")),
+                        version: TransactionVersion::ONE,
+                    },
+                )
+            ],
             starknet_version: StarknetVersion::default(),
         };
     );


### PR DESCRIPTION
This PR ignores inconsistent pending data from the gateway.

The gateway can emit inconsistent pending data, which we are in-turn currently passing onto our users. This occurs because the gateway has multiple feeder servers which store independent cached copies of the pending state which are not synchronized. This does not affect non-pending data as that is backed by a single database.

This PR works-around this by ensuring that only monotonically increasing pending data is emitted. i.e. only emit pending data if there are more transactions than before. Currently it is possible that pending calls will contain less txs than the call before.

~~I'm still trying to figure out how to test this with the mock.~~

-- edit -- 
I've refactored it entirely to separate the state update and block downloading entirely. While its still not great, I think its easier to reason about.

Unfortunately a side effect was requiring clone which added some mock complexity.