### PR TITLE
Prevent the global class cache from returning classes that are not yet declared

### DIFF
--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -5,6 +5,7 @@ pub(crate) mod error;
 pub(crate) mod estimate;
 pub(crate) mod execution_state;
 pub(crate) mod felt;
+pub(crate) mod lru_cache;
 pub(crate) mod pending;
 pub(crate) mod simulate;
 pub(crate) mod state_reader;

--- a/crates/executor/src/lru_cache.rs
+++ b/crates/executor/src/lru_cache.rs
@@ -1,0 +1,57 @@
+use blockifier::{
+    execution::contract_class::ContractClass,
+    state::{errors::StateError, state_api::StateResult},
+};
+use cached::{Cached, SizedCache};
+use pathfinder_common::BlockNumber;
+use starknet_api::core::ClassHash as StarknetClassHash;
+use std::sync::{Mutex, MutexGuard};
+use tracing::warn;
+
+lazy_static::lazy_static! {
+    pub static ref GLOBAL_CACHE: LruContractCache = LruContractCache::new();
+}
+
+#[derive(Clone)]
+pub struct Entry {
+    pub definition: ContractClass,
+    /// The height at which the class was declared
+    pub height: BlockNumber,
+}
+
+/// An LRU contract class cache
+pub struct LruContractCache(Mutex<SizedCache<StarknetClassHash, Entry>>);
+
+impl LruContractCache {
+    fn new() -> Self {
+        Self(Mutex::new(SizedCache::with_size(128)))
+    }
+
+    fn locked_cache(&self) -> StateResult<MutexGuard<'_, SizedCache<StarknetClassHash, Entry>>> {
+        self.0.lock().map_err(|err| {
+            warn!("Contract class cache lock is poisoned. Cause: {}.", err);
+            StateError::StateReadError("Poisoned lock".to_string())
+        })
+    }
+
+    pub fn get(&self, class_hash: &StarknetClassHash) -> StateResult<Option<Entry>> {
+        Ok(self.locked_cache()?.cache_get(class_hash).cloned())
+    }
+
+    pub fn set(
+        &self,
+        class_hash: StarknetClassHash,
+        contract_class: ContractClass,
+        block_number: BlockNumber,
+    ) -> StateResult<()> {
+        self.locked_cache()?.cache_set(
+            class_hash,
+            Entry {
+                definition: contract_class.clone(),
+                height: block_number,
+            },
+        );
+
+        Ok(())
+    }
+}

--- a/crates/executor/src/state_reader.rs
+++ b/crates/executor/src/state_reader.rs
@@ -1,126 +1,11 @@
-use blockifier::{
-    execution::contract_class::ContractClass,
-    state::{
-        cached_state::{CachedState, GlobalContractCache},
-        errors::StateError,
-        state_api::StateReader,
-        state_api::StateResult,
-    },
-};
-use cached::{Cached, SizedCache};
+use blockifier::state::{errors::StateError, state_api::StateReader};
 use pathfinder_common::{BlockNumber, ClassHash, StorageAddress, StorageValue};
 use pathfinder_crypto::Felt;
-use starknet_api::{
-    core::{ClassHash as StarknetClassHash, CompiledClassHash, ContractAddress, Nonce},
-    hash::StarkFelt,
-    state::StorageKey,
-    StarknetApiError,
-};
-use std::sync::{Arc, Mutex, MutexGuard};
-use tracing::warn;
+use starknet_api::{hash::StarkFelt, StarknetApiError};
+
+use crate::lru_cache::GLOBAL_CACHE;
 
 use super::felt::{IntoFelt, IntoStarkFelt};
