### PR TITLE
fix(pathfinder): exit with non-zero exit status on unintended shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Pathfinder now uses a new JSON-RPC implementation. This also means that we've temporarily removed Websocket support. It will be added back in a later release.
+- Switched to a custom JSON-RPC framework to more easily support multiple specification versions. This may lead to some unexpected changes in behaviour.
+
+### Removed
+
+- JSON-RPC subscription support (`pathfinder_newHeads`). This is temporary while we re-add support to our new JSON-RPC framework.
 
 ## [0.8.2] - 2023-09-28
 
@@ -32,12 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `starknet_getEvents` continuation token formatting. The new format is incompatible with the previous format used v0.8.1 and older.
-- Switched to a custom JSON-RPC framework to more easily support multiple specification versions. This may lead to some unexpected changes in behaviour.
-
-### Removed
-
-- JSON-RPC subscription support (`pathfinder_newHeads`). This is temporary while we re-add support to our new JSON-RPC framework.
-
 
 ## [0.8.1] - 2023-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- pathfinder now exits with a non-zero exit status if any of the service tasks (sync/RPC/monitoring) terminates.
+
 ### Changed
 
 - Switched to a custom JSON-RPC framework to more easily support multiple specification versions. This may lead to some unexpected changes in behaviour.

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -248,7 +248,7 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
         }
     }
 
-    Ok(())
+    anyhow::bail!("Unexpected shutdown");
 }
 
 #[cfg(feature = "tokio-console")]


### PR DESCRIPTION
If any of our running-forever service tasks (sync/RPC/monitoring/P2P) exits that means a fatal error and pathfinder exits.

In those cases pathfinder should exit with a non-zero exit status.