### PR TITLE
fix(rpc/v04/get_transaction_receipt): fix execution and finality status JSON representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- RPC v0.4 `starknet_getTransactionReceipt` incorrect execution and finality status names
+
 ## [0.7.0] - 2023-07-27
 
 ### Added


### PR DESCRIPTION
Execution and finality status values were incorrect -- they were using camel case instead of the screaming snake case expected by the spec.

Closes #1297