### PR TITLE
fix: sync crash due to duplicate blocks submitted by producer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - JSON-RPC requests containing a Cairo 0 class definition were requiring the `debug_info` property to be present in the input program. This was a regression caused by the execution engine change. 
 - Performance for the `starknet_getEvents` JSON-RPC method has been improved for queries involving the pending block.
+- Rare edge case where duplicate blocks caused the sync process to halt due to a `A PRIMARY KEY constraint failed` error.
+- Querying a descync'd feeder gateway causes sync process to end due to missing classes.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Rare edge case where duplicate blocks caused the sync process to halt due to a `A PRIMARY KEY constraint failed` error.
+- Querying a descync'd feeder gateway causes sync process to end due to missing classes.
 - pathfinder now exits with a non-zero exit status if any of the service tasks (sync/RPC/monitoring) terminates.
 
 ### Changed
@@ -27,8 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - JSON-RPC requests containing a Cairo 0 class definition were requiring the `debug_info` property to be present in the input program. This was a regression caused by the execution engine change. 
 - Performance for the `starknet_getEvents` JSON-RPC method has been improved for queries involving the pending block.
-- Rare edge case where duplicate blocks caused the sync process to halt due to a `A PRIMARY KEY constraint failed` error.
-- Querying a descync'd feeder gateway causes sync process to end due to missing classes.
 
 ### Added
 

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -339,14 +339,14 @@ async fn consumer(mut events: Receiver<SyncEvent>, context: ConsumerContext) -> 
         .connection()
         .context("Creating database connection")?;
 
-    let mut latest_timestamp = tokio::task::block_in_place(|| {
+    let (mut latest_timestamp, mut latest_number) = tokio::task::block_in_place(|| {
         let tx = db_conn
             .transaction()
             .context("Creating database transaction")?;
         let latest = tx
             .block_header(pathfinder_storage::BlockId::Latest)
             .context("Fetching latest block header")?
-            .map(|b| b.timestamp)
+            .map(|b| (b.timestamp, b.number))
             .unwrap_or_default();
 
         anyhow::Ok(latest)
@@ -361,6 +361,11 @@ async fn consumer(mut events: Receiver<SyncEvent>, context: ConsumerContext) -> 
                 tracing::info!("L1 sync updated to block {}", update.block_number);
             }
             Block((block, (tx_comm, ev_comm)), state_update, timings) => {
+                if block.block_number <= latest_number {
+                    tracing::debug!("Ignoring duplicate block {}", block.block_number);
+                    continue;
+                }
+
                 let block_number = block.block_number;
                 let block_hash = block.block_hash;
                 let block_timestamp = block.timestamp;
@@ -422,6 +427,7 @@ async fn consumer(mut events: Receiver<SyncEvent>, context: ConsumerContext) -> 
                     (block_timestamp.get() - latest_timestamp.get()) as f64
                 );
                 latest_timestamp = block_timestamp;
+                latest_number = block_number;
 
                 // Give a simple log under INFO level, and a more verbose log
                 // with timing information under DEBUG+ level.
@@ -1179,8 +1185,14 @@ mod tests {
         let blocks = generate_block_data();
         let (a, b, c) = blocks[0].clone();
 
-        event_tx.send(SyncEvent::Block(a.clone(), b.clone(), c.clone())).await.unwrap();
-        event_tx.send(SyncEvent::Block(a.clone(), b.clone(), c.clone())).await.unwrap();
+        event_tx
+            .send(SyncEvent::Block(a.clone(), b.clone(), c.clone()))
+            .await
+            .unwrap();
+        event_tx
+            .send(SyncEvent::Block(a.clone(), b.clone(), c.clone()))
+            .await
+            .unwrap();
         drop(event_tx);
 
         let context = ConsumerContext {

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -1186,11 +1186,11 @@ mod tests {
         let (a, b, c) = blocks[0].clone();
 
         event_tx
-            .send(SyncEvent::Block(a.clone(), b.clone(), c.clone()))
+            .send(SyncEvent::Block(a.clone(), b.clone(), c))
             .await
             .unwrap();
         event_tx
-            .send(SyncEvent::Block(a.clone(), b.clone(), c.clone()))
+            .send(SyncEvent::Block(a.clone(), b.clone(), c))
             .await
             .unwrap();
         drop(event_tx);

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -78,14 +78,17 @@ pub async fn poll_pending<S: GatewayApi + Clone + Send + 'static>(
                     prev_block = Some(block.clone());
                     tracing::trace!("Pending block data changed");
 
-                    download_classes_and_emit_event(
+                    if let Err(e) = download_classes_and_emit_event(
                         &tx_event,
                         sequencer,
                         &storage,
                         block,
                         Arc::new(state_update),
                     )
-                    .await?;
+                    .await
+                    {
+                        tracing::debug!(reason=?e, "Failed to download pending classes");
+                    }
                 } else {
                     tracing::trace!("No change in pending block data");
                 }


### PR DESCRIPTION
This PR fixes a rare crash in the sync process caused by a database race condition between the producer and consumer of L2 blocks.

The scenario that this fixes is:

1. Consumer updates database to block N
2. Producer emits block N+1 into queue for consumer
3. Producer crashes
4. Producer is restarted with the latest block in database (N)
5. Producer emits block N+1
6. Consumer updates database with block N+1
7. Consumer attempts to update database with block N+1 again and crashes due to Primary key constraint

The "fix" is to ignore blocks that are below the consumers latest block.

In addition this PR also now ignores pending blocks who's classes are missing. This was the cause of the crashes in (3) for the user who reported this issue. The missing classes can occur if we get unlucky and query a feeder gateway which is desync'd and doesn't know about the new pending classes yet. We now ignore the pending block data for the iteration in which this occurs.