### PR TITLE
chore: fix `redundant explicit link target` errors for `cargo doc`

### DIFF
--- a/crates/rpc/src/felt.rs
+++ b/crates/rpc/src/felt.rs
@@ -1,4 +1,4 @@
-//! Contains the [RpcFelt] and [RpcFelt251] wrappers around [Felt](stark_hash::Felt) which
+//! Contains the [RpcFelt] and [RpcFelt251] wrappers around [Felt] which
 //! implement RPC compliant serialization.
 //!
 //! The wrappers implement [serde_with::SerializeAs] which allows annotating

--- a/crates/storage/src/params.rs
+++ b/crates/storage/src/params.rs
@@ -283,7 +283,7 @@ impl<'a> RowExt for &rusqlite::Row<'a> {
     }
 }
 
-/// Implements [ToSql] for the target [Felt](stark_hash::Felt) newtype.
+/// Implements [ToSql] for the target [Felt] newtype.
 ///
 /// Writes the full underlying bytes (no compression).
 macro_rules! to_sql_felt {


### PR DESCRIPTION
This is new for Rust 1.73.0.
