### PR TITLE
fix: ignore unknown builtin counters

### DIFF
--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -218,9 +218,11 @@ pub mod transaction {
         pub n_memory_holes: u64,
     }
 
+    // This struct purposefully allows for unknown fields as it is not critical to
+    // store these counters perfectly. Failure would be far more costly than simply
+    // ignoring them.
     #[derive(Copy, Clone, Default, Debug, Deserialize, Serialize, PartialEq, Eq, Dummy)]
     #[serde(default)]
-    #[serde(deny_unknown_fields)]
     pub struct BuiltinCounters {
         pub output_builtin: u64,
         pub pedersen_builtin: u64,


### PR DESCRIPTION
Failing to sync is far more costly than ignoring some counters.

#1238 fixed not parsing the builtin's correctly: objects with unknown builtins silently truncated to the empty variant which was not intended. With this fix inplace, we ran into parsing failures due to an unknown counter which was fixed in #1244.

After discussion with starkware, this PR now ignores such unknown builtin counters instead of erroring and halting sync progress.