### PR TITLE
fix(executor): remove check for L2-to-L1 message ordering correctness

### DIFF
--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -180,7 +180,6 @@ impl TryFrom<blockifier::execution::call_info::CallInfo> for FunctionInvocation 
     fn try_from(
         call_info: blockifier::execution::call_info::CallInfo,
     ) -> Result<Self, Self::Error> {
-        call_info.get_sorted_l2_to_l1_payloads_length()?;
         let messages = ordered_l2_to_l1_messages(&call_info);
 
         let internal_calls = call_info


### PR DESCRIPTION
The checks `get_sorted_l2_to_l1_payloads_length()` does are valid only for the top-level `CallInfo` objects in a `TransactionExecutionInfo` object. Blockifier already does that check during fee calculation.

Since we were calling it in a `TryFrom` implementation that calls itself recursively for inner calls this might have lead to false positive errors.

Closes #1605 