### PR TITLE
fix(rpc): gateway errors are not passed through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - some cairo 0 classes are not downloaded which can cause execution methods to fail
   - this bug was introduced in v0.6.4 and requires a resync to fix
+- gateway error messages are not passed through for `add_xxx_transaction` methods
 
 ## [0.6.6] - 2023-07-10
 

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -38,6 +38,8 @@ pub enum RpcError {
     #[error("Too many keys provided in a filter")]
     TooManyKeysInFilter { limit: usize, requested: usize },
     #[error(transparent)]
+    GatewayError(starknet_gateway_types::error::StarknetError),
+    #[error(transparent)]
     Internal(anyhow::Error),
 }
 
@@ -59,7 +61,9 @@ impl RpcError {
             RpcError::ContractError => 40,
             RpcError::InvalidContractClass => 50,
             RpcError::ProofLimitExceeded { .. } => 10000,
-            RpcError::Internal(_) => jsonrpsee::types::error::ErrorCode::InternalError.code(),
+            RpcError::GatewayError(_) | RpcError::Internal(_) => {
+                jsonrpsee::types::error::ErrorCode::InternalError.code()
+            }
         }
     }
 }


### PR DESCRIPTION
This PR includes the `anyhow` backtrace in the internal RPC error message.

Previousl we used `#[error(transparent)]` which forwards to anyhow's display impl - which in turn exludes the error's backtrace. This led to somewhat useless error messages.

Closes #1211.