### PR TITLE
feat(rpc/v0.4): syncing and receipt

### DIFF
--- a/crates/rpc/src/v04.rs
+++ b/crates/rpc/src/v04.rs
@@ -60,7 +60,7 @@ pub fn register_methods(module: Module) -> anyhow::Result<Module> {
         )?
         .register_method(
             "v0.4_starknet_getTransactionReceipt",
-            v02_method::get_transaction_receipt,
+            v04_method::get_transaction_receipt,
         )?
         .register_method_with_no_input(
             "v0.4_starknet_pendingTransactions",

--- a/crates/rpc/src/v04.rs
+++ b/crates/rpc/src/v04.rs
@@ -66,7 +66,7 @@ pub fn register_methods(module: Module) -> anyhow::Result<Module> {
             "v0.4_starknet_pendingTransactions",
             v02_method::pending_transactions,
         )?
-        .register_method_with_no_input("v0.4_starknet_syncing", v02_method::syncing)?
+        .register_method_with_no_input("v0.4_starknet_syncing", v04_method::syncing)?
         // Specific implementations for v0.3
         .register_method("v0.4_starknet_getEvents", v03_method::get_events)?
         .register_method("v0.4_starknet_getStateUpdate", v03_method::get_state_update)?

--- a/crates/rpc/src/v04/method.rs
+++ b/crates/rpc/src/v04/method.rs
@@ -1,3 +1,5 @@
 pub(super) mod estimate_message_fee;
+mod syncing;
 
 pub(super) use estimate_message_fee::estimate_message_fee;
+pub(super) use syncing::syncing;

--- a/crates/rpc/src/v04/method.rs
+++ b/crates/rpc/src/v04/method.rs
@@ -1,5 +1,7 @@
 pub(super) mod estimate_message_fee;
+mod get_transaction_receipt;
 mod syncing;
 
 pub(super) use estimate_message_fee::estimate_message_fee;
+pub(super) use get_transaction_receipt::get_transaction_receipt;
 pub(super) use syncing::syncing;

--- a/crates/rpc/src/v04/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v04/method/get_transaction_receipt.rs
@@ -1,0 +1,727 @@
+use crate::context::RpcContext;
+use anyhow::Context;
+use pathfinder_common::TransactionHash;
+
+#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+pub struct GetTransactionReceiptInput {
+    transaction_hash: TransactionHash,
+}
+
+crate::error::generate_rpc_error_subset!(GetTransactionReceiptError: TxnHashNotFound);
+
+pub async fn get_transaction_receipt(
+    context: RpcContext,
+    input: GetTransactionReceiptInput,
+) -> Result<types::MaybePendingTransactionReceipt, GetTransactionReceiptError> {
+    // First check pending data as this is in-mem and should be faster.
+    if let Some(pending) = &context.pending_data {
+        let receipt_transaction = pending.block().await.and_then(|block| {
+            block
+                .transaction_receipts
+                .iter()
+                .zip(block.transactions.iter())
+                .find_map(|(receipt, tx)| {
+                    (receipt.transaction_hash == input.transaction_hash)
+                        .then(|| (receipt.clone(), tx.clone()))
+                })
+        });
+
+        if let Some((receipt, transaction)) = receipt_transaction {
+            let pending =
+                types::PendingTransactionReceipt::from(receipt, &transaction, context.version);
+            return Ok(types::MaybePendingTransactionReceipt::Pending(pending));
+        };
+    }
+
+    let storage = context.storage.clone();
+    let span = tracing::Span::current();
+
+    let jh = tokio::task::spawn_blocking(move || {
+        let _g = span.enter();
+        let mut db = storage
+            .connection()
+            .context("Opening database connection")?;
+
+        let db_tx = db.transaction().context("Creating database transaction")?;
+
+        let (transaction, receipt, block_hash) = db_tx
+            .transaction_with_receipt(input.transaction_hash)
+            .context("Reading transaction receipt from database")?
+            .ok_or(GetTransactionReceiptError::TxnHashNotFound)?;
+
+        let block_number = db_tx
+            .block_id(block_hash.into())
+            .context("Querying block number")?
+            .context("Block number info missing")?
+            .0;
+
+        let l1_accepted = db_tx
+            .block_is_l1_accepted(block_number.into())
+            .context("Quering block status")?;
+
+        let finality_status = if l1_accepted {
+            types::FinalityStatus::AcceptedOnL1
+        } else {
+            types::FinalityStatus::AcceptedOnL2
+        };
+
+        Ok(types::MaybePendingTransactionReceipt::Normal(
+            types::TransactionReceipt::with_block_data(
+                receipt,
+                finality_status,
+                block_hash,
+                block_number,
+                transaction,
+                context.version,
+            ),
+        ))
+    });
+
+    jh.await.context("Database read panic or shutting down")?
+}
+
+pub mod types {
+    use crate::context::RpcVersion;
+    use crate::felt::{RpcFelt, RpcFelt251};
+    use crate::v02::types::reply::BlockStatus;
+    use pathfinder_common::{
+        BlockHash, BlockNumber, ContractAddress, EthereumAddress, EventData, EventKey, Fee,
+        L1ToL2MessagePayloadElem, L2ToL1MessagePayloadElem, TransactionHash,
+    };
+    use pathfinder_serde::EthereumAddressAsHexStr;
+    use serde::Serialize;
+    use serde_with::serde_as;
+    use starknet_gateway_types::reply::transaction::{L1ToL2Message, L2ToL1Message};
+
+    /// L2 transaction receipt as returned by the RPC API.
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+    #[serde(untagged)]
+    pub enum MaybePendingTransactionReceipt {
+        Normal(TransactionReceipt),
+        Pending(PendingTransactionReceipt),
+    }
+
+    /// Non-pending L2 transaction receipt as returned by the RPC API.
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+    #[serde(tag = "type")]
+    pub enum TransactionReceipt {
+        #[serde(rename = "INVOKE")]
+        Invoke(InvokeTransactionReceipt),
+        #[serde(rename = "DECLARE")]
+        Declare(DeclareTransactionReceipt),
+        #[serde(rename = "L1_HANDLER")]
+        L1Handler(L1HandlerTransactionReceipt),
+        // FIXME regenesis: remove Deploy receipt type after regenesis
+        // We are keeping this type of receipt until regenesis
+        // only to support older pre-0.11.0 blocks
+        #[serde(rename = "DEPLOY")]
+        Deploy(DeployTransactionReceipt),
+        #[serde(rename = "DEPLOY_ACCOUNT")]
+        DeployAccount(DeployAccountTransactionReceipt),
+    }
+
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+    pub struct InvokeTransactionReceipt {
+        #[serde(flatten)]
+        pub common: CommonTransactionReceiptProperties,
+    }
+
+    #[serde_as]
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+    pub struct CommonTransactionReceiptProperties {
+        #[serde_as(as = "RpcFelt")]
+        pub transaction_hash: TransactionHash,
+        pub actual_fee: Fee,
+        #[serde_as(as = "RpcFelt")]
+        pub block_hash: BlockHash,
+        pub block_number: BlockNumber,
+        pub messages_sent: Vec<MessageToL1>,
+        pub events: Vec<Event>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub revert_reason: Option<String>,
+        pub execution_status: ExecutionStatus,
+        pub finality_status: FinalityStatus,
+    }
+
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[serde(rename = "SCREAMING_SNAKE_CASE")]
+    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+    pub enum ExecutionStatus {
+        Succeeded,
+        Reverted,
+    }
+
+    impl From<starknet_gateway_types::reply::transaction::ExecutionStatus> for ExecutionStatus {
+        fn from(value: starknet_gateway_types::reply::transaction::ExecutionStatus) -> Self {
+            match value {
+                starknet_gateway_types::reply::transaction::ExecutionStatus::Succeeded => {
+                    Self::Succeeded
+                }
+                starknet_gateway_types::reply::transaction::ExecutionStatus::Reverted => {
+                    Self::Reverted
+                }
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[serde(rename = "SCREAMING_SNAKE_CASE")]
+    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+    pub enum FinalityStatus {
+        AcceptedOnL2,
+        AcceptedOnL1,
+    }
+
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+    pub struct L1HandlerTransactionReceipt {
+        #[serde(flatten)]
+        pub common: CommonTransactionReceiptProperties,
+    }
+
+    #[serde_as]
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+    pub struct DeployTransactionReceipt {
+        #[serde(flatten)]
+        pub common: CommonTransactionReceiptProperties,
+        #[serde_as(as = "RpcFelt251")]
+        pub contract_address: ContractAddress,
+    }
+
+    #[serde_as]
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+    pub struct DeployAccountTransactionReceipt {
+        #[serde(flatten)]
+        pub common: CommonTransactionReceiptProperties,
+        #[serde_as(as = "RpcFelt251")]
+        pub contract_address: ContractAddress,
+    }
+
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+    pub struct DeclareTransactionReceipt {
+        #[serde(flatten)]
+        pub common: CommonTransactionReceiptProperties,
+    }
+
+    impl TransactionReceipt {
+        pub fn with_block_data(
+            receipt: starknet_gateway_types::reply::transaction::Receipt,
+            finality_status: FinalityStatus,
+            block_hash: BlockHash,
+            block_number: BlockNumber,
+            transaction: starknet_gateway_types::reply::transaction::Transaction,
+            rpc_version: RpcVersion,
+        ) -> Self {
+            let common = CommonTransactionReceiptProperties {
+                transaction_hash: receipt.transaction_hash,
+                actual_fee: receipt
+                    .actual_fee
+                    .unwrap_or_else(|| Fee(Default::default())),
+                block_hash,
+                block_number,
+                messages_sent: receipt
+                    .l2_to_l1_messages
+                    .into_iter()
+                    .map(|msg| MessageToL1::from(msg, rpc_version))
+                    .collect(),
+                events: receipt.events.into_iter().map(Event::from).collect(),
+                revert_reason: receipt.revert_error,
+                execution_status: receipt.execution_status.into(),
+                finality_status,
+            };
+
+            use starknet_gateway_types::reply::transaction::Transaction::*;
+            match transaction {
+                Declare(_) => Self::Declare(DeclareTransactionReceipt { common }),
+                Deploy(tx) => Self::Deploy(DeployTransactionReceipt {
+                    common,
+                    contract_address: tx.contract_address,
+                }),
+                DeployAccount(tx) => Self::DeployAccount(DeployAccountTransactionReceipt {
+                    common,
+                    contract_address: tx.contract_address,
+                }),
+                Invoke(_) => Self::Invoke(InvokeTransactionReceipt { common }),
+                L1Handler(_) => Self::L1Handler(L1HandlerTransactionReceipt { common }),
+            }
+        }
+    }
+
+    /// Non-pending L2 transaction receipt as returned by the RPC API.
+    ///
+    /// Pending receipts don't have status, status_data, block_hash, block_number fields
+    #[serde_as]
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+    #[serde(tag = "type")]
+    pub enum PendingTransactionReceipt {
+        #[serde(rename = "INVOKE")]
+        Invoke(PendingInvokeTransactionReceipt),
+        #[serde(rename = "DECLARE")]
+        Declare(PendingDeclareTransactionReceipt),
+        #[serde(rename = "DEPLOY")]
+        Deploy(PendingDeployTransactionReceipt),
+        #[serde(rename = "DEPLOY_ACCOUNT")]
+        DeployAccount(PendingDeployAccountTransactionReceipt),
+        #[serde(rename = "L1_HANDLER")]
+        L1Handler(PendingL1HandlerTransactionReceipt),
+    }
+
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+    pub struct PendingInvokeTransactionReceipt {
+        #[serde(flatten)]
+        pub common: CommonPendingTransactionReceiptProperties,
+    }
+    #[serde_as]
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+    pub struct CommonPendingTransactionReceiptProperties {
+        pub transaction_hash: TransactionHash,
+        pub actual_fee: Fee,
+        pub messages_sent: Vec<MessageToL1>,
+        pub events: Vec<Event>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub revert_reason: Option<String>,
+        pub execution_status: ExecutionStatus,
+        pub finality_status: FinalityStatus,
+    }
+
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+    pub struct PendingDeclareTransactionReceipt {
+        #[serde(flatten)]
+        pub common: CommonPendingTransactionReceiptProperties,
+    }
+
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+    pub struct PendingDeployTransactionReceipt {
+        #[serde(flatten)]
+        pub common: CommonPendingTransactionReceiptProperties,
+
+        pub contract_address: ContractAddress,
+    }
+
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+    pub struct PendingDeployAccountTransactionReceipt {
+        #[serde(flatten)]
+        pub common: CommonPendingTransactionReceiptProperties,
+
+        pub contract_address: ContractAddress,
+    }
+
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+    pub struct PendingL1HandlerTransactionReceipt {
+        #[serde(flatten)]
+        pub common: CommonPendingTransactionReceiptProperties,
+    }
+
+    impl PendingTransactionReceipt {
+        pub fn from(
+            receipt: starknet_gateway_types::reply::transaction::Receipt,
+            transaction: &starknet_gateway_types::reply::transaction::Transaction,
+            rpc_version: RpcVersion,
+        ) -> Self {
+            let common = CommonPendingTransactionReceiptProperties {
+                transaction_hash: receipt.transaction_hash,
+                actual_fee: receipt
+                    .actual_fee
+                    .unwrap_or_else(|| Fee(Default::default())),
+                messages_sent: receipt
+                    .l2_to_l1_messages
+                    .into_iter()
+                    .map(|msg| MessageToL1::from(msg, rpc_version))
+                    .collect(),
+                events: receipt.events.into_iter().map(Event::from).collect(),
+                revert_reason: receipt.revert_error,
+                execution_status: receipt.execution_status.into(),
+                finality_status: FinalityStatus::AcceptedOnL2,
+            };
+
+            use starknet_gateway_types::reply::transaction::Transaction::*;
+            match transaction {
+                Declare(_) => Self::Declare(PendingDeclareTransactionReceipt { common }),
+                Deploy(tx) => Self::Deploy(PendingDeployTransactionReceipt {
+                    common,
+                    contract_address: tx.contract_address,
+                }),
+                DeployAccount(tx) => Self::DeployAccount(PendingDeployAccountTransactionReceipt {
+                    common,
+                    contract_address: tx.contract_address,
+                }),
+                Invoke(_) => Self::Invoke(PendingInvokeTransactionReceipt { common }),
+                L1Handler(_) => Self::L1Handler(PendingL1HandlerTransactionReceipt { common }),
+            }
+        }
+    }
+
+    /// Message sent from L2 to L1.
+    #[serde_as]
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+    #[serde(deny_unknown_fields)]
+    pub struct MessageToL1 {
+        // RPC spec v0.3: `MSG_TO_L1` has a new mandatory `from_address` field.
+        // This way it works for both versions without copying much code around.
+        #[serde_as(as = "Option<RpcFelt251>")]
+        #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub from_address: Option<ContractAddress>,
+        #[serde_as(as = "EthereumAddressAsHexStr")]
+        pub to_address: EthereumAddress,
+        #[serde_as(as = "Vec<RpcFelt>")]
+        pub payload: Vec<L2ToL1MessagePayloadElem>,
+    }
+
+    impl MessageToL1 {
+        fn from(msg: L2ToL1Message, rpc_version: RpcVersion) -> Self {
+            Self {
+                from_address: (!matches!(rpc_version, RpcVersion::V02)).then_some(msg.from_address),
+                to_address: msg.to_address,
+                payload: msg.payload,
+            }
+        }
+    }
+
+    /// Message sent from L1 to L2.
+    #[serde_as]
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+    #[serde(deny_unknown_fields)]
+    pub struct MessageToL2 {
+        #[serde_as(as = "EthereumAddressAsHexStr")]
+        pub from_address: EthereumAddress,
+        #[serde_as(as = "Vec<RpcFelt>")]
+        pub payload: Vec<L1ToL2MessagePayloadElem>,
+    }
+
+    impl From<L1ToL2Message> for MessageToL2 {
+        fn from(msg: L1ToL2Message) -> Self {
+            Self {
+                from_address: msg.from_address,
+                payload: msg.payload,
+            }
+        }
+    }
+
+    /// Event emitted as a part of a transaction.
+    #[serde_as]
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+    #[serde(deny_unknown_fields)]
+    pub struct Event {
+        #[serde_as(as = "RpcFelt251")]
+        pub from_address: ContractAddress,
+        #[serde_as(as = "Vec<RpcFelt>")]
+        pub keys: Vec<EventKey>,
+        #[serde_as(as = "Vec<RpcFelt>")]
+        pub data: Vec<EventData>,
+    }
+
+    impl From<pathfinder_common::event::Event> for Event {
+        fn from(e: pathfinder_common::event::Event) -> Self {
+            Self {
+                from_address: e.from_address,
+                keys: e.keys,
+                data: e.data,
+            }
+        }
+    }
+
+    /// Represents transaction status.
+    #[derive(Copy, Clone, Debug, Serialize, PartialEq, Eq)]
+    #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+    #[serde(deny_unknown_fields)]
+    pub enum TransactionStatus {
+        #[serde(rename = "ACCEPTED_ON_L2")]
+        AcceptedOnL2,
+        #[serde(rename = "ACCEPTED_ON_L1")]
+        AcceptedOnL1,
+        #[serde(rename = "REJECTED")]
+        Rejected,
+    }
+
+    impl From<BlockStatus> for TransactionStatus {
+        fn from(status: BlockStatus) -> Self {
+            match status {
+                BlockStatus::Pending => TransactionStatus::AcceptedOnL2,
+                BlockStatus::AcceptedOnL2 => TransactionStatus::AcceptedOnL2,
+                BlockStatus::AcceptedOnL1 => TransactionStatus::AcceptedOnL1,
+                BlockStatus::Rejected => TransactionStatus::Rejected,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // TODO: add serialization tests for each receipt variant..
+
+    use super::*;
+    use pathfinder_common::macro_prelude::*;
+    use pathfinder_common::{BlockNumber, EthereumAddress, Fee};
+    use primitive_types::H160;
+
+    mod parsing {
+        use super::*;
+
+        use jsonrpsee::types::Params;
+
+        #[test]
+        fn positional_args() {
+            let positional = r#"[
+                "0xdeadbeef"
+            ]"#;
+            let positional = Params::new(Some(positional));
+
+            let input = positional.parse::<GetTransactionReceiptInput>().unwrap();
+            assert_eq!(
+                input,
+                GetTransactionReceiptInput {
+                    transaction_hash: transaction_hash!("0xdeadbeef")
+                }
+            )
+        }
+
+        #[test]
+        fn named_args() {
+            let named_args = r#"{
+                "transaction_hash": "0xdeadbeef"
+            }"#;
+            let named_args = Params::new(Some(named_args));
+
+            let input = named_args.parse::<GetTransactionReceiptInput>().unwrap();
+            assert_eq!(
+                input,
+                GetTransactionReceiptInput {
+                    transaction_hash: transaction_hash!("0xdeadbeef")
+                }
+            )
+        }
+    }
+
+    mod errors {
+        use super::*;
+
+        #[tokio::test]
+        async fn hash_not_found() {
+            let context = RpcContext::for_tests();
+            let input = GetTransactionReceiptInput {
+                transaction_hash: transaction_hash_bytes!(b"non_existent"),
+            };
+
+            let result = get_transaction_receipt(context, input).await;
+
+            assert_matches::assert_matches!(
+                result,
+                Err(GetTransactionReceiptError::TxnHashNotFound)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn success() {
+        let context = RpcContext::for_tests();
+        let input = GetTransactionReceiptInput {
+            transaction_hash: transaction_hash_bytes!(b"txn 0"),
+        };
+
+        let result = get_transaction_receipt(context, input).await.unwrap();
+        use types::*;
+        assert_eq!(
+            result,
+            MaybePendingTransactionReceipt::Normal(TransactionReceipt::Invoke(
+                InvokeTransactionReceipt {
+                    common: CommonTransactionReceiptProperties {
+                        transaction_hash: transaction_hash_bytes!(b"txn 0"),
+                        actual_fee: Fee::ZERO,
+                        block_hash: block_hash_bytes!(b"genesis"),
+                        block_number: BlockNumber::new_or_panic(0),
+                        messages_sent: vec![],
+                        events: vec![Event {
+                            data: vec![event_data_bytes!(b"event 0 data")],
+                            from_address: contract_address_bytes!(b"event 0 from addr"),
+                            keys: vec![event_key_bytes!(b"event 0 key")],
+                        }],
+                        execution_status: ExecutionStatus::Succeeded,
+                        finality_status: FinalityStatus::AcceptedOnL1,
+                        revert_reason: None,
+                    }
+                }
+            ))
+        )
+    }
+
+    #[tokio::test]
+    async fn success_v02() {
+        let context = RpcContext::for_tests().with_version("v0.2");
+        let input = GetTransactionReceiptInput {
+            transaction_hash: transaction_hash_bytes!(b"txn 6"),
+        };
+
+        let result = get_transaction_receipt(context, input).await.unwrap();
+        use types::*;
+        assert_eq!(
+            result,
+            MaybePendingTransactionReceipt::Normal(TransactionReceipt::Invoke(
+                InvokeTransactionReceipt {
+                    common: CommonTransactionReceiptProperties {
+                        transaction_hash: transaction_hash_bytes!(b"txn 6"),
+                        actual_fee: Fee::ZERO,
+                        block_hash: block_hash_bytes!(b"latest"),
+                        block_number: BlockNumber::new_or_panic(2),
+                        messages_sent: vec![MessageToL1 {
+                            from_address: None, // RPC v0.2 does not have this field
+                            to_address: EthereumAddress(H160::zero()),
+                            payload: vec![
+                                l2_to_l1_message_payload_elem!("0x1"),
+                                l2_to_l1_message_payload_elem!("0x2"),
+                                l2_to_l1_message_payload_elem!("0x3"),
+                            ],
+                        }],
+                        events: vec![],
+                        execution_status: ExecutionStatus::Succeeded,
+                        finality_status: FinalityStatus::AcceptedOnL2,
+                        revert_reason: None,
+                    }
+                }
+            ))
+        )
+    }
+
+    #[tokio::test]
+    async fn success_v03() {
+        let context = RpcContext::for_tests().with_version("v0.3");
+        let input = GetTransactionReceiptInput {
+            transaction_hash: transaction_hash_bytes!(b"txn 6"),
+        };
+
+        let result = get_transaction_receipt(context, input).await.unwrap();
+        use types::*;
+        assert_eq!(
+            result,
+            MaybePendingTransactionReceipt::Normal(TransactionReceipt::Invoke(
+                InvokeTransactionReceipt {
+                    common: CommonTransactionReceiptProperties {
+                        transaction_hash: transaction_hash_bytes!(b"txn 6"),
+                        actual_fee: Fee::ZERO,
+                        block_hash: block_hash_bytes!(b"latest"),
+                        block_number: BlockNumber::new_or_panic(2),
+                        messages_sent: vec![MessageToL1 {
+                            from_address: Some(contract_address!("0xcafebabe")),
+                            to_address: EthereumAddress(H160::zero()),
+                            payload: vec![
+                                l2_to_l1_message_payload_elem!("0x1"),
+                                l2_to_l1_message_payload_elem!("0x2"),
+                                l2_to_l1_message_payload_elem!("0x3"),
+                            ],
+                        }],
+                        events: vec![],
+                        execution_status: ExecutionStatus::Succeeded,
+                        finality_status: FinalityStatus::AcceptedOnL2,
+                        revert_reason: None,
+                    }
+                }
+            ))
+        )
+    }
+
+    #[tokio::test]
+    async fn pending() {
+        let context = RpcContext::for_tests_with_pending()
+            .await
+            .with_version("v0.3");
+        let transaction_hash = transaction_hash_bytes!(b"pending tx hash 0");
+        let input = GetTransactionReceiptInput { transaction_hash };
+
+        let result = get_transaction_receipt(context, input).await.unwrap();
+        use types::*;
+        assert_eq!(
+            result,
+            MaybePendingTransactionReceipt::Pending(PendingTransactionReceipt::Invoke(
+                PendingInvokeTransactionReceipt {
+                    common: CommonPendingTransactionReceiptProperties {
+                        transaction_hash,
+                        actual_fee: Fee::ZERO,
+                        messages_sent: vec![],
+                        events: vec![
+                            Event {
+                                data: vec![],
+                                from_address: contract_address!("0xabcddddddd"),
+                                keys: vec![event_key_bytes!(b"pending key")],
+                            },
+                            Event {
+                                data: vec![],
+                                from_address: contract_address!("0xabcddddddd"),
+                                keys: vec![event_key_bytes!(b"pending key")],
+                            },
+                            Event {
+                                data: vec![],
+                                from_address: contract_address!("0xabcaaaaaaa"),
+                                keys: vec![event_key_bytes!(b"pending key 2")],
+                            },
+                        ],
+                        revert_reason: None,
+                        execution_status: ExecutionStatus::Succeeded,
+                        finality_status: FinalityStatus::AcceptedOnL2
+                    }
+                }
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn reverted() {
+        let context = RpcContext::for_tests_with_pending()
+            .await
+            .with_version("v0.3");
+        let input = GetTransactionReceiptInput {
+            transaction_hash: transaction_hash_bytes!(b"txn reverted"),
+        };
+        // Should be a reverted invoke receipt.
+        let receipt = get_transaction_receipt(context.clone(), input)
+            .await
+            .unwrap();
+
+        let receipt = match receipt {
+            types::MaybePendingTransactionReceipt::Normal(types::TransactionReceipt::Invoke(x)) => {
+                x
+            }
+            _ => panic!(),
+        };
+
+        assert_eq!(
+            receipt.common.execution_status,
+            types::ExecutionStatus::Reverted
+        );
+
+        let input = GetTransactionReceiptInput {
+            transaction_hash: transaction_hash_bytes!(b"pending reverted"),
+        };
+
+        // Should be a reverted pending invoke receipt.
+        let receipt = get_transaction_receipt(context, input).await.unwrap();
+
+        let receipt = match receipt {
+            types::MaybePendingTransactionReceipt::Pending(
+                types::PendingTransactionReceipt::Invoke(x),
+            ) => x,
+            _ => panic!(),
+        };
+
+        assert_eq!(
+            receipt.common.execution_status,
+            types::ExecutionStatus::Reverted
+        );
+    }
+}

--- a/crates/rpc/src/v04/method/syncing.rs
+++ b/crates/rpc/src/v04/method/syncing.rs
@@ -1,0 +1,149 @@
+use pathfinder_common::{BlockHash, BlockNumber};
+
+use crate::context::RpcContext;
+use crate::felt::RpcFelt;
+
+crate::error::generate_rpc_error_subset!(SyncingError);
+
+pub async fn syncing(context: RpcContext) -> Result<SyncingOuput, SyncingError> {
+    // Scoped so I don't have to think too hard about mutex guard drop semantics.
+    let value = { context.sync_status.status.read().await.clone() };
+
+    use crate::v02::types::syncing::Syncing;
+    let value = match value {
+        Syncing::False(_) => SyncingOuput::False,
+        Syncing::Status(status) => {
+            let status = SyncingStatus {
+                starting_block_num: status.starting.number,
+                current_block_num: status.current.number,
+                highest_block_num: status.highest.number,
+                starting_block_hash: status.starting.hash,
+                current_block_hash: status.current.hash,
+                highest_block_hash: status.highest.hash,
+            };
+            SyncingOuput::Status(status)
+        }
+    };
+
+    Ok(value)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SyncingOuput {
+    False,
+    Status(SyncingStatus),
+}
+
+impl serde::Serialize for SyncingOuput {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            SyncingOuput::False => serializer.serialize_str("false"),
+            SyncingOuput::Status(inner) => serializer.serialize_newtype_struct("status", &inner),
+        }
+    }
+}
+
+#[serde_with::serde_as]
+#[derive(Clone, Copy, Debug, serde::Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
+pub struct SyncingStatus {
+    starting_block_num: BlockNumber,
+    current_block_num: BlockNumber,
+    highest_block_num: BlockNumber,
+    #[serde_as(as = "RpcFelt")]
+    starting_block_hash: BlockHash,
+    #[serde_as(as = "RpcFelt")]
+    current_block_hash: BlockHash,
+    #[serde_as(as = "RpcFelt")]
+    highest_block_hash: BlockHash,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SyncingOuput;
+    use crate::context::RpcContext;
+    use pathfinder_common::macro_prelude::*;
+    mod serde {
+        use super::super::{SyncingOuput, SyncingStatus};
+
+        #[test]
+        fn not_syncing() {
+            let json = serde_json::to_string(&SyncingOuput::False).unwrap();
+            assert_eq!(json, r#""false""#);
+        }
+
+        #[test]
+        fn syncing() {
+            use super::*;
+            use pathfinder_common::BlockNumber;
+
+            let status = SyncingStatus {
+                starting_block_num: BlockNumber::new_or_panic(12),
+                current_block_num: BlockNumber::new_or_panic(45),
+                highest_block_num: BlockNumber::new_or_panic(772),
+                starting_block_hash: block_hash!("0xabcdef"),
+                current_block_hash: block_hash!("0x12345677"),
+                highest_block_hash: block_hash!("0x1144ffaacc"),
+            };
+            let value = SyncingOuput::Status(status);
+            let json = serde_json::to_value(value).unwrap();
+
+            let expected = serde_json::json!( {
+                "starting_block_num": 12,
+                "current_block_num": 45,
+                "highest_block_num": 772,
+                "starting_block_hash": "0xabcdef",
+                "current_block_hash": "0x12345677",
+                "highest_block_hash": "0x1144ffaacc",
+            });
+
+            assert_eq!(json, expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn syncing() {
+        use crate::v02::types::syncing::NumberedBlock;
+        use crate::v02::types::syncing::Status as V2Status;
+        use crate::v02::types::syncing::Syncing as V2Syncing;
+        use pathfinder_common::BlockNumber;
+
+        let status = V2Syncing::Status(V2Status {
+            starting: NumberedBlock::from(("aabb", 1)),
+            current: NumberedBlock::from(("ccddee", 2)),
+            highest: NumberedBlock::from(("eeffaacc", 3)),
+        });
+
+        let expected = super::SyncingStatus {
+            starting_block_num: BlockNumber::new_or_panic(1),
+            current_block_num: BlockNumber::new_or_panic(2),
+            highest_block_num: BlockNumber::new_or_panic(3),
+            starting_block_hash: block_hash!("0xaabb"),
+            current_block_hash: block_hash!("0xccddee"),
+            highest_block_hash: block_hash!("0xeeffaacc"),
+        };
+        let expected = SyncingOuput::Status(expected);
+
+        let context = RpcContext::for_tests();
+        *context.sync_status.status.write().await = status;
+
+        let result = super::syncing(context).await.unwrap();
+
+        assert_eq!(result, expected);
+    }
+
+    #[tokio::test]
+    async fn not_syncing() {
+        let status = crate::v02::types::syncing::Syncing::False(false);
+
+        let context = RpcContext::for_tests();
+        *context.sync_status.status.write().await = status;
+
+        let result = super::syncing(context).await.unwrap();
+
+        assert_eq!(result, SyncingOuput::False);
+    }
+}


### PR DESCRIPTION
This PR adds support for `starknet_syncing` and `starknet_getTransactionReceipt` for RPC v0.4.

`starknet_syncing` changed the block height representation from hex string to integer.

`starknet_getTransactionReceipt` requires allowing for reverted txns whereas in v0.3 those are explicity converted to errors. I tried to converge to a single overall type, but the result types also changed.

Closes #1271 and #1273 