### PR TITLE
feat(rpc): add `state_diff` property to `L1_HANDLER_TRANSACTION_TRACE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - RPC errors now only include the root cause if white-listed as non-sensitive
+- RPC v0.5 updated from v0.5.0 to v0.5.1
 
 ### Fixed
 

--- a/crates/executor/src/simulate.rs
+++ b/crates/executor/src/simulate.rs
@@ -313,6 +313,7 @@ fn to_trace(
         }),
         TransactionType::L1Handler => TransactionTrace::L1Handler(L1HandlerTransactionTrace {
             function_invocation: maybe_function_invocation?,
+            state_diff,
         }),
     };
 

--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -68,6 +68,7 @@ pub struct InvokeTransactionTrace {
 #[derive(Debug)]
 pub struct L1HandlerTransactionTrace {
     pub function_invocation: Option<FunctionInvocation>,
+    pub state_diff: StateDiff,
 }
 
 #[derive(Debug, Eq, PartialEq)]

--- a/crates/rpc/src/v05/method/simulate_transactions.rs
+++ b/crates/rpc/src/v05/method/simulate_transactions.rs
@@ -431,12 +431,14 @@ pub mod dto {
     pub struct L1HandlerTxnTrace {
         #[serde(default)]
         pub function_invocation: Option<FunctionInvocation>,
+        pub state_diff: StateDiff,
     }
 
     impl From<pathfinder_executor::types::L1HandlerTransactionTrace> for L1HandlerTxnTrace {
         fn from(trace: pathfinder_executor::types::L1HandlerTransactionTrace) -> Self {
             Self {
                 function_invocation: trace.function_invocation.map(Into::into),
+                state_diff: trace.state_diff.into(),
             }
         }
     }

--- a/crates/rpc/src/v05/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v05/method/trace_block_transactions.rs
@@ -119,6 +119,7 @@ pub(crate) fn map_gateway_trace(
         }),
         GatewayTransaction::L1Handler(_) => TransactionTrace::L1Handler(L1HandlerTxnTrace {
             function_invocation: trace.function_invocation.map(Into::into),
+            state_diff: Default::default(),
         }),
     }
 }


### PR DESCRIPTION
To comply with version 0.5.1 of the RPC specification, this commit adds the `state_diff` to L1 handler transaction traces.