### PR TITLE
Fix `starknet_simulateTransaction` for transactions sending L2->L1 message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - system contract updates are not correctly stored
+- `starknet_simulateTransaction` fails for transactions sending L2->L1 messages
 
 ### Changed
 

--- a/crates/rpc/fixtures/ext_py/tx_traces.json
+++ b/crates/rpc/fixtures/ext_py/tx_traces.json
@@ -1,165 +1,176 @@
 [
     {
-      "fee_estimation": {
-        "gas_consumed": "0x1365",
-        "gas_price": "0x598ec8f684",
-        "overall_fee": "0x6c8ee3f950e14"
-      },
-      "trace": {
-        "function_invocation": {
-          "messages": [],
-          "caller_address": "0x0",
-          "events": [],
-          "class_hash": "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
-          "internal_calls": [
-            {
-              "messages": [],
-              "caller_address": "0x0",
-              "events": [
-                {
-                  "order": 1,
-                  "keys": [
-                    "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
-                  ],
-                  "data": [
-                    "0x4705945f0a755c6ca0df850d274f2cf55872e1ce6cb3c26d992a3f5c8680d2e",
-                    "0x1",
-                    "0x1"
-                  ]
-                }
-              ],
-              "class_hash": "0x33434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2",
-              "internal_calls": [
-                {
-                  "messages": [],
-                  "caller_address": "0x398e624a0f1d7d45050e3ddeee9f79604a7a6929d651ed4b01bc64cdfafc6af",
-                  "events": [],
-                  "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
-                  "internal_calls": [
+        "fee_estimation": {
+            "gas_consumed": "0x1365",
+            "gas_price": "0x598ec8f684",
+            "overall_fee": "0x6c8ee3f950e14"
+        },
+        "trace": {
+            "function_invocation": {
+                "messages": [],
+                "caller_address": "0x0",
+                "events": [],
+                "class_hash": "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+                "internal_calls": [
                     {
-                      "messages": [],
-                      "caller_address": "0x398e624a0f1d7d45050e3ddeee9f79604a7a6929d651ed4b01bc64cdfafc6af",
-                      "events": [
-                        {
-                          "order": 0,
-                          "keys": [
-                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
-                          ],
-                          "data": [
-                            "0x398e624a0f1d7d45050e3ddeee9f79604a7a6929d651ed4b01bc64cdfafc6af",
+                        "messages": [],
+                        "caller_address": "0x0",
+                        "events": [
+                            {
+                                "order": 1,
+                                "keys": [
+                                    "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+                                ],
+                                "data": [
+                                    "0x4705945f0a755c6ca0df850d274f2cf55872e1ce6cb3c26d992a3f5c8680d2e",
+                                    "0x1",
+                                    "0x1"
+                                ]
+                            }
+                        ],
+                        "class_hash": "0x33434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2",
+                        "internal_calls": [
+                            {
+                                "messages": [],
+                                "caller_address": "0x398e624a0f1d7d45050e3ddeee9f79604a7a6929d651ed4b01bc64cdfafc6af",
+                                "events": [],
+                                "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                                "internal_calls": [
+                                    {
+                                        "messages": [
+                                            {
+                                                "payload": [
+                                                    "0x0",
+                                                    "0x81cba20f97d0be71da41df73fca3dd7186fe84e4",
+                                                    "0x6a94d74f430000",
+                                                    "0x0"
+                                                ],
+                                                "to_address": "0xae0Ee0A63A2cE6BaeEFFE56e7714FB4EFE48D419",
+                                                "order": 0
+                                            }
+                                        ],
+                                        "caller_address": "0x398e624a0f1d7d45050e3ddeee9f79604a7a6929d651ed4b01bc64cdfafc6af",
+                                        "events": [
+                                            {
+                                                "order": 0,
+                                                "keys": [
+                                                    "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                                                ],
+                                                "data": [
+                                                    "0x398e624a0f1d7d45050e3ddeee9f79604a7a6929d651ed4b01bc64cdfafc6af",
+                                                    "0x13894c2403b65bc92804020e483ad34e6460a57ceb53b3133bdfd07923258c7",
+                                                    "0xb1a2bc2ec50000",
+                                                    "0x0"
+                                                ]
+                                            }
+                                        ],
+                                        "class_hash": "0x2760f25d5a4fb2bdde5f561fd0b44a3dee78c28903577d37d669939d97036a0",
+                                        "internal_calls": [],
+                                        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                                        "execution_resources": {
+                                            "n_memory_holes": 42,
+                                            "n_steps": 526,
+                                            "builtin_instance_counter": {
+                                                "pedersen_builtin": 4,
+                                                "range_check_builtin": 21
+                                            }
+                                        },
+                                        "call_type": "DELEGATE",
+                                        "entry_point_type": "EXTERNAL",
+                                        "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                                        "calldata": [
+                                            "0x13894c2403b65bc92804020e483ad34e6460a57ceb53b3133bdfd07923258c7",
+                                            "0xb1a2bc2ec50000",
+                                            "0x0"
+                                        ],
+                                        "result": [
+                                            "0x1"
+                                        ]
+                                    }
+                                ],
+                                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                                "execution_resources": {
+                                    "n_memory_holes": 42,
+                                    "n_steps": 586,
+                                    "builtin_instance_counter": {
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 21
+                                    }
+                                },
+                                "call_type": "CALL",
+                                "entry_point_type": "EXTERNAL",
+                                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                                "calldata": [
+                                    "0x13894c2403b65bc92804020e483ad34e6460a57ceb53b3133bdfd07923258c7",
+                                    "0xb1a2bc2ec50000",
+                                    "0x0"
+                                ],
+                                "result": [
+                                    "0x1"
+                                ]
+                            }
+                        ],
+                        "contract_address": "0x398e624a0f1d7d45050e3ddeee9f79604a7a6929d651ed4b01bc64cdfafc6af",
+                        "execution_resources": {
+                            "n_memory_holes": 45,
+                            "n_steps": 805,
+                            "builtin_instance_counter": {
+                                "pedersen_builtin": 4,
+                                "range_check_builtin": 24
+                            }
+                        },
+                        "call_type": "DELEGATE",
+                        "entry_point_type": "EXTERNAL",
+                        "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                        "calldata": [
+                            "0x1",
+                            "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                            "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                            "0x0",
+                            "0x3",
+                            "0x3",
                             "0x13894c2403b65bc92804020e483ad34e6460a57ceb53b3133bdfd07923258c7",
                             "0xb1a2bc2ec50000",
                             "0x0"
-                          ]
-                        }
-                      ],
-                      "class_hash": "0x2760f25d5a4fb2bdde5f561fd0b44a3dee78c28903577d37d669939d97036a0",
-                      "internal_calls": [],
-                      "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-                      "execution_resources": {
-                        "n_memory_holes": 42,
-                        "n_steps": 526,
-                        "builtin_instance_counter": {
-                          "pedersen_builtin": 4,
-                          "range_check_builtin": 21
-                        }
-                      },
-                      "call_type": "DELEGATE",
-                      "entry_point_type": "EXTERNAL",
-                      "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
-                      "calldata": [
-                        "0x13894c2403b65bc92804020e483ad34e6460a57ceb53b3133bdfd07923258c7",
-                        "0xb1a2bc2ec50000",
-                        "0x0"
-                      ],
-                      "result": [
-                        "0x1"
-                      ]
+                        ],
+                        "result": [
+                            "0x1"
+                        ]
                     }
-                  ],
-                  "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-                  "execution_resources": {
-                    "n_memory_holes": 42,
-                    "n_steps": 586,
+                ],
+                "contract_address": "0x398e624a0f1d7d45050e3ddeee9f79604a7a6929d651ed4b01bc64cdfafc6af",
+                "execution_resources": {
+                    "n_memory_holes": 45,
+                    "n_steps": 865,
                     "builtin_instance_counter": {
-                      "pedersen_builtin": 4,
-                      "range_check_builtin": 21
+                        "pedersen_builtin": 4,
+                        "range_check_builtin": 24
                     }
-                  },
-                  "call_type": "CALL",
-                  "entry_point_type": "EXTERNAL",
-                  "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
-                  "calldata": [
+                },
+                "call_type": "CALL",
+                "entry_point_type": "EXTERNAL",
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                "calldata": [
+                    "0x1",
+                    "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                    "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                    "0x0",
+                    "0x3",
+                    "0x3",
                     "0x13894c2403b65bc92804020e483ad34e6460a57ceb53b3133bdfd07923258c7",
                     "0xb1a2bc2ec50000",
                     "0x0"
-                  ],
-                  "result": [
+                ],
+                "result": [
                     "0x1"
-                  ]
-                }
-              ],
-              "contract_address": "0x398e624a0f1d7d45050e3ddeee9f79604a7a6929d651ed4b01bc64cdfafc6af",
-              "execution_resources": {
-                "n_memory_holes": 45,
-                "n_steps": 805,
-                "builtin_instance_counter": {
-                  "pedersen_builtin": 4,
-                  "range_check_builtin": 24
-                }
-              },
-              "call_type": "DELEGATE",
-              "entry_point_type": "EXTERNAL",
-              "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
-              "calldata": [
-                "0x1",
-                "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-                "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
-                "0x0",
-                "0x3",
-                "0x3",
-                "0x13894c2403b65bc92804020e483ad34e6460a57ceb53b3133bdfd07923258c7",
-                "0xb1a2bc2ec50000",
-                "0x0"
-              ],
-              "result": [
-                "0x1"
-              ]
-            }
-          ],
-          "contract_address": "0x398e624a0f1d7d45050e3ddeee9f79604a7a6929d651ed4b01bc64cdfafc6af",
-          "execution_resources": {
-            "n_memory_holes": 45,
-            "n_steps": 865,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 4,
-              "range_check_builtin": 24
-            }
-          },
-          "call_type": "CALL",
-          "entry_point_type": "EXTERNAL",
-          "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
-          "calldata": [
-            "0x1",
-            "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-            "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
-            "0x0",
-            "0x3",
-            "0x3",
-            "0x13894c2403b65bc92804020e483ad34e6460a57ceb53b3133bdfd07923258c7",
-            "0xb1a2bc2ec50000",
-            "0x0"
-          ],
-          "result": [
-            "0x1"
-          ]
-        },
-        "signature": [
-          "0x7b91e638a4ff65401caa8dccc1db4c3577a4903bb492134951a98e4aeec2694",
-          "0x14ae9bca705396e80ac11db763b04f99744aa5423728cc1d8b633641d240959",
-          "0x724bd33f5e52ac0a0f53d277ba26b7270131d968a9ff4fe26a00007d1f2ea22",
-          "0x664e5ffb985db8cc34d66dc97602b4e81fbfbe81eda833d600b536a3d438ead"
-        ]
-      }
+                ]
+            },
+            "signature": [
+                "0x7b91e638a4ff65401caa8dccc1db4c3577a4903bb492134951a98e4aeec2694",
+                "0x14ae9bca705396e80ac11db763b04f99744aa5423728cc1d8b633641d240959",
+                "0x724bd33f5e52ac0a0f53d277ba26b7270131d968a9ff4fe26a00007d1f2ea22",
+                "0x664e5ffb985db8cc34d66dc97602b4e81fbfbe81eda833d600b536a3d438ead"
+            ]
+        }
     }
 ]

