### PR TITLE
ci: refactor and improve times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,15 @@ jobs:
       - uses: Noelware/setup-protoc@1.1.0
       - uses: taiki-e/install-action@nextest
       - name: Compile unit tests
-        run: cargo nextest run --all-targets --all-features --workspace --locked --no-run
-
+        run: cargo nextest run --all-targets --all-features --workspace --locked --no-run --timings
       - name: Run unit tests
         run: timeout 10m cargo nextest run --no-fail-fast --all-targets --all-features --workspace --locked
+      - name: Store timings
+        uses: actions/upload-artifact@v3
+        with: 
+          name: timings
+          path: target/cargo-timings/
+          if-no-files-found: warn
 
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - uses: Noelware/setup-protoc@1.1.0
       - uses: taiki-e/install-action@nextest
       - name: Compile unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: Noelware/setup-protoc@1.1.0
       - uses: taiki-e/install-action@nextest
       - name: Compile unit tests
-        run: timeout 25m cargo nextest run --all-targets --all-features --workspace --locked --no-run
+        run: cargo nextest run --all-targets --all-features --workspace --locked --no-run
 
       - name: Run unit tests
         run: timeout 10m cargo nextest run --no-fail-fast --all-targets --all-features --workspace --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,23 +80,6 @@ jobs:
       - run: |
           cargo sort --check --workspace
 
-  msrv:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: read msrv
-        id: msrv
-        run: |
-          msrv=$(grep -P "rust-version =" Cargo.toml | awk '{print $3}' | tr -d '"')
-          echo Found msrc: $msrv
-          echo "MSRV=$msrv" >> "$GITHUB_OUTPUT"
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ steps.msrv.outputs.MSRV }}
-      - uses: Noelware/setup-protoc@1.1.0
-      - name: check
-        run: cargo check
-
   fuzz_targets:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           remove-docker-images: 'true'
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+      - uses: rui314/setup-mold@v1
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
@@ -88,19 +89,6 @@ jobs:
         with:
           toolchain: nightly
       - uses: rui314/setup-mold@v1
-        with:
-          mold-version: 1.4.1
-          make-default: false
-      - name: Enable mold
-        run: |
-          mkdir -p $HOME/.cargo
-          cat << EOF >> $HOME/.cargo/config.toml
-          [target.x86_64-unknown-linux-gnu]
-          linker = "/usr/bin/clang"
-          rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]
-          EOF
-
-          cat $HOME/.cargo/config.toml
       - run: cargo install cargo-fuzz
       - name: stark_hash
         run: cargo fuzz build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
       - uses: Noelware/setup-protoc@1.1.0
       - run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings -D rust_2018_idioms
 
@@ -55,7 +54,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-      - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all -- --check
 
   doc:
@@ -65,7 +63,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
       - uses: Noelware/setup-protoc@1.1.0
       - run: cargo doc --no-deps --document-private-items
 
@@ -78,7 +75,6 @@ jobs:
         with:
           crate: cargo-sort
           version: "^1.0.9"
-      - uses: Swatinem/rust-cache@v2
       - run: |
           cargo sort --check --workspace
 
@@ -96,7 +92,6 @@ jobs:
         with:
           toolchain: ${{ steps.msrv.outputs.MSRV }}
       - uses: Noelware/setup-protoc@1.1.0
-      - uses: Swatinem/rust-cache@v2
       - name: check
         run: cargo check
 
@@ -121,9 +116,6 @@ jobs:
           EOF
 
           cat $HOME/.cargo/config.toml
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: "mold"
       - run: cargo install cargo-fuzz
       - name: stark_hash
         run: cargo fuzz build
