### PR TITLE
feat: estimate message fee schema changes

### DIFF
--- a/crates/rpc/src/context.rs
+++ b/crates/rpc/src/context.rs
@@ -15,6 +15,7 @@ pub enum RpcVersion {
     V01,
     V02,
     V03,
+    V04,
 }
 
 impl RpcVersion {
@@ -23,6 +24,7 @@ impl RpcVersion {
             "v0.1" => Self::V01,
             "v0.2" => Self::V02,
             "v0.3" => Self::V03,
+            "v0.4" => Self::V04,
             _ => Self::default(),
         }
     }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -12,6 +12,7 @@ mod pathfinder;
 pub mod test_client;
 pub mod v02;
 pub mod v03;
+pub mod v04;
 pub mod websocket;
 
 use crate::metrics::logger::{MaybeRpcMetricsLogger, RpcMetricsLogger};

--- a/crates/rpc/src/middleware/versioning.rs
+++ b/crates/rpc/src/middleware/versioning.rs
@@ -45,6 +45,7 @@ pub(crate) async fn prefix_rpc_method_names_with_version(
         // that's why we have to account for those separately.
         "/rpc/v0.2" | "/rpc/v0.2/" => &[("starknet_", "v0.2_"), ("pathfinder_", "v0.2_")][..],
         "/" | "/rpc/v0.3" | "/rpc/v0.3/" => &[("starknet_", "v0.3_"), ("pathfinder_", "v0.3_")][..],
+        "/rpc/v0.4" | "/rpc/v0.4/" => &[("starknet_", "v0.4_"), ("pathfinder_", "v0.4_")][..],
         "/rpc/pathfinder/v0.1" | "/rpc/pathfinder/v0.1/" => &[("pathfinder_", "v0.1_")][..],
         _ => {
             return Err(BoxError::from(VersioningError::InvalidPath));

--- a/crates/rpc/src/v03/method.rs
+++ b/crates/rpc/src/v03/method.rs
@@ -4,10 +4,10 @@ mod get_events;
 mod get_state_update;
 pub(crate) mod simulate_transaction;
 
-pub(super) use estimate_fee::estimate_fee;
+pub(crate) use estimate_fee::estimate_fee;
 pub(crate) use estimate_message_fee::estimate_message_fee;
-pub(super) use get_events::get_events;
-pub(super) use get_state_update::get_state_update;
+pub(crate) use get_events::get_events;
+pub(crate) use get_state_update::get_state_update;
 pub(crate) use simulate_transaction::simulate_transaction;
 
 pub(crate) mod common {

--- a/crates/rpc/src/v03/method/estimate_message_fee.rs
+++ b/crates/rpc/src/v03/method/estimate_message_fee.rs
@@ -9,9 +9,9 @@ use super::common::prepare_handle_and_block;
 
 #[derive(Deserialize, Debug, PartialEq, Eq)]
 pub struct EstimateMessageFeeInput {
-    message: FunctionCall,
-    sender_address: EthereumAddress,
-    block_id: BlockId,
+    pub message: FunctionCall,
+    pub sender_address: EthereumAddress,
+    pub block_id: BlockId,
 }
 
 crate::error::generate_rpc_error_subset!(

--- a/crates/rpc/src/v04.rs
+++ b/crates/rpc/src/v04.rs
@@ -1,0 +1,88 @@
+use crate::module::Module;
+
+use crate::v02::method as v02_method;
+use crate::v03::method as v03_method;
+
+/// Registers all methods for the v0.3 RPC API
+pub fn register_methods(module: Module) -> anyhow::Result<Module> {
+    let module = module
+        // Reused from v0.2
+        .register_method(
+            "v0.4_starknet_addDeclareTransaction",
+            v02_method::add_declare_transaction,
+        )?
+        .register_method(
+            "v0.4_starknet_addDeployAccountTransaction",
+            v02_method::add_deploy_account_transaction,
+        )?
+        .register_method(
+            "v0.4_starknet_addInvokeTransaction",
+            v02_method::add_invoke_transaction,
+        )?
+        .register_method_with_no_input(
+            "v0.4_starknet_blockHashAndNumber",
+            v02_method::block_hash_and_number,
+        )?
+        .register_method_with_no_input("v0.4_starknet_blockNumber", v02_method::block_number)?
+        .register_method("v0.4_starknet_call", v02_method::call)?
+        .register_method_with_no_input("v0.4_starknet_chainId", v02_method::chain_id)?
+        .register_method("v0.4_starknet_estimateFee", v03_method::estimate_fee)?
+        .register_method(
+            "v0.4_starknet_getBlockWithTxHashes",
+            v02_method::get_block_with_tx_hashes,
+        )?
+        .register_method(
+            "v0.4_starknet_getBlockWithTxs",
+            v02_method::get_block_with_txs,
+        )?
+        .register_method(
+            "v0.4_starknet_getBlockTransactionCount",
+            v02_method::get_block_transaction_count,
+        )?
+        .register_method("v0.4_starknet_getClass", v02_method::get_class)?
+        .register_method("v0.4_starknet_getClassAt", v02_method::get_class_at)?
+        .register_method(
+            "v0.4_starknet_getClassHashAt",
+            v02_method::get_class_hash_at,
+        )?
+        .register_method("v0.4_starknet_getNonce", v02_method::get_nonce)?
+        .register_method("v0.4_starknet_getStorageAt", v02_method::get_storage_at)?
+        .register_method(
+            "v0.4_starknet_getTransactionByBlockIdAndIndex",
+            v02_method::get_transaction_by_block_id_and_index,
+        )?
+        .register_method(
+            "v0.4_starknet_getTransactionByHash",
+            v02_method::get_transaction_by_hash,
+        )?
+        .register_method(
+            "v0.4_starknet_getTransactionReceipt",
+            v02_method::get_transaction_receipt,
+        )?
+        .register_method_with_no_input(
+            "v0.4_starknet_pendingTransactions",
+            v02_method::pending_transactions,
+        )?
+        .register_method_with_no_input("v0.4_starknet_syncing", v02_method::syncing)?
+        // Specific implementations for v0.3
+        .register_method("v0.4_starknet_getEvents", v03_method::get_events)?
+        .register_method("v0.4_starknet_getStateUpdate", v03_method::get_state_update)?
+        .register_method(
+            "v0.4_starknet_simulateTransaction",
+            v03_method::simulate_transaction,
+        )?
+        .register_method(
+            "v0.4_starknet_estimateMessageFee",
+            v03_method::estimate_message_fee,
+        )?
+        .register_method(
+            "v0.4_pathfinder_getProof",
+            crate::pathfinder::methods::get_proof,
+        )?
+        .register_method(
+            "v0.4_pathfinder_getTransactionStatus",
+            crate::pathfinder::methods::get_transaction_status,
+        )?;
+
+    Ok(module)
+}

--- a/crates/rpc/src/v04.rs
+++ b/crates/rpc/src/v04.rs
@@ -1,7 +1,10 @@
 use crate::module::Module;
 
+mod method;
+
 use crate::v02::method as v02_method;
 use crate::v03::method as v03_method;
+use crate::v04::method as v04_method;
 
 /// Registers all methods for the v0.3 RPC API
 pub fn register_methods(module: Module) -> anyhow::Result<Module> {
@@ -72,16 +75,17 @@ pub fn register_methods(module: Module) -> anyhow::Result<Module> {
             v03_method::simulate_transaction,
         )?
         .register_method(
-            "v0.4_starknet_estimateMessageFee",
-            v03_method::estimate_message_fee,
-        )?
-        .register_method(
             "v0.4_pathfinder_getProof",
             crate::pathfinder::methods::get_proof,
         )?
         .register_method(
             "v0.4_pathfinder_getTransactionStatus",
             crate::pathfinder::methods::get_transaction_status,
+        )?
+        // Specific v0.4 implementations
+        .register_method(
+            "v0.4_starknet_estimateMessageFee",
+            v04_method::estimate_message_fee,
         )?;
 
     Ok(module)

--- a/crates/rpc/src/v04/method.rs
+++ b/crates/rpc/src/v04/method.rs
@@ -1,0 +1,3 @@
+pub(super) mod estimate_message_fee;
+
+pub(super) use estimate_message_fee::estimate_message_fee;

--- a/crates/rpc/src/v04/method/estimate_message_fee.rs
+++ b/crates/rpc/src/v04/method/estimate_message_fee.rs
@@ -1,0 +1,37 @@
+use pathfinder_common::{BlockId, CallParam, ContractAddress, EntryPoint, EthereumAddress};
+
+use crate::context::RpcContext;
+use crate::v02::method::call::FunctionCall;
+use crate::v02::types::reply::FeeEstimate;
+use crate::v03::method::estimate_message_fee::EstimateMessageFeeError;
+
+#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+pub struct EstimateMessageFeeInput {
+    message: MsgFromL1,
+    block_id: BlockId,
+}
+
+#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+pub struct MsgFromL1 {
+    pub from_address: EthereumAddress,
+    pub to_address: ContractAddress,
+    pub entry_point_selector: EntryPoint,
+    pub payload: Vec<CallParam>,
+}
+
+pub async fn estimate_message_fee(
+    context: RpcContext,
+    input: EstimateMessageFeeInput,
+) -> Result<FeeEstimate, EstimateMessageFeeError> {
+    let input = crate::v03::method::estimate_message_fee::EstimateMessageFeeInput {
+        message: FunctionCall {
+            contract_address: input.message.to_address,
+            entry_point_selector: input.message.entry_point_selector,
+            calldata: input.message.payload,
+        },
+        sender_address: input.message.from_address,
+        block_id: input.block_id,
+    };
+
+    crate::v03::method::estimate_message_fee(context, input).await
+}


### PR DESCRIPTION
This PR bootstraps initial v0.4 RPC support and updates `starknet_estimateMessageFee` to match the latest schema.

I've bootstrapepd v0.4 support by just copying across the v0.3 methods. 

`starknet_estimateMessageFee` is split into v0.3 and v0.4 by mapping the latters input changes to the formers. 