### PR TITLE
fix(rpc): accept json content with encoding specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- RPC server does not accept `charset=utf-8` in the `Content-Type` header
+
 ## [0.9.2] - 2023-10-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6547,6 +6547,7 @@ dependencies = [
  "hyper",
  "lazy_static",
  "metrics",
+ "mime",
  "pathfinder-common",
  "pathfinder-compiler",
  "pathfinder-ethereum",

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -15,6 +15,7 @@ futures = { workspace = true }
 http = { workspace = true }
 hyper = "0.14.27"
 metrics = { workspace = true }
+mime = "0.3"
 pathfinder-common = { path = "../common" }
 pathfinder-compiler = { path = "../compiler" }
 pathfinder-ethereum = { path = "../ethereum" }

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -2,10 +2,8 @@ use std::collections::HashMap;
 
 use axum::async_trait;
 use axum::extract::State;
-use axum::headers::ContentType;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::TypedHeader;
 use futures::{Future, FutureExt};
 use http::HeaderValue;
 use serde::de::DeserializeOwned;

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -741,7 +741,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn accepts_json_with_charset8() {
+    async fn accepts_json_with_charset_utf8() {
         async fn always_success(_ctx: RpcContext) -> RpcResult {
             Ok(json!("Success"))
         }
@@ -778,7 +778,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn accepts_json_with_charset16() {
+    async fn rejects_json_with_charset_utf16() {
         async fn always_success(_ctx: RpcContext) -> RpcResult {
             Ok(json!("Success"))
         }
@@ -788,8 +788,6 @@ mod tests {
             .build(RpcContext::for_tests());
 
         let url = spawn_server(router).await;
-
-        let expected = json!({"jsonrpc": "2.0", "result": "Success", "id": 1});
 
         let client = reqwest::Client::new();
         let res = client
@@ -807,11 +805,9 @@ mod tests {
             .send()
             .await
             .unwrap()
-            .json::<Value>()
-            .await
-            .unwrap();
+            .status();
 
-        assert_eq!(res, expected);
+        assert_eq!(res, reqwest::StatusCode::UNSUPPORTED_MEDIA_TYPE);
     }
 
     #[tokio::test]

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -116,10 +116,10 @@ pub async fn rpc_handler(
     body: axum::body::Bytes,
 ) -> impl axum::response::IntoResponse {
     // Only json content allowed.
-    if content_type != ContentType::json() {
-        if &content_type.to_string() != "application/json; charset=utf-8" {
-            return StatusCode::UNSUPPORTED_MEDIA_TYPE.into_response();
-        }
+    if content_type != ContentType::json()
+        && content_type.to_string().as_str() != "application/json; charset=utf-8"
+    {
+        return StatusCode::UNSUPPORTED_MEDIA_TYPE.into_response();
     }
 
     #[inline]

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -745,9 +745,9 @@ mod tests {
             .send()
             .await
             .unwrap()
-        .json::<Value>()
-        .await
-        .unwrap();
+            .json::<Value>()
+            .await
+            .unwrap();
 
         assert_eq!(res, expected);
     }


### PR DESCRIPTION
This PR allows for `content-type: application/json; charset=utf-8` for RPC requests.

Previously only `content-type: application/json` was allowed. It seems the spec for this is quite unofficial and is separated in multiple locations.

From what I could piece together it seems json itself defaults to utf-8 if not specified, but allows other utf-X encodings in theory.

This PR only whitelists utf-8 because that's what the internal parsing assumes. We can in theory attempt to support other utf encodings but I don't think that's really worth trying.