### PR TITLE
fix: build errors after sloppy merge

### DIFF
--- a/crates/rpc/src/middleware/versioning.rs
+++ b/crates/rpc/src/middleware/versioning.rs
@@ -504,10 +504,11 @@ mod tests {
     #[tokio::test]
     async fn regression_disallow_version_prefix_leakage_to_caller() {
         let context = RpcContext::for_tests();
-        let (_server_handle, address) = RpcServer::new("127.0.0.1:0".parse().unwrap(), context)
-            .run()
-            .await
-            .unwrap();
+        let (_server_handle, address) =
+            RpcServer::new("127.0.0.1:0".parse().unwrap(), context, DefaultVersion::V03)
+                .run()
+                .await
+                .unwrap();
 
         let client = TestClientBuilder::default()
             .address(address)

--- a/crates/rpc/tests/versioning.rs
+++ b/crates/rpc/tests/versioning.rs
@@ -2,30 +2,15 @@
 //! that relies on metric values in a separate binary makes more sense than using an inter-test
 //! locking mechanism which can cause weird test failures without any obvious clue to what might
 //! have caused those failures in the first place.
-use rstest::rstest;
-
 use pathfinder_rpc::DefaultVersion;
 
-#[rstest]
-#[case(DefaultVersion::V03)]
-#[case(DefaultVersion::V04)]
 #[tokio::test]
-async fn api_versions_are_routed_correctly_for_all_methods(
-    #[case] default_version: DefaultVersion,
-) {
+async fn api_versions_are_routed_correctly_for_all_methods() {
     use pathfinder_common::test_utils::metrics::{FakeRecorder, ScopedRecorderGuard};
     use pathfinder_rpc::middleware::versioning::test_utils::{method_names, paths};
     use pathfinder_rpc::test_client::TestClientBuilder;
     use pathfinder_rpc::{context::RpcContext, metrics::logger::RpcMetricsLogger, RpcServer};
     use serde_json::json;
-
-    let context = RpcContext::for_tests();
-    let (_server_handle, address) =
-        RpcServer::new("127.0.0.1:0".parse().unwrap(), context, default_version)
-            .with_logger(RpcMetricsLogger)
-            .run()
-            .await
-            .unwrap();
 
     let v03_methods = method_names::COMMON_FOR_V03_V04
         .into_iter()
@@ -38,53 +23,63 @@ async fn api_versions_are_routed_correctly_for_all_methods(
     let pathfinder_methods = method_names::COMMON_FOR_ALL
         .into_iter()
         .chain(method_names::PATHFINDER_ONLY.into_iter())
-        .collect();
+        .collect::<Vec<_>>();
 
-    let (root_prefix, root_methods) = match default_version {
-        DefaultVersion::V03 => ("v0.3", v03_methods.clone()),
-        DefaultVersion::V04 => ("v0.4", v04_methods.clone()),
-    };
-
-    for (paths, version, methods) in vec![
-        (paths::ROOT, root_prefix, root_methods),
-        (paths::V03, "v0.3", v03_methods),
-        (paths::V04, "v0.4", v04_methods),
-        (paths::PATHFINDER, "v0.1", pathfinder_methods),
-    ]
-    .into_iter()
-    {
-        let recorder = FakeRecorder::default();
-        let handle = recorder.handle();
-        // Automatically deregister the recorder
-        let _guard = ScopedRecorderGuard::new(recorder);
-
-        // Perform all the calls but don't assert the results just yet
-        for (i, path) in paths.iter().map(ToOwned::to_owned).enumerate() {
-            let client = TestClientBuilder::default()
-                .address(address)
-                .endpoint(path.into())
-                .build()
+    for default_version in [DefaultVersion::V03, DefaultVersion::V04] {
+        let context = RpcContext::for_tests();
+        let (_server_handle, address) =
+            RpcServer::new("127.0.0.1:0".parse().unwrap(), context, default_version)
+                .with_logger(RpcMetricsLogger)
+                .run()
+                .await
                 .unwrap();
 
-            for method in methods.iter() {
-                let res = client.request::<serde_json::Value>(method, json!([])).await;
+        let (root_prefix, root_methods) = match default_version {
+            DefaultVersion::V03 => ("v0.3", &v03_methods[..]),
+            DefaultVersion::V04 => ("v0.4", &v04_methods[..]),
+        };
 
-                match res {
-                    Err(jsonrpsee::core::Error::Call(
-                        jsonrpsee::types::error::CallError::Custom(e),
-                    )) if e.code() == jsonrpsee::types::error::METHOD_NOT_FOUND_CODE => {
-                        panic!("Unregistered method called, path: {path}, method: {method}")
-                    }
-                    Ok(_) | Err(_) => {
-                        let expected_counter = (i as u64) + 1;
-                        let actual_counter = handle.get_counter_value_by_label(
-                            "rpc_method_calls_total",
-                            [("method", method), ("version", version)],
-                        );
-                        assert_eq!(
-                            actual_counter, expected_counter,
-                            "path: {path}, method: {method}"
-                        );
+        for (paths, version, methods) in vec![
+            (paths::ROOT, root_prefix, root_methods),
+            (paths::V03, "v0.3", &v03_methods),
+            (paths::V04, "v0.4", &v04_methods),
+            (paths::PATHFINDER, "v0.1", &pathfinder_methods),
+        ]
+        .into_iter()
+        {
+            let recorder = FakeRecorder::default();
+            let handle = recorder.handle();
+            // Automatically deregister the recorder
+            let _guard = ScopedRecorderGuard::new(recorder);
+
+            // Perform all the calls but don't assert the results just yet
+            for (i, path) in paths.iter().map(ToOwned::to_owned).enumerate() {
+                let client = TestClientBuilder::default()
+                    .address(address)
+                    .endpoint(path.into())
+                    .build()
+                    .unwrap();
+
+                for method in methods.iter() {
+                    let res = client.request::<serde_json::Value>(method, json!([])).await;
+
+                    match res {
+                        Err(jsonrpsee::core::Error::Call(
+                            jsonrpsee::types::error::CallError::Custom(e),
+                        )) if e.code() == jsonrpsee::types::error::METHOD_NOT_FOUND_CODE => {
+                            panic!("Unregistered method called, path: {path}, method: {method}")
+                        }
+                        Ok(_) | Err(_) => {
+                            let expected_counter = (i as u64) + 1;
+                            let actual_counter = handle.get_counter_value_by_label(
+                                "rpc_method_calls_total",
+                                [("method", method), ("version", version)],
+                            );
+                            assert_eq!(
+                                actual_counter, expected_counter,
+                                "path: {path}, method: {method}"
+                            );
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Additionally:
- fix race condition in integration test if using `cargo test` - global recorder set twice.