### PR TITLE
chore(py): upgrade `cairo-lang` to 0.12.2a0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- `cairo-lang` upgraded to 0.12.2a0
+
 ## [0.7.2] - 2023-08-16
 
 ### Fixed

--- a/crates/rpc/src/cairo/ext_py.rs
+++ b/crates/rpc/src/cairo/ext_py.rs
@@ -639,7 +639,7 @@ mod tests {
 
         let transactions = vec![valid_invoke_v1(account_address)];
 
-        const EXPECTED_GAS_CONSUMED: u64 = 4938;
+        const EXPECTED_GAS_CONSUMED: u64 = 4939;
 
         for (gas_price_u64, block, use_past_block) in [
             (1, latest_block_number.into(), true),

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Pathfinder Python worker subprocess"
 readme = "README.md"
 dependencies = [
-    "cairo-lang == 0.12.1a0",
+    "cairo-lang == 0.12.2a0",
     "zstandard == 0.20.0",
     "cachetools == 5.3.0",
     # required so that pip-compile can properly resolve dependencies
@@ -17,12 +17,7 @@ dependencies = [
 requires-python = ">=3.9"
 
 [project.optional-dependencies]
-dev = [
-    "pip-tools",
-    "pytest == 7.1.3",
-    "flake8 == 5.0.4",
-    "black == 22.10.0",
-]
+dev = ["pip-tools", "pytest == 7.1.3", "flake8 == 5.0.4", "black == 22.10.0"]
 
 [project.scripts]
 pathfinder_python_worker = "pathfinder_worker.call:main"

--- a/py/requirements-dev.txt
+++ b/py/requirements-dev.txt
@@ -10,7 +10,7 @@ aiohttp==3.8.5
     #   web3
 aiosignal==1.3.1
     # via aiohttp
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via aiohttp
 attrs==23.1.0
     # via
@@ -20,7 +20,7 @@ attrs==23.1.0
     #   referencing
 base58==2.1.1
     # via multiaddr
-bitarray==2.7.6
+bitarray==2.8.1
     # via eth-account
 black==22.10.0
     # via pathfinder-worker (pyproject.toml)
@@ -30,9 +30,9 @@ cachetools==5.3.0
     # via
     #   cairo-lang
     #   pathfinder-worker (pyproject.toml)
-cairo-lang==0.12.1a0
+cairo-lang==0.12.2a0
     # via pathfinder-worker (pyproject.toml)
-certifi==2023.5.7
+certifi==2023.7.22
     # via requests
 charset-normalizer==3.2.0
     # via
@@ -42,7 +42,7 @@ click==8.1.6
     # via
     #   black
     #   pip-tools
-cytoolz==0.12.1
+cytoolz==0.12.2
     # via
     #   eth-keyfile
     #   eth-utils
@@ -84,6 +84,10 @@ eth-utils==1.9.5
     #   eth-rlp
     #   rlp
     #   web3
+execnet==2.0.2
+    # via
+    #   cairo-lang
+    #   pytest-xdist
 fastecdsa==2.3.0
     # via cairo-lang
 flake8==5.0.4
@@ -94,6 +98,10 @@ frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
+gprof2dot==2022.7.29
+    # via
+    #   cairo-lang
+    #   pytest-profiling
 hexbytes==0.3.1
     # via
     #   eth-account
@@ -107,15 +115,15 @@ iniconfig==2.0.0
     # via pytest
 ipfshttpclient==0.8.0a2
     # via web3
-jsonschema==4.18.4
+jsonschema==4.19.0
     # via web3
 jsonschema-specifications==2023.7.1
     # via jsonschema
-lark==1.1.6
+lark==1.1.7
     # via cairo-lang
 lru-dict==1.2.0
     # via web3
-marshmallow==3.19.0
+marshmallow==3.20.1
     # via
     #   cairo-lang
     #   marshmallow-dataclass
@@ -145,7 +153,7 @@ mypy-extensions==1.0.0
     #   typing-inspect
 netaddr==0.8.0
     # via multiaddr
-numpy==1.25.1
+numpy==1.25.2
     # via cairo-lang
 packaging==23.1
     # via
@@ -154,13 +162,13 @@ packaging==23.1
     #   pytest
 parsimonious==0.8.1
     # via eth-abi
-pathspec==0.11.1
+pathspec==0.11.2
     # via black
-pip-tools==7.1.0
+pip-tools==7.3.0
     # via pathfinder-worker (pyproject.toml)
-pipdeptree==2.10.2
+pipdeptree==2.13.0
     # via cairo-lang
-platformdirs==3.9.1
+platformdirs==3.10.0
     # via black
 pluggy==1.2.0
     # via pytest
@@ -185,11 +193,17 @@ pytest==7.1.3
     #   cairo-lang
     #   pathfinder-worker (pyproject.toml)
     #   pytest-asyncio
+    #   pytest-profiling
+    #   pytest-xdist
 pytest-asyncio==0.21.1
+    # via cairo-lang
+pytest-profiling==1.7.0
+    # via cairo-lang
+pytest-xdist==3.3.1
     # via cairo-lang
 pyyaml==6.0.1
     # via cairo-lang
-referencing==0.30.0
+referencing==0.30.2
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -210,6 +224,7 @@ six==1.16.0
     #   ecdsa
     #   multiaddr
     #   parsimonious
+    #   pytest-profiling
 sympy==1.12
     # via cairo-lang
 tomli==2.0.1
@@ -239,7 +254,7 @@ web3==5.31.4
     #   pathfinder-worker (pyproject.toml)
 websockets==9.1
     # via web3
-wheel==0.40.0
+wheel==0.41.1
     # via pip-tools
 yarl==1.9.2
     # via aiohttp

--- a/py/src/pathfinder_worker/call.py
+++ b/py/src/pathfinder_worker/call.py
@@ -69,7 +69,7 @@ try:
     from starkware.starknet.definitions.error_codes import StarknetErrorCode
     from starkware.starknet.definitions.general_config import (
         DEFAULT_GAS_PRICE,
-        DEFAULT_MAX_STEPS,
+        DEFAULT_TX_MAX_STEPS,
         DEFAULT_SEQUENCER_ADDRESS,
         DEFAULT_VALIDATE_MAX_STEPS,
         StarknetChainId,
@@ -112,7 +112,7 @@ except ModuleNotFoundError:
 
 # used from tests, and the query which asserts that the schema is of expected version.
 EXPECTED_SCHEMA_REVISION = 39
-EXPECTED_CAIRO_VERSION = "0.12.1a0"
+EXPECTED_CAIRO_VERSION = "0.12.2a0"
 
 # this is set by pathfinder automatically when #[cfg(debug_assertions)]
 DEV_MODE = os.environ.get("PATHFINDER_PROFILE") == "dev"
@@ -966,7 +966,7 @@ def create_general_config(chain_id: StarknetChainId) -> StarknetGeneralConfig:
             "enforce_l1_handler_fee": False,
             "event_commitment_tree_height": constants.EVENT_COMMITMENT_TREE_HEIGHT,
             "global_state_commitment_tree_height": constants.CONTRACT_ADDRESS_BITS,
-            "invoke_tx_max_n_steps": DEFAULT_MAX_STEPS,
+            "invoke_tx_max_n_steps": DEFAULT_TX_MAX_STEPS,
             "min_gas_price": DEFAULT_GAS_PRICE,
             "sequencer_address": hex(DEFAULT_SEQUENCER_ADDRESS),
             "starknet_os_config": {

--- a/py/tests/pathfinder_worker/test_call.py
+++ b/py/tests/pathfinder_worker/test_call.py
@@ -1227,7 +1227,7 @@ def test_nonce_with_dummy():
         (
             # in this block the acct contract has been deployed, so it has nonce=0
             dataclasses.replace(base_command, at_block=f'0x{(b"another block").hex()}'),
-            [FeeEstimation(gas_consumed=2490, gas_price=1, overall_fee=2490)],
+            [FeeEstimation(gas_consumed=2491, gas_price=1, overall_fee=2491)],
         ),
         (
             dataclasses.replace(
@@ -1252,7 +1252,7 @@ def test_nonce_with_dummy():
                 at_block=f'0x{(b"third block").hex()}',
                 transactions=[base_transaction_and_class_hash_hint_with_nonce_1],
             ),
-            [FeeEstimation(gas_consumed=2490, gas_price=1, overall_fee=2490)],
+            [FeeEstimation(gas_consumed=2491, gas_price=1, overall_fee=2491)],
         ),
         (
             dataclasses.replace(
@@ -1289,7 +1289,7 @@ def test_nonce_with_dummy():
                 transactions=[base_transaction_and_class_hash_hint_with_nonce_2],
                 pending_nonces={0x123: 2},
             ),
-            [FeeEstimation(gas_consumed=2490, gas_price=1, overall_fee=2490)],
+            [FeeEstimation(gas_consumed=2491, gas_price=1, overall_fee=2491)],
         ),
         (
             dataclasses.replace(
@@ -1618,9 +1618,9 @@ def test_estimate_fee_for_sierra_declare_through_account():
 
     assert output == [
         FeeEstimation(
-            gas_consumed=2476,
+            gas_consumed=3700,
             gas_price=1,
-            overall_fee=2476,
+            overall_fee=3700,
         )
     ]
 
@@ -1873,7 +1873,7 @@ def test_estimate_fee_for_deploy_newly_declared_sierra_account():
 
     assert output == [
         # DECLARE an account contract class
-        FeeEstimation(overall_fee=2476, gas_price=1, gas_consumed=2476),
+        FeeEstimation(overall_fee=3700, gas_price=1, gas_consumed=3700),
         # DEPLOY_ACCOUNT the class declared in the previous transaction
         FeeEstimation(overall_fee=3099, gas_price=1, gas_consumed=3099),
     ]


### PR DESCRIPTION
This involves following up some renames and updating expected fee estimation results.
