### PR TITLE
Chris/rpc v0.4 new error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - system contract updates are not correctly stored
 - `starknet_simulateTransaction` fails for transactions sending L2->L1 messages
+- deprecated error code 21 `INVALID_MESSAGE_SELECTOR` is used in RPC v0.3
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ This can be used to interact with a custom Starknet gateway, or to use a gateway
 
 You can interact with Starknet using the JSON-RPC API. Pathfinder supports the official Starknet RPC API and in addition supplements this with its own pathfinder specific extensions such as `pathfinder_getProof`.
 
-Currently pathfinder supports `v0.3.0` and `v0.4.0` versions of the Starknet JSON-RPC specification.
+Currently pathfinder supports `v0.3` and `v0.4` versions of the Starknet JSON-RPC specification.
 The `path` of the URL used to access the JSON-RPC server determines which version of the API is served:
 
 - the `v0.3.0` API is exposed on the `/` and `/rpc/v0.3` path
@@ -197,12 +197,11 @@ Note that the pathfinder extension is versioned separately from the Starknet spe
 
 ### API `v0.4.0`
 
-`starknet_simulateTransactions` currently treats the `SKIP_FEE_CHARGE` flag as permamently enabled.
+`starknet_simulateTransactions` currently always requires the `SKIP_FEE_CHARGE` flag until we upgrade to using starknet-in-rust as our execution engine.
 
 ### pathfinder extension API
 
 You can find the API specification [here](doc/rpc/pathfinder_rpc_api.json).
-
 
 ## Monitoring API
 

--- a/README.md
+++ b/README.md
@@ -186,13 +186,18 @@ This can be used to interact with a custom Starknet gateway, or to use a gateway
 
 You can interact with Starknet using the JSON-RPC API. Pathfinder supports the official Starknet RPC API and in addition supplements this with its own pathfinder specific extensions such as `pathfinder_getProof`.
 
-Currently pathfinder supports `v0.3.0` versions of the Starknet JSON-RPC specification.
+Currently pathfinder supports `v0.3.0` and `v0.4.0` versions of the Starknet JSON-RPC specification.
 The `path` of the URL used to access the JSON-RPC server determines which version of the API is served:
 
 - the `v0.3.0` API is exposed on the `/` and `/rpc/v0.3` path
+- the `v0.4.0` API is exposed on the `/` and `/rpc/v0.4` path
 - the pathfinder extension API is exposed on `/rpc/pathfinder/v0.1`
 
 Note that the pathfinder extension is versioned separately from the Starknet specification itself.
+
+### API `v0.4.0`
+
+`starknet_simulateTransactions` currently treats the `SKIP_FEE_CHARGE` flag as permamently enabled.
 
 ### pathfinder extension API
 

