### PR TITLE
fix: receipt builtins are not parsed

### DIFF
--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -213,52 +213,23 @@ pub mod transaction {
     #[derive(Copy, Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq, Dummy)]
     #[serde(deny_unknown_fields)]
     pub struct ExecutionResources {
-        pub builtin_instance_counter: execution_resources::BuiltinInstanceCounter,
+        pub builtin_instance_counter: BuiltinCounters,
         pub n_steps: u64,
         pub n_memory_holes: u64,
     }
 
-    /// Types used when deserializing L2 execution resources related data.
-    pub mod execution_resources {
-        use fake::{Dummy, Fake, Faker};
-        use serde::{Deserialize, Serialize};
-
-        /// Sometimes `builtin_instance_counter` JSON object is returned empty.
-        #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-        #[serde(untagged)]
-        #[serde(deny_unknown_fields)]
-        pub enum BuiltinInstanceCounter {
-            Normal(NormalBuiltinInstanceCounter),
-            Empty(EmptyBuiltinInstanceCounter),
-        }
-
-        impl Default for BuiltinInstanceCounter {
-            fn default() -> Self {
-                Self::Normal(Default::default())
-            }
-        }
-
-        impl<T> Dummy<T> for BuiltinInstanceCounter {
-            fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &T, rng: &mut R) -> Self {
-                // We don't care about the other variant which was a patch
-                // over some old receipts missing this data
-                BuiltinInstanceCounter::Normal(Faker.fake_with_rng(rng))
-            }
-        }
-
-        #[derive(Copy, Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq, Dummy)]
-        #[serde(deny_unknown_fields)]
-        pub struct NormalBuiltinInstanceCounter {
-            pub bitwise_builtin: u64,
-            pub ecdsa_builtin: u64,
-            pub ec_op_builtin: u64,
-            pub output_builtin: u64,
-            pub pedersen_builtin: u64,
-            pub range_check_builtin: u64,
-        }
-
-        #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-        pub struct EmptyBuiltinInstanceCounter {}
+    #[derive(Copy, Clone, Default, Debug, Deserialize, Serialize, PartialEq, Eq, Dummy)]
+    #[serde(default)]
+    #[serde(deny_unknown_fields)]
+    pub struct BuiltinCounters {
+        pub output_builtin: u64,
+        pub pedersen_builtin: u64,
+        pub range_check_builtin: u64,
+        pub ecdsa_builtin: u64,
+        pub bitwise_builtin: u64,
+        pub ec_op_builtin: u64,
+        pub keccak_builtin: u64,
+        pub poseidon_builtin: u64,
     }
 
     /// Represents deserialized L1 to L2 message.

--- a/crates/pathfinder/src/p2p_network/client.rs
+++ b/crates/pathfinder/src/p2p_network/client.rs
@@ -322,16 +322,17 @@ pub mod conv {
                             execution_resources: Some(gw::ExecutionResources {
                                 builtin_instance_counter: {
                                     let b = common.execution_resources.builtin_instance_counter;
-                                    gw::execution_resources::BuiltinInstanceCounter::Normal(
-                                        gw::execution_resources::NormalBuiltinInstanceCounter {
-                                            bitwise_builtin: b.bitwise_builtin,
-                                            ecdsa_builtin: b.ecdsa_builtin,
-                                            ec_op_builtin: b.ec_op_builtin,
-                                            output_builtin: b.output_builtin,
-                                            pedersen_builtin: b.pedersen_builtin,
-                                            range_check_builtin: b.range_check_builtin,
-                                        },
-                                    )
+                                    gw::BuiltinCounters {
+                                        bitwise_builtin: b.bitwise_builtin,
+                                        ecdsa_builtin: b.ecdsa_builtin,
+                                        ec_op_builtin: b.ec_op_builtin,
+                                        output_builtin: b.output_builtin,
+                                        pedersen_builtin: b.pedersen_builtin,
+                                        range_check_builtin: b.range_check_builtin,
+                                        // FIXME once p2p has these builtins.
+                                        keccak_builtin: Default::default(),
+                                        poseidon_builtin: Default::default(),
+                                    }
                                 },
                                 n_steps: common.execution_resources.n_steps,
                                 n_memory_holes: common.execution_resources.n_memory_holes,

--- a/crates/pathfinder/src/p2p_network/sync_handlers.rs
+++ b/crates/pathfinder/src/p2p_network/sync_handlers.rs
@@ -295,12 +295,7 @@ mod conv {
                 }),
                 execution_resources: {
                     let x = gw_r.execution_resources.unwrap_or_default();
-                    let b = match x.builtin_instance_counter {
-                        gw::execution_resources::BuiltinInstanceCounter::Normal(n) => n,
-                        gw::execution_resources::BuiltinInstanceCounter::Empty(_) => {
-                            Default::default()
-                        }
-                    };
+                    let b = x.builtin_instance_counter;
                     ExecutionResources {
                         builtin_instance_counter: BuiltinInstanceCounter {
                             bitwise_builtin: b.bitwise_builtin,

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -175,7 +175,6 @@ pub mod test_utils {
     use starknet_gateway_types::{
         pending::PendingData,
         reply::transaction::{
-            execution_resources::{BuiltinInstanceCounter, EmptyBuiltinInstanceCounter},
             DeployTransaction, EntryPointType, ExecutionResources, InvokeTransaction,
             InvokeTransactionV0, Receipt, Transaction,
         },
@@ -388,9 +387,7 @@ pub mod test_utils {
             actual_fee: None,
             events: vec![],
             execution_resources: Some(ExecutionResources {
-                builtin_instance_counter: BuiltinInstanceCounter::Empty(
-                    EmptyBuiltinInstanceCounter {},
-                ),
+                builtin_instance_counter: Default::default(),
                 n_memory_holes: 0,
                 n_steps: 0,
             }),
@@ -555,9 +552,7 @@ pub mod test_utils {
                     },
                 ],
                 execution_resources: Some(ExecutionResources {
-                    builtin_instance_counter: BuiltinInstanceCounter::Empty(
-                        EmptyBuiltinInstanceCounter {},
-                    ),
+                    builtin_instance_counter: Default::default(),
                     n_memory_holes: 0,
                     n_steps: 0,
                 }),
@@ -572,9 +567,7 @@ pub mod test_utils {
                 actual_fee: None,
                 events: vec![],
                 execution_resources: Some(ExecutionResources {
-                    builtin_instance_counter: BuiltinInstanceCounter::Empty(
-                        EmptyBuiltinInstanceCounter {},
-                    ),
+                    builtin_instance_counter: Default::default(),
                     n_memory_holes: 0,
                     n_steps: 0,
                 }),

--- a/crates/storage/src/connection/event.rs
+++ b/crates/storage/src/connection/event.rs
@@ -775,10 +775,7 @@ mod tests {
                 actual_fee: None,
                 events: expected_events[..3].to_vec(),
                 execution_resources: Some(gateway_tx::ExecutionResources {
-                    builtin_instance_counter:
-                        gateway_tx::execution_resources::BuiltinInstanceCounter::Empty(
-                            gateway_tx::execution_resources::EmptyBuiltinInstanceCounter {},
-                        ),
+                    builtin_instance_counter: Default::default(),
                     n_steps: 0,
                     n_memory_holes: 0,
                 }),
@@ -793,10 +790,7 @@ mod tests {
                 actual_fee: None,
                 events: expected_events[3..].to_vec(),
                 execution_resources: Some(gateway_tx::ExecutionResources {
-                    builtin_instance_counter:
-                        gateway_tx::execution_resources::BuiltinInstanceCounter::Empty(
-                            gateway_tx::execution_resources::EmptyBuiltinInstanceCounter {},
-                        ),
+                    builtin_instance_counter: Default::default(),
                     n_steps: 0,
                     n_memory_holes: 0,
                 }),

--- a/crates/storage/src/test_utils.rs
+++ b/crates/storage/src/test_utils.rs
@@ -127,10 +127,7 @@ pub(crate) fn create_transactions_and_receipts(
                 vec![]
             },
             execution_resources: Some(transaction::ExecutionResources {
-                builtin_instance_counter:
-                    transaction::execution_resources::BuiltinInstanceCounter::Empty(
-                        transaction::execution_resources::EmptyBuiltinInstanceCounter {},
-                    ),
+                builtin_instance_counter: Default::default(),
                 n_steps: i as u64 + 987,
                 n_memory_holes: i as u64 + 1177,
             }),


### PR DESCRIPTION
Fixes builtin's not being correctly parsed.

I've opted to go with default to zero values, instead of options to represent the builtins. I'm happy to change this, but I think less remapping / indirection is better ergonomincally.

Closes #1237.
