### PR TITLE
feat: partial reverted txn support for v0.3 rpc

### DIFF
--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -609,26 +609,10 @@ pub mod test_utils {
                 execution_status: Default::default(),
                 revert_error: Default::default(),
             },
-            // Copy of the receipt[0] but reverted
+            // Reverted and without events
             Receipt {
                 actual_fee: None,
-                events: vec![
-                    Event {
-                        data: vec![],
-                        from_address: contract_address!("0xabcddddddd"),
-                        keys: vec![event_key_bytes!(b"pending key")],
-                    },
-                    Event {
-                        data: vec![],
-                        from_address: contract_address!("0xabcddddddd"),
-                        keys: vec![event_key_bytes!(b"pending key")],
-                    },
-                    Event {
-                        data: vec![],
-                        from_address: contract_address!("0xabcaaaaaaa"),
-                        keys: vec![event_key_bytes!(b"pending key 2")],
-                    },
-                ],
+                events: vec![],
                 execution_resources: Some(ExecutionResources {
                     builtin_instance_counter: BuiltinInstanceCounter::Empty(
                         EmptyBuiltinInstanceCounter {},
@@ -638,8 +622,8 @@ pub mod test_utils {
                 }),
                 l1_to_l2_consumed_message: None,
                 l2_to_l1_messages: vec![],
-                transaction_hash: transactions[0].hash(),
-                transaction_index: TransactionIndex::new_or_panic(0),
+                transaction_hash: transactions[2].hash(),
+                transaction_index: TransactionIndex::new_or_panic(2),
                 execution_status:
                     starknet_gateway_types::reply::transaction::ExecutionStatus::Reverted,
                 revert_error: Some("Reverted!".to_owned()),

--- a/crates/rpc/src/v02/method/get_block_transaction_count.rs
+++ b/crates/rpc/src/v02/method/get_block_transaction_count.rs
@@ -138,7 +138,7 @@ mod tests {
     async fn test_latest() {
         let context = RpcContext::for_tests();
         let block_id = BlockId::Latest;
-        check_count(context, block_id, 4).await;
+        check_count(context, block_id, 5).await;
     }
 
     #[tokio::test]

--- a/crates/rpc/src/v02/method/pending_transactions.rs
+++ b/crates/rpc/src/v02/method/pending_transactions.rs
@@ -48,9 +48,22 @@ mod tests {
             constructor_calldata: vec![],
         };
 
+        let tx2 = InvokeTransactionV0 {
+            common: CommonDeclareInvokeTransactionProperties {
+                hash: transaction_hash_bytes!(b"pending reverted"),
+                max_fee: crate::v02::types::request::Call::DEFAULT_MAX_FEE,
+                signature: vec![],
+                nonce: TransactionNonce::ZERO,
+            },
+            contract_address: contract_address_bytes!(b"pending contract addr 0"),
+            entry_point_selector: entry_point_bytes!(b"entry point 0"),
+            calldata: vec![],
+        };
+
         let expected = vec![
             Transaction::Invoke(InvokeTransaction::V0(tx0)),
             Transaction::Deploy(tx1),
+            Transaction::Invoke(InvokeTransaction::V0(tx2)),
         ];
 
         let context = RpcContext::for_tests_with_pending().await;


### PR DESCRIPTION
This PR adds support for reverted transactions in `starknet_getTransactionReceipt` and `pathfinder_getTransactionStatus`.

`starknet_getTransactionReceipt` throws an error for reverted transactions as it cannot represent them in the v0.3 RPC specification and this is the closest analogue to what currently occurs.

`pathfinder_getTransactionStatus` now checks the receipt for the reverted status and maps it accordingly.

Closes #1234 and #1232.