### PR TITLE
fix(rpc/get_nonce): return zero for nonce of contracts deployed in pending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rare edge case where duplicate blocks caused the sync process to halt due to a `A PRIMARY KEY constraint failed` error.
 - Querying a descync'd feeder gateway causes sync process to end due to missing classes.
 - `starknet_getStorageAt` no longer returns ContractNotFound when querying for non-existent keys for contracts deployed in the pending block.
+- `starknet_getNonce` no longer returns ContractNotFound when querying for nonce of contracts deployed in the pending block.
 
 ### Changed
 

--- a/crates/rpc/src/v02/method/get_nonce.rs
+++ b/crates/rpc/src/v02/method/get_nonce.rs
@@ -223,6 +223,19 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn contract_deployed_in_pending_defaults_to_zero() {
+        let context = RpcContext::for_tests_with_pending().await;
+
+        // This contract is deployed in the pending block but does not have a nonce update.
+        let input = GetNonceInput {
+            block_id: BlockId::Pending,
+            contract_address: contract_address_bytes!(b"pending contract 0 address"),
+        };
+        let nonce = get_nonce(context, input).await.unwrap();
+        assert_eq!(nonce.0, ContractNonce::ZERO);
+    }
+
+    #[tokio::test]
     async fn pending() {
         use super::get_pending_nonce;
         use std::sync::Arc;


### PR DESCRIPTION
Due to a bug in our fallback logic we returned "Contract not found" errors when the contract has been deployed in the pending block.

This PR fixes this by enabling the zero-fallback if the contract has been (re)deployed in the pending block (as opposed to our previous requirement of existing on the latest block).

Closes #1409 