### PR TITLE
feat(executor): use blockifier `main-v0.12.3` branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ dependencies = [
  "num-traits 0.2.16",
  "rusticata-macros",
  "thiserror",
- "time 0.3.28",
+ "time 0.3.26",
 ]
 
 [[package]]
@@ -436,7 +436,7 @@ dependencies = [
  "num-traits 0.2.16",
  "rusticata-macros",
  "thiserror",
- "time 0.3.28",
+ "time 0.3.26",
 ]
 
 [[package]]
@@ -900,14 +900,13 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blockifier"
-version = "0.2.0-rc0"
-source = "git+https://github.com/starkware-libs/blockifier?rev=ebf48c445b965c5c55b8c724338be7c6e21ffdd4#ebf48c445b965c5c55b8c724338be7c6e21ffdd4"
+version = "0.4.0-rc0"
+source = "git+https://github.com/starkware-libs/blockifier?rev=16e60551ba0f55a110e9c0acb2c16ec43b3758c4#16e60551ba0f55a110e9c0acb2c16ec43b3758c4"
 dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-secp256k1",
  "ark-secp256r1",
- "cached",
  "cairo-felt 0.8.7",
  "cairo-lang-casm 2.1.1",
  "cairo-lang-runner",
@@ -2624,7 +2623,7 @@ dependencies = [
  "num-integer",
  "num-traits 0.2.16",
  "serde",
- "time 0.3.28",
+ "time 0.3.26",
 ]
 
 [[package]]
@@ -2641,7 +2640,7 @@ dependencies = [
  "num-integer",
  "num-traits 0.2.16",
  "serde",
- "time 0.3.28",
+ "time 0.3.26",
 ]
 
 [[package]]
@@ -6417,7 +6416,7 @@ dependencies = [
  "starknet_api",
  "tempfile",
  "thiserror",
- "time 0.3.28",
+ "time 0.3.26",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -7338,7 +7337,7 @@ checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.28",
+ "time 0.3.26",
  "x509-parser 0.13.2",
  "yasna",
 ]
@@ -7351,7 +7350,7 @@ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.28",
+ "time 0.3.26",
  "yasna",
 ]
 
@@ -7902,18 +7901,18 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7997,7 +7996,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.28",
+ "time 0.3.26",
 ]
 
 [[package]]
