### PR TITLE
chore: fix Rust 1.72 clippy warnings and formatting

### DIFF
--- a/crates/pathfinder/src/p2p_network/sync_handlers.rs
+++ b/crates/pathfinder/src/p2p_network/sync_handlers.rs
@@ -730,6 +730,7 @@ mod tests {
             }
 
             fn any_forward() -> BoxedStrategy<(u64, u64)> {
+                #[allow(clippy::arc_with_non_send_sync)]
                 prop_oneof![
                     // Occurance 4:1
                     4 => overlapping_forward(),
@@ -763,6 +764,7 @@ mod tests {
             }
 
             pub fn any_backward() -> BoxedStrategy<(u64, u64)> {
+                #[allow(clippy::arc_with_non_send_sync)]
                 prop_oneof![
                     // Occurance 4:1
                     4 => overlapping_backward(),

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -394,13 +394,12 @@ pub async fn download_new_classes(
                 let Some(casm_hash) = state_update
                     .declared_sierra_classes
                     .iter()
-                    .find_map(|(sierra, casm)| {
-                        (sierra.0 == class_hash.0).then_some(*casm)
-                    }) else {
-                        // This can occur if the sierra was in here as a deploy contract, if the class was
-                        // declared in a previous block but not yet persisted by the database.
-                        continue;
-                    };
+                    .find_map(|(sierra, casm)| (sierra.0 == class_hash.0).then_some(*casm))
+                else {
+                    // This can occur if the sierra was in here as a deploy contract, if the class was
+                    // declared in a previous block but not yet persisted by the database.
+                    continue;
+                };
                 tx_event
                     .send(SyncEvent::SierraClass {
                         sierra_definition,

--- a/crates/rpc/src/pathfinder/methods/get_transaction_status.rs
+++ b/crates/rpc/src/pathfinder/methods/get_transaction_status.rs
@@ -37,9 +37,10 @@ pub async fn get_transaction_status(
 
         let Some((_, receipt, block_hash)) = db_tx
             .transaction_with_receipt(input.transaction_hash)
-            .context("Fetching receipt from database")? else {
-                return anyhow::Ok(None);
-            };
+            .context("Fetching receipt from database")?
+        else {
+            return anyhow::Ok(None);
+        };
 
         if receipt.execution_status == ExecutionStatus::Reverted {
             return Ok(Some(TransactionStatus::Reverted));

--- a/crates/storage/src/connection/state_update.rs
+++ b/crates/storage/src/connection/state_update.rs
@@ -138,12 +138,9 @@ pub(super) fn state_update(
     tx: &Transaction<'_>,
     block: BlockId,
 ) -> anyhow::Result<Option<StateUpdate>> {
-    let Some((
-        block_number,
-        block_hash,
-        state_commitment,
-        parent_state_commitment
-    )) = block_details(tx, block).context("Querying block header")? else {
+    let Some((block_number, block_hash, state_commitment, parent_state_commitment)) =
+        block_details(tx, block).context("Querying block header")?
+    else {
         return Ok(None);
     };
 

--- a/crates/storage/src/connection/state_update.rs
+++ b/crates/storage/src/connection/state_update.rs
@@ -676,11 +676,13 @@ mod tests {
             let (contract, key, expected) = state_update
                 .contract_updates
                 .iter()
-                .next()
-                .map(|(addr, update)| {
-                    let (key, value) = update.storage.iter().next().unwrap();
-                    (*addr, *key, *value)
+                .flat_map(|(addr, update)| {
+                    update
+                        .storage
+                        .iter()
+                        .map(|(key, value)| (*addr, *key, *value))
                 })
+                .next()
                 .unwrap();
 
             // Valid key and contract.

--- a/crates/storage/src/connection/transaction.rs
+++ b/crates/storage/src/connection/transaction.rs
@@ -390,7 +390,7 @@ mod tests {
 
         let body = transactions
             .into_iter()
-            .zip(receipts.into_iter())
+            .zip(receipts)
             .map(|(t, r)| (t, r))
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
Fix new warnings that were introduced by upgrading to Rust 1.72.