### PR TITLE
chore: Remove support for testnet2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Removed
+
+- Removed support for `--network testnet2`
+
 ## [0.9.7] - 2023-11-21
 
 ### Fixed

--- a/crates/common/src/consts.rs
+++ b/crates/common/src/consts.rs
@@ -17,6 +17,3 @@ pub const MAINNET_GENESIS_HASH: BlockHash =
 
 pub const INTEGRATION_GENESIS_HASH: BlockHash =
     block_hash!("03ae41b0f023e53151b0c8ab8b9caafb7005d5f41c9ab260276d5bdc49726279");
-
-pub const TESTNET2_GENESIS_HASH: BlockHash =
-    block_hash!("04163f64ea0258f21fd05b478e2306ab2daeb541bdbd3bf29a9874dc5cd4b64e");

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -341,7 +341,6 @@ pub enum Chain {
     Mainnet,
     Testnet,
     Integration,
-    Testnet2,
     Custom,
 }
 
@@ -363,7 +362,6 @@ impl ChainId {
 
     pub const MAINNET: Self = Self::from_slice_unwrap(b"SN_MAIN");
     pub const TESTNET: Self = Self::from_slice_unwrap(b"SN_GOERLI");
-    pub const TESTNET2: Self = Self::from_slice_unwrap(b"SN_GOERLI2");
     pub const INTEGRATION: Self = Self::from_slice_unwrap(b"SN_GOERLI");
 }
 