-
-/// A `StateReader` wrapper designed to cache the compiled contract classes.
-/// Contract classes are immutable once deployed so caching should not cause any side effect.
-pub(super) struct LruCachedReader<R>
-where
-    R: StateReader,
-{
-    compiled_class_cache: GlobalContractCache,
-    inner_reader: R,
-}
-
-impl<R> LruCachedReader<R>
-where
-    R: StateReader,
-{
-    /// Build a `CachedState` on top of an `LruCachedReader`, sharing the same underlying cache.
-    pub fn _new_cached_state(inner_reader: R) -> anyhow::Result<CachedState<LruCachedReader<R>>> {
-        // `CachedState` already has a [move_classes_to_global_cache](https://docs.rs/blockifier/0.3.0-rc0/blockifier/state/cached_state/struct.CachedState.html#method.move_classes_to_global_cache)
-        // method that we might want to use instead, but relying on it would make this cache much
-        // less self-contained as these calls would have to be made in various places.
-        // One of the reasons for this is that we can't wrap the `CachedReader` in another layer of
-        // the `State` trait as `blockifier` explicitly requires a `CachedReader` in the signature
-        // of some methods we use.
-        let reader = Self::_new(inner_reader)?;
-        let cache = reader.compiled_class_cache.clone();
-        Ok(CachedState::new(reader, cache))
-    }
-
-    fn _new(inner_reader: R) -> anyhow::Result<Self> {
-        lazy_static::lazy_static!(
-            static ref CONTRACT_CACHE: GlobalContractCache = {
-                let inner = SizedCache::with_size(128);
-                GlobalContractCache(Arc::new(Mutex::new(inner)))
-            };
-        );
-
-        Ok(Self {
-            compiled_class_cache: CONTRACT_CACHE.clone(),
-            inner_reader,
-        })
-    }
-
-    fn locked_cache(
-        &mut self,
-    ) -> StateResult<MutexGuard<'_, SizedCache<StarknetClassHash, ContractClass>>> {
-        self.compiled_class_cache.0.lock().map_err(|err| {
-            warn!("Contract class cache lock is poisoned. Cause: {}.", err);
-            StateError::StateReadError("Poisoned lock".to_string())
-        })
-    }
-}
-
-impl<R> StateReader for LruCachedReader<R>
-where
-    R: StateReader,
-{
-    fn get_storage_at(
-        &mut self,
-        contract_address: ContractAddress,
-        key: StorageKey,
-    ) -> StateResult<StarkFelt> {
-        self.inner_reader.get_storage_at(contract_address, key)
-    }
-
-    fn get_nonce_at(&mut self, contract_address: ContractAddress) -> StateResult<Nonce> {
-        self.inner_reader.get_nonce_at(contract_address)
-    }
-
-    fn get_class_hash_at(
-        &mut self,
-        contract_address: ContractAddress,
-    ) -> StateResult<StarknetClassHash> {
-        self.inner_reader.get_class_hash_at(contract_address)
-    }
-
-    fn get_compiled_contract_class(
-        &mut self,
-        class_hash: &StarknetClassHash,
-    ) -> StateResult<ContractClass> {
-        // Check the cache, if not found then lookup & insert.
-        // Because the lookup can take quite a lot of time and classes are insert-only, it's better
-        // to separate the get & set operations and release the lock in the meantime.
-        if let Some(contract_class) = self.locked_cache()?.cache_get(class_hash) {
-            return Ok(contract_class.clone());
-        }
-
-        let contract_class = self.inner_reader.get_compiled_contract_class(class_hash)?;
-
-        self.locked_cache()?
-            .cache_set(*class_hash, contract_class.clone());
-
-        Ok(contract_class)
-    }
-
-    fn get_compiled_class_hash(
-        &mut self,
-        class_hash: StarknetClassHash,
-    ) -> StateResult<CompiledClassHash> {
-        self.inner_reader.get_compiled_class_hash(class_hash)
-    }
-}
 
 pub(super) struct PathfinderStateReader<'tx> {
     transaction: &'tx pathfinder_storage::Transaction<'tx>,
@@ -148,7 +33,17 @@ impl<'tx> PathfinderStateReader<'tx> {
         self.block_number.map(Into::into)
     }
 
