### PR TITLE
fix spelling of Equilibrium

### DIFF
--- a/crates/p2p_stream/src/codec.rs
+++ b/crates/p2p_stream/src/codec.rs
@@ -1,4 +1,4 @@
-// Equlibrium Labs: This work is an extension of libp2p's request-response protocol,
+// Equilibrium Labs: This work is an extension of libp2p's request-response protocol,
 // hence the original copyright notice is included below.
 //
 //

--- a/crates/p2p_stream/src/handler.rs
+++ b/crates/p2p_stream/src/handler.rs
@@ -1,4 +1,4 @@
-// Equlibrium Labs: This work is an extension of libp2p's request-response protocol,
+// Equilibrium Labs: This work is an extension of libp2p's request-response protocol,
 // hence the original copyright notice is included below.
 //
 //

--- a/crates/p2p_stream/src/handler/protocol.rs
+++ b/crates/p2p_stream/src/handler/protocol.rs
@@ -1,4 +1,4 @@
-// Equlibrium Labs: This work is an extension of libp2p's request-response protocol,
+// Equilibrium Labs: This work is an extension of libp2p's request-response protocol,
 // hence the original copyright notice is included below.
 //
 //

--- a/crates/p2p_stream/src/lib.rs
+++ b/crates/p2p_stream/src/lib.rs
@@ -1,4 +1,4 @@
-// Equlibrium Labs: This work is an extension of libp2p's request-response protocol,
+// Equilibrium Labs: This work is an extension of libp2p's request-response protocol,
 // hence the original copyright notice is included below.
 //
 //


### PR DESCRIPTION
In four places it was missing the first 'i'
