### PR TITLE
fix(rpc/v05): fix TRANSACTION_TRACE type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- JSON-RPC 0.5 transaction traces now have the required `type` property.
+
 ## [0.9.4] - 2023-11-02
 
 ### Changed

--- a/crates/rpc/src/v05/method/simulate_transactions.rs
+++ b/crates/rpc/src/v05/method/simulate_transactions.rs
@@ -312,11 +312,15 @@ pub mod dto {
     }
 
     #[derive(Clone, Debug, Serialize, Eq, PartialEq)]
-    #[serde(untagged)]
+    #[serde(tag = "type")]
     pub enum TransactionTrace {
+        #[serde(rename = "DECLARE")]
         Declare(DeclareTxnTrace),
+        #[serde(rename = "DEPLOY_ACCOUNT")]
         DeployAccount(DeployAccountTxnTrace),
+        #[serde(rename = "INVOKE")]
         Invoke(InvokeTxnTrace),
+        #[serde(rename = "L1_HANDLER")]
         L1Handler(L1HandlerTxnTrace),
     }
 


### PR DESCRIPTION
In the 0.5.0 spec TRANSACTION_TRACE now has a `type` property carrying the type of the transaction that has produced the trace.