### PR TITLE
fix(executor): map VM errors to custom errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - RPC v0.5 incorrectly has a status field in pending `starknet_getBlockWithXXX` responses.
+- Error details for many execution-related issues were not properly sent back to the JSON client and were logged on WARN level instead.
 
 ## [0.9.5] - 2023-11-09
 

--- a/crates/executor/src/error.rs
+++ b/crates/executor/src/error.rs
@@ -26,9 +26,9 @@ impl From<TransactionExecutionError> for CallError {
                 EntryPointExecutionError::PreExecutionError(
                     PreExecutionError::UninitializedStorageAddress(_),
                 ) => Self::ContractNotFound,
-                _ => Self::Internal(anyhow::anyhow!("Internal error: {}", e)),
+                _ => Self::Custom(anyhow::anyhow!("Execution error: {}", e)),
             },
-            e => Self::Internal(anyhow::anyhow!("Internal error: {}", e)),
+            e => Self::Custom(anyhow::anyhow!("Execution error: {}", e)),
         }
     }
 }
@@ -42,20 +42,23 @@ impl From<EntryPointExecutionError> for CallError {
             EntryPointExecutionError::PreExecutionError(
                 PreExecutionError::UninitializedStorageAddress(_),
             ) => Self::ContractNotFound,
-            _ => Self::Internal(anyhow::anyhow!("Internal error: {}", e)),
+            _ => Self::Custom(anyhow::anyhow!("Execution error: {}", e)),
         }
     }
 }
 
 impl From<StateError> for CallError {
     fn from(e: StateError) -> Self {
-        Self::Internal(anyhow::anyhow!("Internal state error: {}", e))
+        match e {
+            StateError::StateReadError(_) => Self::Internal(e.into()),
+            _ => Self::Custom(anyhow::anyhow!("State error: {}", e)),
+        }
     }
 }
 
 impl From<starknet_api::StarknetApiError> for CallError {
     fn from(value: starknet_api::StarknetApiError) -> Self {
-        Self::Internal(value.into())
+        Self::Custom(value.into())
     }
 }
 

--- a/crates/executor/src/simulate.rs
+++ b/crates/executor/src/simulate.rs
@@ -71,7 +71,7 @@ pub fn simulate(
         match tx_info {
             Ok(tx_info) => {
                 if let Some(revert_error) = tx_info.revert_error {
-                    tracing::info!(%revert_error, "Transaction reverted");
+                    tracing::trace!(%revert_error, "Transaction reverted");
                     return Err(CallError::Reverted(revert_error));
                 }
 


### PR DESCRIPTION
Otherwise we don't properly return those to the JSON-RPC client and log them on WARN log level instead.

None of these errors (apart from the anyhow::Error mapping) are internal issues but instead errors that were encountered during contract execution.

Closes #1530 