@@ -8404,9 +8403,8 @@ dependencies = [
 
 [[package]]
 name = "starknet_api"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6e445fbd6bf3826dda26fd64aa5311353b4799c9bd1119d6ec1906be4c73bf"
+version = "0.1.0"
+source = "git+https://github.com/starkware-libs/starknet-api?rev=8f620bc#8f620bcec38b47ce0f2515f3ef158f4c6319608f"
 dependencies = [
  "cairo-lang-starknet 2.1.1",
  "derive_more",
@@ -8687,9 +8685,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.28"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
+checksum = "a79d09ac6b08c1ab3906a2f7cc2e81a0e27c7ae89c63812df75e52bef0751e07"
 dependencies = [
  "deranged",
  "itoa",
@@ -8708,9 +8706,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.14"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
+checksum = "75c65469ed6b3a4809d987a41eb1dc918e9bc1d92211cbad7ae82931846f7451"
 dependencies = [
  "time-core",
 ]
@@ -9088,7 +9086,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time 0.3.28",
+ "time 0.3.26",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -9397,7 +9395,7 @@ checksum = "bbc5ad0d9d26b2c49a5ab7da76c3e79d3ee37e7821799f8223fcb8f2f391a2e7"
 dependencies = [
  "anyhow",
  "rustversion",
- "time 0.3.28",
+ "time 0.3.26",
 ]
 
 [[package]]
@@ -9647,7 +9645,7 @@ dependencies = [
  "sha2 0.10.7",
  "stun",
  "thiserror",
- "time 0.3.28",
+ "time 0.3.26",
  "tokio",
  "turn",
  "url",
@@ -10062,7 +10060,7 @@ dependencies = [
  "ring",
  "rusticata-macros",
  "thiserror",
- "time 0.3.28",
+ "time 0.3.26",
 ]
 
 [[package]]
@@ -10080,7 +10078,7 @@ dependencies = [
  "oid-registry 0.6.1",
  "rusticata-macros",
  "thiserror",
- "time 0.3.28",
+ "time 0.3.26",
 ]
 
 [[package]]
@@ -10124,7 +10122,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "time 0.3.28",
+ "time 0.3.26",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ async-trait = "0.1.73"
 axum = { version = "0.6.19", features = ["macros"] }
 base64 = "0.13.1"
 bitvec = "1.0.1"
-blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "ebf48c445b965c5c55b8c724338be7c6e21ffdd4" }
+blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "16e60551ba0f55a110e9c0acb2c16ec43b3758c4" }
 bytes = "1.4.0"
 # This one needs to match the version used by blockifier
 cairo-vm = "=0.8.2"
@@ -62,12 +62,12 @@ rand = "0.8.5"
 reqwest = { version = "0.11.18", features = ["json"] }
 rstest = "0.18.2"
 semver = "1.0.18"
-serde = "=1.0.188"
+serde = "=1.0.171"
 serde_json = "1.0.105"
 serde_with = "3.0.0"
 sha3 = "0.10"
 # This one needs to match the version used by blockifier
-starknet_api = "=0.4.1"
+starknet_api = { git = "https://github.com/starkware-libs/starknet-api", rev = "8f620bc" }
 thiserror = "1.0.48"
 tokio = "1.29.1"
 tracing = "0.1.37"

--- a/crates/executor/src/block_context.rs
+++ b/crates/executor/src/block_context.rs
@@ -37,7 +37,6 @@ pub(super) fn construct_block_context(
             PatriciaKey::try_from(execution_state.sequencer_address.0.into_starkfelt())
                 .expect("Sequencer address overflow"),
         ),
-        deprecated_fee_token_address: fee_token_address,
         fee_token_address,
         vm_resource_fee_cost: Arc::new(default_resource_fee_costs()),
         gas_price: execution_state.gas_price.as_u128(),

--- a/crates/executor/src/simulate.rs
+++ b/crates/executor/src/simulate.rs
@@ -181,9 +181,9 @@ fn transaction_declared_deprecated_class(transaction: &Transaction) -> Option<Cl
         Transaction::AccountTransaction(
             blockifier::transaction::account_transaction::AccountTransaction::Declare(tx),
         ) => match tx.tx() {
-            starknet_api::transaction::DeclareTransaction::V0(_)
-            | starknet_api::transaction::DeclareTransaction::V1(_) => {
-                Some(ClassHash(tx.class_hash().0.into_felt()))
+            starknet_api::transaction::DeclareTransaction::V0(tx)
+            | starknet_api::transaction::DeclareTransaction::V1(tx) => {
+                Some(ClassHash(tx.class_hash.0.into_felt()))
             }
             starknet_api::transaction::DeclareTransaction::V2(_) => None,
         },

--- a/crates/executor/src/transaction.rs
+++ b/crates/executor/src/transaction.rs
@@ -11,16 +11,16 @@ pub fn transaction_hash(transaction: &Transaction) -> TransactionHash {
         match transaction {
             Transaction::AccountTransaction(tx) => match tx {
                 blockifier::transaction::account_transaction::AccountTransaction::Declare(tx) => {
-                    tx.tx_hash()
+                    tx.tx().transaction_hash()
                 }
                 blockifier::transaction::account_transaction::AccountTransaction::DeployAccount(
                     tx,
-                ) => tx.tx_hash,
+                ) => tx.transaction_hash,
                 blockifier::transaction::account_transaction::AccountTransaction::Invoke(tx) => {
-                    tx.tx_hash
+                    tx.transaction_hash()
                 }
             },
-            Transaction::L1HandlerTransaction(tx) => tx.tx_hash,
+            Transaction::L1HandlerTransaction(tx) => tx.tx.transaction_hash,
         }
         .0
         .into_felt(),

--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, HashSet};
 
-use blockifier::execution::call_info::OrderedL2ToL1Message;
+use blockifier::execution::entry_point::OrderedL2ToL1Message;
 use pathfinder_common::{
     CasmHash, ClassHash, ContractAddress, ContractNonce, SierraHash, StorageAddress, StorageValue,
 };
@@ -140,11 +140,11 @@ pub struct ReplacedClass {
     pub class_hash: ClassHash,
 }
 
-impl TryFrom<blockifier::execution::call_info::CallInfo> for FunctionInvocation {
+impl TryFrom<blockifier::execution::entry_point::CallInfo> for FunctionInvocation {
     type Error = blockifier::transaction::errors::TransactionExecutionError;
 
     fn try_from(
-        call_info: blockifier::execution::call_info::CallInfo,
+        call_info: blockifier::execution::entry_point::CallInfo,
     ) -> Result<Self, Self::Error> {
         call_info.get_sorted_l2_to_l1_payloads_length()?;
         let messages = ordered_l2_to_l1_messages(&call_info);
@@ -218,8 +218,8 @@ impl From<starknet_api::deprecated_contract_class::EntryPointType> for EntryPoin
     }
 }
 
-impl From<blockifier::execution::call_info::OrderedEvent> for Event {
-    fn from(value: blockifier::execution::call_info::OrderedEvent) -> Self {
+impl From<blockifier::execution::entry_point::OrderedEvent> for Event {
+    fn from(value: blockifier::execution::entry_point::OrderedEvent) -> Self {
         Self {
             order: value.order as i64,
             data: value
@@ -240,7 +240,7 @@ impl From<blockifier::execution::call_info::OrderedEvent> for Event {
 }
 
 fn ordered_l2_to_l1_messages(
-    call_info: &blockifier::execution::call_info::CallInfo,
+    call_info: &blockifier::execution::entry_point::CallInfo,
 ) -> Vec<MsgToL1> {
     let mut messages = BTreeMap::new();
 

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -59,7 +59,7 @@ starknet-gateway-client = { path = "../gateway-client" }
 starknet-gateway-types = { path = "../gateway-types" }
 tempfile = "3.8"
 thiserror = "1.0.48"
-time = { version = "0.3.28", features = ["macros"] }
+time = { version = "0.3.26", features = ["macros"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.17", features = [

--- a/crates/rpc/src/executor.rs
+++ b/crates/rpc/src/executor.rs
@@ -155,15 +155,16 @@ pub(crate) fn map_broadcasted_transaction(
                         PatriciaKey::try_from(tx.sender_address.get().into_starkfelt())
                             .expect("No sender address overflow expected"),
                     ),
+                    transaction_hash: starknet_api::transaction::TransactionHash(
+                        transaction_hash.0.into_starkfelt(),
+                    ),
                 };
 
                 let tx = pathfinder_executor::Transaction::from_api(
                     starknet_api::transaction::Transaction::Declare(
                         starknet_api::transaction::DeclareTransaction::V0(tx),
                     ),
-                    starknet_api::transaction::TransactionHash(transaction_hash.0.into_starkfelt()),
                     Some(contract_class),
-                    None,
                     None,
                 )?;
                 Ok(tx)
@@ -194,15 +195,16 @@ pub(crate) fn map_broadcasted_transaction(
                         PatriciaKey::try_from(tx.sender_address.get().into_starkfelt())
                             .expect("No sender address overflow expected"),
                     ),
+                    transaction_hash: starknet_api::transaction::TransactionHash(
+                        transaction_hash.0.into_starkfelt(),
+                    ),
                 };
 
                 let tx = pathfinder_executor::Transaction::from_api(
                     starknet_api::transaction::Transaction::Declare(
                         starknet_api::transaction::DeclareTransaction::V1(tx),
                     ),
-                    starknet_api::transaction::TransactionHash(transaction_hash.0.into_starkfelt()),
                     Some(contract_class),
-                    None,
                     None,
                 )?;
                 Ok(tx)
@@ -241,15 +243,16 @@ pub(crate) fn map_broadcasted_transaction(
                     compiled_class_hash: starknet_api::core::CompiledClassHash(
                         tx.compiled_class_hash.0.into_starkfelt(),
                     ),
+                    transaction_hash: starknet_api::transaction::TransactionHash(
+                        transaction_hash.0.into_starkfelt(),
+                    ),
                 };
 
                 let tx = pathfinder_executor::Transaction::from_api(
                     starknet_api::transaction::Transaction::Declare(
                         starknet_api::transaction::DeclareTransaction::V2(tx),
                     ),
-                    starknet_api::transaction::TransactionHash(transaction_hash.0.into_starkfelt()),
                     Some(casm_contract_definition),
-                    None,
                     None,
                 )?;
 
@@ -268,7 +271,7 @@ pub(crate) fn map_broadcasted_transaction(
                     signature: starknet_api::transaction::TransactionSignature(
                         tx.signature.iter().map(|s| s.0.into_starkfelt()).collect(),
                     ),
-                    contract_address: starknet_api::core::ContractAddress(
+                    sender_address: starknet_api::core::ContractAddress(
                         PatriciaKey::try_from(tx.contract_address.get().into_starkfelt())
                             .expect("No sender address overflow expected"),
                     ),
@@ -278,14 +281,16 @@ pub(crate) fn map_broadcasted_transaction(
                     calldata: starknet_api::transaction::Calldata(std::sync::Arc::new(
                         tx.calldata.iter().map(|c| c.0.into_starkfelt()).collect(),
                     )),
+                    transaction_hash: starknet_api::transaction::TransactionHash(
+                        transaction_hash.0.into_starkfelt(),
+                    ),
+                    nonce: starknet_api::core::Nonce(Felt::ZERO.into_starkfelt()),
                 };
 
                 let tx = pathfinder_executor::Transaction::from_api(
                     starknet_api::transaction::Transaction::Invoke(
                         starknet_api::transaction::InvokeTransaction::V0(tx),
                     ),
-                    starknet_api::transaction::TransactionHash(transaction_hash.0.into_starkfelt()),
-                    None,
                     None,
                     None,
                 )?;
@@ -311,14 +316,15 @@ pub(crate) fn map_broadcasted_transaction(
                     calldata: starknet_api::transaction::Calldata(std::sync::Arc::new(
                         tx.calldata.iter().map(|c| c.0.into_starkfelt()).collect(),
                     )),
+                    transaction_hash: starknet_api::transaction::TransactionHash(
+                        transaction_hash.0.into_starkfelt(),
+                    ),
                 };
 
                 let tx = pathfinder_executor::Transaction::from_api(
                     starknet_api::transaction::Transaction::Invoke(
                         starknet_api::transaction::InvokeTransaction::V1(tx),
                     ),
-                    starknet_api::transaction::TransactionHash(transaction_hash.0.into_starkfelt()),
-                    None,
                     None,
                     None,
                 )?;
@@ -353,17 +359,19 @@ pub(crate) fn map_broadcasted_transaction(
                         .map(|c| c.0.into_starkfelt())
                         .collect(),
                 )),
+                transaction_hash: starknet_api::transaction::TransactionHash(
+                    transaction_hash.0.into_starkfelt(),
+                ),
+                contract_address: starknet_api::core::ContractAddress(
+                    PatriciaKey::try_from(deployed_contract_address.get().into_starkfelt())
+                        .expect("No sender address overflow expected"),
+                ),
             };
 
             let tx = pathfinder_executor::Transaction::from_api(
                 starknet_api::transaction::Transaction::DeployAccount(tx),
-                starknet_api::transaction::TransactionHash(transaction_hash.0.into_starkfelt()),
                 None,
                 None,
-                Some(starknet_api::core::ContractAddress(
-                    PatriciaKey::try_from(deployed_contract_address.get().into_starkfelt())
-                        .expect("No sender address overflow expected"),
-                )),
             )?;
 
             Ok(tx)
@@ -409,15 +417,14 @@ pub fn compose_executor_transaction(
                         PatriciaKey::try_from(tx.sender_address.get().into_starkfelt())
                             .expect("No sender address overflow expected"),
                     ),
+                    transaction_hash: tx_hash,
                 };
 
                 let tx = pathfinder_executor::Transaction::from_api(
                     starknet_api::transaction::Transaction::Declare(
                         starknet_api::transaction::DeclareTransaction::V0(tx),
                     ),
-                    tx_hash,
                     Some(contract_class),
-                    None,
                     None,
                 )?;
 
@@ -447,15 +454,14 @@ pub fn compose_executor_transaction(
                         PatriciaKey::try_from(tx.sender_address.get().into_starkfelt())
                             .expect("No sender address overflow expected"),
                     ),
+                    transaction_hash: tx_hash,
                 };
 
                 let tx = pathfinder_executor::Transaction::from_api(
                     starknet_api::transaction::Transaction::Declare(
                         starknet_api::transaction::DeclareTransaction::V1(tx),
                     ),
-                    tx_hash,
                     Some(contract_class),
-                    None,
                     None,
                 )?;
 
@@ -487,15 +493,14 @@ pub fn compose_executor_transaction(
                     compiled_class_hash: starknet_api::core::CompiledClassHash(
                         tx.compiled_class_hash.0.into_starkfelt(),
                     ),
+                    transaction_hash: tx_hash,
                 };
 
                 let tx = pathfinder_executor::Transaction::from_api(
                     starknet_api::transaction::Transaction::Declare(
                         starknet_api::transaction::DeclareTransaction::V2(tx),
                     ),
-                    tx_hash,
                     Some(contract_class),
-                    None,
                     None,
                 )?;
 
@@ -540,14 +545,14 @@ pub fn compose_executor_transaction(
                         .map(|c| c.0.into_starkfelt())
                         .collect(),
                 )),
+                transaction_hash: tx_hash,
+                contract_address,
             };
 
             let tx = pathfinder_executor::Transaction::from_api(
                 starknet_api::transaction::Transaction::DeployAccount(tx),
-                tx_hash,
                 None,
                 None,
-                Some(contract_address),
             )?;
 
             Ok(tx)
@@ -565,7 +570,7 @@ pub fn compose_executor_transaction(
                             .map(|s| s.0.into_starkfelt())
                             .collect(),
                     ),
-                    contract_address: starknet_api::core::ContractAddress(
+                    sender_address: starknet_api::core::ContractAddress(
                         PatriciaKey::try_from(tx.sender_address.get().into_starkfelt())
                             .expect("No sender address overflow expected"),
                     ),
@@ -578,14 +583,14 @@ pub fn compose_executor_transaction(
                             .map(|c| c.0.into_starkfelt())
                             .collect(),
                     )),
+                    transaction_hash: tx_hash,
+                    nonce: starknet_api::core::Nonce(Felt::ZERO.into_starkfelt()),
                 };
 
                 let tx = pathfinder_executor::Transaction::from_api(
                     starknet_api::transaction::Transaction::Invoke(
                         starknet_api::transaction::InvokeTransaction::V0(tx),
                     ),
-                    tx_hash,
-                    None,
                     None,
                     None,
                 )?;
@@ -615,14 +620,13 @@ pub fn compose_executor_transaction(
                             .map(|c| c.0.into_starkfelt())
                             .collect(),
                     )),
+                    transaction_hash: tx_hash,
                 };
 
                 let tx = pathfinder_executor::Transaction::from_api(
                     starknet_api::transaction::Transaction::Invoke(
                         starknet_api::transaction::InvokeTransaction::V1(tx),
                     ),
-                    tx_hash,
-                    None,
                     None,
                     None,
                 )?;
@@ -650,14 +654,13 @@ pub fn compose_executor_transaction(
                         .map(|c| c.0.into_starkfelt())
                         .collect(),
                 )),
+                transaction_hash: tx_hash,
             };
 
             let tx = pathfinder_executor::Transaction::from_api(
                 starknet_api::transaction::Transaction::L1Handler(tx),
-                tx_hash,
                 None,
                 Some(starknet_api::transaction::Fee(1_000_000_000_000)),
-                None,
             )?;
 
             Ok(tx)

