### PR TITLE
feat: Add a global class cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6567,7 +6567,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "blockifier",
+ "cached",
  "cairo-vm",
+ "lazy_static",
  "pathfinder-common",
  "pathfinder-storage",
  "primitive-types",

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -8,7 +8,9 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 anyhow = { workspace = true }
 blockifier = { workspace = true }
+cached = "0.44.0"
 cairo-vm = "0.8.7"
+lazy_static = { workspace = true }
 pathfinder-common = { path = "../common" }
 pathfinder-storage = { path = "../storage" }
 primitive-types = { workspace = true, features = ["serde"] }

--- a/crates/executor/src/state_reader.rs
+++ b/crates/executor/src/state_reader.rs
@@ -1,9 +1,126 @@
-use blockifier::state::{errors::StateError, state_api::StateReader};
+use blockifier::{
+    execution::contract_class::ContractClass,
+    state::{
+        cached_state::{CachedState, GlobalContractCache},
+        errors::StateError,
+        state_api::StateReader,
+        state_api::StateResult,
+    },
+};
+use cached::{Cached, SizedCache};
 use pathfinder_common::{BlockNumber, ClassHash, StorageAddress, StorageValue};
 use stark_hash::Felt;
-use starknet_api::{hash::StarkFelt, StarknetApiError};
+use starknet_api::{
+    core::{ClassHash as StarknetClassHash, CompiledClassHash, ContractAddress, Nonce},
+    hash::StarkFelt,
+    state::StorageKey,
+    StarknetApiError,
+};
+use std::sync::{Arc, Mutex, MutexGuard};
+use tracing::warn;
 
 use super::felt::{IntoFelt, IntoStarkFelt};
+
+/// A `StateReader` wrapper designed to cache the compiled contract classes.
+/// Contract classes are immutable once deployed so caching should not cause any side effect.
+pub(super) struct LruCachedReader<R>
+where
+    R: StateReader,
+{
+    compiled_class_cache: GlobalContractCache,
+    inner_reader: R,
+}
+
+impl<R> LruCachedReader<R>
+where
+    R: StateReader,
+{
+    /// Build a `CachedState` on top of an `LruCachedReader`, sharing the same underlying cache.
+    pub fn new_cached_state(inner_reader: R) -> anyhow::Result<CachedState<LruCachedReader<R>>> {
+        // `CachedState` already has a [move_classes_to_global_cache](https://docs.rs/blockifier/0.3.0-rc0/blockifier/state/cached_state/struct.CachedState.html#method.move_classes_to_global_cache)
+        // method that we might want to use instead, but relying on it would make this cache much
+        // less self-contained as these calls would have to be made in various places.
+        // One of the reasons for this is that we can't wrap the `CachedReader` in another layer of
+        // the `State` trait as `blockifier` explicitly requires a `CachedReader` in the signature
+        // of some methods we use.
+        let reader = Self::new(inner_reader)?;
+        let cache = reader.compiled_class_cache.clone();
+        Ok(CachedState::new(reader, cache))
+    }
+
+    fn new(inner_reader: R) -> anyhow::Result<Self> {
+        lazy_static::lazy_static!(
+            static ref CONTRACT_CACHE: GlobalContractCache = {
+                let inner = SizedCache::with_size(128);
+                GlobalContractCache(Arc::new(Mutex::new(inner)))
+            };
+        );
+
+        Ok(Self {
+            compiled_class_cache: CONTRACT_CACHE.clone(),
+            inner_reader,
+        })
+    }
+
+    fn locked_cache(
+        &mut self,
+    ) -> StateResult<MutexGuard<'_, SizedCache<StarknetClassHash, ContractClass>>> {
+        self.compiled_class_cache.0.lock().map_err(|err| {
+            warn!("Contract class cache lock is poisoned. Cause: {}.", err);
+            StateError::StateReadError("Poisoned lock".to_string())
+        })
+    }
+}
+
+impl<R> StateReader for LruCachedReader<R>
+where
+    R: StateReader,
+{
+    fn get_storage_at(
+        &mut self,
+        contract_address: ContractAddress,
+        key: StorageKey,
+    ) -> StateResult<StarkFelt> {
+        self.inner_reader.get_storage_at(contract_address, key)
+    }
+
+    fn get_nonce_at(&mut self, contract_address: ContractAddress) -> StateResult<Nonce> {
+        self.inner_reader.get_nonce_at(contract_address)
+    }
+
+    fn get_class_hash_at(
+        &mut self,
+        contract_address: ContractAddress,
+    ) -> StateResult<StarknetClassHash> {
+        self.inner_reader.get_class_hash_at(contract_address)
+    }
+
+    fn get_compiled_contract_class(
+        &mut self,
+        class_hash: &StarknetClassHash,
+    ) -> StateResult<ContractClass> {
+        // Check the cache, if not found then lookup & insert.
+        // Because the lookup can take quite a lot of time and classes are insert-only, it's better
+        // to separate the get & set operations and release the lock in the meantime.
+        if let Some(contract_class) = self.locked_cache()?.cache_get(class_hash) {
+            return Ok(contract_class.clone());
+        }
+
+        let contract_class = self.inner_reader.get_compiled_contract_class(class_hash)?;
+
+        self.locked_cache()?
+            .cache_set(*class_hash, contract_class.clone());
+
+        Ok(contract_class)
+    }
+
+    fn get_compiled_class_hash(
+        &mut self,
+        class_hash: StarknetClassHash,
+    ) -> StateResult<CompiledClassHash> {
+        self.inner_reader.get_compiled_class_hash(class_hash)
+    }
+}
 
 pub(super) struct PathfinderStateReader<'conn> {
     transaction: pathfinder_storage::Transaction<'conn>,


### PR DESCRIPTION
As instructed in #1364, this PR aims at adding a cache for the compiled contract classes.

As contract classes are insert-only and their absence isn't cached, this PR should not have any other effect than improving performance in the typical use-cases.

This cache brings a 20-30% speed improvement to the `re_execute` scenario. 16MB are enough to get most of the benefits.

Delete once completed: #1364