### PR TITLE
docs: readme and comment fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Currently pathfinder supports `v0.3` and `v0.4` versions of the Starknet JSON-RP
 The `path` of the URL used to access the JSON-RPC server determines which version of the API is served:
 
 - the `v0.3.0` API is exposed on the `/` and `/rpc/v0.3` path
-- the `v0.4.0` API is exposed on the `/` and `/rpc/v0.4` path
+- the `v0.4.0` API is exposed on the `/rpc/v0.4` path
 - the pathfinder extension API is exposed on `/rpc/pathfinder/v0.1`
 
 Note that the pathfinder extension is versioned separately from the Starknet specification itself.

--- a/crates/stark_poseidon/src/poseidon.rs
+++ b/crates/stark_poseidon/src/poseidon.rs
@@ -6,7 +6,7 @@ const PARTIAL_ROUNDS: usize = 83;
 
 include!(concat!(env!("OUT_DIR"), "/poseidon_consts.rs"));
 
-/// Linear layer for MDS matrix M = ((3,1,1), (1,-1,1), (1,1,2))
+/// Linear layer for MDS matrix M = ((3,1,1), (1,-1,1), (1,1,-2))
 /// Given state vector x, it returns Mx, optimized by precomputing t.
 #[inline(always)]
 fn mix(state: &mut PoseidonState) {


### PR DESCRIPTION
Fixes readme stating rpc v0.4 is served at `/` and a missing negation in the poseidon matrix doc comment.

Closes #1292 
