### PR TITLE
feat: suppport color output configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- control log color output via `--color auto|always|never`
+
 ### Fixed
 
 - system contract updates are not correctly stored

--- a/crates/gateway-types/Cargo.toml
+++ b/crates/gateway-types/Cargo.toml
@@ -19,7 +19,10 @@ primitive-types = "0.12.1"
 rand = { version = "0.8.5", optional = true }
 reqwest = "0.11.13"
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true, features = ["arbitrary_precision", "raw_value"] }
+serde_json = { workspace = true, features = [
+    "arbitrary_precision",
+    "raw_value",
+] }
 serde_with = { workspace = true }
 sha3 = "0.10"
 stark_hash = { path = "../stark_hash" }
@@ -30,5 +33,7 @@ tokio = { workspace = true }
 [dev-dependencies]
 assert_matches = { workspace = true }
 # Due to pathfinder_common::starkhash!() usage
+fake = { version = "2.5.0", features = ["derive"] }
+rand = { version = "0.8.5" }
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 tokio = { workspace = true, features = ["macros", "test-util"] }

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -3,7 +3,7 @@ name = "pathfinder"
 version = "0.6.7"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-rust-version = "1.65"
+rust-version = "1.70"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -51,7 +51,7 @@ time = { version = "0.3.20", features = ["macros"] }
 tokio = { workspace = true, features = ["process"] }
 toml = "0.5.9"
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3.16", features = ["env-filter", "time"] }
+tracing-subscriber = { version = "0.3.16", features = ["env-filter", "time", "ansi"] }
 url = "2.3.1"
 warp = "0.3.3"
 

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -141,6 +141,35 @@ Examples:
         env = "PATHFINDER_HEAD_POLL_INTERVAL_SECONDS"
     )]
     poll_interval: std::num::NonZeroU64,
+
+    #[arg(
+        long = "color",
+        long_help = "This flag controls when to use colors in the output logs.",
+        default_value = "auto",
+        env = "PATHFINDER_COLOR",
+        value_name = "WHEN"
+    )]
+    color: Color,
+}
+
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq)]
+pub enum Color {
+    Auto,
+    Never,
+    Always,
+}
+
+impl Color {
+    /// Returns true if color should be enabled, either because the setting is [Color::Always],
+    /// or because it is [Color::Auto] and stdout is targetting a terminal.
+    pub fn is_color_enabled(&self) -> bool {
+        use std::io::IsTerminal;
+        match self {
+            Color::Auto => std::io::stdout().is_terminal(),
+            Color::Never => false,
+            Color::Always => true,
+        }
+    }
 }
 
 #[derive(clap::Args)]
@@ -288,6 +317,7 @@ pub struct Config {
     pub sqlite_wal: JournalMode,
     pub max_rpc_connections: std::num::NonZeroU32,
     pub poll_interval: std::time::Duration,
+    pub color: Color,
 }
 
 pub struct WebSocket {
@@ -381,6 +411,7 @@ impl Config {
             },
             max_rpc_connections: cli.max_rpc_connections,
             poll_interval: std::time::Duration::from_secs(cli.poll_interval.get()),
+            color: cli.color,
         }
     }
 }


### PR DESCRIPTION
This PR adds configuration for tracing log color output.

Currently we always (afaict) output logs in color.

Adds the configuration option `--color = auto | always | never` where `auto` is the default. Technically this is a breaking change if we consider text color to be part of the guarantee - which I don't.

`auto` will output color if stdout is going to terminal, false otherwise.

For context here is what ripgrep does:

```
--color <WHEN>                           
    This flag controls when to use colors. The default setting is 'auto', which
    means ripgrep will try to guess when to use colors. For example, if ripgrep is
    printing to a terminal, then it will use colors, but if it is redirected to a
    file or a pipe, then it will suppress color output. ripgrep will suppress color
    output in some other circumstances as well. For example, if the TERM
    environment variable is not set or set to 'dumb', then ripgrep will not use
    colors.
    
    The possible values for this flag are:
    
        never    Colors will never be used.
        auto     The default. ripgrep tries to be smart.
        always   Colors will always be used regardless of where output is sent.
        ansi     Like 'always', but emits ANSI escapes (even in a Windows console).
    
    When the --vimgrep flag is given to ripgrep, then the default value for the
    --color flag changes to 'never'.
```

There are additional options one can pursue, but I'm not sure we need the complexity? There are environment variables one can / should maybe honour in addition to this e.g. `dumb` terminal setting etc. but I'm no expert here - wdyt? There is [supports_color](https://docs.rs/supports-color/latest/supports_color/) which appears to do some of what we want but maybe just checking `TERM == dumb` is better..

Then there is also the question of ansi color.. apparently that's also different? I'm not sure what the color output we were getting was? The `with_ansi(true)` setting requires the ansi feature flag which we didn't have before so it's unclear to me how / why we were getting colors.. unless its non-ansi colors? But I don't see how to enable / disable that then.

`is_terminal` also requires msrv 1.70.

Closes #1223 