### PR TITLE
fix(rpc/get_storage_at): return zero for non-existent keys of contracts deployed in pending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pathfinder now exits with a non-zero exit status if any of the service tasks (sync/RPC/monitoring) terminates.
 - Rare edge case where duplicate blocks caused the sync process to halt due to a `A PRIMARY KEY constraint failed` error.
 - Querying a descync'd feeder gateway causes sync process to end due to missing classes.
+- `starknet_getStorageAt` no longer returns ContractNotFound when querying for non-existent keys for contracts deployed in the pending block.
 
 ### Changed
 

--- a/crates/rpc/src/v02/method/get_storage_at.rs
+++ b/crates/rpc/src/v02/method/get_storage_at.rs
@@ -23,7 +23,7 @@ pub async fn get_storage_at(
     context: RpcContext,
     input: GetStorageAtInput,
 ) -> Result<GetStorageOutput, GetStorageAtError> {
-    let block_id = match input.block_id {
+    let (block_id, contract_exists_in_pending) = match input.block_id {
         BlockId::Pending => {
             match context
                 .pending_data
@@ -32,25 +32,32 @@ pub async fn get_storage_at(
                 .await
             {
                 Some(update) => {
-                    let pending_value = update
-                        .contract_updates
-                        .get(&input.contract_address)
-                        .and_then(|update| {
-                            update
-                                .storage
-                                .iter()
-                                .find_map(|(key, value)| (key == &input.key).then_some(*value))
-                        });
+                    let value =
+                        update
+                            .contract_updates
+                            .get(&input.contract_address)
+                            .map(|update| {
+                                update
+                                    .storage
+                                    .iter()
+                                    .find_map(|(key, value)| (key == &input.key).then_some(*value))
+                            });
 
-                    match pending_value {
-                        Some(value) => return Ok(GetStorageOutput(value)),
-                        None => pathfinder_storage::BlockId::Latest,
+                    match value {
+                        Some(Some(value)) => return Ok(GetStorageOutput(value)),
+                        // Contract exists but no such key was present in pending
+                        Some(None) => (pathfinder_storage::BlockId::Latest, true),
+                        // Contract not updated in pending
+                        None => (pathfinder_storage::BlockId::Latest, false),
                     }
                 }
-                None => pathfinder_storage::BlockId::Latest,
+                None => (pathfinder_storage::BlockId::Latest, false),
             }
         }
-        other => other.try_into().expect("Only pending cast should fail"),
+        other => (
+            other.try_into().expect("Only pending cast should fail"),
+            false,
+        ),
     };
 
     let storage = context.storage.clone();
@@ -76,7 +83,9 @@ pub async fn get_storage_at(
         match value {
             Some(value) => Ok(GetStorageOutput(value)),
             None => {
-                if tx.contract_exists(input.contract_address, block_id)? {
+                if contract_exists_in_pending
+                    || tx.contract_exists(input.contract_address, block_id)?
+                {
                     Ok(GetStorageOutput(StorageValue::ZERO))
                 } else {
                     Err(GetStorageAtError::ContractNotFound)

--- a/crates/rpc/src/v02/method/get_storage_at.rs
+++ b/crates/rpc/src/v02/method/get_storage_at.rs
@@ -211,6 +211,14 @@ mod tests {
                 // Pending data is absent, fallback to the latest block
                 assert_value(b"storage value 2"),
             ),
+            (
+                ctx.clone(),
+                contract_address_bytes!(b"pending contract 0 address"),
+                non_existent_key,
+                BlockId::Pending,
+                // Contract has been deployed in pending but key has not been updated
+                assert_value(&[0]),
+            ),
             // Other block ids - happy paths
             (
                 ctx.clone(),


### PR DESCRIPTION
Due to a bug in our fallback logic we returned "Contract not found" errors when the contract has been deployed in the pending block.

This PR fixes this by enabling the zero-fallback if the contract exists in the pending block (as opposed to our previous requirement of existing on the latest block).

Closes #1408 