### PR TITLE
chore(CODEOWNERS): fix global rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
 # review automation, hopefully, so we don't have to toggle boxes on every one.
 
 # assign these always as reviewers
-* @eqlabs/starknet
-* @pierre-l
+* @eqlabs/starknet @pierre-l


### PR DESCRIPTION
Later matches have a precedence so we should have all default codeowners in a single line.
