### PR TITLE
feat: update newHeads subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default RPC version is now v0.5 (was v0.4). This can be manually configured to any version.
 - Goerli testnet network selection is now `--network testnet-goerli`, removed `--network testnet`
 - Goerli integration network selection is now `--network integration-goerli`, removed `--network testnet`
+- Reworked `newHeads` subscription output to more accurately represent header data.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Note that the pathfinder extension is versioned separately from the Starknet spe
 
 ### pathfinder extension API
 
-You can find the API specification [here](doc/rpc/pathfinder_rpc_api.json).
+Here are links to our [API extensions](doc/rpc/pathfinder_rpc_api.json) and [websocket API](doc/rpc/pathfinder_ws.json).
 
 ## Monitoring API
 

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -102,7 +102,6 @@ where
 {
     fn from(value: &SyncContext<G, E>) -> Self {
         Self {
-            broadcasters: value.websocket_txs.clone(),
             sequencer: value.sequencer.clone(),
             chain: value.chain,
             chain_id: value.chain_id,
@@ -146,7 +145,7 @@ where
         head_poll_interval,
         pending_data,
         block_validation_mode: _,
-        websocket_txs: _,
+        websocket_txs,
         block_cache_size,
         restart_delay,
         verify_tree_hashes: _,
@@ -207,6 +206,7 @@ where
         state,
         pending_data,
         verify_tree_hashes: context.verify_tree_hashes,
+        websocket_txs,
     };
     let mut consumer_handle = tokio::spawn(consumer(event_receiver, consumer_context));
 
@@ -325,6 +325,7 @@ struct ConsumerContext {
     pub state: Arc<SyncState>,
     pub pending_data: WatchSender<Arc<PendingData>>,
     pub verify_tree_hashes: bool,
+    pub websocket_txs: Option<TopicBroadcasters>,
 }
 
 async fn consumer(mut events: Receiver<SyncEvent>, context: ConsumerContext) -> anyhow::Result<()> {
@@ -333,6 +334,7 @@ async fn consumer(mut events: Receiver<SyncEvent>, context: ConsumerContext) -> 
         state,
         pending_data,
         verify_tree_hashes,
+        mut websocket_txs,
     } = context;
 
     let mut last_block_start = std::time::Instant::now();
@@ -388,6 +390,7 @@ async fn consumer(mut events: Receiver<SyncEvent>, context: ConsumerContext) -> 
                     *signature,
                     verify_tree_hashes,
                     storage.clone(),
+                    &mut websocket_txs,
                 )
                 .await
                 .with_context(|| format!("Update L2 state to {block_number}"))?;
@@ -703,6 +706,7 @@ async fn l2_update(
     // we need this so that we can create extra read-only transactions for
     // parallel contract state updates
     storage: Storage,
+    websocket_txs: &mut Option<TopicBroadcasters>,
 ) -> anyhow::Result<()> {
     tokio::task::block_in_place(move || {
         let transaction = connection
@@ -817,7 +821,15 @@ async fn l2_update(
             }
         }
 
-        transaction.commit().context("Commit database transaction")
+        transaction
+            .commit()
+            .context("Commit database transaction")?;
+
+        if let Some(sender) = websocket_txs {
+            _ = sender.new_head.send_if_receiving(header.into());
+        }
+
+        Ok(())
     })?;
 
     Ok(())
@@ -1134,6 +1146,7 @@ mod tests {
             state: Arc::new(SyncState::default()),
             pending_data: tx,
             verify_tree_hashes: false,
+            websocket_txs: None,
         };
 
         consumer(event_rx, context).await.unwrap();
@@ -1178,6 +1191,7 @@ mod tests {
             state: Arc::new(SyncState::default()),
             pending_data: tx,
             verify_tree_hashes: false,
+            websocket_txs: None,
         };
 
         consumer(event_rx, context).await.unwrap();
@@ -1234,6 +1248,7 @@ mod tests {
             state: Arc::new(SyncState::default()),
             pending_data: tx,
             verify_tree_hashes: false,
+            websocket_txs: None,
         };
 
         consumer(event_rx, context).await.unwrap();
@@ -1277,6 +1292,7 @@ mod tests {
             state: Arc::new(SyncState::default()),
             pending_data: tx,
             verify_tree_hashes: false,
+            websocket_txs: None,
         };
 
         consumer(event_rx, context).await.unwrap();
@@ -1312,6 +1328,7 @@ mod tests {
             state: Arc::new(SyncState::default()),
             pending_data: tx,
             verify_tree_hashes: false,
+            websocket_txs: None,
         };
 
         consumer(event_rx, context).await.unwrap();
@@ -1350,6 +1367,7 @@ mod tests {
             state: Arc::new(SyncState::default()),
             pending_data: tx,
             verify_tree_hashes: false,
+            websocket_txs: None,
         };
 
         consumer(event_rx, context).await.unwrap();
@@ -1385,6 +1403,7 @@ mod tests {
             state: Arc::new(SyncState::default()),
             pending_data: tx,
             verify_tree_hashes: false,
+            websocket_txs: None,
         };
 
         consumer(event_rx, context).await.unwrap();

--- a/crates/rpc/src/jsonrpc/websocket.rs
+++ b/crates/rpc/src/jsonrpc/websocket.rs
@@ -5,13 +5,23 @@
 //! Requires the `--rpc.websocket.enabled` cli option.
 //!
 //! Manual testing can be performed using `wscat`:
-//! ```bash
+//! ```
 //! > pierre:~/pathfinder$ wscat -c ws://localhost:9545/ws
 //! Connected (press CTRL+C to quit)
 //! > {"jsonrpc":"2.0", "id": 1, "method": "pathfinder_subscribe", "params": ["newHeads"]}
 //! < {"jsonrpc":"2.0","result":0,"id":1}
-//! < {"jsonrpc":"2.0","method":"pathfinder_subscription","result":{"truncated":""}}
+//! < {"jsonrpc":"2.0","method":"pathfinder_subscription","result":{"subscription":0,"result":{"block_hash":"0x383d92f0136b3c345b71348a08d424434c9e0ba009001740d6bba2b1404118f","block_number":907613,"gas_price":"0x3b9aca0c","parent_block_hash":"0x798f79f86d483e04322e305f14a5c1889b12d1bea4e7b0e403754f5acd3204b","sequencer_address":"0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8","starknet_version":"0.12.3","state_commitment":"0x23e851c43f40e51dfa78872ecf87c2763aef34cd48142db6e1004e1fe5d7a22","status":"ACCEPTED_ON_L2","timestamp":1700733281}}}
 //! ```
+//!
+//! Subscriptions may lag behind because of a slow network or slow client and result in an error:
+//! ```
+//! > pierre:~/pathfinder$ wscat -c ws://localhost:9545/ws
+//! Connected (press CTRL+C to quit)
+//! > {"jsonrpc":"2.0", "id": 1, "method": "pathfinder_subscribe", "params": ["newHeads"]}
+//! < {"jsonrpc":"2.0","result":0,"id":1}
+//! < {"jsonrpc":"2.0","error":{"code":-32099,"message":"Websocket subscription closed","data":{"id":0,"reason":"Lagging stream, some headers were skipped. Closing subscription."}},"id":null}
+//! ```
+
 mod data;
 mod logic;
 

--- a/crates/rpc/src/jsonrpc/websocket.rs
+++ b/crates/rpc/src/jsonrpc/websocket.rs
@@ -2,7 +2,10 @@
 //! See also the [Infura Ethereum API spec](https://docs.infura.io/networks/ethereum/json-rpc-methods/subscription-methods/eth_subscribe)
 //! as well as the [Alchemy subscription API doc](https://docs.alchemy.com/reference/subscription-api)
 //!
+//! See the [OpenRPC](../../../doc/rpc/pathfinder_ws.json) spec for this implementation.
+//!
 //! Requires the `--rpc.websocket.enabled` cli option.
+//!
 //!
 //! Manual testing can be performed using `wscat`:
 //! ```
@@ -10,7 +13,7 @@
 //! Connected (press CTRL+C to quit)
 //! > {"jsonrpc":"2.0", "id": 1, "method": "pathfinder_subscribe", "params": ["newHeads"]}
 //! < {"jsonrpc":"2.0","result":0,"id":1}
-//! < {"jsonrpc":"2.0","method":"pathfinder_subscription","result":{"subscription":0,"result":{"block_hash":"0x383d92f0136b3c345b71348a08d424434c9e0ba009001740d6bba2b1404118f","block_number":907613,"gas_price":"0x3b9aca0c","parent_block_hash":"0x798f79f86d483e04322e305f14a5c1889b12d1bea4e7b0e403754f5acd3204b","sequencer_address":"0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8","starknet_version":"0.12.3","state_commitment":"0x23e851c43f40e51dfa78872ecf87c2763aef34cd48142db6e1004e1fe5d7a22","status":"ACCEPTED_ON_L2","timestamp":1700733281}}}
+//! < {"jsonrpc":"2.0","method":"pathfinder_subscription","result":{"subscription":0,"event":{"class_commitment":"0x4a1c4c3cd477eb052655963781fd7ae0cd647752f01595e4e33fed2ab0eff90","eth_l1_gas_price":1000000015,"event_commitment":"0x79789afccc8f0cac4a3992b2b52cc15f560b4f5a997d883b29d73236b2dfce7","event_count":387,"hash":"0x412edf5929693f8d6bb29512d1a777066dfbf493f3ee64bcb14c64165f5006b","number":908104,"parent_hash":"0x16562de7d258e27809ec6b3d3da5edaedc6526a046442f2f5d72fe7c5dc0a1d","sequencer_address":"0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8","starknet_version":"0.12.3","state_commitment":"0x1d00410c349e70996834a144598bc762602df09cd38a51c25528fb2fd662403","storage_commitment":"0x5129d4a27efa0429975f67440314ab921cc554681ac3ecf476850c1f6b723bf","strk_l1_gas_price":0,"timestamp":1700823087,"transaction_commitment":"0x273bfec6af3c812b59a864e67334132d5bd26c570a9b202e0adce2bb4d6b0cf","transaction_count":36}}}
 //! ```
 //!
 //! Subscriptions may lag behind because of a slow network or slow client and result in an error:

--- a/crates/rpc/src/jsonrpc/websocket/data.rs
+++ b/crates/rpc/src/jsonrpc/websocket/data.rs
@@ -1,21 +1,11 @@
 //! See [the parent module documentation](super)
 
 use crate::jsonrpc::{RequestId, RpcError, RpcResponse};
-use pathfinder_common::BlockHash;
-use pathfinder_common::BlockNumber;
-use pathfinder_common::BlockTimestamp;
-use pathfinder_common::GasPrice;
-use pathfinder_common::SequencerAddress;
-use pathfinder_common::StarknetVersion;
-use pathfinder_common::StateCommitment;
 use serde::ser::Error;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::borrow::Cow;
 use std::sync::Arc;
-
-use pathfinder_serde::GasPriceAsHexStr;
-use starknet_gateway_types::reply::{Block, Status};
 
 #[derive(serde::Deserialize, Serialize)]
 pub(super) struct Kind<'a> {
@@ -177,41 +167,40 @@ where
 }
 
 #[serde_with::serde_as]
