### PR TITLE
feat(rpc/v04): add new error codes for `starknet_addXXXTransaction` methods

### DIFF
--- a/crates/gateway-types/src/error.rs
+++ b/crates/gateway-types/src/error.rs
@@ -98,6 +98,20 @@ pub enum KnownStarknetErrorCode {
     UnauthorizedEntryPointForInvoke,
     #[serde(rename = "StarknetErrorCode.INVALID_CONTRACT_CLASS")]
     InvalidContractClass,
+    #[serde(rename = "StarknetErrorCode.CLASS_ALREADY_DECLARED")]
+    ClassAlreadyDeclared,
+    #[serde(rename = "StarkErrorCode.INVALID_SIGNATURE")]
+    InvalidSignature,
+    #[serde(rename = "StarknetErrorCode.INSUFFICIENT_ACCOUNT_BALANCE")]
+    InsufficientAccountBalance,
+    #[serde(rename = "StarknetErrorCode.INSUFFICIENT_MAX_FEE")]
+    InsufficientMaxFee,
+    #[serde(rename = "StarknetErrorCode.VALIDATE_FAILURE")]
+    ValidateFailure,
+    #[serde(rename = "StarknetErrorCode.CONTRACT_BYTECODE_SIZE_TOO_LARGE")]
+    ContractBytecodeSizeTooLarge,
+    #[serde(rename = "StarknetErrorCode.DUPLICATED_TRANSACTION")]
+    DuplicatedTransaction,
 }
 
 #[cfg(test)]

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -50,11 +50,13 @@ pub enum RpcError {
     #[error("Compilation failed")]
     CompilationFailed,
     #[error("Contract bytecode size is too large")]
-    ContractBytecodeSizeTooLarge,
+    ContractBytecodeSizeIsTooLarge,
     #[error("Sender address in not an account contract")]
     NonAccount,
     #[error("A transaction with the same hash already exists in the mempool")]
     DuplicateTransaction,
+    #[error("The compiled class hash did not match the one supplied in the transaction")]
+    CompiledClassHashMismatch,
     #[error(transparent)]
     GatewayError(starknet_gateway_types::error::StarknetError),
     #[error(transparent)]
@@ -84,9 +86,10 @@ impl RpcError {
             RpcError::InsufficientAccountBalance => 54,
             RpcError::ValidationFailure => 55,
             RpcError::CompilationFailed => 56,
-            RpcError::ContractBytecodeSizeTooLarge => 57,
+            RpcError::ContractBytecodeSizeIsTooLarge => 57,
             RpcError::NonAccount => 58,
             RpcError::DuplicateTransaction => 59,
+            RpcError::CompiledClassHashMismatch => 60,
             RpcError::ProofLimitExceeded { .. } => 10000,
             RpcError::GatewayError(_) | RpcError::Internal(_) => {
                 jsonrpsee::types::error::ErrorCode::InternalError.code()

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -37,6 +37,24 @@ pub enum RpcError {
     ProofLimitExceeded { limit: u32, requested: u32 },
     #[error("Too many keys provided in a filter")]
     TooManyKeysInFilter { limit: usize, requested: usize },
+    #[error("Class already declared")]
+    ClassAlreadyDeclared,
+    #[error("Invalid transaction nonce")]
+    InvalidTransactionNonce,
+    #[error("Max fee is smaller than the validation's actual fee")]
+    InsufficientMaxFee,
+    #[error("Account balance is smaller than the transaction's max_fee")]
+    InsufficientAccountBalance,
+    #[error("Account validation failed")]
+    ValidationFailure,
+    #[error("Compilation failed")]
+    CompilationFailed,
+    #[error("Contract bytecode size is too large")]
+    ContractBytecodeSizeTooLarge,
+    #[error("Sender address in not an account contract")]
+    NonAccount,
+    #[error("A transaction with the same hash already exists in the mempool")]
+    DuplicateTransaction,
     #[error(transparent)]
     GatewayError(starknet_gateway_types::error::StarknetError),
     #[error(transparent)]
@@ -60,6 +78,15 @@ impl RpcError {
             RpcError::TooManyKeysInFilter { .. } => 34,
             RpcError::ContractError => 40,
             RpcError::InvalidContractClass => 50,
+            RpcError::ClassAlreadyDeclared => 51,
+            RpcError::InvalidTransactionNonce => 52,
+            RpcError::InsufficientMaxFee => 53,
+            RpcError::InsufficientAccountBalance => 54,
+            RpcError::ValidationFailure => 55,
+            RpcError::CompilationFailed => 56,
+            RpcError::ContractBytecodeSizeTooLarge => 57,
+            RpcError::NonAccount => 58,
+            RpcError::DuplicateTransaction => 59,
             RpcError::ProofLimitExceeded { .. } => 10000,
             RpcError::GatewayError(_) | RpcError::Internal(_) => {
                 jsonrpsee::types::error::ErrorCode::InternalError.code()

--- a/crates/rpc/src/v04.rs
+++ b/crates/rpc/src/v04.rs
@@ -16,7 +16,7 @@ pub fn register_methods(module: Module) -> anyhow::Result<Module> {
         )?
         .register_method(
             "v0.4_starknet_addDeployAccountTransaction",
-            v02_method::add_deploy_account_transaction,
+            v04_method::add_deploy_account_transaction,
         )?
         .register_method(
             "v0.4_starknet_addInvokeTransaction",

--- a/crates/rpc/src/v04.rs
+++ b/crates/rpc/src/v04.rs
@@ -20,7 +20,7 @@ pub fn register_methods(module: Module) -> anyhow::Result<Module> {
         )?
         .register_method(
             "v0.4_starknet_addInvokeTransaction",
-            v02_method::add_invoke_transaction,
+            v04_method::add_invoke_transaction,
         )?
         .register_method_with_no_input(
             "v0.4_starknet_blockHashAndNumber",

--- a/crates/rpc/src/v04.rs
+++ b/crates/rpc/src/v04.rs
@@ -12,7 +12,7 @@ pub fn register_methods(module: Module) -> anyhow::Result<Module> {
         // Reused from v0.2
         .register_method(
             "v0.4_starknet_addDeclareTransaction",
-            v02_method::add_declare_transaction,
+            v04_method::add_declare_transaction,
         )?
         .register_method(
             "v0.4_starknet_addDeployAccountTransaction",

--- a/crates/rpc/src/v04/method.rs
+++ b/crates/rpc/src/v04/method.rs
@@ -1,7 +1,9 @@
-pub(super) mod estimate_message_fee;
+mod add_declare_transaction;
+mod estimate_message_fee;
 mod get_transaction_receipt;
 mod syncing;
 
+pub(super) use add_declare_transaction::add_declare_transaction;
 pub(super) use estimate_message_fee::estimate_message_fee;
 pub(super) use get_transaction_receipt::get_transaction_receipt;
 pub(super) use syncing::syncing;

--- a/crates/rpc/src/v04/method.rs
+++ b/crates/rpc/src/v04/method.rs
@@ -1,9 +1,11 @@
 mod add_declare_transaction;
+mod add_invoke_transaction;
 mod estimate_message_fee;
 mod get_transaction_receipt;
 mod syncing;
 
 pub(super) use add_declare_transaction::add_declare_transaction;
+pub(super) use add_invoke_transaction::add_invoke_transaction;
 pub(super) use estimate_message_fee::estimate_message_fee;
 pub(super) use get_transaction_receipt::get_transaction_receipt;
 pub(super) use syncing::syncing;

--- a/crates/rpc/src/v04/method.rs
+++ b/crates/rpc/src/v04/method.rs
@@ -1,10 +1,12 @@
 mod add_declare_transaction;
+mod add_deploy_account_transaction;
 mod add_invoke_transaction;
 mod estimate_message_fee;
 mod get_transaction_receipt;
 mod syncing;
 
 pub(super) use add_declare_transaction::add_declare_transaction;
+pub(super) use add_deploy_account_transaction::add_deploy_account_transaction;
 pub(super) use add_invoke_transaction::add_invoke_transaction;
 pub(super) use estimate_message_fee::estimate_message_fee;
 pub(super) use get_transaction_receipt::get_transaction_receipt;

--- a/crates/rpc/src/v04/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v04/method/add_declare_transaction.rs
@@ -1,0 +1,546 @@
+use crate::context::RpcContext;
+use crate::felt::RpcFelt;
+use crate::v02::types::request::BroadcastedDeclareTransaction;
+use pathfinder_common::{ClassHash, TransactionHash};
+use starknet_gateway_client::GatewayApi;
+use starknet_gateway_types::error::{SequencerError, StarknetError};
+use starknet_gateway_types::request::add_transaction::{
+    CairoContractDefinition, ContractDefinition, SierraContractDefinition,
+};
+
+#[derive(Debug)]
+pub enum AddDeclareTransactionError {
+    InvalidContractClass,
+    ClassAlreadyDeclared,
+    InvalidTransactionNonce,
+    InsufficientMaxFee,
+    InsufficientAccountBalance,
+    ValidationFailure,
+    CompilationFailed,
+    ContractBytecodeSizeTooLarge,
+    DuplicateTransaction,
+    GatewayError(StarknetError),
+    Internal(anyhow::Error),
+}
+
+impl From<AddDeclareTransactionError> for crate::error::RpcError {
+    fn from(value: AddDeclareTransactionError) -> Self {
+        match value {
+            AddDeclareTransactionError::InvalidContractClass => Self::InvalidContractClass,
+            AddDeclareTransactionError::ClassAlreadyDeclared => Self::ClassAlreadyDeclared,
+            AddDeclareTransactionError::InvalidTransactionNonce => Self::InvalidTransactionNonce,
+            AddDeclareTransactionError::InsufficientMaxFee => Self::InsufficientMaxFee,
+            AddDeclareTransactionError::InsufficientAccountBalance => {
+                Self::InsufficientAccountBalance
+            }
+            AddDeclareTransactionError::ValidationFailure => Self::ValidationFailure,
+            AddDeclareTransactionError::CompilationFailed => Self::CompilationFailed,
+            AddDeclareTransactionError::ContractBytecodeSizeTooLarge => {
+                Self::ContractBytecodeSizeTooLarge
+            }
+            AddDeclareTransactionError::DuplicateTransaction => Self::DuplicateTransaction,
+            AddDeclareTransactionError::GatewayError(x) => Self::GatewayError(x),
+            AddDeclareTransactionError::Internal(x) => Self::Internal(x),
+        }
+    }
+}
+
+impl From<anyhow::Error> for AddDeclareTransactionError {
+    fn from(value: anyhow::Error) -> Self {
+        AddDeclareTransactionError::Internal(value)
+    }
+}
+
+impl From<SequencerError> for AddDeclareTransactionError {
+    fn from(e: SequencerError) -> Self {
+        use starknet_gateway_types::error::KnownStarknetErrorCode::{
+            ClassAlreadyDeclared, CompilationFailed, ContractBytecodeSizeTooLarge,
+            DuplicatedTransaction, InsufficientAccountBalance, InsufficientMaxFee,
+            InvalidContractClass, InvalidProgram, InvalidTransactionNonce, ValidateFailure,
+        };
+        match e {
+            SequencerError::StarknetError(e)
+                if e.code == InvalidProgram.into() || e.code == InvalidContractClass.into() =>
+            {
+                AddDeclareTransactionError::InvalidContractClass
+            }
+            SequencerError::StarknetError(e) if e.code == ClassAlreadyDeclared.into() => {
+                AddDeclareTransactionError::ClassAlreadyDeclared
+            }
+            SequencerError::StarknetError(e) if e.code == CompilationFailed.into() => {
+                AddDeclareTransactionError::CompilationFailed
+            }
+            SequencerError::StarknetError(e) if e.code == ContractBytecodeSizeTooLarge.into() => {
+                AddDeclareTransactionError::ContractBytecodeSizeTooLarge
+            }
+            SequencerError::StarknetError(e) if e.code == DuplicatedTransaction.into() => {
+                AddDeclareTransactionError::DuplicateTransaction
+            }
+            SequencerError::StarknetError(e) if e.code == InsufficientAccountBalance.into() => {
+                AddDeclareTransactionError::InsufficientAccountBalance
+            }
+            SequencerError::StarknetError(e) if e.code == InsufficientMaxFee.into() => {
+                AddDeclareTransactionError::InsufficientMaxFee
+            }
+            SequencerError::StarknetError(e) if e.code == InvalidTransactionNonce.into() => {
+                AddDeclareTransactionError::InvalidTransactionNonce
+            }
+            SequencerError::StarknetError(e) if e.code == ValidateFailure.into() => {
+                AddDeclareTransactionError::ValidationFailure
+            }
+            SequencerError::StarknetError(other) => AddDeclareTransactionError::GatewayError(other),
+            _ => AddDeclareTransactionError::Internal(e.into()),
+        }
+    }
+}
+
+#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub enum Transaction {
+    #[serde(rename = "DECLARE")]
+    Declare(BroadcastedDeclareTransaction),
+}
+
+#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+pub struct AddDeclareTransactionInput {
+    declare_transaction: Transaction,
+    // An undocumented parameter that we forward to the sequencer API
+    // A deploy token is required to deploy contracts on Starknet mainnet only.
+    #[serde(default)]
+    token: Option<String>,
+}
+
+#[serde_with::serde_as]
+#[derive(serde::Serialize, Debug, PartialEq, Eq)]
+pub struct AddDeclareTransactionOutput {
+    #[serde_as(as = "RpcFelt")]
+    transaction_hash: TransactionHash,
+    #[serde_as(as = "RpcFelt")]
+    class_hash: ClassHash,
+}
+
+pub async fn add_declare_transaction(
+    context: RpcContext,
+    input: AddDeclareTransactionInput,
+) -> Result<AddDeclareTransactionOutput, AddDeclareTransactionError> {
+    match input.declare_transaction {
+        Transaction::Declare(BroadcastedDeclareTransaction::V1(tx)) => {
+            let contract_definition: CairoContractDefinition = tx
+                .contract_class
+                .try_into()
+                .map_err(|e| anyhow::anyhow!("Failed to convert contract definition: {}", e))?;
+
+            let response = context
+                .sequencer
+                .add_declare_transaction(
+                    tx.version,
+                    tx.max_fee,
+                    tx.signature,
+                    tx.nonce,
+                    ContractDefinition::Cairo(contract_definition),
+                    tx.sender_address,
+                    None,
+                    input.token,
+                )
+                .await?;
+
+            Ok(AddDeclareTransactionOutput {
+                transaction_hash: response.transaction_hash,
+                class_hash: response.class_hash,
+            })
+        }
+        Transaction::Declare(BroadcastedDeclareTransaction::V2(tx)) => {
+            let contract_definition: SierraContractDefinition = tx
+                .contract_class
+                .try_into()
+                .map_err(|e| anyhow::anyhow!("Failed to convert contract definition: {}", e))?;
+
+            let response = context
+                .sequencer
+                .add_declare_transaction(
+                    tx.version,
+                    tx.max_fee,
+                    tx.signature,
+                    tx.nonce,
+                    ContractDefinition::Sierra(contract_definition),
+                    tx.sender_address,
+                    Some(tx.compiled_class_hash),
+                    input.token,
+                )
+                .await?;
+
+            Ok(AddDeclareTransactionOutput {
+                transaction_hash: response.transaction_hash,
+                class_hash: response.class_hash,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::v02::types::request::{
+        BroadcastedDeclareTransaction, BroadcastedDeclareTransactionV1,
+        BroadcastedDeclareTransactionV2,
+    };
+    use crate::v02::types::{CairoContractClass, ContractClass, SierraContractClass};
+    use pathfinder_common::macro_prelude::*;
+    use pathfinder_common::{CasmHash, ContractAddress, Fee, TransactionNonce, TransactionVersion};
+    use stark_hash::Felt;
+    use starknet_gateway_test_fixtures::class_definitions::{
+        CAIRO_2_0_0_STACK_OVERFLOW, CONTRACT_DEFINITION,
+    };
+
+    lazy_static::lazy_static! {
+        pub static ref CONTRACT_CLASS: CairoContractClass = {
+            ContractClass::from_definition_bytes(CONTRACT_DEFINITION).unwrap().as_cairo().unwrap()
+        };
+
+        pub static ref CONTRACT_CLASS_WITH_INVALID_PRIME: CairoContractClass = {
+            let mut definition: serde_json::Value = serde_json::from_slice(CONTRACT_DEFINITION).unwrap();
+            // change program.prime to an invalid one
+            *definition.get_mut("program").unwrap().get_mut("prime").unwrap() = serde_json::json!("0x1");
+            let definition = serde_json::to_vec(&definition).unwrap();
+            ContractClass::from_definition_bytes(&definition).unwrap().as_cairo().unwrap()
+        };
+
+        pub static ref CONTRACT_CLASS_JSON: String = {
+            serde_json::to_string(&*CONTRACT_CLASS).unwrap()
+        };
+
+        pub static ref SIERRA_CLASS_JSON: String = {
+            serde_json::to_string(&*SIERRA_CLASS).unwrap()
+        };
+
+        pub static ref SIERRA_CLASS: SierraContractClass = {
+            ContractClass::from_definition_bytes(CAIRO_2_0_0_STACK_OVERFLOW).unwrap().as_sierra().unwrap()
+        };
+    }
+
+    mod parsing {
+        mod v1 {
+            use super::super::*;
+            use crate::v02::types::request::BroadcastedDeclareTransactionV1;
+
+            fn test_declare_txn() -> Transaction {
+                Transaction::Declare(BroadcastedDeclareTransaction::V1(
+                    BroadcastedDeclareTransactionV1 {
+                        max_fee: fee!("0x1"),
+                        version: TransactionVersion::ONE,
+                        signature: vec![],
+                        nonce: TransactionNonce(Felt::ZERO),
+                        contract_class: CONTRACT_CLASS.clone(),
+                        sender_address: ContractAddress::new_or_panic(Felt::from_u64(1)),
+                    },
+                ))
+            }
+
+            #[test]
+            fn positional_args() {
+                use jsonrpsee::types::Params;
+
+                let positional = format!(
+                    r#"[
+                        {{
+                            "type": "DECLARE",
+                            "version": "0x1",
+                            "max_fee": "0x1",
+                            "signature": [],
+                            "nonce": "0x0",
+                            "contract_class": {},
+                            "sender_address": "0x1"
+                        }}
+                    ]"#,
+                    CONTRACT_CLASS_JSON.clone()
+                );
+                let positional = Params::new(Some(&positional));
+
+                let input = positional.parse::<AddDeclareTransactionInput>().unwrap();
+                let expected = AddDeclareTransactionInput {
+                    declare_transaction: test_declare_txn(),
+                    token: None,
+                };
+                assert_eq!(input, expected);
+            }
+
+            #[test]
+            fn named_args() {
+                use jsonrpsee::types::Params;
+
+                let named = format!(
+                    r#"{{
+                        "declare_transaction": {{
+                            "type": "DECLARE",
+                            "version": "0x1",
+                            "max_fee": "0x1",
+                            "signature": [],
+                            "nonce": "0x0",
+                            "contract_class": {},
+                            "sender_address": "0x1"
+                        }},
+                        "token": "token"
+                    }}"#,
+                    CONTRACT_CLASS_JSON.clone()
+                );
+                let named = Params::new(Some(&named));
+
+                let input = named.parse::<AddDeclareTransactionInput>().unwrap();
+                let expected = AddDeclareTransactionInput {
+                    declare_transaction: test_declare_txn(),
+                    token: Some("token".to_owned()),
+                };
+                assert_eq!(input, expected);
+            }
+        }
+
+        mod v2 {
+            use super::super::*;
+            use crate::v02::types::request::BroadcastedDeclareTransactionV2;
+
+            fn test_declare_txn() -> Transaction {
+                Transaction::Declare(BroadcastedDeclareTransaction::V2(
+                    BroadcastedDeclareTransactionV2 {
+                        max_fee: fee!("0x1"),
+                        version: TransactionVersion::TWO,
+                        signature: vec![],
+                        nonce: TransactionNonce(Felt::ZERO),
+                        contract_class: SIERRA_CLASS.clone(),
+                        sender_address: ContractAddress::new_or_panic(Felt::from_u64(1)),
+                        compiled_class_hash: CasmHash(Felt::from_u64(1)),
+                    },
+                ))
+            }
+
+            #[test]
+            fn positional_args() {
+                use jsonrpsee::types::Params;
+
+                let positional = format!(
+                    r#"[
+                        {{
+                            "type": "DECLARE",
+                            "version": "0x2",
+                            "max_fee": "0x1",
+                            "signature": [],
+                            "nonce": "0x0",
+                            "contract_class": {},
+                            "sender_address": "0x1",
+                            "compiled_class_hash": "0x1"
+                        }}
+                    ]"#,
+                    SIERRA_CLASS_JSON.clone()
+                );
+                let positional = Params::new(Some(&positional));
+
+                let input = positional.parse::<AddDeclareTransactionInput>().unwrap();
+                let expected = AddDeclareTransactionInput {
+                    declare_transaction: test_declare_txn(),
+                    token: None,
+                };
+                pretty_assertions::assert_eq!(input, expected);
+            }
+
+            #[test]
+            fn named_args() {
+                use jsonrpsee::types::Params;
+
+                let named = format!(
+                    r#"{{
+                        "declare_transaction": {{
+                            "type": "DECLARE",
+                            "version": "0x2",
+                            "max_fee": "0x1",
+                            "signature": [],
+                            "nonce": "0x0",
+                            "contract_class": {},
+                            "sender_address": "0x1",
+                            "compiled_class_hash": "0x1"
+                        }},
+                        "token": "token"
+                    }}"#,
+                    SIERRA_CLASS_JSON.clone()
+                );
+                let named = Params::new(Some(&named));
+
+                let input = named.parse::<AddDeclareTransactionInput>().unwrap();
+                let expected = AddDeclareTransactionInput {
+                    declare_transaction: test_declare_txn(),
+                    token: Some("token".to_owned()),
+                };
+                pretty_assertions::assert_eq!(input, expected);
+            }
+        }
+    }
+
+    #[test_log::test(tokio::test)]
+    #[ignore = "gateway 429"]
+    async fn invalid_contract_definition_v1() {
+        let context = RpcContext::for_tests();
+
+        let invalid_contract_class = CairoContractClass {
+            program: "".to_owned(),
+            ..CONTRACT_CLASS.clone()
+        };
+
+        let declare_transaction = Transaction::Declare(BroadcastedDeclareTransaction::V1(
+            BroadcastedDeclareTransactionV1 {
+                version: TransactionVersion::ONE,
+                max_fee: Fee(Default::default()),
+                signature: vec![],
+                nonce: TransactionNonce(Default::default()),
+                contract_class: invalid_contract_class,
+                sender_address: ContractAddress::new_or_panic(Felt::from_u64(1)),
+            },
+        ));
+
+        let input = AddDeclareTransactionInput {
+            declare_transaction,
+            token: None,
+        };
+        let error = add_declare_transaction(context, input).await.unwrap_err();
+        assert_matches::assert_matches!(error, AddDeclareTransactionError::InvalidContractClass);
+    }
+
+    #[test_log::test(tokio::test)]
+    #[ignore = "gateway 429"]
+    async fn invalid_contract_definition_v2() {
+        let context = RpcContext::for_tests_on(pathfinder_common::Chain::Integration);
+
+        let invalid_contract_class = SierraContractClass {
+            sierra_program: vec![],
+            ..SIERRA_CLASS.clone()
+        };
+
+        let declare_transaction = Transaction::Declare(BroadcastedDeclareTransaction::V2(
+            BroadcastedDeclareTransactionV2 {
+                version: TransactionVersion::TWO,
+                max_fee: Fee(Felt::from_be_slice(&u64::MAX.to_be_bytes()).unwrap()),
+                signature: vec![],
+                nonce: TransactionNonce(Default::default()),
+                contract_class: invalid_contract_class,
+                sender_address: ContractAddress::new_or_panic(Felt::from_u64(1)),
+                // Taken from
+                // https://external.integration.starknet.io/feeder_gateway/get_state_update?blockNumber=283364
+                compiled_class_hash: casm_hash!(
+                    "0x711c0c3e56863e29d3158804aac47f424241eda64db33e2cc2999d60ee5105"
+                ),
+            },
+        ));
+
+        let input = AddDeclareTransactionInput {
+            declare_transaction,
+            token: None,
+        };
+        let error = add_declare_transaction(context, input).await.unwrap_err();
+        assert_matches::assert_matches!(error, AddDeclareTransactionError::InvalidContractClass);
+    }
+
+    #[test_log::test(tokio::test)]
+    #[ignore = "gateway 429"]
+    async fn invalid_contract_class() {
+        let context = RpcContext::for_tests();
+
+        let declare_transaction = Transaction::Declare(BroadcastedDeclareTransaction::V1(
+            BroadcastedDeclareTransactionV1 {
+                version: TransactionVersion::ONE,
+                max_fee: fee!("0xfffffffffff"),
+                signature: vec![],
+                nonce: TransactionNonce(Default::default()),
+                contract_class: CONTRACT_CLASS_WITH_INVALID_PRIME.clone(),
+                sender_address: ContractAddress::new_or_panic(Felt::from_u64(1)),
+            },
+        ));
+
+        let input = AddDeclareTransactionInput {
+            declare_transaction,
+            token: None,
+        };
+        let error = add_declare_transaction(context, input).await.unwrap_err();
+        assert_matches::assert_matches!(error, AddDeclareTransactionError::InvalidContractClass);
+    }
+
+    #[test_log::test(tokio::test)]
+    #[ignore = "gateway 429"]
+    async fn duplicate_transaction() {
+        let context = RpcContext::for_tests();
+
+        let declare_transaction = Transaction::Declare(BroadcastedDeclareTransaction::V1(
+            BroadcastedDeclareTransactionV1 {
+                version: TransactionVersion::ONE,
+                max_fee: Fee(Felt::from_be_slice(&u64::MAX.to_be_bytes()).unwrap()),
+                signature: vec![],
+                nonce: TransactionNonce(Default::default()),
+                contract_class: CONTRACT_CLASS.clone(),
+                sender_address: ContractAddress::new_or_panic(Felt::from_u64(1)),
+            },
+        ));
+
+        let input = AddDeclareTransactionInput {
+            declare_transaction,
+            token: None,
+        };
+        let error = add_declare_transaction(context, input).await.unwrap_err();
+        assert_matches::assert_matches!(error, AddDeclareTransactionError::DuplicateTransaction);
+    }
+
+    #[test_log::test(tokio::test)]
+    #[ignore = "gateway 429"]
+    async fn insufficient_max_fee() {
+        let context = RpcContext::for_tests_on(pathfinder_common::Chain::Integration);
+
+        let declare_transaction = Transaction::Declare(BroadcastedDeclareTransaction::V2(
+            BroadcastedDeclareTransactionV2 {
+                version: TransactionVersion::TWO,
+                max_fee: Fee(felt!("0x01")),
+                signature: vec![],
+                nonce: TransactionNonce(Default::default()),
+                contract_class: SIERRA_CLASS.clone(),
+                sender_address: ContractAddress::new_or_panic(Felt::from_u64(1)),
+                compiled_class_hash: casm_hash!(
+                    "0x688e44b1d8612222a25cf742c8e1493af4640fa74b1a7707bde2002df51ea8c"
+                ),
+            },
+        ));
+
+        let input = AddDeclareTransactionInput {
+            declare_transaction,
+            token: None,
+        };
+        let err = add_declare_transaction(context, input).await.unwrap_err();
+        assert_matches::assert_matches!(
+            err,
+            AddDeclareTransactionError::InsufficientAccountBalance
+        );
+    }
+
+    #[test_log::test(tokio::test)]
+    #[ignore = "gateway 429"]
+    async fn insufficient_account_balance() {
+        let context = RpcContext::for_tests_on(pathfinder_common::Chain::Integration);
+
+        let declare_transaction = Transaction::Declare(BroadcastedDeclareTransaction::V2(
+            BroadcastedDeclareTransactionV2 {
+                version: TransactionVersion::TWO,
+                max_fee: Fee(Felt::from_be_slice(&u64::MAX.to_be_bytes()).unwrap()),
+                signature: vec![],
+                nonce: TransactionNonce(Default::default()),
+                contract_class: SIERRA_CLASS.clone(),
+                sender_address: ContractAddress::new_or_panic(Felt::from_u64(1)),
+                compiled_class_hash: casm_hash!(
+                    "0x688e44b1d8612222a25cf742c8e1493af4640fa74b1a7707bde2002df51ea8c"
+                ),
+            },
+        ));
+
+        let input = AddDeclareTransactionInput {
+            declare_transaction,
+            token: None,
+        };
+        let err = add_declare_transaction(context, input).await.unwrap_err();
+        assert_matches::assert_matches!(
+            err,
+            AddDeclareTransactionError::InsufficientAccountBalance
+        );
+    }
+}

--- a/crates/rpc/src/v04/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/v04/method/add_deploy_account_transaction.rs
@@ -1,0 +1,205 @@
+use crate::context::RpcContext;
+use crate::felt::{RpcFelt, RpcFelt251};
+use crate::v02::types::request::BroadcastedDeployAccountTransaction;
+use pathfinder_common::{ContractAddress, TransactionHash};
+use starknet_gateway_client::GatewayApi;
+use starknet_gateway_types::error::{SequencerError, StarknetError};
+
+#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub enum Transaction {
+    #[serde(rename = "DEPLOY_ACCOUNT")]
+    DeployAccount(BroadcastedDeployAccountTransaction),
+}
+
+#[derive(Debug, serde::Deserialize, PartialEq, Eq)]
+pub struct AddDeployAccountTransactionInput {
+    deploy_account_transaction: Transaction,
+}
+
+#[serde_with::serde_as]
+#[derive(serde::Serialize, Debug, PartialEq, Eq)]
+pub struct AddDeployAccountTransactionOutput {
+    #[serde_as(as = "RpcFelt")]
+    transaction_hash: TransactionHash,
+    #[serde_as(as = "RpcFelt251")]
+    contract_address: ContractAddress,
+}
+
+#[derive(Debug)]
+pub enum AddDeployAccountTransactionError {
+    ClassHashNotFound,
+    InvalidTransactionNonce,
+    InsufficientMaxFee,
+    InsufficientAccountBalance,
+    ValidationFailure,
+    DuplicateTransaction,
+    GatewayError(StarknetError),
+    Internal(anyhow::Error),
+}
+
+impl From<AddDeployAccountTransactionError> for crate::error::RpcError {
+    fn from(value: AddDeployAccountTransactionError) -> Self {
+        use AddDeployAccountTransactionError::*;
+        match value {
+            ClassHashNotFound => Self::ClassHashNotFound,
+            InvalidTransactionNonce => Self::InvalidTransactionNonce,
+            InsufficientMaxFee => Self::InsufficientMaxFee,
+            InsufficientAccountBalance => Self::InsufficientAccountBalance,
+            ValidationFailure => Self::ValidationFailure,
+            DuplicateTransaction => Self::DuplicateTransaction,
+            GatewayError(x) => Self::GatewayError(x),
+            Internal(x) => Self::Internal(x),
+        }
+    }
+}
+
+impl From<anyhow::Error> for AddDeployAccountTransactionError {
+    fn from(value: anyhow::Error) -> Self {
+        AddDeployAccountTransactionError::Internal(value)
+    }
+}
+
+impl From<SequencerError> for AddDeployAccountTransactionError {
+    fn from(e: SequencerError) -> Self {
+        use starknet_gateway_types::error::KnownStarknetErrorCode::{
+            DuplicatedTransaction, InsufficientAccountBalance, InsufficientMaxFee,
+            InvalidTransactionNonce, UndeclaredClass, ValidateFailure,
+        };
+        match e {
+            SequencerError::StarknetError(e) if e.code == UndeclaredClass.into() => {
+                AddDeployAccountTransactionError::ClassHashNotFound
+            }
+            SequencerError::StarknetError(e) if e.code == DuplicatedTransaction.into() => {
+                AddDeployAccountTransactionError::DuplicateTransaction
+            }
+            SequencerError::StarknetError(e) if e.code == InsufficientAccountBalance.into() => {
+                AddDeployAccountTransactionError::InsufficientAccountBalance
+            }
+            SequencerError::StarknetError(e) if e.code == InsufficientMaxFee.into() => {
+                AddDeployAccountTransactionError::InsufficientMaxFee
+            }
+            SequencerError::StarknetError(e) if e.code == InvalidTransactionNonce.into() => {
+                AddDeployAccountTransactionError::InvalidTransactionNonce
+            }
+            SequencerError::StarknetError(e) if e.code == ValidateFailure.into() => {
+                AddDeployAccountTransactionError::ValidationFailure
+            }
+            SequencerError::StarknetError(other) => {
+                AddDeployAccountTransactionError::GatewayError(other)
+            }
+            _ => AddDeployAccountTransactionError::Internal(e.into()),
+        }
+    }
+}
+
+pub async fn add_deploy_account_transaction(
+    context: RpcContext,
+    input: AddDeployAccountTransactionInput,
+) -> Result<AddDeployAccountTransactionOutput, AddDeployAccountTransactionError> {
+    let Transaction::DeployAccount(tx) = input.deploy_account_transaction;
+    let response = context
+        .sequencer
+        .add_deploy_account(
+            tx.version,
+            tx.max_fee,
+            tx.signature,
+            tx.nonce,
+            tx.contract_address_salt,
+            tx.class_hash,
+            tx.constructor_calldata,
+        )
+        .await?;
+
+    Ok(AddDeployAccountTransactionOutput {
+        transaction_hash: response.transaction_hash,
+        contract_address: response.address,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pathfinder_common::macro_prelude::*;
+    use pathfinder_common::{TransactionNonce, TransactionVersion};
+
+    const INPUT_JSON: &str = r#"{
+        "max_fee": "0xbf391377813",
+        "version": "0x1",
+        "constructor_calldata": [
+            "0677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1"
+        ],
+        "signature": [
+            "07dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5",
+            "071456dded17015d1234779889d78f3e7c763ddcfd2662b19e7843c7542614f8"
+        ],
+        "nonce": "0x0",
+        "class_hash": "01fac3074c9d5282f0acc5c69a4781a1c711efea5e73c550c5d9fb253cf7fd3d",
+        "contract_address_salt": "06d44a6aecb4339e23a9619355f101cf3cb9baec289fcd9fd51486655c1bb8a8",
+        "type": "DEPLOY_ACCOUNT"
+    }"#;
+
+    #[tokio::test]
+    async fn test_parse_input_named() {
+        let json = format!("{{\"deploy_account_transaction\":{INPUT_JSON}}}");
+        let input: AddDeployAccountTransactionInput =
+            serde_json::from_str(&json).expect("parse named input");
+
+        assert_eq!(input, get_input());
+    }
+
+    #[tokio::test]
+    async fn test_parse_input_positional() {
+        let json = format!("[{INPUT_JSON}]");
+        let input: AddDeployAccountTransactionInput =
+            serde_json::from_str(&json).expect("parse positional input");
+
+        assert_eq!(input, get_input());
+    }
+
+    fn get_input() -> AddDeployAccountTransactionInput {
+        AddDeployAccountTransactionInput {
+            deploy_account_transaction: Transaction::DeployAccount(
+                BroadcastedDeployAccountTransaction {
+                    version: TransactionVersion::ONE,
+                    max_fee: fee!("0xbf391377813"),
+                    signature: vec![
+                        transaction_signature_elem!(
+                            "07dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5"
+                        ),
+                        transaction_signature_elem!(
+                            "071456dded17015d1234779889d78f3e7c763ddcfd2662b19e7843c7542614f8"
+                        ),
+                    ],
+                    nonce: TransactionNonce::ZERO,
+
+                    contract_address_salt: contract_address_salt!(
+                        "06d44a6aecb4339e23a9619355f101cf3cb9baec289fcd9fd51486655c1bb8a8"
+                    ),
+                    constructor_calldata: vec![call_param!(
+                        "0677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1"
+                    )],
+                    class_hash: class_hash!(
+                        "01fac3074c9d5282f0acc5c69a4781a1c711efea5e73c550c5d9fb253cf7fd3d"
+                    ),
+                },
+            ),
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "gateway 429"]
+    async fn duplicate_transaction() {
+        let context = RpcContext::for_tests();
+
+        let input = get_input();
+
+        let error = add_deploy_account_transaction(context, input)
+            .await
+            .expect_err("add_deploy_account_transaction");
+        assert_matches::assert_matches!(
+            error,
+            AddDeployAccountTransactionError::DuplicateTransaction
+        );
+    }
+}

--- a/crates/rpc/src/v04/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/v04/method/add_invoke_transaction.rs
@@ -1,0 +1,267 @@
+use crate::context::RpcContext;
+use crate::felt::RpcFelt;
+use crate::v02::types::request::BroadcastedInvokeTransaction;
+use pathfinder_common::TransactionHash;
+use starknet_gateway_client::GatewayApi;
+use starknet_gateway_types::error::{SequencerError, StarknetError};
+
+#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub enum Transaction {
+    #[serde(rename = "INVOKE")]
+    Invoke(BroadcastedInvokeTransaction),
+}
+
+#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+pub struct AddInvokeTransactionInput {
+    invoke_transaction: Transaction,
+}
+
+#[serde_with::serde_as]
+#[derive(serde::Serialize, Debug, PartialEq, Eq)]
+pub struct AddInvokeTransactionOutput {
+    #[serde_as(as = "RpcFelt")]
+    transaction_hash: TransactionHash,
+}
+
+#[derive(Debug)]
+pub enum AddInvokeTransactionError {
+    InvalidTransactionNonce,
+    InsufficientMaxFee,
+    InsufficientAccountBalance,
+    ValidationFailure,
+    DuplicateTransaction,
+    GatewayError(StarknetError),
+    Internal(anyhow::Error),
+}
+
+impl From<AddInvokeTransactionError> for crate::error::RpcError {
+    fn from(value: AddInvokeTransactionError) -> Self {
+        match value {
+            AddInvokeTransactionError::InvalidTransactionNonce => Self::InvalidTransactionNonce,
+            AddInvokeTransactionError::InsufficientMaxFee => Self::InsufficientMaxFee,
+            AddInvokeTransactionError::InsufficientAccountBalance => {
+                Self::InsufficientAccountBalance
+            }
+            AddInvokeTransactionError::ValidationFailure => Self::ValidationFailure,
+            AddInvokeTransactionError::DuplicateTransaction => Self::DuplicateTransaction,
+            AddInvokeTransactionError::GatewayError(x) => Self::GatewayError(x),
+            AddInvokeTransactionError::Internal(x) => Self::Internal(x),
+        }
+    }
+}
+
+impl From<anyhow::Error> for AddInvokeTransactionError {
+    fn from(value: anyhow::Error) -> Self {
+        AddInvokeTransactionError::Internal(value)
+    }
+}
+
+impl From<SequencerError> for AddInvokeTransactionError {
+    fn from(e: SequencerError) -> Self {
+        use starknet_gateway_types::error::KnownStarknetErrorCode::{
+            DuplicatedTransaction, InsufficientAccountBalance, InsufficientMaxFee,
+            InvalidTransactionNonce, ValidateFailure,
+        };
+        match e {
+            SequencerError::StarknetError(e) if e.code == DuplicatedTransaction.into() => {
+                AddInvokeTransactionError::DuplicateTransaction
+            }
+            SequencerError::StarknetError(e) if e.code == InsufficientAccountBalance.into() => {
+                AddInvokeTransactionError::InsufficientAccountBalance
+            }
+            SequencerError::StarknetError(e) if e.code == InsufficientMaxFee.into() => {
+                AddInvokeTransactionError::InsufficientMaxFee
+            }
+            SequencerError::StarknetError(e) if e.code == InvalidTransactionNonce.into() => {
+                AddInvokeTransactionError::InvalidTransactionNonce
+            }
+            SequencerError::StarknetError(e) if e.code == ValidateFailure.into() => {
+                AddInvokeTransactionError::ValidationFailure
+            }
+            SequencerError::StarknetError(other) => AddInvokeTransactionError::GatewayError(other),
+            _ => AddInvokeTransactionError::Internal(e.into()),
+        }
+    }
+}
+
+pub async fn add_invoke_transaction(
+    context: RpcContext,
+    input: AddInvokeTransactionInput,
+) -> Result<AddInvokeTransactionOutput, AddInvokeTransactionError> {
+    let Transaction::Invoke(tx) = input.invoke_transaction;
+    let response = match tx {
+        BroadcastedInvokeTransaction::V1(v1) => {
+            context
+                .sequencer
+                .add_invoke_transaction(
+                    v1.version,
+                    v1.max_fee,
+                    v1.signature,
+                    v1.nonce,
+                    v1.sender_address,
+                    v1.calldata,
+                )
+                .await?
+        }
+    };
+
+    Ok(AddInvokeTransactionOutput {
+        transaction_hash: response.transaction_hash,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::v02::types::request::BroadcastedInvokeTransactionV1;
+    use pathfinder_common::macro_prelude::*;
+    use pathfinder_common::TransactionVersion;
+
+    fn test_invoke_txn() -> Transaction {
+        Transaction::Invoke(BroadcastedInvokeTransaction::V1(
+            BroadcastedInvokeTransactionV1 {
+                version: TransactionVersion::ONE,
+                max_fee: fee!("0x4F388496839"),
+                signature: vec![
+                    transaction_signature_elem!(
+                        "07dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5"
+                    ),
+                    transaction_signature_elem!(
+                        "071456dded17015d1234779889d78f3e7c763ddcfd2662b19e7843c7542614f8"
+                    ),
+                ],
+                nonce: transaction_nonce!("0x1"),
+                sender_address: contract_address!(
+                    "023371b227eaecd8e8920cd429357edddd2cd0f3fee6abaacca08d3ab82a7cdd"
+                ),
+                calldata: vec![
+                    call_param!("0x1"),
+                    call_param!("0677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1"),
+                    call_param!("0362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320"),
+                    call_param!("0x0"),
+                    call_param!("0x1"),
+                    call_param!("0x1"),
+                    call_param!("0x2b"),
+                    call_param!("0x0"),
+                ],
+            },
+        ))
+    }
+
+    mod parsing {
+        use super::*;
+
+        #[test]
+        fn positional_args() {
+            use jsonrpsee::types::Params;
+
+            let positional = r#"[
+                {
+                    "type": "INVOKE",
+                    "version": "0x1",
+                    "max_fee": "0x4f388496839",
+                    "signature": [
+                        "0x07dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5",
+                        "0x071456dded17015d1234779889d78f3e7c763ddcfd2662b19e7843c7542614f8"
+                    ],
+                    "nonce": "0x1",
+                    "sender_address": "0x023371b227eaecd8e8920cd429357edddd2cd0f3fee6abaacca08d3ab82a7cdd",
+                    "calldata": [
+                        "0x1",
+                        "0x0677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1",
+                        "0x0362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320",
+                        "0x0",
+                        "0x1",
+                        "0x1",
+                        "0x2b",
+                        "0x0"
+                    ]
+                }
+            ]"#;
+            let positional = Params::new(Some(positional));
+
+            let input = positional.parse::<AddInvokeTransactionInput>().unwrap();
+            let expected = AddInvokeTransactionInput {
+                invoke_transaction: test_invoke_txn(),
+            };
+            pretty_assertions::assert_eq!(input, expected);
+        }
+
+        #[test]
+        fn named_args() {
+            use jsonrpsee::types::Params;
+
+            let named = r#"{
+                "invoke_transaction": {
+                    "type": "INVOKE",
+                    "version": "0x1",
+                    "max_fee": "0x4f388496839",
+                    "signature": [
+                        "0x07dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5",
+                        "0x071456dded17015d1234779889d78f3e7c763ddcfd2662b19e7843c7542614f8"
+                    ],
+                    "nonce": "0x1",
+                    "sender_address": "0x023371b227eaecd8e8920cd429357edddd2cd0f3fee6abaacca08d3ab82a7cdd",
+                    "calldata": [
+                        "0x1",
+                        "0x0677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1",
+                        "0x0362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320",
+                        "0x0",
+                        "0x1",
+                        "0x1",
+                        "0x2b",
+                        "0x0"
+                    ]
+                }
+            }"#;
+            let named = Params::new(Some(named));
+
+            let input = named.parse::<AddInvokeTransactionInput>().unwrap();
+            let expected = AddInvokeTransactionInput {
+                invoke_transaction: test_invoke_txn(),
+            };
+            assert_eq!(input, expected);
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "gateway 429"]
+    async fn duplicate_transaction() {
+        use crate::v02::types::request::BroadcastedInvokeTransactionV1;
+
+        let context = RpcContext::for_tests();
+        let input = BroadcastedInvokeTransactionV1 {
+            version: TransactionVersion::ONE,
+            max_fee: fee!("0x630a0aff77"),
+            signature: vec![
+                transaction_signature_elem!(
+                    "07ccc81b438581c9360120e0ba0ef52c7d031bdf20a4c2bc3820391b29a8945f"
+                ),
+                transaction_signature_elem!(
+                    "02c11c60d11daaa0043eccdc824bb44f87bc7eb2e9c2437e1654876ab8fa7cad"
+                ),
+            ],
+            nonce: transaction_nonce!("0x2"),
+            sender_address: contract_address!(
+                "03fdcbeb68e607c8febf01d7ef274cbf68091a0bd1556c0b8f8e80d732f7850f"
+            ),
+            calldata: vec![
+                call_param!("0x1"),
+                call_param!("01d809111da75d5e735b6f9573a1ddff78fb6ff7633a0b34273e0c5ddeae349a"),
+                call_param!("0362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320"),
+                call_param!("0x0"),
+                call_param!("0x1"),
+                call_param!("0x1"),
+                call_param!("0x1"),
+            ],
+        };
+
+        let input = AddInvokeTransactionInput {
+            invoke_transaction: Transaction::Invoke(BroadcastedInvokeTransaction::V1(input)),
+        };
+
+        let error = add_invoke_transaction(context, input).await.unwrap_err();
+        assert_matches::assert_matches!(error, AddInvokeTransactionError::DuplicateTransaction);
+    }
+}


### PR DESCRIPTION
This PR adds a `v04` variant of `starknet_addDeclareTransaction`, `starknet_addDeployAccountTransaction` and `starknet_addInvokeTransaction`.

The 0.4 JSON-RPC specification for the write API is _almost_ the same as the 0.3 one but provides more detailed error codes on why the transaction failed. Starknet 0.12.0 is now doing more thorough validation on the gateway and now returns errors for:

* invalid signature
* invalid nonce
* insufficient balance
* insufficient max_fee

This PR adds the required `StarknetErrorCode` variants and the `RpcError` variants as well as the proper error mapping code in the JSON-RPC methods.

Fixes #1253
Fixes #1254
Fixes #1255 