### PR TITLE
fix(rpc): `starknet_getBlockWithXXX` has status for pending responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- RPC v0.5 incorrectly has a status field in pending `starknet_getBlockWithXXX` responses.
+
 ## [0.9.5] - 2023-11-09
 
 ### Added

--- a/crates/rpc/src/v02/types.rs
+++ b/crates/rpc/src/v02/types.rs
@@ -1215,6 +1215,12 @@ pub mod reply {
         Rejected,
     }
 
+    impl BlockStatus {
+        pub fn is_pending(&self) -> bool {
+            self == &Self::Pending
+        }
+    }
+
     impl From<starknet_gateway_types::reply::Status> for BlockStatus {
         fn from(status: starknet_gateway_types::reply::Status) -> Self {
             use starknet_gateway_types::reply::Status::*;


### PR DESCRIPTION
An alternative implementation would be an `Option<BlockStatus>` but that requires checking the status mapping in various places.

Closes #1527 
