### PR TITLE
chore(github/ci): 'integration*' tests were already run by nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,6 @@ jobs:
 
       - name: Run unit tests
         run: timeout 5m cargo nextest run --no-fail-fast --all-targets --all-features --workspace --locked
-          
-      - name: Run integration tests
-        run: timeout 3m cargo test --test integration* --locked
 
   clippy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It turns out `nextest` runs _all_ tests, including the ones we've been running separately.