### PR TITLE
feat(rpc/get_events): improve continuation_token handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - JSON-RPC requests containing a Cairo 0 class definition were requiring the `debug_info` property to be present in the input program. This was a regression caused by the execution engine change. 
+- Performance for the `starknet_getEvents` JSON-RPC method has been improved for queries involving the pending block.
 
 ### Added
 
 - `--sync.verify_tree_node_data` which enables verifies state tree nodes as they are loaded from disk. This is a debugging tool to identify disk corruption impacting tree node data. This should only be enabled when debugging a state root mismatch.
+
 
 ## [0.8.1] - 2023-09-07
 

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -117,7 +117,7 @@ impl StorageAddress {
 }
 
 /// A Starknet block number.
-#[derive(Copy, Debug, Clone, Default, PartialEq, Eq, PartialOrd, Hash)]
+#[derive(Copy, Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BlockNumber(u64);
 
 macros::i64_backed_u64::new_get_partialeq!(BlockNumber);

--- a/crates/pathfinder/src/p2p_network/sync_handlers/v0.rs
+++ b/crates/pathfinder/src/p2p_network/sync_handlers/v0.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use pathfinder_common::{BlockHash, BlockNumber, ClassHash};
-use pathfinder_storage::{Storage, Transaction, V03KeyFilter};
+use pathfinder_storage::{Storage, Transaction};
 
 #[cfg(not(test))]
 const MAX_HEADERS_COUNT: u64 = 1000;
@@ -103,13 +103,7 @@ fn block_headers(
             .try_into()
             .context("Number of transactions exceeds 32 bits")?;
 
-        // TODO check if there are faster ways to do this
-        let event_count = tx.event_count(
-            block_number.into(),
-            block_number.into(),
-            None,
-            &V03KeyFilter::new(vec![]),
-        )?;
+        let event_count = tx.event_count_for_block(block_number.into())?;
 
         headers.push(conv::header::from(
             header,

--- a/crates/storage/src/connection.rs
+++ b/crates/storage/src/connection.rs
@@ -191,16 +191,6 @@ impl<'inner> Transaction<'inner> {
         event::get_events(self, filter)
     }
 
-    pub fn event_count(
-        &self,
-        from_block: Option<BlockNumber>,
-        to_block: Option<BlockNumber>,
-        contract_address: Option<ContractAddress>,
-        keys: &dyn KeyFilter,
-    ) -> anyhow::Result<usize> {
-        event::event_count(self, from_block, to_block, contract_address, keys)
-    }
-
     pub fn insert_sierra_class(
         &self,
         sierra_hash: &SierraHash,

--- a/crates/storage/src/connection.rs
+++ b/crates/storage/src/connection.rs
@@ -191,6 +191,10 @@ impl<'inner> Transaction<'inner> {
         event::get_events(self, filter)
     }
 
+    pub fn event_count_for_block(&self, block: BlockId) -> anyhow::Result<usize> {
+        event::event_count_for_block(self, block)
+    }
+
     pub fn insert_sierra_class(
         &self,
         sierra_hash: &SierraHash,


### PR DESCRIPTION
`continuation_token` now includes a block number to continue from and a relative offset to the beginning of that page. Page number for the pending page is considered to be latest block number plus one.
    
This approach has two advantages:

* we can use the block number from the token as from_block in the query, leading to a smaller range to check
* we can construct the next continuation_token without knowing the number of all events matching in the database even for the pending case