### PR TITLE
fix(executor): downgrade cairo-vm to 0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,7 +901,7 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 [[package]]
 name = "blockifier"
 version = "0.2.0-rc0"
-source = "git+https://github.com/eqlabs/blockifier?rev=60f5166d3de33870d0c6462908a02a21572a3929#60f5166d3de33870d0c6462908a02a21572a3929"
+source = "git+https://github.com/starkware-libs/blockifier?rev=ebf48c445b965c5c55b8c724338be7c6e21ffdd4#ebf48c445b965c5c55b8c724338be7c6e21ffdd4"
 dependencies = [
  "ark-ec",
  "ark-ff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2662,9 +2662,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm"
-version = "0.8.7"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00d9bf139b0fe845627cf09d11af43eec9575dba702033bf6b08050c776b8553"
+checksum = "656c25c13b6ffcc75e081292f3c23f27e429b3d4b8d69ecdc327a441798e91f4"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ base64 = "0.13.1"
 bitvec = "1.0.1"
 blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "ebf48c445b965c5c55b8c724338be7c6e21ffdd4" }
 bytes = "1.4.0"
+# This one needs to match the version used by blockifier
+cairo-vm = "=0.8.2"
 clap = "4.1.13"
 const_format = "0.2.31"
 criterion = "0.5.1"
@@ -65,7 +67,7 @@ serde_json = "1.0.105"
 serde_with = "3.0.0"
 sha3 = "0.10"
 # This one needs to match the version used by blockifier
-starknet_api = "0.4.1"
+starknet_api = "=0.4.1"
 thiserror = "1.0.48"
 tokio = "1.29.1"
 tracing = "0.1.37"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ async-trait = "0.1.73"
 axum = { version = "0.6.19", features = ["macros"] }
 base64 = "0.13.1"
 bitvec = "1.0.1"
-blockifier = { git = "https://github.com/eqlabs/blockifier", rev = "60f5166d3de33870d0c6462908a02a21572a3929" }
+blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "ebf48c445b965c5c55b8c724338be7c6e21ffdd4" }
 bytes = "1.4.0"
 clap = "4.1.13"
 const_format = "0.2.31"

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 anyhow = { workspace = true }
 blockifier = { workspace = true }
 cached = "0.44.0"
-cairo-vm = "0.8.7"
+cairo-vm = { workspace = true }
 lazy_static = { workspace = true }
 pathfinder-common = { path = "../common" }
 pathfinder-storage = { path = "../storage" }

--- a/crates/executor/src/block_context.rs
+++ b/crates/executor/src/block_context.rs
@@ -43,7 +43,7 @@ pub(super) fn construct_block_context(
         gas_price: execution_state.gas_price.as_u128(),
         invoke_tx_max_n_steps: 1_000_000,
         validate_max_n_steps: 1_000_000,
-        max_recursion_depth: 15,
+        max_recursion_depth: 50,
     })
 }
 

--- a/crates/executor/src/block_context.rs
+++ b/crates/executor/src/block_context.rs
@@ -43,7 +43,7 @@ pub(super) fn construct_block_context(
         gas_price: execution_state.gas_price.as_u128(),
         invoke_tx_max_n_steps: 1_000_000,
         validate_max_n_steps: 1_000_000,
-        max_recursion_depth: 50,
+        max_recursion_depth: 15,
     })
 }
 


### PR DESCRIPTION
cairo-vm 0.8.7 turns out to be incompatible with 0.8.2 which causes issues when producing a traceback for recursive calls.

This change downgrades cairo-vm to 0.8.2.