### PR TITLE
fix(executor): bump `invoke_tx_max_n_steps` to 3M

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - RPC errors do not always include the root cause. For example, some gateway error messages are not output when pathfinder forwards the request.
 - RPC trace object uses wrong property `reverted_reason` instead of `revert_reason`
+- RPC execution steps limits have been updated to match the setup of the Starknet sequencer
 
 ### Added
 

--- a/crates/executor/src/block_context.rs
+++ b/crates/executor/src/block_context.rs
@@ -42,7 +42,7 @@ pub(super) fn construct_block_context(
         fee_token_address,
         vm_resource_fee_cost: Arc::new(default_resource_fee_costs()),
         gas_price: execution_state.header.gas_price.0,
-        invoke_tx_max_n_steps: 1_000_000,
+        invoke_tx_max_n_steps: 3_000_000,
         validate_max_n_steps: 1_000_000,
         max_recursion_depth: 50,
     })


### PR DESCRIPTION

Our previous value of 1M might cause execution-related methods to run out of steps and return an error, while the exact same calls did work on the Starknet gateway.

Closes #1474 