--- a/crates/gateway-types/src/error.rs
+++ b/crates/gateway-types/src/error.rs
@@ -110,8 +110,12 @@ pub enum KnownStarknetErrorCode {
     ValidateFailure,
     #[serde(rename = "StarknetErrorCode.CONTRACT_BYTECODE_SIZE_TOO_LARGE")]
     ContractBytecodeSizeTooLarge,
+    #[serde(rename = "StarknetErrorCode.CONTRACT_CLASS_OBJECT_SIZE_TOO_LARGE")]
+    ContractClassObjectSizeTooLarge,
     #[serde(rename = "StarknetErrorCode.DUPLICATED_TRANSACTION")]
     DuplicatedTransaction,
+    #[serde(rename = "StarknetErrorCode.INVALID_CONTRACT_CLASS_VERSION")]
+    InvalidContractClassVersion,
 }
 
 #[cfg(test)]

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -7,67 +7,60 @@
 /// The Starknet JSON-RPC error variants.
 #[derive(thiserror::Error, Debug)]
 pub enum RpcError {
-    #[error("Failed to write transaction")] // 1
+    #[error("Failed to write transaction")]
     FailedToReceiveTxn,
-    #[error("Contract not found")] // 20
+    #[error("Contract not found")]
     ContractNotFound,
-    // v03 trace api spec
-    // INVALID_BLOCK_HASH "Invalid block hash" 24
-    // v04 trace api spec
-    // INVALID_BLOCK_HASH "Invalid block hash" 26
-    #[error("Block not found")] // 24
+    #[error("Block not found")]
     BlockNotFound,
-    // v03,v04 trace api spec
-    // INVALID_TXN_HASH "Invalid transaction hash"
-    #[error("Transaction hash not found")] // 25
+    #[error("Transaction hash not found")]
     TxnHashNotFoundV03,
-    #[error("Invalid transaction index in a block")] // 27
+    #[error("Invalid transaction index in a block")]
     InvalidTxnIndex,
-    #[error("Class hash not found")] // 28
+    #[error("Class hash not found")]
     ClassHashNotFound,
-    #[error("Transaction hash not found")] // 29
+    #[error("Transaction hash not found")]
     TxnHashNotFoundV04,
-    #[error("Requested page size is too big")] // 31
+    #[error("Requested page size is too big")]
     PageSizeTooBig,
-    #[error("There are no blocks")] // 32
+    #[error("There are no blocks")]
     NoBlocks,
-    #[error("The supplied continuation token is invalid or unknown")] // 33
+    #[error("The supplied continuation token is invalid or unknown")]
     InvalidContinuationToken,
-    #[error("Contract error")] // 40
-    ContractError,
-    #[error("Invalid contract class")] // 50
-    InvalidContractClass,
-    #[error("Too many storage keys requested")]
-    ProofLimitExceeded { limit: u32, requested: u32 },
-    #[error("Too many keys provided in a filter")] // 34
+    #[error("Too many keys provided in a filter")]
     TooManyKeysInFilter { limit: usize, requested: usize },
-    #[error("Class already declared")] // 51 largest v03
+    #[error("Contract error")]
+    ContractError,
+    #[error("Invalid contract class")]
+    InvalidContractClass,
+    #[error("Class already declared")]
     ClassAlreadyDeclared,
-    #[error("Invalid transaction nonce")] // 52 v04 onwards only
+    #[error("Invalid transaction nonce")]
     InvalidTransactionNonce,
-    // 53
     #[error("Max fee is smaller than the minimal transaction cost (validation plus fee transfer)")]
     InsufficientMaxFee,
-    #[error("Account balance is smaller than the transaction's max_fee")] // 54
+    #[error("Account balance is smaller than the transaction's max_fee")]
     InsufficientAccountBalance,
-    #[error("Account validation failed")] // 55
+    #[error("Account validation failed")]
     ValidationFailure,
-    #[error("Compilation failed")] // 56
+    #[error("Compilation failed")]
     CompilationFailed,
-    #[error("Contract class size it too large")] // 57
+    #[error("Contract class size it too large")]
     ContractClassSizeIsTooLarge,
-    #[error("Sender address in not an account contract")] // 58
+    #[error("Sender address in not an account contract")]
     NonAccount,
-    #[error("A transaction with the same hash already exists in the mempool")] // 59
+    #[error("A transaction with the same hash already exists in the mempool")]
     DuplicateTransaction,
-    #[error("The compiled class hash did not match the one supplied in the transaction")] // 60
+    #[error("The compiled class hash did not match the one supplied in the transaction")]
     CompiledClassHashMismatch,
-    #[error("The transaction version is not supported")] // 61
+    #[error("The transaction version is not supported")]
     UnsupportedTxVersion,
-    #[error("The contract class version is not supported")] // 62
+    #[error("The contract class version is not supported")]
     UnsupportedContractClassVersion,
-    #[error("An unexpected error occured")] // 63
+    #[error("An unexpected error occured")]
     UnexpectedError { data: String },
+    #[error("Too many storage keys requested")]
+    ProofLimitExceeded { limit: u32, requested: u32 },
     #[error(transparent)]
     GatewayError(starknet_gateway_types::error::StarknetError),
     #[error(transparent)]
@@ -79,11 +72,7 @@ impl RpcError {
         match self {
             RpcError::FailedToReceiveTxn => 1,
             RpcError::ContractNotFound => 20,
-            // v03 trace api spec
-            // INVALID_BLOCK_HASH 24
             RpcError::BlockNotFound => 24,
-            // v03 trace api spec
-            // INVALID_TXN_HASH 25
             RpcError::TxnHashNotFoundV03 => 25,
             RpcError::InvalidTxnIndex => 27,
             RpcError::ClassHashNotFound => 28,

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -13,8 +13,6 @@ pub enum RpcError {
     ContractNotFound,
     #[error("Invalid message selector")] // ?
     InvalidMessageSelector,
-    #[error("Invalid call data")] // ?
-    InvalidCallData,
     // v03 trace api spec
     // INVALID_BLOCK_HASH "Invalid block hash" 24
     // v04 trace api spec
@@ -84,7 +82,6 @@ impl RpcError {
             RpcError::FailedToReceiveTxn => 1,
             RpcError::ContractNotFound => 20,
             RpcError::InvalidMessageSelector => 21, // removed in v03
-            RpcError::InvalidCallData => 22,        // removed in v03
             // v03 trace api spec
             // INVALID_BLOCK_HASH 24
             RpcError::BlockNotFound => 24,

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -7,56 +7,71 @@
 /// The Starknet JSON-RPC error variants.
 #[derive(thiserror::Error, Debug)]
 pub enum RpcError {
-    #[error("Failed to write transaction")]
+    #[error("Failed to write transaction")] // 1
     FailedToReceiveTxn,
-    #[error("Contract not found")]
+    #[error("Contract not found")] // 20
     ContractNotFound,
-    #[error("Invalid message selector")]
+    #[error("Invalid message selector")] // ?
     InvalidMessageSelector,
-    #[error("Invalid call data")]
+    #[error("Invalid call data")] // ?
     InvalidCallData,
-    #[error("Block not found")]
+    // v03 trace api spec
+    // INVALID_BLOCK_HASH "Invalid block hash" 24
+    // v04 trace api spec
+    // INVALID_BLOCK_HASH "Invalid block hash" 26
+    #[error("Block not found")] // 24
     BlockNotFound,
-    #[error("Transaction hash not found")]
-    TxnHashNotFound,
-    #[error("Invalid transaction index in a block")]
+    // v03,v04 trace api spec
+    // INVALID_TXN_HASH "Invalid transaction hash"
+    #[error("Transaction hash not found")] // 25
+    TxnHashNotFoundV03,
+    #[error("Invalid transaction index in a block")] // 27
     InvalidTxnIndex,
-    #[error("Class hash not found")]
+    #[error("Class hash not found")] // 28
     ClassHashNotFound,
-    #[error("Requested page size is too big")]
+    #[error("Transaction hash not found")] // 29
+    TxnHashNotFoundV04,
+    #[error("Requested page size is too big")] // 31
     PageSizeTooBig,
-    #[error("There are no blocks")]
+    #[error("There are no blocks")] // 32
     NoBlocks,
-    #[error("The supplied continuation token is invalid or unknown")]
+    #[error("The supplied continuation token is invalid or unknown")] // 33
     InvalidContinuationToken,
-    #[error("Contract error")]
+    #[error("Contract error")] // 40
     ContractError,
-    #[error("Invalid contract class")]
+    #[error("Invalid contract class")] // 50
     InvalidContractClass,
     #[error("Too many storage keys requested")]
     ProofLimitExceeded { limit: u32, requested: u32 },
-    #[error("Too many keys provided in a filter")]
+    #[error("Too many keys provided in a filter")] // 34
     TooManyKeysInFilter { limit: usize, requested: usize },
-    #[error("Class already declared")]
+    #[error("Class already declared")] // 51 largest v03
     ClassAlreadyDeclared,
-    #[error("Invalid transaction nonce")]
+    #[error("Invalid transaction nonce")] // 52 v04 onwards only
     InvalidTransactionNonce,
-    #[error("Max fee is smaller than the validation's actual fee")]
+    // 53
+    #[error("Max fee is smaller than the minimal transaction cost (validation plus fee transfer)")]
     InsufficientMaxFee,
-    #[error("Account balance is smaller than the transaction's max_fee")]
+    #[error("Account balance is smaller than the transaction's max_fee")] // 54
     InsufficientAccountBalance,
-    #[error("Account validation failed")]
+    #[error("Account validation failed")] // 55
     ValidationFailure,
-    #[error("Compilation failed")]
+    #[error("Compilation failed")] // 56
     CompilationFailed,
-    #[error("Contract bytecode size is too large")]
-    ContractBytecodeSizeIsTooLarge,
-    #[error("Sender address in not an account contract")]
+    #[error("Contract class size it too large")] // 57
+    ContractClassSizeIsTooLarge,
+    #[error("Sender address in not an account contract")] // 58
     NonAccount,
-    #[error("A transaction with the same hash already exists in the mempool")]
+    #[error("A transaction with the same hash already exists in the mempool")] // 59
     DuplicateTransaction,
-    #[error("The compiled class hash did not match the one supplied in the transaction")]
+    #[error("The compiled class hash did not match the one supplied in the transaction")] // 60
     CompiledClassHashMismatch,
+    #[error("The transaction version is not supported")] // 61
+    UnsupportedTxVersion,
+    #[error("The contract class version is not supported")] // 62
+    UnsupportedContractClassVersion,
+    #[error("An unexpected error occured")] // 63
+    UnexpectedError { data: String },
     #[error(transparent)]
     GatewayError(starknet_gateway_types::error::StarknetError),
     #[error(transparent)]
@@ -68,12 +83,17 @@ impl RpcError {
         match self {
             RpcError::FailedToReceiveTxn => 1,
             RpcError::ContractNotFound => 20,
-            RpcError::InvalidMessageSelector => 21,
-            RpcError::InvalidCallData => 22,
+            RpcError::InvalidMessageSelector => 21, // removed in v03
+            RpcError::InvalidCallData => 22,        // removed in v03
+            // v03 trace api spec
+            // INVALID_BLOCK_HASH 24
             RpcError::BlockNotFound => 24,
-            RpcError::TxnHashNotFound => 25,
+            // v03 trace api spec
+            // INVALID_TXN_HASH 25
+            RpcError::TxnHashNotFoundV03 => 25,
             RpcError::InvalidTxnIndex => 27,
             RpcError::ClassHashNotFound => 28,
+            RpcError::TxnHashNotFoundV04 => 29,
             RpcError::PageSizeTooBig => 31,
             RpcError::NoBlocks => 32,
             RpcError::InvalidContinuationToken => 33,
@@ -86,10 +106,13 @@ impl RpcError {
             RpcError::InsufficientAccountBalance => 54,
             RpcError::ValidationFailure => 55,
             RpcError::CompilationFailed => 56,
-            RpcError::ContractBytecodeSizeIsTooLarge => 57,
+            RpcError::ContractClassSizeIsTooLarge => 57,
             RpcError::NonAccount => 58,
             RpcError::DuplicateTransaction => 59,
             RpcError::CompiledClassHashMismatch => 60,
+            RpcError::UnsupportedTxVersion => 61,
+            RpcError::UnsupportedContractClassVersion => 62,
+            RpcError::UnexpectedError { .. } => 63,
             RpcError::ProofLimitExceeded { .. } => 10000,
             RpcError::GatewayError(_) | RpcError::Internal(_) => {
                 jsonrpsee::types::error::ErrorCode::InternalError.code()

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -11,8 +11,6 @@ pub enum RpcError {
     FailedToReceiveTxn,
     #[error("Contract not found")] // 20
     ContractNotFound,
-    #[error("Invalid message selector")] // ?
-    InvalidMessageSelector,
     // v03 trace api spec
     // INVALID_BLOCK_HASH "Invalid block hash" 24
     // v04 trace api spec
@@ -81,7 +79,6 @@ impl RpcError {
         match self {
             RpcError::FailedToReceiveTxn => 1,
             RpcError::ContractNotFound => 20,
-            RpcError::InvalidMessageSelector => 21, // removed in v03
             // v03 trace api spec
             // INVALID_BLOCK_HASH 24
             RpcError::BlockNotFound => 24,

--- a/crates/rpc/src/v02/method/call.rs
+++ b/crates/rpc/src/v02/method/call.rs
@@ -6,7 +6,6 @@ crate::error::generate_rpc_error_subset!(
     CallError: BlockNotFound,
     ContractNotFound,
     InvalidMessageSelector,
-    InvalidCallData,
     ContractError
 );
 

--- a/crates/rpc/src/v02/method/get_transaction_by_hash.rs
+++ b/crates/rpc/src/v02/method/get_transaction_by_hash.rs
@@ -8,7 +8,7 @@ pub struct GetTransactionByHashInput {
     transaction_hash: TransactionHash,
 }
 
-crate::error::generate_rpc_error_subset!(GetTransactionByHashError: TxnHashNotFound);
+crate::error::generate_rpc_error_subset!(GetTransactionByHashError: TxnHashNotFoundV03);
 
 pub async fn get_transaction_by_hash(
     context: RpcContext,
@@ -43,7 +43,7 @@ pub async fn get_transaction_by_hash(
         db_tx
             .transaction(input.transaction_hash)
             .context("Reading transaction from database")?
-            .ok_or(GetTransactionByHashError::TxnHashNotFound)
+            .ok_or(GetTransactionByHashError::TxnHashNotFoundV03)
             .map(|tx| tx.into())
     });
 
@@ -109,7 +109,7 @@ mod tests {
 
             assert_matches::assert_matches!(
                 result,
-                Err(GetTransactionByHashError::TxnHashNotFound)
+                Err(GetTransactionByHashError::TxnHashNotFoundV03)
             );
         }
     }

--- a/crates/rpc/src/v02/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v02/method/get_transaction_receipt.rs
@@ -9,7 +9,7 @@ pub struct GetTransactionReceiptInput {
     transaction_hash: TransactionHash,
 }
 
-crate::error::generate_rpc_error_subset!(GetTransactionReceiptError: TxnHashNotFound);
+crate::error::generate_rpc_error_subset!(GetTransactionReceiptError: TxnHashNotFoundV03);
 
 pub async fn get_transaction_receipt(
     context: RpcContext,
@@ -55,7 +55,7 @@ pub async fn get_transaction_receipt(
         let (transaction, receipt, block_hash) = db_tx
             .transaction_with_receipt(input.transaction_hash)
             .context("Reading transaction receipt from database")?
-            .ok_or(GetTransactionReceiptError::TxnHashNotFound)?;
+            .ok_or(GetTransactionReceiptError::TxnHashNotFoundV03)?;
 
         if receipt.execution_status == ExecutionStatus::Reverted {
             let reason = receipt.revert_error.unwrap_or_default();
@@ -628,7 +628,7 @@ mod tests {
 
             assert_matches::assert_matches!(
                 result,
-                Err(GetTransactionReceiptError::TxnHashNotFound)
+                Err(GetTransactionReceiptError::TxnHashNotFoundV03)
             );
         }
     }

--- a/crates/rpc/src/v03/method/estimate_fee.rs
+++ b/crates/rpc/src/v03/method/estimate_fee.rs
@@ -16,8 +16,7 @@ crate::error::generate_rpc_error_subset!(
     EstimateFeeError: BlockNotFound,
     ContractNotFound,
     ContractError,
-    InvalidMessageSelector,
-    InvalidCallData
+    InvalidMessageSelector
 );
 
 impl From<crate::cairo::ext_py::CallFailure> for EstimateFeeError {

--- a/crates/rpc/src/v03/method/estimate_fee.rs
+++ b/crates/rpc/src/v03/method/estimate_fee.rs
@@ -15,8 +15,7 @@ pub struct EstimateFeeInput {
 crate::error::generate_rpc_error_subset!(
     EstimateFeeError: BlockNotFound,
     ContractNotFound,
-    ContractError,
-    InvalidMessageSelector
+    ContractError
 );
 
 impl From<crate::cairo::ext_py::CallFailure> for EstimateFeeError {
@@ -25,7 +24,9 @@ impl From<crate::cairo::ext_py::CallFailure> for EstimateFeeError {
         match c {
             NoSuchBlock => Self::BlockNotFound,
             NoSuchContract => Self::ContractNotFound,
-            InvalidEntryPoint => Self::InvalidMessageSelector,
+            InvalidEntryPoint => {
+                Self::Internal(anyhow::anyhow!("Internal error: invalid entry point"))
+            }
             ExecutionFailed(e) => Self::Internal(anyhow::anyhow!("Internal error: {e}")),
             // Intentionally hide the message under Internal
             Internal(_) | Shutdown => Self::Internal(anyhow::anyhow!("Internal error")),

--- a/crates/rpc/src/v03/method/simulate_transaction.rs
+++ b/crates/rpc/src/v03/method/simulate_transaction.rs
@@ -406,18 +406,10 @@ mod tests {
                 {
                     "contract_address_salt": "0x46c0d4abf0192a788aca261e58d7031576f7d8ea5229f452b0f23e691dd5971",
                     "max_fee": "0x0",
-                    "signature": [
-                        "0x296ab4b0b7cb0c6929c4fb1e04b782511dffb049f72a90efe5d53f0515eab88",
-                        "0x4e80d8bb98a9baf47f6f0459c2329a5401538576e76436acaf5f56c573c7d77"
-                    ],
-                    "class_hash": "0x2b63cad399dd78efbc9938631e74079cbf19c9c08828e820e7606f46b947513",
                     "signature": [],
                     "class_hash": DUMMY_ACCOUNT_CLASS_HASH,
                     "nonce": "0x0",
                     "version": "0x100000000000000000000000000000001",
-                    "constructor_calldata": [
-                        "0x63c056da088a767a6685ea0126f447681b5bceff5629789b70738bc26b5469d"
-                    ],
                     "version": TransactionVersion::ONE_WITH_QUERY_VERSION,
                     "constructor_calldata": [],
                     "type": "DEPLOY_ACCOUNT"

--- a/crates/rpc/src/v04.rs
+++ b/crates/rpc/src/v04.rs
@@ -71,8 +71,8 @@ pub fn register_methods(module: Module) -> anyhow::Result<Module> {
         .register_method("v0.4_starknet_getEvents", v03_method::get_events)?
         .register_method("v0.4_starknet_getStateUpdate", v03_method::get_state_update)?
         .register_method(
-            "v0.4_starknet_simulateTransaction",
-            v03_method::simulate_transaction,
+            "v0.4_starknet_simulateTransactions",
+            v04_method::simulate_transactions,
         )?
         .register_method(
             "v0.4_pathfinder_getProof",

--- a/crates/rpc/src/v04/method.rs
+++ b/crates/rpc/src/v04/method.rs
@@ -3,6 +3,7 @@ mod add_deploy_account_transaction;
 mod add_invoke_transaction;
 mod estimate_message_fee;
 mod get_transaction_receipt;
+mod simulate_transactions;
 mod syncing;
 
 pub(super) use add_declare_transaction::add_declare_transaction;
@@ -10,4 +11,108 @@ pub(super) use add_deploy_account_transaction::add_deploy_account_transaction;
 pub(super) use add_invoke_transaction::add_invoke_transaction;
 pub(super) use estimate_message_fee::estimate_message_fee;
 pub(super) use get_transaction_receipt::get_transaction_receipt;
+pub(super) use simulate_transactions::simulate_transactions;
 pub(super) use syncing::syncing;
+
+pub(crate) mod common {
+    use std::sync::Arc;
+
+    use pathfinder_common::{BlockId, BlockTimestamp, StateUpdate};
+    use starknet_gateway_types::pending::PendingData;
+
+    use crate::{
+        cairo::ext_py::{BlockHashNumberOrLatest, GasPriceSource, Handle},
+        context::RpcContext,
+    };
+
+    pub async fn prepare_handle_and_block(
+        context: &RpcContext,
+        block_id: BlockId,
+    ) -> Result<
+        (
+            &Handle,
+            GasPriceSource,
+            BlockHashNumberOrLatest,
+            Option<BlockTimestamp>,
+            Option<Arc<StateUpdate>>,
+        ),
+        anyhow::Error,
+    > {
+        let handle = context
+            .call_handle
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Unsupported configuration"))?;
+
+        // discussed during estimateFee work: when user is requesting using block_hash use the
+        // gasPrice from the starknet_blocks::gas_price column, otherwise (tags) get the latest
+        // eth_gasPrice.
+        //
+        // the fact that [`base_block_and_pending_for_call`] transforms pending cases to use
+        // actual parent blocks by hash is an internal transformation we do for correctness,
+        // unrelated to this consideration.
+        let gas_price = if matches!(block_id, BlockId::Pending | BlockId::Latest) {
+            let gas_price = match context.eth_gas_price.as_ref() {
+                Some(cached) => cached.get().await,
+                None => None,
+            };
+
+            let gas_price =
+                gas_price.ok_or_else(|| anyhow::anyhow!("Current eth_gasPrice is unavailable"))?;
+
+            GasPriceSource::Current(gas_price)
+        } else {
+            GasPriceSource::PastBlock
+        };
+
+        let (when, pending_timestamp, pending_update) =
+            base_block_and_pending_for_call(block_id, &context.pending_data).await?;
+
+        Ok((handle, gas_price, when, pending_timestamp, pending_update))
+    }
+
+    /// Transforms the request to call or estimate fee at some point in time to the type expected
+    /// by [`crate::cairo::ext_py`] with the optional, latest pending data.
+    pub async fn base_block_and_pending_for_call(
+        at_block: BlockId,
+        pending_data: &Option<PendingData>,
+    ) -> Result<
+        (
+            BlockHashNumberOrLatest,
+            Option<BlockTimestamp>,
+            Option<Arc<StateUpdate>>,
+        ),
+        anyhow::Error,
+    > {
+        use crate::cairo::ext_py::Pending;
+
+        match BlockHashNumberOrLatest::try_from(at_block) {
+            Ok(when) => Ok((when, None, None)),
+            Err(Pending) => {
+                // we must have pending_data configured for pending requests, otherwise we fail
+                // fast.
+                match pending_data {
+                    Some(pending) => {
+                        // call on this particular parent block hash; if it's not found at query time over
+                        // at python, it should fall back to latest and **disregard** the pending data.
+                        let pending_on_top_of_a_block = pending
+                            .state_update_on_parent_block()
+                            .await
+                            .map(|(parent_block, timestamp, data)| {
+                                (parent_block.into(), Some(timestamp), Some(data))
+                            });
+
+                        // if there is no pending data available, just execute on whatever latest.
+                        Ok(pending_on_top_of_a_block.unwrap_or((
+                            BlockHashNumberOrLatest::Latest,
+                            None,
+                            None,
+                        )))
+                    }
+                    None => Err(anyhow::anyhow!(
+                        "Pending data not supported in this configuration"
+                    )),
+                }
+            }
+        }
+    }
+}

--- a/crates/rpc/src/v04/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v04/method/add_declare_transaction.rs
@@ -37,7 +37,7 @@ impl From<AddDeclareTransactionError> for crate::error::RpcError {
             AddDeclareTransactionError::ValidationFailure => Self::ValidationFailure,
             AddDeclareTransactionError::CompilationFailed => Self::CompilationFailed,
             AddDeclareTransactionError::ContractBytecodeSizeTooLarge => {
-                Self::ContractBytecodeSizeIsTooLarge
+                Self::ContractClassSizeIsTooLarge
             }
             AddDeclareTransactionError::DuplicateTransaction => Self::DuplicateTransaction,
             AddDeclareTransactionError::CompiledClassHashMismatch => {

--- a/crates/rpc/src/v04/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v04/method/add_declare_transaction.rs
@@ -3,31 +3,31 @@ use crate::felt::RpcFelt;
 use crate::v02::types::request::BroadcastedDeclareTransaction;
 use pathfinder_common::{ClassHash, TransactionHash};
 use starknet_gateway_client::GatewayApi;
-use starknet_gateway_types::error::{SequencerError, StarknetError};
+use starknet_gateway_types::error::SequencerError;
 use starknet_gateway_types::request::add_transaction::{
     CairoContractDefinition, ContractDefinition, SierraContractDefinition,
 };
 
 #[derive(Debug)]
 pub enum AddDeclareTransactionError {
-    InvalidContractClass,
     ClassAlreadyDeclared,
     InvalidTransactionNonce,
     InsufficientMaxFee,
     InsufficientAccountBalance,
     ValidationFailure,
     CompilationFailed,
-    ContractBytecodeSizeTooLarge,
+    ContractClassSizeIsTooLarge,
     DuplicateTransaction,
     CompiledClassHashMismatch,
-    GatewayError(StarknetError),
-    Internal(anyhow::Error),
+    NonAccount,
+    UnsupportedTransactionVersion,
+    UnsupportedContractClassVersion,
+    UnexpectedError(String),
 }
 
 impl From<AddDeclareTransactionError> for crate::error::RpcError {
     fn from(value: AddDeclareTransactionError) -> Self {
         match value {
-            AddDeclareTransactionError::InvalidContractClass => Self::InvalidContractClass,
             AddDeclareTransactionError::ClassAlreadyDeclared => Self::ClassAlreadyDeclared,
             AddDeclareTransactionError::InvalidTransactionNonce => Self::InvalidTransactionNonce,
             AddDeclareTransactionError::InsufficientMaxFee => Self::InsufficientMaxFee,
@@ -36,22 +36,26 @@ impl From<AddDeclareTransactionError> for crate::error::RpcError {
             }
             AddDeclareTransactionError::ValidationFailure => Self::ValidationFailure,
             AddDeclareTransactionError::CompilationFailed => Self::CompilationFailed,
-            AddDeclareTransactionError::ContractBytecodeSizeTooLarge => {
+            AddDeclareTransactionError::ContractClassSizeIsTooLarge => {
                 Self::ContractClassSizeIsTooLarge
             }
             AddDeclareTransactionError::DuplicateTransaction => Self::DuplicateTransaction,
             AddDeclareTransactionError::CompiledClassHashMismatch => {
                 Self::CompiledClassHashMismatch
             }
-            AddDeclareTransactionError::GatewayError(x) => Self::GatewayError(x),
-            AddDeclareTransactionError::Internal(x) => Self::Internal(x),
+            AddDeclareTransactionError::NonAccount => Self::NonAccount,
+            AddDeclareTransactionError::UnsupportedTransactionVersion => Self::UnsupportedTxVersion,
+            AddDeclareTransactionError::UnsupportedContractClassVersion => {
+                Self::UnsupportedContractClassVersion
+            }
+            AddDeclareTransactionError::UnexpectedError(data) => Self::UnexpectedError { data },
         }
     }
 }
 
 impl From<anyhow::Error> for AddDeclareTransactionError {
     fn from(value: anyhow::Error) -> Self {
-        AddDeclareTransactionError::Internal(value)
+        AddDeclareTransactionError::UnexpectedError(value.to_string())
     }
 }
 
@@ -59,24 +63,23 @@ impl From<SequencerError> for AddDeclareTransactionError {
     fn from(e: SequencerError) -> Self {
         use starknet_gateway_types::error::KnownStarknetErrorCode::{
             ClassAlreadyDeclared, CompilationFailed, ContractBytecodeSizeTooLarge,
-            DuplicatedTransaction, InsufficientAccountBalance, InsufficientMaxFee,
-            InvalidCompiledClassHash, InvalidContractClass, InvalidProgram,
-            InvalidTransactionNonce, ValidateFailure,
+            ContractClassObjectSizeTooLarge, DuplicatedTransaction, EntryPointNotFound,
+            InsufficientAccountBalance, InsufficientMaxFee, InvalidCompiledClassHash,
+            InvalidContractClassVersion, InvalidTransactionNonce, InvalidTransactionVersion,
+            ValidateFailure,
         };
         match e {
-            SequencerError::StarknetError(e)
-                if e.code == InvalidProgram.into() || e.code == InvalidContractClass.into() =>
-            {
-                AddDeclareTransactionError::InvalidContractClass
-            }
             SequencerError::StarknetError(e) if e.code == ClassAlreadyDeclared.into() => {
                 AddDeclareTransactionError::ClassAlreadyDeclared
             }
             SequencerError::StarknetError(e) if e.code == CompilationFailed.into() => {
                 AddDeclareTransactionError::CompilationFailed
             }
-            SequencerError::StarknetError(e) if e.code == ContractBytecodeSizeTooLarge.into() => {
-                AddDeclareTransactionError::ContractBytecodeSizeTooLarge
+            SequencerError::StarknetError(e)
+                if e.code == ContractBytecodeSizeTooLarge.into()
+                    || e.code == ContractClassObjectSizeTooLarge.into() =>
+            {
+                AddDeclareTransactionError::ContractClassSizeIsTooLarge
             }
             SequencerError::StarknetError(e) if e.code == DuplicatedTransaction.into() => {
                 AddDeclareTransactionError::DuplicateTransaction
@@ -96,8 +99,16 @@ impl From<SequencerError> for AddDeclareTransactionError {
             SequencerError::StarknetError(e) if e.code == InvalidCompiledClassHash.into() => {
                 AddDeclareTransactionError::CompiledClassHashMismatch
             }
-            SequencerError::StarknetError(other) => AddDeclareTransactionError::GatewayError(other),
-            _ => AddDeclareTransactionError::Internal(e.into()),
+            SequencerError::StarknetError(e) if e.code == InvalidTransactionVersion.into() => {
+                AddDeclareTransactionError::UnsupportedTransactionVersion
+            }
+            SequencerError::StarknetError(e) if e.code == InvalidContractClassVersion.into() => {
+                AddDeclareTransactionError::UnsupportedContractClassVersion
+            }
+            SequencerError::StarknetError(e) if e.code == EntryPointNotFound.into() => {
+                AddDeclareTransactionError::NonAccount
+            }
+            _ => AddDeclareTransactionError::UnexpectedError(e.to_string()),
         }
     }
 }
@@ -407,7 +418,7 @@ mod tests {
             token: None,
         };
         let error = add_declare_transaction(context, input).await.unwrap_err();
-        assert_matches::assert_matches!(error, AddDeclareTransactionError::InvalidContractClass);
+        assert_matches::assert_matches!(error, AddDeclareTransactionError::UnexpectedError(_));
     }
 
     #[test_log::test(tokio::test)]
@@ -441,7 +452,7 @@ mod tests {
             token: None,
         };
         let error = add_declare_transaction(context, input).await.unwrap_err();
-        assert_matches::assert_matches!(error, AddDeclareTransactionError::InvalidContractClass);
+        assert_matches::assert_matches!(error, AddDeclareTransactionError::UnexpectedError(_));
     }
 
     #[test_log::test(tokio::test)]
@@ -465,7 +476,7 @@ mod tests {
             token: None,
         };
         let error = add_declare_transaction(context, input).await.unwrap_err();
-        assert_matches::assert_matches!(error, AddDeclareTransactionError::InvalidContractClass);
+        assert_matches::assert_matches!(error, AddDeclareTransactionError::UnexpectedError(_));
     }
 
     #[test_log::test(tokio::test)]

--- a/crates/rpc/src/v04/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v04/method/get_transaction_receipt.rs
@@ -7,7 +7,7 @@ pub struct GetTransactionReceiptInput {
     transaction_hash: TransactionHash,
 }
 
-crate::error::generate_rpc_error_subset!(GetTransactionReceiptError: TxnHashNotFound);
+crate::error::generate_rpc_error_subset!(GetTransactionReceiptError: TxnHashNotFoundV04);
 
 pub async fn get_transaction_receipt(
     context: RpcContext,
@@ -47,7 +47,7 @@ pub async fn get_transaction_receipt(
         let (transaction, receipt, block_hash) = db_tx
             .transaction_with_receipt(input.transaction_hash)
             .context("Reading transaction receipt from database")?
-            .ok_or(GetTransactionReceiptError::TxnHashNotFound)?;
+            .ok_or(GetTransactionReceiptError::TxnHashNotFoundV04)?;
 
         let block_number = db_tx
             .block_id(block_hash.into())
@@ -524,7 +524,7 @@ mod tests {
 
             assert_matches::assert_matches!(
                 result,
-                Err(GetTransactionReceiptError::TxnHashNotFound)
+                Err(GetTransactionReceiptError::TxnHashNotFoundV04)
             );
         }
     }

--- a/crates/rpc/src/v04/method/simulate_transactions.rs
+++ b/crates/rpc/src/v04/method/simulate_transactions.rs
@@ -1,0 +1,481 @@
+use crate::{
+    cairo::ext_py::{
+        types::{
+            EntryPointType, FeeEstimate, FunctionInvocation, MsgToL1, TransactionSimulation,
+            TransactionTrace,
+        },
+        CallFailure,
+    },
+    context::RpcContext,
+    v02::{
+        method::call::FunctionCall,
+        types::{reply, request::BroadcastedTransaction},
+    },
+};
+
+use anyhow::anyhow;
+use pathfinder_common::{BlockId, CallParam, ContractAddress, EntryPoint};
+use serde::{Deserialize, Serialize};
+use stark_hash::Felt;
+
+use super::common::prepare_handle_and_block;
+
+#[derive(Deserialize, Debug)]
+pub struct SimulateTrasactionInput {
+    block_id: BlockId,
+    transactions: Vec<BroadcastedTransaction>,
+    simulation_flags: dto::SimulationFlags,
+}
+
+#[derive(Debug, Serialize, Eq, PartialEq)]
+pub struct SimulateTransactionOutput(pub Vec<dto::SimulatedTransaction>);
+
+crate::error::generate_rpc_error_subset!(
+    SimulateTransactionError: BlockNotFound,
+    ContractNotFound,
+    ContractError
+);
+
+impl From<CallFailure> for SimulateTransactionError {
+    fn from(value: CallFailure) -> Self {
+        match value {
+            CallFailure::NoSuchBlock => Self::BlockNotFound,
+            CallFailure::NoSuchContract => Self::ContractNotFound,
+            CallFailure::InvalidEntryPoint => Self::ContractError,
+            CallFailure::ExecutionFailed(e) => Self::Internal(anyhow!("Execution failed: {e}")),
+            CallFailure::Internal(_) | CallFailure::Shutdown => {
+                Self::Internal(anyhow!("Internal error"))
+            }
+        }
+    }
+}
+
+pub async fn simulate_transactions(
+    context: RpcContext,
+    input: SimulateTrasactionInput,
+) -> Result<SimulateTransactionOutput, SimulateTransactionError> {
+    let (handle, gas_price, at_block, pending_timestamp, pending_update) =
+        prepare_handle_and_block(&context, input.block_id).await?;
+
+    let skip_validate = input
+        .simulation_flags
+        .0
+        .iter()
+        .any(|flag| flag == &dto::SimulationFlag::SkipValidate);
+    let txs = handle
+        .simulate_transaction(
+            at_block,
+            gas_price,
+            pending_update,
+            pending_timestamp,
+            input.transactions,
+            skip_validate,
+        )
+        .await?;
+
+    let txs: Result<Vec<dto::SimulatedTransaction>, SimulateTransactionError> =
+        txs.into_iter().map(map_tx).collect();
+    Ok(SimulateTransactionOutput(txs?))
+}
+
+fn map_tx(
+    tx: TransactionSimulation,
+) -> Result<dto::SimulatedTransaction, SimulateTransactionError> {
+    Ok(dto::SimulatedTransaction {
+        fee_estimation: Some(map_fee(tx.fee_estimation)),
+        transaction_trace: Some(map_trace(tx.trace)?),
+    })
+}
+
+fn map_fee(fee: FeeEstimate) -> reply::FeeEstimate {
+    reply::FeeEstimate {
+        gas_consumed: fee.gas_consumed,
+        gas_price: fee.gas_price,
+        overall_fee: fee.overall_fee,
+    }
+}
+
+fn map_function_invocation(mut fi: FunctionInvocation) -> dto::FunctionInvocation {
+    use crate::cairo::ext_py::types;
+    dto::FunctionInvocation {
+        call_type: fi.call_type.map(|call_type| match call_type {
+            types::CallType::Call => dto::CallType::Call,
+            types::CallType::Delegate => dto::CallType::LibraryCall,
+        }),
+        caller_address: fi.caller_address,
+        calls: fi
+            .internal_calls
+            .take()
+            .map(|calls| calls.into_iter().map(map_function_invocation).collect()),
+        class_hash: fi.class_hash,
+        entry_point_type: fi.entry_point_type.map(Into::into),
+        events: fi.events.map(|events| {
+            events
+                .into_iter()
+                .map(|event| dto::Event {
+                    data: event.data,
+                    keys: event.keys,
+                })
+                .collect()
+        }),
+        messages: fi
+            .messages
+            .map(|messages| map_messages(messages, fi.contract_address)),
+        function_call: FunctionCall {
+            calldata: fi.calldata.into_iter().map(CallParam).collect(),
+            contract_address: fi.contract_address,
+            entry_point_selector: EntryPoint(fi.selector),
+        },
+        result: fi.result,
+    }
+}
+
+fn map_messages(messages: Vec<MsgToL1>, from_address: ContractAddress) -> Vec<dto::MsgToL1> {
+    messages
+        .into_iter()
+        .map(|msg| dto::MsgToL1 {
+            payload: msg.payload,
+            to_address: msg.to_address,
+            from_address: from_address.0,
+        })
+        .collect()
+}
+
+fn map_trace(
+    mut trace: TransactionTrace,
+) -> Result<dto::TransactionTrace, SimulateTransactionError> {
+    let invocations = (
+        trace.validate_invocation.take(),
+        trace.function_invocation.take(),
+        trace.fee_transfer_invocation.take(),
+    );
+    match invocations {
+        (Some(val), Some(fun), fee)
+            if fun.entry_point_type == Some(EntryPointType::Constructor) =>
+        {
+            Ok(dto::TransactionTrace::DeployAccount(
+                dto::DeployAccountTxnTrace {
+                    fee_transfer_invocation: fee.map(map_function_invocation),
+                    validate_invocation: Some(map_function_invocation(val)),
+                    constructor_invocation: Some(map_function_invocation(fun)),
+                },
+            ))
+        }
+        (Some(val), Some(fun), fee) if fun.entry_point_type == Some(EntryPointType::External) => {
+            Ok(dto::TransactionTrace::Invoke(dto::InvokeTxnTrace {
+                fee_transfer_invocation: fee.map(map_function_invocation),
+                validate_invocation: Some(map_function_invocation(val)),
+                execute_invocation: Some(map_function_invocation(fun)),
+            }))
+        }
+        (Some(val), _, fee) => Ok(dto::TransactionTrace::Declare(dto::DeclareTxnTrace {
+            fee_transfer_invocation: fee.map(map_function_invocation),
+            validate_invocation: Some(map_function_invocation(val)),
+        })),
+        (_, Some(fun), _) => Ok(dto::TransactionTrace::L1Handler(dto::L1HandlerTxnTrace {
+            function_invocation: Some(map_function_invocation(fun)),
+        })),
+        _ => Err(SimulateTransactionError::Internal(anyhow!(
+            "Unmatched transaction trace: '{trace:?}'"
+        ))),
+    }
+}
+
+pub mod dto {
+    use serde_with::serde_as;
+
+    use crate::felt::RpcFelt;
+    use crate::v02::method::call::FunctionCall;
+    use crate::v02::types::reply::FeeEstimate;
+
+    use super::*;
+
+    #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
+    pub struct SimulationFlags(pub Vec<SimulationFlag>);
+
+    #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
+    pub enum SimulationFlag {
+        #[serde(rename = "SKIP_FEE_CHARGE")]
+        SkipFeeCharge,
+        #[serde(rename = "SKIP_VALIDATE")]
+        SkipValidate,
+    }
+
+    #[serde_with::serde_as]
+    #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
+    pub struct Signature(#[serde_as(as = "Vec<RpcFelt>")] pub Vec<Felt>);
+
+    #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
+    pub enum CallType {
+        #[serde(rename = "CALL")]
+        Call,
+        #[serde(rename = "LIBRARY_CALL")]
+        LibraryCall,
+    }
+
+    #[serde_with::serde_as]
+    #[serde_with::skip_serializing_none]
+    #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
+    pub struct FunctionInvocation {
+        #[serde(default)]
+        pub call_type: Option<CallType>,
+        #[serde(default)]
+        #[serde_as(as = "Option<RpcFelt>")]
+        pub caller_address: Option<Felt>,
+        #[serde(default)]
+        pub calls: Option<Vec<FunctionInvocation>>,
+        #[serde(default)]
+        #[serde_as(as = "Option<RpcFelt>")]
+        pub class_hash: Option<Felt>,
+        #[serde(default)]
+        pub entry_point_type: Option<EntryPointType>,
+        #[serde(default)]
+        pub events: Option<Vec<Event>>,
+        #[serde(flatten)]
+        pub function_call: FunctionCall,
+        #[serde(default)]
+        pub messages: Option<Vec<MsgToL1>>,
+        #[serde(default)]
+        #[serde_as(as = "Option<Vec<RpcFelt>>")]
+        pub result: Option<Vec<Felt>>,
+    }
+
+    #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
+    pub enum EntryPointType {
+        #[serde(rename = "CONSTRUCTOR")]
+        Constructor,
+        #[serde(rename = "EXTERNAL")]
+        External,
+        #[serde(rename = "L1_HANDLER")]
+        L1Handler,
+    }
+
+    impl From<crate::cairo::ext_py::types::EntryPointType> for EntryPointType {
+        fn from(value: crate::cairo::ext_py::types::EntryPointType) -> Self {
+            use crate::cairo::ext_py::types::EntryPointType::*;
+            match value {
+                Constructor => Self::Constructor,
+                External => Self::External,
+                L1Handler => Self::L1Handler,
+            }
+        }
+    }
+
+    #[serde_with::serde_as]
+    #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
+    pub struct MsgToL1 {
+        #[serde_as(as = "Vec<RpcFelt>")]
+        pub payload: Vec<Felt>,
+        #[serde_as(as = "RpcFelt")]
+        pub to_address: Felt,
+        #[serde_as(as = "RpcFelt")]
+        pub from_address: Felt,
+    }
+
+    #[serde_with::serde_as]
+    #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
+    pub struct Event {
+        #[serde_as(as = "Vec<RpcFelt>")]
+        pub data: Vec<Felt>,
+        #[serde_as(as = "Vec<RpcFelt>")]
+        pub keys: Vec<Felt>,
+    }
+
+    #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
+    #[serde(untagged)]
+    pub enum TransactionTrace {
+        Declare(DeclareTxnTrace),
+        DeployAccount(DeployAccountTxnTrace),
+        Invoke(InvokeTxnTrace),
+        L1Handler(L1HandlerTxnTrace),
+    }
+
+    #[serde_with::skip_serializing_none]
+    #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
+    pub struct DeclareTxnTrace {
+        #[serde(default)]
+        pub fee_transfer_invocation: Option<FunctionInvocation>,
+        #[serde(default)]
+        pub validate_invocation: Option<FunctionInvocation>,
+    }
+
+    #[serde_with::skip_serializing_none]
+    #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
+    pub struct DeployAccountTxnTrace {
+        #[serde(default)]
+        pub constructor_invocation: Option<FunctionInvocation>,
+        #[serde(default)]
+        pub fee_transfer_invocation: Option<FunctionInvocation>,
+        #[serde(default)]
+        pub validate_invocation: Option<FunctionInvocation>,
+    }
+
+    #[serde_with::skip_serializing_none]
+    #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
+    pub struct InvokeTxnTrace {
+        #[serde(default)]
+        pub execute_invocation: Option<FunctionInvocation>,
+        #[serde(default)]
+        pub fee_transfer_invocation: Option<FunctionInvocation>,
+        #[serde(default)]
+        pub validate_invocation: Option<FunctionInvocation>,
+    }
+
+    #[serde_with::skip_serializing_none]
+    #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
+    pub struct L1HandlerTxnTrace {
+        #[serde(default)]
+        pub function_invocation: Option<FunctionInvocation>,
+    }
+
+    #[serde_with::skip_serializing_none]
+    #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
+    pub struct SimulatedTransaction {
+        #[serde(default)]
+        pub fee_estimation: Option<FeeEstimate>,
+        #[serde(default)]
+        pub transaction_trace: Option<TransactionTrace>,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use pathfinder_common::macro_prelude::*;
+    use pathfinder_common::{
+        felt, BlockHash, BlockHeader, BlockNumber, BlockTimestamp, Chain, GasPrice,
+        TransactionVersion,
+    };
+    use pathfinder_storage::{JournalMode, Storage};
+    use starknet_gateway_test_fixtures::class_definitions::{
+        DUMMY_ACCOUNT, DUMMY_ACCOUNT_CLASS_HASH,
+    };
+    use tempfile::tempdir;
+
+    use crate::v02::types::reply::FeeEstimate;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_simulate_transaction() {
+        let dir = tempdir().expect("tempdir");
+        let mut db_path = dir.path().to_path_buf();
+        db_path.push("db.sqlite");
+
+        let storage = Storage::migrate(db_path, JournalMode::WAL)
+            .expect("storage")
+            .create_pool(NonZeroU32::new(1).unwrap())
+            .unwrap();
+
+        {
+            let mut db = storage.connection().unwrap();
+            let tx = db.transaction().expect("tx");
+
+            tx.insert_cairo_class(DUMMY_ACCOUNT_CLASS_HASH, DUMMY_ACCOUNT)
+                .expect("insert class");
+
+            let header = BlockHeader::builder()
+                .with_number(BlockNumber::GENESIS + 1)
+                .with_timestamp(BlockTimestamp::new_or_panic(1))
+                .with_gas_price(GasPrice(1))
+                .finalize_with_hash(BlockHash::ZERO);
+
+            tx.insert_block_header(&header).unwrap();
+            tx.commit().unwrap();
+        }
+
+        let (call_handle, _join_handle) = crate::cairo::ext_py::start(
+            storage.path().into(),
+            std::num::NonZeroUsize::try_from(1).unwrap(),
+            futures::future::pending(),
+            Chain::Testnet,
+        )
+        .await
+        .unwrap();
+
+        let rpc = RpcContext::for_tests()
+            .with_storage(storage)
+            .with_call_handling(call_handle);
+
+        let input_json = serde_json::json!({
+            "block_id": {"block_number": 1},
+            "transactions": [
+                {
+                    "contract_address_salt": "0x46c0d4abf0192a788aca261e58d7031576f7d8ea5229f452b0f23e691dd5971",
+                    "max_fee": "0x0",
+                    "signature": [],
+                    "class_hash": DUMMY_ACCOUNT_CLASS_HASH,
+                    "nonce": "0x0",
+                    "version": "0x100000000000000000000000000000001",
+                    "version": TransactionVersion::ONE_WITH_QUERY_VERSION,
+                    "constructor_calldata": [],
+                    "type": "DEPLOY_ACCOUNT"
+                }
+            ],
+            "simulation_flags": []
+        });
+        let input = SimulateTrasactionInput::deserialize(&input_json).unwrap();
+
+        let expected: Vec<dto::SimulatedTransaction> = {
+            use dto::*;
+            vec![
+            SimulatedTransaction {
+                fee_estimation: Some(
+                    FeeEstimate {
+                        gas_consumed: 0xc19.into(),
+                        gas_price: 1.into(),
+                        overall_fee: 0xc19.into(),
+                    }
+                ),
+                transaction_trace: Some(
+                    TransactionTrace::DeployAccount(
+                        DeployAccountTxnTrace {
+                            constructor_invocation: Some(
+                                FunctionInvocation {
+                                    call_type: Some(CallType::Call),
+                                    caller_address: Some(felt!("0x0")),
+                                    calls: Some(vec![]),
+                                    class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
+                                    entry_point_type: Some(EntryPointType::Constructor),
+                                    events: Some(vec![]),
+                                    function_call: FunctionCall {
+                                        calldata: vec![],
+                                        contract_address: contract_address!("0x00798C1BFDAF2077F4900E37C8815AFFA8D217D46DB8A84C3FBA1838C8BD4A65"),
+                                        entry_point_selector: entry_point!("0x028FFE4FF0F226A9107253E17A904099AA4F63A02A5621DE0576E5AA71BC5194"),
+                                    },
+                                    messages: Some(vec![]),
+                                    result: Some(vec![]),
+                                },
+                            ),
+                            validate_invocation: Some(
+                                FunctionInvocation {
+                                    call_type: Some(CallType::Call),
+                                    caller_address: Some(felt!("0x0")),
+                                    calls: Some(vec![]),
+                                    class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
+                                    entry_point_type: Some(EntryPointType::External),
+                                    events: Some(vec![]),
+                                    function_call: FunctionCall {
+                                        calldata: vec![
+                                            CallParam(DUMMY_ACCOUNT_CLASS_HASH.0),
+                                            call_param!("0x046C0D4ABF0192A788ACA261E58D7031576F7D8EA5229F452B0F23E691DD5971"),
+                                        ],
+                                        contract_address: contract_address!("0x00798C1BFDAF2077F4900E37C8815AFFA8D217D46DB8A84C3FBA1838C8BD4A65"),
+                                        entry_point_selector: entry_point!("0x036FCBF06CD96843058359E1A75928BEACFAC10727DAB22A3972F0AF8AA92895"),
+                                    },
+                                    messages: Some(vec![]),
+                                    result: Some(vec![]),
+                                },
+                            ),
+                            fee_transfer_invocation: None,
+                        },
+                    ),
+                ),
+            }]
+        };
+
+        let result = simulate_transactions(rpc, input).await.expect("result");
+        pretty_assertions::assert_eq!(result.0, expected);
+    }
+}


### PR DESCRIPTION
Fixes #1283 

---------------------------

~~I'm unsure about [removing `InvalidMessageSelector`](https://github.com/eqlabs/pathfinder/pull/1289/commits/a2758fbe146bb3af51747a2ea8a8fe1e54951ce1) which was removed in v03 spec but is used in our version of v03 in call and estimate fee, which makes our impl deviate from the spec.
I don't know if any libs/services rely on that specific variant (but still this is a breaking change).~~
Edit: it's bug fix as we need to stick to the spec.

There's no such issue with the other removed variant as it was dead code.