--- a/crates/rpc/src/cairo/ext_py/types.rs
+++ b/crates/rpc/src/cairo/ext_py/types.rs
@@ -4,7 +4,6 @@ use serde_with::serde_as;
 use stark_hash::Felt;
 
 use crate::felt::RpcFelt;
-use crate::v03::method::simulate_transaction::dto::{EntryPointType, MsgToL1};
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -63,6 +62,25 @@ pub struct FunctionInvocation {
     pub messages: Option<Vec<MsgToL1>>,
     #[serde(default)]
     pub result: Option<Vec<Felt>>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub enum EntryPointType {
+    #[serde(rename = "CONSTRUCTOR")]
+    Constructor,
+    #[serde(rename = "EXTERNAL")]
+    External,
+    #[serde(rename = "L1_HANDLER")]
+    L1Handler,
+}
+
+#[serde_with::serde_as]
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct MsgToL1 {
+    #[serde_as(as = "Vec<RpcFelt>")]
+    pub payload: Vec<Felt>,
+    #[serde_as(as = "RpcFelt")]
+    pub to_address: Felt,
 }
 
 #[serde_as]


### PR DESCRIPTION
Our type used to parse L2->L1 messages didn't match what the cairo-lang code in the Python subprocess was outputting: these message objects don't have a `from_address` property.

Unfortunately neither the test fixture we are using for testing deserialization nor the end-to-end test has any of these messages so we didn't have sufficient test coverage here.

I've added a single example message (from a real trace) to the JSON fixture.

Fixes #1225 