### PR TITLE
fix: system updates are not stored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- system contract updates are not correctly stored
+
 ## [0.6.7] - 2023-07-17
 
 ### Fixed

--- a/crates/storage/src/schema.rs
+++ b/crates/storage/src/schema.rs
@@ -5,6 +5,7 @@ mod revision_0032;
 mod revision_0033;
 mod revision_0034;
 mod revision_0035;
+mod revision_0036;
 
 pub(crate) use base::base_schema;
 
@@ -19,6 +20,7 @@ pub fn migrations() -> &'static [MigrationFn] {
         revision_0033::migrate,
         revision_0034::migrate,
         revision_0035::migrate,
+        revision_0036::migrate,
     ]
 }
 

--- a/crates/storage/src/schema/revision_0036.rs
+++ b/crates/storage/src/schema/revision_0036.rs
@@ -1,0 +1,50 @@
+use anyhow::Context;
+use pathfinder_common::{ContractAddress, StorageValue};
+use stark_hash::Felt;
+
+use crate::params::{params, RowExt};
+
+/// This migration adds the system contract updates which were mistakenly never inserted.
+///
+/// Thankfully we can avoid looking these values up in the state trie as the values can
+/// be entirely determined from past blocks.
+///
+/// Each block, the system contract at 0x1 gets a new storage item referencing the block number
+/// and hash from 10 blocks in the past.
+///     key   = block number
+///     value = block hash
+pub(crate) fn migrate(tx: &rusqlite::Transaction<'_>) -> anyhow::Result<()> {
+    let mut select = tx
+        .prepare_cached(
+            r"SELECT current.number, past.number, past.hash FROM starknet_blocks current
+    JOIN starknet_versions ON current.version_id = starknet_versions.id 
+    JOIN starknet_blocks past ON current.number - 10 = past.number
+    WHERE starknet_versions.version = '0.12.0'",
+        )
+        .context("Preparing select statement")?;
+
+    let rows = select.query_map([], |row| {
+        let current = row.get_block_number(0)?;
+        let past = row.get_block_number(1)?;
+        let hash = row.get_block_hash(2)?;
+
+        Ok((current, past, hash))
+    })?;
+
+    let mut insert = tx.prepare_cached(
+        "INSERT INTO storage_updates (block_number, contract_address, storage_address, storage_value) VALUES (?, ?, ?, ?)"
+    )
+    .context("Preparing insert statement")?;
+
+    for result in rows {
+        let (current, past, hash) = result?;
+
+        let past = StorageValue(Felt::from(past.get()));
+
+        insert
+            .execute(params![&current, &ContractAddress::ONE, &past, &hash])
+            .context("Inserting storage update")?;
+    }
+
+    Ok(())
+}

--- a/py/src/pathfinder_worker/call.py
+++ b/py/src/pathfinder_worker/call.py
@@ -111,7 +111,7 @@ except ModuleNotFoundError:
 
 
 # used from tests, and the query which asserts that the schema is of expected version.
-EXPECTED_SCHEMA_REVISION = 35
+EXPECTED_SCHEMA_REVISION = 36
 EXPECTED_CAIRO_VERSION = "0.12.0"
 
 # this is set by pathfinder automatically when #[cfg(debug_assertions)]


### PR DESCRIPTION
This PR fixes system storage updates not being stored.

The state update refactor separated the system contract updates from the user contract storage updates. I forgot to change the storage method which inserts state updates to handle this correctly.

This PR:

1. fixes the state update insert method
2. adds a migration to re-insert the missing updates

(2) relies on the fact that only a single system contract exists and is well-defined ito storage values. It also implicitly relies on the fact that we will require another release before another system contract is released i.e. users should not be able to continue running without upgrading before another system contract is 