### PR TITLE
fix: nested RPC error messages are hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- RPC errors do not always include the root cause. For example, some gateway error messages are not output when pathfinder forwards the request.
+
 ## [0.9.3] - 2023-10-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - RPC errors do not always include the root cause. For example, some gateway error messages are not output when pathfinder forwards the request.
+- RPC trace object uses wrong property `reverted_reason` instead of `revert_reason`
 
 ## [0.9.3] - 2023-10-16
 

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -1,7 +1,7 @@
-//! Defines [RpcError], the Starknet JSON-RPC specification's error variants.
+//! Defines [ApplicationError], the Starknet JSON-RPC specification's error variants.
 //!
 //! In addition, it supplies the [generate_rpc_error_subset!] macro which should be used
-//! by each JSON-RPC method to trivially create its subset of [RpcError] along with the boilerplate involved.
+//! by each JSON-RPC method to trivially create its subset of [ApplicationError] along with the boilerplate involved.
 #![macro_use]
 use serde_json::json;
 
@@ -13,7 +13,7 @@ pub enum TraceError {
 
 /// The Starknet JSON-RPC error variants.
 #[derive(thiserror::Error, Debug)]
-pub enum RpcError {
+pub enum ApplicationError {
     #[error("Failed to write transaction")]
     FailedToReceiveTxn,
     #[error("Contract not found")]
@@ -82,45 +82,45 @@ pub enum RpcError {
     Internal(anyhow::Error),
 }
 
-impl RpcError {
+impl ApplicationError {
     pub fn code(&self) -> i32 {
         match self {
             // Taken from the official starknet json rpc api.
             // https://github.com/starkware-libs/starknet-specs
-            RpcError::FailedToReceiveTxn => 1,
-            RpcError::NoTraceAvailable(_) => 10,
-            RpcError::ContractNotFound => 20,
-            RpcError::BlockNotFound => 24,
-            RpcError::TxnHashNotFoundV03 => 25,
-            RpcError::InvalidTxnHash => 25,
-            RpcError::InvalidBlockHash => 26,
-            RpcError::InvalidTxnIndex => 27,
-            RpcError::ClassHashNotFound => 28,
-            RpcError::TxnHashNotFoundV04 => 29,
-            RpcError::PageSizeTooBig => 31,
-            RpcError::NoBlocks => 32,
-            RpcError::InvalidContinuationToken => 33,
-            RpcError::TooManyKeysInFilter { .. } => 34,
-            RpcError::ContractError => 40,
-            RpcError::ContractErrorV05 { .. } => 40,
-            RpcError::InvalidContractClass => 50,
-            RpcError::ClassAlreadyDeclared => 51,
-            RpcError::InvalidTransactionNonce => 52,
-            RpcError::InsufficientMaxFee => 53,
-            RpcError::InsufficientAccountBalance => 54,
-            RpcError::ValidationFailure => 55,
-            RpcError::CompilationFailed => 56,
-            RpcError::ContractClassSizeIsTooLarge => 57,
-            RpcError::NonAccount => 58,
-            RpcError::DuplicateTransaction => 59,
-            RpcError::CompiledClassHashMismatch => 60,
-            RpcError::UnsupportedTxVersion => 61,
-            RpcError::UnsupportedContractClassVersion => 62,
-            RpcError::UnexpectedError { .. } => 63,
+            ApplicationError::FailedToReceiveTxn => 1,
+            ApplicationError::NoTraceAvailable(_) => 10,
+            ApplicationError::ContractNotFound => 20,
+            ApplicationError::BlockNotFound => 24,
+            ApplicationError::TxnHashNotFoundV03 => 25,
+            ApplicationError::InvalidTxnHash => 25,
+            ApplicationError::InvalidBlockHash => 26,
+            ApplicationError::InvalidTxnIndex => 27,
+            ApplicationError::ClassHashNotFound => 28,
+            ApplicationError::TxnHashNotFoundV04 => 29,
+            ApplicationError::PageSizeTooBig => 31,
+            ApplicationError::NoBlocks => 32,
+            ApplicationError::InvalidContinuationToken => 33,
+            ApplicationError::TooManyKeysInFilter { .. } => 34,
+            ApplicationError::ContractError => 40,
+            ApplicationError::ContractErrorV05 { .. } => 40,
+            ApplicationError::InvalidContractClass => 50,
+            ApplicationError::ClassAlreadyDeclared => 51,
+            ApplicationError::InvalidTransactionNonce => 52,
+            ApplicationError::InsufficientMaxFee => 53,
+            ApplicationError::InsufficientAccountBalance => 54,
+            ApplicationError::ValidationFailure => 55,
+            ApplicationError::CompilationFailed => 56,
+            ApplicationError::ContractClassSizeIsTooLarge => 57,
+            ApplicationError::NonAccount => 58,
+            ApplicationError::DuplicateTransaction => 59,
+            ApplicationError::CompiledClassHashMismatch => 60,
+            ApplicationError::UnsupportedTxVersion => 61,
+            ApplicationError::UnsupportedContractClassVersion => 62,
+            ApplicationError::UnexpectedError { .. } => 63,
             // doc/rpc/pathfinder_rpc_api.json
-            RpcError::ProofLimitExceeded { .. } => 10000,
+            ApplicationError::ProofLimitExceeded { .. } => 10000,
             // https://www.jsonrpc.org/specification#error_object
-            RpcError::GatewayError(_) | RpcError::Internal(_) => -32603,
+            ApplicationError::GatewayError(_) | ApplicationError::Internal(_) => -32603,
         }
     }
 
@@ -129,36 +129,36 @@ impl RpcError {
         // here whenever a new variant is added. This will prevent adding a stateful
         // error variant but forgetting to forward its data.
         match self {
-            RpcError::FailedToReceiveTxn => None,
-            RpcError::ContractNotFound => None,
-            RpcError::BlockNotFound => None,
-            RpcError::TxnHashNotFoundV03 => None,
-            RpcError::InvalidTxnIndex => None,
-            RpcError::InvalidTxnHash => None,
-            RpcError::InvalidBlockHash => None,
-            RpcError::ClassHashNotFound => None,
-            RpcError::TxnHashNotFoundV04 => None,
-            RpcError::PageSizeTooBig => None,
-            RpcError::NoBlocks => None,
-            RpcError::InvalidContinuationToken => None,
-            RpcError::ContractError => None,
-            RpcError::InvalidContractClass => None,
-            RpcError::ClassAlreadyDeclared => None,
-            RpcError::InvalidTransactionNonce => None,
-            RpcError::InsufficientMaxFee => None,
-            RpcError::InsufficientAccountBalance => None,
-            RpcError::ValidationFailure => None,
-            RpcError::CompilationFailed => None,
-            RpcError::ContractClassSizeIsTooLarge => None,
-            RpcError::NonAccount => None,
-            RpcError::DuplicateTransaction => None,
-            RpcError::CompiledClassHashMismatch => None,
-            RpcError::UnsupportedTxVersion => None,
-            RpcError::UnsupportedContractClassVersion => None,
-            RpcError::GatewayError(error) => Some(json!({
+            ApplicationError::FailedToReceiveTxn => None,
+            ApplicationError::ContractNotFound => None,
+            ApplicationError::BlockNotFound => None,
+            ApplicationError::TxnHashNotFoundV03 => None,
+            ApplicationError::InvalidTxnIndex => None,
+            ApplicationError::InvalidTxnHash => None,
+            ApplicationError::InvalidBlockHash => None,
+            ApplicationError::ClassHashNotFound => None,
+            ApplicationError::TxnHashNotFoundV04 => None,
+            ApplicationError::PageSizeTooBig => None,
+            ApplicationError::NoBlocks => None,
+            ApplicationError::InvalidContinuationToken => None,
+            ApplicationError::ContractError => None,
+            ApplicationError::InvalidContractClass => None,
+            ApplicationError::ClassAlreadyDeclared => None,
+            ApplicationError::InvalidTransactionNonce => None,
+            ApplicationError::InsufficientMaxFee => None,
+            ApplicationError::InsufficientAccountBalance => None,
+            ApplicationError::ValidationFailure => None,
+            ApplicationError::CompilationFailed => None,
+            ApplicationError::ContractClassSizeIsTooLarge => None,
+            ApplicationError::NonAccount => None,
+            ApplicationError::DuplicateTransaction => None,
+            ApplicationError::CompiledClassHashMismatch => None,
+            ApplicationError::UnsupportedTxVersion => None,
+            ApplicationError::UnsupportedContractClassVersion => None,
+            ApplicationError::GatewayError(error) => Some(json!({
                 "error": error,
             })),
-            RpcError::Internal(error) => {
+            ApplicationError::Internal(error) => {
                 let error = error.to_string();
                 if error.is_empty() {
                     None
@@ -168,20 +168,20 @@ impl RpcError {
                     }))
                 }
             }
-            RpcError::NoTraceAvailable(error) => Some(json!({
+            ApplicationError::NoTraceAvailable(error) => Some(json!({
                 "error": error,
             })),
-            RpcError::ContractErrorV05 { revert_error } => Some(json!({
+            ApplicationError::ContractErrorV05 { revert_error } => Some(json!({
                 "revert_error": revert_error
             })),
-            RpcError::TooManyKeysInFilter { limit, requested } => Some(json!({
+            ApplicationError::TooManyKeysInFilter { limit, requested } => Some(json!({
                 "limit": limit,
                 "requested": requested,
             })),
-            RpcError::UnexpectedError { data } => Some(json!({
+            ApplicationError::UnexpectedError { data } => Some(json!({
                 "error": data,
             })),
-            RpcError::ProofLimitExceeded { limit, requested } => Some(json!({
+            ApplicationError::ProofLimitExceeded { limit, requested } => Some(json!({
                 "limit": limit,
                 "requested": requested,
             })),
@@ -189,9 +189,9 @@ impl RpcError {
     }
 }
 
-/// Generates an enum subset of [RpcError] along with boilerplate for mapping the variants back to [RpcError].
+/// Generates an enum subset of [ApplicationError] along with boilerplate for mapping the variants back to [ApplicationError].
 ///
-/// This is useful for RPC methods which only emit a few of the [RpcError] variants as this macro can be
+/// This is useful for RPC methods which only emit a few of the [ApplicationError] variants as this macro can be
 /// used to quickly create the enum-subset with the required glue code. This greatly improves the type safety
 /// of the method.
 ///
@@ -199,7 +199,7 @@ impl RpcError {
 /// ```ignore
 /// generate_rpc_error_subset!(<enum_name>: <variant a>, <variant b>, <variant N>);
 /// ```
-/// Note that the variants __must__ match the [RpcError] variant names and that [RpcError::Internal]
+/// Note that the variants __must__ match the [ApplicationError] variant names and that [ApplicationError::Internal]
 /// is always included by default (and therefore should not be part of macro input).
 ///
 /// An `Internal` only variant can be generated using `generate_rpc_error_subset!(<enum_name>)`.
@@ -301,7 +301,7 @@ macro_rules! generate_rpc_error_subset {
     // By pushing the arms from this level downwards, and creating the match statement at the lowest
     // level, we guarantee that only valid valid Rust will bubble back up.
     (@from_def, $enum_name:ident, $($variants:ident),*) => {
-        impl From<$enum_name> for crate::error::RpcError {
+        impl From<$enum_name> for crate::error::ApplicationError {
             fn from(x: $enum_name) -> Self {
                 generate_rpc_error_subset!(@parse, x, $enum_name, {}, $($variants),*)
             }
@@ -344,7 +344,7 @@ pub(super) use generate_rpc_error_subset;
 #[cfg(test)]
 mod tests {
     mod rpc_error_subset {
-        use super::super::{generate_rpc_error_subset, RpcError};
+        use super::super::{generate_rpc_error_subset, ApplicationError};
         use assert_matches::assert_matches;
 
         #[test]
@@ -357,22 +357,22 @@ mod tests {
         fn single_variant() {
             generate_rpc_error_subset!(Single: ContractNotFound);
 
-            let original = RpcError::from(Single::ContractNotFound);
+            let original = ApplicationError::from(Single::ContractNotFound);
 
-            assert_matches!(original, RpcError::ContractNotFound);
+            assert_matches!(original, ApplicationError::ContractNotFound);
         }
 
         #[test]
         fn multi_variant() {
             generate_rpc_error_subset!(Multi: ContractNotFound, NoBlocks, ContractError);
 
-            let contract_not_found = RpcError::from(Multi::ContractNotFound);
-            let no_blocks = RpcError::from(Multi::NoBlocks);
-            let contract_error = RpcError::from(Multi::ContractError);
+            let contract_not_found = ApplicationError::from(Multi::ContractNotFound);
+            let no_blocks = ApplicationError::from(Multi::NoBlocks);
+            let contract_error = ApplicationError::from(Multi::ContractError);
 
-            assert_matches!(contract_not_found, RpcError::ContractNotFound);
-            assert_matches!(no_blocks, RpcError::NoBlocks);
-            assert_matches!(contract_error, RpcError::ContractError);
+            assert_matches!(contract_not_found, ApplicationError::ContractNotFound);
+            assert_matches!(no_blocks, ApplicationError::NoBlocks);
+            assert_matches!(contract_error, ApplicationError::ContractError);
         }
     }
 }

--- a/crates/rpc/src/jsonrpc/error.rs
+++ b/crates/rpc/src/jsonrpc/error.rs
@@ -10,7 +10,7 @@ pub enum RpcError {
     MethodNotFound,
     InvalidParams,
     InternalError(anyhow::Error),
-    ApplicationError(crate::error::RpcError),
+    ApplicationError(crate::error::ApplicationError),
     WebsocketSubscriptionClosed {
         subscription_id: u32,
         reason: String,
@@ -103,7 +103,7 @@ impl Serialize for RpcError {
 
 impl<E> From<E> for RpcError
 where
-    E: Into<crate::error::RpcError>,
+    E: Into<crate::error::ApplicationError>,
 {
     fn from(value: E) -> Self {
         Self::ApplicationError(value.into())

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -90,9 +90,10 @@ impl RpcRouter {
 
         let output = match result {
             Ok(output) => output,
-            Err(_e) => {
-                tracing::warn!(method=%request.method, "RPC method panic'd");
-                Err(RpcError::InternalError(anyhow::anyhow!("Internal error")))
+            Err(e) => {
+                tracing::warn!(method=%request.method, backtrace=?e, "RPC method panic'd");
+                // No error message so that the caller cannot learn to abuse this.
+                Err(RpcError::InternalError(anyhow::anyhow!("")))
             }
         };
 

--- a/crates/rpc/src/pathfinder/methods/get_proof.rs
+++ b/crates/rpc/src/pathfinder/methods/get_proof.rs
@@ -27,7 +27,7 @@ impl From<anyhow::Error> for GetProofError {
         Self::Internal(e)
     }
 }
-impl From<GetProofError> for crate::error::RpcError {
+impl From<GetProofError> for crate::error::ApplicationError {
     fn from(x: GetProofError) -> Self {
         match x {
             GetProofError::ProofLimitExceeded { limit, requested } => {

--- a/crates/rpc/src/v02/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v02/method/add_declare_transaction.rs
@@ -15,7 +15,7 @@ pub enum AddDeclareTransactionError {
     Internal(anyhow::Error),
 }
 
-impl From<AddDeclareTransactionError> for crate::error::RpcError {
+impl From<AddDeclareTransactionError> for crate::error::ApplicationError {
     fn from(value: AddDeclareTransactionError) -> Self {
         match value {
             AddDeclareTransactionError::InvalidContractClass => Self::InvalidContractClass,

--- a/crates/rpc/src/v02/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/v02/method/add_deploy_account_transaction.rs
@@ -34,7 +34,7 @@ pub enum AddDeployAccountTransactionError {
     Internal(anyhow::Error),
 }
 
-impl From<AddDeployAccountTransactionError> for crate::error::RpcError {
+impl From<AddDeployAccountTransactionError> for crate::error::ApplicationError {
     fn from(value: AddDeployAccountTransactionError) -> Self {
         match value {
             AddDeployAccountTransactionError::ClassHashNotFound => Self::ClassHashNotFound,

--- a/crates/rpc/src/v02/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/v02/method/add_invoke_transaction.rs
@@ -31,7 +31,7 @@ pub enum AddInvokeTransactionError {
     Internal(anyhow::Error),
 }
 
-impl From<AddInvokeTransactionError> for crate::error::RpcError {
+impl From<AddInvokeTransactionError> for crate::error::ApplicationError {
     fn from(value: AddInvokeTransactionError) -> Self {
         match value {
             AddInvokeTransactionError::GatewayError(x) => Self::GatewayError(x),

--- a/crates/rpc/src/v03/method/get_events.rs
+++ b/crates/rpc/src/v03/method/get_events.rs
@@ -23,7 +23,7 @@ impl From<anyhow::Error> for GetEventsError {
     }
 }
 
-impl From<GetEventsError> for crate::error::RpcError {
+impl From<GetEventsError> for crate::error::ApplicationError {
     fn from(e: GetEventsError) -> Self {
         match e {
             GetEventsError::Internal(internal) => Self::Internal(internal),

--- a/crates/rpc/src/v04/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v04/method/add_declare_transaction.rs
@@ -25,7 +25,7 @@ pub enum AddDeclareTransactionError {
     UnexpectedError(String),
 }
 
-impl From<AddDeclareTransactionError> for crate::error::RpcError {
+impl From<AddDeclareTransactionError> for crate::error::ApplicationError {
     fn from(value: AddDeclareTransactionError) -> Self {
         match value {
             AddDeclareTransactionError::ClassAlreadyDeclared => Self::ClassAlreadyDeclared,

--- a/crates/rpc/src/v04/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/v04/method/add_deploy_account_transaction.rs
@@ -40,7 +40,7 @@ pub enum AddDeployAccountTransactionError {
     UnexpectedError(String),
 }
 
-impl From<AddDeployAccountTransactionError> for crate::error::RpcError {
+impl From<AddDeployAccountTransactionError> for crate::error::ApplicationError {
     fn from(value: AddDeployAccountTransactionError) -> Self {
         use AddDeployAccountTransactionError::*;
         match value {

--- a/crates/rpc/src/v04/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/v04/method/add_invoke_transaction.rs
@@ -37,7 +37,7 @@ pub enum AddInvokeTransactionError {
     UnexpectedError(String),
 }
 
-impl From<AddInvokeTransactionError> for crate::error::RpcError {
+impl From<AddInvokeTransactionError> for crate::error::ApplicationError {
     fn from(value: AddInvokeTransactionError) -> Self {
         match value {
             AddInvokeTransactionError::InvalidTransactionNonce => Self::InvalidTransactionNonce,

--- a/crates/rpc/src/v04/method/trace_transaction.rs
+++ b/crates/rpc/src/v04/method/trace_transaction.rs
@@ -8,7 +8,7 @@ use tokio::task::JoinError;
 use crate::{
     compose_executor_transaction,
     context::RpcContext,
-    error::{RpcError, TraceError},
+    error::{ApplicationError, TraceError},
     executor::ExecutionStateError,
 };
 
@@ -66,12 +66,14 @@ impl From<anyhow::Error> for TraceTransactionError {
     }
 }
 
-impl From<TraceTransactionError> for RpcError {
+impl From<TraceTransactionError> for ApplicationError {
     fn from(value: TraceTransactionError) -> Self {
         match value {
-            TraceTransactionError::InvalidTxnHash => RpcError::InvalidTxnHash,
-            TraceTransactionError::NoTraceAvailable(status) => RpcError::NoTraceAvailable(status),
-            TraceTransactionError::Internal(e) => RpcError::Internal(e),
+            TraceTransactionError::InvalidTxnHash => ApplicationError::InvalidTxnHash,
+            TraceTransactionError::NoTraceAvailable(status) => {
+                ApplicationError::NoTraceAvailable(status)
+            }
+            TraceTransactionError::Internal(e) => ApplicationError::Internal(e),
         }
     }
 }

--- a/crates/rpc/src/v05/method/call.rs
+++ b/crates/rpc/src/v05/method/call.rs
@@ -1,5 +1,5 @@
 use crate::context::RpcContext;
-use crate::error::RpcError;
+use crate::error::ApplicationError;
 use crate::felt::RpcFelt;
 use anyhow::Context;
 use pathfinder_common::{BlockId, CallParam, CallResultValue, ContractAddress, EntryPoint};
@@ -40,15 +40,15 @@ impl From<crate::executor::ExecutionStateError> for CallError {
     }
 }
 
-impl From<CallError> for RpcError {
+impl From<CallError> for ApplicationError {
     fn from(value: CallError) -> Self {
         match value {
-            CallError::BlockNotFound => RpcError::BlockNotFound,
-            CallError::ContractNotFound => RpcError::ContractNotFound,
+            CallError::BlockNotFound => ApplicationError::BlockNotFound,
+            CallError::ContractNotFound => ApplicationError::ContractNotFound,
             CallError::ContractErrorV05 { revert_error } => {
-                RpcError::ContractErrorV05 { revert_error }
+                ApplicationError::ContractErrorV05 { revert_error }
             }
-            CallError::Internal(e) => RpcError::Internal(e),
+            CallError::Internal(e) => ApplicationError::Internal(e),
         }
     }
 }

--- a/crates/rpc/src/v05/method/estimate_fee.rs
+++ b/crates/rpc/src/v05/method/estimate_fee.rs
@@ -1,7 +1,9 @@
 use anyhow::Context;
 use serde_with::serde_as;
 
-use crate::{context::RpcContext, error::RpcError, v02::types::request::BroadcastedTransaction};
+use crate::{
+    context::RpcContext, error::ApplicationError, v02::types::request::BroadcastedTransaction,
+};
 use pathfinder_common::BlockId;
 
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
@@ -47,15 +49,15 @@ impl From<crate::executor::ExecutionStateError> for EstimateFeeError {
     }
 }
 
-impl From<EstimateFeeError> for RpcError {
+impl From<EstimateFeeError> for ApplicationError {
     fn from(value: EstimateFeeError) -> Self {
         match value {
-            EstimateFeeError::BlockNotFound => RpcError::BlockNotFound,
-            EstimateFeeError::ContractNotFound => RpcError::ContractNotFound,
+            EstimateFeeError::BlockNotFound => ApplicationError::BlockNotFound,
+            EstimateFeeError::ContractNotFound => ApplicationError::ContractNotFound,
             EstimateFeeError::ContractErrorV05 { revert_error } => {
-                RpcError::ContractErrorV05 { revert_error }
+                ApplicationError::ContractErrorV05 { revert_error }
             }
-            EstimateFeeError::Internal(e) => RpcError::Internal(e),
+            EstimateFeeError::Internal(e) => ApplicationError::Internal(e),
         }
     }
 }

--- a/crates/rpc/src/v05/method/estimate_message_fee.rs
+++ b/crates/rpc/src/v05/method/estimate_message_fee.rs
@@ -9,7 +9,7 @@ use pathfinder_executor::IntoStarkFelt;
 use stark_hash::Felt;
 use starknet_api::core::PatriciaKey;
 
-use crate::{context::RpcContext, error::RpcError, v05::method::estimate_fee::FeeEstimate};
+use crate::{context::RpcContext, error::ApplicationError, v05::method::estimate_fee::FeeEstimate};
 
 #[derive(Debug)]
 pub enum EstimateMessageFeeError {
@@ -47,15 +47,15 @@ impl From<crate::executor::ExecutionStateError> for EstimateMessageFeeError {
     }
 }
 
-impl From<EstimateMessageFeeError> for RpcError {
+impl From<EstimateMessageFeeError> for ApplicationError {
     fn from(value: EstimateMessageFeeError) -> Self {
         match value {
-            EstimateMessageFeeError::BlockNotFound => RpcError::BlockNotFound,
-            EstimateMessageFeeError::ContractNotFound => RpcError::ContractNotFound,
+            EstimateMessageFeeError::BlockNotFound => ApplicationError::BlockNotFound,
+            EstimateMessageFeeError::ContractNotFound => ApplicationError::ContractNotFound,
             EstimateMessageFeeError::ContractErrorV05 { revert_error } => {
-                RpcError::ContractErrorV05 { revert_error }
+                ApplicationError::ContractErrorV05 { revert_error }
             }
-            EstimateMessageFeeError::Internal(e) => RpcError::Internal(e),
+            EstimateMessageFeeError::Internal(e) => ApplicationError::Internal(e),
         }
     }
 }

--- a/crates/rpc/src/v05/method/simulate_transactions.rs
+++ b/crates/rpc/src/v05/method/simulate_transactions.rs
@@ -33,7 +33,7 @@ impl From<anyhow::Error> for SimulateTransactionError {
     }
 }
 
-impl From<SimulateTransactionError> for crate::error::RpcError {
+impl From<SimulateTransactionError> for crate::error::ApplicationError {
     fn from(e: SimulateTransactionError) -> Self {
         match e {
             SimulateTransactionError::Internal(internal) => Self::Internal(internal),

--- a/crates/rpc/src/v05/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v05/method/trace_block_transactions.rs
@@ -36,7 +36,7 @@ impl From<anyhow::Error> for TraceBlockTransactionsError {
     }
 }
 
-impl From<TraceBlockTransactionsError> for crate::error::RpcError {
+impl From<TraceBlockTransactionsError> for crate::error::ApplicationError {
     fn from(value: TraceBlockTransactionsError) -> Self {
         match value {
             TraceBlockTransactionsError::Internal(e) => Self::Internal(e),

--- a/crates/rpc/src/v05/method/trace_transaction.rs
+++ b/crates/rpc/src/v05/method/trace_transaction.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     context::RpcContext,
-    error::{RpcError, TraceError},
+    error::{ApplicationError, TraceError},
     executor::ExecutionStateError,
 };
 
@@ -70,15 +70,17 @@ impl From<super::trace_block_transactions::TraceBlockTransactionsError> for Trac
     }
 }
 
-impl From<TraceTransactionError> for RpcError {
+impl From<TraceTransactionError> for ApplicationError {
     fn from(value: TraceTransactionError) -> Self {
         match value {
-            TraceTransactionError::InvalidTxnHash => RpcError::InvalidTxnHash,
-            TraceTransactionError::NoTraceAvailable(status) => RpcError::NoTraceAvailable(status),
-            TraceTransactionError::ContractErrorV05 { revert_error } => {
-                RpcError::ContractErrorV05 { revert_error }
+            TraceTransactionError::InvalidTxnHash => ApplicationError::InvalidTxnHash,
+            TraceTransactionError::NoTraceAvailable(status) => {
+                ApplicationError::NoTraceAvailable(status)
             }
-            TraceTransactionError::Internal(e) => RpcError::Internal(e),
+            TraceTransactionError::ContractErrorV05 { revert_error } => {
+                ApplicationError::ContractErrorV05 { revert_error }
+            }
+            TraceTransactionError::Internal(e) => ApplicationError::Internal(e),
         }
     }
 }


### PR DESCRIPTION
This PR maps RPC errors with state to the error response's `data` field.

The JSON-RPC specification allows for an optional `data` field for errors. This PR maps any error state to this field. Currently, any state is manually surfaced via the error's message property but we often forget to pipe this through.

This PR instead separates the two concerns, making it harder to forget. State is now mapped to `data` and an error's message should remain constant.

As an example, the response for error `UnexpectedError("root cause")`. Before
```json
{
  "code": 63,
  "message": "An unexpected error occurred"
}
```
after
```json
{
  "code": 63,
  "message": "An unexpected error occurred",
  "data": {
    "error": "root_cause"
  }
}
```

One notable change is that internal errors now contain their actual errors in the data field.

Some discussion points and open questions:
1. Should `data` be structured? i.e. `Value` or just `String`? Currently it is structured.
2. How should internal error be mapped? [Here](https://docs.rs/anyhow/latest/anyhow/struct.Error.html#display-representations) are the options. Currently it only surfaces the top level error and no context. We could also do a custom representation using an actual json structure e.g. an object with `root_cause`, `level 0`, `level 1` etc for each layer in the error.

Closes #1463.
