### PR TITLE
feat(rpc/v0.5.1): use delegate instead of library call

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ The `path` of the URL used to access the JSON-RPC server determines which versio
 
 - the `v0.3.0` API is exposed on the `/rpc/v0.3` and `/rpc/v0_3` path
 - the `v0.4.0` API is exposed on the `/`, `/rpc/v0.4` and `/rpc/v0_4` path
-- the `v0.5.0` API is exposed on the `/rpc/v0.5` and `/rpc/v0_5` path
+- the `v0.5.1` API is exposed on the `/rpc/v0.5` and `/rpc/v0_5` path
 - the pathfinder extension API is exposed on `/rpc/pathfinder/v0.1`
 
 Note that the pathfinder extension is versioned separately from the Starknet specification itself.

--- a/crates/rpc/src/v05.rs
+++ b/crates/rpc/src/v05.rs
@@ -38,7 +38,7 @@ pub fn register_routes() -> RpcRouterBuilder {
         .register("starknet_getBlockWithTxs"                 , method::get_block_with_txs)
         .register("starknet_getTransactionStatus"            , method::get_transaction_status)
         .register("starknet_simulateTransactions"            , method::simulate_transactions)
-        .register("starknet_specVersion"                     , method::spec_version)
+        .register("starknet_specVersion"                     , || "v0.5.1")
         .register("starknet_traceBlockTransactions"          , method::trace_block_transactions)
         .register("starknet_traceTransaction"                , method::trace_transaction)
 

--- a/crates/rpc/src/v05/method.rs
+++ b/crates/rpc/src/v05/method.rs
@@ -6,7 +6,6 @@ mod get_block_with_txs;
 mod get_transaction_receipt;
 mod get_transaction_status;
 mod simulate_transactions;
-mod spec_version;
 mod trace_block_transactions;
 mod trace_transaction;
 
@@ -18,6 +17,5 @@ pub(crate) use get_block_with_txs::get_block_with_txs;
 pub(crate) use get_transaction_receipt::get_transaction_receipt;
 pub(crate) use get_transaction_status::get_transaction_status;
 pub(crate) use simulate_transactions::simulate_transactions;
-pub(crate) use spec_version::spec_version;
 pub(crate) use trace_block_transactions::trace_block_transactions;
 pub(crate) use trace_transaction::trace_transaction;

--- a/crates/rpc/src/v05/method/simulate_transactions.rs
+++ b/crates/rpc/src/v05/method/simulate_transactions.rs
@@ -188,7 +188,7 @@ pub mod dto {
         #[serde(rename = "CALL")]
         Call,
         #[serde(rename = "LIBRARY_CALL")]
-        LibraryCall,
+        _LibraryCall,
         #[serde(rename = "DELEGATE")]
         Delegate,
     }
@@ -198,7 +198,7 @@ pub mod dto {
             use pathfinder_executor::types::CallType::*;
             match value {
                 Call => Self::Call,
-                Delegate => Self::LibraryCall,
+                Delegate => Self::Delegate,
             }
         }
     }

--- a/crates/rpc/src/v05/method/spec_version.rs
+++ b/crates/rpc/src/v05/method/spec_version.rs
@@ -1,7 +1,0 @@
-use crate::context::RpcContext;
-
-crate::error::generate_rpc_error_subset!(SpecVersionError);
-
-pub async fn spec_version(_context: RpcContext) -> Result<String, SpecVersionError> {
-    Ok("0.5.0".to_owned())
-}

--- a/doc/rpc/v05/starknet_api_openrpc.json
+++ b/doc/rpc/v05/starknet_api_openrpc.json
@@ -1,7 +1,7 @@
 {
     "openrpc": "1.0.0-rc1",
     "info": {
-        "version": "0.5.0",
+        "version": "0.5.1",
         "title": "StarkNet Node API",
         "license": {}
     },
@@ -922,6 +922,8 @@
                             }
                         },
                         "required": [
+                            "block_hash",
+                            "block_number",
                             "transaction_hash"
                         ]
                     }
@@ -2702,8 +2704,7 @@
                     "finality_status",
                     "execution_status",
                     "execution_resources"
