### PR TITLE
Concurrent RPC batch processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RPC errors do not always include the root cause. For example, some gateway error messages are not output when pathfinder forwards the request.
 - RPC trace object uses wrong property `reverted_reason` instead of `revert_reason`
 
+### Added
+
+- Added the ability to concurrently process RPC batches, see the `rpc.batch-concurrency-limit` CLI argument.
+
 ## [0.9.3] - 2023-10-16
 
 ### Fixed

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -186,6 +186,18 @@ This should only be enabled for debugging purposes as it adds substantial proces
         value_name = "BOOL"
     )]
     verify_tree_node_data: bool,
+
+    #[arg(
+        long = "rpc.batch-concurrency-limit",
+        long_help = "Sets the concurrency limit for request batch processing. \
+            May lower the latency for large batches. \
+            ⚠ While the response order is eventually preserved, execution may be performed out of \
+            order.\
+            Setting this to 1 effectively disables concurrency.",
+        env = "PATHFINDER_RPC_BATCH_CONCURRENCY_LIMIT",
+        default_value = "1"
+    )]
+    rpc_batch_concurrency_limit: NonZeroUsize,
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq)]
@@ -422,6 +434,7 @@ pub struct Config {
     pub p2p: P2PConfig,
     pub debug: DebugConfig,
     pub verify_tree_hashes: bool,
+    pub rpc_batch_concurrency_limit: NonZeroUsize,
 }
 
 pub struct Ethereum {
@@ -596,6 +609,7 @@ impl Config {
             p2p: P2PConfig::parse_or_exit(cli.p2p),
             debug: DebugConfig::parse(cli.debug),
             verify_tree_hashes: cli.verify_tree_node_data,
+            rpc_batch_concurrency_limit: cli.rpc_batch_concurrency_limit,
         }
     }
 }

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -163,6 +163,7 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
         pathfinder_context.network_id,
         pathfinder_context.gateway.clone(),
         rx_pending,
+        config.rpc_batch_concurrency_limit,
     );
 
     let context = if config.websocket.enabled {

--- a/crates/rpc/src/context.rs
+++ b/crates/rpc/src/context.rs
@@ -5,6 +5,7 @@ use crate::pending::PendingWatcher;
 use crate::SyncState;
 use pathfinder_common::ChainId;
 use pathfinder_storage::Storage;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 type SequencerClient = starknet_gateway_client::Client;
@@ -20,6 +21,7 @@ pub struct RpcContext {
     pub eth_gas_price: gas_price::Cached,
     pub sequencer: SequencerClient,
     pub websocket: Option<WebsocketContext>,
+    pub batch_concurrency_limit: NonZeroUsize,
 }
 
 impl RpcContext {
@@ -30,6 +32,7 @@ impl RpcContext {
         chain_id: ChainId,
         sequencer: SequencerClient,
         pending_data: tokio_watch::Receiver<Arc<PendingData>>,
+        batch_concurrency_limit: NonZeroUsize,
     ) -> Self {
         let pending_data = PendingWatcher::new(pending_data);
         Self {
@@ -41,6 +44,7 @@ impl RpcContext {
             eth_gas_price: gas_price::Cached::new(sequencer.clone()),
             sequencer,
             websocket: None,
+            batch_concurrency_limit,
         }
     }
 
@@ -69,6 +73,7 @@ impl RpcContext {
             chain_id,
             sequencer.disable_retry_for_tests(),
             rx,
+            NonZeroUsize::new(8).unwrap(),
         )
     }
 


### PR DESCRIPTION
Makes the `RpcRouter` capable of handling request batches concurrently.

Adds a `rpc-batch-concurrency-limit` CLI argument to control this.

Closes #1448
