### PR TITLE
fix(rpc): set content-type header to application/json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- RPC server does not set `content-type: application/json`
+
 ## [0.9.1] - 2023-10-11
 
 ### Fixed

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -738,4 +738,35 @@ mod tests {
 
         assert_eq!(res, expected);
     }
+
+    #[tokio::test]
+    async fn response_hash_content_type_json() {
+        fn always_success() -> &'static str {
+            "Success"
+        }
+
+        let router = RpcRouter::builder("vTEST")
+            .register("success", always_success)
+            .build(RpcContext::for_tests());
+
+        let url = spawn_server(router).await;
+
+        let client = reqwest::Client::new();
+        let res = client
+            .post(url.clone())
+            .json(&json!(
+                {"jsonrpc": "2.0", "method": "success", "id": 1}
+            ))
+            .send()
+            .await
+            .unwrap();
+
+        use reqwest::header::CONTENT_TYPE;
+        let content_type = res
+            .headers()
+            .get(CONTENT_TYPE)
+            .expect("content-type header should be set");
+
+        assert_eq!(content_type, "application/json");
+    }
 }

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -170,10 +170,10 @@ pub async fn rpc_handler(
     let mut response = handle(state, body).await.into_response();
 
     use http::header::CONTENT_TYPE;
-    const APPLICATION_JSON: HeaderValue = HeaderValue::from_static("application/json");
+    static APPLICATION_JSON: HeaderValue = HeaderValue::from_static("application/json");
     response
         .headers_mut()
-        .insert(CONTENT_TYPE, APPLICATION_JSON);
+        .insert(CONTENT_TYPE, APPLICATION_JSON.clone());
     response
 }
 


### PR DESCRIPTION
This PR sets the `content-type` header to `application/json`. 

Currently axum defaults it to `content-type: application/octet-stream` which is of course incorrect.

I'm not sure if this is the correct way of handling this - apparently one should respect the `Accept` header of the request? But since this is always json, I don't think we need to check or worry about this?

Fixes #1431 