### PR TITLE
chore(pathfinder): remove num_cpus crate dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6461,7 +6461,6 @@ dependencies = [
  "metrics-exporter-prometheus",
  "mimalloc",
  "mockall",
- "num_cpus",
  "p2p",
  "p2p_proto_v0",
  "pathfinder-common",

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -28,7 +28,6 @@ lazy_static = { workspace = true }
 lru = "0.11.1"
 metrics = { workspace = true }
 metrics-exporter-prometheus = "0.11.0"
-num_cpus = "1.16.0"
 p2p = { path = "../p2p", optional = true }
 p2p_proto_v0 = { path = "../p2p_proto_v0", optional = true }
 pathfinder-common = { path = "../common" }

--- a/crates/pathfinder/examples/re_execute.rs
+++ b/crates/pathfinder/examples/re_execute.rs
@@ -27,7 +27,7 @@ fn main() -> anyhow::Result<()> {
         .compact()
         .init();
 
-    let n_cpus = num_cpus::get();
+    let n_cpus = std::thread::available_parallelism().unwrap().get();
 
     let database_path = std::env::args().nth(1).unwrap();
     let storage = Storage::migrate(database_path.into(), JournalMode::WAL)?
@@ -54,7 +54,7 @@ fn main() -> anyhow::Result<()> {
 
     let (tx, rx) = crossbeam_channel::bounded::<Work>(10);
 
-    let executors = (0..num_cpus::get())
+    let executors = (0..n_cpus)
         .map(|_| {
             let storage = storage.clone();
             let rx = rx.clone();

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -109,8 +109,10 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
       Try increasing the file limit to using `ulimit` or similar tooling.",
     )?;
 
+    let available_parallelism = std::thread::available_parallelism()?;
+
     let execution_storage_pool_size = config.execution_concurrency.unwrap_or_else(|| {
-        std::num::NonZeroU32::new(num_cpus::get() as u32)
+        std::num::NonZeroU32::new(available_parallelism.get() as u32)
             .expect("The number of CPU cores should be non-zero")
     });
     let execution_storage = storage_manager


### PR DESCRIPTION
In favor of just using `std::thread::available_parallelism()`.
