### PR TITLE
feat: loosen gateway parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - RPC v0.4 `starknet_getTransactionReceipt` incorrect execution and finality status names
+- `pathfinder_getTransactionStatus` fails to parse v0.12.1 gateway replies
 
 ## [0.7.0] - 2023-07-27
 

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -155,31 +155,12 @@ pub mod call {
 }
 
 /// Used to deserialize replies to Starknet transaction requests.
+///
+/// We only care about the status so we ignore other fields.
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
 pub struct Transaction {
-    #[serde(default)]
-    pub block_hash: Option<BlockHash>,
-    #[serde(default)]
-    pub block_number: Option<BlockNumber>,
     pub status: Status,
-    #[serde(default)]
-    pub transaction: Option<transaction::Transaction>,
-    #[serde(default)]
-    pub transaction_index: Option<u64>,
-    #[serde(default)]
-    pub transaction_failure_reason: Option<transaction::Failure>,
-}
-
-/// Used to deserialize replies to Starknet transaction status requests.
-#[serde_as]
-#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct TransactionStatus {
-    #[serde(default)]
-    pub block_hash: Option<BlockHash>,
-    pub tx_status: Status,
 }
 
 /// Types used when deserializing L2 transaction related data.

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -942,14 +942,10 @@ pub mod state_update {
 /// Used to deserialize replies to Starknet Ethereum contract requests.
 #[serde_as]
 #[derive(Clone, Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct EthContractAddresses {
     #[serde(rename = "Starknet")]
     #[serde_as(as = "EthereumAddressAsHexStr")]
     pub starknet: EthereumAddress,
-    #[serde_as(as = "EthereumAddressAsHexStr")]
-    #[serde(rename = "GpsStatementVerifier")]
-    pub gps_statement_verifier: EthereumAddress,
 }
 
 pub mod add_transaction {
@@ -1255,5 +1251,17 @@ mod tests {
             assert_eq!(receipt.execution_status, ExecutionStatus::Reverted);
             assert_eq!(receipt.revert_error, Some("reason goes here".to_owned()));
         }
+    }
+
+    #[test]
+    fn eth_contract_addresses_ignores_extra_fields() {
+        // Some gateway mocks include extra addesses, check that we can still parse these.
+        let json = serde_json::json!({
+            "Starknet": "0x12345abcd",
+            "GpsStatementVerifier": "0xaabdde",
+            "MemoryPageFactRegistry": "0xdeadbeef"
+        });
+
+        serde_json::from_value::<crate::reply::EthContractAddresses>(json).unwrap();
     }
 }

--- a/crates/gateway-types/src/transaction_hash.rs
+++ b/crates/gateway-types/src/transaction_hash.rs
@@ -459,15 +459,19 @@ mod tests {
     use pathfinder_common::ChainId;
     use starknet_gateway_test_fixtures::{v0_11_0, v0_8_2, v0_9_0};
 
+    #[derive(serde::Deserialize)]
+    struct TxWrapper {
+        transaction: crate::reply::transaction::Transaction,
+    }
+
     macro_rules! case {
         ($target:expr) => {{
             let line = line!();
 
             (
-                serde_json::from_str::<crate::reply::Transaction>($target)
+                serde_json::from_str::<crate::transaction_hash::tests::TxWrapper>($target)
                     .expect(&format!("deserialization is Ok, line: {line}"))
-                    .transaction
-                    .expect(&format!("transaction is Some, line: {line}")),
+                    .transaction,
                 line,
             )
         }};

--- a/crates/rpc/src/v02/types.rs
+++ b/crates/rpc/src/v02/types.rs
@@ -675,18 +675,6 @@ pub mod reply {
         pub calldata: Vec<CallParam>,
     }
 
-    impl TryFrom<starknet_gateway_types::reply::Transaction> for Transaction {
-        type Error = anyhow::Error;
-
-        fn try_from(txn: starknet_gateway_types::reply::Transaction) -> Result<Self, Self::Error> {
-            let txn = txn
-                .transaction
-                .ok_or_else(|| anyhow::anyhow!("Transaction not found."))?;
-
-            Ok(txn.into())
-        }
-    }
-
     impl From<GatewayTransaction> for Transaction {
         fn from(txn: GatewayTransaction) -> Self {
             Self::from(&txn)


### PR DESCRIPTION
This PR loosens the parsing of two gateway responses.

I've reduced the type to just the status as we only use `get_transaction` for this.

I've also reduced the ethereum address type to the only field we use.

Fixes #1307 and fixes #1304.
