### PR TITLE
fix(rpc): fix `gas_consumed` calculation for v3 transactions

### DIFF
--- a/crates/executor/src/estimate.rs
+++ b/crates/executor/src/estimate.rs
@@ -13,7 +13,6 @@ pub fn estimate(
     transactions: Vec<Transaction>,
     skip_validate: bool,
 ) -> Result<Vec<FeeEstimate>, TransactionExecutionError> {
-    let gas_price: U256 = execution_state.header.eth_l1_gas_price.0.into();
     let block_number = execution_state.header.number;
 
     let (mut state, block_context) = execution_state.starknet_state()?;
@@ -23,6 +22,7 @@ pub fn estimate(
         let _span = tracing::debug_span!("estimate", transaction_hash=%super::transaction::transaction_hash(&transaction), %block_number, %transaction_idx).entered();
 
         let fee_type = &super::transaction::fee_type(&transaction);
+        let gas_price: U256 = block_context.gas_prices.get_by_fee_type(fee_type).into();
 
         let tx_info = transaction
             .execute(&mut state, &block_context, false, !skip_validate)

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -67,6 +67,7 @@ impl PendingWatcher {
             let data = PendingData {
                 block: PendingBlock {
                     eth_l1_gas_price: latest.eth_l1_gas_price,
+                    strk_l1_gas_price: Some(latest.strk_l1_gas_price),
                     timestamp: latest.timestamp,
                     parent_hash: latest.hash,
                     starknet_version: latest.starknet_version,
@@ -110,6 +111,7 @@ mod tests {
 
         let latest = BlockHeader::builder()
             .with_eth_l1_gas_price(GasPrice(1234))
+            .with_strk_l1_gas_price(GasPrice(3377))
             .with_timestamp(BlockTimestamp::new_or_panic(6777))
             .finalize_with_hash(block_hash_bytes!(b"latest hash"));
 
@@ -121,6 +123,7 @@ mod tests {
                 parent_hash: latest.hash,
                 timestamp: BlockTimestamp::new_or_panic(112233),
                 eth_l1_gas_price: GasPrice(51123),
+                strk_l1_gas_price: Some(GasPrice(44411)),
                 ..Default::default()
             },
             state_update: StateUpdate::default().with_contract_nonce(
@@ -158,6 +161,7 @@ mod tests {
         let latest = parent
             .child_builder()
             .with_eth_l1_gas_price(GasPrice(1234))
+            .with_strk_l1_gas_price(GasPrice(3377))
             .with_timestamp(BlockTimestamp::new_or_panic(6777))
             .finalize_with_hash(block_hash_bytes!(b"latest hash"));
 
@@ -169,6 +173,7 @@ mod tests {
 
         let mut expected = PendingData::default();
         expected.block.eth_l1_gas_price = latest.eth_l1_gas_price;
+        expected.block.strk_l1_gas_price = Some(latest.strk_l1_gas_price);
         expected.block.timestamp = latest.timestamp;
         expected.block.parent_hash = latest.hash;
         expected.block.starknet_version = latest.starknet_version;

--- a/crates/rpc/src/test_setup.rs
+++ b/crates/rpc/src/test_setup.rs
@@ -50,6 +50,7 @@ pub async fn test_storage<F: FnOnce(StateUpdate) -> StateUpdate>(
         .with_number(block1_number)
         .with_timestamp(BlockTimestamp::new_or_panic(1))
         .with_eth_l1_gas_price(GasPrice(1))
+        .with_strk_l1_gas_price(GasPrice(2))
         .with_sequencer_address(sequencer_address!(
             "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8"
         ))


### PR DESCRIPTION
v3 transactions are supposed to use the STRK gas price for the calculation of the fee estimation. This PR fixes that, and also adds a missing initialization to the STRK gas price when the pending block is invalid/missing.

Closes #1604 