### PR TITLE
fix(executor): add block hash value to the state for trace execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Block hash for current block minus 10 is now available via the `get_block_hash` syscall when calling `starknet_trace*` methods.
+
 ## [0.9.6] - 2023-11-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Block hash for current block minus 10 is now available via the `get_block_hash` syscall when calling `starknet_trace*` methods.
+- `get_block_hash` syscall always returns `0x0` when calling `starknet_trace*` methods
 
 ## [0.9.6] - 2023-11-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `get_block_hash` syscall always returns `0x0` when calling `starknet_trace*` methods
+- `get_block_hash` syscall returns `0x0` for the latest available block (current - 10) when executing `starknet_trace*` methods
 
 ## [0.9.6] - 2023-11-20
 

--- a/crates/executor/src/execution_state.rs
+++ b/crates/executor/src/execution_state.rs
@@ -37,7 +37,8 @@ impl<'tx> ExecutionState<'tx> {
         );
         let mut cached_state = LruCachedReader::new_cached_state(raw_reader)?;
 
-        // if we're running on parent state we have to set the block hash for block_number - 10 in the state
+        // Perform system contract updates if we are executing ontop of a parent block.
+        // Currently this is only the block hash from 10 blocks ago.
         if self.execute_on_parent_state && self.header.number.get() >= 10 {
             let block_number_whose_hash_becomes_available =
                 pathfinder_common::BlockNumber::new_or_panic(self.header.number.get() - 10);

--- a/crates/executor/src/simulate.rs
+++ b/crates/executor/src/simulate.rs
@@ -276,8 +276,6 @@ fn to_trace(
     execution_info: blockifier::transaction::objects::TransactionExecutionInfo,
     state_diff: StateDiff,
 ) -> Result<TransactionTrace, TransactionExecutionError> {
-    tracing::trace!(?execution_info, "Transforming trace");
-
     let validate_invocation = execution_info
         .validate_call_info
         .map(TryInto::try_into)

--- a/crates/executor/src/simulate.rs
+++ b/crates/executor/src/simulate.rs
@@ -104,7 +104,9 @@ pub fn trace_one(
 ) -> Result<TransactionTrace, CallError> {
     let (mut state, block_context) = execution_state.starknet_state()?;
 
-    for tx in transactions {
+    for (transaction_idx, tx) in transactions.into_iter().enumerate() {
+        let _span = tracing::debug_span!("simulate", transaction_hash=%super::transaction::transaction_hash(&tx), %transaction_idx).entered();
+
         let hash = transaction_hash(&tx);
         let tx_type = transaction_type(&tx);
         let tx_declared_deprecated_class_hash = transaction_declared_deprecated_class(&tx);
@@ -135,7 +137,9 @@ pub fn trace_all(
     let (mut state, block_context) = execution_state.starknet_state()?;
 
     let mut ret = Vec::with_capacity(transactions.len());
-    for tx in transactions {
+    for (transaction_idx, tx) in transactions.into_iter().enumerate() {
+        let _span = tracing::debug_span!("simulate", transaction_hash=%super::transaction::transaction_hash(&tx), %transaction_idx).entered();
+
         let hash = transaction_hash(&tx);
         let tx_type = transaction_type(&tx);
         let tx_declared_deprecated_class_hash = transaction_declared_deprecated_class(&tx);


### PR DESCRIPTION
Historical block hashes (up to block_number - 10) should be available in the state with contract_address=1, key=block_number. This is not a problem for non-trace methods as there we use the state from the block specified (which already has this update from system contracts), but for tracing we're setting up our state reader with the state at the previous block.

Because of this we're missing the block hash value for block_number - 10 specifically which might cause execution issues with contracts using the `get_block_hash` system call.

Closes #1547