### PR TITLE
fix(rpc/v06): add `simulation_flags` argument to `starknet_estimateFee`

### DIFF
--- a/crates/executor/src/estimate.rs
+++ b/crates/executor/src/estimate.rs
@@ -11,6 +11,7 @@ use primitive_types::U256;
 pub fn estimate(
     mut execution_state: ExecutionState<'_>,
     transactions: Vec<Transaction>,
+    skip_validate: bool,
 ) -> Result<Vec<FeeEstimate>, TransactionExecutionError> {
     let gas_price: U256 = execution_state.header.eth_l1_gas_price.0.into();
     let block_number = execution_state.header.number;
@@ -24,7 +25,7 @@ pub fn estimate(
         let fee_type = &super::transaction::fee_type(&transaction);
 
         let tx_info = transaction
-            .execute(&mut state, &block_context, false, true)
+            .execute(&mut state, &block_context, false, !skip_validate)
             .and_then(|mut tx_info| {
                 if tx_info.actual_fee.0 == 0 {
                     // fee is not calculated by default for L1 handler transactions and if max_fee is zero, we have to do that explicitly

--- a/crates/pathfinder/examples/re_execute.rs
+++ b/crates/pathfinder/examples/re_execute.rs
@@ -155,7 +155,7 @@ fn execute(storage: Storage, chain_id: ChainId, rx: crossbeam_channel::Receiver<
             }
         };
 
-        match pathfinder_executor::estimate(execution_state, transactions) {
+        match pathfinder_executor::estimate(execution_state, transactions, false) {
             Ok(fee_estimates) => {
                 for (estimate, receipt) in fee_estimates.iter().zip(work.receipts.iter()) {
                     if let Some(actual_fee) = receipt.actual_fee {

--- a/crates/rpc/src/v05/method/estimate_fee.rs
+++ b/crates/rpc/src/v05/method/estimate_fee.rs
@@ -135,7 +135,7 @@ pub async fn estimate_fee(
             .map(|tx| crate::executor::map_broadcasted_transaction(tx, context.chain_id))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let result = pathfinder_executor::estimate(state, transactions)?;
+        let result = pathfinder_executor::estimate(state, transactions, false)?;
 
         Ok::<_, EstimateFeeError>(result)
     })

--- a/crates/rpc/src/v05/method/estimate_message_fee.rs
+++ b/crates/rpc/src/v05/method/estimate_message_fee.rs
@@ -120,7 +120,7 @@ pub async fn estimate_message_fee(
 
         let transaction = create_executor_transaction(input, context.chain_id)?;
 
-        let result = pathfinder_executor::estimate(state, vec![transaction])?;
+        let result = pathfinder_executor::estimate(state, vec![transaction], false)?;
 
         Ok::<_, EstimateMessageFeeError>(result)
     })


### PR DESCRIPTION
The latest 0.6.0-rc3 JSON-RPC specification has added a flag to skip transaction validation.

Closes #1580