### PR TITLE
feat(rpc/0.5): add tracing methods

### DIFF
--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use blockifier::execution::call_info::OrderedL2ToL1Message;
 use pathfinder_common::ContractAddress;
 use stark_hash::Felt;
+use starknet_gateway_types::reply::state_update::StateDiff;
 
 use super::felt::IntoFelt;
 
@@ -34,10 +35,28 @@ pub enum TransactionTrace {
     L1Handler(L1HandlerTransactionTrace),
 }
 
+impl TransactionTrace {
+    pub fn clear_state_diff(&mut self) {
+        match self {
+            Self::Declare(declare) => {
+                declare.state_diff = None;
+            }
+            Self::DeployAccount(deploy) => {
+                deploy.state_diff = None;
+            }
+            Self::Invoke(invoke) => {
+                invoke.state_diff = None;
+            }
+            _ => (),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct DeclareTransactionTrace {
     pub validate_invocation: Option<FunctionInvocation>,
     pub fee_transfer_invocation: Option<FunctionInvocation>,
+    pub state_diff: Option<StateDiff>,
 }
 
 #[derive(Debug)]
@@ -45,6 +64,7 @@ pub struct DeployAccountTransactionTrace {
     pub validate_invocation: Option<FunctionInvocation>,
     pub constructor_invocation: Option<FunctionInvocation>,
     pub fee_transfer_invocation: Option<FunctionInvocation>,
+    pub state_diff: Option<StateDiff>,
 }
 
 #[derive(Debug)]
@@ -58,6 +78,7 @@ pub struct InvokeTransactionTrace {
     pub validate_invocation: Option<FunctionInvocation>,
     pub execute_invocation: ExecuteInvocation,
     pub fee_transfer_invocation: Option<FunctionInvocation>,
+    pub state_diff: Option<StateDiff>,
 }
 
 #[derive(Debug)]

--- a/crates/rpc/src/v03/method.rs
+++ b/crates/rpc/src/v03/method.rs
@@ -1,7 +1,7 @@
 pub(crate) mod estimate_fee;
 pub(crate) mod estimate_message_fee;
 mod get_events;
-mod get_state_update;
+pub(crate) mod get_state_update;
 pub(crate) mod simulate_transaction;
 
 pub(crate) use estimate_fee::estimate_fee;

--- a/crates/rpc/src/v03/method/get_state_update.rs
+++ b/crates/rpc/src/v03/method/get_state_update.rs
@@ -61,7 +61,7 @@ fn get_state_update_from_storage(
     Ok(state_update.into())
 }
 
-mod types {
+pub mod types {
     use crate::felt::{RpcFelt, RpcFelt251};
     use pathfinder_common::state_update::ContractClassUpdate;
     use pathfinder_common::{

--- a/crates/rpc/src/v04/method.rs
+++ b/crates/rpc/src/v04/method.rs
@@ -21,7 +21,7 @@ pub(crate) use get_transaction_by_block_and_index::get_transaction_by_block_id_a
 pub(crate) use get_transaction_by_hash::get_transaction_by_hash;
 pub(super) use get_transaction_receipt::get_transaction_receipt;
 pub(super) use pending_transactions::pending_transactions;
-pub(super) use simulate_transactions::simulate_transactions;
+pub(crate) use simulate_transactions::simulate_transactions;
 pub(crate) use syncing::syncing;
-pub(super) use trace_block_transactions::trace_block_transactions;
-pub(super) use trace_transaction::trace_transaction;
+pub(crate) use trace_block_transactions::trace_block_transactions;
+pub(crate) use trace_transaction::trace_transaction;

--- a/crates/rpc/src/v05.rs
+++ b/crates/rpc/src/v05.rs
@@ -29,6 +29,10 @@ pub fn register_routes() -> RpcRouterBuilder {
         .register("starknet_getTransactionByHash"            , v04_method::get_transaction_by_hash)
         .register("starknet_syncing"                         , v04_method::syncing)
 
+        .register("starknet_simulateTransactions"            , v04_method::simulate_transactions)
+        .register("starknet_traceTransaction"                , v04_method::trace_transaction)
+        .register("starknet_traceBlockTransactions"          , v04_method::trace_block_transactions)
+
         .register("starknet_specVersion"                     , method::spec_version)
 
         .register("pathfinder_getProof"                      , crate::pathfinder::methods::get_proof)


### PR DESCRIPTION
Closes https://github.com/eqlabs/pathfinder/issues/1398

Add RPC API v0.5 methods:
- `starknet_simulateTransactions`
- `starknet_traceTransaction`
- `starknet_traceBlockTransactions`

TODO:
- [x] impl `map_state_diff`
- [ ] clear `state_diff` in RPC v0.4
- [ ] `block_id` instead of `block_hash` in RPC v0.5 `starknet_traceBlockTransactions`
- [ ] add respective changelog entry