### PR TITLE
ci: fix msrv check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,8 +2,3 @@
 
 # assign these always as reviewers
 * @eqlabs/starknet
-
-# notify on these specifically
-/crates/stark_curve @mikdk
-/crates/stark_hash @mikdk
-/crates/stark_poseidon @mikdk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.MSRV }}
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v2
+      - name: Install protoc
+        run: |
+          sudo apt-get install -y protobuf-compiler
       - uses: Swatinem/rust-cache@v2
       - name: check
         run: cargo check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,14 +112,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: baptiste0928/cargo-install@v2
+      - name: read msrv
+        id: msrv
+        run: |
+          msrv=$(grep -P "rust-version =" crates/pathfinder/Cargo.toml | awk '{print $3}' | tr -d '"')
+          echo Found msrc: $msrv
+          echo "MSRV=$msrv" >> "$GITHUB_OUTPUT"
+      - uses: dtolnay/rust-toolchain@master
         with:
-          crate: cargo-msrv
-          version: "^0.15.1"
+          toolchain: ${{ steps.msrv.outputs.MSRV }}
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
       - uses: Swatinem/rust-cache@v2
-      - run: |
-          cargo msrv --path crates/pathfinder verify
+      - name: check
+        run: cargo check
 
   python:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR replaces the failing MSRV action with a simple custom one and removes mikdk from codeowners to reduce the spam.

The MSRV check is replaced by a simple:
1. grep for msrv from manifest
2. install that rust version
3. cargo check