### PR TITLE
Simplify the Felt251 deserializer

### DIFF
--- a/crates/common/src/macros.rs
+++ b/crates/common/src/macros.rs
@@ -185,29 +185,8 @@ macro_rules! felt_newtypes {
                 where
                     D: serde::Deserializer<'de>,
                 {
-                    struct Felt251Vistitor;
-
-                    impl<'de> serde::de::Visitor<'de> for Felt251Vistitor {
-                        type Value = $target;
-
-                        fn expecting(
-                            &self,
-                            formatter: &mut std::fmt::Formatter<'_>,
-                        ) -> std::fmt::Result {
-                            formatter.write_str("A hex string with at most 251 bits set.")
-                        }
-
-                        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-                        where
-                            E: serde::de::Error,
-                        {
-                            let felt = Felt::from_hex_str(v).map_err(serde::de::Error::custom)?;
-
-                            Self::Value::new(felt).context("Felt251 overflow").map_err(serde::de::Error::custom)
-                        }
-                    }
-
-                    de.deserialize_str(Felt251Vistitor)
+                    let felt = Felt::deserialize(de)?;
+                    $target::new(felt).context("Felt251 overflow").map_err(serde::de::Error::custom)
                 }
             }
         }


### PR DESCRIPTION
Rely on the existing logic of the regular Felt struct.

This avoid some duplicated code and boilerplate, but has the side effect of changing the error message:

From
```
A hex string with at most 251 bits set.
```

To
```
a hex string of up to 64 digits with an optional '0x' prefix
```

[`impl Deserialize for Felt`](https://github.com/eqlabs/pathfinder/blob/main/crates/rpc/src/felt.rs#L215)