### PR TITLE
feat(rpc): make JSON-RPC v0.4 the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `cairo-lang` upgraded to 0.12.2
 - Cairo compiler upgraded to 2.1.1
+- default RPC API version changed from v0.3 to v0.4
 
 ### Fixed
 

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -94,7 +94,7 @@ Examples:
     #[arg(
         long = "rpc.root-version",
         long_help = "Version of the JSON-RPC API to serve on the / (root) path",
-        default_value = "v03",
+        default_value = "v04",
         env = "PATHFINDER_RPC_ROOT_VERSION"
     )]
     rpc_root_version: RpcVersion,


### PR DESCRIPTION
That is, this PR changes the API version we serve on root to 0.4.
