### PR TITLE
feat(rpc): add standardize RPC endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Host JSON-RPC on `/rpc/v0_x` in addition to the existing `/rpc/v0.x` endpoints. This applies to all supported JSON-RPC versions.
+
 ### Changed
 
 - RPC errors now only include the root cause if white-listed as non-sensitive

--- a/README.md
+++ b/README.md
@@ -245,9 +245,9 @@ You can interact with Starknet using the JSON-RPC API. Pathfinder supports the o
 Currently pathfinder supports `v0.3`, `v0.4`, and `v0.5` versions of the Starknet JSON-RPC specification.
 The `path` of the URL used to access the JSON-RPC server determines which version of the API is served:
 
-- the `v0.3.0` API is exposed on the `/rpc/v0.3` path
-- the `v0.4.0` API is exposed on the `/` and `/rpc/v0.4` path
-- the `v0.5.0` API is exposed on the `/rpc/v0.5` path
+- the `v0.3.0` API is exposed on the `/rpc/v0.3` and `/rpc/v0_3` path
+- the `v0.4.0` API is exposed on the `/`, `/rpc/v0.4` and `/rpc/v0_4` path
+- the `v0.5.0` API is exposed on the `/rpc/v0.5` and `/rpc/v0_5` path
 - the pathfinder extension API is exposed on `/rpc/pathfinder/v0.1`
 
 Note that the pathfinder extension is versioned separately from the Starknet specification itself.

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -154,10 +154,13 @@ impl RpcServer {
             .route("/", get(empty_body).post(rpc_handler))
             .with_state(default_router)
             .route("/rpc/v0.3", post(rpc_handler))
+            .route("/rpc/v0_3", post(rpc_handler))
             .with_state(v03_routes)
             .route("/rpc/v0.4", post(rpc_handler))
+            .route("/rpc/v0_4", post(rpc_handler))
             .with_state(v04_routes)
             .route("/rpc/v0.5", post(rpc_handler))
+            .route("/rpc/v0_5", post(rpc_handler))
             .with_state(v05_routes)
             .route("/rpc/pathfinder/v0.1", post(rpc_handler))
             .with_state(pathfinder_routes);
@@ -830,17 +833,32 @@ mod tests {
     #[case::v05_trace("/rpc/v0.5", "v05/starknet_trace_api_openrpc.json", &[])]
     #[case::v05_write("/rpc/v0.5", "v05/starknet_write_api.json",         &[])]
     #[case::v05_pathfinder("/rpc/v0.5", "pathfinder_rpc_api.json", &["pathfinder_version"])]
+    #[case::v0_5_api  ("/rpc/v0_5", "v05/starknet_api_openrpc.json", &[])]
+    #[case::v0_5_trace("/rpc/v0_5", "v05/starknet_trace_api_openrpc.json", &[])]
+    #[case::v0_5_write("/rpc/v0_5", "v05/starknet_write_api.json",         &[])]
+    #[case::v0_5_pathfinder("/rpc/v0_5", "pathfinder_rpc_api.json", &["pathfinder_version"])]
 
     #[case::v04_api  ("/rpc/v0.4", "v04/starknet_api_openrpc.json",       &[])]
     #[case::v04_trace("/rpc/v0.4", "v04/starknet_trace_api_openrpc.json", &[])]
     #[case::v04_write("/rpc/v0.4", "v04/starknet_write_api.json",         &[])]
     #[case::v04_pathfinder("/rpc/v0.4", "pathfinder_rpc_api.json", &["pathfinder_version"])]
+    #[case::v0_4_api  ("/rpc/v0_4", "v04/starknet_api_openrpc.json", &[])]
+    #[case::v0_4_trace("/rpc/v0_4", "v04/starknet_trace_api_openrpc.json", &[])]
+    #[case::v0_4_write("/rpc/v0_4", "v04/starknet_write_api.json",         &[])]
+    #[case::v0_4_pathfinder("/rpc/v0_4", "pathfinder_rpc_api.json", &["pathfinder_version"])]
 
     #[case::v03_api  ("/rpc/v0.3", "v03/starknet_api_openrpc.json",       &[])]
     #[case::v03_trace("/rpc/v0.3", "v03/starknet_trace_api_openrpc.json", 
         &["starknet_traceTransaction", "starknet_traceBlockTransactions"])]
     #[case::v03_write ("/rpc/v0.3", "v03/starknet_write_api.json",         &[])]
     #[case::v03_pathfinder("/rpc/v0.3", "pathfinder_rpc_api.json", &["pathfinder_version"])]
+    #[case::pathfinder("/rpc/pathfinder/v0.1", "pathfinder_rpc_api.json", &[])]
+    #[case::v0_3_api  ("/rpc/v0_3", "v03/starknet_api_openrpc.json",       &[])]
+    #[case::v0_3_trace("/rpc/v0_3", "v03/starknet_trace_api_openrpc.json", 
+        &["starknet_traceTransaction", "starknet_traceBlockTransactions"])]
+    #[case::v0_3_write ("/rpc/v0_3", "v03/starknet_write_api.json",         &[])]
+    #[case::v0_3_pathfinder("/rpc/v0_3", "pathfinder_rpc_api.json", &["pathfinder_version"])]
+    
     #[case::pathfinder("/rpc/pathfinder/v0.1", "pathfinder_rpc_api.json", &[])]
 
     #[tokio::test]


### PR DESCRIPTION
Add RPC endpoints using `/rpc/vX_Y` in addition to `/rpc/vX.Y`.

This is part of an effort to standardize these endpoints across all nodes. In time we will deprecate and remove `/rpc/vX.Y`.

An open question is: should we instead move to hosting them on root instead of in `/rpc`. i.e. `/vX_Y` which is more inline with other nodes. We originally chose a more directory like structure, in case we ever wanted to host more (non-json-rpc) things on the same port. This still makes sense to me, but we also have nothing else hosted here..


Update: waiting on starkware feedback regarding `/rpc/xxx` or `/xxx`.