-#[derive(Clone, Debug, serde::Deserialize, PartialEq, Eq, serde::Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct BlockHeader {
-    pub block_hash: BlockHash,
-    pub block_number: BlockNumber,
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BlockHeader(pub pathfinder_common::BlockHeader);
 
-    #[serde_as(as = "Option<GasPriceAsHexStr>")]
-    #[serde(default)]
-    pub gas_price: Option<GasPrice>,
-    pub parent_block_hash: BlockHash,
-
-    #[serde(default)]
-    pub sequencer_address: Option<SequencerAddress>,
-
-    #[serde(alias = "state_root")]
-    pub state_commitment: StateCommitment,
-    pub status: Status,
-    pub timestamp: BlockTimestamp,
-
-    #[serde(default)]
-    pub starknet_version: StarknetVersion,
+impl From<pathfinder_common::BlockHeader> for BlockHeader {
+    fn from(value: pathfinder_common::BlockHeader) -> Self {
+        Self(value)
+    }
 }
 
-impl From<&Block> for BlockHeader {
-    fn from(b: &Block) -> Self {
-        Self {
-            block_hash: b.block_hash,
-            block_number: b.block_number,
-            gas_price: b.eth_l1_gas_price,
-            parent_block_hash: b.parent_block_hash,
-            sequencer_address: b.sequencer_address,
-            state_commitment: b.state_commitment,
-            status: b.status,
-            timestamp: b.timestamp,
-            starknet_version: b.starknet_version.clone(),
-        }
+impl serde::Serialize for BlockHeader {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+
+        let mut map = serializer.serialize_map(Some(15))?;
+
+        map.serialize_entry("hash", &self.0.hash)?;
+        map.serialize_entry("parent_hash", &self.0.parent_hash)?;
+        map.serialize_entry("number", &self.0.number)?;
+        map.serialize_entry("timestamp", &self.0.timestamp)?;
+        map.serialize_entry("eth_l1_gas_price", &self.0.eth_l1_gas_price)?;
+        map.serialize_entry("strk_l1_gas_price", &self.0.strk_l1_gas_price)?;
+        map.serialize_entry("sequencer_address", &self.0.sequencer_address)?;
+        map.serialize_entry("starknet_version", &self.0.starknet_version)?;
+        map.serialize_entry("class_commitment", &self.0.class_commitment)?;
+        map.serialize_entry("event_commitment", &self.0.event_commitment)?;
+        map.serialize_entry("state_commitment", &self.0.state_commitment)?;
+        map.serialize_entry("storage_commitment", &self.0.storage_commitment)?;
+        map.serialize_entry("transaction_commitment", &self.0.transaction_commitment)?;
+        map.serialize_entry("transaction_count", &self.0.transaction_count)?;
+        map.serialize_entry("event_count", &self.0.event_count)?;
+
+        map.end()
     }
 }

--- a/crates/rpc/src/jsonrpc/websocket/data.rs
+++ b/crates/rpc/src/jsonrpc/websocket/data.rs
@@ -183,23 +183,41 @@ impl serde::Serialize for BlockHeader {
     {
         use serde::ser::SerializeMap;
 
+        let &pathfinder_common::BlockHeader {
+            hash,
+            parent_hash,
+            number,
+            timestamp,
+            eth_l1_gas_price,
+            strk_l1_gas_price,
+            sequencer_address,
+            starknet_version,
+            class_commitment,
+            event_commitment,
+            state_commitment,
+            storage_commitment,
+            transaction_commitment,
+            transaction_count,
+            event_count,
+        } = &self.0;
+
         let mut map = serializer.serialize_map(Some(15))?;
 
-        map.serialize_entry("hash", &self.0.hash)?;
-        map.serialize_entry("parent_hash", &self.0.parent_hash)?;
-        map.serialize_entry("number", &self.0.number)?;
-        map.serialize_entry("timestamp", &self.0.timestamp)?;
-        map.serialize_entry("eth_l1_gas_price", &self.0.eth_l1_gas_price)?;
-        map.serialize_entry("strk_l1_gas_price", &self.0.strk_l1_gas_price)?;
-        map.serialize_entry("sequencer_address", &self.0.sequencer_address)?;
-        map.serialize_entry("starknet_version", &self.0.starknet_version)?;
-        map.serialize_entry("class_commitment", &self.0.class_commitment)?;
-        map.serialize_entry("event_commitment", &self.0.event_commitment)?;
-        map.serialize_entry("state_commitment", &self.0.state_commitment)?;
-        map.serialize_entry("storage_commitment", &self.0.storage_commitment)?;
-        map.serialize_entry("transaction_commitment", &self.0.transaction_commitment)?;
-        map.serialize_entry("transaction_count", &self.0.transaction_count)?;
-        map.serialize_entry("event_count", &self.0.event_count)?;
+        map.serialize_entry("hash", &hash)?;
+        map.serialize_entry("parent_hash", &parent_hash)?;
+        map.serialize_entry("number", &number)?;
+        map.serialize_entry("timestamp", &timestamp)?;
+        map.serialize_entry("eth_l1_gas_price", &eth_l1_gas_price)?;
+        map.serialize_entry("strk_l1_gas_price", &strk_l1_gas_price)?;
+        map.serialize_entry("sequencer_address", &sequencer_address)?;
+        map.serialize_entry("starknet_version", &starknet_version)?;
+        map.serialize_entry("class_commitment", &class_commitment)?;
+        map.serialize_entry("event_commitment", &event_commitment)?;
+        map.serialize_entry("state_commitment", &state_commitment)?;
+        map.serialize_entry("storage_commitment", &storage_commitment)?;
+        map.serialize_entry("transaction_commitment", &transaction_commitment)?;
+        map.serialize_entry("transaction_count", &transaction_count)?;
+        map.serialize_entry("event_count", &event_count)?;
 
         map.end()
     }

--- a/crates/rpc/src/jsonrpc/websocket/data.rs
+++ b/crates/rpc/src/jsonrpc/websocket/data.rs
@@ -183,7 +183,7 @@ impl serde::Serialize for BlockHeader {
     {
         use serde::ser::SerializeMap;
 
-        let &pathfinder_common::BlockHeader {
+        let pathfinder_common::BlockHeader {
             hash,
             parent_hash,
             number,

--- a/crates/rpc/src/jsonrpc/websocket/logic.rs
+++ b/crates/rpc/src/jsonrpc/websocket/logic.rs
@@ -352,12 +352,9 @@ mod tests {
     use crate::jsonrpc::{RpcError, RpcResponse};
     use axum::routing::get;
     use futures::{SinkExt, StreamExt};
-    use pathfinder_common::BlockHash;
-    use pathfinder_common::StateCommitment;
     use serde::Serialize;
     use serde_json::value::RawValue;
     use serde_json::{json, Number, Value};
-    use starknet_gateway_types::reply::Status;
     use std::borrow::Cow;
     use std::time::Duration;
     use tokio::net::TcpStream;
@@ -461,17 +458,7 @@ mod tests {
     }
 
     fn header_sample() -> BlockHeader {
-        BlockHeader {
-            block_hash: BlockHash::default(),
-            block_number: Default::default(),
-            gas_price: None,
-            parent_block_hash: BlockHash::default(),
-            sequencer_address: None,
-            state_commitment: StateCommitment::default(),
-            status: Status::NotReceived,
-            timestamp: Default::default(),
-            starknet_version: Default::default(),
-        }
+        BlockHeader(Default::default())
     }
 
     struct Client {

--- a/crates/rpc/src/jsonrpc/websocket/logic.rs
+++ b/crates/rpc/src/jsonrpc/websocket/logic.rs
@@ -269,6 +269,7 @@ async fn header_subscription(
                     "Lagging header stream, missed some events, closing subscription"
                 );
 
+                // No explicit break here, the loop will be broken by the dropped receiver.
                 ResponseEvent::SubscriptionClosed {
                     subscription_id,
                     reason: "Lagging stream, some headers were skipped. Closing subscription."

--- a/doc/rpc/pathfinder_rpc_api.json
+++ b/doc/rpc/pathfinder_rpc_api.json
@@ -267,61 +267,6 @@
                     "ABORTED"
                 ],
                 "description": "The status of a transaction"
-            },
-            "BLOCK_HEADER": {
-                "type": "object",
-                "properties": {
-                    "hash": {
-                        "ref": "#/components/schemas/FELT"
-                    },
-                    "parent_hash": {
-                        "ref": "#/components/schemas/FELT"
-                    },
-                    "number": {
-                        "type": "integer"
-                    },
-                    "timestamp": {
-                        "type": "integer"
-                    },
-                    "gas_price": {
-                        "ref": "#/components/schemas/FELT"
-                    },
-                    "sequencer_address": {
-                        "ref": "#/components/schemas/FELT"
-                    },
-                    "starknet_version": {
-                        "ref": "string"
-                    },
-                    "class_commitment": {
-                        "ref": "#/components/schemas/FELT"
-                    },
-                    "event_commitment": {
-                        "ref": "#/components/schemas/FELT"
-                    },
-                    "state_commitment": {
-                        "ref": "#/components/schemas/FELT"
-                    },
-                    "storage_commitment": {
-                        "ref": "#/components/schemas/FELT"
-                    },
-                    "transaction_commitment": {
-                        "ref": "#/components/schemas/FELT"
-                    }
-                },
-                "required": [
-                    "hash",
-                    "parent_hash",
-                    "number",
-                    "timestamp",
-                    "gas_price",
-                    "sequencer_address",
-                    "starknet_version",
-                    "class_commitment",
-                    "event_commitment",
-                    "state_commitment",
-                    "storage_commitment",
-                    "transaction_commitment"
-                ]
             }
         },
         "errors": {

--- a/doc/rpc/pathfinder_ws.json
+++ b/doc/rpc/pathfinder_ws.json
@@ -15,16 +15,20 @@
                     "name": "kind",
                     "summary": "The type of subscription",
                     "required": true,
-                    "type": "string",
-                    "enum": [
-                        "newHeads"
-                    ]
+                    "schema": {
+                        "type": "string",
+                        "enum": [
+                            "newHeads"
+                        ]
+                    }
                 }
             ],
             "result": {
                 "name": "subscription ID",
                 "description": "An identifier for this subscription stream used to associate events with this subscription.",
-                "type": "integer"
+                "schema": {
+                    "type": "integer"
+                }
             }
         },
         {
@@ -36,38 +40,45 @@
                     "name": "subscription ID",
                     "summary": "The subscription to close",
                     "required": true,
-                    "type": "integer"
+                    "schema": {
+                        "type": "integer"
+                    }
                 }
             ],
             "result": {
                 "name": "Unsubscription result",
                 "description": "True if the unsubscription was successful",
-                "type": "bool"
+                "schema": {
+                    "type": "boolean"
+                }
             }
         },
         {
             "name": "pathfinder_subscription",
             "summary": "A subscription event notification sent by the node.",
+            "params": [],
             "result": {
+                "name": "Subscription event",
                 "schema": {
-                    "subscription": {
-                        "name": "Subscription ID",
-                        "summary": "The subscription this event is for",
-                        "required": true,
-                        "type": "integer"
+                    "type": "object",
+                    "properties": {
+                        "subscription": {
+                            "name": "Subscription ID",
+                            "summary": "The subscription this event is for",
+                            "type": "integer"
+                        },
+                        "event": {
+                            "$ref": "#/components/schemas/BLOCK_HEADER"
+                        }  
                     },
-                    "result": {
-                        "summary": "The event data",
-                        "required": true,
-                        "oneOf": [
-                            {
-                                "summary": "Sent by 'newHeads' subscriptions",
-                                "$ref": "#/components/schemas/BLOCK_HEADER"
-                            }
-                        ]
-                    }
+                    "required": ["subscription", "event"]
                 }
-            }
+            },
+            "errors": [
+                {
+                    "$ref": "#/components/errors/WEBSOCKET_SUBSCRIPTION_CLOSED"
+                }
+            ]
         }
     ],
     "components": {
@@ -141,6 +152,28 @@
                 ]
             }
         },
