### PR TITLE
feat(rpc): add support for final JSON-RPC 0.4.0 specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RPC v0.4 `starknet_getTransactionReceipt` incorrect execution and finality status names
 - `pathfinder_getTransactionStatus` fails to parse v0.12.1 gateway replies
 
+### Changed
+
+- RPC v0.4.0 support (previously supported v0.4.0-rc3)
+
 ## [0.7.0] - 2023-07-27
 
 ### Added

--- a/crates/rpc/src/v02/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v02/method/add_declare_transaction.rs
@@ -78,6 +78,11 @@ pub async fn add_declare_transaction(
     input: AddDeclareTransactionInput,
 ) -> Result<AddDeclareTransactionOutput, AddDeclareTransactionError> {
     match input.declare_transaction {
+        Transaction::Declare(BroadcastedDeclareTransaction::V0(_)) => {
+            Err(AddDeclareTransactionError::Internal(anyhow::anyhow!(
+                "Declare v0 transactions are not allowed"
+            )))
+        }
         Transaction::Declare(BroadcastedDeclareTransaction::V1(tx)) => {
             let contract_definition: CairoContractDefinition = tx
                 .contract_class

--- a/crates/rpc/src/v04/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v04/method/add_declare_transaction.rs
@@ -143,6 +143,9 @@ pub async fn add_declare_transaction(
     input: AddDeclareTransactionInput,
 ) -> Result<AddDeclareTransactionOutput, AddDeclareTransactionError> {
     match input.declare_transaction {
+        Transaction::Declare(BroadcastedDeclareTransaction::V0(_)) => {
+            Err(AddDeclareTransactionError::UnsupportedTransactionVersion)
+        }
         Transaction::Declare(BroadcastedDeclareTransaction::V1(tx)) => {
             let contract_definition: CairoContractDefinition = tx
                 .contract_class


### PR DESCRIPTION
This PR adds Declare v0 transaction support for "broadcasted" transactions -- which was the only thing missing for our support for the JSON-RPC 0.4.0 specification.

Closes #1305 