### PR TITLE
fix(rpc/v06): add v06-specific `starknet_getTransaction*` methods

### DIFF
--- a/crates/rpc/src/v06.rs
+++ b/crates/rpc/src/v06.rs
@@ -27,8 +27,6 @@ pub fn register_routes() -> RpcRouterBuilder {
         .register("starknet_addDeclareTransaction"           , v04_method::add_declare_transaction)
         .register("starknet_addDeployAccountTransaction"     , v04_method::add_deploy_account_transaction)
         .register("starknet_addInvokeTransaction"            , v04_method::add_invoke_transaction)
-        .register("starknet_getTransactionByBlockIdAndIndex" , v04_method::get_transaction_by_block_id_and_index)
-        .register("starknet_getTransactionByHash"            , v04_method::get_transaction_by_hash)
         .register("starknet_syncing"                         , v04_method::syncing)
 
         .register("starknet_call"                            , v05_method::call)
@@ -38,6 +36,8 @@ pub fn register_routes() -> RpcRouterBuilder {
         .register("starknet_estimateFee"                     , method::estimate_fee)
         .register("starknet_getBlockWithTxHashes"            , method::get_block_with_tx_hashes)
         .register("starknet_getBlockWithTxs"                 , method::get_block_with_txs)
+        .register("starknet_getTransactionByBlockIdAndIndex" , method::get_transaction_by_block_id_and_index)
+        .register("starknet_getTransactionByHash"            , method::get_transaction_by_hash)
         .register("starknet_getTransactionReceipt"           , method::get_transaction_receipt)
         .register("starknet_simulateTransactions"            , method::simulate_transactions)
         .register("starknet_specVersion"                     , || "0.6.0-rc4")

--- a/crates/rpc/src/v06/method.rs
+++ b/crates/rpc/src/v06/method.rs
@@ -1,6 +1,8 @@
 mod estimate_fee;
 mod get_block_with_tx_hashes;
 mod get_block_with_txs;
+mod get_transaction_by_block_id_and_index;
+mod get_transaction_by_hash;
 pub(crate) mod get_transaction_receipt;
 mod simulate_transactions;
 mod trace_block_transactions;
@@ -9,6 +11,8 @@ mod trace_transaction;
 pub(crate) use estimate_fee::estimate_fee;
 pub(crate) use get_block_with_tx_hashes::get_block_with_tx_hashes;
 pub(crate) use get_block_with_txs::get_block_with_txs;
+pub(crate) use get_transaction_by_block_id_and_index::get_transaction_by_block_id_and_index;
+pub(crate) use get_transaction_by_hash::get_transaction_by_hash;
 pub(super) use get_transaction_receipt::get_transaction_receipt;
 pub(crate) use simulate_transactions::simulate_transactions;
 pub(crate) use trace_block_transactions::trace_block_transactions;

--- a/crates/rpc/src/v06/method/get_transaction_by_block_id_and_index.rs
+++ b/crates/rpc/src/v06/method/get_transaction_by_block_id_and_index.rs
@@ -1,0 +1,18 @@
+use crate::context::RpcContext;
+use crate::v02::method::get_transaction_by_block_id_and_index::{
+    get_transaction_by_block_id_and_index_impl, GetTransactionByBlockIdAndIndexError,
+    GetTransactionByBlockIdAndIndexInput,
+};
+use crate::v06::types::TransactionWithHash;
+
+pub async fn get_transaction_by_block_id_and_index(
+    context: RpcContext,
+    input: GetTransactionByBlockIdAndIndexInput,
+) -> Result<TransactionWithHash, GetTransactionByBlockIdAndIndexError> {
+    get_transaction_by_block_id_and_index_impl(context, input)
+        .await
+        .map(|x| {
+            let common_tx = pathfinder_common::transaction::Transaction::from(x);
+            common_tx.into()
+        })
+}

--- a/crates/rpc/src/v06/method/get_transaction_by_hash.rs
+++ b/crates/rpc/src/v06/method/get_transaction_by_hash.rs
@@ -1,0 +1,19 @@
+use crate::context::RpcContext;
+use crate::v06::types::TransactionWithHash;
+
+use crate::v02::method::get_transaction_by_hash as v02_get_transaction_by_hash;
+
+crate::error::generate_rpc_error_subset!(GetTransactionByHashError: TxnHashNotFound);
+
+pub async fn get_transaction_by_hash(
+    context: RpcContext,
+    input: v02_get_transaction_by_hash::GetTransactionByHashInput,
+) -> Result<TransactionWithHash, GetTransactionByHashError> {
+    v02_get_transaction_by_hash::get_transaction_by_hash_impl(context, input)
+        .await?
+        .map(|x| {
+            let common_tx = pathfinder_common::transaction::Transaction::from(x);
+            common_tx.into()
+        })
+        .ok_or(GetTransactionByHashError::TxnHashNotFound)
+}


### PR DESCRIPTION
These map to the v06 representation of transactions -- that is, they are returning v3 transactions as intended, not their v1-mapped representation.

Closes: #1607 