### PR TITLE
ok on root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - control log color output via `--color auto|always|never`
 - if Sierra to CASM compilation fails we now fall back to fetching CASM from the gateway
-- RPC server health check on:
-  - `/` if the request body is empty
+- Negate bot spam on response metrics by returning `Ok(200)` on `/` RPC queries. Web crawlers and bots often poke this endpoint which previously skewed response failure metrics when these were rejected.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - control log color output via `--color auto|always|never`
 - if Sierra to CASM compilation fails we now fall back to fetching CASM from the gateway
+- RPC server health check on:
+  - `/` if the request body is empty
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3744,6 +3744,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "globset"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6537,6 +6543,7 @@ dependencies = [
  "pretty_assertions",
  "primitive-types",
  "reqwest",
+ "rstest",
  "serde",
  "serde_json",
  "serde_with",
@@ -7454,9 +7461,9 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de1bb486a691878cd320c2f0d319ba91eeaa2e894066d8b5f8f117c000e9d962"
+checksum = "2b96577ca10cb3eade7b337eb46520108a67ca2818a24d0b63f41fd62bc9651c"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7466,15 +7473,18 @@ dependencies = [
 
 [[package]]
 name = "rstest_macros"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8"
+checksum = "225e674cf31712b8bb15fdbca3ec0c1b9d825c5a24407ff2b7e005fb6a29ba03"
 dependencies = [
  "cfg-if",
+ "glob",
  "proc-macro2",
  "quote",
+ "regex",
+ "relative-path",
  "rustc_version",
- "syn 1.0.109",
+ "syn 2.0.26",
  "unicode-ident",
 ]
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,15 @@ Note that the pathfinder extension is versioned separately from the Starknet spe
 
 You can find the API specification [here](doc/rpc/pathfinder_rpc_api.json).
 
+### Health
+
+To check the health status of the RPC server without resorting to the [monitoring api](#monitoring-api) use the following endpoints:
+- `/` (root), provided that the request body is empty.
+
+A `200 OK` status is returned if the RPC server is healthy.
+
+Note that this method is HTTP verb agnostic.
+
 ## Monitoring API
 
 Pathfinder has a monitoring API which can be enabled with the `--monitor-address` configuration option.

--- a/README.md
+++ b/README.md
@@ -203,15 +203,6 @@ Note that the pathfinder extension is versioned separately from the Starknet spe
 
 You can find the API specification [here](doc/rpc/pathfinder_rpc_api.json).
 
-### Health
-
-To check the health status of the RPC server without resorting to the [monitoring api](#monitoring-api) use the following endpoints:
-- `/` (root), provided that the request body is empty.
-
-A `200 OK` status is returned if the RPC server is healthy.
-
-Note that this method is HTTP verb agnostic.
-
 ## Monitoring API
 
 Pathfinder has a monitoring API which can be enabled with the `--monitor-address` configuration option.

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -70,7 +70,7 @@ pretty_assertions = "1.3.0"
 proptest = "1.2.0"
 rand = "0.8"
 rand_chacha = "0.3.1"
-rstest = "0.17.0"
+rstest = "0.18.1"
 serde_with = { workspace = true }
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -45,6 +45,7 @@ jsonrpsee = { version = "0.16.2", default-features = false, features = ["async-c
 lazy_static = "1.4.0"
 pretty_assertions = "1.3.0"
 reqwest = { version = "0.11.13", features = ["json"] }
+rstest = "0.18.1"
 stark_hash = { path = "../stark_hash" }
 tempfile = "3.4"
 test-log = { version = "0.2.11", default-features = false, features = ["trace"] }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -91,12 +91,13 @@ impl RpcServer {
                 .option_layer(self.cors)
                 .map_result(middleware::versioning::try_map_errors_to_responses)
                 .filter_async(
-					|result: Request<Body>| async move {
+					|request: Request<Body>| async move {
 					// skip method_name checks for websocket handshake
-					if result.headers().get("sec-websocket-key").is_some() {
-						return Ok(result);
+					if request.headers().get("sec-websocket-key").is_some() {
+						return Ok(request);
 					}
-                    middleware::versioning::prefix_rpc_method_names_with_version(result, TEN_MB).await
+
+                    middleware::versioning::prefix_rpc_method_names_with_version(request, TEN_MB).await
                 })
             )
             .build(self.addr)

--- a/crates/rpc/src/middleware/versioning.rs
+++ b/crates/rpc/src/middleware/versioning.rs
@@ -53,14 +53,10 @@ pub(crate) async fn prefix_rpc_method_names_with_version(
     // makes it a different path from the original,
     // that's why we have to account for those separately.
     let prefixes = match path {
-        // Health check endpoints
+        // Special health check endpoint to satisfy bots
         // - we don't really care about the http method here
         // - root is treated as a health check endpoint **only if it has an empty body**
-        // - health ignores the body, which is **never** read
         "/" if body.is_end_stream() => {
-            return Err(BoxError::from(VersioningError::HealthCheck));
-        }
-        "/health" | "/health/" => {
             return Err(BoxError::from(VersioningError::HealthCheck));
         }
         // RPC endpoints
@@ -357,11 +353,6 @@ mod tests {
     // Root requires empty body to become health
     #[case("", "", 200, "")]
     #[case("/", "", 200, "")]
-    // Genuine health does not matter about the body
-    #[case("/health", "", 200, "")]
-    #[case("/health/", "", 200, "")]
-    #[case("/health", "body is ignored", 200, "")]
-    #[case("/health/", "body is ignored", 200, "")]
     #[tokio::test]
     async fn health_ignores_http_method(
         #[case] path: &str,

--- a/crates/rpc/src/middleware/versioning.rs
+++ b/crates/rpc/src/middleware/versioning.rs
@@ -215,7 +215,7 @@ mod response {
     pub(super) fn method_not_allowed() -> Response<Body> {
         with_body(
             StatusCode::METHOD_NOT_ALLOWED,
-            "Used HTTP Method is not allowed. POST or OPTIONS is required\n",
+            "Only POST or OPTIONS method is allowed\n",
         )
     }
 


### PR DESCRIPTION
Fixes #1218 

---------------------------

The rpc server now returns HTTP status 200 with an empty body on:
- `/` (root), only if the request body is empty,
- `/health`, regardless of the request body (which is not even read).
Http method is in those cases ignored just in case to maintain backward compatibility, as [chichi13](https://github.com/chichi13) you don't mention which http method is used by the bots.

An additional http method check has been added for valid RPC paths (including `/` with a non-empty request body) as I discovered we had a bug where one could for example send a GET request (with valid json) and receive a reply with an RPC error code instead of HTTP 405 (Method not allowed).