### PR TITLE
fix(executor): upgrade blockifier dependency to latest main-v0.12.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,7 +901,7 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 [[package]]
 name = "blockifier"
 version = "0.4.0-rc0"
-source = "git+https://github.com/starkware-libs/blockifier?rev=16e60551ba0f55a110e9c0acb2c16ec43b3758c4#16e60551ba0f55a110e9c0acb2c16ec43b3758c4"
+source = "git+https://github.com/starkware-libs/blockifier?rev=b5dfbd31ff879cb8309b1e5e21d8f8556c796b6a#b5dfbd31ff879cb8309b1e5e21d8f8556c796b6a"
 dependencies = [
  "ark-ec",
  "ark-ff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ async-trait = "0.1.73"
 axum = { version = "0.6.19", features = ["macros"] }
 base64 = "0.13.1"
 bitvec = "1.0.1"
-blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "16e60551ba0f55a110e9c0acb2c16ec43b3758c4" }
+blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "b5dfbd31ff879cb8309b1e5e21d8f8556c796b6a" }
 bytes = "1.4.0"
 # This one needs to match the version used by blockifier
 cairo-vm = "=0.8.2"

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -180,6 +180,10 @@ impl TransactionVersion {
         self
     }
 
+    pub const fn has_query_version(&self) -> bool {
+        self.0 .0[15] & 0b0000_0001 != 0
+    }
+
     pub const ZERO: Self = Self(H256::zero());
     pub const ONE: Self = Self(H256([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/crates/executor/src/transaction.rs
+++ b/crates/executor/src/transaction.rs
@@ -15,7 +15,7 @@ pub fn transaction_hash(transaction: &Transaction) -> TransactionHash {
                 }
                 blockifier::transaction::account_transaction::AccountTransaction::DeployAccount(
                     tx,
-                ) => tx.transaction_hash,
+                ) => tx.transaction_hash(),
                 blockifier::transaction::account_transaction::AccountTransaction::Invoke(tx) => {
                     tx.transaction_hash()
                 }

--- a/crates/rpc/src/executor.rs
+++ b/crates/rpc/src/executor.rs
@@ -31,6 +31,8 @@ pub(crate) fn map_broadcasted_transaction(
 
                 let transaction_hash = transaction.transaction_hash(chain_id, Some(class_hash));
 
+                let version = tx.version;
+
                 let contract_class_json = tx
                     .contract_class
                     .serialize_to_json()
@@ -63,6 +65,7 @@ pub(crate) fn map_broadcasted_transaction(
                     ),
                     Some(contract_class),
                     None,
+                    version.has_query_version(),
                 )?;
                 Ok(tx)
             }
@@ -70,6 +73,8 @@ pub(crate) fn map_broadcasted_transaction(
                 let class_hash = tx.contract_class.class_hash()?.hash();
 
                 let transaction_hash = transaction.transaction_hash(chain_id, Some(class_hash));
+
+                let version = tx.version;
 
                 let contract_class_json = tx
                     .contract_class
@@ -103,6 +108,7 @@ pub(crate) fn map_broadcasted_transaction(
                     ),
                     Some(contract_class),
                     None,
+                    version.has_query_version(),
                 )?;
                 Ok(tx)
             }
@@ -111,6 +117,8 @@ pub(crate) fn map_broadcasted_transaction(
 
                 let transaction_hash =
                     transaction.transaction_hash(chain_id, Some(sierra_class_hash));
+
+                let version = tx.version;
 
                 let casm_contract_definition =
                     pathfinder_compiler::compile_to_casm_with_latest_compiler(
@@ -151,6 +159,7 @@ pub(crate) fn map_broadcasted_transaction(
                     ),
                     Some(casm_contract_definition),
                     None,
+                    version.has_query_version(),
                 )?;
 
                 Ok(tx)
@@ -159,6 +168,8 @@ pub(crate) fn map_broadcasted_transaction(
         BroadcastedTransaction::Invoke(tx) => match tx {
             crate::v02::types::request::BroadcastedInvokeTransaction::V0(tx) => {
                 let transaction_hash = transaction.transaction_hash(chain_id, None);
+
+                let version = tx.version;
 
                 let tx = starknet_api::transaction::InvokeTransactionV0 {
                     // TODO: maybe we should store tx.max_fee as u128 internally?
@@ -190,12 +201,15 @@ pub(crate) fn map_broadcasted_transaction(
                     ),
                     None,
                     None,
+                    version.has_query_version(),
                 )?;
 
                 Ok(tx)
             }
             crate::v02::types::request::BroadcastedInvokeTransaction::V1(tx) => {
                 let transaction_hash = transaction.transaction_hash(chain_id, None);
+
+                let version = tx.version;
 
                 let tx = starknet_api::transaction::InvokeTransactionV1 {
                     // TODO: maybe we should store tx.max_fee as u128 internally?
@@ -224,6 +238,7 @@ pub(crate) fn map_broadcasted_transaction(
                     ),
                     None,
                     None,
+                    version.has_query_version(),
                 )?;
 
                 Ok(tx)
@@ -231,6 +246,8 @@ pub(crate) fn map_broadcasted_transaction(
         },
         BroadcastedTransaction::DeployAccount(tx) => {
             let transaction_hash = transaction.transaction_hash(chain_id, None);
+
+            let version = tx.version;
 
             let deployed_contract_address = tx.deployed_contract_address();
 
@@ -269,6 +286,7 @@ pub(crate) fn map_broadcasted_transaction(
                 starknet_api::transaction::Transaction::DeployAccount(tx),
                 None,
                 None,
+                version.has_query_version(),
             )?;
 
             Ok(tx)
@@ -320,6 +338,7 @@ pub fn compose_executor_transaction(
                     ),
                     Some(contract_class),
                     None,
+                    false,
                 )?;
 
                 Ok(tx)
@@ -354,6 +373,7 @@ pub fn compose_executor_transaction(
                     ),
                     Some(contract_class),
                     None,
+                    false,
                 )?;
 
                 Ok(tx)
@@ -390,6 +410,7 @@ pub fn compose_executor_transaction(
                     ),
                     Some(contract_class),
                     None,
+                    false,
                 )?;
 
                 Ok(tx)
@@ -435,6 +456,7 @@ pub fn compose_executor_transaction(
                 starknet_api::transaction::Transaction::DeployAccount(tx),
                 None,
                 None,
+                false,
             )?;
 
             Ok(tx)
@@ -469,6 +491,7 @@ pub fn compose_executor_transaction(
                     ),
                     None,
                     None,
+                    false,
                 )?;
 
                 Ok(tx)
@@ -499,6 +522,7 @@ pub fn compose_executor_transaction(
                     ),
                     None,
                     None,
+                    false,
                 )?;
 
                 Ok(tx)
@@ -528,6 +552,7 @@ pub fn compose_executor_transaction(
                 starknet_api::transaction::Transaction::L1Handler(tx),
                 None,
                 Some(starknet_api::transaction::Fee(1_000_000_000_000)),
+                false,
             )?;
 
             Ok(tx)

--- a/crates/rpc/src/v05/method/estimate_message_fee.rs
+++ b/crates/rpc/src/v05/method/estimate_message_fee.rs
@@ -169,6 +169,7 @@ fn create_executor_transaction(
         starknet_api::transaction::Transaction::L1Handler(tx),
         None,
         Some(starknet_api::transaction::Fee(1)),
+        false,
     )?;
     Ok(transaction)
 }


### PR DESCRIPTION
This version solves the query version flag issue (where the flag was not set when queried via the `get_execution_info` syscall).