### PR TITLE
fix(gateway-types/receipt): add `segment_arena` builtin

### DIFF
--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -230,6 +230,7 @@ pub mod transaction {
         pub ec_op_builtin: u64,
         pub keccak_builtin: u64,
         pub poseidon_builtin: u64,
+        pub segment_arena_builtin: u64,
     }
 
     /// Represents deserialized L1 to L2 message.

--- a/crates/pathfinder/src/p2p_network/client.rs
+++ b/crates/pathfinder/src/p2p_network/client.rs
@@ -332,6 +332,7 @@ pub mod conv {
                                         // FIXME once p2p has these builtins.
                                         keccak_builtin: Default::default(),
                                         poseidon_builtin: Default::default(),
+                                        segment_arena_builtin: Default::default(),
                                     }
                                 },
                                 n_steps: common.execution_resources.n_steps,


### PR DESCRIPTION
For some reason this was not on the ALL_BUILTINS list in cairo-lang but still shows up in transaction receipt execution resources.
