### PR TITLE
Fall back to fetching CASM from feeder gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - control log color output via `--color auto|always|never`
+- if Sierra to CASM compilation fails we now fall back to fetching CASM from the gateway
 
 ### Fixed
 

--- a/crates/gateway-client/src/builder.rs
+++ b/crates/gateway-client/src/builder.rs
@@ -125,6 +125,7 @@ impl<'a> Request<'a, stage::Method> {
         add_transaction,
         get_block,
         get_class_by_hash,
+        get_compiled_class_by_class_hash,
         get_transaction,
         get_state_update,
         get_contract_addresses,

--- a/crates/pathfinder/src/state/sync/class.rs
+++ b/crates/pathfinder/src/state/sync/class.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use pathfinder_common::{Chain, ClassHash, SierraHash, StarknetVersion};
+use pathfinder_common::{ClassHash, SierraHash, StarknetVersion};
 use starknet_gateway_client::GatewayApi;
 
 pub enum DownloadedClass {
@@ -17,7 +17,6 @@ pub enum DownloadedClass {
 pub async fn download_class<SequencerClient: GatewayApi>(
     sequencer: &SequencerClient,
     class_hash: ClassHash,
-    chain: Chain,
     version: StarknetVersion,
 ) -> Result<DownloadedClass, anyhow::Error> {
     use starknet_gateway_types::class_hash::compute_class_hash;
@@ -28,52 +27,65 @@ pub async fn download_class<SequencerClient: GatewayApi>(
         .with_context(|| format!("Downloading class {}", class_hash.0))?
         .to_vec();
 
-    tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
-        let hash = compute_class_hash(&definition).context("Computing class hash")?;
+    let (hash, definition) = tokio::task::spawn_blocking(move || -> (anyhow::Result<_>, _) {
+        (
+            compute_class_hash(&definition).context("Computing class hash"),
+            definition,
+        )
+    })
+    .await?;
+    let hash = hash?;
 
-        use starknet_gateway_types::class_hash::ComputedClassHash;
-        match hash {
-            ComputedClassHash::Cairo(hash) => {
-                if class_hash != hash {
-                    tracing::warn!(expected=%class_hash, computed=%hash, "Cairo 0 class hash mismatch");
-                }
-
-                Ok(DownloadedClass::Cairo {
-                    definition,
-                    hash,
-                })
+    use starknet_gateway_types::class_hash::ComputedClassHash;
+    match hash {
+        ComputedClassHash::Cairo(hash) => {
+            if class_hash != hash {
+                tracing::warn!(expected=%class_hash, computed=%hash, "Cairo 0 class hash mismatch");
             }
-            starknet_gateway_types::class_hash::ComputedClassHash::Sierra(hash) => {
-                anyhow::ensure!(
-                    class_hash == hash,
-                    "Class hash mismatch, {} instead of {}",
-                    hash,
-                    class_hash.0
-                );
 
-                // FIXME(integration reset): work-around for integration containing Sierra classes
-                // that are incompatible with production compiler. This will get "fixed" in the future
-                // by resetting integration to remove these classes at which point we can revert this.
-                //
-                // The work-around ignores compilation errors on integration, and instead replaces the
-                // casm definition with empty bytes.
-                let casm_definition = crate::sierra::compile_to_casm(&definition, &version)
-                    .context("Compiling Sierra class");
-                let casm_definition = match (casm_definition, chain) {
-                    (Ok(casm_definition), _) => casm_definition,
-                    (Err(_), Chain::Integration) => {
-                        tracing::info!(class_hash=%hash, "Ignored CASM compilation failure integration network");
-                        Vec::new()
-                    }
-                    (Err(e), _) => return Err(e),
-                };
-
-                Ok(DownloadedClass::Sierra {
-                    sierra_definition: definition,
-                    sierra_hash: SierraHash(hash.0),
-                    casm_definition,
-                }                )
-            }
+            Ok(DownloadedClass::Cairo { definition, hash })
         }
-    }).await.context("Joining class processing task")?
+        starknet_gateway_types::class_hash::ComputedClassHash::Sierra(hash) => {
+            anyhow::ensure!(
+                class_hash == hash,
+                "Class hash mismatch, {} instead of {}",
+                hash,
+                class_hash.0
+            );
+
+            // FIXME(integration reset): work-around for integration containing Sierra classes
+            // that are incompatible with production compiler. This will get "fixed" in the future
+            // by resetting integration to remove these classes at which point we can revert this.
+            //
+            // The work-around ignores compilation errors on integration, and instead replaces the
+            // casm definition with empty bytes.
+            let (casm_definition, sierra_definition) =
+                tokio::task::spawn_blocking(move || -> (anyhow::Result<_>, _) {
+                    (
+                        crate::sierra::compile_to_casm(&definition, &version)
+                            .context("Compiling Sierra class"),
+                        definition,
+                    )
+                })
+                .await?;
+
+            let casm_definition = match casm_definition {
+                Ok(casm_definition) => casm_definition,
+                Err(error) => {
+                    tracing::info!(class_hash=%hash, ?error, "CASM compilation failed, falling back to fetching from gateway");
+                    sequencer
+                        .pending_casm_by_hash(class_hash)
+                        .await
+                        .with_context(|| format!("Downloading CASM {}", class_hash.0))?
+                        .to_vec()
+                }
+            };
+
+            Ok(DownloadedClass::Sierra {
+                sierra_definition,
+                sierra_hash: SierraHash(hash.0),
+                casm_definition,
+            })
+        }
+    }
 }

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -149,7 +149,6 @@ where
                                 sequencer.clone(),
                                 (head.1, head.2),
                                 interval,
-                                chain,
                                 storage.clone(),
                             )
                             .await
@@ -243,7 +242,6 @@ where
             &state_update,
             &sequencer,
             &tx_event,
-            chain,
             &block.starknet_version,
             storage.clone(),
         )
@@ -292,7 +290,6 @@ pub async fn download_new_classes(
     state_update: &StateUpdate,
     sequencer: &impl GatewayApi,
     tx_event: &mpsc::Sender<SyncEvent>,
-    chain: Chain,
     version: &StarknetVersion,
     storage: Storage,
 ) -> Result<(), anyhow::Error> {
@@ -346,7 +343,7 @@ pub async fn download_new_classes(
     .context("Querying database for missing classes")?;
 
     for class_hash in require_downloading {
-        let class = download_class(sequencer, class_hash, chain, version.clone())
+        let class = download_class(sequencer, class_hash, version.clone())
             .await
             .with_context(|| format!("Downloading class {}", class_hash.0))?;
 

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -1,4 +1,4 @@
-use pathfinder_common::{Chain, StateUpdate};
+use pathfinder_common::StateUpdate;
 use pathfinder_storage::Storage;
 use starknet_gateway_client::GatewayApi;
 use starknet_gateway_types::reply::MaybePendingBlock;
@@ -24,7 +24,6 @@ pub async fn poll_pending(
         pathfinder_common::StateCommitment,
     ),
     poll_interval: std::time::Duration,
-    chain: Chain,
     storage: Storage,
 ) -> anyhow::Result<(Option<Block>, Option<StateUpdate>)> {
     use anyhow::Context;
@@ -141,7 +140,6 @@ pub async fn poll_pending(
                 update.as_ref(),
                 &sequencer,
                 &tx_event,
-                chain,
                 &block.starknet_version,
                 storage.clone(),
             )
@@ -166,7 +164,7 @@ mod tests {
     use assert_matches::assert_matches;
     use pathfinder_common::macro_prelude::*;
     use pathfinder_common::{
-        BlockHash, BlockNumber, BlockTimestamp, Chain, GasPrice, StarknetVersion, StateCommitment,
+        BlockHash, BlockNumber, BlockTimestamp, GasPrice, StarknetVersion, StateCommitment,
         StateUpdate, TransactionVersion,
     };
     use pathfinder_storage::Storage;
@@ -244,7 +242,6 @@ mod tests {
                 sequencer,
                 (PARENT_HASH, PARENT_ROOT),
                 std::time::Duration::ZERO,
-                Chain::Testnet,
                 Storage::in_memory().unwrap(),
             )
             .await
@@ -285,7 +282,6 @@ mod tests {
                 sequencer,
                 (PARENT_HASH, PARENT_ROOT),
                 std::time::Duration::ZERO,
-                Chain::Testnet,
                 Storage::in_memory().unwrap(),
             )
             .await
@@ -321,7 +317,6 @@ mod tests {
                 sequencer,
                 (PARENT_HASH, PARENT_ROOT),
                 std::time::Duration::ZERO,
-                Chain::Testnet,
                 Storage::in_memory().unwrap(),
             )
             .await
@@ -357,7 +352,6 @@ mod tests {
                 sequencer,
                 (PARENT_HASH, PARENT_ROOT),
                 std::time::Duration::ZERO,
-                Chain::Testnet,
                 Storage::in_memory().unwrap(),
             )
             .await
@@ -389,7 +383,6 @@ mod tests {
                 sequencer,
                 (PARENT_HASH, PARENT_ROOT),
                 std::time::Duration::ZERO,
-                Chain::Testnet,
                 Storage::in_memory().unwrap(),
             )
             .await
@@ -468,7 +461,6 @@ mod tests {
                 sequencer,
                 (PARENT_HASH, PARENT_ROOT),
                 std::time::Duration::ZERO,
-                Chain::Testnet,
                 Storage::in_memory().unwrap(),
             )
             .await
@@ -535,7 +527,6 @@ mod tests {
                 sequencer,
                 (PARENT_HASH, PARENT_ROOT),
                 std::time::Duration::ZERO,
-                Chain::Testnet,
                 Storage::in_memory().unwrap(),
             )
             .await


### PR DESCRIPTION
In case of a Sierra to CASM compilation failure pathfinder now falls back to fetching the compiled class definition from the feeder gateway.

---------------------------

We've seen countless issues with the Sierra to CASM compiler in the past few weeks and have now found an incompatibility of cairo 2.0.2 with a class defined on Starknet 0.11.2 (using compiler 1.1.0). ([This class](https://testnet.starkscan.co/class/0x034807a4ea6dcdd18ff5cf577c4d8c62c87f0d58f1592605d2d33f168f2a7296).)

To make pathfinder sync operation more robust in the future this PR adds a fallback: if compilation fails we now fall back to just fetching the compiled CASM definition from the feeder gateway.
