### PR TITLE
feat: store transaction execution status

### DIFF
--- a/crates/storage/src/schema.rs
+++ b/crates/storage/src/schema.rs
@@ -6,6 +6,7 @@ mod revision_0033;
 mod revision_0034;
 mod revision_0035;
 mod revision_0036;
+mod revision_0037;
 
 pub(crate) use base::base_schema;
 
@@ -21,6 +22,7 @@ pub fn migrations() -> &'static [MigrationFn] {
         revision_0034::migrate,
         revision_0035::migrate,
         revision_0036::migrate,
+        revision_0037::migrate,
     ]
 }
 

--- a/crates/storage/src/schema/revision_0037.rs
+++ b/crates/storage/src/schema/revision_0037.rs
@@ -1,0 +1,19 @@
+use anyhow::Context;
+
+/// Adds the `execution_status` integer column to the `starknet_transactions` table. The column
+/// is an enum where existing rows get assigned 0 == SUCCESS, and reverted txns will get assigned 1
+/// for reverted.
+///
+/// Important to note that this was implemented before reverted txns were introduced i.e. all txns before
+/// this time were automatically succesful.
+pub(crate) fn migrate(tx: &rusqlite::Transaction<'_>) -> anyhow::Result<()> {
+    tx.execute(
+        r"
+ALTER TABLE starknet_transactions
+    ADD COLUMN execution_status INTEGER NOT NULL DEFAULT 0",
+        [],
+    )
+    .context("Adding execution_status column to transactions table")?;
+
+    Ok(())
+}

--- a/py/src/pathfinder_worker/call.py
+++ b/py/src/pathfinder_worker/call.py
@@ -111,7 +111,7 @@ except ModuleNotFoundError:
 
 
 # used from tests, and the query which asserts that the schema is of expected version.
-EXPECTED_SCHEMA_REVISION = 36
+EXPECTED_SCHEMA_REVISION = 37
 EXPECTED_CAIRO_VERSION = "0.12.1a0"
 
 # this is set by pathfinder automatically when #[cfg(debug_assertions)]


### PR DESCRIPTION
This PR stores a transaction's execution status as a separate column.

Starknet v0.12.1 introduces reverted transactions. We need to ignore reverted transactions for RPC v0.3 and therefore need this change to be able to filter them out.

The status is also still embedded in the compressed json that we store, and I elected not to change it during reads i.e. this column is currently only used to write into, and will only be used to filter on byt RPC methods.