### PR TITLE
fix(sync): return state update as well when receiving a full block in poll_pending()

### DIFF
--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -49,7 +49,7 @@ pub async fn poll_pending<S: GatewayApi + Clone + Send + 'static>(
             }
             MaybePendingBlock::Block(block) => {
                 tracing::trace!(hash=%block.block_hash, "Found full block, exiting pending mode.");
-                return Ok((Some(block), None));
+                return Ok((Some(block), Some(state_update)));
             }
             MaybePendingBlock::Pending(pending) if pending.parent_hash != head.0 => {
                 tracing::trace!(


### PR DESCRIPTION
poll_pending() already had an optimization: in case it was receiving a full block instead of pending it returned the data it had to the l2 sync code which could then process the block data without re-fetching it from the feeder gateway.

Unfortunately the code was _not_ returning the state update even though we're now fetching the block data _and_ the state update for the pending block with a single call.
