### PR TITLE
feat(rpc): make gas price an U256

### DIFF
--- a/crates/rpc/src/cairo/ext_py/ser.rs
+++ b/crates/rpc/src/cairo/ext_py/ser.rs
@@ -27,8 +27,8 @@ pub(crate) enum ChildCommand<'a> {
         common: CommonProperties<'a>,
 
         // zero means use the gas price from the block.
-        #[serde_as(as = "&pathfinder_serde::H256AsHexStr")]
-        gas_price: &'a primitive_types::H256,
+        #[serde_as(as = "&pathfinder_serde::U256AsHexStr")]
+        gas_price: &'a primitive_types::U256,
         transactions: &'a [TransactionAndClassHashHint],
     },
     EstimateMsgFee {
@@ -36,8 +36,8 @@ pub(crate) enum ChildCommand<'a> {
         common: CommonProperties<'a>,
 
         // zero means use the gas price from the block.
-        #[serde_as(as = "&pathfinder_serde::H256AsHexStr")]
-        gas_price: &'a primitive_types::H256,
+        #[serde_as(as = "&pathfinder_serde::U256AsHexStr")]
+        gas_price: &'a primitive_types::U256,
 
         sender_address: EthereumAddress,
         contract_address: &'a ContractAddress,
@@ -49,8 +49,8 @@ pub(crate) enum ChildCommand<'a> {
         common: CommonProperties<'a>,
 
         // zero means use the gas price from the block.
-        #[serde_as(as = "&pathfinder_serde::H256AsHexStr")]
-        gas_price: &'a primitive_types::H256,
+        #[serde_as(as = "&pathfinder_serde::U256AsHexStr")]
+        gas_price: &'a primitive_types::U256,
         transactions: &'a [TransactionAndClassHashHint],
         skip_validate: &'a bool,
     },

