### PR TITLE
feat(rpc/v06): add `TRANSACTION_EXECUTION_ERROR`

### DIFF
--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -14,7 +14,7 @@ pub mod types;
 pub use block_context::ETH_FEE_TOKEN_ADDRESS;
 pub use call::call;
 pub use class::{parse_casm_definition, parse_deprecated_class_definition};
-pub use error::CallError;
+pub use error::{CallError, TransactionExecutionError};
 pub use estimate::estimate;
 pub use execution_state::ExecutionState;
 pub use felt::{IntoFelt, IntoStarkFelt};

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -76,6 +76,11 @@ pub enum ApplicationError {
     ProofLimitExceeded { limit: u32, requested: u32 },
     #[error("Internal error")]
     GatewayError(starknet_gateway_types::error::StarknetError),
+    #[error("Transaction execution error")]
+    TransactionExecutionError {
+        transaction_index: usize,
+        error: String,
+    },
     /// Internal errors are errors whose details we don't want to show to the end user.
     /// These are logged, and a simple "internal error" message is shown to the end
     /// user.
@@ -107,6 +112,7 @@ impl ApplicationError {
             ApplicationError::TooManyKeysInFilter { .. } => 34,
             ApplicationError::ContractError => 40,
             ApplicationError::ContractErrorV05 { .. } => 40,
+            ApplicationError::TransactionExecutionError { .. } => 41,
             ApplicationError::InvalidContractClass => 50,
             ApplicationError::ClassAlreadyDeclared => 51,
             ApplicationError::InvalidTransactionNonce => 52,
@@ -162,6 +168,13 @@ impl ApplicationError {
             ApplicationError::UnsupportedContractClassVersion => None,
             ApplicationError::GatewayError(error) => Some(json!({
                 "error": error,
+            })),
+            ApplicationError::TransactionExecutionError {
+                transaction_index,
+                error,
+            } => Some(json!({
+                "transaction_index": transaction_index,
+                "execution_error": error,
             })),
             ApplicationError::Internal(_) => None,
             ApplicationError::Custom(cause) => {

--- a/crates/rpc/src/v04/method/simulate_transactions.rs
+++ b/crates/rpc/src/v04/method/simulate_transactions.rs
@@ -5,7 +5,7 @@ use crate::{
 use anyhow::Context;
 use pathfinder_common::{BlockId, CallParam, EntryPoint};
 use pathfinder_crypto::Felt;
-use pathfinder_executor::{types::TransactionSimulation, CallError};
+use pathfinder_executor::{types::TransactionSimulation, TransactionExecutionError};
 use serde::{Deserialize, Serialize};
 use starknet_gateway_types::reply::transaction::Transaction as GatewayTransaction;
 use starknet_gateway_types::trace as gateway_trace;
@@ -27,15 +27,18 @@ crate::error::generate_rpc_error_subset!(
     ContractError
 );
 
-impl From<CallError> for SimulateTransactionError {
-    fn from(value: CallError) -> Self {
-        use CallError::*;
+impl From<TransactionExecutionError> for SimulateTransactionError {
+    fn from(value: TransactionExecutionError) -> Self {
+        use TransactionExecutionError::*;
         match value {
-            ContractNotFound => Self::ContractNotFound,
-            InvalidMessageSelector => Self::ContractError,
-            Reverted(revert_error) => {
-                Self::Custom(anyhow::anyhow!("Transaction reverted: {}", revert_error))
-            }
+            ExecutionError {
+                transaction_index,
+                error,
+            } => Self::Custom(anyhow::anyhow!(
+                "Execution error at transaction index {}: {}",
+                transaction_index,
+                error
+            )),
             Internal(e) => Self::Internal(e),
             Custom(e) => Self::Custom(e),
         }

--- a/crates/rpc/src/v04/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v04/method/trace_block_transactions.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use pathfinder_common::{BlockHash, TransactionHash};
-use pathfinder_executor::{CallError, ExecutionState};
+use pathfinder_executor::{ExecutionState, TransactionExecutionError};
 use serde::{Deserialize, Serialize};
 use starknet_gateway_client::GatewayApi;
 use starknet_gateway_types::reply::transaction::Transaction as GatewayTransaction;
@@ -39,16 +39,20 @@ impl From<ExecutionStateError> for TraceBlockTransactionsError {
     }
 }
 
-impl From<CallError> for TraceBlockTransactionsError {
-    fn from(value: CallError) -> Self {
+impl From<TransactionExecutionError> for TraceBlockTransactionsError {
+    fn from(value: TransactionExecutionError) -> Self {
+        use TransactionExecutionError::*;
         match value {
-            CallError::ContractNotFound => Self::Custom(anyhow::anyhow!("Contract not found")),
-            CallError::InvalidMessageSelector => {
-                Self::Custom(anyhow::anyhow!("Invalid message selector"))
-            }
-            CallError::Reverted(reason) => Self::Custom(anyhow::anyhow!("Reverted: {reason}")),
-            CallError::Internal(e) => Self::Internal(e),
-            CallError::Custom(e) => Self::Custom(e),
+            ExecutionError {
+                transaction_index,
+                error,
+            } => Self::Custom(anyhow::anyhow!(
+                "Execution error at transaction index {}: {}",
+                transaction_index,
+                error
+            )),
+            Internal(e) => Self::Internal(e),
+            Custom(e) => Self::Custom(e),
         }
     }
 }

--- a/crates/rpc/src/v04/method/trace_transaction.rs
+++ b/crates/rpc/src/v04/method/trace_transaction.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use pathfinder_common::TransactionHash;
-use pathfinder_executor::{CallError, ExecutionState};
+use pathfinder_executor::{ExecutionState, TransactionExecutionError};
 use serde::{Deserialize, Serialize};
 use starknet_gateway_client::GatewayApi;
 
@@ -41,16 +41,20 @@ impl From<ExecutionStateError> for TraceTransactionError {
     }
 }
 
-impl From<CallError> for TraceTransactionError {
-    fn from(value: CallError) -> Self {
+impl From<TransactionExecutionError> for TraceTransactionError {
+    fn from(value: TransactionExecutionError) -> Self {
+        use TransactionExecutionError::*;
         match value {
-            CallError::ContractNotFound => Self::Custom(anyhow::anyhow!("Contract not found")),
-            CallError::InvalidMessageSelector => {
-                Self::Custom(anyhow::anyhow!("Invalid message selector"))
-            }
-            CallError::Reverted(reason) => Self::Custom(anyhow::anyhow!("Reverted: {reason}")),
-            CallError::Internal(e) => Self::Internal(e),
-            CallError::Custom(e) => Self::Custom(e),
+            ExecutionError {
+                transaction_index,
+                error,
+            } => Self::Custom(anyhow::anyhow!(
+                "Execution error at transaction index {}: {}",
+                transaction_index,
+                error
+            )),
+            Internal(e) => Self::Internal(e),
+            Custom(e) => Self::Custom(e),
         }
     }
 }

--- a/crates/rpc/src/v05/method/call.rs
+++ b/crates/rpc/src/v05/method/call.rs
@@ -26,7 +26,9 @@ impl From<pathfinder_executor::CallError> for CallError {
         match value {
             ContractNotFound => Self::ContractNotFound,
             InvalidMessageSelector => Self::Custom(anyhow::anyhow!("Invalid message selector")),
-            Reverted(revert_error) => Self::ContractErrorV05 { revert_error },
+            ContractError(error) => Self::ContractErrorV05 {
+                revert_error: format!("Execution error: {}", error),
+            },
             Internal(e) => Self::Internal(e),
             Custom(e) => Self::Custom(e),
         }

--- a/crates/rpc/src/v05/method/estimate_fee.rs
+++ b/crates/rpc/src/v05/method/estimate_fee.rs
@@ -29,13 +29,19 @@ impl From<anyhow::Error> for EstimateFeeError {
     }
 }
 
-impl From<pathfinder_executor::CallError> for EstimateFeeError {
-    fn from(value: pathfinder_executor::CallError) -> Self {
-        use pathfinder_executor::CallError::*;
+impl From<pathfinder_executor::TransactionExecutionError> for EstimateFeeError {
+    fn from(value: pathfinder_executor::TransactionExecutionError) -> Self {
+        use pathfinder_executor::TransactionExecutionError::*;
         match value {
-            ContractNotFound => Self::ContractNotFound,
-            InvalidMessageSelector => Self::Internal(anyhow::anyhow!("Invalid message selector")),
-            Reverted(revert_error) => Self::ContractErrorV05 { revert_error },
+            ExecutionError {
+                transaction_index,
+                error,
+            } => Self::ContractErrorV05 {
+                revert_error: format!(
+                    "Execution error at transaction index {}: {}",
+                    transaction_index, error
+                ),
+            },
             Internal(e) => Self::Internal(e),
             Custom(e) => Self::Custom(e),
         }

--- a/crates/rpc/src/v05/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v05/method/trace_block_transactions.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use pathfinder_common::{BlockId, TransactionHash};
-use pathfinder_executor::{CallError, ExecutionState};
+use pathfinder_executor::{ExecutionState, TransactionExecutionError};
 use serde::{Deserialize, Serialize};
 use starknet_gateway_client::GatewayApi;
 use starknet_gateway_types::trace::TransactionTrace as GatewayTxTrace;
@@ -66,16 +66,20 @@ impl From<ExecutionStateError> for TraceBlockTransactionsError {
     }
 }
 
-impl From<CallError> for TraceBlockTransactionsError {
-    fn from(value: CallError) -> Self {
+impl From<TransactionExecutionError> for TraceBlockTransactionsError {
+    fn from(value: TransactionExecutionError) -> Self {
+        use TransactionExecutionError::*;
         match value {
-            CallError::ContractNotFound => Self::Custom(anyhow::anyhow!("Contract not found")),
-            CallError::InvalidMessageSelector => {
-                Self::Custom(anyhow::anyhow!("Invalid message selector"))
-            }
-            CallError::Reverted(revert_error) => Self::ContractErrorV05 { revert_error },
-            CallError::Internal(e) => Self::Internal(e),
-            CallError::Custom(e) => Self::Custom(e),
+            ExecutionError {
+                transaction_index,
+                error,
+            } => Self::Custom(anyhow::anyhow!(
+                "Execution error at transaction index {}: {}",
+                transaction_index,
+                error
+            )),
+            Internal(e) => Self::Internal(e),
+            Custom(e) => Self::Custom(e),
         }
     }
 }

--- a/crates/rpc/src/v06.rs
+++ b/crates/rpc/src/v06.rs
@@ -32,10 +32,10 @@ pub fn register_routes() -> RpcRouterBuilder {
         .register("starknet_syncing"                         , v04_method::syncing)
 
         .register("starknet_call"                            , v05_method::call)
-        .register("starknet_estimateFee"                     , v05_method::estimate_fee)
         .register("starknet_estimateMessageFee"              , v05_method::estimate_message_fee)
         .register("starknet_getTransactionStatus"            , v05_method::get_transaction_status)
 
+        .register("starknet_estimateFee"                     , method::estimate_fee)
         .register("starknet_getBlockWithTxHashes"            , method::get_block_with_tx_hashes)
         .register("starknet_getBlockWithTxs"                 , method::get_block_with_txs)
         .register("starknet_getTransactionReceipt"           , method::get_transaction_receipt)

--- a/crates/rpc/src/v06/method.rs
+++ b/crates/rpc/src/v06/method.rs
@@ -1,3 +1,4 @@
+mod estimate_fee;
 mod get_block_with_tx_hashes;
 mod get_block_with_txs;
 pub(crate) mod get_transaction_receipt;
@@ -5,6 +6,7 @@ mod simulate_transactions;
 mod trace_block_transactions;
 mod trace_transaction;
 
+pub(crate) use estimate_fee::estimate_fee;
 pub(crate) use get_block_with_tx_hashes::get_block_with_tx_hashes;
 pub(crate) use get_block_with_txs::get_block_with_txs;
 pub(super) use get_transaction_receipt::get_transaction_receipt;

--- a/crates/rpc/src/v06/method/estimate_fee.rs
+++ b/crates/rpc/src/v06/method/estimate_fee.rs
@@ -1,0 +1,384 @@
+use anyhow::Context;
+use pathfinder_executor::ExecutionState;
+use serde_with::serde_as;
+
+use crate::{
+    context::RpcContext, error::ApplicationError, v02::types::request::BroadcastedTransaction,
+};
+use pathfinder_common::BlockId;
+
+#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct EstimateFeeInput {
+    pub request: Vec<BroadcastedTransaction>,
+    pub block_id: BlockId,
+}
+
+#[derive(Debug)]
+pub enum EstimateFeeError {
+    Internal(anyhow::Error),
+    Custom(anyhow::Error),
+    BlockNotFound,
+    TransactionExecutionError {
+        transaction_index: usize,
+        error: String,
+    },
+}
+
+impl From<anyhow::Error> for EstimateFeeError {
+    fn from(e: anyhow::Error) -> Self {
+        Self::Internal(e)
+    }
+}
+
+impl From<pathfinder_executor::TransactionExecutionError> for EstimateFeeError {
+    fn from(value: pathfinder_executor::TransactionExecutionError) -> Self {
+        use pathfinder_executor::TransactionExecutionError::*;
+        match value {
+            ExecutionError {
+                transaction_index,
+                error,
+            } => Self::TransactionExecutionError {
+                transaction_index,
+                error,
+            },
+            Internal(e) => Self::Internal(e),
+            Custom(e) => Self::Custom(e),
+        }
+    }
+}
+
+impl From<crate::executor::ExecutionStateError> for EstimateFeeError {
+    fn from(error: crate::executor::ExecutionStateError) -> Self {
+        use crate::executor::ExecutionStateError::*;
+        match error {
+            BlockNotFound => Self::BlockNotFound,
+            Internal(e) => Self::Internal(e),
+        }
+    }
+}
+
+impl From<EstimateFeeError> for ApplicationError {
+    fn from(value: EstimateFeeError) -> Self {
+        match value {
+            EstimateFeeError::BlockNotFound => ApplicationError::BlockNotFound,
+            EstimateFeeError::TransactionExecutionError {
+                transaction_index,
+                error,
+            } => ApplicationError::TransactionExecutionError {
+                transaction_index,
+                error,
+            },
+            EstimateFeeError::Internal(e) => ApplicationError::Internal(e),
+            EstimateFeeError::Custom(e) => ApplicationError::Custom(e),
+        }
+    }
+}
+
+#[serde_as]
+#[derive(Clone, Debug, serde::Serialize, PartialEq, Eq)]
+pub struct FeeEstimate {
+    #[serde_as(as = "pathfinder_serde::U256AsHexStr")]
+    pub gas_consumed: primitive_types::U256,
+    #[serde_as(as = "pathfinder_serde::U256AsHexStr")]
+    pub gas_price: primitive_types::U256,
+    #[serde_as(as = "pathfinder_serde::U256AsHexStr")]
+    pub overall_fee: primitive_types::U256,
+}
+
+impl From<pathfinder_executor::types::FeeEstimate> for FeeEstimate {
+    fn from(value: pathfinder_executor::types::FeeEstimate) -> Self {
+        Self {
+            gas_consumed: value.gas_consumed,
+            gas_price: value.gas_price,
+            overall_fee: value.overall_fee,
+        }
+    }
+}
+
+pub async fn estimate_fee(
+    context: RpcContext,
+    input: EstimateFeeInput,
+) -> Result<Vec<FeeEstimate>, EstimateFeeError> {
+    let span = tracing::Span::current();
+
+    let result = tokio::task::spawn_blocking(move || {
+        let _g = span.enter();
+        let mut db = context
+            .storage
+            .connection()
+            .context("Creating database connection")?;
+        let db = db.transaction().context("Creating database transaction")?;
+
+        let (header, pending) = match input.block_id {
+            BlockId::Pending => {
+                let pending = context
+                    .pending_data
+                    .get(&db)
+                    .context("Querying pending data")?;
+
+                (pending.header(), Some(pending.state_update.clone()))
+            }
+            other => {
+                let block_id = other.try_into().expect("Only pending cast should fail");
+                let header = db
+                    .block_header(block_id)
+                    .context("Querying block header")?
+                    .ok_or(EstimateFeeError::BlockNotFound)?;
+
+                (header, None)
+            }
+        };
+
+        let state = ExecutionState::simulation(&db, context.chain_id, header, pending);
+
+        let transactions = input
+            .request
+            .iter()
+            .map(|tx| crate::executor::map_broadcasted_transaction(tx, context.chain_id))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let result = pathfinder_executor::estimate(state, transactions)?;
+
+        Ok::<_, EstimateFeeError>(result)
+    })
+    .await
+    .context("Executing transaction")??;
+
+    Ok(result.into_iter().map(Into::into).collect())
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::v02::types::request::BroadcastedInvokeTransaction;
+    use pathfinder_common::{
+        felt, BlockHash, CallParam, ContractAddress, Fee, TransactionNonce,
+        TransactionSignatureElem, TransactionVersion,
+    };
+
+    mod parsing {
+        use super::*;
+        use serde_json::json;
+
+        fn test_invoke_txn() -> BroadcastedTransaction {
+            BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(
+                crate::v02::types::request::BroadcastedInvokeTransactionV1 {
+                    version: TransactionVersion::ONE_WITH_QUERY_VERSION,
+                    max_fee: Fee(felt!("0x6")),
+                    signature: vec![TransactionSignatureElem(felt!("0x7"))],
+                    nonce: TransactionNonce(felt!("0x8")),
+                    sender_address: ContractAddress::new_or_panic(felt!("0xaaa")),
+                    calldata: vec![CallParam(felt!("0xff"))],
+                },
+            ))
+        }
+
+        #[test]
+        fn positional_args() {
+            let positional = json!([
+                [
+                    {
+                        "type": "INVOKE",
+                        "version": "0x100000000000000000000000000000001",
+                        "max_fee": "0x6",
+                        "signature": [
+                            "0x7"
+                        ],
+                        "nonce": "0x8",
+                        "sender_address": "0xaaa",
+                        "calldata": [
+                            "0xff"
+                        ]
+                    }
+                ],
+                { "block_hash": "0xabcde" }
+            ]);
+
+            let input = serde_json::from_value::<EstimateFeeInput>(positional).unwrap();
+            let expected = EstimateFeeInput {
+                request: vec![test_invoke_txn()],
+                block_id: BlockId::Hash(BlockHash(felt!("0xabcde"))),
+            };
+            assert_eq!(input, expected);
+        }
+
+        #[test]
+        fn named_args() {
+            let named_args = json!({
+                "request": [
+                    {
+                        "type": "INVOKE",
+                        "version": "0x100000000000000000000000000000001",
+                        "max_fee": "0x6",
+                        "signature": [
+                            "0x7"
+                        ],
+                        "nonce": "0x8",
+                        "sender_address": "0xaaa",
+                        "calldata": [
+                            "0xff"
+                        ]
+                    }
+                ],
+                "block_id": { "block_hash": "0xabcde" }
+            });
+            let input = serde_json::from_value::<EstimateFeeInput>(named_args).unwrap();
+            let expected = EstimateFeeInput {
+                request: vec![test_invoke_txn()],
+                block_id: BlockId::Hash(BlockHash(felt!("0xabcde"))),
+            };
+            assert_eq!(input, expected);
+        }
+    }
+
+    mod in_memory {
+
+        use super::*;
+
+        use pathfinder_common::{macro_prelude::*, EntryPoint};
+
+        use pathfinder_common::felt;
+
+        use crate::v02::types::request::{
+            BroadcastedDeclareTransaction, BroadcastedDeclareTransactionV2,
+            BroadcastedInvokeTransactionV0, BroadcastedInvokeTransactionV1,
+        };
+        use crate::v02::types::{ContractClass, SierraContractClass};
+
+        #[test_log::test(tokio::test)]
+        async fn declare_deploy_and_invoke_sierra_class() {
+            let (context, last_block_header, account_contract_address, universal_deployer_address) =
+                crate::test_setup::test_context().await;
+
+            let sierra_definition =
+                include_bytes!("../../../fixtures/contracts/storage_access.json");
+            let sierra_hash =
+                class_hash!("0544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90");
+            let casm_hash =
+                casm_hash!("0x069032ff71f77284e1a0864a573007108ca5cc08089416af50f03260f5d6d4d8");
+
+            let contract_class: SierraContractClass =
+                ContractClass::from_definition_bytes(sierra_definition)
+                    .unwrap()
+                    .as_sierra()
+                    .unwrap();
+
+            assert_eq!(contract_class.class_hash().unwrap().hash(), sierra_hash);
+
+            let max_fee = Fee::default();
+
+            // declare test class
+            let declare_transaction = BroadcastedTransaction::Declare(
+                BroadcastedDeclareTransaction::V2(BroadcastedDeclareTransactionV2 {
+                    version: TransactionVersion::TWO,
+                    max_fee,
+                    signature: vec![],
+                    nonce: TransactionNonce(Default::default()),
+                    contract_class,
+                    sender_address: account_contract_address,
+                    compiled_class_hash: casm_hash,
+                }),
+            );
+            // deploy with unversal deployer contract
+            let deploy_transaction = BroadcastedTransaction::Invoke(
+                BroadcastedInvokeTransaction::V1(BroadcastedInvokeTransactionV1 {
+                    nonce: transaction_nonce!("0x1"),
+                    version: TransactionVersion::ONE,
+                    max_fee,
+                    signature: vec![],
+                    sender_address: account_contract_address,
+                    calldata: vec![
+                        CallParam(*universal_deployer_address.get()),
+                        // Entry point selector for the called contract, i.e. AccountCallArray::selector
+                        CallParam(EntryPoint::hashed(b"deployContract").0),
+                        // Length of the call data for the called contract, i.e. AccountCallArray::data_len
+                        call_param!("4"),
+                        // classHash
+                        CallParam(sierra_hash.0),
+                        // salt
+                        call_param!("0x0"),
+                        // unique
+                        call_param!("0x0"),
+                        // calldata_len
+                        call_param!("0x0"),
+                    ],
+                }),
+            );
+            // invoke deployed contract
+            let invoke_transaction = BroadcastedTransaction::Invoke(
+                BroadcastedInvokeTransaction::V1(BroadcastedInvokeTransactionV1 {
+                    nonce: transaction_nonce!("0x2"),
+                    version: TransactionVersion::ONE,
+                    max_fee,
+                    signature: vec![],
+                    sender_address: account_contract_address,
+                    calldata: vec![
+                        // address of the deployed test contract
+                        CallParam(felt!(
+                            "0x012592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7"
+                        )),
+                        // Entry point selector for the called contract, i.e. AccountCallArray::selector
+                        CallParam(EntryPoint::hashed(b"get_data").0),
+                        // Length of the call data for the called contract, i.e. AccountCallArray::data_len
+                        call_param!("0"),
+                    ],
+                }),
+            );
+
+            // do the same invoke with a v0 transaction
+            let invoke_v0_transaction = BroadcastedTransaction::Invoke(
+                BroadcastedInvokeTransaction::V0(BroadcastedInvokeTransactionV0 {
+                    version: TransactionVersion::ONE,
+                    max_fee,
+                    signature: vec![],
+                    contract_address: contract_address!(
+                        "0x012592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7"
+                    ),
+                    entry_point_selector: EntryPoint::hashed(b"get_data"),
+                    calldata: vec![],
+                }),
+            );
+
+            let input = EstimateFeeInput {
+                request: vec![
+                    declare_transaction,
+                    deploy_transaction,
+                    invoke_transaction,
+                    invoke_v0_transaction,
+                ],
+                block_id: BlockId::Number(last_block_header.number),
+            };
+            let result = estimate_fee(context, input).await.unwrap();
+            let declare_expected = FeeEstimate {
+                gas_consumed: 3700.into(),
+                gas_price: 1.into(),
+                overall_fee: 3700.into(),
+            };
+            let deploy_expected = FeeEstimate {
+                gas_consumed: 4337.into(),
+                gas_price: 1.into(),
+                overall_fee: 4337.into(),
+            };
+            let invoke_expected = FeeEstimate {
+                gas_consumed: 2491.into(),
+                gas_price: 1.into(),
+                overall_fee: 2491.into(),
+            };
+            let invoke_v0_expected = FeeEstimate {
+                gas_consumed: 1260.into(),
+                gas_price: 1.into(),
+                overall_fee: 1260.into(),
+            };
+            assert_eq!(
+                result,
+                vec![
+                    declare_expected,
+                    deploy_expected,
+                    invoke_expected,
+                    invoke_v0_expected
+                ]
+            );
+        }
+    }
+}

--- a/crates/rpc/src/v06/method/trace_transaction.rs
+++ b/crates/rpc/src/v06/method/trace_transaction.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use pathfinder_common::TransactionHash;
-use pathfinder_executor::{CallError, ExecutionState};
+use pathfinder_executor::{ExecutionState, TransactionExecutionError};
 use serde::{Deserialize, Serialize};
 use starknet_gateway_client::GatewayApi;
 
@@ -42,16 +42,20 @@ impl From<ExecutionStateError> for TraceTransactionError {
     }
 }
 
-impl From<CallError> for TraceTransactionError {
-    fn from(value: CallError) -> Self {
+impl From<TransactionExecutionError> for TraceTransactionError {
+    fn from(value: TransactionExecutionError) -> Self {
+        use TransactionExecutionError::*;
         match value {
-            CallError::ContractNotFound => Self::Custom(anyhow::anyhow!("Contract not found")),
-            CallError::InvalidMessageSelector => {
-                Self::Custom(anyhow::anyhow!("Invalid message selector"))
-            }
-            CallError::Reverted(revert_error) => Self::ContractErrorV05 { revert_error },
-            CallError::Internal(e) => Self::Internal(e),
-            CallError::Custom(e) => Self::Custom(e),
+            ExecutionError {
+                transaction_index,
+                error,
+            } => Self::Custom(anyhow::anyhow!(
+                "Transaction execution failed at index {}: {}",
+                transaction_index,
+                error
+            )),
+            Internal(e) => Self::Internal(e),
+            Custom(e) => Self::Custom(e),
         }
     }
 }
@@ -68,7 +72,6 @@ impl From<super::trace_block_transactions::TraceBlockTransactionsError> for Trac
         match e {
             Internal(e) => Self::Internal(e),
             BlockNotFound => Self::Custom(anyhow::anyhow!("Block not found")),
-            ContractErrorV05 { revert_error } => Self::ContractErrorV05 { revert_error },
             Custom(e) => Self::Custom(e),
         }
     }

--- a/crates/rpc/src/v06/method/trace_transaction.rs
+++ b/crates/rpc/src/v06/method/trace_transaction.rs
@@ -28,7 +28,7 @@ pub struct TraceTransactionOutput(pub TransactionTrace);
 pub enum TraceTransactionError {
     Internal(anyhow::Error),
     Custom(anyhow::Error),
-    InvalidTxnHash,
+    TxnHashNotFound,
     NoTraceAvailable(TraceError),
     ContractErrorV05 { revert_error: String },
 }
@@ -83,7 +83,7 @@ impl From<super::trace_block_transactions::TraceConversionError> for TraceTransa
 impl From<TraceTransactionError> for ApplicationError {
     fn from(value: TraceTransactionError) -> Self {
         match value {
-            TraceTransactionError::InvalidTxnHash => ApplicationError::InvalidTxnHash,
+            TraceTransactionError::TxnHashNotFound => ApplicationError::TxnHashNotFound,
             TraceTransactionError::NoTraceAvailable(status) => {
                 ApplicationError::NoTraceAvailable(status)
             }
@@ -156,7 +156,7 @@ pub async fn trace_transaction(
         } else {
             let block_hash = db
                 .transaction_block_hash(input.transaction_hash)?
-                .ok_or(TraceTransactionError::InvalidTxnHash)?;
+                .ok_or(TraceTransactionError::TxnHashNotFound)?;
 
             let header = db
                 .block_header(block_hash.into())


### PR DESCRIPTION
In the 0.6.0-rc3 version of the JSON-RPC specification `starknet_estimateFee` and `starknet_simulateTransactions` are expected to return a `TRANSACTION_EXECUTION_ERROR` in case execution fails. This new error type contains the transaction index (and the error string) in a structured way as additional data.

This PR introduces a `TransactionExecutionError` type into the `pathfinder_executor` crate that can better describe errors during executing a sequence of transactions. The `CallError` type is now only used for stand-alone contract calls (eg by `starknet_call`).

It then uses the information available in the new `TransactionExecutionError` type to return the new error info required by the specification.

Closes #1582 
