### PR TITLE
fix(rpc): add `deny_unknown_fields` to JSON-RPC input request structs

### DIFF
--- a/crates/rpc/src/v02/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v02/method/add_declare_transaction.rs
@@ -56,6 +56,7 @@ pub enum Transaction {
 }
 
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct AddDeclareTransactionInput {
     declare_transaction: Transaction,
     // An undocumented parameter that we forward to the sequencer API

--- a/crates/rpc/src/v02/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/v02/method/add_deploy_account_transaction.rs
@@ -13,6 +13,7 @@ pub enum Transaction {
 }
 
 #[derive(Debug, serde::Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct AddDeployAccountTransactionInput {
     deploy_account_transaction: Transaction,
 }

--- a/crates/rpc/src/v02/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/v02/method/add_invoke_transaction.rs
@@ -13,6 +13,7 @@ pub enum Transaction {
 }
 
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct AddInvokeTransactionInput {
     invoke_transaction: Transaction,
 }

--- a/crates/rpc/src/v02/method/call.rs
+++ b/crates/rpc/src/v02/method/call.rs
@@ -25,12 +25,14 @@ impl From<crate::cairo::ext_py::CallFailure> for CallError {
 }
 
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct CallInput {
     request: FunctionCall,
     block_id: BlockId,
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct FunctionCall {
     pub contract_address: ContractAddress,
     pub entry_point_selector: EntryPoint,

--- a/crates/rpc/src/v02/method/get_block.rs
+++ b/crates/rpc/src/v02/method/get_block.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 
 #[derive(Deserialize, Debug, PartialEq, Eq)]
 #[cfg_attr(test, derive(Copy, Clone))]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockInput {
     block_id: BlockId,
 }

--- a/crates/rpc/src/v02/method/get_block_transaction_count.rs
+++ b/crates/rpc/src/v02/method/get_block_transaction_count.rs
@@ -3,6 +3,7 @@ use anyhow::Context;
 use pathfinder_common::BlockId;
 
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockTransactionCountInput {
     block_id: BlockId,
 }

--- a/crates/rpc/src/v02/method/get_class.rs
+++ b/crates/rpc/src/v02/method/get_class.rs
@@ -7,6 +7,7 @@ use starknet_gateway_types::pending::PendingData;
 crate::error::generate_rpc_error_subset!(GetClassError: BlockNotFound, ClassHashNotFound);
 
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct GetClassInput {
     block_id: BlockId,
     class_hash: ClassHash,

--- a/crates/rpc/src/v02/method/get_class_at.rs
+++ b/crates/rpc/src/v02/method/get_class_at.rs
@@ -7,6 +7,7 @@ use starknet_gateway_types::pending::PendingData;
 crate::error::generate_rpc_error_subset!(GetClassAtError: BlockNotFound, ContractNotFound);
 
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct GetClassAtInput {
     block_id: BlockId,
     contract_address: ContractAddress,

--- a/crates/rpc/src/v02/method/get_class_hash_at.rs
+++ b/crates/rpc/src/v02/method/get_class_hash_at.rs
@@ -7,6 +7,7 @@ use starknet_gateway_types::pending::PendingData;
 crate::error::generate_rpc_error_subset!(GetClassHashAtError: BlockNotFound, ContractNotFound);
 
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct GetClassHashAtInput {
     block_id: BlockId,
     contract_address: ContractAddress,

--- a/crates/rpc/src/v02/method/get_nonce.rs
+++ b/crates/rpc/src/v02/method/get_nonce.rs
@@ -5,6 +5,7 @@ use pathfinder_common::{BlockId, ContractAddress, ContractNonce};
 use starknet_gateway_types::pending::PendingData;
 
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct GetNonceInput {
     block_id: BlockId,
     contract_address: ContractAddress,

--- a/crates/rpc/src/v02/method/get_storage_at.rs
+++ b/crates/rpc/src/v02/method/get_storage_at.rs
@@ -5,6 +5,7 @@ use pathfinder_common::{BlockId, ContractAddress, StorageAddress, StorageValue};
 use serde::Deserialize;
 
 #[derive(Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct GetStorageAtInput {
     pub contract_address: ContractAddress,
     pub key: StorageAddress,

--- a/crates/rpc/src/v02/method/get_transaction_by_block_id_and_index.rs
+++ b/crates/rpc/src/v02/method/get_transaction_by_block_id_and_index.rs
@@ -5,6 +5,7 @@ use pathfinder_common::{BlockId, TransactionIndex};
 use starknet_gateway_types::reply::transaction::Transaction as GatewayTransaction;
 
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct GetTransactionByBlockIdAndIndexInput {
     block_id: BlockId,
     index: TransactionIndex,

--- a/crates/rpc/src/v02/method/get_transaction_by_hash.rs
+++ b/crates/rpc/src/v02/method/get_transaction_by_hash.rs
@@ -6,6 +6,7 @@ use pathfinder_common::TransactionHash;
 use starknet_gateway_types::reply::transaction::Transaction as GatewayTransaction;
 
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct GetTransactionByHashInput {
     transaction_hash: TransactionHash,
 }

--- a/crates/rpc/src/v02/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v02/method/get_transaction_receipt.rs
@@ -5,6 +5,7 @@ use pathfinder_common::TransactionHash;
 use starknet_gateway_types::reply::transaction::ExecutionStatus;
 
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct GetTransactionReceiptInput {
     transaction_hash: TransactionHash,
 }

--- a/crates/rpc/src/v03/method/estimate_fee.rs
+++ b/crates/rpc/src/v03/method/estimate_fee.rs
@@ -7,6 +7,7 @@ use pathfinder_common::BlockId;
 use super::common::prepare_handle_and_block;
 
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct EstimateFeeInput {
     request: Vec<BroadcastedTransaction>,
     block_id: BlockId,

--- a/crates/rpc/src/v03/method/estimate_message_fee.rs
+++ b/crates/rpc/src/v03/method/estimate_message_fee.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 use super::common::prepare_handle_and_block;
 
 #[derive(Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct EstimateMessageFeeInput {
     pub message: FunctionCall,
     pub sender_address: EthereumAddress,

--- a/crates/rpc/src/v03/method/get_events.rs
+++ b/crates/rpc/src/v03/method/get_events.rs
@@ -37,6 +37,7 @@ impl From<GetEventsError> for crate::error::RpcError {
 
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
 #[cfg_attr(test, derive(Clone))]
+#[serde(deny_unknown_fields)]
 pub struct GetEventsInput {
     filter: EventFilter,
 }

--- a/crates/rpc/src/v03/method/get_state_update.rs
+++ b/crates/rpc/src/v03/method/get_state_update.rs
@@ -3,6 +3,7 @@ use anyhow::{anyhow, Context};
 use pathfinder_common::BlockId;
 
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct GetStateUpdateInput {
     block_id: BlockId,
 }

--- a/crates/rpc/src/v03/method/simulate_transaction.rs
+++ b/crates/rpc/src/v03/method/simulate_transaction.rs
@@ -21,6 +21,7 @@ use stark_hash::Felt;
 use super::common::prepare_handle_and_block;
 
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct SimulateTrasactionInput {
     block_id: BlockId,
     // `transactions` used to be called `transaction` in the JSON-RPC 0.3.0 specification.

--- a/crates/rpc/src/v04/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v04/method/add_declare_transaction.rs
@@ -121,6 +121,7 @@ pub enum Transaction {
 }
 
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct AddDeclareTransactionInput {
     declare_transaction: Transaction,
     // An undocumented parameter that we forward to the sequencer API

--- a/crates/rpc/src/v04/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/v04/method/add_deploy_account_transaction.rs
@@ -13,6 +13,7 @@ pub enum Transaction {
 }
 
 #[derive(Debug, serde::Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct AddDeployAccountTransactionInput {
     deploy_account_transaction: Transaction,
 }

--- a/crates/rpc/src/v04/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/v04/method/add_invoke_transaction.rs
@@ -13,6 +13,7 @@ pub enum Transaction {
 }
 
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct AddInvokeTransactionInput {
     invoke_transaction: Transaction,
 }

--- a/crates/rpc/src/v04/method/estimate_message_fee.rs
+++ b/crates/rpc/src/v04/method/estimate_message_fee.rs
@@ -6,6 +6,7 @@ use crate::v02::types::reply::FeeEstimate;
 use crate::v03::method::estimate_message_fee::EstimateMessageFeeError;
 
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct EstimateMessageFeeInput {
     message: MsgFromL1,
     block_id: BlockId,

--- a/crates/rpc/src/v04/method/get_block_with_txs.rs
+++ b/crates/rpc/src/v04/method/get_block_with_txs.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 
 #[derive(Deserialize, Debug, PartialEq, Eq)]
 #[cfg_attr(test, derive(Copy, Clone))]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockInput {
     block_id: BlockId,
 }

--- a/crates/rpc/src/v04/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v04/method/get_transaction_receipt.rs
@@ -3,6 +3,7 @@ use anyhow::Context;
 use pathfinder_common::TransactionHash;
 
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct GetTransactionReceiptInput {
     transaction_hash: TransactionHash,
 }

--- a/crates/rpc/src/v04/method/simulate_transactions.rs
+++ b/crates/rpc/src/v04/method/simulate_transactions.rs
@@ -21,6 +21,7 @@ use stark_hash::Felt;
 use super::common::prepare_handle_and_block;
 
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct SimulateTrasactionInput {
     block_id: BlockId,
     transactions: Vec<BroadcastedTransaction>,


### PR DESCRIPTION
Otherwise we allow for unknown fields in the JSON-RPC request.

Fixes #1342