--- a/crates/rpc/src/v05/method/estimate_message_fee.rs
+++ b/crates/rpc/src/v05/method/estimate_message_fee.rs
@@ -136,14 +136,15 @@ fn create_executor_transaction(
             input.message.entry_point_selector.0.into_starkfelt(),
         ),
         calldata: starknet_api::transaction::Calldata(Arc::new(calldata)),
+        transaction_hash: starknet_api::transaction::TransactionHash(
+            transaction_hash.0.into_starkfelt(),
+        ),
     };
 
     let transaction = pathfinder_executor::Transaction::from_api(
         starknet_api::transaction::Transaction::L1Handler(tx),
-        starknet_api::transaction::TransactionHash(transaction_hash.0.into_starkfelt()),
         None,
         Some(starknet_api::transaction::Fee(1)),
-        None,
     )?;
     Ok(transaction)
 }


### PR DESCRIPTION
NOTE: this is supposed to be a temporary measure until fixes are merged back to the blockifier branch for 0.13.0.

This PR downgrades our `blockifier` dependency to use the `main-v0.12.3` branch. This branch will later contain a fix for the query version issue but is using a much older `starknet_api` dependency which we need to adapt our code to.

We also have to downgrade a few third party dependencies (like `serde` and `time`) so that they are compatible with this branch of `starknet_api` and `blockifier`.