@@ -372,7 +370,6 @@ impl std::fmt::Display for Chain {
         match self {
             Chain::Mainnet => f.write_str("Mainnet"),
             Chain::Testnet => f.write_str("Görli"),
-            Chain::Testnet2 => f.write_str("Görli2"),
             Chain::Integration => f.write_str("Integration"),
             Chain::Custom => f.write_str("Custom"),
         }

--- a/crates/ethereum/src/lib.rs
+++ b/crates/ethereum/src/lib.rs
@@ -7,7 +7,6 @@ pub mod core_addr {
 
     pub const MAINNET: [u8; 20] = Decoder::Hex.decode(b"c662c410C0ECf747543f5bA90660f6ABeBD9C8c4");
     pub const TESTNET: [u8; 20] = Decoder::Hex.decode(b"de29d060D45901Fb19ED6C6e959EB22d8626708e");
-    pub const TESTNET2: [u8; 20] = Decoder::Hex.decode(b"a4eD3aD27c294565cB0DCc993BDdCC75432D498c");
     pub const INTEGRATION: [u8; 20] =
         Decoder::Hex.decode(b"d5c325D183C592C94998000C5e0EED9e6655c020");
 }

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -334,11 +334,6 @@ impl Client {
         Self::with_base_url(Url::parse("https://alpha4.starknet.io/").unwrap()).unwrap()
     }
 
-    /// Creates a [Client] for [Chain::Testnet2].
-    pub fn testnet2() -> Self {
-        Self::with_base_url(Url::parse("https://alpha4-2.starknet.io/").unwrap()).unwrap()
-    }
-
     /// Creates a [Client] for [Chain::Integration].
     pub fn integration() -> Self {
         Self::with_base_url(Url::parse("https://external.integration.starknet.io").unwrap())
@@ -399,8 +394,7 @@ impl Client {
     /// Returns the [network chain](Chain) this client is operating on.
     pub async fn chain(&self) -> anyhow::Result<Chain> {
         use pathfinder_common::consts::{
-            INTEGRATION_GENESIS_HASH, MAINNET_GENESIS_HASH, TESTNET2_GENESIS_HASH,
-            TESTNET_GENESIS_HASH,
+            INTEGRATION_GENESIS_HASH, MAINNET_GENESIS_HASH, TESTNET_GENESIS_HASH,
         };
         // unwrap is safe as `block_hash` is always present for non-pending blocks.
         let genesis_hash = self
@@ -412,7 +406,6 @@ impl Client {
 
         match genesis_hash {
             testnet if testnet == TESTNET_GENESIS_HASH => Ok(Chain::Testnet),
-            testnet2 if testnet2 == TESTNET2_GENESIS_HASH => Ok(Chain::Testnet2),
             mainnet if mainnet == MAINNET_GENESIS_HASH => Ok(Chain::Mainnet),
             integration if integration == INTEGRATION_GENESIS_HASH => Ok(Chain::Integration),
             other => Err(anyhow::anyhow!("Unknown genesis block hash: {}", other.0)),

--- a/crates/gateway-types/src/transaction_hash.rs
+++ b/crates/gateway-types/src/transaction_hash.rs
@@ -43,14 +43,6 @@ pub fn verify(txn: &Transaction, chain_id: ChainId, block_number: BlockNumber) -
                 chain_id
             }
         }
-        // Earlier blocks on testnet2 used the same chain id as testnet (ie. goerli)
-        ChainId::TESTNET2 => {
-            if block_number.get() <= 21086 {
-                ChainId::TESTNET
-            } else {
-                chain_id
-            }
-        }
         _ => chain_id,
     };
 

--- a/crates/pathfinder/examples/feeder_gateway.rs
+++ b/crates/pathfinder/examples/feeder_gateway.rs
@@ -23,7 +23,7 @@ pub struct ContractAddresses {
 /// Serve feeder gateway REST endpoints required for pathfinder to sync.
 ///
 /// Usage:
-/// `cargo run --release -p pathfinder --example feeder_gateway ./testnet2.sqlite`
+/// `cargo run --release -p pathfinder --example feeder_gateway ./goerli.sqlite`
 ///
 /// Then pathfinder can be run with the following arguments to use this tool as a sync source:
 ///
@@ -209,7 +209,7 @@ async fn serve() -> anyhow::Result<()> {
 
 fn get_chain(tx: &pathfinder_storage::Transaction<'_>) -> anyhow::Result<Chain> {
     use pathfinder_common::consts::{
-        INTEGRATION_GENESIS_HASH, MAINNET_GENESIS_HASH, TESTNET2_GENESIS_HASH, TESTNET_GENESIS_HASH,
+        INTEGRATION_GENESIS_HASH, MAINNET_GENESIS_HASH, TESTNET_GENESIS_HASH,
     };
 
     let genesis_hash = tx
@@ -221,7 +221,6 @@ fn get_chain(tx: &pathfinder_storage::Transaction<'_>) -> anyhow::Result<Chain> 
     let chain = match genesis_hash {
         MAINNET_GENESIS_HASH => Chain::Mainnet,
         TESTNET_GENESIS_HASH => Chain::Testnet,
-        TESTNET2_GENESIS_HASH => Chain::Testnet2,
         INTEGRATION_GENESIS_HASH => Chain::Integration,
         _other => Chain::Custom,
     };
@@ -242,10 +241,6 @@ fn contract_addresses(chain: Chain) -> anyhow::Result<ContractAddresses> {
         },
         Chain::Testnet => ContractAddresses {
             core: parse("de29d060D45901Fb19ED6C6e959EB22d8626708e"),
-            gps: parse("8f97970aC5a9aa8D130d35146F5b59c4aef57963"),
-        },
-        Chain::Testnet2 => ContractAddresses {
-            core: parse("a4eD3aD27c294565cB0DCc993BDdCC75432D498c"),
             gps: parse("8f97970aC5a9aa8D130d35146F5b59c4aef57963"),
         },
         Chain::Integration | Chain::Custom => ContractAddresses {

--- a/crates/pathfinder/examples/re_execute.rs
+++ b/crates/pathfinder/examples/re_execute.rs
@@ -105,7 +105,7 @@ fn main() -> anyhow::Result<()> {
 
 fn get_chain_id(tx: &pathfinder_storage::Transaction<'_>) -> anyhow::Result<ChainId> {
     use pathfinder_common::consts::{
-        INTEGRATION_GENESIS_HASH, MAINNET_GENESIS_HASH, TESTNET2_GENESIS_HASH, TESTNET_GENESIS_HASH,
+        INTEGRATION_GENESIS_HASH, MAINNET_GENESIS_HASH, TESTNET_GENESIS_HASH,
     };
 
     let (_, genesis_hash) = tx
@@ -116,7 +116,6 @@ fn get_chain_id(tx: &pathfinder_storage::Transaction<'_>) -> anyhow::Result<Chai
     let chain = match genesis_hash {
         MAINNET_GENESIS_HASH => ChainId::MAINNET,
         TESTNET_GENESIS_HASH => ChainId::TESTNET,
-        TESTNET2_GENESIS_HASH => ChainId::TESTNET2,
         INTEGRATION_GENESIS_HASH => ChainId::INTEGRATION,
         _ => anyhow::bail!("Unknown chain"),
     };

--- a/crates/pathfinder/examples/verify_block_hashes.rs
+++ b/crates/pathfinder/examples/verify_block_hashes.rs
@@ -19,9 +19,8 @@ fn main() -> anyhow::Result<()> {
     let (chain, chain_id) = match chain_name.as_str() {
         "mainnet" => (Chain::Mainnet, ChainId::MAINNET),
         "goerli" => (Chain::Testnet, ChainId::TESTNET),
-        "testnet2" => (Chain::Testnet2, ChainId::TESTNET2),
         "integration" => (Chain::Integration, ChainId::INTEGRATION),
-        _ => panic!("Expected chain name: mainnet/goerli/testnet2/integration"),
+        _ => panic!("Expected chain name: mainnet/goerli/integration"),
     };
 
     let database_path = std::env::args().nth(2).unwrap();

--- a/crates/pathfinder/examples/verify_transaction_hashes.rs
+++ b/crates/pathfinder/examples/verify_transaction_hashes.rs
@@ -17,9 +17,8 @@ fn main() -> anyhow::Result<()> {
     let chain_id = match chain_name.as_str() {
         "mainnet" => ChainId::MAINNET,
         "goerli" => ChainId::TESTNET,
-        "testnet2" => ChainId::TESTNET2,
         "integration" => ChainId::INTEGRATION,
-        _ => panic!("Expected chain name: mainnet/goerli/testnet2/integration"),
+        _ => panic!("Expected chain name: mainnet/goerli/integration"),
     };
     let database_path = std::env::args().nth(2).unwrap();
     let start_block = std::env::args().nth(3).unwrap_or("0".into());

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -329,7 +329,6 @@ struct DebugCli {
 enum Network {
     Mainnet,
     Testnet,
-    Testnet2,
     Integration,
     Custom,
 }
@@ -339,7 +338,6 @@ impl From<Network> for clap::builder::OsStr {
         match value {
             Network::Mainnet => "mainnet",
             Network::Testnet => "testnet",
-            Network::Testnet2 => "testnet2",
             Network::Integration => "integration",
             Network::Custom => "custom",
         }
@@ -445,7 +443,6 @@ pub struct Ethereum {
 pub enum NetworkConfig {
     Mainnet,
     Testnet,
-    Testnet2,
     Integration,
     Custom {
         gateway: Url,
@@ -496,7 +493,6 @@ impl NetworkConfig {
             (Some(non_custom), None, None, None) => match non_custom {
                 Mainnet => NetworkConfig::Mainnet,
                 Testnet => NetworkConfig::Testnet,
-                Testnet2 => NetworkConfig::Testnet2,
                 Integration => NetworkConfig::Integration,
                 Custom => unreachable!("Network::Custom handled in outer arm already"),
             },

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -79,7 +79,6 @@ async fn async_main() -> anyhow::Result<()> {
         let network_label = match &network {
             NetworkConfig::Mainnet => "mainnet",
             NetworkConfig::Testnet => "testnet",
-            NetworkConfig::Testnet2 => "testnet2",
             NetworkConfig::Integration => "integration",
             NetworkConfig::Custom { .. } => "custom",
         };
@@ -492,13 +491,6 @@ mod pathfinder_context {
                     database: data_directory.join("goerli.sqlite"),
                     l1_core_address: H160::from(core_addr::TESTNET),
                 },
-                NetworkConfig::Testnet2 => Self {
-                    network: Chain::Testnet2,
-                    network_id: ChainId::TESTNET2,
-                    gateway: GatewayClient::testnet2(),
-                    database: data_directory.join("testnet2.sqlite"),
-                    l1_core_address: H160::from(core_addr::TESTNET2),
-                },
                 NetworkConfig::Integration => Self {
                     network: Chain::Integration,
                     network_id: ChainId::INTEGRATION,
@@ -547,7 +539,6 @@ mod pathfinder_context {
             let network = match l1_core_address.as_bytes() {
                 x if x == core_addr::MAINNET => Chain::Mainnet,
                 x if x == core_addr::TESTNET => Chain::Testnet,
-                x if x == core_addr::TESTNET2 => Chain::Testnet2,
                 x if x == core_addr::INTEGRATION => Chain::Integration,
                 _ => Chain::Custom,
             };
@@ -576,7 +567,6 @@ fn verify_networks(starknet: Chain, ethereum: EthereumChain) -> anyhow::Result<(
             Chain::Mainnet => EthereumChain::Mainnet,
             Chain::Testnet => EthereumChain::Goerli,
             Chain::Integration => EthereumChain::Goerli,
-            Chain::Testnet2 => EthereumChain::Goerli,
             Chain::Custom => unreachable!("Already checked against"),
         };
 
@@ -605,14 +595,12 @@ async fn verify_database(
 
     if let Some(database_genesis) = db_genesis {
         use pathfinder_common::consts::{
-            INTEGRATION_GENESIS_HASH, MAINNET_GENESIS_HASH, TESTNET2_GENESIS_HASH,
-            TESTNET_GENESIS_HASH,
+            INTEGRATION_GENESIS_HASH, MAINNET_GENESIS_HASH, TESTNET_GENESIS_HASH,
         };
 
         let db_network = match database_genesis {
             MAINNET_GENESIS_HASH => Chain::Mainnet,
             TESTNET_GENESIS_HASH => Chain::Testnet,
-            TESTNET2_GENESIS_HASH => Chain::Testnet2,
             INTEGRATION_GENESIS_HASH => Chain::Integration,
             _other => Chain::Custom,
         };

--- a/crates/pathfinder/src/state/block_hash.rs
+++ b/crates/pathfinder/src/state/block_hash.rs
@@ -160,14 +160,6 @@ mod meta {
         )),
     };
 
-    const TESTNET2_METAINFO: BlockHashMetaInfo = BlockHashMetaInfo {
-        first_0_7_block: BlockNumber::new_or_panic(0),
-        not_verifiable_range: None,
-        fallback_sequencer_address: Some(sequencer_address!(
-            "046a89ae102987331d369645031b49c27738ed096f2789c24449966da4c6de6b"
-        )),
-    };
-
     const MAINNET_METAINFO: BlockHashMetaInfo = BlockHashMetaInfo {
         first_0_7_block: BlockNumber::new_or_panic(833),
         not_verifiable_range: None,
@@ -194,7 +186,6 @@ mod meta {
         match chain {
             Chain::Mainnet => &MAINNET_METAINFO,
             Chain::Testnet => &TESTNET_METAINFO,
-            Chain::Testnet2 => &TESTNET2_METAINFO,
             Chain::Integration => &INTEGRATION_METAINFO,
             Chain::Custom => &CUSTOM_METAINFO,
         }

--- a/crates/rpc/src/context.rs
+++ b/crates/rpc/src/context.rs
@@ -58,7 +58,6 @@ impl RpcContext {
             Chain::Mainnet => (ChainId::MAINNET, SequencerClient::mainnet()),
             Chain::Testnet => (ChainId::TESTNET, SequencerClient::testnet()),
             Chain::Integration => (ChainId::INTEGRATION, SequencerClient::integration()),
-            Chain::Testnet2 => (ChainId::TESTNET2, SequencerClient::testnet2()),
             Chain::Custom => unreachable!("Should not be testing with custom chain"),
         };
 


### PR DESCRIPTION
Remove most of the occurrences of "testnet2", leaving only these required for [gateway-types::transaction_hash::tests::computation](https://github.com/pierre-l/pathfinder/blob/deprecate-testnet2/crates/gateway-types/src/transaction_hash.rs#L473)

Running Pathfinder with `--network testnet2` will now result in an error:
```
error: invalid value 'testnet2' for '--network <NETWORK>'
  [possible values: mainnet, testnet, integration, custom]
```

Related: #1548