### PR TITLE
feat(rpc/v05): add `starknet_getTransactionStatus` implementation

### DIFF
--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -60,7 +60,7 @@ pub trait GatewayApi: Sync {
     async fn transaction(
         &self,
         transaction_hash: TransactionHash,
-    ) -> Result<reply::Transaction, SequencerError> {
+    ) -> Result<reply::TransactionStatus, SequencerError> {
         unimplemented!();
     }
 
@@ -183,7 +183,7 @@ impl<T: GatewayApi + Sync + Send> GatewayApi for std::sync::Arc<T> {
     async fn transaction(
         &self,
         transaction_hash: TransactionHash,
-    ) -> Result<reply::Transaction, SequencerError> {
+    ) -> Result<reply::TransactionStatus, SequencerError> {
         self.as_ref().transaction(transaction_hash).await
     }
 
@@ -481,7 +481,7 @@ impl GatewayApi for Client {
     async fn transaction(
         &self,
         transaction_hash: TransactionHash,
-    ) -> Result<reply::Transaction, SequencerError> {
+    ) -> Result<reply::TransactionStatus, SequencerError> {
         self.feeder_gateway_request()
             .get_transaction()
             .with_transaction_hash(transaction_hash)
@@ -1055,7 +1055,7 @@ mod tests {
         }
     }
 
-    mod transaction {
+    mod transaction_status {
         use super::{reply::Status, *};
         use pretty_assertions::assert_eq;
 
@@ -1120,7 +1120,10 @@ mod tests {
                     "/feeder_gateway/get_transaction?transactionHash={}",
                     INVALID_TX_HASH.0.to_hex_str()
                 ),
-                (r#"{"status": "NOT_RECEIVED"}"#, 200),
+                (
+                    r#"{"status": "NOT_RECEIVED", "finality_status": "NOT_RECEIVED"}"#,
+                    200,
+                ),
             )]);
             assert_eq!(
                 client.transaction(INVALID_TX_HASH).await.unwrap().status,

--- a/crates/gateway-test-fixtures/fixtures/0.9.0/txn/declare.json
+++ b/crates/gateway-test-fixtures/fixtures/0.9.0/txn/declare.json
@@ -1,16 +1,18 @@
 {
+    "execution_status": "SUCCEEDED",
+    "finality_status": "ACCEPTED_ON_L1",
     "status": "ACCEPTED_ON_L1",
     "block_hash": "0x40ffdbd9abbc4fc64652c50db94a29bce65c183316f304a95df624de708e746",
     "block_number": 231579,
     "transaction_index": 30,
     "transaction": {
+        "transaction_hash": "0x6d346ba207eb124355960c19c737698ad37a3c920a588b741e0130ff5bd4d6d",
+        "version": "0x0",
+        "max_fee": "0x0",
+        "signature": [],
+        "nonce": "0x0",
         "class_hash": "0x71e6ef53e53e6f5ca792fc4a5799a33e6f4118e4fd1d948dca3a371506f0cc7",
         "sender_address": "0x1",
-        "nonce": "0x0",
-        "max_fee": "0x0",
-        "version": "0x0",
-        "transaction_hash": "0x6d346ba207eb124355960c19c737698ad37a3c920a588b741e0130ff5bd4d6d",
-        "signature": [],
         "type": "DECLARE"
     }
 }

--- a/crates/gateway-test-fixtures/fixtures/0.9.0/txn/deploy.json
+++ b/crates/gateway-test-fixtures/fixtures/0.9.0/txn/deploy.json
@@ -1,9 +1,13 @@
 {
+    "execution_status": "SUCCEEDED",
+    "finality_status": "ACCEPTED_ON_L1",
     "status": "ACCEPTED_ON_L1",
     "block_hash": "0x40ffdbd9abbc4fc64652c50db94a29bce65c183316f304a95df624de708e746",
     "block_number": 231579,
     "transaction_index": 8,
     "transaction": {
+        "transaction_hash": "0x3d7623443283d9a0cec946492db78b06d57642a551745ddfac8d3f1f4fcc2a8",
+        "version": "0x0",
         "contract_address": "0x54c6883e459baeac4a9052ee109b86b9f81adbcdcb1f65a05dceec4c34d5cf9",
         "contract_address_salt": "0x655a594122f68f5e821834e606e1243b249a88555fac2d548f7acbee7863f62",
         "class_hash": "0x3523d31a077d891b4d888f9d3c7d33bdac2c0a06f89c08307a7f7b68f681c98",
@@ -11,7 +15,6 @@
             "0x734d2849eb47e10c59e5a433d425675849cb37338b1d7c4c4afb1e0ca42133",
             "0xffad0128dbd859ef97a246a2d2c00680dedc8d850ff9b6ebcc8b94ee9625bb"
         ],
-        "transaction_hash": "0x3d7623443283d9a0cec946492db78b06d57642a551745ddfac8d3f1f4fcc2a8",
         "type": "DEPLOY"
     }
 }

--- a/crates/gateway-test-fixtures/fixtures/0.9.0/txn/invoke.json
+++ b/crates/gateway-test-fixtures/fixtures/0.9.0/txn/invoke.json
@@ -1,12 +1,19 @@
 {
+    "execution_status": "SUCCEEDED",
+    "finality_status": "ACCEPTED_ON_L1",
     "status": "ACCEPTED_ON_L1",
     "block_hash": "0x40ffdbd9abbc4fc64652c50db94a29bce65c183316f304a95df624de708e746",
     "block_number": 231579,
     "transaction_index": 0,
     "transaction": {
-        "contract_address": "0x7463cdd01f6e6a4f13084ea9eee170298b0bbe3faa17f46924c85bb284d4c98",
+        "transaction_hash": "0x587d93f2339b7f2beda040187dbfcb9e076ce4a21eb8d15ae64819718817fbe",
+        "version": "0x0",
+        "max_fee": "0x1ee7b2b881350",
+        "signature": [
+            "0x6e82c6752bd13e29b68cf0c8b0d4eb9133b5a056336a842bff01756e514d04a",
+            "0xa87f00c9e39fd0711aaea4edae0f00044384188a87f489170ac383e3ad087f"
+        ],
         "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
-        "entry_point_type": "EXTERNAL",
         "calldata": [
             "0x3",
             "0x72df4dc5b6c4df72e4288857317caf2ce9da166ab8719ab8306516a2fddfff7",
@@ -40,12 +47,7 @@
             "0x0",
             "0x17"
         ],
-        "signature": [
-            "0x6e82c6752bd13e29b68cf0c8b0d4eb9133b5a056336a842bff01756e514d04a",
-            "0xa87f00c9e39fd0711aaea4edae0f00044384188a87f489170ac383e3ad087f"
-        ],
-        "transaction_hash": "0x587d93f2339b7f2beda040187dbfcb9e076ce4a21eb8d15ae64819718817fbe",
-        "max_fee": "0x1ee7b2b881350",
+        "contract_address": "0x7463cdd01f6e6a4f13084ea9eee170298b0bbe3faa17f46924c85bb284d4c98",
         "type": "INVOKE_FUNCTION"
     }
 }

--- a/crates/gateway-test-fixtures/fixtures/0.9.0/txn/status.json
+++ b/crates/gateway-test-fixtures/fixtures/0.9.0/txn/status.json
@@ -1,4 +1,0 @@
-{
-    "tx_status": "ACCEPTED_ON_L1",
-    "block_hash": "0x39a1c02cb636bbcb8758b9a03dc3139b5b923ef7fbf7ddef6c8eca058236dd0"
-}

--- a/crates/gateway-test-fixtures/src/lib.rs
+++ b/crates/gateway-test-fixtures/src/lib.rs
@@ -42,7 +42,6 @@ pub mod v0_9_0 {
         pub const DECLARE: &str = str_fixture!("0.9.0/txn/declare.json");
         pub const DEPLOY: &str = str_fixture!("0.9.0/txn/deploy.json");
         pub const INVOKE: &str = str_fixture!("0.9.0/txn/invoke.json");
-        pub const STATUS: &str = str_fixture!("0.9.0/txn/status.json");
     }
 }
 

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -162,7 +162,7 @@ pub mod call {
 /// feeder gateway.
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
-pub struct Transaction {
+pub struct TransactionStatus {
     pub status: Status,
     pub finality_status: transaction_status::FinalityStatus,
     #[serde(default)]

--- a/crates/pathfinder/src/p2p_network/client.rs
+++ b/crates/pathfinder/src/p2p_network/client.rs
@@ -302,7 +302,7 @@ impl GatewayApi for HybridClient {
     async fn transaction(
         &self,
         transaction_hash: TransactionHash,
-    ) -> Result<reply::Transaction, SequencerError> {
+    ) -> Result<reply::TransactionStatus, SequencerError> {
         self.as_sequencer().transaction(transaction_hash).await
     }
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -828,7 +828,7 @@ mod tests {
     #[case::root_pathfinder("/", "pathfinder_rpc_api.json", &["pathfinder_version"])]
 
     #[case::v05_api  ("/rpc/v0.5", "v05/starknet_api_openrpc.json",       
-        &["starknet_getTransactionStatus", "starknet_getTransactionReceipt"])]
+        &["starknet_getTransactionReceipt"])]
     #[case::v05_trace("/rpc/v0.5", "v05/starknet_trace_api_openrpc.json", 
         &["starknet_traceTransaction","starknet_simulateTransactions", "starknet_traceBlockTransactions"])]
     #[case::v05_write("/rpc/v0.5", "v05/starknet_write_api.json",         &[])]

--- a/crates/rpc/src/v05.rs
+++ b/crates/rpc/src/v05.rs
@@ -35,6 +35,7 @@ pub fn register_routes() -> RpcRouterBuilder {
 
         .register("starknet_getBlockWithTxHashes"            , method::get_block_with_tx_hashes)
         .register("starknet_getBlockWithTxs"                 , method::get_block_with_txs)
+        .register("starknet_getTransactionStatus"            , method::get_transaction_status)
         .register("starknet_specVersion"                     , method::spec_version)
 
         .register("pathfinder_getProof"                      , crate::pathfinder::methods::get_proof)

--- a/crates/rpc/src/v05/method.rs
+++ b/crates/rpc/src/v05/method.rs
@@ -1,7 +1,9 @@
 mod get_block_with_tx_hashes;
 mod get_block_with_txs;
+mod get_transaction_status;
 mod spec_version;
 
 pub(crate) use get_block_with_tx_hashes::get_block_with_tx_hashes;
 pub(crate) use get_block_with_txs::get_block_with_txs;
+pub(crate) use get_transaction_status::get_transaction_status;
 pub(crate) use spec_version::spec_version;

--- a/crates/rpc/src/v05/method/get_transaction_status.rs
+++ b/crates/rpc/src/v05/method/get_transaction_status.rs
@@ -1,0 +1,290 @@
+use anyhow::Context;
+use pathfinder_common::TransactionHash;
+use serde_with::skip_serializing_none;
+use starknet_gateway_types::pending::PendingData;
+
+use crate::context::RpcContext;
+
+#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+pub struct GetTransactionStatusInput {
+    transaction_hash: TransactionHash,
+}
+
+#[derive(serde::Serialize, Debug, PartialEq, Eq)]
+#[skip_serializing_none]
+pub struct GetTransactionStatusOutput {
+    finality_status: FinalityStatus,
+    /// Not present for received or rejected transactions.
+    execution_status: Option<ExecutionStatus>,
+}
+
+#[derive(Copy, Clone, Debug, serde::Serialize, PartialEq, Eq)]
+pub enum FinalityStatus {
+    #[serde(rename = "RECEIVED")]
+    Received,
+    #[serde(rename = "REJECTED")]
+    Rejected,
+    #[serde(rename = "ACCEPTED_ON_L1")]
+    AcceptedOnL1,
+    #[serde(rename = "ACCEPTED_ON_L2")]
+    AcceptedOnL2,
+}
+
+impl TryFrom<starknet_gateway_types::reply::transaction_status::FinalityStatus> for FinalityStatus {
+    type Error = anyhow::Error;
+
+    fn try_from(
+        value: starknet_gateway_types::reply::transaction_status::FinalityStatus,
+    ) -> Result<Self, Self::Error> {
+        use starknet_gateway_types::reply::transaction_status::FinalityStatus;
+        match value {
+            FinalityStatus::NotReceived => {
+                Err(anyhow::anyhow!("Transaction not received by the gateway"))
+            }
+            FinalityStatus::Received => Ok(Self::Received),
+            FinalityStatus::AcceptedOnL1 => Ok(Self::AcceptedOnL1),
+            FinalityStatus::AcceptedOnL2 => Ok(Self::AcceptedOnL2),
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Serialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ExecutionStatus {
+    Succeeded,
+    Reverted,
+}
+
+// Conversion for status from receipts.
+impl From<starknet_gateway_types::reply::transaction::ExecutionStatus> for ExecutionStatus {
+    fn from(value: starknet_gateway_types::reply::transaction::ExecutionStatus) -> Self {
+        use starknet_gateway_types::reply::transaction::ExecutionStatus;
+        match value {
+            ExecutionStatus::Succeeded => Self::Succeeded,
+            ExecutionStatus::Reverted => Self::Reverted,
+        }
+    }
+}
+
+crate::error::generate_rpc_error_subset!(GetTransactionStatusError: TxnHashNotFoundV04);
+
+pub async fn get_transaction_status(
+    context: RpcContext,
+    input: GetTransactionStatusInput,
+) -> Result<GetTransactionStatusOutput, GetTransactionStatusError> {
+    // Check in pending block.
+    if let Some(pending) = &context.pending_data {
+        if let Some(status) = pending_status(pending, &input.transaction_hash).await {
+            return Ok(status);
+        }
+    }
+
+    // Check database.
+    let span = tracing::Span::current();
+
+    let db_status = tokio::task::spawn_blocking(move || {
+        let _g = span.enter();
+
+        let mut db = context
+            .storage
+            .connection()
+            .context("Opening database connection")?;
+        let db_tx = db.transaction().context("Creating database transaction")?;
+
+        let Some((_, receipt, block_hash)) = db_tx
+            .transaction_with_receipt(input.transaction_hash)
+            .context("Fetching receipt from database")?
+        else {
+            return anyhow::Ok(None);
+        };
+
+        let l1_accepted = db_tx
+            .block_is_l1_accepted(block_hash.into())
+            .context("Quering block's status")?;
+
+        let finality_status = if l1_accepted {
+            FinalityStatus::AcceptedOnL1
+        } else {
+            FinalityStatus::AcceptedOnL2
+        };
+
+        Ok(Some(GetTransactionStatusOutput {
+            finality_status,
+            execution_status: Some(receipt.execution_status.into()),
+        }))
+    })
+    .await
+    .context("Joining database task")??;
+
+    if let Some(db_status) = db_status {
+        return Ok(db_status);
+    }
+
+    // Check gateway for rejected transactions.
+    use starknet_gateway_client::GatewayApi;
+    context
+        .sequencer
+        .transaction(input.transaction_hash)
+        .await
+        .context("Fetching transaction from gateway")
+        .and_then(|tx| {
+            use starknet_gateway_types::reply::transaction_status::FinalityStatus as GatewayFinalityStatus;
+            use starknet_gateway_types::reply::transaction_status::ExecutionStatus as GatewayExecutionStatus;
+
+            match (tx.finality_status, tx.execution_status) {
+                (_, GatewayExecutionStatus::Rejected) => Ok(GetTransactionStatusOutput {
+                    finality_status: FinalityStatus::Rejected,
+                    execution_status: None,
+                }),
+                (GatewayFinalityStatus::Received, _) => Ok(GetTransactionStatusOutput {
+                    finality_status: FinalityStatus::Received,
+                    execution_status: None,
+                }),
+                (finality_status, GatewayExecutionStatus::Reverted) => Ok(GetTransactionStatusOutput {
+                    finality_status: finality_status.try_into()?,
+                    execution_status: Some(ExecutionStatus::Reverted),
+                }),
+                (finality_status, GatewayExecutionStatus::Succeeded) => Ok(GetTransactionStatusOutput {
+                    finality_status: finality_status.try_into()?,
+                    execution_status: Some(ExecutionStatus::Succeeded),
+                }),
+            }
+        })
+        .map_err(|_| GetTransactionStatusError::TxnHashNotFoundV04)
+}
+
+async fn pending_status(
+    pending: &PendingData,
+    tx_hash: &TransactionHash,
+) -> Option<GetTransactionStatusOutput> {
+    pending
+        .block()
+        .await
+        .map(|block| {
+            block.transaction_receipts.iter().find_map(|rx| {
+                if &rx.transaction_hash == tx_hash {
+                    Some(GetTransactionStatusOutput {
+                        finality_status: FinalityStatus::AcceptedOnL2,
+                        execution_status: Some(rx.execution_status.clone().into()),
+                    })
+                } else {
+                    None
+                }
+            })
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+
+    use pathfinder_common::macro_prelude::*;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn l1_accepted() {
+        let context = RpcContext::for_tests();
+        // This transaction is in block 0 which is L1 accepted.
+        let tx_hash = transaction_hash_bytes!(b"txn 0");
+        let input = GetTransactionStatusInput {
+            transaction_hash: tx_hash,
+        };
+        let status = get_transaction_status(context, input).await.unwrap();
+
+        assert_eq!(
+            status,
+            GetTransactionStatusOutput {
+                finality_status: FinalityStatus::AcceptedOnL1,
+                execution_status: Some(ExecutionStatus::Succeeded)
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn l2_accepted() {
+        let context = RpcContext::for_tests();
+        // This transaction is in block 1 which is not L1 accepted.
+        let tx_hash = transaction_hash_bytes!(b"txn 1");
+        let input = GetTransactionStatusInput {
+            transaction_hash: tx_hash,
+        };
+        let status = get_transaction_status(context, input).await.unwrap();
+
+        assert_eq!(
+            status,
+            GetTransactionStatusOutput {
+                finality_status: FinalityStatus::AcceptedOnL2,
+                execution_status: Some(ExecutionStatus::Succeeded)
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn pending() {
+        let context = RpcContext::for_tests_with_pending().await;
+        let tx_hash = transaction_hash_bytes!(b"pending tx hash 0");
+        let input = GetTransactionStatusInput {
+            transaction_hash: tx_hash,
+        };
+        let status = get_transaction_status(context, input).await.unwrap();
+
+        assert_eq!(
+            status,
+            GetTransactionStatusOutput {
+                finality_status: FinalityStatus::AcceptedOnL2,
+                execution_status: Some(ExecutionStatus::Succeeded)
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn rejected() {
+        let input = GetTransactionStatusInput {
+            // Transaction hash known to be rejected by the testnet gateway.
+            transaction_hash: transaction_hash!(
+                "0x07c64b747bdb0831e7045925625bfa6309c422fded9527bacca91199a1c8d212"
+            ),
+        };
+        let context = RpcContext::for_tests();
+        let status = get_transaction_status(context, input).await.unwrap();
+
+        assert_eq!(
+            status,
+            GetTransactionStatusOutput {
+                finality_status: FinalityStatus::Rejected,
+                execution_status: None,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn reverted() {
+        let context = RpcContext::for_tests_with_pending().await;
+        let input = GetTransactionStatusInput {
+            transaction_hash: transaction_hash_bytes!(b"txn reverted"),
+        };
+        let status = get_transaction_status(context.clone(), input)
+            .await
+            .unwrap();
+        assert_eq!(
+            status,
+            GetTransactionStatusOutput {
+                finality_status: FinalityStatus::AcceptedOnL2,
+                execution_status: Some(ExecutionStatus::Reverted),
+            }
+        );
+
+        let input = GetTransactionStatusInput {
+            transaction_hash: transaction_hash_bytes!(b"pending reverted"),
+        };
+        let status = get_transaction_status(context, input).await.unwrap();
+        assert_eq!(
+            status,
+            GetTransactionStatusOutput {
+                finality_status: FinalityStatus::AcceptedOnL2,
+                execution_status: Some(ExecutionStatus::Reverted),
+            }
+        );
+    }
+}


### PR DESCRIPTION
This PR adds an implementation for `starknet_getTransactionStatus`.

Implementation is mostly straightforward, except for the mapping of responses from the feeder gateway where there's a slight difference in representation of `REJECTED` and `RECEIVED` transactions.

In the JSON-RPC specification `REJECTED` transactions are represented with `finality_status: "REJECTED"` and no `execution_status` whereas on the feeder gateway they are `finality_status: "RECEIVED"` and `execution_status: "REJECTED"`.

For JSON-RPC there's no `execution_status` for `RECEIVED` / `REJECTED` transactions.

Closes issue #1440