### PR TITLE
chore(ci): use a single build job for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: Noelware/setup-protoc@1.1.0
       - uses: taiki-e/install-action@nextest
       - name: Compile unit tests
-        run: cargo nextest run --all-targets --all-features --workspace --locked --no-run --timings
+        run: cargo nextest run --build-jobs=1 --all-targets --all-features --workspace --locked --no-run --timings
       - name: Run unit tests
         run: timeout 10m cargo nextest run --no-fail-fast --all-targets --all-features --workspace --locked
       - name: Store timings


### PR DESCRIPTION
Compiling our tests seem to run out of memory in some cases, leading to timeouts and a failed job.

This change makes sure we use only a single build job in the hope that this will help us avoid running out of memory.
