### PR TITLE
chore(github/ci): leave more space on `/` and `/mnt` for the test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
           remove-haskell: 'true'
           remove-codeql: 'true'
           remove-docker-images: 'true'
+          root-reserve-mb: '2048'
+          temp-reserve-mb: '2048'
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@v1


### PR DESCRIPTION
We're using the [maximize-build-space](https://github.com/easimon/maximize-build-space) action so that we have plenty of space for the `target` directory in the build. However, the default settings of that action mean that it leaves very minimal free space on `/` and `/mnt`.

We've seen `rust-cache` restores fail because because of lack of disk space -- with the cache item being ~1.2 GB it's entirely possible that it ran out of temporary space for the compressed archive.
