### PR TITLE
feat: distinguish internal and custom errs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- RPC errors now only include the root cause if white-listed as non-sensitive
+
 ### Fixed
 
 - JSON-RPC 0.5 transaction traces now have the required `type` property.

--- a/crates/executor/src/error.rs
+++ b/crates/executor/src/error.rs
@@ -10,6 +10,7 @@ pub enum CallError {
     InvalidMessageSelector,
     Reverted(String),
     Internal(anyhow::Error),
+    Custom(anyhow::Error),
 }
 
 impl From<TransactionExecutionError> for CallError {

--- a/crates/gateway-types/src/error.rs
+++ b/crates/gateway-types/src/error.rs
@@ -10,7 +10,7 @@ pub enum SequencerError {
     /// Errors directly coming from reqwest
     #[error(transparent)]
     ReqwestError(#[from] reqwest::Error),
-    /// Custom errors that we fidded with because the original error was either
+    /// Custom errors that we fiddled with because the original error was either
     /// not informative enough or bloated
     #[error("error decoding response body: invalid error variant")]
     InvalidStarknetErrorVariant,

--- a/crates/rpc/src/jsonrpc/error.rs
+++ b/crates/rpc/src/jsonrpc/error.rs
@@ -46,8 +46,6 @@ impl RpcError {
             RpcError::InvalidRequest => "Invalid Request".into(),
             RpcError::MethodNotFound { .. } => "Method not found".into(),
             RpcError::InvalidParams => "Invalid params".into(),
-            // TODO: this is not necessarily a good idea. All internal errors are returned here, even
-            // ones that we probably should not disclose.
             RpcError::InternalError(_) => "Internal error".into(),
             RpcError::ApplicationError(e) => e.to_string().into(),
             RpcError::WebsocketSubscriptionClosed { .. } => "Websocket subscription closed".into(),
@@ -64,16 +62,7 @@ impl RpcError {
                 "reason": reason,
             })),
             RpcError::ApplicationError(e) => e.data(),
-            RpcError::InternalError(error) => {
-                let error = error.to_string();
-                if error.is_empty() {
-                    None
-                } else {
-                    Some(json!({
-                        "error": error.to_string(),
-                    }))
-                }
-            }
+            RpcError::InternalError(_) => None,
             RpcError::ParseError => None,
             RpcError::InvalidRequest => None,
             RpcError::MethodNotFound => None,

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -93,8 +93,9 @@ impl RpcRouter {
             Ok(output) => output,
             Err(e) => {
                 tracing::warn!(method=%request.method, backtrace=?e, "RPC method panic'd");
-                // No error message so that the caller cannot learn to abuse this.
-                Err(RpcError::InternalError(anyhow::anyhow!("")))
+                Err(RpcError::InternalError(anyhow::anyhow!(
+                    "RPC method panic'd"
+                )))
             }
         };
 

--- a/crates/rpc/src/pathfinder/methods/get_proof.rs
+++ b/crates/rpc/src/pathfinder/methods/get_proof.rs
@@ -22,11 +22,13 @@ pub enum GetProofError {
     BlockNotFound,
     ProofLimitExceeded { limit: u32, requested: u32 },
 }
+
 impl From<anyhow::Error> for GetProofError {
     fn from(e: anyhow::Error) -> Self {
         Self::Internal(e)
     }
 }
+
 impl From<GetProofError> for crate::error::ApplicationError {
     fn from(x: GetProofError) -> Self {
         match x {

--- a/crates/rpc/src/v02/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v02/method/add_declare_transaction.rs
@@ -13,6 +13,7 @@ pub enum AddDeclareTransactionError {
     InvalidContractClass,
     GatewayError(StarknetError),
     Internal(anyhow::Error),
+    Custom(anyhow::Error),
 }
 
 impl From<AddDeclareTransactionError> for crate::error::ApplicationError {
@@ -21,6 +22,7 @@ impl From<AddDeclareTransactionError> for crate::error::ApplicationError {
             AddDeclareTransactionError::InvalidContractClass => Self::InvalidContractClass,
             AddDeclareTransactionError::GatewayError(x) => Self::GatewayError(x),
             AddDeclareTransactionError::Internal(x) => Self::Internal(x),
+            AddDeclareTransactionError::Custom(x) => Self::Custom(x),
         }
     }
 }
@@ -80,7 +82,7 @@ pub async fn add_declare_transaction(
 ) -> Result<AddDeclareTransactionOutput, AddDeclareTransactionError> {
     match input.declare_transaction {
         Transaction::Declare(BroadcastedDeclareTransaction::V0(_)) => {
-            Err(AddDeclareTransactionError::Internal(anyhow::anyhow!(
+            Err(AddDeclareTransactionError::Custom(anyhow::anyhow!(
                 "Declare v0 transactions are not allowed"
             )))
         }

--- a/crates/rpc/src/v02/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/v02/method/add_deploy_account_transaction.rs
@@ -44,12 +44,6 @@ impl From<AddDeployAccountTransactionError> for crate::error::ApplicationError {
     }
 }
 
-impl From<anyhow::Error> for AddDeployAccountTransactionError {
-    fn from(value: anyhow::Error) -> Self {
-        AddDeployAccountTransactionError::Internal(value)
-    }
-}
-
 pub async fn add_deploy_account_transaction(
     context: RpcContext,
     input: AddDeployAccountTransactionInput,

--- a/crates/rpc/src/v02/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/v02/method/add_invoke_transaction.rs
@@ -40,12 +40,6 @@ impl From<AddInvokeTransactionError> for crate::error::ApplicationError {
     }
 }
 
-impl From<anyhow::Error> for AddInvokeTransactionError {
-    fn from(value: anyhow::Error) -> Self {
-        AddInvokeTransactionError::Internal(value)
-    }
-}
-
 pub async fn add_invoke_transaction(
     context: RpcContext,
     input: AddInvokeTransactionInput,

--- a/crates/rpc/src/v02/method/call.rs
+++ b/crates/rpc/src/v02/method/call.rs
@@ -10,8 +10,9 @@ impl From<crate::v05::method::call::CallError> for CallError {
             crate::v05::method::call::CallError::BlockNotFound => Self::BlockNotFound,
             crate::v05::method::call::CallError::ContractNotFound => Self::ContractNotFound,
             crate::v05::method::call::CallError::ContractErrorV05 { revert_error } => {
-                Self::Internal(anyhow::anyhow!("Transaction reverted: {}", revert_error))
+                Self::Custom(anyhow::anyhow!("Transaction reverted: {}", revert_error))
             }
+            crate::v05::method::call::CallError::Custom(e) => Self::Custom(e),
         }
     }
 }

--- a/crates/rpc/src/v03/method/estimate_fee.rs
+++ b/crates/rpc/src/v03/method/estimate_fee.rs
@@ -17,8 +17,9 @@ impl From<crate::v05::method::estimate_fee::EstimateFeeError> for EstimateFeeErr
             BlockNotFound => Self::BlockNotFound,
             ContractNotFound => Self::ContractNotFound,
             ContractErrorV05 { revert_error } => {
-                Self::Internal(anyhow::anyhow!("Transaction reverted: {}", revert_error))
+                Self::Custom(anyhow::anyhow!("Transaction reverted: {}", revert_error))
             }
+            Custom(e) => Self::Custom(e),
         }
     }
 }

--- a/crates/rpc/src/v03/method/estimate_message_fee.rs
+++ b/crates/rpc/src/v03/method/estimate_message_fee.rs
@@ -29,6 +29,7 @@ impl From<crate::v05::method::estimate_message_fee::EstimateMessageFeeError>
             ContractErrorV05 { revert_error } => {
                 Self::Internal(anyhow::anyhow!("Transaction reverted: {}", revert_error))
             }
+            Custom(error) => Self::Custom(error),
         }
     }
 }
@@ -255,7 +256,7 @@ mod tests {
         let rpc = setup(Setup::Full).await.expect("RPC context");
         assert_matches::assert_matches!(
             estimate_message_fee(rpc, input).await,
-            Err(EstimateMessageFeeError::Internal(_))
+            Err(EstimateMessageFeeError::Custom(_))
         );
     }
 }

