### PR TITLE
fix prefix leakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - RPC v0.3 `starknet_estimateFee` example
+- RPC method names could be prefixed with API version
 
 ## [0.7.2] - 2023-08-16
 


### PR DESCRIPTION
Users could call an RPC method whose name was prefixed with correct version in the method name field, for example both work correctly:


```
{"jsonrpc":"2.0","id":"0","method":"starknet_chainId"}
{"jsonrpc":"2.0","id":"0","method":"v0.3_starknet_chainId"}
```

even though the latter (`v0.3_starknet_chainId`) is a non-existent method name.
