### PR TITLE
feat(rpc): make version of the JSON-RPC API served on the root path configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - RPC v0.3 `starknet_estimateFee` example
 
+### Added
+
+- Added the `rpc.root-version` command-line option (and the corresponding PATHFINDER_RPC_ROOT_VERSION environment variable)
+  to control the version of the JSON-RPC API pathfinder serves on the `/` path
+
 ## [0.7.2] - 2023-08-16
 
 ### Fixed

--- a/crates/common/src/test_utils.rs
+++ b/crates/common/src/test_utils.rs
@@ -178,7 +178,7 @@ pub mod metrics {
                         .map(|&(key, val)| Label::new(key, val))
                         .collect::<Vec<_>>(),
                 ))
-                .unwrap()
+                .expect("Unregistered counter name")
                 .0
                 .load(Ordering::Relaxed)
         }

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -90,6 +90,14 @@ Examples:
     rpc_cors_domains: Vec<String>,
 
     #[arg(
+        long = "rpc.root-version",
+        long_help = "Version of the JSON-RPC API to serve on the / (root) path",
+        default_value = "v03",
+        env = "PATHFINDER_RPC_ROOT_VERSION"
+    )]
+    rpc_root_version: RpcVersion,
+
+    #[arg(
         long = "monitor-address",
         long_help = "The address at which pathfinder will serve monitoring related information",
         value_name = "IP:PORT",
@@ -170,6 +178,12 @@ impl Color {
             Color::Always => true,
         }
     }
+}
+
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq)]
+pub enum RpcVersion {
+    V03,
+    V04,
 }
 
 #[derive(clap::Args)]
@@ -309,6 +323,7 @@ pub struct Config {
     pub ethereum: Ethereum,
     pub rpc_address: SocketAddr,
     pub rpc_cors_domains: Option<AllowedOrigins>,
+    pub rpc_root_version: RpcVersion,
     pub ws: Option<WebSocket>,
     pub monitor_address: Option<SocketAddr>,
     pub network: Option<NetworkConfig>,
@@ -398,6 +413,7 @@ impl Config {
             },
             rpc_address: cli.rpc_address,
             rpc_cors_domains: parse_cors_or_exit(cli.rpc_cors_domains),
+            rpc_root_version: cli.rpc_root_version,
             ws: cli.ws.then_some(WebSocket {
                 capacity: cli.ws_capacity,
             }),

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -149,11 +149,12 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syse
         false => context,
     };
 
-    let rpc_server = pathfinder_rpc::RpcServer::new(
-        config.rpc_address,
-        context,
-        pathfinder_rpc::DefaultVersion::default(),
-    );
+    let default_version = match config.rpc_root_version {
+        config::RpcVersion::V03 => pathfinder_rpc::DefaultVersion::V03,
+        config::RpcVersion::V04 => pathfinder_rpc::DefaultVersion::V04,
+    };
+
+    let rpc_server = pathfinder_rpc::RpcServer::new(config.rpc_address, context, default_version);
     let rpc_server = match config.rpc_cors_domains {
         Some(allowed_origins) => rpc_server.with_cors(allowed_origins),
         None => rpc_server,

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -149,7 +149,11 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syse
         false => context,
     };
 
-    let rpc_server = pathfinder_rpc::RpcServer::new(config.rpc_address, context);
+    let rpc_server = pathfinder_rpc::RpcServer::new(
+        config.rpc_address,
+        context,
+        pathfinder_rpc::DefaultVersion::default(),
+    );
     let rpc_server = match config.rpc_cors_domains {
         Some(allowed_origins) => rpc_server.with_cors(allowed_origins),
         None => rpc_server,

--- a/crates/rpc/src/metrics.rs
+++ b/crates/rpc/src/metrics.rs
@@ -143,7 +143,9 @@ pub mod logger {
 
     #[cfg(test)]
     mod tests {
-        use crate::{context::RpcContext, test_client::TestClientBuilder, RpcServer};
+        use crate::{
+            context::RpcContext, test_client::TestClientBuilder, DefaultVersion, RpcServer,
+        };
         use jsonrpsee::core::Error;
         use jsonrpsee::types::error::{CallError, METHOD_NOT_FOUND_CODE};
         use serde_json::json;
@@ -151,11 +153,12 @@ pub mod logger {
         #[tokio::test]
         async fn invalid_method_name_without_underscore_doesnt_crash_the_server() {
             let context = RpcContext::for_tests();
-            let (_server_handle, address) = RpcServer::new("127.0.0.1:0".parse().unwrap(), context)
-                .with_logger(crate::metrics::logger::RpcMetricsLogger)
-                .run()
-                .await
-                .unwrap();
+            let (_server_handle, address) =
+                RpcServer::new("127.0.0.1:0".parse().unwrap(), context, DefaultVersion::V03)
+                    .with_logger(crate::metrics::logger::RpcMetricsLogger)
+                    .run()
+                    .await
+                    .unwrap();
 
             let client = TestClientBuilder::default()
                 .address(address)

--- a/crates/rpc/src/middleware/cors.rs
+++ b/crates/rpc/src/middleware/cors.rs
@@ -19,7 +19,7 @@ pub fn with_allowed_origins(allowed_origins: AllowedOrigins) -> CorsLayer {
 
 #[cfg(test)]
 mod tests {
-    use crate::{context::RpcContext, RpcServer};
+    use crate::{context::RpcContext, DefaultVersion, RpcServer};
     use http::HeaderValue;
 
     #[tokio::test]
@@ -34,7 +34,8 @@ mod tests {
             (None, None, line!()),
         ] {
             let context = RpcContext::for_tests();
-            let server = RpcServer::new("127.0.0.1:0".parse().unwrap(), context);
+            let server =
+                RpcServer::new("127.0.0.1:0".parse().unwrap(), context, DefaultVersion::V03);
             let server = match allowed {
                 Some(allowed) => server.with_cors(allowed.into()),
                 None => server,


### PR DESCRIPTION
This PR adds the `rpc.root-version` command line argument (and the corresponding `PATHFINDER_RPC_ROOT_VERSION` environment variable) that can be used to select which version of the JSON-RPC API gets served on the root path.

The default is the `v0.3` API we've been using previously.

Fixes #1321 

