### PR TITLE
chore: remove unused deps from Cargo.toml files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6209,7 +6209,6 @@ dependencies = [
  "hex",
  "libp2p 0.51.3",
  "p2p_proto",
- "pathfinder-common",
  "prost",
  "rand 0.8.5",
  "serde",
@@ -6244,7 +6243,6 @@ dependencies = [
 name = "p2p_proto"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "fake",
  "p2p_proto_derive",
  "primitive-types",
@@ -6399,7 +6397,6 @@ dependencies = [
  "clap",
  "console-subscriber",
  "const-decoder",
- "criterion",
  "fake",
  "flate2",
  "futures",
@@ -6473,17 +6470,12 @@ name = "pathfinder-ethereum"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "assert_matches",
  "async-trait",
  "const-decoder",
- "futures",
  "hex",
  "httpmock",
  "keccak-hash",
- "lazy_static",
  "pathfinder-common",
- "pathfinder-retry",
- "pretty_assertions",
  "primitive-types",
  "reqwest",
  "serde_json",
@@ -6589,7 +6581,6 @@ dependencies = [
  "const_format",
  "data-encoding",
  "fake",
- "flate2",
  "hex",
  "lazy_static",
  "pathfinder-common",
@@ -6605,7 +6596,6 @@ dependencies = [
  "serde_with",
  "sha3",
  "stark_hash",
- "starknet-gateway-client",
  "starknet-gateway-types",
  "tempfile",
  "thiserror",

--- a/crates/ethereum/Cargo.toml
+++ b/crates/ethereum/Cargo.toml
@@ -10,12 +10,9 @@ rust-version = "1.62"
 anyhow = { workspace = true }
 async-trait = "0.1.59"
 const-decoder = "0.3.0"
-futures = { version = "0.3", default-features = false, features = ["std"] }
 hex = "0.4.3"
 keccak-hash = "0.10.0"
-lazy_static = "1.4.0"
 pathfinder-common = { path = "../common" }
-pathfinder-retry = { path = "../retry" }
 primitive-types = "0.12.1"
 reqwest = { version = "0.11.13", features = ["json"] }
 serde_json = { workspace = true }
@@ -25,8 +22,6 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-assert_matches = { workspace = true }
 hex = "0.4.3"
 httpmock = "0.6.7"
-pretty_assertions = "1.3.0"
 tokio = { workspace = true, features = ["macros"] }

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -10,10 +10,24 @@ license = "MIT OR Apache-2.0"
 anyhow = { workspace = true }
 async-trait = "0.1.58"
 base64 = "0.13.0"
-clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
 delay_map = "0.1.2"
 futures = "0.3.21"
-libp2p = { version = "0.51.3", default-features = false, features = ["identify", "gossipsub", "kad", "noise", "ping", "dns", "tcp", "tokio", "yamux", "request-response", "autonat", "relay", "dcutr", "macros"] }
+libp2p = { version = "0.51.3", default-features = false, features = [
+    "identify",
+    "gossipsub",
+    "kad",
+    "noise",
+    "ping",
+    "dns",
+    "tcp",
+    "tokio",
+    "yamux",
+    "request-response",
+    "autonat",
+    "relay",
+    "dcutr",
+    "macros",
+] }
 p2p_proto = { path = "../p2p_proto" }
 prost = "0.11.2"
 serde = { workspace = true, features = ["derive"] }
@@ -22,15 +36,17 @@ sha2 = "0.10.2"
 stark_hash = { path = "../stark_hash" }
 tokio = { version = "1.20.1", features = ["rt-multi-thread", "macros", "sync"] }
 tracing = "0.1.31"
-tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
 zeroize = "1.5.7"
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
 env_logger = "0.10.0"
 fake = { workspace = true }
 hex = "0.4.3"
-pathfinder-common = { path = "../common" }
 rand = { workspace = true }
-test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
+test-log = { version = "0.2.11", default-features = false, features = [
+    "trace",
+] }
 tokio = { version = "1.20.1", features = ["test-util"] }
+tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }

--- a/crates/p2p_proto/Cargo.toml
+++ b/crates/p2p_proto/Cargo.toml
@@ -6,7 +6,6 @@ license = "MIT"
 build = "build.rs"
 
 [dependencies]
-anyhow = { workspace = true }
 fake = { version = "2.5.0", features = ["derive"] }
 p2p_proto_derive = { path = "../p2p_proto_derive" }
 primitive-types = "0.12.1"

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -42,7 +42,10 @@ primitive-types = "0.12.1"
 reqwest = { version = "0.11.13", features = ["json"] }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true, features = ["arbitrary_precision", "raw_value"] }
+serde_json = { workspace = true, features = [
+    "arbitrary_precision",
+    "raw_value",
+] }
 stark_hash = { path = "../stark_hash" }
 starknet-gateway-client = { path = "../gateway-client" }
 starknet-gateway-types = { path = "../gateway-types" }
@@ -52,7 +55,11 @@ time = { version = "0.3.20", features = ["macros"] }
 tokio = { workspace = true, features = ["process"] }
 toml = "0.5.9"
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3.16", features = ["env-filter", "time", "ansi"] }
+tracing-subscriber = { version = "0.3.16", features = [
+    "env-filter",
+    "time",
+    "ansi",
+] }
 url = "2.3.1"
 warp = "0.3.3"
 
@@ -60,7 +67,6 @@ warp = "0.3.3"
 assert_matches = { workspace = true }
 bytes = "1.3.0"
 const-decoder = "0.3.0"
-criterion = { workspace = true }
 fake = { version = "2.5.0", features = ["derive"] }
 flate2 = "1.0.25"
 http = "0.2.8"
@@ -78,4 +84,7 @@ zstd = "0.12"
 
 [build-dependencies]
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true, features = ["arbitrary_precision", "raw_value"] }
+serde_json = { workspace = true, features = [
+    "arbitrary_precision",
+    "raw_value",
+] }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -13,7 +13,6 @@ bitvec = "0.20.4"
 const_format = { workspace = true }
 data-encoding = "2.3.3"
 fake = { version = "2.5.0", features = ["derive"] }
-flate2 = "1.0.25"
 hex = "0.4.3"
 lazy_static = "1.4.0"
 pathfinder-common = { path = "../common" }
@@ -25,11 +24,13 @@ r2d2_sqlite = "0.21.0"
 rand = { version = "0.8.5" }
 rusqlite = { version = "0.28.0", features = ["bundled", "functions"] }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true, features = ["arbitrary_precision", "raw_value"] }
+serde_json = { workspace = true, features = [
+    "arbitrary_precision",
+    "raw_value",
+] }
 serde_with = { workspace = true }
 sha3 = "0.10"
 stark_hash = { path = "../stark_hash" }
-starknet-gateway-client = { path = "../gateway-client" }
 starknet-gateway-types = { path = "../gateway-types" }
 thiserror = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
The list of deps to remove was generated using
`cargo +nightly udeps --all-targets --workspace --all-features`