### PR TITLE
feat(rpc/v0.5): support execution methods

### DIFF
--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -916,6 +916,7 @@ mod tests {
     #[case::v05_starknet_blockHashAndNumber("/rpc/v0.5", "starknet_blockHashAndNumber")]
     #[case::v05_starknet_blockNumber("/rpc/v0.5", "starknet_blockNumber")]
     #[case::v05_starknet_call("/rpc/v0.5", "starknet_call")]
+    #[case::v05_starknet_estimateFee("/rpc/v0.5", "starknet_estimateFee")]
     #[case::v05_starknet_getBlockTransactionCount("/rpc/v0.5", "starknet_getBlockTransactionCount")]
     #[case::v05_starknet_getBlockWithTxHashes("/rpc/v0.5", "starknet_getBlockWithTxHashes")]
     #[case::v05_starknet_getBlockWithTxs("/rpc/v0.5", "starknet_getBlockWithTxs")]

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -917,6 +917,7 @@ mod tests {
     #[case::v05_starknet_blockNumber("/rpc/v0.5", "starknet_blockNumber")]
     #[case::v05_starknet_call("/rpc/v0.5", "starknet_call")]
     #[case::v05_starknet_estimateFee("/rpc/v0.5", "starknet_estimateFee")]
+    #[case::v05_starknet_estimateMessageFee("/rpc/v0.5", "starknet_estimateMessageFee")]
     #[case::v05_starknet_getBlockTransactionCount("/rpc/v0.5", "starknet_getBlockTransactionCount")]
     #[case::v05_starknet_getBlockWithTxHashes("/rpc/v0.5", "starknet_getBlockWithTxHashes")]
     #[case::v05_starknet_getBlockWithTxs("/rpc/v0.5", "starknet_getBlockWithTxs")]

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -915,6 +915,7 @@ mod tests {
     #[case::v05_starknet_addInvokeTransaction("/rpc/v0.5", "starknet_addInvokeTransaction")]
     #[case::v05_starknet_blockHashAndNumber("/rpc/v0.5", "starknet_blockHashAndNumber")]
     #[case::v05_starknet_blockNumber("/rpc/v0.5", "starknet_blockNumber")]
+    #[case::v05_starknet_call("/rpc/v0.5", "starknet_call")]
     #[case::v05_starknet_getBlockTransactionCount("/rpc/v0.5", "starknet_getBlockTransactionCount")]
     #[case::v05_starknet_getBlockWithTxHashes("/rpc/v0.5", "starknet_getBlockWithTxHashes")]
     #[case::v05_starknet_getBlockWithTxs("/rpc/v0.5", "starknet_getBlockWithTxs")]

--- a/crates/rpc/src/v04/method.rs
+++ b/crates/rpc/src/v04/method.rs
@@ -15,7 +15,7 @@ mod trace_transaction;
 pub(crate) use add_declare_transaction::add_declare_transaction;
 pub(crate) use add_deploy_account_transaction::add_deploy_account_transaction;
 pub(crate) use add_invoke_transaction::add_invoke_transaction;
-pub(super) use estimate_message_fee::estimate_message_fee;
+pub(crate) use estimate_message_fee::estimate_message_fee;
 pub(super) use get_block_with_txs::get_block_with_txs;
 pub(crate) use get_transaction_by_block_and_index::get_transaction_by_block_id_and_index;
 pub(crate) use get_transaction_by_hash::get_transaction_by_hash;

--- a/crates/rpc/src/v05.rs
+++ b/crates/rpc/src/v05.rs
@@ -15,14 +15,13 @@ pub fn register_routes() -> RpcRouterBuilder {
         .register("starknet_call"                            , v02_method::call)
         .register("starknet_chainId"                         , v02_method::chain_id)
         .register("starknet_getBlockTransactionCount"        , v02_method::get_block_transaction_count)
-        .register("starknet_getBlockWithTxHashes"            , method::get_block_with_tx_hashes)
-        .register("starknet_getBlockWithTxs"                 , method::get_block_with_txs)
         .register("starknet_getClass"                        , v02_method::get_class)
         .register("starknet_getClassAt"                      , v02_method::get_class_at)
         .register("starknet_getClassHashAt"                  , v02_method::get_class_hash_at)
         .register("starknet_getNonce"                        , v02_method::get_nonce)
         .register("starknet_getStorageAt"                    , v02_method::get_storage_at)
         
+        .register("starknet_estimateFee"                     , v03_method::estimate_fee)
         .register("starknet_getEvents"                       , v03_method::get_events)
         .register("starknet_getStateUpdate"                  , v03_method::get_state_update)
 
@@ -33,6 +32,8 @@ pub fn register_routes() -> RpcRouterBuilder {
         .register("starknet_getTransactionByHash"            , v04_method::get_transaction_by_hash)
         .register("starknet_syncing"                         , v04_method::syncing)
 
+        .register("starknet_getBlockWithTxHashes"            , method::get_block_with_tx_hashes)
+        .register("starknet_getBlockWithTxs"                 , method::get_block_with_txs)
         .register("starknet_specVersion"                     , method::spec_version)
 
         .register("pathfinder_getProof"                      , crate::pathfinder::methods::get_proof)

--- a/crates/rpc/src/v05.rs
+++ b/crates/rpc/src/v05.rs
@@ -28,6 +28,7 @@ pub fn register_routes() -> RpcRouterBuilder {
         .register("starknet_addDeclareTransaction"           , v04_method::add_declare_transaction)
         .register("starknet_addDeployAccountTransaction"     , v04_method::add_deploy_account_transaction)
         .register("starknet_addInvokeTransaction"            , v04_method::add_invoke_transaction)
+        .register("starknet_estimateMessageFee"              , v04_method::estimate_message_fee)
         .register("starknet_getTransactionByBlockIdAndIndex" , v04_method::get_transaction_by_block_id_and_index)
         .register("starknet_getTransactionByHash"            , v04_method::get_transaction_by_hash)
         .register("starknet_syncing"                         , v04_method::syncing)

--- a/crates/rpc/src/v05.rs
+++ b/crates/rpc/src/v05.rs
@@ -12,6 +12,7 @@ pub fn register_routes() -> RpcRouterBuilder {
     RpcRouter::builder("v0.5")
         .register("starknet_blockHashAndNumber"              , v02_method::block_hash_and_number)
         .register("starknet_blockNumber"                     , v02_method::block_number)
+        .register("starknet_call"                            , v02_method::call)
         .register("starknet_chainId"                         , v02_method::chain_id)
         .register("starknet_getBlockTransactionCount"        , v02_method::get_block_transaction_count)
         .register("starknet_getBlockWithTxHashes"            , method::get_block_with_tx_hashes)


### PR DESCRIPTION
Closes #1442, closes #1443 and closes #1444.

There were no changes in any of these from v0.4. The specification types got juggled around a bit, but ended up identical to what we already had before.

In addition, `starknet_estimateFee` still accepts Declare v0 since these were re-activated on mainnet and it seems like a bad idea to disable this.
