### PR TITLE
feat: tree node data verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- `--sync.verify_tree_node_data` which enables verifies state tree nodes as they are loaded from disk. This is a debugging tool to identify disk corruption impacting tree node data. This should only be enabled when debugging a state root mismatch.
+
 ## [0.8.1] - 2023-09-07
 
 ### Fixed

--- a/crates/merkle-tree/src/class.rs
+++ b/crates/merkle-tree/src/class.rs
@@ -26,6 +26,11 @@ impl<'tx> ClassCommitmentTree<'tx> {
         Self { tree, storage }
     }
 
+    pub fn with_verify_hashes(mut self, verify_hashes: bool) -> Self {
+        self.tree = self.tree.with_verify_hashes(verify_hashes);
+        self
+    }
+
     /// Adds a leaf node for a Sierra -> CASM commitment.
     ///
     /// Note that the leaf value is _not_ the Cairo hash, but a hashed value based on that.

--- a/crates/merkle-tree/src/contract.rs
+++ b/crates/merkle-tree/src/contract.rs
@@ -37,6 +37,11 @@ impl<'tx> ContractsStorageTree<'tx> {
         Self { tree, storage }
     }
 
+    pub fn with_verify_hashes(mut self, verify_hashes: bool) -> Self {
+        self.tree = self.tree.with_verify_hashes(verify_hashes);
+        self
+    }
+
     #[allow(dead_code)]
     pub fn get(&self, address: StorageAddress) -> anyhow::Result<Option<StorageValue>> {
         let value = self.tree.get(&self.storage, address.view_bits())?;
@@ -88,6 +93,11 @@ impl<'tx> StorageCommitmentTree<'tx> {
         let storage = transaction.storage_trie_reader();
 
         Ok(Self { tree, storage })
+    }
+
+    pub fn with_verify_hashes(mut self, verify_hashes: bool) -> Self {
+        self.tree = self.tree.with_verify_hashes(verify_hashes);
+        self
     }
 
     pub fn get(&self, address: ContractAddress) -> anyhow::Result<Option<ContractStateHash>> {

--- a/crates/merkle-tree/src/contract.rs
+++ b/crates/merkle-tree/src/contract.rs
@@ -85,14 +85,11 @@ pub struct StorageCommitmentTree<'tx> {
 }
 
 impl<'tx> StorageCommitmentTree<'tx> {
-    pub fn load(
-        transaction: &'tx Transaction<'tx>,
-        root: StorageCommitment,
-    ) -> anyhow::Result<Self> {
+    pub fn load(transaction: &'tx Transaction<'tx>, root: StorageCommitment) -> Self {
         let tree = MerkleTree::new(root.0);
         let storage = transaction.storage_trie_reader();
 
-        Ok(Self { tree, storage })
+        Self { tree, storage }
     }
 
     pub fn with_verify_hashes(mut self, verify_hashes: bool) -> Self {

--- a/crates/merkle-tree/src/contract_state.rs
+++ b/crates/merkle-tree/src/contract_state.rs
@@ -17,6 +17,7 @@ pub fn update_contract_state(
     new_class_hash: Option<ClassHash>,
     storage_commitment_tree: &StorageCommitmentTree<'_>,
     transaction: &Transaction<'_>,
+    verify_hashes: bool,
 ) -> anyhow::Result<ContractStateHash> {
     // Update the contract state tree.
     let state_hash = storage_commitment_tree
@@ -41,7 +42,7 @@ pub fn update_contract_state(
 
     // Load the contract tree and insert the updates.
     let new_root = if !updates.is_empty() {
-        let mut contract_tree = ContractsStorageTree::load(transaction, old_root);
+        let mut contract_tree = ContractsStorageTree::load(transaction, old_root).with_verify_hashes(verify_hashes);
         for (key, value) in updates {
             contract_tree
                 .set(*key, *value)

--- a/crates/merkle-tree/src/contract_state.rs
+++ b/crates/merkle-tree/src/contract_state.rs
@@ -42,7 +42,8 @@ pub fn update_contract_state(
 
     // Load the contract tree and insert the updates.
     let new_root = if !updates.is_empty() {
-        let mut contract_tree = ContractsStorageTree::load(transaction, old_root).with_verify_hashes(verify_hashes);
+        let mut contract_tree =
+            ContractsStorageTree::load(transaction, old_root).with_verify_hashes(verify_hashes);
         for (key, value) in updates {
             contract_tree
                 .set(*key, *value)

--- a/crates/merkle-tree/src/tree.rs
+++ b/crates/merkle-tree/src/tree.rs
@@ -60,7 +60,7 @@ use std::{cell::RefCell, rc::Rc};
 pub struct MerkleTree<H: FeltHash, const HEIGHT: usize> {
     root: Rc<RefCell<InternalNode>>,
     _hasher: std::marker::PhantomData<H>,
-    /// If enables, node hashes are verified as they are resolved. This allows 
+    /// If enables, node hashes are verified as they are resolved. This allows
     /// testing for database corruption.
     verify_hashes: bool,
 }
@@ -527,7 +527,8 @@ impl<H: FeltHash, const HEIGHT: usize> MerkleTree<H, HEIGHT> {
         if self.verify_hashes {
             let calculated_hash = node.hash::<H>();
 
-            anyhow::ensure!(hash == calculated_hash,
+            anyhow::ensure!(
+                hash == calculated_hash,
                 r"Node data is corrupt.
 
 Expected:   {hash}

--- a/crates/merkle-tree/src/tree.rs
+++ b/crates/merkle-tree/src/tree.rs
@@ -60,6 +60,9 @@ use std::{cell::RefCell, rc::Rc};
 pub struct MerkleTree<H: FeltHash, const HEIGHT: usize> {
     root: Rc<RefCell<InternalNode>>,
     _hasher: std::marker::PhantomData<H>,
+    /// If enables, node hashes are verified as they are resolved. This allows 
+    /// testing for database corruption.
+    verify_hashes: bool,
 }
 
 /// The result of committing a [MerkleTree]. Contains the new root and any
@@ -77,7 +80,13 @@ impl<H: FeltHash, const HEIGHT: usize> MerkleTree<H, HEIGHT> {
         Self {
             root: root_node,
             _hasher: std::marker::PhantomData,
+            verify_hashes: false,
         }
+    }
+
+    pub fn with_verify_hashes(mut self, verify_hashes: bool) -> Self {
+        self.verify_hashes = verify_hashes;
+        self
     }
 
     pub fn empty() -> Self {
@@ -514,6 +523,20 @@ impl<H: FeltHash, const HEIGHT: usize> MerkleTree<H, HEIGHT> {
         let node = storage
             .get(&hash)?
             .with_context(|| format!("Node at height {height} does not exist: {hash}"))?;
+
+        if self.verify_hashes {
+            let calculated_hash = node.hash::<H>();
+
+            anyhow::ensure!(hash == calculated_hash,
+                r"Node data is corrupt.
+
+Expected:   {hash}
+Calculated: {calculated_hash}
+
+Node: {node:?}
+"
+            );
+        }
 
         let node = match node {
             TrieNode::Binary { left, right } => InternalNode::Binary(BinaryNode {

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -185,6 +185,20 @@ Examples:
     #[cfg(not(feature = "p2p"))]
     #[clap(skip)]
     debug: (),
+
+    #[arg(
+        long = "sync.verify_tree_node_data",
+        long_help = r"When enabled, state tree node hashes are verified when loaded from disk.
+
+This can be used to identify tree node data corruption which is useful when debugging a state commitment mismatch.
+
+This should only be enabled for debugging purposes as it adds substantial processing cost to every block.
+",
+        default_value = "false",
+        env = "PATHFINDER_VERIFY_TREE_NODE_HASHES",
+        value_name = "BOOL"
+    )]
+    verify_tree_node_data: bool,
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq)]
@@ -419,6 +433,7 @@ pub struct Config {
     pub color: Color,
     pub p2p: P2PConfig,
     pub debug: DebugConfig,
+    pub verify_tree_hashes: bool,
 }
 
 pub struct WebSocket {
@@ -598,6 +613,7 @@ impl Config {
             color: cli.color,
             p2p: P2PConfig::parse_or_exit(cli.p2p),
             debug: DebugConfig::parse(cli.debug),
+            verify_tree_hashes: cli.verify_tree_node_data,
         }
     }
 }

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -185,6 +185,7 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
         websocket_txs: rpc_server.get_ws_senders(),
         block_cache_size: 1_000,
         restart_delay: config.debug.restart_delay,
+        verify_tree_hashes: config.verify_tree_hashes,
     };
 
     let sync_handle = tokio::spawn(state::sync(sync_context, state::l1::sync, state::l2::sync));

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -844,7 +844,6 @@ fn update_starknet_state(
         .unwrap_or((StorageCommitment::ZERO, ClassCommitment::ZERO));
 
     let mut storage_commitment_tree = StorageCommitmentTree::load(transaction, storage_commitment)
-        .context("Loading storage trie")?
         .with_verify_hashes(verify_hashes);
 
     for (contract, update) in &state_update.contract_updates {

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -280,6 +280,7 @@ pub mod test_utils {
             Some(class0_hash),
             &storage_commitment_tree,
             &db_txn,
+            false,
         )
         .unwrap();
         storage_commitment_tree
@@ -299,6 +300,7 @@ pub mod test_utils {
             Some(class1_hash),
             &storage_commitment_tree,
             &db_txn,
+            false,
         )
         .unwrap();
         storage_commitment_tree
@@ -311,6 +313,7 @@ pub mod test_utils {
             None,
             &storage_commitment_tree,
             &db_txn,
+            false,
         )
         .unwrap();
         storage_commitment_tree
@@ -330,6 +333,7 @@ pub mod test_utils {
             None,
             &storage_commitment_tree,
             &db_txn,
+            false,
         )
         .unwrap();
         storage_commitment_tree
@@ -342,6 +346,7 @@ pub mod test_utils {
             Some(class2_hash),
             &storage_commitment_tree,
             &db_txn,
+            false,
         )
         .unwrap();
         storage_commitment_tree

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -272,7 +272,7 @@ pub mod test_utils {
             .unwrap();
 
         let mut storage_commitment_tree =
-            StorageCommitmentTree::load(&db_txn, StorageCommitment(Felt::ZERO)).unwrap();
+            StorageCommitmentTree::load(&db_txn, StorageCommitment(Felt::ZERO));
         let contract_state_hash = update_contract_state(
             contract0_addr,
             &contract0_update,
@@ -291,8 +291,7 @@ pub mod test_utils {
             .insert_storage_trie(storage_commitment0, &nodes)
             .unwrap();
 
-        let mut storage_commitment_tree =
-            StorageCommitmentTree::load(&db_txn, storage_commitment0).unwrap();
+        let mut storage_commitment_tree = StorageCommitmentTree::load(&db_txn, storage_commitment0);
         let contract_state_hash = update_contract_state(
             contract1_addr,
             &contract1_update0,
@@ -324,8 +323,7 @@ pub mod test_utils {
             .insert_storage_trie(storage_commitment1, &nodes)
             .unwrap();
 
-        let mut storage_commitment_tree =
-            StorageCommitmentTree::load(&db_txn, storage_commitment1).unwrap();
+        let mut storage_commitment_tree = StorageCommitmentTree::load(&db_txn, storage_commitment1);
         let contract_state_hash = update_contract_state(
             contract1_addr,
             &contract1_update2,

--- a/crates/rpc/src/pathfinder/methods/get_proof.rs
+++ b/crates/rpc/src/pathfinder/methods/get_proof.rs
@@ -194,8 +194,7 @@ pub async fn get_proof(
             )
         };
 
-        let mut storage_commitment_tree =
-            StorageCommitmentTree::load(&tx, storage_commitment).context("Loading storage trie")?;
+        let mut storage_commitment_tree = StorageCommitmentTree::load(&tx, storage_commitment);
 
         // Generate a proof for this contract. If the contract does not exist, this will
         // be a "non membership" proof.


### PR DESCRIPTION
This PR adds tree node data verification.

Adds a configuration item `--sync.verify_tree_node_data = BOOL` (default `false`). This enables verifiying the data of a tree node when it is first loaded from disk.

This can be used to remotely debug state root mismatches as a result of disk corruption.