### PR TITLE
PoC p2p sync behind GatewayApi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: timeout 25m cargo nextest run --all-targets --all-features --workspace --locked --no-run
 
       - name: Run unit tests
-        run: timeout 5m cargo nextest run --no-fail-fast --all-targets --all-features --workspace --locked
+        run: timeout 7m cargo nextest run --no-fail-fast --all-targets --all-features --workspace --locked
 
   clippy:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4772,7 +4772,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "log",
- "lru",
+ "lru 0.10.1",
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
@@ -5145,6 +5145,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "718e8fae447df0c7e1ba7f5189829e63fd536945c8988d61444c19039f16b670"
 dependencies = [
  "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "lru"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eedb2bdbad7e0634f83989bf596f497b070130daaa398ab22d84c39e266deec5"
+dependencies = [
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -6007,6 +6016,7 @@ dependencies = [
  "futures",
  "http",
  "lazy_static",
+ "lru 0.11.0",
  "metrics",
  "metrics-exporter-prometheus",
  "mockall",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,12 +347,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "asn1_der"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
-
-[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4592,38 +4586,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0a0d2f693675f49ded13c5d510c48b78069e23cbd9108d7ccd59f6dc568819"
-dependencies = [
- "bytes",
- "futures",
- "futures-timer",
- "getrandom 0.2.10",
- "instant",
- "libp2p-autonat 0.9.1",
- "libp2p-core 0.38.0",
- "libp2p-dns 0.38.0",
- "libp2p-identify 0.41.1",
- "libp2p-kad 0.42.1",
- "libp2p-mdns 0.42.0",
- "libp2p-metrics 0.11.0",
- "libp2p-noise 0.41.0",
- "libp2p-ping 0.41.0",
- "libp2p-quic",
- "libp2p-relay 0.14.0",
- "libp2p-swarm 0.41.1",
- "libp2p-tcp 0.38.0",
- "libp2p-webrtc",
- "libp2p-yamux 0.42.0",
- "multiaddr 0.16.0",
- "parking_lot 0.12.1",
- "pin-project",
- "smallvec",
-]
-
-[[package]]
-name = "libp2p"
 version = "0.51.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f210d259724eae82005b5c48078619b7745edb7b76de370b03f8ba59ea103097"
@@ -4634,27 +4596,27 @@ dependencies = [
  "getrandom 0.2.10",
  "instant",
  "libp2p-allow-block-list",
- "libp2p-autonat 0.10.2",
+ "libp2p-autonat",
  "libp2p-connection-limits",
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "libp2p-dcutr",
- "libp2p-dns 0.39.0",
+ "libp2p-dns",
  "libp2p-gossipsub",
- "libp2p-identify 0.42.2",
+ "libp2p-identify",
  "libp2p-identity",
- "libp2p-kad 0.43.3",
- "libp2p-mdns 0.43.1",
- "libp2p-metrics 0.12.0",
- "libp2p-noise 0.42.2",
- "libp2p-ping 0.42.0",
+ "libp2p-kad",
+ "libp2p-mdns",
+ "libp2p-metrics",
+ "libp2p-noise",
+ "libp2p-ping",
  "libp2p-quic",
- "libp2p-relay 0.15.2",
- "libp2p-request-response 0.24.1",
- "libp2p-swarm 0.42.2",
- "libp2p-tcp 0.39.0",
+ "libp2p-relay",
+ "libp2p-request-response",
+ "libp2p-swarm",
+ "libp2p-tcp",
  "libp2p-webrtc",
- "libp2p-yamux 0.43.1",
- "multiaddr 0.17.1",
+ "libp2p-yamux",
+ "multiaddr",
  "pin-project",
 ]
 
@@ -4664,29 +4626,10 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "510daa05efbc25184458db837f6f9a5143888f1caa742426d92e1833ddd38a50"
 dependencies = [
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.42.2",
+ "libp2p-swarm",
  "void",
-]
-
-[[package]]
-name = "libp2p-autonat"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705aa16b15f8438eea368b06cb0461ac885df35152b25ec31dfade1179a687cd"
-dependencies = [
- "async-trait",
- "futures",
- "futures-timer",
- "instant",
- "libp2p-core 0.38.0",
- "libp2p-request-response 0.23.0",
- "libp2p-swarm 0.41.1",
- "log",
- "prost",
- "prost-build",
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -4699,10 +4642,10 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-request-response 0.24.1",
- "libp2p-swarm 0.42.2",
+ "libp2p-request-response",
+ "libp2p-swarm",
  "log",
  "quick-protobuf",
  "rand 0.8.5",
@@ -4714,44 +4657,10 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4caa33f1d26ed664c4fe2cca81a08c8e07d4c1c04f2f4ac7655c2dd85467fda0"
 dependencies = [
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.42.2",
+ "libp2p-swarm",
  "void",
-]
-
-[[package]]
-name = "libp2p-core"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a8fcd392ff67af6cc3f03b1426c41f7f26b6b9aff2dc632c1c56dd649e571f"
-dependencies = [
- "asn1_der",
- "bs58",
- "ed25519-dalek",
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "instant",
- "log",
- "multiaddr 0.16.0",
- "multihash 0.16.3",
- "multistream-select",
- "once_cell",
- "parking_lot 0.12.1",
- "pin-project",
- "prost",
- "prost-build",
- "rand 0.8.5",
- "rw-stream-sink",
- "sec1",
- "sha2 0.10.7",
- "smallvec",
- "thiserror",
- "unsigned-varint",
- "void",
- "zeroize",
 ]
 
 [[package]]
@@ -4767,8 +4676,8 @@ dependencies = [
  "instant",
  "libp2p-identity",
  "log",
- "multiaddr 0.17.1",
- "multihash 0.17.0",
+ "multiaddr",
+ "multihash",
  "multistream-select",
  "once_cell",
  "parking_lot 0.12.1",
@@ -4793,9 +4702,9 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.42.2",
+ "libp2p-swarm",
  "log",
  "quick-protobuf",
  "quick-protobuf-codec",
@@ -4805,26 +4714,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e42a271c1b49f789b92f7fc87749fa79ce5c7bdc88cbdfacb818a4bca47fec5"
-dependencies = [
- "futures",
- "libp2p-core 0.38.0",
- "log",
- "parking_lot 0.12.1",
- "smallvec",
- "trust-dns-resolver",
-]
-
-[[package]]
-name = "libp2p-dns"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146ff7034daae62077c415c2376b8057368042df6ab95f5432ad5e88568b1554"
 dependencies = [
  "futures",
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "log",
  "parking_lot 0.12.1",
  "smallvec",
@@ -4846,11 +4741,11 @@ dependencies = [
  "futures",
  "hex_fmt",
  "instant",
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.42.2",
+ "libp2p-swarm",
  "log",
- "prometheus-client 0.19.0",
+ "prometheus-client",
  "quick-protobuf",
  "quick-protobuf-codec",
  "rand 0.8.5",
@@ -4865,27 +4760,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.41.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c052d0026f4817b44869bfb6810f4e1112f43aec8553f2cb38881c524b563abf"
-dependencies = [
- "asynchronous-codec",
- "futures",
- "futures-timer",
- "libp2p-core 0.38.0",
- "libp2p-swarm 0.41.1",
- "log",
- "lru 0.8.1",
- "prost",
- "prost-build",
- "prost-codec",
- "smallvec",
- "thiserror",
- "void",
-]
-
-[[package]]
-name = "libp2p-identify"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5455f472243e63b9c497ff320ded0314254a9eb751799a39c283c6f20b793f3c"
@@ -4894,11 +4768,11 @@ dependencies = [
  "either",
  "futures",
  "futures-timer",
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.42.2",
+ "libp2p-swarm",
  "log",
- "lru 0.10.1",
+ "lru",
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
@@ -4915,41 +4789,13 @@ dependencies = [
  "bs58",
  "ed25519-dalek",
  "log",
- "multiaddr 0.17.1",
- "multihash 0.17.0",
+ "multiaddr",
+ "multihash",
  "quick-protobuf",
  "rand 0.8.5",
  "sha2 0.10.7",
  "thiserror",
  "zeroize",
-]
-
-[[package]]
-name = "libp2p-kad"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2766dcd2be8c87d5e1f35487deb22d765f49c6ae1251b3633efe3b25698bd3d2"
-dependencies = [
- "arrayvec",
- "asynchronous-codec",
- "bytes",
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "instant",
- "libp2p-core 0.38.0",
- "libp2p-swarm 0.41.1",
- "log",
- "prost",
- "prost-build",
- "rand 0.8.5",
- "sha2 0.10.7",
- "smallvec",
- "thiserror",
- "uint",
- "unsigned-varint",
- "void",
 ]
 
 [[package]]
@@ -4966,9 +4812,9 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.42.2",
+ "libp2p-swarm",
  "log",
  "quick-protobuf",
  "rand 0.8.5",
@@ -4982,26 +4828,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f378264aade9872d6ccd315c0accc18be3a35d15fc1b9c36e5b6f983b62b5b"
-dependencies = [
- "data-encoding",
- "futures",
- "if-watch",
- "libp2p-core 0.38.0",
- "libp2p-swarm 0.41.1",
- "log",
- "rand 0.8.5",
- "smallvec",
- "socket2 0.4.9",
- "tokio",
- "trust-dns-proto",
- "void",
-]
-
-[[package]]
-name = "libp2p-mdns"
 version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19983e1f949f979a928f2c603de1cf180cc0dc23e4ac93a62651ccb18341460b"
@@ -5009,9 +4835,9 @@ dependencies = [
  "data-encoding",
  "futures",
  "if-watch",
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.42.2",
+ "libp2p-swarm",
  "log",
  "rand 0.8.5",
  "smallvec",
@@ -5019,21 +4845,6 @@ dependencies = [
  "tokio",
  "trust-dns-proto",
  "void",
-]
-
-[[package]]
-name = "libp2p-metrics"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad8a64f29da86005c86a4d2728b8a0719e9b192f4092b609fd8790acb9dec55"
-dependencies = [
- "libp2p-core 0.38.0",
- "libp2p-identify 0.41.1",
- "libp2p-kad 0.42.1",
- "libp2p-ping 0.41.0",
- "libp2p-relay 0.14.0",
- "libp2p-swarm 0.41.1",
- "prometheus-client 0.18.1",
 ]
 
 [[package]]
@@ -5042,38 +4853,15 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a42ec91e227d7d0dafa4ce88b333cdf5f277253873ab087555c92798db2ddd46"
 dependencies = [
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "libp2p-dcutr",
  "libp2p-gossipsub",
- "libp2p-identify 0.42.2",
- "libp2p-kad 0.43.3",
- "libp2p-ping 0.42.0",
- "libp2p-relay 0.15.2",
- "libp2p-swarm 0.42.2",
- "prometheus-client 0.19.0",
-]
-
-[[package]]
-name = "libp2p-noise"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a978cb57efe82e892ec6f348a536bfbd9fee677adbe5689d7a93ad3a9bffbf2e"
-dependencies = [
- "bytes",
- "curve25519-dalek 3.2.0",
- "futures",
- "libp2p-core 0.38.0",
- "log",
- "once_cell",
- "prost",
- "prost-build",
- "rand 0.8.5",
- "sha2 0.10.7",
- "snow",
- "static_assertions",
- "thiserror",
- "x25519-dalek 1.1.1",
- "zeroize",
+ "libp2p-identify",
+ "libp2p-kad",
+ "libp2p-ping",
+ "libp2p-relay",
+ "libp2p-swarm",
+ "prometheus-client",
 ]
 
 [[package]]
@@ -5085,7 +4873,7 @@ dependencies = [
  "bytes",
  "curve25519-dalek 3.2.0",
  "futures",
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "libp2p-identity",
  "log",
  "once_cell",
@@ -5101,22 +4889,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "929fcace45a112536e22b3dcfd4db538723ef9c3cb79f672b98be2cc8e25f37f"
-dependencies = [
- "futures",
- "futures-timer",
- "instant",
- "libp2p-core 0.38.0",
- "libp2p-swarm 0.41.1",
- "log",
- "rand 0.8.5",
- "void",
-]
-
-[[package]]
-name = "libp2p-ping"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e57759c19c28a73ef1eb3585ca410cefb72c1a709fcf6de1612a378e4219202"
@@ -5125,8 +4897,8 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core 0.39.2",
- "libp2p-swarm 0.42.2",
+ "libp2p-core",
+ "libp2p-swarm",
  "log",
  "rand 0.8.5",
  "void",
@@ -5142,7 +4914,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "libp2p-identity",
  "libp2p-tls",
  "log",
@@ -5152,32 +4924,6 @@ dependencies = [
  "rustls 0.20.8",
  "thiserror",
  "tokio",
-]
-
-[[package]]
-name = "libp2p-relay"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffb67f6b6cce19cfeab9b10b77fbff756a66a1c143cba7deb8c3f964fadcb59"
-dependencies = [
- "asynchronous-codec",
- "bytes",
- "either",
- "futures",
- "futures-timer",
- "instant",
- "libp2p-core 0.38.0",
- "libp2p-swarm 0.41.1",
- "log",
- "pin-project",
- "prost",
- "prost-build",
- "prost-codec",
- "rand 0.8.5",
- "smallvec",
- "static_assertions",
- "thiserror",
- "void",
 ]
 
 [[package]]
@@ -5192,9 +4938,9 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.42.2",
+ "libp2p-swarm",
  "log",
  "quick-protobuf",
  "quick-protobuf-codec",
@@ -5206,24 +4952,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3236168796727bfcf4927f766393415361e2c644b08bedb6a6b13d957c9a4884"
-dependencies = [
- "async-trait",
- "bytes",
- "futures",
- "instant",
- "libp2p-core 0.38.0",
- "libp2p-swarm 0.41.1",
- "log",
- "rand 0.8.5",
- "smallvec",
- "unsigned-varint",
-]
-
-[[package]]
-name = "libp2p-request-response"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffdb374267d42dc5ed5bc53f6e601d4a64ac5964779c6e40bb9e4f14c1e30d5"
@@ -5231,33 +4959,11 @@ dependencies = [
  "async-trait",
  "futures",
  "instant",
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.42.2",
+ "libp2p-swarm",
  "rand 0.8.5",
  "smallvec",
-]
-
-[[package]]
-name = "libp2p-swarm"
-version = "0.41.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a35472fe3276b3855c00f1c032ea8413615e030256429ad5349cdf67c6e1a0"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "instant",
- "libp2p-core 0.38.0",
- "libp2p-swarm-derive 0.31.0",
- "log",
- "pin-project",
- "rand 0.8.5",
- "smallvec",
- "thiserror",
- "tokio",
- "void",
 ]
 
 [[package]]
@@ -5272,25 +4978,14 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm-derive 0.32.0",
+ "libp2p-swarm-derive",
  "log",
  "rand 0.8.5",
  "smallvec",
  "tokio",
  "void",
-]
-
-[[package]]
-name = "libp2p-swarm-derive"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d527d5827582abd44a6d80c07ff8b50b4ee238a8979e05998474179e79dc400"
-dependencies = [
- "heck 0.4.1",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -5306,22 +5001,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b257baf6df8f2df39678b86c578961d48cc8b68642a12f0f763f56c8e5858d"
-dependencies = [
- "futures",
- "futures-timer",
- "if-watch",
- "libc",
- "libp2p-core 0.38.0",
- "log",
- "socket2 0.4.9",
- "tokio",
-]
-
-[[package]]
-name = "libp2p-tcp"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d33698596d7722d85d3ab0c86c2c322254fce1241e91208e3679b4eb3026cf"
@@ -5330,7 +5009,7 @@ dependencies = [
  "futures-timer",
  "if-watch",
  "libc",
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "log",
  "socket2 0.4.9",
  "tokio",
@@ -5344,7 +5023,7 @@ checksum = "ff08d13d0dc66e5e9ba6279c1de417b84fa0d0adc3b03e5732928c180ec02781"
 dependencies = [
  "futures",
  "futures-rustls",
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "libp2p-identity",
  "rcgen 0.10.0",
  "ring",
@@ -5368,11 +5047,11 @@ dependencies = [
  "futures-timer",
  "hex",
  "if-watch",
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-noise 0.42.2",
+ "libp2p-noise",
  "log",
- "multihash 0.17.0",
+ "multihash",
  "quick-protobuf",
  "quick-protobuf-codec",
  "rand 0.8.5",
@@ -5388,26 +5067,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f63594a0aa818642d9d4915c791945053877253f08a3626f13416b5cd928a29"
-dependencies = [
- "futures",
- "libp2p-core 0.38.0",
- "log",
- "parking_lot 0.12.1",
- "thiserror",
- "yamux",
-]
-
-[[package]]
-name = "libp2p-yamux"
 version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd21d950662700a385d4c6d68e2f5f54d778e97068cdd718522222ef513bda"
 dependencies = [
  "futures",
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "log",
  "thiserror",
  "yamux",
@@ -5471,15 +5136,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 dependencies = [
  "value-bag",
-]
-
-[[package]]
-name = "lru"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
-dependencies = [
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -5735,24 +5391,6 @@ dependencies = [
 
 [[package]]
 name = "multiaddr"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aebdb21e90f81d13ed01dc84123320838e53963c2ca94b60b305d3fa64f31e"
-dependencies = [
- "arrayref",
- "byteorder",
- "data-encoding",
- "multibase",
- "multihash 0.16.3",
- "percent-encoding",
- "serde",
- "static_assertions",
- "unsigned-varint",
- "url",
-]
-
-[[package]]
-name = "multiaddr"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b36f567c7099511fa8612bbbb52dda2419ce0bdbacf31714e3a5ffdb766d3bd"
@@ -5762,7 +5400,7 @@ dependencies = [
  "data-encoding",
  "log",
  "multibase",
- "multihash 0.17.0",
+ "multihash",
  "percent-encoding",
  "serde",
  "static_assertions",
@@ -5779,19 +5417,6 @@ dependencies = [
  "base-x",
  "data-encoding",
  "data-encoding-macro",
-]
-
-[[package]]
-name = "multihash"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
-dependencies = [
- "core2",
- "digest 0.10.7",
- "multihash-derive",
- "sha2 0.10.7",
- "unsigned-varint",
 ]
 
 [[package]]
@@ -6189,7 +5814,7 @@ dependencies = [
  "fake",
  "futures",
  "hex",
- "libp2p 0.51.3",
+ "libp2p",
  "p2p_proto",
  "prost",
  "rand 0.8.5",
@@ -6212,7 +5837,7 @@ dependencies = [
  "base64 0.13.1",
  "clap",
  "futures",
- "libp2p 0.50.0",
+ "libp2p",
  "serde",
  "serde_json",
  "tokio",
@@ -6915,18 +6540,6 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83cd1b99916654a69008fd66b4f9397fbe08e6e51dfe23d4417acf5d3b8cb87c"
-dependencies = [
- "dtoa",
- "itoa",
- "parking_lot 0.12.1",
- "prometheus-client-derive-text-encode",
-]
-
-[[package]]
-name = "prometheus-client"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6fa99d535dd930d1249e6c79cb3c2915f9172a540fe2b02a4c8f9ca954721e"
@@ -6942,17 +6555,6 @@ name = "prometheus-client-derive-encode"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b6a5217beb0ad503ee7fa752d451c905113d70721b937126158f3106a48cc1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "prometheus-client-derive-text-encode"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a455fbcb954c1a7decf3c586e860fd7889cddf4b8e164be736dbac95a953cd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7009,19 +6611,6 @@ dependencies = [
  "syn 1.0.109",
  "tempfile",
  "which",
-]
-
-[[package]]
-name = "prost-codec"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc34979ff898b6e141106178981ce2596c387ea6e62533facfc61a37fc879c0"
-dependencies = [
- "asynchronous-codec",
- "bytes",
- "prost",
- "thiserror",
- "unsigned-varint",
 ]
 
 [[package]]
@@ -9077,8 +8666,6 @@ checksum = "d86a8dc7f45e4c1b0d30e43038c38f274e77af056aa5f74b93c2cf9eb3c1c836"
 dependencies = [
  "asynchronous-codec",
  "bytes",
- "futures-io",
- "futures-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5816,6 +5816,7 @@ dependencies = [
  "hex",
  "libp2p",
  "p2p_proto",
+ "pathfinder-common",
  "prost",
  "rand 0.8.5",
  "serde",
@@ -5995,6 +5996,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-trait",
+ "base64 0.13.1",
  "bitvec",
  "bytes",
  "clap",
@@ -6041,6 +6043,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "warp",
+ "zeroize",
  "zstd",
 ]
 

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -1,7 +1,7 @@
 //! Starknet L2 sequencer client.
 use pathfinder_common::{
-    BlockHash, BlockHeader, BlockId, BlockNumber, CallParam, CasmHash, Chain, ClassHash,
-    ContractAddress, ContractAddressSalt, Fee, StateUpdate, TransactionHash, TransactionNonce,
+    BlockHash, BlockId, BlockNumber, CallParam, CasmHash, Chain, ClassHash, ContractAddress,
+    ContractAddressSalt, Fee, StateUpdate, TransactionHash, TransactionNonce,
     TransactionSignatureElem, TransactionVersion,
 };
 use reqwest::Url;
@@ -138,12 +138,7 @@ pub trait GatewayApi: Sync {
 #[cfg_attr(feature = "test-utils", mockall::automock)]
 #[async_trait::async_trait]
 pub trait GossipApi: Sync {
-    async fn propagate_block_header(
-        &self,
-        header: BlockHeader,
-        transaction_count: u32,
-        event_count: u32,
-    ) {
+    async fn propagate_head(&self, block_number: BlockNumber, block_hash: BlockHash) {
         // Intentionally does nothing for default impl
     }
 }

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -613,6 +613,9 @@ impl GatewayApi for Client {
 #[async_trait::async_trait]
 impl GossipApi for Client {}
 
+#[async_trait::async_trait]
+impl GossipApi for () {}
+
 pub mod test_utils {
     use super::Client;
     use starknet_gateway_types::error::KnownStarknetErrorCode;

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 anyhow = { workspace = true }
 async-trait = "0.1.58"
-base64 = "0.13.0"
+base64 = "0.13.1"
 delay_map = "0.1.2"
 futures = "0.3.21"
 libp2p = { version = "0.51.3", default-features = false, features = [
@@ -29,7 +29,9 @@ libp2p = { version = "0.51.3", default-features = false, features = [
     "macros",
 ] }
 p2p_proto = { path = "../p2p_proto" }
+pathfinder-common = { path = "../common" }
 prost = "0.11.2"
+rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = "0.10.2"

--- a/crates/p2p/examples/generate_key.rs
+++ b/crates/p2p/examples/generate_key.rs
@@ -1,6 +1,7 @@
 #![deny(rust_2018_idioms)]
 
 use libp2p::identity::Keypair;
+use libp2p::PeerId;
 
 fn main() -> anyhow::Result<()> {
     let keypair = Keypair::generate_ed25519();
@@ -8,7 +9,10 @@ fn main() -> anyhow::Result<()> {
     let private_key = keypair.to_protobuf_encoding()?;
     let encoded_private_key = base64::encode(private_key);
 
-    println!("{encoded_private_key}");
+    let peer_id = PeerId::from_public_key(&keypair.public());
+
+    // Peer id is here just for convenience/debugging.
+    println!(r#"{{"private_key":"{encoded_private_key}","peer_id":"{peer_id}"}}"#);
 
     Ok(())
 }

--- a/crates/p2p/examples/peer.rs
+++ b/crates/p2p/examples/peer.rs
@@ -162,8 +162,8 @@ async fn main() -> anyhow::Result<()> {
                 };
                 p2p_client.send_sync_response(channel, response).await;
             }
-            p2p::Event::BlockPropagation(block_propagation) => {
-                tracing::info!(?block_propagation, "Block Propagation");
+            p2p::Event::BlockPropagation { from, message } => {
+                tracing::info!(?from, ?message, "Block Propagation");
             }
             p2p::Event::Test(_) => {}
         }

--- a/crates/p2p/src/behaviour.rs
+++ b/crates/p2p/src/behaviour.rs
@@ -97,6 +97,11 @@ impl Behaviour {
         Ok(())
     }
 
+    pub fn get_capability_providers(&mut self, capability: &str) -> kad::QueryId {
+        let key = string_to_key(capability);
+        self.kademlia.get_providers(key)
+    }
+
     pub fn subscribe_topic(&mut self, topic: &IdentTopic) -> anyhow::Result<()> {
         self.gossipsub.subscribe(topic)?;
         Ok(())

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -4,16 +4,19 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::Context;
 use delay_map::HashSetDelay;
 use futures::StreamExt;
 use libp2p::gossipsub::{self, IdentTopic};
 use libp2p::identity::Keypair;
 use libp2p::kad::record::Key;
 use libp2p::kad::{BootstrapError, BootstrapOk, KademliaEvent, QueryId, QueryResult};
+use libp2p::multiaddr::Protocol;
 use libp2p::request_response::{self, RequestId, ResponseChannel};
 use libp2p::swarm::{SwarmBuilder, SwarmEvent};
 use libp2p::Multiaddr;
 use libp2p::{identify, PeerId};
+use pathfinder_common::{BlockHash, BlockNumber, ClassHash};
 use tokio::sync::{mpsc, oneshot, RwLock};
 
 mod behaviour;
@@ -35,14 +38,14 @@ pub fn new(
     peers: Arc<RwLock<peers::Peers>>,
     periodic_cfg: PeriodicTaskConfig,
 ) -> (Client, EventReceiver, MainLoop) {
-    let peer_id = keypair.public().to_peer_id();
+    let my_peer_id = keypair.public().to_peer_id();
 
     let (behaviour, relay_transport) = behaviour::Behaviour::new(&keypair);
 
     let swarm = SwarmBuilder::with_executor(
         transport::create(&keypair, relay_transport),
         behaviour,
-        peer_id,
+        my_peer_id,
         executor::TokioExecutor(),
     )
     .build();
@@ -53,6 +56,7 @@ pub fn new(
     (
         Client {
             sender: command_sender,
+            my_peer_id,
         },
         event_receiver,
         MainLoop::new(swarm, command_receiver, event_sender, peers, periodic_cfg),
@@ -83,9 +87,276 @@ impl Default for PeriodicTaskConfig {
     }
 }
 
+/// _High level_ client for p2p interaction.
+/// Frees the caller from managing peers manually.
+#[derive(Clone, Debug)]
+pub struct SyncClient {
+    client: Client,
+    block_propagation_topic: String,
+    _peers: Arc<RwLock<peers::Peers>>,
+}
+
+pub type HeadTx = tokio::sync::watch::Sender<Option<(BlockNumber, BlockHash)>>;
+pub type HeadRx = tokio::sync::watch::Receiver<Option<(BlockNumber, BlockHash)>>;
+
+// FIXME make sure the api looks reasonable from the perspective of
+// the __user__, which is the sync driving algo/entity
+impl SyncClient {
+    pub fn new(
+        client: Client,
+        block_propagation_topic: String,
+        peers: Arc<RwLock<peers::Peers>>,
+    ) -> Self {
+        Self {
+            client,
+            block_propagation_topic,
+            _peers: peers,
+        }
+    }
+
+    // Propagate new L2 head header
+    pub async fn propagate_new_header(
+        &self,
+        header: p2p_proto::common::BlockHeader,
+    ) -> anyhow::Result<()> {
+        tracing::debug!(block_number=%header.number, topic=%self.block_propagation_topic,
+            "Propagating header"
+        );
+
+        self.client
+            .publish_propagation_message(
+                &self.block_propagation_topic,
+                p2p_proto::propagation::Message::NewBlockHeader(
+                    p2p_proto::propagation::NewBlockHeader { header },
+                ),
+            )
+            .await
+    }
+
+    async fn shuffled_peers_with_sync_capability(&self) -> Vec<PeerId> {
+        use rand::seq::SliceRandom;
+        let mut peers = self
+            .client
+            .get_capability_providers("core/blocks-sync/1")
+            .await
+            .unwrap_or_default();
+
+        let _i_should_have_the_capability_too = peers.remove(&self.client.my_peer_id);
+        debug_assert!(_i_should_have_the_capability_too);
+
+        let mut peers = peers.into_iter().collect::<Vec<_>>();
+        peers.shuffle(&mut rand::thread_rng());
+
+        tracing::debug!(?peers, "shuffled_peers_with_sync_capability");
+
+        peers
+    }
+
+    pub async fn block_headers(
+        &self,
+        // start_block_hash: BlockHash, // FIXME, hash to avoid DB lookup
+        start_block: BlockNumber, // TODO number or hash
+        num_blocks: usize,        // FIXME, use range?
+    ) -> Option<Vec<p2p_proto::common::BlockHeader>> {
+        if num_blocks == 0 {
+            return Some(Vec::new());
+        }
+
+        let count: u64 = num_blocks.try_into().ok()?;
+
+        for peer in self.shuffled_peers_with_sync_capability().await {
+            let response = self
+                .client
+                .send_sync_request(
+                    peer,
+                    p2p_proto::sync::Request::GetBlockHeaders(p2p_proto::sync::GetBlockHeaders {
+                        start_block: start_block.get(),
+                        count,
+                        size_limit: u64::MAX, // FIXME
+                        direction: p2p_proto::sync::Direction::Forward,
+                    }),
+                )
+                .await;
+
+            match response {
+                Ok(p2p_proto::sync::Response::BlockHeaders(x)) => {
+                    if x.headers.is_empty() {
+                        tracing::debug!(%peer, "Got empty block headers response");
+                        continue;
+                    } else {
+                        return Some(x.headers);
+                    }
+                }
+                Ok(_) => {
+                    tracing::debug!(%peer, "Got unexpected response to GetBlockHeaders");
+                    continue;
+                }
+                Err(error) => {
+                    tracing::debug!(%peer, %error, "GetBlockHeaders failed");
+                    continue;
+                }
+            }
+        }
+
+        tracing::debug!(%start_block, %num_blocks, "No peers with block headers found for");
+
+        None
+    }
+
+    pub async fn block_bodies(
+        &self,
+        start_block_hash: BlockHash, // FIXME, hash to avoid DB lookup
+        num_blocks: usize,           // FIXME, use range?
+    ) -> Option<Vec<p2p_proto::common::BlockBody>> {
+        if num_blocks == 0 {
+            return Some(Vec::new());
+        }
+
+        let count: u64 = num_blocks.try_into().ok()?;
+
+        for peer in self.shuffled_peers_with_sync_capability().await {
+            let response = self
+                .client
+                .send_sync_request(
+                    peer,
+                    p2p_proto::sync::Request::GetBlockBodies(p2p_proto::sync::GetBlockBodies {
+                        start_block: start_block_hash.0,
+                        count,
+                        size_limit: u64::MAX, // FIXME
+                        direction: p2p_proto::sync::Direction::Forward,
+                    }),
+                )
+                .await;
+
+            match response {
+                Ok(p2p_proto::sync::Response::BlockBodies(x)) => {
+                    if x.block_bodies.is_empty() {
+                        tracing::debug!(%peer, "Got empty block bodies response");
+                        continue;
+                    } else {
+                        return Some(x.block_bodies);
+                    }
+                }
+                Ok(_) => {
+                    tracing::debug!(%peer, "Got unexpected response to GetBlockBodies");
+                    continue;
+                }
+                Err(error) => {
+                    tracing::debug!(%peer, %error, "GetBlockBodies failed");
+                    continue;
+                }
+            }
+        }
+
+        tracing::debug!(%start_block_hash, %num_blocks, "No peers with block bodies found for");
+
+        None
+    }
+
+    pub async fn state_updates(
+        &self,
+        start_block_hash: BlockHash, // FIXME, hash to avoid DB lookup
+        num_blocks: usize,           // FIXME, use range?
+    ) -> Option<Vec<p2p_proto::sync::BlockStateUpdateWithHash>> {
+        if num_blocks == 0 {
+            return Some(Vec::new());
+        }
+
+        let count: u64 = num_blocks.try_into().ok()?;
+
+        for peer in self.shuffled_peers_with_sync_capability().await {
+            let response = self
+                .client
+                .send_sync_request(
+                    peer,
+                    p2p_proto::sync::Request::GetStateDiffs(p2p_proto::sync::GetStateDiffs {
+                        start_block: start_block_hash.0,
+                        count,
+                        size_limit: u64::MAX, // FIXME
+                        direction: p2p_proto::sync::Direction::Forward,
+                    }),
+                )
+                .await;
+            match response {
+                Ok(p2p_proto::sync::Response::StateDiffs(x)) => {
+                    if x.block_state_updates.is_empty() {
+                        tracing::debug!(%peer, "Got empty state updates response");
+                        continue;
+                    } else {
+                        return Some(x.block_state_updates);
+                    }
+                }
+                Ok(_) => {
+                    tracing::debug!(%peer, "Got unexpected response to GetStateDiffs");
+                    continue;
+                }
+                Err(error) => {
+                    tracing::debug!(%peer, %error, "GetStateDiffs failed");
+                    continue;
+                }
+            }
+        }
+
+        tracing::debug!(%start_block_hash, %num_blocks, "No peers with state updates found for");
+
+        None
+    }
+
+    pub async fn contract_classes(
+        &self,
+        class_hashes: Vec<ClassHash>,
+    ) -> Option<p2p_proto::sync::Classes> {
+        if class_hashes.is_empty() {
+            return Some(p2p_proto::sync::Classes {
+                classes: Vec::new(),
+            });
+        }
+
+        let class_hashes = class_hashes.into_iter().map(|x| x.0).collect::<Vec<_>>();
+
+        for peer in self.shuffled_peers_with_sync_capability().await {
+            let response = self
+                .client
+                .send_sync_request(
+                    peer,
+                    p2p_proto::sync::Request::GetClasses(p2p_proto::sync::GetClasses {
+                        class_hashes: class_hashes.clone(),
+                        size_limit: u64::MAX, // FIXME
+                    }),
+                )
+                .await;
+            match response {
+                Ok(p2p_proto::sync::Response::Classes(x)) => {
+                    if x.classes.is_empty() {
+                        tracing::debug!(%peer, "Got empty classes response");
+                        continue;
+                    } else {
+                        return Some(x);
+                    }
+                }
+                Ok(_) => {
+                    tracing::debug!(%peer, "Got unexpected response to GetClasses");
+                    continue;
+                }
+                Err(error) => {
+                    tracing::debug!(%peer, %error, "GetStateDiffs failed");
+                    continue;
+                }
+            }
+        }
+
+        tracing::debug!(?class_hashes, "No peers with classes found for");
+
+        None
+    }
+}
+
+/// _Low level_ client for p2p interaction.
+/// For syncing use [`SyncClient`] instead.
 #[derive(Clone, Debug)]
 pub struct Client {
     sender: mpsc::Sender<Command>,
+    my_peer_id: PeerId,
 }
 
 impl Client {
@@ -121,6 +392,30 @@ impl Client {
             .await
             .expect("Command receiver not to be dropped");
         receiver.await.expect("Sender not to be dropped")
+    }
+
+    pub async fn get_capability_providers(
+        &self,
+        capability: &str,
+    ) -> anyhow::Result<HashSet<PeerId>> {
+        let (sender, mut receiver) = mpsc::channel(1);
+        self.sender
+            .send(Command::GetCapabilityProviders {
+                capability: capability.to_owned(),
+                sender,
+            })
+            .await
+            .expect("Command receiver not to be dropped");
+
+        let mut providers = HashSet::new();
+
+        while let Some(partial_result) = receiver.recv().await {
+            let more_providers =
+                partial_result.with_context(|| format!("Getting providers for {capability}"))?;
+            providers.extend(more_providers.into_iter());
+        }
+
+        Ok(providers)
     }
 
     pub async fn subscribe_topic(&self, topic: &str) -> anyhow::Result<()> {
@@ -171,7 +466,7 @@ impl Client {
         self.sender
             .send(Command::PublishPropagationMessage {
                 topic,
-                message: Box::new(message),
+                message: message.into(),
                 sender,
             })
             .await
@@ -209,6 +504,10 @@ enum Command {
         capability: String,
         sender: EmptyResultSender,
     },
+    GetCapabilityProviders {
+        capability: String,
+        sender: mpsc::Sender<anyhow::Result<HashSet<PeerId>>>,
+    },
     SubscribeTopic {
         topic: IdentTopic,
         sender: EmptyResultSender,
@@ -238,10 +537,6 @@ enum Command {
 #[derive(Debug)]
 pub enum TestCommand {
     GetPeersFromDHT(oneshot::Sender<HashSet<PeerId>>),
-    GetProviders {
-        key: Vec<u8>,
-        sender: mpsc::Sender<Result<HashSet<PeerId>, ()>>,
-    },
 }
 
 #[derive(Debug)]
@@ -257,7 +552,10 @@ pub enum Event {
         request: p2p_proto::sync::Request,
         channel: ResponseChannel<p2p_proto::sync::Response>,
     },
-    BlockPropagation(p2p_proto::propagation::Message),
+    BlockPropagation {
+        from: PeerId,
+        message: Box<p2p_proto::propagation::Message>,
+    },
     /// For testing purposes only
     Test(TestEvent),
 }
@@ -276,21 +574,23 @@ pub enum TestEvent {
 pub type EventReceiver = mpsc::Receiver<Event>;
 
 pub struct MainLoop {
+    bootstrap_cfg: BootstrapConfig,
     swarm: libp2p::swarm::Swarm<behaviour::Behaviour>,
     command_receiver: mpsc::Receiver<Command>,
     event_sender: mpsc::Sender<Event>,
-
     peers: Arc<RwLock<peers::Peers>>,
-
     pending_dials: HashMap<PeerId, EmptyResultSender>,
     pending_block_sync_requests:
         HashMap<RequestId, oneshot::Sender<anyhow::Result<p2p_proto::sync::Response>>>,
     pending_block_sync_status_requests: HashSet<RequestId>,
-
     request_sync_status: HashSetDelay<PeerId>,
-
-    bootstrap_cfg: BootstrapConfig,
+    pending_queries: PendingQueries,
     _pending_test_queries: TestQueries,
+}
+
+#[derive(Debug, Default)]
+struct PendingQueries {
+    pub get_providers: HashMap<QueryId, mpsc::Sender<anyhow::Result<HashSet<PeerId>>>>,
 }
 
 impl MainLoop {
@@ -302,6 +602,7 @@ impl MainLoop {
         periodic_cfg: PeriodicTaskConfig,
     ) -> Self {
         Self {
+            bootstrap_cfg: periodic_cfg.bootstrap,
             swarm,
             command_receiver,
             event_sender,
@@ -310,7 +611,7 @@ impl MainLoop {
             pending_block_sync_requests: Default::default(),
             pending_block_sync_status_requests: Default::default(),
             request_sync_status: HashSetDelay::new(periodic_cfg.status_period),
-            bootstrap_cfg: periodic_cfg.bootstrap,
+            pending_queries: Default::default(),
             _pending_test_queries: Default::default(),
         }
     }
@@ -321,11 +622,39 @@ impl MainLoop {
         let mut bootstrap_interval =
             tokio::time::interval_at(bootstrap_start, self.bootstrap_cfg.period);
 
+        let mut network_status_interval = tokio::time::interval(Duration::from_secs(2));
+        let me = *self.swarm.local_peer_id();
+
         loop {
             let bootstrap_interval_tick = bootstrap_interval.tick();
             tokio::pin!(bootstrap_interval_tick);
 
+            let network_status_interval_tick = network_status_interval.tick();
+            tokio::pin!(network_status_interval_tick);
+
             tokio::select! {
+                _ = network_status_interval_tick => {
+                    let dht = self.swarm.behaviour_mut().kademlia
+                        .kbuckets()
+                        // Cannot .into_iter() a KBucketRef, hence the inner collect followed by flat_map
+                        .map(|kbucket_ref| {
+                            kbucket_ref
+                                .iter()
+                                .map(|entry_ref| *entry_ref.node.key.preimage())
+                                .collect::<Vec<_>>()
+                        })
+                        .flat_map(|peers_in_bucket| peers_in_bucket.into_iter())
+                        .collect::<HashSet<_>>();
+                    let guard = self.peers.read().await;
+                    let connected = guard.connected().collect::<Vec<_>>();
+
+                    tracing::info!(
+                        "Network status: me {}, connected {:?}, dht {:?}",
+                        me,
+                        connected,
+                        dht,
+                    );
+                }
                 _ = bootstrap_interval_tick => {
                     tracing::debug!("Doing periodical bootstrap");
                     _ = self.swarm.behaviour_mut().kademlia.bootstrap();
@@ -469,16 +798,19 @@ impl MainLoop {
             })) => {
                 match p2p_proto::propagation::Message::from_protobuf_encoding(message.data.as_ref())
                 {
-                    Ok(event) => {
+                    Ok(decoded_message) => {
                         tracing::debug!(
                             "Gossipsub Event Message: [id={}][peer={}] {:?} ({} bytes)",
                             id,
                             peer_id,
-                            event,
+                            decoded_message,
                             message.data.len()
                         );
                         self.event_sender
-                            .send(Event::BlockPropagation(event))
+                            .send(Event::BlockPropagation {
+                                from: peer_id,
+                                message: decoded_message.into(),
+                            })
                             .await?;
                     }
                     Err(e) => {
@@ -522,8 +854,57 @@ impl MainLoop {
                                     )
                                     .await;
                                 }
+                                QueryResult::GetProviders(result) => {
+                                    use libp2p::kad::GetProvidersOk;
+
+                                    let result = match result {
+                                        Ok(GetProvidersOk::FoundProviders {
+                                            providers, ..
+                                        }) => Ok(providers),
+                                        Ok(GetProvidersOk::FinishedWithNoAdditionalRecord {
+                                            ..
+                                        }) => Ok(Default::default()),
+                                        Err(e) => Err(e.into()),
+                                    };
+
+                                    let sender = self
+                                        .pending_queries
+                                        .get_providers
+                                        .remove(&id)
+                                        .expect("Query to be pending");
+
+                                    sender
+                                        .send(result)
+                                        .await
+                                        .expect("Receiver not to be dropped");
+                                }
                                 _ => self.test_query_completed(id, result).await,
                             }
+                        } else if let QueryResult::GetProviders(result) = result {
+                            use libp2p::kad::GetProvidersOk;
+
+                            let result = match result {
+                                Ok(GetProvidersOk::FoundProviders { providers, .. }) => {
+                                    Ok(providers)
+                                }
+                                Ok(_) => Ok(Default::default()),
+                                Err(_) => {
+                                    unreachable!(
+                                        "when a query times out libp2p makes it the last stage"
+                                    )
+                                }
+                            };
+
+                            let sender = self
+                                .pending_queries
+                                .get_providers
+                                .get(&id)
+                                .expect("Query to be pending");
+
+                            sender
+                                .send(result)
+                                .await
+                                .expect("Receiver not to be dropped");
                         } else {
                             self.test_query_progressed(id, result).await;
                         }
@@ -579,7 +960,6 @@ impl MainLoop {
                         request_id,
                         response,
                     } => {
-                        tracing::debug!(?response, %peer, "Received block sync response");
                         if self.pending_block_sync_status_requests.remove(&request_id) {
                             // this was a status response, handle this internally
                             if let p2p_proto::sync::Response::Status(status) = response {
@@ -629,7 +1009,15 @@ impl MainLoop {
             // test purposes
             // ===========================
             event => {
-                tracing::trace!(?event, "Ignoring event");
+                match &event {
+                    SwarmEvent::NewListenAddr { address, .. } => {
+                        let my_peerid = *self.swarm.local_peer_id();
+                        let address = address.clone().with(Protocol::P2p(my_peerid.into()));
+
+                        tracing::debug!(%address, "New listen");
+                    }
+                    _ => tracing::trace!(?event, "Ignoring event"),
+                }
                 self.handle_event_for_test(event).await;
                 Ok(())
             }
@@ -681,6 +1069,13 @@ impl MainLoop {
                     Err(e) => sender.send(Err(e)),
                 };
             }
+            Command::GetCapabilityProviders { capability, sender } => {
+                let query_id = self
+                    .swarm
+                    .behaviour_mut()
+                    .get_capability_providers(&capability);
+                self.pending_queries.get_providers.insert(query_id, sender);
+            }
             Command::SubscribeTopic { topic, sender } => {
                 let _ = match self.swarm.behaviour_mut().subscribe_topic(&topic) {
                     Ok(_) => {
@@ -695,7 +1090,7 @@ impl MainLoop {
                 request,
                 sender,
             } => {
-                tracing::debug!(?request, "Sending block sync request");
+                tracing::debug!(?request, "Sending sync request");
 
                 let request_id = self
                     .swarm
@@ -707,7 +1102,7 @@ impl MainLoop {
             Command::SendSyncResponse { channel, response } => {
                 // This might fail, but we're just ignoring it. In case of failure a
                 // RequestResponseEvent::InboundFailure will or has been be emitted.
-                tracing::debug!(?response, "Sending block sync response");
+                tracing::debug!(%response, "Sending sync response");
 
                 let _ = self
                     .swarm
@@ -716,7 +1111,7 @@ impl MainLoop {
                     .send_response(channel, response);
             }
             Command::SendSyncStatusRequest { peer_id, status } => {
-                tracing::debug!(?status, "Sending block sync status");
+                tracing::debug!(?status, "Sending sync status request");
 
                 let request_id = self
                     .swarm

--- a/crates/p2p/src/tests.rs
+++ b/crates/p2p/src/tests.rs
@@ -237,10 +237,7 @@ async fn provide_capability() {
     // no other event to rely on
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    // sha256("blah")
-    let key =
-        hex::decode("8b7df143d91c716ecfa5fc1730022f6b421b05cedee8fd52b1fc65a96030ad52").unwrap();
-    let providers = peer2.client.for_test().get_providers(key).await.unwrap();
+    let providers = peer2.client.get_capability_providers("blah").await.unwrap();
 
     assert_eq!(providers, [peer1.peer_id].into());
 }
@@ -267,7 +264,7 @@ async fn subscription_and_propagation() {
     });
 
     let mut propagated_to_peer2 = filter_events(peer2.event_receiver, |event| match event {
-        Event::BlockPropagation(message) => Some(message),
+        Event::BlockPropagation { message, .. } => Some(message),
         _ => None,
     });
 
@@ -288,7 +285,7 @@ async fn subscription_and_propagation() {
             .await
             .unwrap();
 
-        let msg = propagated_to_peer2.recv().await.unwrap();
+        let msg = *propagated_to_peer2.recv().await.unwrap();
 
         assert_eq!(msg, expected);
     }

--- a/crates/p2p_bootstrap/Cargo.toml
+++ b/crates/p2p_bootstrap/Cargo.toml
@@ -8,10 +8,10 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = { workspace = true }
-base64 = "0.13.0"
+base64 = "0.13.1"
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
 futures = "0.3.21"
-libp2p = { version = "0.50.0", default-features = false, features = ["identify", "kad", "noise", "ping", "dns", "tcp", "tokio", "yamux", "relay", "autonat", "macros"] }
+libp2p = { version = "0.51.3", default-features = false, features = ["identify", "kad", "noise", "ping", "dns", "tcp", "tokio", "yamux", "autonat", "relay", "dcutr", "macros"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { version = "1.20.1", features = ["rt-multi-thread", "macros"] }

--- a/crates/p2p_bootstrap/src/main.rs
+++ b/crates/p2p_bootstrap/src/main.rs
@@ -115,8 +115,9 @@ async fn main() -> anyhow::Result<()> {
                 let network_info = swarm.network_info();
                 let num_peers = network_info.num_peers();
                 let connection_counters = network_info.connection_counters();
-                let num_connections = connection_counters.num_connections();
-                tracing::info!(%num_peers, %num_connections, "Peer-to-peer status")
+                let num_established_connections = connection_counters.num_established();
+                let num_pending_connections = connection_counters.num_pending();
+                tracing::info!(%num_peers, %num_established_connections, %num_pending_connections, "Network status")
             }
             _ = bootstrap_interval_tick => {
                 tracing::debug!("Doing periodical bootstrap");

--- a/crates/p2p_proto/src/sync.rs
+++ b/crates/p2p_proto/src/sync.rs
@@ -17,7 +17,11 @@ pub enum Request {
     Status(Status),
 }
 
-const MAX_UNCOMPRESSED_MESSAGE_SIZE: usize = 1024 * 1024;
+// FIXME !!! even block bodies on testnet2 get too bit at some point
+// FIXME !!! this is going to be fixed ASAP along with the update
+// FIXME !!! of the proto files as now we don't have a decent
+// FIXME !!! way to handle message partitioning
+const MAX_UNCOMPRESSED_MESSAGE_SIZE: usize = 20 * 1024 * 1024;
 
 impl Request {
     pub fn from_protobuf_encoding(bytes: &[u8]) -> std::io::Result<Self> {

--- a/crates/p2p_proto/src/sync.rs
+++ b/crates/p2p_proto/src/sync.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Display, Write};
+
 use fake::Dummy;
 use stark_hash::Felt;
 
@@ -171,6 +173,46 @@ pub enum Response {
     StateDiffs(StateDiffs),
     Classes(Classes),
     Status(Status),
+}
+
+impl Display for Response {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Response::BlockHeaders(BlockHeaders { headers }) => {
+                write!(f, "BlockHeaders[len={};block-numbers:", headers.len())?;
+                for header in headers {
+                    write!(f, "{},", header.number)?;
+                }
+                f.write_char(']')
+            }
+            Response::BlockBodies(BlockBodies { block_bodies }) => {
+                write!(f, "BlockBodies[len={}]", block_bodies.len())
+            }
+            Response::StateDiffs(StateDiffs {
+                block_state_updates,
+            }) => {
+                write!(
+                    f,
+                    "StateDiffs[len={};block-hashes:",
+                    block_state_updates.len()
+                )?;
+                for diff in block_state_updates {
+                    write!(f, "{},", diff.block_hash)?;
+                }
+                f.write_char(']')
+            }
+            Response::Classes(Classes { classes }) => {
+                write!(f, "Classes[len={};compressed-class-sizes:", classes.len())?;
+                for class in classes {
+                    write!(f, "{},", class.class.len())?;
+                }
+                f.write_char(']')
+            }
+            Response::Status(Status { height, hash, .. }) => {
+                write!(f, "Status{{height:{height},hash:{hash},...}}")
+            }
+        }
+    }
 }
 
 impl Response {

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -20,10 +20,12 @@ anyhow = { workspace = true }
 async-trait = "0.1.59"
 base64 = { version = "0.13.1", optional = true }
 bitvec = { workspace = true }
+bytes = "1.3.0"
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
 console-subscriber = { version = "0.1.8", optional = true }
 futures = { version = "0.3", default-features = false, features = ["std"] }
 lazy_static = "1.4.0"
+lru = "0.11.0"
 metrics = "0.20.1"
 metrics-exporter-prometheus = "0.11.0"
 p2p = { path = "../p2p", optional = true }
@@ -64,7 +66,6 @@ zstd = "0.12"
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-bytes = "1.3.0"
 const-decoder = "0.3.0"
 fake = { version = "2.5.0", features = ["derive"] }
 flate2 = "1.0.25"

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -58,6 +58,7 @@ tracing-subscriber = { version = "0.3.16", features = [
 ] }
 url = "2.3.1"
 warp = "0.3.3"
+zstd = "0.12"
 
 [dev-dependencies]
 assert_matches = { workspace = true }
@@ -77,7 +78,6 @@ rstest = "0.18.1"
 serde_with = { workspace = true }
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 tokio = { workspace = true, features = ["test-util"] }
-zstd = "0.12"
 
 [build-dependencies]
 serde = { workspace = true, features = ["derive"] }

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -13,11 +13,12 @@ path = "src/lib.rs"
 [features]
 tokio-console = ["console-subscriber", "tokio/tracing"]
 rpc-full-serde = []
-p2p = ["dep:p2p", "dep:p2p_proto"]
+p2p = ["dep:base64", "dep:p2p", "dep:p2p_proto", "dep:zeroize"]
 
 [dependencies]
 anyhow = { workspace = true }
 async-trait = "0.1.59"
+base64 = { version = "0.13.1", optional = true }
 bitvec = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
 console-subscriber = { version = "0.1.8", optional = true }
@@ -58,6 +59,7 @@ tracing-subscriber = { version = "0.3.16", features = [
 ] }
 url = "2.3.1"
 warp = "0.3.3"
+zeroize = { version = "1.3.0", optional = true }
 zstd = "0.12"
 
 [dev-dependencies]

--- a/crates/pathfinder/src/p2p_network.rs
+++ b/crates/pathfinder/src/p2p_network.rs
@@ -156,6 +156,7 @@ async fn handle_p2p_event(
                 Request::GetClasses(r) => {
                     Response::Classes(sync_handlers::get_classes(r, storage).await?)
                 }
+                // TODO if from != myself && new_head > current_head {send}
                 Request::Status(_) => Response::Status(current_status(chain_id, sync_state).await),
             };
             p2p_client.send_sync_response(channel, response).await;
@@ -163,6 +164,7 @@ async fn handle_p2p_event(
         p2p::Event::BlockPropagation { from, message } => {
             tracing::info!(%from, ?message, "Block Propagation");
             if let p2p_proto::propagation::Message::NewBlockHeader(h) = *message {
+                // TODO if from != myself && new_head > current_head {send}
                 _ = tx.send(Some((
                     BlockNumber::new_or_panic(h.header.number),
                     BlockHash(h.header.hash),

--- a/crates/pathfinder/src/p2p_network.rs
+++ b/crates/pathfinder/src/p2p_network.rs
@@ -158,8 +158,9 @@ async fn handle_p2p_event(
                     Response::Classes(sync_handlers::get_classes(r, storage).await?)
                 }
                 Request::Status(incoming_status) => {
-                    // FIXME proxies sometimes fail to propagate (Gossipsub publish failed: InsufficientPeers)
-                    // so use status as fallback for the time being util we figure out why
+                    // Use status as fallback until the first head propagation message received
+                    // Using status endlessly will cause false positive reorgs in the sync logic
+                    // when sync reaches this false|temporary head
                     tx.send_if_modified(|head| {
                         let current_height = head.unwrap_or_default().0.get();
 

--- a/crates/pathfinder/src/p2p_network/client.rs
+++ b/crates/pathfinder/src/p2p_network/client.rs
@@ -402,9 +402,13 @@ impl GatewayApi for HybridClient {
     async fn head(&self) -> Result<(BlockNumber, BlockHash), SequencerError> {
         match self {
             HybridClient::GatewayProxy { sequencer, .. } => sequencer.head().await,
-            HybridClient::NonPropagatingP2P { head_rx, .. } => (*head_rx.borrow()).ok_or(
-                error::block_not_found("Haven't received any gossiped head yet"),
-            ),
+            HybridClient::NonPropagatingP2P { head_rx, .. } => {
+                let head = *head_rx.borrow();
+                tracing::trace!(?head, "HybridClient::head");
+                head.ok_or(error::block_not_found(
+                    "Haven't received any gossiped head yet",
+                ))
+            }
         }
     }
 }

--- a/crates/pathfinder/src/p2p_network/client.rs
+++ b/crates/pathfinder/src/p2p_network/client.rs
@@ -1,6 +1,443 @@
 //! Sync related data retrieval from other peers
+//!
+//! This is a temporary wrapper around proper p2p sync|propagation api that fits into
+//! current sequential sync logic and will be removed when __proper__ sync algo is
+//! integrated. What it does is just split methods between a "proxy" node
+//! that syncs from the gateway and propagates new headers and a
+//! "proper" p2p node which only syncs via p2p.
 
-// TODO temporary hybrid p2p/gw client goes here
+use lru::LruCache;
+use p2p::HeadRx;
+use pathfinder_common::{
+    BlockHash, BlockHeader, BlockId, BlockNumber, CallParam, CasmHash, ClassHash, ContractAddress,
+    ContractAddressSalt, Fee, StateUpdate, TransactionHash, TransactionNonce,
+    TransactionSignatureElem, TransactionVersion,
+};
+use starknet_gateway_client::{GatewayApi, GossipApi};
+use starknet_gateway_types::reply;
+use starknet_gateway_types::request::add_transaction::ContractDefinition;
+use starknet_gateway_types::{error::SequencerError, reply::Block};
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
+
+/// Hybrid, as it uses either p2p or the gateway depending on role and api call
+#[derive(Clone, Debug)]
+pub enum HybridClient {
+    /// Syncs from the feeder gateway, propagates new headers via p2p/gossipsub
+    /// Proxies blockchain data to non propagating nodes via p2p
+    GatewayProxy {
+        p2p_client: p2p::SyncClient,
+        sequencer: starknet_gateway_client::Client,
+    },
+    /// Syncs from p2p network, does not propagate
+    NonPropagatingP2P {
+        p2p_client: p2p::SyncClient,
+        sequencer: starknet_gateway_client::Client,
+        head_rx: HeadRx,
+        /// We need to cache the last two fetched blocks via p2p otherwise sync logic will
+        /// produce a false reorg from genesis when we loose connection to other p2p nodes.
+        /// This was we can stay at the same height while we are disconnected.
+        block_lru: BlockLru,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub struct BlockLru {
+    inner: Arc<Mutex<LruCache<BlockNumber, Block>>>,
+}
+
+impl Default for BlockLru {
+    fn default() -> Self {
+        Self {
+            // We only need 2 blocks: the last one and its parent
+            inner: Arc::new(Mutex::new(LruCache::new(NonZeroUsize::new(2).unwrap()))),
+        }
+    }
+}
+
+impl BlockLru {
+    fn get(&self, number: BlockNumber) -> Option<Block> {
+        let mut guard = self.inner.lock().unwrap();
+        guard.get(&number).cloned()
+    }
+
+    fn insert(&self, block: Block) {
+        let mut guard = self.inner.lock().unwrap();
+        guard.put(block.block_number, block);
+    }
+}
+
+impl HybridClient {
+    pub fn new(
+        i_am_proxy: bool,
+        p2p_client: p2p::SyncClient,
+        sequencer: starknet_gateway_client::Client,
+        head_rx: HeadRx,
+    ) -> Self {
+        if i_am_proxy {
+            Self::GatewayProxy {
+                p2p_client,
+                sequencer,
+            }
+        } else {
+            Self::NonPropagatingP2P {
+                p2p_client,
+                sequencer,
+                head_rx,
+                block_lru: Default::default(),
+            }
+        }
+    }
+
+    fn as_sequencer(&self) -> &starknet_gateway_client::Client {
+        match self {
+            HybridClient::GatewayProxy { sequencer, .. } => sequencer,
+            HybridClient::NonPropagatingP2P { sequencer, .. } => sequencer,
+        }
+    }
+}
+
+/// A hacky temporary way to wrap p2p related errors
+mod error {
+    use starknet_gateway_types::error::{
+        KnownStarknetErrorCode, SequencerError, StarknetError, StarknetErrorCode,
+    };
+
+    pub fn block_not_found(message: impl ToString) -> SequencerError {
+        SequencerError::StarknetError(StarknetError {
+            code: StarknetErrorCode::Known(KnownStarknetErrorCode::BlockNotFound),
+            message: message.to_string(),
+        })
+    }
+
+    pub fn class_not_found(message: impl ToString) -> SequencerError {
+        SequencerError::StarknetError(StarknetError {
+            code: StarknetErrorCode::Known(KnownStarknetErrorCode::UndeclaredClass),
+            message: message.to_string(),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl GatewayApi for HybridClient {
+    async fn block(&self, block: BlockId) -> Result<reply::MaybePendingBlock, SequencerError> {
+        use error::block_not_found;
+
+        match self {
+            HybridClient::GatewayProxy { sequencer, .. } => sequencer.block(block).await,
+            HybridClient::NonPropagatingP2P {
+                p2p_client,
+                // last_block,
+                block_lru,
+                ..
+            } => match block {
+                BlockId::Number(n) => {
+                    if let Some(block) = block_lru.get(n) {
+                        tracing::trace!(number=%n, "HybridClient: using cached block");
+                        return Ok(block.into());
+                    }
+
+                    let mut headers = p2p_client.block_headers(n, 1).await.ok_or_else(|| {
+                        block_not_found(format!("No peers with headers for block {n}"))
+                    })?;
+
+                    if headers.len() != 1 {
+                        return Err(block_not_found(format!(
+                            "Headers len for block {n} is {}, expected 1",
+                            headers.len()
+                        )));
+                    }
+
+                    let header = headers.swap_remove(0);
+
+                    let mut bodies = p2p_client
+                        .block_bodies(BlockHash(header.hash), 1)
+                        .await
+                        .ok_or_else(|| {
+                            block_not_found(format!("No peers with bodies for block {n}"))
+                        })?;
+
+                    if bodies.len() != 1 {
+                        return Err(block_not_found(format!(
+                            "Bodies len for block {n} is {}, expected 1",
+                            headers.len()
+                        )));
+                    }
+
+                    let body = bodies.swap_remove(0);
+                    let (transactions, transaction_receipts) =
+                        conv::body::try_from_p2p(body).map_err(block_not_found)?;
+                    let header = conv::header::try_from_p2p(header).map_err(block_not_found)?;
+
+                    let block = reply::Block {
+                        block_hash: header.hash,
+                        block_number: header.number,
+                        gas_price: Some(header.gas_price),
+                        parent_block_hash: header.parent_hash,
+                        sequencer_address: Some(header.sequencer_address),
+                        state_commitment: header.state_commitment,
+                        // FIXME
+                        status: starknet_gateway_types::reply::Status::AcceptedOnL2,
+                        timestamp: header.timestamp,
+                        transaction_receipts,
+                        transactions,
+                        starknet_version: header.starknet_version,
+                    };
+
+                    block_lru.insert(block.clone());
+                    tracing::trace!(number=%n, "HybridClient: updating cached block");
+
+                    Ok(block.into())
+                }
+                BlockId::Latest => {
+                    unreachable!("GatewayApi.head() is used in sync and sync status instead")
+                }
+                BlockId::Hash(_) => unreachable!("not used in sync"),
+                BlockId::Pending => {
+                    unreachable!("pending should be disabled when p2p is enabled")
+                }
+            },
+        }
+    }
+
+    async fn block_without_retry(
+        &self,
+        block: BlockId,
+    ) -> Result<reply::MaybePendingBlock, SequencerError> {
+        match self {
+            HybridClient::GatewayProxy { sequencer, .. } => {
+                sequencer.block_without_retry(block).await
+            }
+            HybridClient::NonPropagatingP2P { .. } => {
+                unreachable!("used for gas price and not in sync")
+            }
+        }
+    }
+
+    async fn class_by_hash(&self, class_hash: ClassHash) -> Result<bytes::Bytes, SequencerError> {
+        use error::class_not_found;
+
+        match self {
+            HybridClient::GatewayProxy { sequencer, .. } => {
+                sequencer.class_by_hash(class_hash).await
+            }
+            HybridClient::NonPropagatingP2P { p2p_client, .. } => {
+                let classes = p2p_client
+                    .contract_classes(vec![class_hash])
+                    .await
+                    .ok_or_else(|| class_not_found(format!("No peers with class {class_hash}")))?;
+                let mut classes = classes.classes;
+
+                if classes.len() != 1 {
+                    return Err(class_not_found(format!(
+                        "Classes len is {}, expected 1",
+                        classes.len()
+                    )));
+                }
+
+                let p2p_proto::common::RawClass { class } = classes.swap_remove(0);
+
+                let class = zstd::decode_all(class.as_slice())
+                    .map_err(|_| class_not_found("zstd failed"))?;
+
+                Ok(class.into())
+            }
+        }
+    }
+
+    async fn pending_class_by_hash(
+        &self,
+        class_hash: ClassHash,
+    ) -> Result<bytes::Bytes, SequencerError> {
+        use error::class_not_found;
+
+        match self {
+            HybridClient::GatewayProxy { sequencer, .. } => {
+                sequencer.pending_class_by_hash(class_hash).await
+            }
+            HybridClient::NonPropagatingP2P { p2p_client, .. } => {
+                let classes = p2p_client
+                    .contract_classes(vec![class_hash])
+                    .await
+                    .ok_or_else(|| class_not_found(format!("No peers with class {class_hash}")))?;
+                let mut classes = classes.classes;
+
+                if classes.len() != 1 {
+                    return Err(class_not_found(format!(
+                        "Classes len is {}, expected 1",
+                        classes.len()
+                    )));
+                }
+
+                let p2p_proto::common::RawClass { class } = classes.swap_remove(0);
+
+                let class = zstd::decode_all(class.as_slice())
+                    .map_err(|_| class_not_found("zstd failed"))?;
+
+                Ok(class.into())
+            }
+        }
+    }
+
+    async fn transaction(
+        &self,
+        transaction_hash: TransactionHash,
+    ) -> Result<reply::Transaction, SequencerError> {
+        self.as_sequencer().transaction(transaction_hash).await
+    }
+
+    async fn state_update(&self, block: BlockId) -> Result<StateUpdate, SequencerError> {
+        use error::block_not_found;
+
+        match self {
+            HybridClient::GatewayProxy { sequencer, .. } => sequencer.state_update(block).await,
+            HybridClient::NonPropagatingP2P { p2p_client, .. } => match block {
+                BlockId::Hash(hash) => {
+                    let mut state_updates =
+                        p2p_client.state_updates(hash, 1).await.ok_or_else(|| {
+                            block_not_found(format!("No peers with state update for block {hash}"))
+                        })?;
+
+                    if state_updates.len() != 1 {
+                        return Err(block_not_found(format!(
+                            "State updates len is {}, expected 1",
+                            state_updates.len()
+                        )));
+                    }
+
+                    let state_update = state_updates.swap_remove(0);
+
+                    let state_update =
+                        conv::state_update::try_from_p2p(state_update).map_err(block_not_found)?;
+
+                    if state_update.block_hash == hash {
+                        Ok(state_update.into())
+                    } else {
+                        Err(block_not_found("Block hash mismatch"))
+                    }
+                }
+                _ => unreachable!("not used in sync"),
+            },
+        }
+    }
+
+    async fn eth_contract_addresses(&self) -> Result<reply::EthContractAddresses, SequencerError> {
+        self.as_sequencer().eth_contract_addresses().await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn add_invoke_transaction(
+        &self,
+        version: TransactionVersion,
+        max_fee: Fee,
+        signature: Vec<TransactionSignatureElem>,
+        nonce: TransactionNonce,
+        contract_address: ContractAddress,
+        calldata: Vec<CallParam>,
+    ) -> Result<reply::add_transaction::InvokeResponse, SequencerError> {
+        self.as_sequencer()
+            .add_invoke_transaction(
+                version,
+                max_fee,
+                signature,
+                nonce,
+                contract_address,
+                calldata,
+            )
+            .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn add_declare_transaction(
+        &self,
+        version: TransactionVersion,
+        max_fee: Fee,
+        signature: Vec<TransactionSignatureElem>,
+        nonce: TransactionNonce,
+        contract_definition: ContractDefinition,
+        sender_address: ContractAddress,
+        compiled_class_hash: Option<CasmHash>,
+        token: Option<String>,
+    ) -> Result<reply::add_transaction::DeclareResponse, SequencerError> {
+        self.as_sequencer()
+            .add_declare_transaction(
+                version,
+                max_fee,
+                signature,
+                nonce,
+                contract_definition,
+                sender_address,
+                compiled_class_hash,
+                token,
+            )
+            .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn add_deploy_account(
+        &self,
+        version: TransactionVersion,
+        max_fee: Fee,
+        signature: Vec<TransactionSignatureElem>,
+        nonce: TransactionNonce,
+        contract_address_salt: ContractAddressSalt,
+        class_hash: ClassHash,
+        calldata: Vec<CallParam>,
+    ) -> Result<reply::add_transaction::DeployAccountResponse, SequencerError> {
+        self.as_sequencer()
+            .add_deploy_account(
+                version,
+                max_fee,
+                signature,
+                nonce,
+                contract_address_salt,
+                class_hash,
+                calldata,
+            )
+            .await
+    }
+
+    /// This is a **temporary** measure to keep the sync logic unchanged
+    ///
+    /// TODO remove me when sync is changed to use the high level (ie. peer unaware) p2p API
+    async fn head(&self) -> Result<(BlockNumber, BlockHash), SequencerError> {
+        match self {
+            HybridClient::GatewayProxy { sequencer, .. } => sequencer.head().await,
+            HybridClient::NonPropagatingP2P { head_rx, .. } => (*head_rx.borrow()).ok_or(
+                error::block_not_found("Haven't received any gossiped head yet"),
+            ),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl GossipApi for HybridClient {
+    async fn propagate_block_header(
+        &self,
+        header: BlockHeader,
+        transaction_count: u32,
+        event_count: u32,
+    ) {
+        match self {
+            HybridClient::GatewayProxy { p2p_client, .. } => {
+                match p2p_client
+                    .propagate_new_header(super::sync_handlers::conv::header::from(
+                        header,
+                        transaction_count,
+                        event_count,
+                    ))
+                    .await
+                {
+                    Ok(_) => {}
+                    Err(error) => tracing::warn!(%error, "Propagating block header failed"),
+                }
+            }
+            HybridClient::NonPropagatingP2P { .. } => {
+                // This is why it's called non-propagating
+            }
+        }
+    }
+}
 
 /// Workaround for the orphan rule - implement conversion fns for types ourside our crate.
 pub mod conv {

--- a/crates/pathfinder/src/p2p_network/sync_handlers.rs
+++ b/crates/pathfinder/src/p2p_network/sync_handlers.rs
@@ -212,6 +212,9 @@ fn classes(
             break;
         };
 
+        // This is a temporary measure to avoid exceeding the max size of a protobuf message.
+        let class = zstd::bulk::compress(&class, 19)?;
+
         classes.push(p2p_proto::common::RawClass { class });
     }
 
@@ -219,8 +222,8 @@ fn classes(
 }
 
 /// Workaround for the orphan rule - implement conversion fns for types ourside our crate.
-mod conv {
-    pub(super) mod header {
+pub(crate) mod conv {
+    pub(crate) mod header {
         use pathfinder_common::BlockHeader;
 
         pub fn from(

--- a/crates/pathfinder/src/p2p_network/sync_handlers.rs
+++ b/crates/pathfinder/src/p2p_network/sync_handlers.rs
@@ -213,7 +213,7 @@ fn classes(
         };
 
         // This is a temporary measure to avoid exceeding the max size of a protobuf message.
-        let class = zstd::bulk::compress(&class, 19)?;
+        let class = zstd::bulk::compress(&class, 0)?;
 
         classes.push(p2p_proto::common::RawClass { class });
     }

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -128,6 +128,7 @@ where
             Some(head) => (head.0 + 1, Some(head)),
             None => (BlockNumber::GENESIS, None),
         };
+
         let t_block = std::time::Instant::now();
         // Next block and state update which we can get for free when exiting poll pending mode
         let mut next_block = None;
@@ -171,18 +172,20 @@ where
                     }
                 }
                 DownloadBlock::Reorg => {
-                    let some_head = head.unwrap();
-                    head = reorg(
-                        &some_head,
-                        chain,
-                        chain_id,
-                        &tx_event,
-                        &sequencer,
-                        block_validation_mode,
-                        &blocks,
-                    )
-                    .await
-                    .context("L2 reorg")?;
+                    head = match head {
+                        Some(some_head) => reorg(
+                            &some_head,
+                            chain,
+                            chain_id,
+                            &tx_event,
+                            &sequencer,
+                            block_validation_mode,
+                            &blocks,
+                        )
+                        .await
+                        .context("L2 reorg")?,
+                        None => None,
+                    };
 
                     match &head {
                         Some((number, hash, commitment, starknet_version)) => {
@@ -444,7 +447,6 @@ async fn download_block(
     sequencer: &impl GatewayApi,
     mode: BlockValidationMode,
 ) -> anyhow::Result<DownloadBlock> {
-    use pathfinder_common::BlockId;
     use starknet_gateway_types::{
         error::KnownStarknetErrorCode::BlockNotFound, reply::MaybePendingBlock,
     };
@@ -495,18 +497,16 @@ async fn download_block(
             // This would occur if we queried past the head of the chain. We now need to check that
             // a reorg hasn't put us too far in the future. This does run into race conditions with
             // the sequencer but this is the best we can do I think.
-            let latest = sequencer
-                .block(BlockId::Latest)
+            let (latest_block_number, latest_block_hash) = sequencer
+                .head()
                 .await
-                .context("Query sequencer for latest block")?
-                .as_block()
-                .context("Latest block is `pending`")?;
+                .context("Query sequencer for latest block")?;
 
-            if latest.block_number + 1 == block_number {
+            if latest_block_number + 1 == block_number {
                 match prev_block_hash {
                     // We are definitely still at the head and it's just that a new block
                     // has not been published yet
-                    Some(parent_block_hash) if parent_block_hash == latest.block_hash => {
+                    Some(parent_block_hash) if parent_block_hash == latest_block_hash => {
                         Ok(DownloadBlock::AtHead)
                     }
                     // Our head is not valid anymore so there must have been a reorg only at this height
@@ -522,6 +522,7 @@ async fn download_block(
         }
         Err(other) => Err(other).context("Download block from sequencer"),
     };
+
     match result {
         Ok(DownloadBlock::Block(block, commitments)) => {
             for (i, txn) in block.transactions.iter().enumerate() {

--- a/crates/storage/src/connection/event.rs
+++ b/crates/storage/src/connection/event.rs
@@ -616,7 +616,6 @@ mod tests {
 
         let mut buf = String::new();
         super::event_keys_to_base64_strings(&event.keys, &mut buf);
-        assert_eq!(buf.capacity(), buf.len());
         assert_eq!(
                     buf,
                     "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQGCM= AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQGCQ= AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQGCU="

--- a/crates/storage/src/fake.rs
+++ b/crates/storage/src/fake.rs
@@ -208,14 +208,6 @@ pub mod init {
                 //
                 state_update.parent_state_commitment = parent_state_commitment;
 
-                // Disallow empty storage entries
-                state_update.contract_updates.iter_mut().for_each(|(_, u)| {
-                    if u.storage.is_empty() {
-                        u.storage
-                            .insert(Faker.fake_with_rng(rng), Faker.fake_with_rng(rng));
-                    }
-                });
-
                 let num_deployed_in_parent = deployed_in_parent.len();
 
                 if num_deployed_in_parent > 0 {


### PR DESCRIPTION
This PR glues existing p2p implementation to the sync logic.

---------------------------

How:
- implementing GatewayApi for a new **temporary** entity that combines the feeder gateway client and a new "sync p2p client"
- I had to do a minor `GatewayApi` change to ease integration (introduced `head()` used in place of `block(Latest)`)
- I also added a temporary `GossipApi` to allow the client to propagate hew head (ie. when the node is of "proxy" type)

Caveats:
- there are 3 types of nodes:
   - bootstrap (from example)
   - gateway proxy
       - syncs from feeder gateway,
       - propagates **global** feeder gateway l2 head via gossipsub,
       - responds to sync requests from other nodes
   - pure p2p
       - syncs from other nodes (proxy and pure p2p),
       - responds to sync requests from other nodes
- now the "sync stack" looks like this for "pure p2p" nodes:
```
pathfinder::sync::l2
----------------------------------------
HybridClient (impl GatewayApi+GossipApi)
----------------------------------------
p2p::SyncClient
----------------------------------------
p2p::Client | p2p::MainLoop
```
- syncing is _somewhat_ tested in a 5 node setup:
    - 1x bootstrap, 2x proxy (1 from image + 1 from genesis), 2x pure p2p (1 from image + 1 from genesis)
    - unfortunately none of them haven't reached _global_ head yet
- i'm using the **old proto** spec
- so the `SyncClient` is very crude and will undergo a lot of changes when the latest proto spec is implemented, (among others: the `p2p::peers::Peers` registry is totally ignored for the time being), it's api is not what we're looking for, I just went with whatever works for me rn
- `HybridClient` is temporary and should be removed asap
- I haven't thought about signing data from the feeder gateway yet

Next steps:
- Implement the latest p2p (proto) spec
- Rework the higher level p2p api (`p2p::SyncClient`) to match our needs. Ideally we'd like to keep some form of the higher level p2p api (`p2p::SyncClient`) that is peer agnostic and _just_ provides the data that sync needs. By that time we should have some alternative sync logic that we could just plug this api into.

-------

Fixes #1326 