-        "errors": {}
+        "errors": {
+            "WEBSOCKET_SUBSCRIPTION_CLOSED": {
+                "code": -32099,
+                "message": "Websocket subscription closed",
+                "data": {
+                    "type": "object",
+                    "description": "More data about the execution failure",
+                    "properties": {
+                        "id": {
+                            "title": "Subscription ID",
+                            "description": "The ID of the closed subscription",
+                            "type": "integer"
+                        },
+                        "reason": {
+                            "title": "Closing reason",
+                            "description": "The reason why the subscription was closed",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["id", "reason"]
+                }
+            }
+        }
     }
 }

--- a/doc/rpc/pathfinder_ws.json
+++ b/doc/rpc/pathfinder_ws.json
@@ -1,0 +1,146 @@
+{
+    "openrpc": "1.2.6",
+    "info": {
+        "title": "Pathfinder websocket RPC API",
+        "version": "0.1",
+        "description": "Provides additional (pathfinder specific) methods over and above the Starknet RPC API"
+    },
+    "methods": [
+        {
+            "name": "pathfinder_subscribe",
+            "summary": "Open a new websocket subscription",
+            "description": "Creates a websocket stream which will fire events of the requested subscription type. Only available for websocket connections.",
+            "params": [
+                {
+                    "name": "kind",
+                    "summary": "The type of subscription",
+                    "required": true,
+                    "type": "string",
+                    "enum": [
+                        "newHeads"
+                    ]
+                }
+            ],
+            "result": {
+                "name": "subscription ID",
+                "description": "An identifier for this subscription stream used to associate events with this subscription.",
+                "type": "integer"
+            }
+        },
+        {
+            "name": "pathfinder_unsubscribe",
+            "summary": "Closes a websocket subscription",
+            "description": "Creates a websocket stream which will fire events of the requested subscription type. Only available for websocket connections.",
+            "params": [
+                {
+                    "name": "subscription ID",
+                    "summary": "The subscription to close",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "result": {
+                "name": "Unsubscription result",
+                "description": "True if the unsubscription was successful",
+                "type": "bool"
+            }
+        },
+        {
+            "name": "pathfinder_subscription",
+            "summary": "A subscription event notification sent by the node.",
+            "result": {
+                "schema": {
+                    "subscription": {
+                        "name": "Subscription ID",
+                        "summary": "The subscription this event is for",
+                        "required": true,
+                        "type": "integer"
+                    },
+                    "result": {
+                        "summary": "The event data",
+                        "required": true,
+                        "oneOf": [
+                            {
+                                "summary": "Sent by 'newHeads' subscriptions",
+                                "$ref": "#/components/schemas/BLOCK_HEADER"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ],
+    "components": {
+        "contentDescriptors": {},
+        "schemas": {
+            "BLOCK_HEADER": {
+                "type": "object",
+                "properties": {
+                    "hash": {
+                        "ref": "#/components/schemas/FELT"
+                    },
+                    "parent_hash": {
+                        "ref": "#/components/schemas/FELT"
+                    },
+                    "number": {
+                        "type": "integer"
+                    },
+                    "timestamp": {
+                        "type": "integer"
+                    },
+                    "eth_l1_gas_price": {
+                        "ref": "#/components/schemas/FELT"
+                    },
+                    "strk_l1_gas_price": {
+                        "ref": "#/components/schemas/FELT"
+                    },
+                    "sequencer_address": {
+                        "ref": "#/components/schemas/FELT"
+                    },
+                    "starknet_version": {
+                        "ref": "string"
+                    },
+                    "class_commitment": {
+                        "ref": "#/components/schemas/FELT"
+                    },
+                    "event_commitment": {
+                        "ref": "#/components/schemas/FELT"
+                    },
+                    "state_commitment": {
+                        "ref": "#/components/schemas/FELT"
+                    },
+                    "storage_commitment": {
+                        "ref": "#/components/schemas/FELT"
+                    },
+                    "transaction_commitment": {
+                        "ref": "#/components/schemas/FELT"
+                    },
+                    "transaction_count": {
+                        "type": "integer"
+                    },
+                    "event_count": {
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "hash",
+                    "parent_hash",
+                    "number",
+                    "timestamp",
+                    "eth_l1_gas_price",
+                    "strk_l1_gas_price",
+                    "sequencer_address",
+                    "starknet_version",
+                    "class_commitment",
+                    "event_commitment",
+                    "state_commitment",
+                    "storage_commitment",
+                    "transaction_commitment",
+                    "transaction_count",
+                    "event_count"
+                ]
+            }
+        },
+        "errors": {}
+    }
+}

--- a/doc/rpc/pathfinder_ws.json
+++ b/doc/rpc/pathfinder_ws.json
@@ -150,6 +150,9 @@
                     "transaction_count",
                     "event_count"
                 ]
+            },
+            "FELT": {
+                "$ref": "./pathfinder_rpc_api.json#/components/schemas/FELT"
             }
         },
         "errors": {


### PR DESCRIPTION
This PR updates the newHeads subscription's documentation and event data. 

We removed and then re-added websocket support. During this process we also removed the specification for these methods, but never added it back.

This PR also changes the event data to reflect the common block header type instead of the gateway type. This is a breaking change, but since we're already breaking things I think this is good.

I'm not very good at writing nor reading JSON-RPC specs, so a careful eye on it would be appreciated.