### PR TITLE
fix(rpc/executor): fix Declare v1 transaction conversion

### DIFF
--- a/crates/rpc/src/executor.rs
+++ b/crates/rpc/src/executor.rs
@@ -245,7 +245,7 @@ pub(crate) fn map_broadcasted_transaction(
 
                 let tx = pathfinder_executor::Transaction::from_api(
                     starknet_api::transaction::Transaction::Declare(
-                        starknet_api::transaction::DeclareTransaction::V0(tx),
+                        starknet_api::transaction::DeclareTransaction::V1(tx),
                     ),
                     starknet_api::transaction::TransactionHash(transaction_hash.0.into_starkfelt()),
                     Some(contract_class),


### PR DESCRIPTION
Previously these were converted to starknet_api's `DeclareTransaction::V0` which is incorrect.

Internally blockifier executes these just the same, so there are no real implications of this fix.