--- a/crates/rpc/src/cairo/ext_py/types.rs
+++ b/crates/rpc/src/cairo/ext_py/types.rs
@@ -86,10 +86,10 @@ pub struct MsgToL1 {
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct FeeEstimate {
-    #[serde_as(as = "pathfinder_serde::H256AsHexStr")]
-    pub gas_consumed: primitive_types::H256,
-    #[serde_as(as = "pathfinder_serde::H256AsHexStr")]
-    pub gas_price: primitive_types::H256,
-    #[serde_as(as = "pathfinder_serde::H256AsHexStr")]
-    pub overall_fee: primitive_types::H256,
+    #[serde_as(as = "pathfinder_serde::U256AsHexStr")]
+    pub gas_consumed: primitive_types::U256,
+    #[serde_as(as = "pathfinder_serde::U256AsHexStr")]
+    pub gas_price: primitive_types::U256,
+    #[serde_as(as = "pathfinder_serde::U256AsHexStr")]
+    pub overall_fee: primitive_types::U256,
 }

--- a/crates/rpc/src/gas_price.rs
+++ b/crates/rpc/src/gas_price.rs
@@ -25,7 +25,7 @@ impl Cached {
 
     /// Returns either a fast fresh value, slower a periodically polled value or fails because
     /// polling has stopped.
-    pub async fn get(&self) -> Option<primitive_types::H256> {
+    pub async fn get(&self) -> Option<primitive_types::U256> {
         let mut rx = {
             let mut g = self.inner.lock().unwrap_or_else(|e| e.into_inner());
 
@@ -86,11 +86,7 @@ impl Cached {
 
                     let now = std::time::Instant::now();
 
-                    let gas_price = {
-                        let mut g = [0u8; 32];
-                        g[16..].copy_from_slice(&gas_price.0.to_be_bytes());
-                        primitive_types::H256::from_slice(&g)
-                    };
+                    let gas_price = gas_price.0.into();
 
                     let mut g = inner.lock().unwrap_or_else(|e| e.into_inner());
                     g.latest.replace((now, gas_price));
@@ -111,6 +107,6 @@ impl Cached {
 
 #[derive(Default)]
 struct Inner {
-    latest: Option<(std::time::Instant, primitive_types::H256)>,
-    next: std::sync::Weak<tokio::sync::broadcast::Sender<Option<primitive_types::H256>>>,
+    latest: Option<(std::time::Instant, primitive_types::U256)>,
+    next: std::sync::Weak<tokio::sync::broadcast::Sender<Option<primitive_types::U256>>>,
 }

--- a/crates/rpc/src/v02/types.rs
+++ b/crates/rpc/src/v02/types.rs
@@ -836,14 +836,14 @@ pub mod reply {
     #[serde(deny_unknown_fields)]
     pub struct FeeEstimate {
         /// The Ethereum gas cost of the transaction
-        #[serde_as(as = "pathfinder_serde::H256AsHexStr")]
-        pub gas_consumed: primitive_types::H256,
+        #[serde_as(as = "pathfinder_serde::U256AsHexStr")]
+        pub gas_consumed: primitive_types::U256,
         /// The gas price (in gwei) that was used in the cost estimation (input to fee estimation)
-        #[serde_as(as = "pathfinder_serde::H256AsHexStr")]
-        pub gas_price: primitive_types::H256,
+        #[serde_as(as = "pathfinder_serde::U256AsHexStr")]
+        pub gas_price: primitive_types::U256,
         /// The estimated fee for the transaction (in gwei), product of gas_consumed and gas_price
-        #[serde_as(as = "pathfinder_serde::H256AsHexStr")]
-        pub overall_fee: primitive_types::H256,
+        #[serde_as(as = "pathfinder_serde::U256AsHexStr")]
+        pub overall_fee: primitive_types::U256,
     }
 
     #[cfg(test)]

--- a/crates/rpc/src/v03/method/estimate_message_fee.rs
+++ b/crates/rpc/src/v03/method/estimate_message_fee.rs
@@ -55,14 +55,12 @@ pub async fn estimate_message_fee(
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
     use pathfinder_common::macro_prelude::*;
     use pathfinder_common::{
         BlockHash, BlockHeader, BlockNumber, BlockTimestamp, Chain, GasPrice, StateUpdate,
     };
     use pathfinder_storage::{JournalMode, Storage};
-    use primitive_types::{H160, H256};
+    use primitive_types::H160;
     use starknet_gateway_test_fixtures::class_definitions::{
         CAIRO_1_1_0_BALANCE_CASM_JSON, CAIRO_1_1_0_BALANCE_SIERRA_JSON,
     };
@@ -222,18 +220,9 @@ mod tests {
     #[tokio::test]
     async fn test_estimate_message_fee() {
         let expected = FeeEstimate {
-            gas_consumed: H256::from_str(
-                "0x00000000000000000000000000000000000000000000000000000000000042d1",
-            )
-            .unwrap(),
-            gas_price: H256::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000001",
-            )
-            .unwrap(),
-            overall_fee: H256::from_str(
-                "0x00000000000000000000000000000000000000000000000000000000000042d1",
-            )
-            .unwrap(),
+            gas_consumed: 0x42d1.into(),
+            gas_price: 1.into(),
+            overall_fee: 0x42d1.into(),
         };
 
         let rpc = setup(Setup::Full).await.expect("RPC context");

--- a/crates/rpc/src/v03/method/simulate_transaction.rs
+++ b/crates/rpc/src/v03/method/simulate_transaction.rs
@@ -429,14 +429,13 @@ mod tests {
 
         let expected: Vec<dto::SimulatedTransaction> = {
             use dto::*;
-            use primitive_types::H256;
             vec![
             SimulatedTransaction {
                 fee_estimation: Some(
                     FeeEstimate {
-                        gas_consumed: H256::from_low_u64_be(0x0c19),
-                        gas_price: H256::from_low_u64_be(0x01),
-                        overall_fee: H256::from_low_u64_be(0x0c19),
+                        gas_consumed: 0xc19.into(),
+                        gas_price: 1.into(),
+                        overall_fee: 0xc19.into(),
                     }
                 ),
                 transaction_trace: Some(

--- a/crates/serde/src/lib.rs
+++ b/crates/serde/src/lib.rs
@@ -5,7 +5,7 @@ use pathfinder_common::{
     BlockNumber, CallParam, ConstructorParam, EthereumAddress, GasPrice, L1ToL2MessagePayloadElem,
     L2ToL1MessagePayloadElem, TransactionSignatureElem, TransactionVersion,
 };
-use primitive_types::{H160, H256};
+use primitive_types::{H160, H256, U256};
 use serde::de::Visitor;
 use serde_with::{serde_conv, DeserializeAs, SerializeAs};
 use stark_hash::{Felt, HexParseError, OverflowError};
@@ -225,10 +225,10 @@ serde_with::serde_conv!(
 );
 
 serde_with::serde_conv!(
-    pub H256AsHexStr,
-    primitive_types::H256,
-    |u: &H256| bytes_to_hex_str(u.as_bytes()),
-    |s: &str| bytes_from_hex_str::<32>(s).map(H256::from)
+    pub U256AsHexStr,
+    primitive_types::U256,
+    |u: &U256| { let mut b = [0u8; 32]; u.to_big_endian(&mut b); bytes_to_hex_str(&b) },
+    |s: &str| bytes_from_hex_str::<32>(s).map(U256::from)
 );
 
 pub struct U64AsHexStr(pub u64);


### PR DESCRIPTION
Using H256 makes comparing/using the gas price values harder with no added benefit.

This chaneg converts gas price to U256 -- with no changes on the Python interface (it still serializes/deserializes into a hex representation).

This PR has been extracted from the starknet_in_rust executor work.