@@ -134,9 +126,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "crates/load-test"
       - name: cargo check
         run: |
           cd crates/load-test

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,0 +1,27 @@
+name: MSRV
+
+on:
+  workflow_dispatch:
+  # Daily at midnight
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  msrv:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v3
+      - name: read msrv
+        id: msrv
+        run: |
+          msrv=$(grep -P "rust-version =" Cargo.toml | awk '{print $3}' | tr -d '"')
+          echo Found msrc: $msrv
+          echo "MSRV=$msrv" >> "$GITHUB_OUTPUT"
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.MSRV }}
+      - uses: Noelware/setup-protoc@1.1.0
+      - name: check
+        run: cargo check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +492,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
 dependencies = [
+ "async-attributes",
  "async-channel",
  "async-global-executor",
  "async-io",
@@ -2567,12 +2578,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
-name = "castaway"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
-
-[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2988,37 +2993,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
  "cipher",
-]
-
-[[package]]
-name = "curl"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
-dependencies = [
- "curl-sys",
- "libc",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "socket2 0.4.9",
- "winapi",
-]
-
-[[package]]
-name = "curl-sys"
-version = "0.4.63+curl-8.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb0fef7046022a1e2ad67a004978f0e3cacb9e3123dc62ce768f92197b771dc"
-dependencies = [
- "cc",
- "libc",
- "libnghttp2-sys",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "winapi",
 ]
 
 [[package]]
@@ -4046,12 +4020,13 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "httpmock"
-version = "0.6.8"
+version = "0.7.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b02e044d3b4c2f94936fb05f9649efa658ca788f44eb6b87554e2033fc8ce93"
+checksum = "729baafac5c497d67ee98569d7bb95a77cb6cd0a8aecda7b8a1a2bed45fd01d2"
 dependencies = [
  "assert-json-diff",
  "async-object-pool",
+ "async-std",
  "async-trait",
  "base64 0.21.5",
  "basic-cookies",
@@ -4059,7 +4034,6 @@ dependencies = [
  "form_urlencoded",
  "futures-util",
  "hyper",
- "isahc",
  "lazy_static",
  "levenshtein",
  "log",
@@ -4339,33 +4313,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "isahc"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "334e04b4d781f436dc315cb1e7515bd96826426345d498149e4bde36b67f8ee9"
-dependencies = [
- "async-channel",
- "castaway",
- "crossbeam-utils",
- "curl",
- "curl-sys",
- "encoding_rs",
- "event-listener",
- "futures-lite",
- "http",
- "log",
- "mime",
- "once_cell",
- "polling",
- "slab",
- "sluice",
- "tracing",
- "tracing-futures",
- "url",
- "waker-fn",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4530,16 +4477,6 @@ name = "libmimalloc-sys"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25d058a81af0d1c22d7a1c948576bee6d673f7af3c0f35564abd6c81122f513d"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "libnghttp2-sys"
-version = "0.1.7+1.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ed28aba195b38d5ff02b9170cbff627e336a20925e43b4945390401c5dc93f"
 dependencies = [
  "cc",
  "libc",
@@ -5062,18 +4999,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
 dependencies = [
  "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
-dependencies = [
- "cc",
- "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -7538,9 +7463,9 @@ checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 
 [[package]]
 name = "similar"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+checksum = "2aeaf503862c419d66959f5d7ca015337d864e9c49485d771b732e2a20453597"
 
 [[package]]
 name = "siphasher"
@@ -7561,17 +7486,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "sluice"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7400c0eff44aa2fcb5e31a5f24ba9716ed90138769e4977a2ba6014ae63eb5"
-dependencies = [
- "async-channel",
- "futures-core",
- "futures-io",
 ]
 
 [[package]]
@@ -8435,16 +8349,6 @@ checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,4 +76,4 @@ thiserror = "1.0.48"
 tokio = "1.29.1"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-zstd = "0.12.4"
+zstd = { version = "0.12.4", features = ["pkg-config"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN TARGETARCH=${TARGETARCH} \
 FROM debian:bookworm-slim AS runner
 ARG TARGETARCH
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates libgmp10 tini && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates libzstd1 libgmp10 tini && rm -rf /var/lib/apt/lists/*
 RUN groupadd --gid 1000 pathfinder && useradd --no-log-init --uid 1000 --gid pathfinder --no-create-home pathfinder
 
 COPY --from=rust-builder /usr/src/pathfinder/pathfinder-${TARGETARCH} /usr/local/bin/pathfinder

--- a/build/prepare.sh
+++ b/build/prepare.sh
@@ -1,14 +1,15 @@
 #!/bin/bash -e
 if [[ "${TARGETARCH}" == "amd64" ]]; then
     apt-get update
-    DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config libssl-dev protobuf-compiler
+    DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config libssl-dev libzstd-dev protobuf-compiler
 elif [[ "${TARGETARCH}" == "arm64" ]]; then
     echo "deb [arch=arm64] http://deb.debian.org/debian bookworm main" >>/etc/apt/sources.list
     apt-get update
-    DEBIAN_FRONTEND=noninteractive apt-get install -y libssl-dev protobuf-compiler gcc-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross
-    apt-get download libssl-dev:arm64 libssl3:arm64
+    DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config libssl-dev libzstd-dev protobuf-compiler gcc-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross
+    apt-get download libssl-dev:arm64 libssl3:arm64 libzstd-dev:arm64
     mkdir -p /build/sysroot
     dpkg -x libssl-dev_*.deb /build/sysroot/
     dpkg -x libssl3_*.deb /build/sysroot/
+    dpkg -x libzstd-dev_*.deb /build/sysroot/
     rustup target add aarch64-unknown-linux-gnu
 fi

--- a/crates/ethereum/Cargo.toml
+++ b/crates/ethereum/Cargo.toml
@@ -22,5 +22,5 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-httpmock = "0.6.8"
+httpmock = "0.7.0-rc.1"
 tokio = { workspace = true, features = ["macros"] }

--- a/doc/install-from-source.md
+++ b/doc/install-from-source.md
@@ -39,7 +39,7 @@ rustup update
 `pathfinder` compilation need additional libraries to be installed (C compiler, linker, other deps)
 
 ```bash
-sudo apt install build-essential libgmp-dev pkg-config libssl-dev protobuf-compiler
+sudo apt install build-essential libgmp-dev pkg-config libssl-dev libzstd-dev protobuf-compiler
 ```
 
 Make sure `protoc` version is at least `3.15`


### PR DESCRIPTION
This PR (hopefully) improves the current CI situation by reducing the time tests take to build.

Highlights:

- Use `mold` linker (somehow this got removed for tests - probably my fault).
- Only cache pushes to main branch. Each entry is 1.2GB which means that we are getting cache churn (max cache is 10GB); instead only cache main which at least should have the bulk of the deps cached then.
- Refactored some deps so that expensive `-sys` crates are no longer bundled but rather use the vendored crates. ~This might cause an issue with docker?~ It does cause docker changes but those have been applied.
