### PR TITLE
Concurrent RPC batch processing

### DIFF
--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -190,7 +190,8 @@ This should only be enabled for debugging purposes as it adds substantial proces
     #[arg(
         long = "rpc-batch-concurrency-limit",
         long_help = "Sets the concurrency limit for request batch processing. \
-            May lower the latency for large batches.",
+            May lower the latency for large batches. ⚠ While the response order is preserved, the \
+            execution order is not.",
         env = "PATHFINDER_RPC_BATCH_CONCURRENCY_LIMIT",
         default_value = "1"
     )]

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -186,6 +186,15 @@ This should only be enabled for debugging purposes as it adds substantial proces
         value_name = "BOOL"
     )]
     verify_tree_node_data: bool,
+
+    #[arg(
+        long = "rpc-batch-concurrency-limit",
+        long_help = "Sets the concurrency limit for request batch processing. \
+            May lower the latency for large batches.",
+        env = "PATHFINDER_RPC_BATCH_CONCURRENCY_LIMIT",
+        default_value = "1"
+    )]
+    rpc_batch_concurrency_limit: NonZeroUsize,
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq)]
@@ -422,6 +431,7 @@ pub struct Config {
     pub p2p: P2PConfig,
     pub debug: DebugConfig,
     pub verify_tree_hashes: bool,
+    pub rpc_batch_concurrency_limit: NonZeroUsize,
 }
 
 pub struct Ethereum {
@@ -596,6 +606,7 @@ impl Config {
             p2p: P2PConfig::parse_or_exit(cli.p2p),
             debug: DebugConfig::parse(cli.debug),
             verify_tree_hashes: cli.verify_tree_node_data,
+            rpc_batch_concurrency_limit: cli.rpc_batch_concurrency_limit,
         }
     }
 }

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -162,6 +162,7 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
         sync_state.clone(),
         pathfinder_context.network_id,
         pathfinder_context.gateway.clone(),
+        config.rpc_batch_concurrency_limit,
     );
 
     let context = match config.poll_pending {

--- a/crates/rpc/src/context.rs
+++ b/crates/rpc/src/context.rs
@@ -4,6 +4,7 @@ use crate::SyncState;
 use pathfinder_common::ChainId;
 use pathfinder_storage::Storage;
 use starknet_gateway_types::pending::PendingData;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 type SequencerClient = starknet_gateway_client::Client;
@@ -18,6 +19,7 @@ pub struct RpcContext {
     pub eth_gas_price: gas_price::Cached,
     pub sequencer: SequencerClient,
     pub websocket: Option<WebsocketContext>,
+    pub batch_concurrency_limit: NonZeroUsize,
 }
 
 impl RpcContext {
@@ -27,6 +29,7 @@ impl RpcContext {
         sync_status: Arc<SyncState>,
         chain_id: ChainId,
         sequencer: SequencerClient,
+        batch_concurrency_limit: NonZeroUsize,
     ) -> Self {
         Self {
             storage,
@@ -37,6 +40,7 @@ impl RpcContext {
             eth_gas_price: gas_price::Cached::new(sequencer.clone()),
             sequencer,
             websocket: None,
+            batch_concurrency_limit,
         }
     }
 
@@ -62,6 +66,7 @@ impl RpcContext {
             sync_state,
             chain_id,
             sequencer.disable_retry_for_tests(),
+            NonZeroUsize::new(8).unwrap(),
         )
     }
 

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -177,11 +177,11 @@ pub async fn rpc_handler(
                 return RpcResponse::INVALID_REQUEST.into_response();
             }
 
-            // TODO Make it configurable
-            let concurrency_limit = NonZeroUsize::new(10).unwrap();
-            let responses = run_concurrently(concurrency_limit, requests.into_iter(), |request| {
-                state.run_request(request.get())
-            })
+            let responses = run_concurrently(
+                state.context.batch_concurrency_limit,
+                requests.into_iter(),
+                |request| state.run_request(request.get()),
+            )
             .await;
 
             // Notifications return none and are skipped.


### PR DESCRIPTION
Makes the `RpcRouter` capable of handling request batches concurrently.

TODO describe config additions

Delete once completed:
- [ ] add all user-facing changes to `CHANGELOG.md`

Closes #1448