--- a/crates/rpc/src/v03/method/get_events.rs
+++ b/crates/rpc/src/v03/method/get_events.rs
@@ -12,6 +12,7 @@ use tokio::task::JoinHandle;
 #[derive(Debug)]
 pub enum GetEventsError {
     Internal(anyhow::Error),
+    Custom(anyhow::Error),
     BlockNotFound,
     PageSizeTooBig,
     InvalidContinuationToken,
@@ -28,6 +29,7 @@ impl From<GetEventsError> for crate::error::ApplicationError {
     fn from(e: GetEventsError) -> Self {
         match e {
             GetEventsError::Internal(internal) => Self::Internal(internal),
+            GetEventsError::Custom(internal) => Self::Custom(internal),
             GetEventsError::BlockNotFound => Self::BlockNotFound,
             GetEventsError::PageSizeTooBig => Self::PageSizeTooBig,
             GetEventsError::InvalidContinuationToken => Self::InvalidContinuationToken,
@@ -162,15 +164,11 @@ pub async fn get_events(
         // We don't add context here, because [StarknetEventsTable::get_events] adds its
         // own context to the errors. This way we get meaningful error information
         // for errors related to query parameters.
-        let page = transaction.events(&filter).map_err(|e| {
-            if let Some(event_filter_error) = e.downcast_ref::<EventFilterError>() {
-                match event_filter_error {
-                    EventFilterError::PageSizeTooBig(_) => GetEventsError::PageSizeTooBig,
-                    EventFilterError::TooManyMatches => GetEventsError::from(e),
-                }
-            } else {
-                GetEventsError::from(e)
-            }
+        let page = transaction.events(&filter).map_err(|e| match e {
+            EventFilterError::PageSizeTooBig(_) => GetEventsError::PageSizeTooBig,
+            EventFilterError::TooManyMatches => GetEventsError::Custom(e.into()),
+            EventFilterError::Internal(e) => GetEventsError::Internal(e),
+            EventFilterError::PageSizeTooSmall => GetEventsError::Custom(e.into()),
         })?;
 
         let new_continuation_token = match page.is_last_page {

--- a/crates/rpc/src/v03/method/simulate_transaction.rs
+++ b/crates/rpc/src/v03/method/simulate_transaction.rs
@@ -32,9 +32,10 @@ impl From<CallError> for SimulateTransactionError {
             ContractNotFound => Self::ContractNotFound,
             InvalidMessageSelector => Self::ContractError,
             Reverted(revert_error) => {
-                Self::Internal(anyhow::anyhow!("Transaction reverted: {}", revert_error))
+                Self::Custom(anyhow::anyhow!("Transaction reverted: {}", revert_error))
             }
             Internal(e) => Self::Internal(e),
+            Custom(e) => Self::Custom(e),
         }
     }
 }

--- a/crates/rpc/src/v04/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/v04/method/add_deploy_account_transaction.rs
@@ -57,12 +57,6 @@ impl From<AddDeployAccountTransactionError> for crate::error::ApplicationError {
     }
 }
 
-impl From<anyhow::Error> for AddDeployAccountTransactionError {
-    fn from(value: anyhow::Error) -> Self {
-        AddDeployAccountTransactionError::UnexpectedError(value.to_string())
-    }
-}
-
 impl From<SequencerError> for AddDeployAccountTransactionError {
     fn from(e: SequencerError) -> Self {
         use starknet_gateway_types::error::KnownStarknetErrorCode::{

--- a/crates/rpc/src/v04/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/v04/method/add_invoke_transaction.rs
@@ -54,12 +54,6 @@ impl From<AddInvokeTransactionError> for crate::error::ApplicationError {
     }
 }
 
-impl From<anyhow::Error> for AddInvokeTransactionError {
-    fn from(value: anyhow::Error) -> Self {
-        AddInvokeTransactionError::UnexpectedError(value.to_string())
-    }
-}
-
 impl From<SequencerError> for AddInvokeTransactionError {
     fn from(e: SequencerError) -> Self {
         use starknet_gateway_types::error::KnownStarknetErrorCode::{

--- a/crates/rpc/src/v04/method/estimate_message_fee.rs
+++ b/crates/rpc/src/v04/method/estimate_message_fee.rs
@@ -20,6 +20,7 @@ impl From<crate::v05::method::estimate_message_fee::EstimateMessageFeeError>
             ContractErrorV05 { revert_error } => {
                 Self::Internal(anyhow::anyhow!("Transaction reverted: {}", revert_error))
             }
+            Custom(error) => Self::Custom(error),
         }
     }
 }

--- a/crates/rpc/src/v04/method/simulate_transactions.rs
+++ b/crates/rpc/src/v04/method/simulate_transactions.rs
@@ -34,9 +34,10 @@ impl From<CallError> for SimulateTransactionError {
             ContractNotFound => Self::ContractNotFound,
             InvalidMessageSelector => Self::ContractError,
             Reverted(revert_error) => {
-                Self::Internal(anyhow::anyhow!("Transaction reverted: {}", revert_error))
+                Self::Custom(anyhow::anyhow!("Transaction reverted: {}", revert_error))
             }
             Internal(e) => Self::Internal(e),
+            Custom(e) => Self::Custom(e),
         }
     }
 }

--- a/crates/rpc/src/v04/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v04/method/trace_block_transactions.rs
@@ -4,7 +4,6 @@ use pathfinder_executor::{CallError, ExecutionState};
 use serde::{Deserialize, Serialize};
 use starknet_gateway_client::GatewayApi;
 use starknet_gateway_types::reply::transaction::Transaction as GatewayTransaction;
-use tokio::task::JoinError;
 
 use crate::executor::VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEWAY;
 use crate::v04::v04_method::simulate_transactions::dto::map_gateway_trace;
@@ -43,19 +42,14 @@ impl From<ExecutionStateError> for TraceBlockTransactionsError {
 impl From<CallError> for TraceBlockTransactionsError {
     fn from(value: CallError) -> Self {
         match value {
-            CallError::ContractNotFound => Self::Internal(anyhow::anyhow!("Contract not found")),
+            CallError::ContractNotFound => Self::Custom(anyhow::anyhow!("Contract not found")),
             CallError::InvalidMessageSelector => {
-                Self::Internal(anyhow::anyhow!("Invalid message selector"))
+                Self::Custom(anyhow::anyhow!("Invalid message selector"))
             }
-            CallError::Reverted(reason) => Self::Internal(anyhow::anyhow!("Reverted: {reason}")),
+            CallError::Reverted(reason) => Self::Custom(anyhow::anyhow!("Reverted: {reason}")),
             CallError::Internal(e) => Self::Internal(e),
+            CallError::Custom(e) => Self::Custom(e),
         }
-    }
-}
-
-impl From<JoinError> for TraceBlockTransactionsError {
-    fn from(e: JoinError) -> Self {
-        Self::Internal(anyhow::anyhow!("Join error: {e}"))
     }
 }
 

--- a/crates/rpc/src/v05/method/estimate_fee.rs
+++ b/crates/rpc/src/v05/method/estimate_fee.rs
@@ -17,6 +17,7 @@ pub struct EstimateFeeInput {
 #[derive(Debug)]
 pub enum EstimateFeeError {
     Internal(anyhow::Error),
+    Custom(anyhow::Error),
     BlockNotFound,
     ContractNotFound,
     ContractErrorV05 { revert_error: String },
@@ -36,6 +37,7 @@ impl From<pathfinder_executor::CallError> for EstimateFeeError {
             InvalidMessageSelector => Self::Internal(anyhow::anyhow!("Invalid message selector")),
             Reverted(revert_error) => Self::ContractErrorV05 { revert_error },
             Internal(e) => Self::Internal(e),
+            Custom(e) => Self::Custom(e),
         }
     }
 }
@@ -59,6 +61,7 @@ impl From<EstimateFeeError> for ApplicationError {
                 ApplicationError::ContractErrorV05 { revert_error }
             }
             EstimateFeeError::Internal(e) => ApplicationError::Internal(e),
+            EstimateFeeError::Custom(e) => ApplicationError::Custom(e),
         }
     }
 }

--- a/crates/rpc/src/v05/method/estimate_message_fee.rs
+++ b/crates/rpc/src/v05/method/estimate_message_fee.rs
@@ -17,6 +17,7 @@ pub enum EstimateMessageFeeError {
     BlockNotFound,
     ContractNotFound,
     ContractErrorV05 { revert_error: String },
+    Custom(anyhow::Error),
 }
 
 impl From<anyhow::Error> for EstimateMessageFeeError {
@@ -29,10 +30,11 @@ impl From<pathfinder_executor::CallError> for EstimateMessageFeeError {
     fn from(c: pathfinder_executor::CallError) -> Self {
         use pathfinder_executor::CallError::*;
         match c {
-            InvalidMessageSelector => Self::Internal(anyhow::anyhow!("Invalid message selector")),
+            InvalidMessageSelector => Self::Custom(anyhow::anyhow!("Invalid message selector")),
             ContractNotFound => Self::ContractNotFound,
             Reverted(revert_error) => Self::ContractErrorV05 { revert_error },
             Internal(e) => Self::Internal(e),
+            Custom(e) => Self::Custom(e),
         }
     }
 }
@@ -56,6 +58,7 @@ impl From<EstimateMessageFeeError> for ApplicationError {
                 ApplicationError::ContractErrorV05 { revert_error }
             }
             EstimateMessageFeeError::Internal(e) => ApplicationError::Internal(e),
+            EstimateMessageFeeError::Custom(e) => ApplicationError::Custom(e),
         }
     }
 }
@@ -401,7 +404,7 @@ mod tests {
         let rpc = setup(Setup::Full).await.expect("RPC context");
         assert_matches::assert_matches!(
             estimate_message_fee(rpc, input).await,
-            Err(EstimateMessageFeeError::Internal(_))
+            Err(EstimateMessageFeeError::Custom(_))
         );
     }
 }

