### PR TITLE
fix: incorrect trace field name

### DIFF
--- a/crates/rpc/src/v03/method/simulate_transaction.rs
+++ b/crates/rpc/src/v03/method/simulate_transaction.rs
@@ -319,7 +319,7 @@ pub(crate) mod dto {
         Empty,
         FunctionInvocation(FunctionInvocation),
         RevertedReason {
-            reverted_reason: String,
+            revert_reason: String,
         },
     }
 
@@ -346,8 +346,8 @@ pub(crate) mod dto {
                         ExecuteInvocation::Empty
                     }
                     pathfinder_executor::types::ExecuteInvocation::RevertedReason(
-                        reverted_reason,
-                    ) => ExecuteInvocation::RevertedReason { reverted_reason },
+                        revert_reason,
+                    ) => ExecuteInvocation::RevertedReason { revert_reason },
                 },
                 fee_transfer_invocation: trace.fee_transfer_invocation.map(Into::into),
             }

--- a/crates/rpc/src/v04/method/simulate_transactions.rs
+++ b/crates/rpc/src/v04/method/simulate_transactions.rs
@@ -330,7 +330,7 @@ pub mod dto {
         Empty,
         FunctionInvocation(FunctionInvocation),
         RevertedReason {
-            reverted_reason: String,
+            revert_reason: String,
         },
     }
 
@@ -357,8 +357,8 @@ pub mod dto {
                         ExecuteInvocation::Empty
                     }
                     pathfinder_executor::types::ExecuteInvocation::RevertedReason(
-                        reverted_reason,
-                    ) => ExecuteInvocation::RevertedReason { reverted_reason },
+                        revert_reason,
+                    ) => ExecuteInvocation::RevertedReason { revert_reason },
                 },
                 fee_transfer_invocation: trace.fee_transfer_invocation.map(Into::into),
             }

--- a/crates/rpc/src/v05/method/simulate_transactions.rs
+++ b/crates/rpc/src/v05/method/simulate_transactions.rs
@@ -358,7 +358,7 @@ pub mod dto {
         Empty,
         FunctionInvocation(FunctionInvocation),
         RevertedReason {
-            reverted_reason: String,
+            revert_reason: String,
         },
     }
 
@@ -386,8 +386,8 @@ pub mod dto {
                         ExecuteInvocation::Empty
                     }
                     pathfinder_executor::types::ExecuteInvocation::RevertedReason(
-                        reverted_reason,
-                    ) => ExecuteInvocation::RevertedReason { reverted_reason },
+                        revert_reason,
+                    ) => ExecuteInvocation::RevertedReason { revert_reason },
                 },
                 fee_transfer_invocation: trace.fee_transfer_invocation.map(Into::into),
                 state_diff: trace.state_diff.into(),


### PR DESCRIPTION
The field name should be `revert_reason` instead of `reverted_reason`.