### PR TITLE
feat(rpc/v06): `starknet_simulateTransaction` should return traces for reverted transactions

### DIFF
--- a/crates/executor/src/simulate.rs
+++ b/crates/executor/src/simulate.rs
@@ -72,9 +72,8 @@ pub fn simulate(
 
         match tx_info {
             Ok(tx_info) => {
-                if let Some(revert_error) = tx_info.revert_error {
+                if let Some(revert_error) = &tx_info.revert_error {
                     tracing::trace!(%revert_error, "Transaction reverted");
-                    return Err(CallError::Reverted(revert_error));
                 }
 
                 tracing::trace!(actual_fee=%tx_info.actual_fee.0, actual_resources=?tx_info.actual_resources, "Transaction simulation finished");

--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -28,12 +28,30 @@ pub struct TransactionSimulation {
     pub fee_estimation: FeeEstimate,
 }
 
+impl TransactionSimulation {
+    pub fn revert_reason(&self) -> Option<&str> {
+        self.trace.revert_reason()
+    }
+}
+
 #[derive(Debug)]
 pub enum TransactionTrace {
     Declare(DeclareTransactionTrace),
     DeployAccount(DeployAccountTransactionTrace),
     Invoke(InvokeTransactionTrace),
     L1Handler(L1HandlerTransactionTrace),
+}
+
+impl TransactionTrace {
+    fn revert_reason(&self) -> Option<&str> {
+        match self {
+            TransactionTrace::Invoke(InvokeTransactionTrace {
+                execute_invocation: ExecuteInvocation::RevertedReason(revert_reason),
+                ..
+            }) => Some(revert_reason.as_str()),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/crates/rpc/src/v05/method/simulate_transactions.rs
+++ b/crates/rpc/src/v05/method/simulate_transactions.rs
@@ -128,8 +128,21 @@ pub async fn simulate_transactions(
 
         let txs =
             pathfinder_executor::simulate(state, transactions, skip_validate, skip_fee_charge)?;
-        let txs = txs.into_iter().map(Into::into).collect();
-        Ok(SimulateTransactionOutput(txs))
+
+        match txs
+            .iter()
+            .filter_map(pathfinder_executor::types::TransactionSimulation::revert_reason)
+            .next()
+        {
+            Some(revert_reason) => Err(SimulateTransactionError::Custom(anyhow::anyhow!(
+                "Transaction reverted: {}",
+                revert_reason
+            ))),
+            None => {
+                let txs = txs.into_iter().map(Into::into).collect();
+                Ok(SimulateTransactionOutput(txs))
+            }
+        }
     })
     .await
     .context("Simulating transaction")?


### PR DESCRIPTION
`starknet_simulateTransactions` used to return an error upon the first reverted transaction.

With the JSON-RPC 0.6.0 API we've agreed to return traces with the reverted reason instead.
    
Post-execution checks are added to `starknet_simulateTransactions` implementations for older JSON-RPC versions that check if there were reverted transactions and throw the same error they were mapping `CallError::Reverted` to.