### PR TITLE
fix(rpc/class): work around starknet_api Cairo 0 class parsing issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- JSON-RPC requests containing a Cairo 0 class definition were requiring the `debug_info` property to be present in the input program. This was a regression caused by the execution engine change. 
+
 ### Added
 
 - `--sync.verify_tree_node_data` which enables verifies state tree nodes as they are loaded from disk. This is a debugging tool to identify disk corruption impacting tree node data. This should only be enabled when debugging a state root mismatch.


### PR DESCRIPTION
starknet_api::deprecated_contract_class::Program requires `debug_info` to be present in the program. That should actually be optional and now this causes a regression where declare transactions with Cairo v0 classes with no `debug_info` present are rejected by pathfinder.

This change adds a workaround for that issue: adds an empty debug info to the program if it's not present in the input before parsing the class with starknet_api.

Closes #1371