### PR TITLE
feat: ff-asm and inlining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5981,7 +5981,6 @@ dependencies = [
  "num-bigint",
  "pretty_assertions",
  "rand",
- "rand_core",
  "serde",
  "serde_json",
 ]

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -14,11 +14,10 @@ path = "src/lib.rs"
 [build-dependencies]
 
 [dependencies]
-ark-ff = { version = "0.4.2", default-features = false }
+ark-ff = { version = "0.4.2", features = ["std", "asm"] }
 bitvec = { workspace = true }
 fake = { workspace = true }
 rand = { workspace = true }
-rand_core = "0.6.4"
 serde = { workspace = true }
 
 [dev-dependencies]

--- a/crates/crypto/src/algebra/field/derive.rs
+++ b/crates/crypto/src/algebra/field/derive.rs
@@ -2,36 +2,42 @@ macro_rules! derive_op {
     ($type:ident,$iface:ident, $fun:ident, $op:tt) => {
         impl std::ops::$iface<Self> for $type {
             type Output = $type;
+            #[inline(always)]
             fn $fun(self, rhs: Self) -> Self::Output {
                 $type(self.0 $op rhs.0)
             }
         }
         impl std::ops::$iface<&Self> for $type {
             type Output = $type;
+            #[inline(always)]
             fn $fun(self, rhs: &Self) -> Self::Output {
                 $type(self.0 $op &rhs.0)
             }
         }
         impl std::ops::$iface<&mut Self> for $type {
             type Output = $type;
+            #[inline(always)]
             fn $fun(self, rhs: &mut Self) -> Self::Output {
                 $type(self.0 $op &rhs.0)
             }
         }
         impl std::ops::$iface<$type> for &$type {
             type Output = $type;
+            #[inline(always)]
             fn $fun(self, rhs: $type) -> Self::Output {
                 $type(self.0.clone() $op rhs.0)
             }
         }
         impl std::ops::$iface<&$type> for &$type {
             type Output = $type;
+            #[inline(always)]
             fn $fun(self, rhs: &$type) -> Self::Output {
                 $type(self.0.clone() $op &rhs.0)
             }
         }
         impl std::ops::$iface<&mut $type> for &$type {
             type Output = $type;
+            #[inline(always)]
             fn $fun(self, rhs: &mut $type) -> Self::Output {
                 $type(self.0.clone() $op &rhs.0)
             }
@@ -43,16 +49,19 @@ pub(crate) use derive_op;
 macro_rules! derive_op_assign {
     ($type:ident, $iface:ident, $fun:ident,$op:tt) => {
         impl std::ops::$iface<Self> for $type {
+            #[inline(always)]
             fn $fun(&mut self, rhs: Self) {
                 self.0 $op rhs.0;
             }
         }
         impl std::ops::$iface<&Self> for $type {
+            #[inline(always)]
             fn $fun(&mut self, rhs: &Self) {
                 self.0 $op &rhs.0;
             }
         }
         impl std::ops::$iface<&mut Self> for $type {
+            #[inline(always)]
             fn $fun(&mut self, rhs: &mut Self) {
                 self.0 $op &rhs.0;
             }

--- a/crates/crypto/src/algebra/field/felt.rs
+++ b/crates/crypto/src/algebra/field/felt.rs
@@ -114,7 +114,7 @@ impl Felt {
         Felt::from_be_bytes(buf)
     }
 
-    pub fn random<R: rand_core::RngCore>(rng: &mut R) -> Self {
+    pub fn random<R: rand::Rng>(rng: &mut R) -> Self {
         let r = MontFelt::random(rng);
         Felt::from(r)
     }


### PR DESCRIPTION
Adds x86-asm for the field via ark-ff-asm. Also inlines field operations, and properly use rand instead of rand_core.

This speed up some crypto operations with 10-30% when compiled with: 

```
RUSTFLAGS="-C target-feature=+bmi2,+adx"
```