### PR TITLE
chore: upgrade bitvec to 1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,26 +692,14 @@ checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "bitvec"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
-dependencies = [
- "funty 1.1.0",
- "radium 0.6.2",
- "tap",
- "wyz 0.2.0",
-]
-
-[[package]]
-name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
- "funty 2.0.0",
- "radium 0.7.0",
+ "funty",
+ "radium",
  "tap",
- "wyz 0.5.1",
+ "wyz",
 ]
 
 [[package]]
@@ -3531,12 +3519,6 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
-
-[[package]]
-name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
@@ -6290,7 +6272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8e946cc0cc711189c0b0249fb8b599cbeeab9784d83c415719368bb8d4ac64"
 dependencies = [
  "arrayvec",
- "bitvec 1.0.1",
+ "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
@@ -6388,7 +6370,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-trait",
- "bitvec 0.20.4",
+ "bitvec",
  "bytes",
  "clap",
  "console-subscriber",
@@ -6442,7 +6424,7 @@ name = "pathfinder-common"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bitvec 0.20.4",
+ "bitvec",
  "fake",
  "metrics",
  "num-bigint 0.4.3",
@@ -6502,7 +6484,7 @@ name = "pathfinder-merkle-tree"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bitvec 0.20.4",
+ "bitvec",
  "pathfinder-common",
  "pathfinder-storage",
  "pretty_assertions",
@@ -6589,7 +6571,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "base64 0.13.1",
- "bitvec 0.20.4",
+ "bitvec",
  "const_format",
  "data-encoding",
  "fake",
@@ -7155,12 +7137,6 @@ dependencies = [
  "r2d2",
  "rusqlite",
 ]
-
-[[package]]
-name = "radium"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "radium"
@@ -8194,7 +8170,7 @@ dependencies = [
 name = "stark_curve"
 version = "0.1.0"
 dependencies = [
- "bitvec 0.20.4",
+ "bitvec",
  "ff 0.12.0",
  "pretty_assertions",
 ]
@@ -8204,7 +8180,7 @@ name = "stark_hash"
 version = "0.1.0"
 dependencies = [
  "assert_matches",
- "bitvec 0.20.4",
+ "bitvec",
  "criterion",
  "fake",
  "hex",
@@ -9789,12 +9765,6 @@ dependencies = [
  "cfg-if",
  "windows-sys",
 ]
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,8 @@ resolver = "2"
 [workspace.dependencies]
 anyhow = "1.0.66"
 assert_matches = "1.5.0"
-clap =  "4.1.13"
+bitvec = "1.0.1"
+clap = "4.1.13"
 const_format = "0.2.31"
 criterion = "0.5.1"
 fake = { version = "2.5.0", features = ["derive"] }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -9,7 +9,7 @@ full-serde = []
 
 [dependencies]
 anyhow = { workspace = true }
-bitvec = "0.20.4"
+bitvec = { workspace = true }
 fake = { version = "2.5.0", features = ["derive"] }
 metrics = { version = "0.20.1" }
 num-bigint = { version = "0.4.3", features = ["serde"] }
@@ -18,7 +18,10 @@ primitive-types = { version = "0.12.1", features = ["serde"] }
 rand = { version = "0.8.5" }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true, features = ["arbitrary_precision", "raw_value"] }
+serde_json = { workspace = true, features = [
+    "arbitrary_precision",
+    "raw_value",
+] }
 serde_with = { workspace = true }
 sha3 = "0.10"
 stark_curve = { path = "../stark_curve" }
@@ -27,4 +30,7 @@ stark_poseidon = { path = "../stark_poseidon" }
 thiserror = { workspace = true }
 
 [build-dependencies]
-vergen = { version = "8", default-features = false, features = ["git", "gitcl"] }
+vergen = { version = "8", default-features = false, features = [
+    "git",
+    "gitcl",
+] }

--- a/crates/common/src/macros.rs
+++ b/crates/common/src/macros.rs
@@ -175,7 +175,7 @@ macro_rules! felt_newtypes {
                     &self.0
                 }
 
-                pub fn view_bits(&self) -> &bitvec::slice::BitSlice<bitvec::order::Msb0, u8> {
+                pub fn view_bits(&self) -> &bitvec::slice::BitSlice<u8, bitvec::order::Msb0> {
                     self.0.view_bits()
                 }
             }

--- a/crates/common/src/trie.rs
+++ b/crates/common/src/trie.rs
@@ -10,7 +10,7 @@ use crate::hash::FeltHash;
 #[derive(Debug, Clone, PartialEq)]
 pub enum TrieNode {
     Binary { left: Felt, right: Felt },
-    Edge { child: Felt, path: BitVec<Msb0, u8> },
+    Edge { child: Felt, path: BitVec<u8, Msb0> },
 }
 
 impl TrieNode {

--- a/crates/merkle-tree/Cargo.toml
+++ b/crates/merkle-tree/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.62"
 
 [dependencies]
 anyhow = { workspace = true }
-bitvec = "0.20.4"
+bitvec = { workspace = true }
 pathfinder-common = { path = "../common" }
 pathfinder-storage = { path = "../storage" }
 rand = "0.8"

--- a/crates/merkle-tree/src/contract.rs
+++ b/crates/merkle-tree/src/contract.rs
@@ -44,7 +44,7 @@ impl<'tx> ContractsStorageTree<'tx> {
     }
 
     /// Generates a proof for `key`. See [`MerkleTree::get_proof`].
-    pub fn get_proof(&self, key: &BitSlice<Msb0, u8>) -> anyhow::Result<Vec<TrieNode>> {
+    pub fn get_proof(&self, key: &BitSlice<u8, Msb0>) -> anyhow::Result<Vec<TrieNode>> {
         self.tree.get_proof(&self.storage, key)
     }
 
@@ -61,7 +61,7 @@ impl<'tx> ContractsStorageTree<'tx> {
     }
 
     /// See [`MerkleTree::dfs`]
-    pub fn dfs<B, F: FnMut(&InternalNode, &BitSlice<Msb0, u8>) -> ControlFlow<B, Visit>>(
+    pub fn dfs<B, F: FnMut(&InternalNode, &BitSlice<u8, Msb0>) -> ControlFlow<B, Visit>>(
         &mut self,
         f: &mut F,
     ) -> anyhow::Result<Option<B>> {
@@ -117,7 +117,7 @@ impl<'tx> StorageCommitmentTree<'tx> {
     }
 
     /// See [`MerkleTree::dfs`]
-    pub fn dfs<B, F: FnMut(&InternalNode, &BitSlice<Msb0, u8>) -> ControlFlow<B, Visit>>(
+    pub fn dfs<B, F: FnMut(&InternalNode, &BitSlice<u8, Msb0>) -> ControlFlow<B, Visit>>(
         &mut self,
         f: &mut F,
     ) -> anyhow::Result<Option<B>> {

--- a/crates/merkle-tree/src/merkle_node.rs
+++ b/crates/merkle-tree/src/merkle_node.rs
@@ -48,7 +48,7 @@ pub struct EdgeNode {
     /// The starting height of this node in the tree.
     pub height: usize,
     /// The path this edge takes.
-    pub path: BitVec<Msb0, u8>,
+    pub path: BitVec<u8, Msb0>,
     /// The child of this node.
     pub child: Rc<RefCell<InternalNode>>,
 }
@@ -101,7 +101,7 @@ impl BinaryNode {
     /// This can be used to check which direction the key descibes in the context
     /// of this binary node i.e. which direction the child along the key's path would
     /// take.
-    pub fn direction(&self, key: &BitSlice<Msb0, u8>) -> Direction {
+    pub fn direction(&self, key: &BitSlice<u8, Msb0>) -> Direction {
         key[self.height].into()
     }
 
@@ -195,14 +195,14 @@ impl InternalNode {
 
 impl EdgeNode {
     /// Returns true if the edge node's path matches the same path given by the key.
-    pub fn path_matches(&self, key: &BitSlice<Msb0, u8>) -> bool {
+    pub fn path_matches(&self, key: &BitSlice<u8, Msb0>) -> bool {
         self.path == key[self.height..self.height + self.path.len()]
     }
 
     /// Returns the common bit prefix between the edge node's path and the given key.
     ///
     /// This is calculated with the edge's height taken into account.
-    pub fn common_path(&self, key: &BitSlice<Msb0, u8>) -> &BitSlice<Msb0, u8> {
+    pub fn common_path(&self, key: &BitSlice<u8, Msb0>) -> &BitSlice<u8, Msb0> {
         let key_path = key.iter().skip(self.height);
         let common_length = key_path
             .zip(self.path.iter())
@@ -285,10 +285,10 @@ mod tests {
                 right: Rc::new(RefCell::new(InternalNode::Leaf(felt!("0xdef")))),
             };
 
-            let mut zero_key = bitvec![Msb0, u8; 1; 251];
+            let mut zero_key = bitvec![u8, Msb0; 1; 251];
             zero_key.set(1, false);
 
-            let mut one_key = bitvec![Msb0, u8; 0; 251];
+            let mut one_key = bitvec![u8, Msb0; 0; 251];
             one_key.set(1, true);
 
             let zero_direction = uut.direction(&zero_key);
@@ -362,7 +362,7 @@ mod tests {
             let child = felt!("0x1234ABCD");
             let child = Rc::new(RefCell::new(InternalNode::Unresolved(child)));
             // Path = 42 in binary.
-            let path = bitvec![Msb0, u8; 1, 0, 1, 0, 1, 0];
+            let path = bitvec![u8, Msb0; 1, 0, 1, 0, 1, 0];
 
             let mut uut = EdgeNode {
                 hash: None,

--- a/crates/merkle-tree/src/tree.rs
+++ b/crates/merkle-tree/src/tree.rs
@@ -153,7 +153,7 @@ impl<H: FeltHash, const HEIGHT: usize> MerkleTree<H, HEIGHT> {
     pub fn set(
         &mut self,
         storage: &impl Storage,
-        key: &BitSlice<Msb0, u8>,
+        key: &BitSlice<u8, Msb0>,
         value: Felt,
     ) -> anyhow::Result<()> {
         if value == Felt::ZERO {
@@ -290,7 +290,7 @@ impl<H: FeltHash, const HEIGHT: usize> MerkleTree<H, HEIGHT> {
     fn delete_leaf(
         &mut self,
         storage: &impl Storage,
-        key: &BitSlice<Msb0, u8>,
+        key: &BitSlice<u8, Msb0>,
     ) -> anyhow::Result<()> {
         // Algorithm explanation:
         //
@@ -375,7 +375,7 @@ impl<H: FeltHash, const HEIGHT: usize> MerkleTree<H, HEIGHT> {
     pub fn get(
         &self,
         storage: &impl Storage,
-        key: &BitSlice<Msb0, u8>,
+        key: &BitSlice<u8, Msb0>,
     ) -> anyhow::Result<Option<Felt>> {
         let result = self
             .traverse(storage, key)?
@@ -401,7 +401,7 @@ impl<H: FeltHash, const HEIGHT: usize> MerkleTree<H, HEIGHT> {
     pub fn get_proof(
         &self,
         storage: &impl Storage,
-        key: &BitSlice<Msb0, u8>,
+        key: &BitSlice<u8, Msb0>,
     ) -> anyhow::Result<Vec<TrieNode>> {
         let mut nodes = self.traverse(storage, key)?;
 
@@ -450,7 +450,7 @@ impl<H: FeltHash, const HEIGHT: usize> MerkleTree<H, HEIGHT> {
     fn traverse(
         &self,
         storage: &impl Storage,
-        dst: &BitSlice<Msb0, u8>,
+        dst: &BitSlice<u8, Msb0>,
     ) -> anyhow::Result<Vec<Rc<RefCell<InternalNode>>>> {
         if self.root.borrow().is_empty() {
             return Ok(Vec::new());
@@ -572,19 +572,19 @@ impl<H: FeltHash, const HEIGHT: usize> MerkleTree<H, HEIGHT> {
         visitor_fn: &mut VisitorFn,
     ) -> anyhow::Result<Option<X>>
     where
-        VisitorFn: FnMut(&InternalNode, &BitSlice<Msb0, u8>) -> ControlFlow<X, Visit>,
+        VisitorFn: FnMut(&InternalNode, &BitSlice<u8, Msb0>) -> ControlFlow<X, Visit>,
     {
         use bitvec::prelude::bitvec;
 
         #[allow(dead_code)]
         struct VisitedNode {
             node: Rc<RefCell<InternalNode>>,
-            path: BitVec<Msb0, u8>,
+            path: BitVec<u8, Msb0>,
         }
 
         let mut visiting = vec![VisitedNode {
             node: self.root.clone(),
-            path: bitvec![Msb0, u8;],
+            path: bitvec![u8, Msb0;],
         }];
 
         loop {
@@ -787,9 +787,9 @@ mod tests {
 
         #[test]
         fn binary_middle() {
-            let key0 = bitvec![Msb0, u8; 0; 251];
+            let key0 = bitvec![u8, Msb0; 0; 251];
 
-            let mut key1 = bitvec![Msb0, u8; 0; 251];
+            let mut key1 = bitvec![u8, Msb0; 0; 251];
             key1.set(50, true);
 
             let value0 = felt!("0xabc");
@@ -808,7 +808,7 @@ mod tests {
                 .cloned()
                 .expect("root should be an edge");
 
-            let expected_path = bitvec![Msb0, u8; 0; 50];
+            let expected_path = bitvec![u8, Msb0; 0; 50];
             assert_eq!(edge.path, expected_path);
             assert_eq!(edge.height, 0);
 
@@ -849,9 +849,9 @@ mod tests {
 
         #[test]
         fn binary_root() {
-            let key0 = bitvec![Msb0, u8; 0; 251];
+            let key0 = bitvec![u8, Msb0; 0; 251];
 
-            let mut key1 = bitvec![Msb0, u8; 0; 251];
+            let mut key1 = bitvec![u8, Msb0; 0; 251];
             key1.set(0, true);
 
             let value0 = felt!("0xabc");
@@ -1274,7 +1274,7 @@ mod tests {
             let storage = TestStorage::default();
 
             let mut visited = vec![];
-            let mut visitor_fn = |node: &InternalNode, path: &BitSlice<Msb0, u8>| {
+            let mut visitor_fn = |node: &InternalNode, path: &BitSlice<u8, Msb0>| {
                 visited.push((node.clone(), path.to_bitvec()));
                 ControlFlow::Continue::<(), Visit>(Default::default())
             };
@@ -1293,7 +1293,7 @@ mod tests {
             uut.set(&storage, key.view_bits(), value).unwrap();
 
             let mut visited = vec![];
-            let mut visitor_fn = |node: &InternalNode, path: &BitSlice<Msb0, u8>| {
+            let mut visitor_fn = |node: &InternalNode, path: &BitSlice<u8, Msb0>| {
                 visited.push((node.clone(), path.to_bitvec()));
                 ControlFlow::Continue::<(), Visit>(Default::default())
             };
@@ -1309,7 +1309,7 @@ mod tests {
                             path: key.view_bits().into(),
                             child: Rc::new(RefCell::new(InternalNode::Leaf(value)))
                         }),
-                        bitvec![Msb0, u8;]
+                        bitvec![u8, Msb0;]
                     ),
                     (InternalNode::Leaf(value), key.view_bits().into())
                 ],
@@ -1331,7 +1331,7 @@ mod tests {
             uut.set(&storage, key_left.view_bits(), value_left).unwrap();
 
             let mut visited = vec![];
-            let mut visitor_fn = |node: &InternalNode, path: &BitSlice<Msb0, u8>| {
+            let mut visitor_fn = |node: &InternalNode, path: &BitSlice<u8, Msb0>| {
                 visited.push((node.clone(), path.to_bitvec()));
                 ControlFlow::Continue::<(), Visit>(Default::default())
             };
@@ -1349,16 +1349,16 @@ mod tests {
                     left: Rc::new(RefCell::new(expected_2.0.clone())),
                     right: Rc::new(RefCell::new(expected_3.0.clone())),
                 }),
-                bitvec![Msb0, u8; 0; 250],
+                bitvec![u8, Msb0; 0; 250],
             );
             let expected_0 = (
                 InternalNode::Edge(EdgeNode {
                     hash: None,
                     height: 0,
-                    path: bitvec![Msb0, u8; 0; 250],
+                    path: bitvec![u8, Msb0; 0; 250],
                     child: Rc::new(RefCell::new(expected_1.0.clone())),
                 }),
-                bitvec![Msb0, u8;],
+                bitvec![u8, Msb0;],
             );
 
             pretty_assertions::assert_eq!(
@@ -1384,7 +1384,7 @@ mod tests {
             uut.set(&storage, key_b.view_bits(), value_b).unwrap();
 
             let mut visited = vec![];
-            let mut visitor_fn = |node: &InternalNode, path: &BitSlice<Msb0, u8>| {
+            let mut visitor_fn = |node: &InternalNode, path: &BitSlice<u8, Msb0>| {
                 visited.push((node.clone(), path.to_bitvec()));
                 ControlFlow::Continue::<(), Visit>(Default::default())
             };
@@ -1399,9 +1399,9 @@ mod tests {
             // 3 4 6
             // a b c
 
-            let path_to_0 = bitvec![Msb0, u8;];
+            let path_to_0 = bitvec![u8, Msb0;];
             let path_to_1 = {
-                let mut p = bitvec![Msb0, u8; 0; 249];
+                let mut p = bitvec![u8, Msb0; 0; 249];
                 *p.get_mut(246).unwrap() = true;
                 p
             };
@@ -1415,7 +1415,7 @@ mod tests {
                 InternalNode::Edge(EdgeNode {
                     hash: None,
                     height: 250,
-                    path: bitvec![Msb0, u8; 1; 1],
+                    path: bitvec![u8, Msb0; 1; 1],
                     child: Rc::new(RefCell::new(expected_6.0.clone())),
                 }),
                 path_to_5,
@@ -1497,7 +1497,7 @@ mod tests {
         /// 3. check that the expected_hash is `value` (we should've reached the leaf)
         fn verify_proof(
             root: Felt,
-            key: &BitSlice<Msb0, u8>,
+            key: &BitSlice<u8, Msb0>,
             value: Felt,
             proofs: &[TrieNode],
         ) -> Option<Membership> {
@@ -1507,7 +1507,7 @@ mod tests {
             }
 
             let mut expected_hash = root;
-            let mut remaining_path: &BitSlice<Msb0, u8> = key;
+            let mut remaining_path: &BitSlice<u8, Msb0> = key;
 
             for proof_node in proofs.iter() {
                 // Hash mismatch? Return None.
@@ -1597,7 +1597,7 @@ mod tests {
 
             /// Calls `get_proof` and `verify_proof` on every key/value pair in the random_tree.
             fn verify(&mut self) {
-                let keys_bits: Vec<&BitSlice<Msb0, u8>> =
+                let keys_bits: Vec<&BitSlice<u8, Msb0>> =
                     self.keys.iter().map(|k| k.view_bits()).collect();
                 let proofs = get_proofs(&keys_bits, &self.tree, &self.storage).unwrap();
                 keys_bits
@@ -1613,7 +1613,7 @@ mod tests {
 
         /// Generates a storage proof for each `key` in `keys` and returns the result in the form of an array.
         fn get_proofs<H: FeltHash, const HEIGHT: usize>(
-            keys: &'_ [&BitSlice<Msb0, u8>],
+            keys: &'_ [&BitSlice<u8, Msb0>],
             tree: &MerkleTree<H, HEIGHT>,
             storage: &impl Storage,
         ) -> anyhow::Result<Vec<Vec<TrieNode>>> {
@@ -1850,7 +1850,7 @@ mod tests {
                 .filter(|key| !keys_set.contains(key)) // Filter out duplicates if there are any
                 .collect();
 
-            let keys_bits: Vec<&BitSlice<Msb0, u8>> =
+            let keys_bits: Vec<&BitSlice<u8, Msb0>> =
                 inexistent_keys.iter().map(|k| k.view_bits()).collect();
             let proofs = get_proofs(&keys_bits, &random_tree.tree, &random_tree.storage).unwrap();
             keys_bits
@@ -1877,7 +1877,7 @@ mod tests {
                 .filter(|value| !values_set.contains(value)) // Filter out duplicates if there are any
                 .collect();
 
-            let keys_bits: Vec<&BitSlice<Msb0, u8>> =
+            let keys_bits: Vec<&BitSlice<u8, Msb0>> =
                 random_tree.keys.iter().map(|k| k.view_bits()).collect();
             let proofs =
                 get_proofs(&keys_bits[..], &random_tree.tree, &random_tree.storage).unwrap();

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -18,7 +18,7 @@ p2p = ["dep:p2p", "dep:p2p_proto"]
 [dependencies]
 anyhow = { workspace = true }
 async-trait = "0.1.59"
-bitvec = "0.20.4"
+bitvec = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
 console-subscriber = { version = "0.1.8", optional = true }
 futures = { version = "0.3", default-features = false, features = ["std"] }

--- a/crates/stark_curve/Cargo.toml
+++ b/crates/stark_curve/Cargo.toml
@@ -10,8 +10,7 @@ name = "stark_curve"
 path = "src/lib.rs"
 
 [dependencies]
-# paritys scale codec locks us here
-bitvec = "0.20.4"
+bitvec = { workspace = true }
 ff = { git = "https://github.com/eqlabs/ff", branch = "var_time_eq", default-features = false, features = [
     "derive",
     "alloc",

--- a/crates/stark_curve/src/curve.rs
+++ b/crates/stark_curve/src/curve.rs
@@ -88,7 +88,7 @@ impl AffinePoint {
         self.x = result_x;
     }
 
-    pub fn multiply(&self, bits: &BitSlice<Lsb0, u64>) -> AffinePoint {
+    pub fn multiply(&self, bits: &BitSlice<u64, Lsb0>) -> AffinePoint {
         let mut product = AffinePoint::identity();
         for b in bits.iter().rev() {
             product.double();
@@ -238,7 +238,7 @@ impl ProjectivePoint {
         self.z = z;
     }
 
-    pub fn multiply(&self, bits: &BitSlice<Lsb0, u64>) -> ProjectivePoint {
+    pub fn multiply(&self, bits: &BitSlice<u64, Lsb0>) -> ProjectivePoint {
         let mut product = ProjectivePoint::identity();
         for b in bits.iter().rev() {
             product.double();

--- a/crates/stark_curve/src/field.rs
+++ b/crates/stark_curve/src/field.rs
@@ -52,7 +52,7 @@ impl FieldElement {
     }
 
     /// Transforms [FieldElement] into little endian bit representation.
-    pub fn into_bits(mut self) -> BitArray<Lsb0, [u64; 4]> {
+    pub fn into_bits(mut self) -> BitArray<[u64; 4], Lsb0> {
         #[cfg(not(target_endian = "little"))]
         {
             unimplemented!("untested and probably unimplemented: big-endian targets")
@@ -85,7 +85,7 @@ mod tests {
     #[test]
     fn bits_zero() {
         let zero = FieldElement::zero().into_bits();
-        let expected = BitArray::<Lsb0, [u64; 4]>::default();
+        let expected = BitArray::<[u64; 4], Lsb0>::default();
 
         assert_eq!(zero, expected);
     }
@@ -94,7 +94,7 @@ mod tests {
     fn bits_one() {
         let one = FieldElement::one().into_bits();
 
-        let mut expected = BitArray::<Lsb0, [u64; 4]>::default();
+        let mut expected = BitArray::<[u64; 4], Lsb0>::default();
         expected.set(0, true);
 
         assert_eq!(one, expected);
@@ -104,7 +104,7 @@ mod tests {
     fn bits_two() {
         let two = (FieldElement::one() + FieldElement::one()).into_bits();
 
-        let mut expected = BitArray::<Lsb0, [u64; 4]>::default();
+        let mut expected = BitArray::<[u64; 4], Lsb0>::default();
         expected.set(1, true);
 
         assert_eq!(two, expected);

--- a/crates/stark_hash/Cargo.toml
+++ b/crates/stark_hash/Cargo.toml
@@ -13,8 +13,7 @@ path = "src/lib.rs"
 stark_curve = { path = "../stark_curve" }
 
 [dependencies]
-# paritys scale codec locks us here
-bitvec = "0.20.4"
+bitvec = { workspace = true }
 fake = { version = "2.5.0", features = ["derive"] }
 rand = { version = "0.8.5" }
 rand_core = "0.6.4"

--- a/crates/stark_hash/src/felt.rs
+++ b/crates/stark_hash/src/felt.rs
@@ -199,12 +199,12 @@ impl Felt {
     }
 
     /// Returns a bit view of the 251 least significant bits in MSB order.
-    pub fn view_bits(&self) -> &BitSlice<Msb0, u8> {
+    pub fn view_bits(&self) -> &BitSlice<u8, Msb0> {
         &self.0.view_bits()[5..]
     }
 
     /// Creates a [Felt] from up-to 251 bits.
-    pub fn from_bits(bits: &BitSlice<Msb0, u8>) -> Result<Self, OverflowError> {
+    pub fn from_bits(bits: &BitSlice<u8, Msb0>) -> Result<Self, OverflowError> {
         if bits.len() > 251 {
             return Err(OverflowError);
         }
@@ -473,7 +473,7 @@ mod tests {
 
     #[test]
     fn bits_round_trip() {
-        let mut bits = bitvec![Msb0, u8; 1; 251];
+        let mut bits = bitvec![u8, Msb0; 1; 251];
         bits.set(0, false);
         bits.set(1, false);
         bits.set(2, false);

--- a/crates/stark_hash/src/hash.rs
+++ b/crates/stark_hash/src/hash.rs
@@ -15,7 +15,7 @@ pub fn stark_hash(a: Felt, b: Felt) -> Felt {
 
     // Preprocessed material is lookup-tables for each chunk of bits
     let table_size = (1 << CURVE_CONSTS_BITS) - 1;
-    let add_points = |acc: &mut ProjectivePoint, bits: &BitSlice<_, u64>, prep: &[AffinePoint]| {
+    let add_points = |acc: &mut ProjectivePoint, bits: &BitSlice<u64, _>, prep: &[AffinePoint]| {
         bits.chunks(CURVE_CONSTS_BITS)
             .enumerate()
             .for_each(|(i, v)| {

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.62"
 [dependencies]
 anyhow = { workspace = true }
 base64 = "0.13.1"
-bitvec = "0.20.4"
+bitvec = { workspace = true }
 const_format = { workspace = true }
 data-encoding = "2.3.3"
 fake = { version = "2.5.0", features = ["derive"] }

--- a/crates/storage/src/connection/trie.rs
+++ b/crates/storage/src/connection/trie.rs
@@ -151,15 +151,15 @@ mod tests {
         };
         let l_node = TrieNode::Edge {
             child: duplicate,
-            path: bitvec::bitvec![Msb0, u8; 1, 0, 1, 1, 1],
+            path: bitvec::bitvec![u8, Msb0; 1, 0, 1, 1, 1],
         };
         let r_node = TrieNode::Edge {
             child: edge,
-            path: bitvec::bitvec![Msb0, u8; 1, 0, 1, 1],
+            path: bitvec::bitvec![u8, Msb0; 1, 0, 1, 1],
         };
         let edge_node = TrieNode::Edge {
             child: duplicate,
-            path: bitvec::bitvec![Msb0, u8; 1, 0, 1, 1, 1, 1, 1],
+            path: bitvec::bitvec![u8, Msb0; 1, 0, 1, 1, 1, 1, 1],
         };
         let duplicate_node = TrieNode::Binary {
             left: leaf_1,


### PR DESCRIPTION
This is a resurrection of @sergey-melnychuk's PR #693 that upgrades bitvec to 1.0.1.

We're no longer limited by third party dependencies in our choice of the bitvec version to use, so we can just upgrade it to latest stable.
