### PR TITLE
feat: increase node index from u32 to u64

### DIFF
--- a/crates/merkle-tree/src/class.rs
+++ b/crates/merkle-tree/src/class.rs
@@ -76,11 +76,11 @@ struct ClassStorage<'tx> {
 }
 
 impl crate::storage::Storage for ClassStorage<'_> {
-    fn get(&self, index: u32) -> anyhow::Result<Option<pathfinder_storage::StoredNode>> {
+    fn get(&self, index: u64) -> anyhow::Result<Option<pathfinder_storage::StoredNode>> {
         self.tx.class_trie_node(index)
     }
 
-    fn hash(&self, index: u32) -> anyhow::Result<Option<Felt>> {
+    fn hash(&self, index: u64) -> anyhow::Result<Option<Felt>> {
         self.tx.class_trie_node_hash(index)
     }
 

--- a/crates/merkle-tree/src/contract.rs
+++ b/crates/merkle-tree/src/contract.rs
@@ -211,11 +211,11 @@ struct ContractStorage<'tx> {
 }
 
 impl crate::storage::Storage for ContractStorage<'_> {
-    fn get(&self, index: u32) -> anyhow::Result<Option<pathfinder_storage::StoredNode>> {
+    fn get(&self, index: u64) -> anyhow::Result<Option<pathfinder_storage::StoredNode>> {
         self.tx.contract_trie_node(index)
     }
 
-    fn hash(&self, index: u32) -> anyhow::Result<Option<Felt>> {
+    fn hash(&self, index: u64) -> anyhow::Result<Option<Felt>> {
         self.tx.contract_trie_node_hash(index)
     }
 
@@ -244,11 +244,11 @@ struct StorageTrieStorage<'tx> {
 }
 
 impl crate::storage::Storage for StorageTrieStorage<'_> {
-    fn get(&self, index: u32) -> anyhow::Result<Option<pathfinder_storage::StoredNode>> {
+    fn get(&self, index: u64) -> anyhow::Result<Option<pathfinder_storage::StoredNode>> {
         self.tx.storage_trie_node(index)
     }
 
-    fn hash(&self, index: u32) -> anyhow::Result<Option<Felt>> {
+    fn hash(&self, index: u64) -> anyhow::Result<Option<Felt>> {
         self.tx.storage_trie_node_hash(index)
     }
 

--- a/crates/merkle-tree/src/merkle_node.rs
+++ b/crates/merkle-tree/src/merkle_node.rs
@@ -17,7 +17,7 @@ pub enum InternalNode {
     /// A node that has not been fetched from storage yet.
     ///
     /// As such, all we know is its hash.
-    Unresolved(u32),
+    Unresolved(u64),
     /// A branch node with exactly two children.
     Binary(BinaryNode),
     /// Describes a path connecting two other nodes.

--- a/crates/merkle-tree/src/storage.rs
+++ b/crates/merkle-tree/src/storage.rs
@@ -5,9 +5,9 @@ use stark_hash::Felt;
 /// Read-only storage used by the [Merkle tree](crate::tree::MerkleTree).
 pub trait Storage {
     /// Returns the node stored at the given index.
-    fn get(&self, index: u32) -> anyhow::Result<Option<StoredNode>>;
+    fn get(&self, index: u64) -> anyhow::Result<Option<StoredNode>>;
     /// Returns the hash of the node at the given index.
-    fn hash(&self, index: u32) -> anyhow::Result<Option<Felt>>;
+    fn hash(&self, index: u64) -> anyhow::Result<Option<Felt>>;
     /// Returns the value of the leaf at the given path.
     fn leaf(&self, path: &BitSlice<u8, Msb0>) -> anyhow::Result<Option<Felt>>;
 }

--- a/crates/merkle-tree/src/transaction.rs
+++ b/crates/merkle-tree/src/transaction.rs
@@ -28,11 +28,11 @@ impl Default for TransactionOrEventTree {
 struct NullStorage;
 
 impl crate::storage::Storage for NullStorage {
-    fn get(&self, _: u32) -> anyhow::Result<Option<StoredNode>> {
+    fn get(&self, _: u64) -> anyhow::Result<Option<StoredNode>> {
         Ok(None)
     }
 
-    fn hash(&self, _: u32) -> anyhow::Result<Option<Felt>> {
+    fn hash(&self, _: u64) -> anyhow::Result<Option<Felt>> {
         Ok(None)
     }
 

--- a/crates/merkle-tree/src/tree.rs
+++ b/crates/merkle-tree/src/tree.rs
@@ -77,7 +77,7 @@ pub struct TrieUpdate {
 }
 
 impl<H: FeltHash, const HEIGHT: usize> MerkleTree<H, HEIGHT> {
-    pub fn new(root: u32) -> Self {
+    pub fn new(root: u64) -> Self {
         let root = Some(Rc::new(RefCell::new(InternalNode::Unresolved(root))));
         Self {
             root,
@@ -469,7 +469,7 @@ impl<H: FeltHash, const HEIGHT: usize> MerkleTree<H, HEIGHT> {
     ///   2. the hashes are correct, and
     ///   3. the root hash matches the known root
     pub fn get_proof(
-        root: u32,
+        root: u64,
         storage: &impl Storage,
         key: &BitSlice<u8, Msb0>,
     ) -> anyhow::Result<Vec<TrieNode>> {
@@ -621,7 +621,7 @@ impl<H: FeltHash, const HEIGHT: usize> MerkleTree<H, HEIGHT> {
     fn resolve(
         &self,
         storage: &impl Storage,
-        index: u32,
+        index: u64,
         height: usize,
     ) -> anyhow::Result<InternalNode> {
         anyhow::ensure!(
@@ -810,16 +810,16 @@ mod tests {
 
     #[derive(Default, Debug)]
     struct TestStorage {
-        nodes: HashMap<u32, (Felt, StoredNode)>,
+        nodes: HashMap<u64, (Felt, StoredNode)>,
         leaves: HashMap<Felt, Felt>,
     }
 
     impl Storage for TestStorage {
-        fn get(&self, node: u32) -> anyhow::Result<Option<StoredNode>> {
+        fn get(&self, node: u64) -> anyhow::Result<Option<StoredNode>> {
             Ok(self.nodes.get(&node).map(|x| x.1.clone()))
         }
 
-        fn hash(&self, node: u32) -> anyhow::Result<Option<Felt>> {
+        fn hash(&self, node: u64) -> anyhow::Result<Option<Felt>> {
             Ok(self.nodes.get(&node).map(|x| x.0))
         }
 
@@ -834,7 +834,7 @@ mod tests {
     fn commit_and_persist<H: FeltHash, const HEIGHT: usize>(
         tree: MerkleTree<H, HEIGHT>,
         storage: &mut TestStorage,
-    ) -> (Felt, u32) {
+    ) -> (Felt, u64) {
         use pathfinder_storage::Child;
 
         for (key, value) in &tree.leaves {
@@ -847,7 +847,7 @@ mod tests {
         let mut indices = HashMap::new();
         let mut idx = storage.nodes.len();
         for hash in update.nodes.keys() {
-            indices.insert(*hash, idx as u32);
+            indices.insert(*hash, idx as u64);
             idx += 1;
         }
 
@@ -1751,7 +1751,7 @@ mod tests {
             keys: Vec<Felt>,
             values: Vec<Felt>,
             root: Felt,
-            root_idx: u32,
+            root_idx: u64,
             storage: TestStorage,
         }
 
@@ -1802,7 +1802,7 @@ mod tests {
         /// Generates a storage proof for each `key` in `keys` and returns the result in the form of an array.
         fn get_proofs(
             keys: &'_ [&BitSlice<u8, Msb0>],
-            root: u32,
+            root: u64,
             storage: &impl Storage,
         ) -> anyhow::Result<Vec<Vec<TrieNode>>> {
             keys.iter()

--- a/crates/storage/src/connection.rs
+++ b/crates/storage/src/connection.rs
@@ -304,7 +304,7 @@ impl<'inner> Transaction<'inner> {
         &self,
         root: ClassCommitment,
         nodes: &HashMap<Felt, Node>,
-    ) -> anyhow::Result<u32> {
+    ) -> anyhow::Result<u64> {
         trie::trie_class::insert(self, root.0, nodes)
     }
 
@@ -313,7 +313,7 @@ impl<'inner> Transaction<'inner> {
         &self,
         root: ContractRoot,
         nodes: &HashMap<Felt, Node>,
-    ) -> anyhow::Result<u32> {
+    ) -> anyhow::Result<u64> {
         trie::trie_contracts::insert(self, root.0, nodes)
     }
 
@@ -322,39 +322,39 @@ impl<'inner> Transaction<'inner> {
         &self,
         root: StorageCommitment,
         nodes: &HashMap<Felt, Node>,
-    ) -> anyhow::Result<u32> {
+    ) -> anyhow::Result<u64> {
         trie::trie_storage::insert(self, root.0, nodes)
     }
 
-    pub fn class_trie_node(&self, index: u32) -> anyhow::Result<Option<StoredNode>> {
+    pub fn class_trie_node(&self, index: u64) -> anyhow::Result<Option<StoredNode>> {
         trie::trie_class::node(self, index)
     }
 
-    pub fn storage_trie_node(&self, index: u32) -> anyhow::Result<Option<StoredNode>> {
+    pub fn storage_trie_node(&self, index: u64) -> anyhow::Result<Option<StoredNode>> {
         trie::trie_storage::node(self, index)
     }
 
-    pub fn contract_trie_node(&self, index: u32) -> anyhow::Result<Option<StoredNode>> {
+    pub fn contract_trie_node(&self, index: u64) -> anyhow::Result<Option<StoredNode>> {
         trie::trie_contracts::node(self, index)
     }
 
-    pub fn class_trie_node_hash(&self, index: u32) -> anyhow::Result<Option<Felt>> {
+    pub fn class_trie_node_hash(&self, index: u64) -> anyhow::Result<Option<Felt>> {
         trie::trie_class::hash(self, index)
     }
 
-    pub fn storage_trie_node_hash(&self, index: u32) -> anyhow::Result<Option<Felt>> {
+    pub fn storage_trie_node_hash(&self, index: u64) -> anyhow::Result<Option<Felt>> {
         trie::trie_storage::hash(self, index)
     }
 
-    pub fn contract_trie_node_hash(&self, index: u32) -> anyhow::Result<Option<Felt>> {
+    pub fn contract_trie_node_hash(&self, index: u64) -> anyhow::Result<Option<Felt>> {
         trie::trie_contracts::hash(self, index)
     }
 
-    pub fn class_root_index(&self, block: BlockNumber) -> anyhow::Result<Option<u32>> {
+    pub fn class_root_index(&self, block: BlockNumber) -> anyhow::Result<Option<u64>> {
         trie::class_root_index(self, block)
     }
 
-    pub fn storage_root_index(&self, block: BlockNumber) -> anyhow::Result<Option<u32>> {
+    pub fn storage_root_index(&self, block: BlockNumber) -> anyhow::Result<Option<u64>> {
         trie::storage_root_index(self, block)
     }
 
@@ -362,7 +362,7 @@ impl<'inner> Transaction<'inner> {
         &self,
         block: BlockNumber,
         contract: ContractAddress,
-    ) -> anyhow::Result<Option<u32>> {
+    ) -> anyhow::Result<Option<u64>> {
         trie::contract_root_index(self, block, contract)
     }
 
@@ -377,7 +377,7 @@ impl<'inner> Transaction<'inner> {
     pub fn insert_class_root(
         &self,
         block_number: BlockNumber,
-        root: Option<u32>,
+        root: Option<u64>,
     ) -> anyhow::Result<()> {
         trie::insert_class_root(self, block_number, root)
     }
@@ -385,7 +385,7 @@ impl<'inner> Transaction<'inner> {
     pub fn insert_storage_root(
         &self,
         block_number: BlockNumber,
-        root: Option<u32>,
+        root: Option<u64>,
     ) -> anyhow::Result<()> {
         trie::insert_storage_root(self, block_number, root)
     }
@@ -394,7 +394,7 @@ impl<'inner> Transaction<'inner> {
         &self,
         block_number: BlockNumber,
         contract: ContractAddress,
-        root: Option<u32>,
+        root: Option<u64>,
     ) -> anyhow::Result<()> {
         trie::insert_contract_root(self, block_number, contract, root)
     }

--- a/crates/storage/src/params.rs
+++ b/crates/storage/src/params.rs
@@ -88,6 +88,7 @@ to_sql_builtin!(
     i32,
     i16,
     i8,
+    u64,
     u32,
     u16,
     u8


### PR DESCRIPTION
Current node indices are u32 of which 31 bits are already fully used on mainnet. This PR bumps this to u64.

A more correct approach would be using new types which will be attemped in a more robust PR in the following days. This PR is more a bandaid to get a release out sooner.