--- a/crates/rpc/src/v05/method/simulate_transactions.rs
+++ b/crates/rpc/src/v05/method/simulate_transactions.rs
@@ -22,6 +22,7 @@ pub struct SimulateTransactionOutput(pub Vec<dto::SimulatedTransaction>);
 #[derive(Debug)]
 pub enum SimulateTransactionError {
     Internal(anyhow::Error),
+    Custom(anyhow::Error),
     BlockNotFound,
     ContractNotFound,
     ContractErrorV05 { revert_error: String },
@@ -37,6 +38,7 @@ impl From<SimulateTransactionError> for crate::error::ApplicationError {
     fn from(e: SimulateTransactionError) -> Self {
         match e {
             SimulateTransactionError::Internal(internal) => Self::Internal(internal),
+            SimulateTransactionError::Custom(internal) => Self::Custom(internal),
             SimulateTransactionError::BlockNotFound => Self::BlockNotFound,
             SimulateTransactionError::ContractNotFound => Self::ContractNotFound,
             SimulateTransactionError::ContractErrorV05 { revert_error } => {
@@ -51,9 +53,10 @@ impl From<CallError> for SimulateTransactionError {
         use CallError::*;
         match value {
             ContractNotFound => Self::ContractNotFound,
-            InvalidMessageSelector => Self::Internal(anyhow::anyhow!("Invalid message selector")),
+            InvalidMessageSelector => Self::Custom(anyhow::anyhow!("Invalid message selector")),
             Reverted(revert_error) => Self::ContractErrorV05 { revert_error },
             Internal(e) => Self::Internal(e),
+            Custom(e) => Self::Custom(e),
         }
     }
 }

--- a/crates/rpc/src/v05/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v05/method/trace_block_transactions.rs
@@ -33,6 +33,7 @@ pub struct TraceBlockTransactionsOutput(pub Vec<Trace>);
 #[derive(Debug)]
 pub enum TraceBlockTransactionsError {
     Internal(anyhow::Error),
+    Custom(anyhow::Error),
     BlockNotFound,
     ContractErrorV05 { revert_error: String },
 }
@@ -51,6 +52,7 @@ impl From<TraceBlockTransactionsError> for crate::error::ApplicationError {
             TraceBlockTransactionsError::ContractErrorV05 { revert_error } => {
                 Self::ContractErrorV05 { revert_error }
             }
+            TraceBlockTransactionsError::Custom(e) => Self::Custom(e),
         }
     }
 }
@@ -67,12 +69,13 @@ impl From<ExecutionStateError> for TraceBlockTransactionsError {
 impl From<CallError> for TraceBlockTransactionsError {
     fn from(value: CallError) -> Self {
         match value {
-            CallError::ContractNotFound => Self::Internal(anyhow::anyhow!("Contract not found")),
+            CallError::ContractNotFound => Self::Custom(anyhow::anyhow!("Contract not found")),
             CallError::InvalidMessageSelector => {
-                Self::Internal(anyhow::anyhow!("Invalid message selector"))
+                Self::Custom(anyhow::anyhow!("Invalid message selector"))
             }
             CallError::Reverted(revert_error) => Self::ContractErrorV05 { revert_error },
             CallError::Internal(e) => Self::Internal(e),
+            CallError::Custom(e) => Self::Custom(e),
         }
     }
 }

--- a/crates/storage/src/connection.rs
+++ b/crates/storage/src/connection.rs
@@ -195,7 +195,10 @@ impl<'inner> Transaction<'inner> {
         transaction::transaction_count(self, block)
     }
 
-    pub fn events(&self, filter: &EventFilter<impl KeyFilter>) -> anyhow::Result<PageOfEvents> {
+    pub fn events(
+        &self,
+        filter: &EventFilter<impl KeyFilter>,
+    ) -> Result<PageOfEvents, EventFilterError> {
         event::get_events(self, filter)
     }
 


### PR DESCRIPTION
Distinguish internal errors from custom errors.
Internal errors may contain sensitive data that should not reach the end user. These are logged upon serialization, and serialization always results in the single "internal error" message.
Custom errors are errors that may occur, that aren't defined in the Starknet spec, and whose details may benefit the end user. These will still be serialized as an internal error, with the underlying error provided in the JSON-RPC error `data` field.

---------------------------

1. Introduce a custom variant in various enums.
2. Use the custom variant where the error details provide value to the end user while not disclosing sensitive information.
3. Keep all `From<anyhow::Error>` implementations mapped to `InternalError` variants. This maintains the existing convention: `anyhow` -> `InternalError`. The use of the custom variant is always explicit.
4. Remove unused `From<anyhow::Error>` implementations.
5. Replace some `unwrap`s with internal errors. This is not strictly necessary for this PR. The motivation here is to avoid the performance costs associated with panics as well as potential side effects such as poisoned locks.
6. Log internal errors as `error`
7. Log custom errors as `debug`

---------------------------

Closes #1467 
