### PR TITLE
feat(rpc/v06): add `starknet_getBlockWithTxs`

### DIFF
--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -836,7 +836,6 @@ mod tests {
             "starknet_estimateFee",
             "starknet_estimateMessageFee",
             "starknet_getBlockWithTxHashes",
-            "starknet_getBlockWithTxs",
             "starknet_getTransactionStatus",
             "starknet_getTransactionReceipt",
         ]

--- a/crates/rpc/src/v05.rs
+++ b/crates/rpc/src/v05.rs
@@ -1,7 +1,7 @@
 use crate::jsonrpc::{RpcRouter, RpcRouterBuilder};
 
-pub mod method;
-mod types;
+pub(crate) mod method;
+pub(crate) mod types;
 
 use crate::v02::method as v02_method;
 use crate::v03::method as v03_method;

--- a/crates/rpc/src/v06.rs
+++ b/crates/rpc/src/v06.rs
@@ -1,5 +1,6 @@
 use crate::jsonrpc::{RpcRouter, RpcRouterBuilder};
 
+mod method;
 pub(crate) mod types;
 
 use crate::v02::method as v02_method;
@@ -26,6 +27,8 @@ pub fn register_routes() -> RpcRouterBuilder {
         .register("starknet_getTransactionByHash"            , v04_method::get_transaction_by_hash)
         .register("starknet_syncing"                         , v04_method::syncing)
 
+        .register("starknet_getBlockWithTxs"                 , method::get_block_with_txs)
+
         // .register("starknet_addDeclareTransaction"           , method::add_declare_transaction)
         // .register("starknet_addDeployAccountTransaction"     , method::add_deploy_account_transaction)
         // .register("starknet_addInvokeTransaction"            , method::add_invoke_transaction)
@@ -33,7 +36,6 @@ pub fn register_routes() -> RpcRouterBuilder {
         // .register("starknet_estimateFee"                     , method::estimate_fee)
         // .register("starknet_estimateMessageFee"              , method::estimate_message_fee)
         // .register("starknet_getBlockWithTxHashes"            , method::get_block_with_tx_hashes)
-        // .register("starknet_getBlockWithTxs"                 , method::get_block_with_txs)
         // .register("starknet_getTransactionStatus"            , method::get_transaction_status)
         // .register("starknet_getTransactionReceipt"           , method::get_transaction_receipt)
         // .register("starknet_simulateTransactions"            , method::simulate_transactions)

--- a/crates/rpc/src/v06/method.rs
+++ b/crates/rpc/src/v06/method.rs
@@ -1,0 +1,3 @@
+mod get_block_with_txs;
+
+pub(crate) use get_block_with_txs::get_block_with_txs;

--- a/crates/rpc/src/v06/method/get_block_with_txs.rs
+++ b/crates/rpc/src/v06/method/get_block_with_txs.rs
@@ -1,0 +1,289 @@
+use crate::context::RpcContext;
+use crate::v02::types::reply::BlockStatus;
+use crate::v06::types::TransactionWithHash;
+
+use anyhow::Context;
+use pathfinder_common::{BlockId, BlockNumber};
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug, PartialEq, Eq)]
+#[cfg_attr(test, derive(Copy, Clone))]
+#[serde(deny_unknown_fields)]
+pub struct GetBlockInput {
+    block_id: BlockId,
+}
+
+crate::error::generate_rpc_error_subset!(GetBlockError: BlockNotFound);
+
+/// Get block information with full transactions given the block id
+pub async fn get_block_with_txs(
+    context: RpcContext,
+    input: GetBlockInput,
+) -> Result<types::Block, GetBlockError> {
+    let storage = context.storage.clone();
+    let span = tracing::Span::current();
+
+    tokio::task::spawn_blocking(move || {
+        let _g = span.enter();
+        let mut connection = storage
+            .connection()
+            .context("Opening database connection")?;
+
+        let transaction = connection
+            .transaction()
+            .context("Creating database transaction")?;
+
+        let block_id = match input.block_id {
+            BlockId::Pending => {
+                let block = context
+                    .pending_data
+                    .get(&transaction)
+                    .context("Querying pending data")?
+                    .block
+                    .clone();
+
+                return Ok(types::Block::from_sequencer(block.into()));
+            }
+            other => other.try_into().expect("Only pending cast should fail"),
+        };
+
+        let header = transaction
+            .block_header(block_id)
+            .context("Reading block from database")?
+            .ok_or(GetBlockError::BlockNotFound)?;
+
+        let l1_accepted = transaction.block_is_l1_accepted(header.number.into())?;
+        let block_status = if l1_accepted {
+            BlockStatus::AcceptedOnL1
+        } else {
+            BlockStatus::AcceptedOnL2
+        };
+
+        let transactions = get_block_transactions(&transaction, header.number)?;
+
+        Ok(types::Block::from_parts(header, block_status, transactions))
+    })
+    .await
+    .context("Database read panic or shutting down")?
+}
+
+/// This function assumes that the block ID is valid i.e. it won't check if the block hash or number exist.
+fn get_block_transactions(
+    db_tx: &pathfinder_storage::Transaction<'_>,
+    block_number: BlockNumber,
+) -> Result<Vec<TransactionWithHash>, GetBlockError> {
+    let txs = db_tx
+        .transaction_data_for_block(block_number.into())
+        .context("Reading transactions from database")?
+        .context("Transaction data missing for block")?
+        .into_iter()
+        .map(|(tx, _rx)| tx.into())
+        .collect();
+
+    Ok(txs)
+}
+
+mod types {
+    use crate::v02::types::reply::BlockStatus;
+    use crate::v06::types::TransactionWithHash;
+    use pathfinder_common::BlockHeader;
+    use serde::Serialize;
+    use serde_with::{serde_as, skip_serializing_none};
+
+    /// L2 Block as returned by the RPC API.
+    #[serde_as]
+    #[skip_serializing_none]
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    pub struct Block {
+        #[serde(flatten)]
+        pub header: crate::v05::types::BlockHeader,
+        #[serde(skip_serializing_if = "BlockStatus::is_pending")]
+        pub status: BlockStatus,
+        pub transactions: Vec<TransactionWithHash>,
+    }
+
+    impl Block {
+        pub fn from_parts(
+            header: BlockHeader,
+            status: BlockStatus,
+            transactions: Vec<TransactionWithHash>,
+        ) -> Self {
+            Self {
+                header: header.into(),
+                status,
+                transactions,
+            }
+        }
+
+        /// Constructs [Block] from [sequencer's block representation](starknet_gateway_types::reply::Block)
+        pub fn from_sequencer(block: starknet_gateway_types::reply::MaybePendingBlock) -> Self {
+            Self {
+                status: block.status().into(),
+                transactions: block
+                    .transactions()
+                    .iter()
+                    .cloned()
+                    .map(Into::into)
+                    .collect(),
+                header: crate::v05::types::BlockHeader::from_sequencer(block),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pathfinder_common::macro_prelude::*;
+    use pathfinder_common::BlockNumber;
+    use serde_json::json;
+
+    #[rstest::rstest]
+    #[case::pending_by_position(json!(["pending"]), BlockId::Pending)]
+    #[case::pending_by_name(json!({"block_id": "pending"}), BlockId::Pending)]
+    #[case::latest_by_position(json!(["latest"]), BlockId::Latest)]
+    #[case::latest_by_name(json!({"block_id": "latest"}), BlockId::Latest)]
+    #[case::number_by_position(json!([{"block_number":123}]), BlockNumber::new_or_panic(123).into())]
+    #[case::number_by_name(json!({"block_id": {"block_number":123}}), BlockNumber::new_or_panic(123).into())]
+    #[case::hash_by_position(json!([{"block_hash": "0xbeef"}]), block_hash!("0xbeef").into())]
+    #[case::hash_by_name(json!({"block_id": {"block_hash": "0xbeef"}}), block_hash!("0xbeef").into())]
+    fn input_parsing(#[case] input: serde_json::Value, #[case] block_id: BlockId) {
+        let input = serde_json::from_value::<GetBlockInput>(input).unwrap();
+
+        let expected = GetBlockInput { block_id };
+
+        assert_eq!(input, expected);
+    }
+
+    #[tokio::test]
+    async fn pending() {
+        let context = RpcContext::for_tests_with_pending().await;
+
+        let result = get_block_with_txs(
+            context,
+            GetBlockInput {
+                block_id: BlockId::Pending,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.header.parent_hash, block_hash_bytes!(b"latest"));
+    }
+
+    #[tokio::test]
+    async fn latest() {
+        let context = RpcContext::for_tests_with_pending().await;
+
+        let result = get_block_with_txs(
+            context,
+            GetBlockInput {
+                block_id: BlockId::Latest,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.header.block_hash, Some(block_hash_bytes!(b"latest")));
+    }
+
+    #[tokio::test]
+    async fn by_number() {
+        let context = RpcContext::for_tests_with_pending().await;
+
+        let result = get_block_with_txs(
+            context,
+            GetBlockInput {
+                block_id: BlockId::Number(BlockNumber::GENESIS),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result.header.block_hash,
+            Some(block_hash_bytes!(b"genesis"))
+        );
+    }
+
+    #[tokio::test]
+    async fn by_hash() {
+        let context = RpcContext::for_tests_with_pending().await;
+
+        let result = get_block_with_txs(
+            context,
+            GetBlockInput {
+                block_id: BlockId::Hash(block_hash_bytes!(b"genesis")),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result.header.block_hash,
+            Some(block_hash_bytes!(b"genesis"))
+        );
+    }
+
+    #[tokio::test]
+    async fn not_found_by_number() {
+        let context = RpcContext::for_tests_with_pending().await;
+
+        let result = get_block_with_txs(
+            context,
+            GetBlockInput {
+                block_id: BlockId::Number(BlockNumber::MAX),
+            },
+        )
+        .await;
+
+        assert_matches::assert_matches!(result, Err(GetBlockError::BlockNotFound));
+    }
+
+    #[tokio::test]
+    async fn not_found_by_hash() {
+        let context = RpcContext::for_tests_with_pending().await;
+
+        let result = get_block_with_txs(
+            context,
+            GetBlockInput {
+                block_id: BlockId::Hash(block_hash_bytes!(b"non-existent")),
+            },
+        )
+        .await;
+
+        assert_matches::assert_matches!(result, Err(GetBlockError::BlockNotFound));
+    }
+
+    #[tokio::test]
+    async fn status_serialization() {
+        // PENDING status should be skipped.
+
+        let context = RpcContext::for_tests_with_pending().await;
+        let pending = get_block_with_txs(
+            context.clone(),
+            GetBlockInput {
+                block_id: BlockId::Pending,
+            },
+        )
+        .await
+        .unwrap();
+        let latest = get_block_with_txs(
+            context,
+            GetBlockInput {
+                block_id: BlockId::Latest,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(pending.status.is_pending());
+        assert!(!latest.status.is_pending());
+
+        let pending = serde_json::to_value(pending).unwrap();
+        let latest = serde_json::to_value(latest).unwrap();
+
+        assert!(pending.get("status").is_none());
+        assert!(latest.get("status").is_some());
+    }
+}


### PR DESCRIPTION
This PR adds a JSON-RPC 0.6.0-specific implementation of `starknet_getBlockWithTxs`. We need this because the transaction representation for v3 transactions is different between earlier versions and 0.6.0.