-                ],
-                "additionalProperties": false
+                ]
             },
             "MSG_TO_L1": {
                 "title": "Message to L1",
@@ -3277,47 +3278,47 @@
                     "steps": {
                         "title": "Steps",
                         "description": "The number of Cairo steps used",
-                        "type": "integer"
+                        "$ref": "#/components/schemas/NUM_AS_HEX"
                     },
                     "memory_holes": {
                         "title": "Memory holes",
                         "description": "The number of unused memory cells (each cell is roughly equivalent to a step)",
-                        "type": "integer"
+                        "$ref": "#/components/schemas/NUM_AS_HEX"
                     },
                     "range_check_builtin_applications": {
                         "title": "Range check applications",
                         "description": "The number of RANGE_CHECK builtin instances",
-                        "type": "integer"
+                        "$ref": "#/components/schemas/NUM_AS_HEX"
                     },
                     "pedersen_builtin_applications": {
                         "title": "Pedersen applications",
                         "description": "The number of Pedersen builtin instances",
-                        "type": "integer"
+                        "$ref": "#/components/schemas/NUM_AS_HEX"
                     },
                     "poseidon_builtin_applications": {
                         "title": "Poseidon applications",
                         "description": "The number of Poseidon builtin instances",
-                        "type": "integer"
+                        "$ref": "#/components/schemas/NUM_AS_HEX"
                     },
                     "ec_op_builtin_applications": {
                         "title": "EC_OP applications",
                         "description": "the number of EC_OP builtin instances",
-                        "type": "integer"
+                        "$ref": "#/components/schemas/NUM_AS_HEX"
                     },
                     "ecdsa_builtin_applications": {
                         "title": "ECDSA applications",
                         "description": "the number of ECDSA builtin instances",
-                        "type": "integer"
+                        "$ref": "#/components/schemas/NUM_AS_HEX"
                     },
                     "bitwise_builtin_applications": {
                         "title": "BITWISE applications",
                         "description": "the number of BITWISE builtin instances",
-                        "type": "integer"
+                        "$ref": "#/components/schemas/NUM_AS_HEX"
                     },
                     "keccak_builtin_applications": {
                         "title": "Keccak applications",
                         "description": "The number of KECCAK builtin instances",
-                        "type": "integer"
+                        "$ref": "#/components/schemas/NUM_AS_HEX"
                     }
                 },
                 "required": [

--- a/doc/rpc/v05/starknet_trace_api_openrpc.json
+++ b/doc/rpc/v05/starknet_trace_api_openrpc.json
@@ -1,7 +1,7 @@
 {
     "openrpc": "1.0.0-rc1",
     "info": {
-        "version": "0.5.0",
+        "version": "0.5.1",
         "title": "StarkNet Trace API",
         "license": {}
     },
@@ -195,11 +195,8 @@
                             }
                         },
                         "required": [
-                            "validate_invocation",
-                            "execute_invocation",
-                            "fee_transfer_invocation",
-                            "state_diff",
-                            "type"
+                            "type",
+                            "execute_invocation"
                         ]
                     },
                     {
@@ -227,9 +224,6 @@
                             }
                         },
                         "required": [
-                            "validate_invocation",
-                            "fee_transfer_invocation",
-                            "state_diff",
                             "type"
                         ]
                     },
@@ -262,11 +256,8 @@
                             }
                         },
                         "required": [
-                            "validate_invocation",
-                            "constructor_invocation",
-                            "fee_transfer_invocation",
-                            "state_diff",
-                            "type"
+                            "type",
+                            "constructor_invocation"
                         ]
                     },
                     {
@@ -278,6 +269,11 @@
                                 "description": "the trace of the __execute__ call or constructor call, depending on the transaction type (none for declare transactions)",
                                 "$ref": "#/components/schemas/FUNCTION_INVOCATION"
                             },
+                            "state_diff": {
+                                "title": "state_diff",
+                                "description": "the state diffs induced by the transaction",
+                                "$ref": "#/components/schemas/STATE_DIFF"
+                            },
                             "type": {
                                 "title": "Type",
                                 "type": "string",
@@ -287,8 +283,8 @@
                             }
                         },
                         "required": [
-                            "function_invocation",
-                            "type"
+                            "type",
+                            "function_invocation"
                         ]
                     }
                 ]
@@ -385,6 +381,7 @@
             "CALL_TYPE": {
                 "type": "string",
                 "enum": [
+                    "DELEGATE",
                     "LIBRARY_CALL",
                     "CALL"
                 ]

--- a/doc/rpc/v05/starknet_write_api.json
+++ b/doc/rpc/v05/starknet_write_api.json
@@ -1,7 +1,7 @@
 {
     "openrpc": "1.0.0-rc1",
     "info": {
-        "version": "0.5.0",
+        "version": "0.5.1",
         "title": "StarkNet Node Write API",
         "license": {}
     },


### PR DESCRIPTION
This PR keeps the blockifier's `CallType::Delegate` variant instead of mapping it to `LibraryCall`. 

This was previously done to comply with the previous RPC spec which did not have the delegate variant.

Also simplify `starknet_specVersion` implementation and bump it to v0.5.1, and update the docs to reflect the v0.5.0 to v0.5.1 bump.

Closes #1511 and closes #1513