-    fn non_cached_compiled_contract_class(&mut self, pathfinder_class_hash: ClassHash, class_hash: &StarknetClassHash) -> Result<ContractClass, StateError> {
+    fn non_cached_compiled_contract_class(
+        &mut self,
+        pathfinder_class_hash: ClassHash,
+        class_hash: &starknet_api::core::ClassHash,
+    ) -> Result<
+        (
+            Option<BlockNumber>,
+            blockifier::execution::contract_class::ContractClass,
+        ),
+        StateError,
+    > {
         tracing::trace!("Getting class");
 
         let block_id = self.state_block_id().ok_or_else(|| {
@@ -158,13 +53,16 @@ impl<'tx> PathfinderStateReader<'tx> {
         })?;
 
         let casm_definition = if self.ignore_block_number_for_classes {
-            self.transaction.casm_definition(pathfinder_class_hash)
+            self.transaction
+                .casm_definition_with_block_number(pathfinder_class_hash)
         } else {
             self.transaction
-                .casm_definition_at(block_id, pathfinder_class_hash)
+                .casm_definition_at_with_block_number(block_id, pathfinder_class_hash)
         };
 
-        if let Some(casm_definition) = casm_definition.map_err(map_anyhow_to_state_err)? {
+        if let Some((definition_block_number, casm_definition)) =
+            casm_definition.map_err(map_anyhow_to_state_err)?
+        {
             let casm_definition = String::from_utf8(casm_definition).map_err(|error| {
                 StateError::StateReadError(format!(
                     "Class definition is not valid UTF-8: {}",
@@ -178,19 +76,26 @@ impl<'tx> PathfinderStateReader<'tx> {
                 )
                 .map_err(StateError::ProgramError)?;
 
-            return Ok(blockifier::execution::contract_class::ContractClass::V1(
-                casm_class,
+            return Ok((
+                definition_block_number,
+                blockifier::execution::contract_class::ContractClass::V1(casm_class),
             ));
         }
 
         let definition = if self.ignore_block_number_for_classes {
-            self.transaction.class_definition(pathfinder_class_hash)
+            self.transaction
+                .class_definition_with_block_number(pathfinder_class_hash)
         } else {
             self.transaction
-                .class_definition_at(block_id, pathfinder_class_hash)
+                .class_definition_at_with_block_number(block_id, pathfinder_class_hash)
+                .map(|option| {
+                    option.map(|(block_number, definition)| (Some(block_number), definition))
+                })
         };
 
-        if let Some(definition) = definition.map_err(map_anyhow_to_state_err)? {
+        if let Some((definition_block_number, definition)) =
+            definition.map_err(map_anyhow_to_state_err)?
+        {
             let definition = String::from_utf8(definition).map_err(|error| {
                 StateError::StateReadError(format!(
                     "Class definition is not valid UTF-8: {}",
@@ -204,8 +109,9 @@ impl<'tx> PathfinderStateReader<'tx> {
                 )
                 .map_err(StateError::ProgramError)?;
 
-            return Ok(blockifier::execution::contract_class::ContractClass::V0(
-                class,
+            return Ok((
+                definition_block_number,
+                blockifier::execution::contract_class::ContractClass::V0(class),
             ));
         }
 
@@ -323,7 +229,23 @@ impl StateReader for PathfinderStateReader<'_> {
             tracing::debug_span!("get_compiled_contract_class", class_hash=%pathfinder_class_hash)
                 .entered();
 
-        self.non_cached_compiled_contract_class(pathfinder_class_hash, class_hash)
+        if let Some(entry) = GLOBAL_CACHE.get(class_hash)? {
+            if let Some(reader_block_number) = self.block_number {
+                if entry.height <= reader_block_number {
+                    tracing::trace!("Global class cache hit");
+                    return Ok(entry.definition);
+                }
+            }
+        }
+
+        let (definition_block_number, contract_class) =
+            self.non_cached_compiled_contract_class(pathfinder_class_hash, class_hash)?;
+
+        if let Some(block_number) = definition_block_number {
+            GLOBAL_CACHE.set(*class_hash, contract_class.clone(), block_number)?;
+        }
+
+        Ok(contract_class)
     }
 
     fn get_compiled_class_hash(

--- a/crates/storage/src/connection.rs
+++ b/crates/storage/src/connection.rs
@@ -264,6 +264,14 @@ impl<'inner> Transaction<'inner> {
         class::class_definition(self, class_hash)
     }
 
+    /// Returns the uncompressed class definition as well as the block number at which it was declared.
+    pub fn class_definition_with_block_number(
+        &self,
+        class_hash: ClassHash,
+    ) -> anyhow::Result<Option<(Option<BlockNumber>, Vec<u8>)>> {
+        class::class_definition_with_block_number(self, class_hash)
+    }
+
     /// Returns the compressed class definition if it has been declared at `block_id`.
     pub fn compressed_class_definition_at(
         &self,
@@ -282,9 +290,28 @@ impl<'inner> Transaction<'inner> {
         class::class_definition_at(self, block_id, class_hash)
     }
 
+    /// Returns the uncompressed class definition if it has been declared at `block_id`, as well as
+    /// the block number at which it was declared.
+    pub fn class_definition_at_with_block_number(
+        &self,
+        block_id: BlockId,
+        class_hash: ClassHash,
+    ) -> anyhow::Result<Option<(BlockNumber, Vec<u8>)>> {
+        class::class_definition_at_with_block_number(self, block_id, class_hash)
+    }
+
     /// Returns the uncompressed compiled class definition.
     pub fn casm_definition(&self, class_hash: ClassHash) -> anyhow::Result<Option<Vec<u8>>> {
         class::casm_definition(self, class_hash)
+    }
+
+    /// Returns the uncompressed compiled class definition, as well as the block number at which it
+    ///  was declared.
+    pub fn casm_definition_with_block_number(
+        &self,
+        class_hash: ClassHash,
+    ) -> anyhow::Result<Option<(Option<BlockNumber>, Vec<u8>)>> {
+        class::casm_definition_with_block_number(self, class_hash)
     }
 
     /// Returns the uncompressed compiled class definition if it has been declared at `block_id`.
@@ -294,6 +321,16 @@ impl<'inner> Transaction<'inner> {
         class_hash: ClassHash,
     ) -> anyhow::Result<Option<Vec<u8>>> {
         class::casm_definition_at(self, block_id, class_hash)
+    }
+
+    /// Returns the uncompressed compiled class definition if it has been declared at `block_id`, as well
+    /// as the block number at which it was declared.
+    pub fn casm_definition_at_with_block_number(
+        &self,
+        block_id: BlockId,
+        class_hash: ClassHash,
+    ) -> anyhow::Result<Option<(Option<BlockNumber>, Vec<u8>)>> {
+        class::casm_definition_at_with_block_number(self, block_id, class_hash)
     }
 
     pub fn contract_class_hash(


### PR DESCRIPTION
Replace the global cache with a height-constrained cache
Invert the cache<->reader relationship: let the reader wrap the cache instead of the other way around
Provide `with_block_number`-suffixed methods to retrieve class definitions
Let the `CachedState` rely on a local cache

**Review commits separately.** The first one was extracted for improved readability.

Closes #1570
