### PR TITLE
fix(rpc/v02/get_transaction_receipt): reverted transactions should be a custom error

### DIFF
--- a/crates/rpc/src/v02/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v02/method/get_transaction_receipt.rs
@@ -43,7 +43,9 @@ pub async fn get_transaction_receipt(
             if receipt.execution_status == ExecutionStatus::Reverted {
                 let reason = receipt.revert_error.unwrap_or_default();
 
-                return Err(anyhow::anyhow!("Reverted: {reason}")).map_err(Into::into);
+                return Err(GetTransactionReceiptError::Custom(anyhow::anyhow!(
+                    "Reverted: {reason}"
+                )));
             }
 
             let pending = types::PendingTransactionReceipt::from(receipt, &transaction);
@@ -58,7 +60,9 @@ pub async fn get_transaction_receipt(
         if receipt.execution_status == ExecutionStatus::Reverted {
             let reason = receipt.revert_error.unwrap_or_default();
 
-            return Err(anyhow::anyhow!("Reverted: {reason}")).map_err(Into::into);
+            return Err(GetTransactionReceiptError::Custom(anyhow::anyhow!(
+                "Reverted: {reason}"
+            )));
         }
 
         let block_number = db_tx


### PR DESCRIPTION
Since introducing custom errors recently internal errors are now logged on WARN level. This causes pathfinder to log a WARN-level error when it's in fact running perfectly OK and returning the expected RPC response. (Which is a custom error for reverted transactions.)
