### PR TITLE
feat(rpc/v06): add `starknet_trace*` methods

### DIFF
--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -831,12 +831,7 @@ mod tests {
     #[case::root_pathfinder("/", "pathfinder_rpc_api.json", &["pathfinder_version"])]
 
     #[case::v0_6_api  ("/rpc/v0_6", "v06/starknet_api_openrpc.json", &[])]
-    #[case::v0_6_trace("/rpc/v0_6", "v06/starknet_trace_api_openrpc.json", 
-        &[
-            "starknet_traceBlockTransactions", 
-            "starknet_traceTransaction"
-        ]
-    )]
+    #[case::v0_6_trace("/rpc/v0_6", "v06/starknet_trace_api_openrpc.json", &[])]
     #[case::v0_6_write("/rpc/v0_6", "v06/starknet_write_api.json", 
         &[
             "starknet_addDeclareTransaction", 

--- a/crates/rpc/src/v06.rs
+++ b/crates/rpc/src/v06.rs
@@ -35,16 +35,15 @@ pub fn register_routes() -> RpcRouterBuilder {
 
         .register("starknet_getBlockWithTxHashes"            , method::get_block_with_tx_hashes)
         .register("starknet_getBlockWithTxs"                 , method::get_block_with_txs)
-        .register("starknet_simulateTransactions"            , method::simulate_transactions)
         .register("starknet_getTransactionReceipt"           , method::get_transaction_receipt)
+        .register("starknet_simulateTransactions"            , method::simulate_transactions)
+        .register("starknet_traceBlockTransactions"          , method::trace_block_transactions)
+        .register("starknet_traceTransaction"                , method::trace_transaction)
 
         // .register("starknet_addDeclareTransaction"           , method::add_declare_transaction)
         // .register("starknet_addDeployAccountTransaction"     , method::add_deploy_account_transaction)
         // .register("starknet_addInvokeTransaction"            , method::add_invoke_transaction)
-        // .register("starknet_getTransactionStatus"            , method::get_transaction_status)
         .register("starknet_specVersion"                     , || "0.6.0-rc1")
-        // .register("starknet_traceBlockTransactions"          , method::trace_block_transactions)
-        // .register("starknet_traceTransaction"                , method::trace_transaction)
 
         .register("pathfinder_getProof"                      , crate::pathfinder::methods::get_proof)
 }

--- a/crates/rpc/src/v06/method.rs
+++ b/crates/rpc/src/v06/method.rs
@@ -2,8 +2,12 @@ mod get_block_with_tx_hashes;
 mod get_block_with_txs;
 pub(crate) mod get_transaction_receipt;
 mod simulate_transactions;
+mod trace_block_transactions;
+mod trace_transaction;
 
 pub(crate) use get_block_with_tx_hashes::get_block_with_tx_hashes;
 pub(crate) use get_block_with_txs::get_block_with_txs;
 pub(super) use get_transaction_receipt::get_transaction_receipt;
 pub(crate) use simulate_transactions::simulate_transactions;
+pub(crate) use trace_block_transactions::trace_block_transactions;
+pub(crate) use trace_transaction::trace_transaction;

--- a/crates/rpc/src/v06/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v06/method/trace_block_transactions.rs
@@ -1,0 +1,503 @@
+use anyhow::Context;
+use pathfinder_common::{BlockId, TransactionHash};
+use pathfinder_executor::{CallError, ExecutionState};
+use serde::{Deserialize, Serialize};
+use starknet_gateway_client::GatewayApi;
+use starknet_gateway_types::trace::TransactionTrace as GatewayTxTrace;
+
+use crate::executor::VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEWAY;
+use crate::v06::method::simulate_transactions::dto::{
+    DeclareTxnTrace, DeployAccountTxnTrace, ExecuteInvocation, InvokeTxnTrace, L1HandlerTxnTrace,
+};
+use crate::{compose_executor_transaction, context::RpcContext, executor::ExecutionStateError};
+
+use starknet_gateway_types::reply::transaction::Transaction as GatewayTransaction;
+
+use super::simulate_transactions::dto::TransactionTrace;
+
+#[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct TraceBlockTransactionsInput {
+    block_id: BlockId,
+}
+
+#[derive(Debug, Serialize, Eq, PartialEq)]
+pub struct Trace {
+    pub transaction_hash: TransactionHash,
+    pub trace_root: TransactionTrace,
+}
+
+#[derive(Debug, Serialize, Eq, PartialEq)]
+pub struct TraceBlockTransactionsOutput(pub Vec<Trace>);
+
+#[derive(Debug)]
+pub enum TraceBlockTransactionsError {
+    Internal(anyhow::Error),
+    Custom(anyhow::Error),
+    BlockNotFound,
+    ContractErrorV05 { revert_error: String },
+}
+
+impl From<anyhow::Error> for TraceBlockTransactionsError {
+    fn from(value: anyhow::Error) -> Self {
+        Self::Internal(value)
+    }
+}
+
+impl From<TraceBlockTransactionsError> for crate::error::ApplicationError {
+    fn from(value: TraceBlockTransactionsError) -> Self {
+        match value {
+            TraceBlockTransactionsError::Internal(e) => Self::Internal(e),
+            TraceBlockTransactionsError::BlockNotFound => Self::BlockNotFound,
+            TraceBlockTransactionsError::ContractErrorV05 { revert_error } => {
+                Self::ContractErrorV05 { revert_error }
+            }
+            TraceBlockTransactionsError::Custom(e) => Self::Custom(e),
+        }
+    }
+}
+
+impl From<ExecutionStateError> for TraceBlockTransactionsError {
+    fn from(value: ExecutionStateError) -> Self {
+        match value {
+            ExecutionStateError::BlockNotFound => Self::BlockNotFound,
+            ExecutionStateError::Internal(e) => Self::Internal(e),
+        }
+    }
+}
+
+impl From<CallError> for TraceBlockTransactionsError {
+    fn from(value: CallError) -> Self {
+        match value {
+            CallError::ContractNotFound => Self::Custom(anyhow::anyhow!("Contract not found")),
+            CallError::InvalidMessageSelector => {
+                Self::Custom(anyhow::anyhow!("Invalid message selector"))
+            }
+            CallError::Reverted(revert_error) => Self::ContractErrorV05 { revert_error },
+            CallError::Internal(e) => Self::Internal(e),
+            CallError::Custom(e) => Self::Custom(e),
+        }
+    }
+}
+
+pub(crate) fn map_gateway_trace(
+    transaction: GatewayTransaction,
+    trace: GatewayTxTrace,
+) -> TransactionTrace {
+    match transaction {
+        GatewayTransaction::Declare(_) => TransactionTrace::Declare(DeclareTxnTrace {
+            fee_transfer_invocation: trace.fee_transfer_invocation.map(Into::into),
+            validate_invocation: trace.validate_invocation.map(Into::into),
+            state_diff: None,
+        }),
+        GatewayTransaction::Deploy(_) => TransactionTrace::DeployAccount(DeployAccountTxnTrace {
+            constructor_invocation: trace.function_invocation.map(Into::into),
+            fee_transfer_invocation: trace.fee_transfer_invocation.map(Into::into),
+            validate_invocation: trace.validate_invocation.map(Into::into),
+            state_diff: None,
+        }),
+        GatewayTransaction::DeployAccount(_) => {
+            TransactionTrace::DeployAccount(DeployAccountTxnTrace {
+                constructor_invocation: trace.function_invocation.map(Into::into),
+                fee_transfer_invocation: trace.fee_transfer_invocation.map(Into::into),
+                validate_invocation: trace.validate_invocation.map(Into::into),
+                state_diff: None,
+            })
+        }
+        GatewayTransaction::Invoke(_) => TransactionTrace::Invoke(InvokeTxnTrace {
+            execute_invocation: if let Some(revert_reason) = trace.revert_error {
+                ExecuteInvocation::RevertedReason { revert_reason }
+            } else {
+                trace
+                    .function_invocation
+                    .map(|invocation| ExecuteInvocation::FunctionInvocation(invocation.into()))
+                    .unwrap_or_else(|| ExecuteInvocation::Empty)
+            },
+            fee_transfer_invocation: trace.fee_transfer_invocation.map(Into::into),
+            validate_invocation: trace.validate_invocation.map(Into::into),
+            state_diff: None,
+        }),
+        GatewayTransaction::L1Handler(_) => TransactionTrace::L1Handler(L1HandlerTxnTrace {
+            function_invocation: trace.function_invocation.map(Into::into),
+            state_diff: None,
+        }),
+    }
+}
+
+pub async fn trace_block_transactions(
+    context: RpcContext,
+    input: TraceBlockTransactionsInput,
+) -> Result<TraceBlockTransactionsOutput, TraceBlockTransactionsError> {
+    enum LocalExecution {
+        Success(Vec<Trace>),
+        Unsupported(Vec<GatewayTransaction>),
+    }
+
+    let span = tracing::Span::current();
+
+    let storage = context.storage.clone();
+    let traces = tokio::task::spawn_blocking(move || {
+        let _g = span.enter();
+
+        let mut db = storage.connection()?;
+        let db = db.transaction()?;
+
+        let (header, transactions) = match input.block_id {
+            BlockId::Pending => {
+                let pending = context
+                    .pending_data
+                    .get(&db)
+                    .context("Querying pending data")?;
+
+                let header = pending.header();
+                let transactions = pending.block.transactions.clone();
+
+                (header, transactions)
+            }
+            other => {
+                let block_id = other.try_into().expect("Only pending should fail");
+                let header = db
+                    .block_header(block_id)?
+                    .ok_or(TraceBlockTransactionsError::BlockNotFound)?;
+
+                let transactions = db
+                    .transactions_for_block(block_id)?
+                    .context("Transaction data missing")?;
+
+                (header, transactions)
+            }
+        };
+
+        let starknet_version = header
+            .starknet_version
+            .parse_as_semver()
+            .context("Parsing starknet version")?
+            .unwrap_or(semver::Version::new(0, 0, 0));
+        if starknet_version
+            < VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEWAY
+        {
+            match input.block_id {
+                BlockId::Pending => {
+                    return Err(TraceBlockTransactionsError::Internal(anyhow::anyhow!(
+                        "Traces are not supported for pending blocks by the feeder gateway"
+                    )))
+                }
+                _ => {
+                    return Ok::<_, TraceBlockTransactionsError>(LocalExecution::Unsupported(
+                        transactions,
+                    ))
+                }
+            }
+        }
+
+        let transactions = transactions
+            .iter()
+            .map(|transaction| compose_executor_transaction(transaction, &db))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let state = ExecutionState::trace(&db, context.chain_id, header, None);
+        let traces = pathfinder_executor::trace_all(state, transactions, true, true)?;
+
+        let result = traces
+            .into_iter()
+            .map(|(hash, trace)| Trace {
+                transaction_hash: hash,
+                trace_root: trace.into(),
+            })
+            .collect();
+
+        Ok(LocalExecution::Success(result))
+    })
+    .await
+    .context("trace_block_transactions: fetch block & transactions")??;
+
+    let transactions = match traces {
+        LocalExecution::Success(traces) => return Ok(TraceBlockTransactionsOutput(traces)),
+        LocalExecution::Unsupported(transactions) => transactions,
+    };
+
+    context
+        .sequencer
+        .block_traces(input.block_id)
+        .await
+        .context("Forwarding to feeder gateway")
+        .map_err(Into::into)
+        .map(|trace| {
+            TraceBlockTransactionsOutput(
+                trace
+                    .traces
+                    .into_iter()
+                    .zip(transactions.into_iter())
+                    .map(|(trace, tx)| {
+                        let transaction_hash = tx.hash();
+                        let trace_root = map_gateway_trace(tx, trace);
+
+                        Trace {
+                            transaction_hash,
+                            trace_root,
+                        }
+                    })
+                    .collect(),
+            )
+        })
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use std::sync::Arc;
+
+    use pathfinder_common::{
+        block_hash, felt, BlockHeader, ChainId, GasPrice, SierraHash, StateUpdate, TransactionIndex,
+    };
+    use starknet_gateway_types::reply::transaction::{ExecutionStatus, Receipt};
+
+    use super::*;
+
+    pub(crate) async fn setup_multi_tx_trace_test(
+    ) -> anyhow::Result<(RpcContext, BlockHeader, Vec<Trace>)> {
+        use super::super::simulate_transactions::tests::fixtures;
+        use super::super::simulate_transactions::tests::setup_storage;
+
+        let (
+            storage,
+            last_block_header,
+            account_contract_address,
+            universal_deployer_address,
+            test_storage_value,
+        ) = setup_storage().await;
+        let context = RpcContext::for_tests().with_storage(storage.clone());
+
+        let transactions = vec![
+            fixtures::input::declare(account_contract_address),
+            fixtures::input::universal_deployer(
+                account_contract_address,
+                universal_deployer_address,
+            ),
+            fixtures::input::invoke(account_contract_address),
+        ];
+
+        let traces = vec![
+            fixtures::expected_output::declare(account_contract_address, &last_block_header)
+                .transaction_trace,
+            fixtures::expected_output::universal_deployer(
+                account_contract_address,
+                &last_block_header,
+                universal_deployer_address,
+            )
+            .transaction_trace,
+            fixtures::expected_output::invoke(
+                account_contract_address,
+                &last_block_header,
+                test_storage_value,
+            )
+            .transaction_trace,
+        ];
+
+        let next_block_header = {
+            let mut db = storage.connection()?;
+            let tx = db.transaction()?;
+
+            tx.insert_sierra_class(
+                &SierraHash(fixtures::SIERRA_HASH.0),
+                fixtures::SIERRA_DEFINITION,
+                &fixtures::CASM_HASH,
+                fixtures::CASM_DEFINITION,
+                "compiler version",
+            )?;
+
+            let next_block_header = BlockHeader::builder()
+                .with_number(last_block_header.number + 1)
+                .with_eth_l1_gas_price(GasPrice(1))
+                .with_parent_hash(last_block_header.hash)
+                .with_starknet_version(last_block_header.starknet_version)
+                .with_sequencer_address(last_block_header.sequencer_address)
+                .with_timestamp(last_block_header.timestamp)
+                .finalize_with_hash(block_hash!("0x1"));
+            tx.insert_block_header(&next_block_header)?;
+
+            let dummy_receipt: Receipt = Receipt {
+                actual_fee: None,
+                events: vec![],
+                execution_resources: None,
+                l1_to_l2_consumed_message: None,
+                l2_to_l1_messages: vec![],
+                transaction_hash: TransactionHash(felt!("0x1")),
+                transaction_index: TransactionIndex::new_or_panic(0),
+                execution_status: ExecutionStatus::default(),
+                revert_error: None,
+            };
+            tx.insert_transaction_data(
+                next_block_header.hash,
+                next_block_header.number,
+                &[
+                    (transactions[0].clone().into(), dummy_receipt.clone()),
+                    (transactions[1].clone().into(), dummy_receipt.clone()),
+                    (transactions[2].clone().into(), dummy_receipt.clone()),
+                ],
+            )?;
+            tx.commit()?;
+
+            next_block_header
+        };
+
+        let traces = vec![
+            Trace {
+                transaction_hash: transactions[0]
+                    .transaction_hash(ChainId::TESTNET, Some(fixtures::SIERRA_HASH)),
+                trace_root: traces[0].clone(),
+            },
+            Trace {
+                transaction_hash: transactions[1].transaction_hash(ChainId::TESTNET, None),
+                trace_root: traces[1].clone(),
+            },
+            Trace {
+                transaction_hash: transactions[2].transaction_hash(ChainId::TESTNET, None),
+                trace_root: traces[2].clone(),
+            },
+        ];
+
+        Ok((context, next_block_header, traces))
+    }
+
+    #[tokio::test]
+    async fn test_multiple_transactions() -> anyhow::Result<()> {
+        let (context, next_block_header, traces) = setup_multi_tx_trace_test().await?;
+
+        let input = TraceBlockTransactionsInput {
+            block_id: next_block_header.hash.into(),
+        };
+        let output = trace_block_transactions(context, input).await.unwrap();
+        let expected = TraceBlockTransactionsOutput(traces);
+
+        pretty_assertions::assert_eq!(output, expected);
+        Ok(())
+    }
+
+    pub(crate) async fn setup_multi_tx_trace_pending_test(
+    ) -> anyhow::Result<(RpcContext, Vec<Trace>)> {
+        use super::super::simulate_transactions::tests::fixtures;
+        use super::super::simulate_transactions::tests::setup_storage;
+
+        let (
+            storage,
+            last_block_header,
+            account_contract_address,
+            universal_deployer_address,
+            test_storage_value,
+        ) = setup_storage().await;
+        let context = RpcContext::for_tests().with_storage(storage.clone());
+
+        let transactions = vec![
+            fixtures::input::declare(account_contract_address),
+            fixtures::input::universal_deployer(
+                account_contract_address,
+                universal_deployer_address,
+            ),
+            fixtures::input::invoke(account_contract_address),
+        ];
+
+        let traces = vec![
+            fixtures::expected_output::declare(account_contract_address, &last_block_header)
+                .transaction_trace,
+            fixtures::expected_output::universal_deployer(
+                account_contract_address,
+                &last_block_header,
+                universal_deployer_address,
+            )
+            .transaction_trace,
+            fixtures::expected_output::invoke(
+                account_contract_address,
+                &last_block_header,
+                test_storage_value,
+            )
+            .transaction_trace,
+        ];
+
+        let pending_block = {
+            let mut db = storage.connection()?;
+            let tx = db.transaction()?;
+
+            tx.insert_sierra_class(
+                &SierraHash(fixtures::SIERRA_HASH.0),
+                fixtures::SIERRA_DEFINITION,
+                &fixtures::CASM_HASH,
+                fixtures::CASM_DEFINITION,
+                "compiler version",
+            )?;
+
+            let dummy_receipt: Receipt = Receipt {
+                actual_fee: None,
+                events: vec![],
+                execution_resources: None,
+                l1_to_l2_consumed_message: None,
+                l2_to_l1_messages: vec![],
+                transaction_hash: TransactionHash(felt!("0x1")),
+                transaction_index: TransactionIndex::new_or_panic(0),
+                execution_status: ExecutionStatus::default(),
+                revert_error: None,
+            };
+
+            let transaction_receipts =
+                vec![dummy_receipt.clone(), dummy_receipt.clone(), dummy_receipt];
+
+            let pending_block = starknet_gateway_types::reply::PendingBlock {
+                eth_l1_gas_price: GasPrice(1),
+                strk_l1_gas_price: Some(GasPrice(1)),
+                parent_hash: last_block_header.hash,
+                sequencer_address: last_block_header.sequencer_address,
+                status: starknet_gateway_types::reply::Status::Pending,
+                timestamp: last_block_header.timestamp,
+                transaction_receipts,
+                transactions: transactions.iter().cloned().map(Into::into).collect(),
+                starknet_version: last_block_header.starknet_version,
+            };
+
+            tx.commit()?;
+
+            pending_block
+        };
+
+        let pending_data = crate::pending::PendingData {
+            block: pending_block,
+            state_update: StateUpdate::default(),
+            number: last_block_header.number + 1,
+        };
+
+        let (tx, rx) = tokio::sync::watch::channel(Default::default());
+        tx.send(Arc::new(pending_data)).unwrap();
+
+        let context = context.with_pending_data(rx);
+
+        let traces = vec![
+            Trace {
+                transaction_hash: transactions[0]
+                    .transaction_hash(ChainId::TESTNET, Some(fixtures::SIERRA_HASH)),
+                trace_root: traces[0].clone(),
+            },
+            Trace {
+                transaction_hash: transactions[1].transaction_hash(ChainId::TESTNET, None),
+                trace_root: traces[1].clone(),
+            },
+            Trace {
+                transaction_hash: transactions[2].transaction_hash(ChainId::TESTNET, None),
+                trace_root: traces[2].clone(),
+            },
+        ];
+
+        Ok((context, traces))
+    }
+
+    #[tokio::test]
+    async fn test_multiple_pending_transactions() -> anyhow::Result<()> {
+        let (context, traces) = setup_multi_tx_trace_pending_test().await?;
+
+        let input = TraceBlockTransactionsInput {
+            block_id: BlockId::Pending,
+        };
+        let output = trace_block_transactions(context, input).await.unwrap();
+        let expected = TraceBlockTransactionsOutput(traces);
+
+        pretty_assertions::assert_eq!(output, expected);
+        Ok(())
+    }
+}

