### PR TITLE
fix(examples/feeder_gateway): update for Starknet 0.13.0

### DIFF
--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -1876,14 +1876,14 @@ pub mod add_transaction {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, serde::Serialize)]
 pub struct BlockSignature {
     pub block_number: BlockNumber,
     pub signature: [BlockCommitmentSignatureElem; 2],
     pub signature_input: BlockSignatureInput,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, serde::Serialize)]
 pub struct BlockSignatureInput {
     pub block_hash: BlockHash,
     pub state_diff_commitment: StateDiffCommitment,

--- a/crates/pathfinder/examples/feeder_gateway.rs
+++ b/crates/pathfinder/examples/feeder_gateway.rs
@@ -3,7 +3,10 @@ use std::num::NonZeroU32;
 
 use anyhow::Context;
 use pathfinder_common::state_update::ContractClassUpdate;
-use pathfinder_common::{BlockHash, BlockNumber, Chain, ClassHash};
+use pathfinder_common::{
+    state_diff_commitment_bytes, BlockCommitmentSignature, BlockCommitmentSignatureElem, BlockHash,
+    BlockNumber, Chain, ClassHash,
+};
 use pathfinder_storage::BlockId;
 use primitive_types::H160;
 use serde::{Deserialize, Serialize};
@@ -75,6 +78,8 @@ async fn serve() -> anyhow::Result<()> {
         block_hash: Option<BlockHash>,
         #[serde(default, rename = "includeBlock")]
         include_block: Option<bool>,
+        #[serde(default, rename = "headerOnly")]
+        header_only: Option<bool>,
     }
 
     impl TryInto<BlockId> for BlockIdParam {
@@ -104,6 +109,8 @@ async fn serve() -> anyhow::Result<()> {
             move |block_id: BlockIdParam| {
                 let storage = storage.clone();
                 async move {
+                    let header_only = block_id.header_only.unwrap_or(false);
+
                     match block_id.try_into() {
                         Ok(block_id) => {
                             let block = tokio::task::spawn_blocking(move || {
@@ -115,9 +122,58 @@ async fn serve() -> anyhow::Result<()> {
 
                             match block {
                                 Ok(block) => {
-                                    Ok(warp::reply::json(&block))
+                                    if header_only {
+                                        #[derive(Serialize)]
+                                        struct HashAndNumber {
+                                            block_hash: BlockHash,
+                                            block_number: BlockNumber,
+                                        }
+
+                                        let reply = HashAndNumber {
+                                            block_hash: block.block_hash,
+                                            block_number: block.block_number,
+                                        };
+
+                                        Ok(warp::reply::json(&reply))
+                                    } else {
+                                        Ok(warp::reply::json(&block))
+                                    }
                                 },
-                                Err(_) => {
+                                Err(e) => {
+                                    tracing::error!("Error fetching block: {:?}", e);
+                                    let error = serde_json::json!({"code": "StarknetErrorCode.BLOCK_NOT_FOUND", "message": "Block number not found"});
+                                    Ok(warp::reply::json(&error))
+                                }
+                            }
+                        },
+                        Err(_) => Err(warp::reject::reject()),
+                    }
+                }
+            }
+        });
+
+    let get_signature = warp::path("get_signature")
+        .and(warp::query::<BlockIdParam>())
+        .and_then({
+            let storage = storage.clone();
+            move |block_id: BlockIdParam| {
+                let storage = storage.clone();
+                async move {
+                    match block_id.try_into() {
+                        Ok(block_id) => {
+                            let signature = tokio::task::spawn_blocking(move || {
+                                let mut connection = storage.connection().unwrap();
+                                let tx = connection.transaction().unwrap();
+
+                                resolve_signature(&tx, block_id)
+                            }).await.unwrap();
+
+                            match signature {
+                                Ok(signature) => {
+                                        Ok(warp::reply::json(&signature))
+                                },
+                                Err(e) => {
+                                    tracing::error!("Error fetching signature: {:?}", e);
                                     let error = serde_json::json!({"code": "StarknetErrorCode.BLOCK_NOT_FOUND", "message": "Block number not found"});
                                     Ok(warp::reply::json(&error))
                                 }
@@ -222,7 +278,8 @@ async fn serve() -> anyhow::Result<()> {
             get_block
                 .or(get_state_update)
                 .or(get_contract_addresses)
-                .or(get_class_by_hash),
+                .or(get_class_by_hash)
+                .or(get_signature),
         )
         .with(warp::filters::trace::request());
 
@@ -325,6 +382,35 @@ fn resolve_block(
         transaction_receipts,
         transactions,
         starknet_version: header.starknet_version,
+    })
+}
+
+#[tracing::instrument(level = "trace", skip(tx))]
+fn resolve_signature(
+    tx: &pathfinder_storage::Transaction<'_>,
+    block_id: BlockId,
+) -> anyhow::Result<starknet_gateway_types::reply::BlockSignature> {
+    let header = tx
+        .block_header(block_id)
+        .context("Fetching block header")?
+        .context("Block header missing")?;
+
+    let signature = tx
+        .signature(block_id)
+        .context("Fetching signature")?
+        // fall back to zero since we might have missing signatures in old DBs
+        .unwrap_or(BlockCommitmentSignature {
+            r: BlockCommitmentSignatureElem::ZERO,
+            s: BlockCommitmentSignatureElem::ZERO,
+        });
+
+    Ok(starknet_gateway_types::reply::BlockSignature {
+        block_number: header.number,
+        signature: [signature.r, signature.s],
+        signature_input: starknet_gateway_types::reply::BlockSignatureInput {
+            block_hash: header.hash,
+            state_diff_commitment: state_diff_commitment_bytes!(b"fake commitment"),
+        },
     })
 }
 

--- a/crates/storage/src/connection.rs
+++ b/crates/storage/src/connection.rs
@@ -463,6 +463,10 @@ impl<'inner> Transaction<'inner> {
         signature::insert_signature(self, block_number, signature)
     }
 
+    pub fn signature(&self, block: BlockId) -> anyhow::Result<Option<BlockCommitmentSignature>> {
+        signature::signature(self, block)
+    }
+
     pub(self) fn inner(&self) -> &rusqlite::Transaction<'_> {
         &self.0
     }

--- a/crates/storage/src/connection/signature.rs
+++ b/crates/storage/src/connection/signature.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use pathfinder_common::{BlockCommitmentSignature, BlockNumber};
 
-use crate::prelude::*;
+use crate::{prelude::*, BlockId};
 
 pub(super) fn insert_signature(
     tx: &Transaction<'_>,
@@ -22,4 +22,128 @@ pub(super) fn insert_signature(
         .context("Inserting signature")?;
 
     Ok(())
+}
+
+pub(super) fn signature(
+    tx: &Transaction<'_>,
+    block: BlockId,
+) -> anyhow::Result<Option<BlockCommitmentSignature>> {
+    match block {
+        BlockId::Latest => tx.inner().query_row(
+            "SELECT signature_r, signature_s FROM block_signatures ORDER BY block_number DESC LIMIT 1",
+            [],
+            |row| {
+                let r = row.get_block_commitment_signature_elem(0)?;
+                let s = row.get_block_commitment_signature_elem(1)?;
+                Ok(BlockCommitmentSignature { r, s })
+            },
+        ),
+        BlockId::Number(number) => tx.inner().query_row(
+            "SELECT signature_r, signature_s FROM block_signatures WHERE block_number = ?",
+            params![&number],
+            |row| {
+                let r = row.get_block_commitment_signature_elem(0)?;
+                let s = row.get_block_commitment_signature_elem(1)?;
+                Ok(BlockCommitmentSignature { r, s })
+            },
+        ),
+        BlockId::Hash(hash) => tx.inner().query_row(
+            r"SELECT signature_r, signature_s
+                FROM block_signatures
+                JOIN block_headers ON block_signatures.block_number = block_headers.number
+                WHERE block_headers.hash = ?",
+            params![&hash],
+            |row| {
+                let r = row.get_block_commitment_signature_elem(0)?;
+                let s = row.get_block_commitment_signature_elem(1)?;
+                Ok(BlockCommitmentSignature { r, s })
+            }
+        ),
+    }
+    .optional()
+    .map_err(|e| e.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use pathfinder_common::macro_prelude::*;
+    use pathfinder_common::prelude::*;
+
+    use super::*;
+    use crate::Connection;
+
+    fn setup() -> (Connection, Vec<BlockHeader>, Vec<BlockCommitmentSignature>) {
+        let storage = crate::Storage::in_memory().unwrap();
+        let mut connection = storage.connection().unwrap();
+        let tx = connection.transaction().unwrap();
+
+        let genesis = BlockHeader::builder()
+            .with_number(BlockNumber::new_or_panic(0))
+            .finalize_with_hash(block_hash_bytes!(b"genesis"));
+        let genesis_signature = BlockCommitmentSignature {
+            r: block_commitment_signature_elem_bytes!(b"genesis r"),
+            s: block_commitment_signature_elem_bytes!(b"genesis s"),
+        };
+
+        let block1 = genesis
+            .child_builder()
+            .finalize_with_hash(block_hash_bytes!(b"block 1 hash"));
+        let block1_signature = BlockCommitmentSignature {
+            r: block_commitment_signature_elem_bytes!(b"block 1 r"),
+            s: block_commitment_signature_elem_bytes!(b"block 1 s"),
+        };
+
+        let headers = vec![genesis, block1];
+        let signatures = vec![genesis_signature, block1_signature];
+        for (header, signature) in headers.iter().zip(&signatures) {
+            tx.insert_block_header(header).unwrap();
+            tx.insert_signature(header.number, signature).unwrap();
+        }
+        tx.commit().unwrap();
+
+        (connection, headers, signatures)
+    }
+
+    #[test]
+    fn get_latest() {
+        let (mut connection, _headers, signatures) = setup();
+        let tx = connection.transaction().unwrap();
+
+        let result = tx.signature(BlockId::Latest).unwrap().unwrap();
+        let expected = signatures.last().unwrap();
+
+        assert_eq!(&result, expected);
+    }
+
+    #[test]
+    fn get_by_number() {
+        let (mut connection, headers, signatures) = setup();
+        let tx = connection.transaction().unwrap();
+
+        for (header, signature) in headers.iter().zip(&signatures) {
+            let result = tx.signature(header.number.into()).unwrap().unwrap();
+
+            assert_eq!(&result, signature);
+        }
+
+        let past_head = headers.last().unwrap().number + 1;
+        let result = tx.signature(past_head.into()).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn get_by_hash() {
+        let (mut connection, headers, signatures) = setup();
+        let tx = connection.transaction().unwrap();
+
+        for (header, signature) in headers.iter().zip(&signatures) {
+            let result = tx.signature(header.hash.into()).unwrap().unwrap();
+
+            assert_eq!(&result, signature);
+        }
+
+        let past_head = headers.last().unwrap().number + 1;
+        let result = tx.signature(past_head.into()).unwrap();
+        assert_eq!(result, None);
+    }
 }

--- a/crates/storage/src/params.rs
+++ b/crates/storage/src/params.rs
@@ -273,6 +273,10 @@ pub trait RowExt {
     row_felt_wrapper!(get_transaction_hash, TransactionHash);
     row_felt_wrapper!(get_contract_state_hash, ContractStateHash);
     row_felt_wrapper!(get_class_commitment_leaf, ClassCommitmentLeafHash);
+    row_felt_wrapper!(
+        get_block_commitment_signature_elem,
+        BlockCommitmentSignatureElem
+    );
 }
 
 impl<'a> RowExt for &rusqlite::Row<'a> {


### PR DESCRIPTION
This PR updates our "fake" feeder gateway server so that we can still sync from that using recent pathfinder releases:

- adds the `get_signature` endpoint (not quite correct, it fakes the state diff commitment value in the response because calculating that is quite slow, and also uses a fake signature if it's missing from the database)
- adds the `includeBlock` query parameter to `get_state_update`
