### PR TITLE
fix(storage/event): improve performance of getEvents queries without a key filter

### DIFF
--- a/crates/storage/src/connection/event.rs
+++ b/crates/storage/src/connection/event.rs
@@ -461,6 +461,9 @@ fn select_query_strategy(
             );
             return Ok(QueryStrategy::KeysFirst);
         }
+    } else {
+        // we have no key filter at all
+        return Ok(QueryStrategy::BlockRangeFirst);
     }
 
     let events_in_block_range =


### PR DESCRIPTION
If there is no key filter specified in the event filter `select_query_stragegy()` will always return `BlockRangeFirst`.

Previously it still determined the number of events covered by the block range query but this is unnecessary since it has no effect on the result and is quite slow for huge ranges.