--- a/crates/rpc/src/v06/method/trace_transaction.rs
+++ b/crates/rpc/src/v06/method/trace_transaction.rs
@@ -1,0 +1,260 @@
+use anyhow::Context;
+use pathfinder_common::TransactionHash;
+use pathfinder_executor::{CallError, ExecutionState};
+use serde::{Deserialize, Serialize};
+use starknet_gateway_client::GatewayApi;
+
+use crate::compose_executor_transaction;
+use crate::executor::VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEWAY;
+use crate::v06::method::trace_block_transactions::map_gateway_trace;
+use crate::{
+    context::RpcContext,
+    error::{ApplicationError, TraceError},
+    executor::ExecutionStateError,
+};
+
+use super::simulate_transactions::dto::TransactionTrace;
+
+#[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct TraceTransactionInput {
+    pub transaction_hash: TransactionHash,
+}
+
+#[derive(Debug, Serialize, Eq, PartialEq)]
+pub struct TraceTransactionOutput(pub TransactionTrace);
+
+#[derive(Debug)]
+pub enum TraceTransactionError {
+    Internal(anyhow::Error),
+    Custom(anyhow::Error),
+    InvalidTxnHash,
+    NoTraceAvailable(TraceError),
+    ContractErrorV05 { revert_error: String },
+}
+
+impl From<ExecutionStateError> for TraceTransactionError {
+    fn from(value: ExecutionStateError) -> Self {
+        match value {
+            ExecutionStateError::BlockNotFound => Self::Custom(anyhow::anyhow!("Block not found")),
+            ExecutionStateError::Internal(e) => Self::Internal(e),
+        }
+    }
+}
+
+impl From<CallError> for TraceTransactionError {
+    fn from(value: CallError) -> Self {
+        match value {
+            CallError::ContractNotFound => Self::Custom(anyhow::anyhow!("Contract not found")),
+            CallError::InvalidMessageSelector => {
+                Self::Custom(anyhow::anyhow!("Invalid message selector"))
+            }
+            CallError::Reverted(revert_error) => Self::ContractErrorV05 { revert_error },
+            CallError::Internal(e) => Self::Internal(e),
+            CallError::Custom(e) => Self::Custom(e),
+        }
+    }
+}
+
+impl From<anyhow::Error> for TraceTransactionError {
+    fn from(e: anyhow::Error) -> Self {
+        Self::Internal(e)
+    }
+}
+
+impl From<super::trace_block_transactions::TraceBlockTransactionsError> for TraceTransactionError {
+    fn from(e: super::trace_block_transactions::TraceBlockTransactionsError) -> Self {
+        use super::trace_block_transactions::TraceBlockTransactionsError::*;
+        match e {
+            Internal(e) => Self::Internal(e),
+            BlockNotFound => Self::Custom(anyhow::anyhow!("Block not found")),
+            ContractErrorV05 { revert_error } => Self::ContractErrorV05 { revert_error },
+            Custom(e) => Self::Custom(e),
+        }
+    }
+}
+
+impl From<TraceTransactionError> for ApplicationError {
+    fn from(value: TraceTransactionError) -> Self {
+        match value {
+            TraceTransactionError::InvalidTxnHash => ApplicationError::InvalidTxnHash,
+            TraceTransactionError::NoTraceAvailable(status) => {
+                ApplicationError::NoTraceAvailable(status)
+            }
+            TraceTransactionError::ContractErrorV05 { revert_error } => {
+                ApplicationError::ContractErrorV05 { revert_error }
+            }
+            TraceTransactionError::Internal(e) => ApplicationError::Internal(e),
+            TraceTransactionError::Custom(e) => ApplicationError::Custom(e),
+        }
+    }
+}
+
+pub async fn trace_transaction(
+    context: RpcContext,
+    input: TraceTransactionInput,
+) -> Result<TraceTransactionOutput, TraceTransactionError> {
+    #[allow(clippy::large_enum_variant)]
+    enum LocalExecution {
+        Success(TransactionTrace),
+        Unsupported(starknet_gateway_types::reply::transaction::Transaction),
+    }
+
+    let span = tracing::Span::current();
+    let local = tokio::task::spawn_blocking(move || {
+        let _g = span.enter();
+
+        let mut db = context
+            .storage
+            .connection()
+            .context("Creating database connection")?;
+        let db = db.transaction().context("Creating database transaction")?;
+
+        // Find the transaction's block.
+        let pending = context
+            .pending_data
+            .get(&db)
+            .context("Querying pending data")?;
+
+        let (header, transactions) = if let Some(pending_idx) = pending
+            .block
+            .transactions
+            .iter()
+            .position(|tx| tx.hash() == input.transaction_hash)
+        {
+            let header = pending.header();
+
+            let starknet_version = header
+                .starknet_version
+                .parse_as_semver()
+                .context("Parsing starknet version")?
+                .unwrap_or(semver::Version::new(0, 0, 0));
+            if starknet_version
+                < VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEWAY
+            {
+                return Ok(LocalExecution::Unsupported(
+                    pending.block.transactions[pending_idx].clone(),
+                ));
+            }
+
+            (
+                header,
+                pending
+                    .block
+                    .transactions
+                    .iter()
+                    .take(pending_idx + 1)
+                    .cloned()
+                    .collect::<Vec<_>>(),
+            )
+        } else {
+            let block_hash = db
+                .transaction_block_hash(input.transaction_hash)?
+                .ok_or(TraceTransactionError::InvalidTxnHash)?;
+
+            let header = db
+                .block_header(block_hash.into())
+                .context("Fetching block header")?
+                .context("Block header is missing")?;
+
+            let starknet_version = header
+                .starknet_version
+                .parse_as_semver()
+                .context("Parsing starknet version")?
+                .unwrap_or(semver::Version::new(0, 0, 0));
+            if starknet_version
+                < VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEWAY
+            {
+                let transaction = db
+                    .transaction(input.transaction_hash)
+                    .context("Fetching transaction data")?
+                    .context("Transaction data missing")?;
+
+                return Ok(LocalExecution::Unsupported(transaction));
+            }
+
+            let transactions = db
+                .transactions_for_block(header.number.into())
+                .context("Fetching block transactions")?
+                .context("Block transactions missing")?;
+
+            let index = transactions
+                .iter()
+                .position(|tx| tx.hash() == input.transaction_hash)
+                .context("Failed to find transaction in the batch")?;
+
+            (
+                header,
+                transactions.into_iter().take(index + 1).collect::<Vec<_>>(),
+            )
+        };
+
+        let state = ExecutionState::trace(&db, context.chain_id, header, None);
+
+        let transactions = transactions
+            .iter()
+            .map(|transaction| compose_executor_transaction(transaction, &db))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        pathfinder_executor::trace_one(state, transactions, input.transaction_hash, true, true)
+            .map_err(TraceTransactionError::from)
+            .map(|x| LocalExecution::Success(x.into()))
+    })
+    .await
+    .context("trace_transaction: execution")??;
+
+    let transaction = match local {
+        LocalExecution::Success(trace) => return Ok(TraceTransactionOutput(trace)),
+        LocalExecution::Unsupported(x) => x,
+    };
+
+    let trace = context
+        .sequencer
+        .transaction_trace(input.transaction_hash)
+        .await
+        .context("Proxying call to feeder gateway")?;
+
+    let trace = map_gateway_trace(transaction, trace);
+
+    Ok(TraceTransactionOutput(trace))
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::super::trace_block_transactions::tests::{
+        setup_multi_tx_trace_pending_test, setup_multi_tx_trace_test,
+    };
+    use super::*;
+
+    #[tokio::test]
+    async fn test_multiple_transactions() -> anyhow::Result<()> {
+        let (context, _, traces) = setup_multi_tx_trace_test().await?;
+
+        for trace in traces {
+            let input = TraceTransactionInput {
+                transaction_hash: trace.transaction_hash,
+            };
+            let output = trace_transaction(context.clone(), input).await.unwrap();
+            let expected = TraceTransactionOutput(trace.trace_root);
+            pretty_assertions::assert_eq!(output, expected);
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_multiple_pending_transactions() -> anyhow::Result<()> {
+        let (context, traces) = setup_multi_tx_trace_pending_test().await?;
+
+        for trace in traces {
+            let input = TraceTransactionInput {
+                transaction_hash: trace.transaction_hash,
+            };
+            let output = trace_transaction(context.clone(), input).await.unwrap();
+            let expected = TraceTransactionOutput(trace.trace_root);
+            pretty_assertions::assert_eq!(output, expected);
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
These are really just copies of the v05 implementation but using the `TransansactionTrace` type for v06.
