### PR TITLE
fix: work-around opaque execution errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Execution errors are opaque and don't always include the root cause.
+
 ## [0.10.0] - 2023-11-29
 
 ### Added

--- a/crates/executor/src/error.rs
+++ b/crates/executor/src/error.rs
@@ -81,12 +81,6 @@ pub enum TransactionExecutionError {
     Custom(anyhow::Error),
 }
 
-impl From<BlockifierTransactionExecutionError> for TransactionExecutionError {
-    fn from(e: BlockifierTransactionExecutionError) -> Self {
-        Self::Custom(e.into())
-    }
-}
-
 impl From<StateError> for TransactionExecutionError {
     fn from(e: StateError) -> Self {
         match e {

--- a/crates/executor/src/error.rs
+++ b/crates/executor/src/error.rs
@@ -101,3 +101,81 @@ impl From<anyhow::Error> for TransactionExecutionError {
         Self::Internal(value)
     }
 }
+
+impl TransactionExecutionError {
+    pub fn new(transaction_index: usize, error: BlockifierTransactionExecutionError) -> Self {
+        Self::ExecutionError {
+            transaction_index,
+            error: match &error {
+                // Some variants don't propagate their child's error so we do this manually until it is
+                // fixed in the blockifier. We have a test to ensure we don't miss fix.
+                BlockifierTransactionExecutionError::ContractConstructorExecutionFailed(x) => {
+                    format!("{error} {x}")
+                }
+                BlockifierTransactionExecutionError::ExecutionError(x) => format!("{error} {x}"),
+                BlockifierTransactionExecutionError::ValidateTransactionError(x) => {
+                    format!("{error} {x}")
+                }
+                other => other.to_string(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod transaction_errors_are_mapped_correctly {
+        //! Some variants in the blockifier are opaque and omit the inner error's data. We've patched this manually
+        //! and this tests ensures we don't accidentally stutter once the blockifier fixes this.
+        use super::*;
+        use blockifier::execution::errors::EntryPointExecutionError;
+
+        #[test]
+        fn contract_constructor_execution_failed() {
+            let child = EntryPointExecutionError::RecursionDepthExceeded;
+            let expected = format!("Contract constructor execution has failed. {child}");
+
+            let err =
+                BlockifierTransactionExecutionError::ContractConstructorExecutionFailed(child);
+            let err = TransactionExecutionError::new(0, err);
+            let err = match err {
+                TransactionExecutionError::ExecutionError { error, .. } => error,
+                _ => unreachable!("unexpected variant"),
+            };
+
+            assert_eq!(err, expected);
+        }
+
+        #[test]
+        fn execution_error() {
+            let child = EntryPointExecutionError::RecursionDepthExceeded;
+            let expected = format!("Transaction execution has failed. {child}");
+
+            let err = BlockifierTransactionExecutionError::ExecutionError(child);
+            let err = TransactionExecutionError::new(0, err);
+            let err = match err {
+                TransactionExecutionError::ExecutionError { error, .. } => error,
+                _ => unreachable!("unexpected variant"),
+            };
+
+            assert_eq!(err, expected);
+        }
+
+        #[test]
+        fn validate_transaction_error() {
+            let child = EntryPointExecutionError::RecursionDepthExceeded;
+            let expected = format!("Transaction validation has failed. {child}");
+
+            let err = BlockifierTransactionExecutionError::ValidateTransactionError(child);
+            let err = TransactionExecutionError::new(0, err);
+            let err = match err {
+                TransactionExecutionError::ExecutionError { error, .. } => error,
+                _ => unreachable!("unexpected variant"),
+            };
+
+            assert_eq!(err, expected);
+        }
+    }
+}

--- a/crates/executor/src/estimate.rs
+++ b/crates/executor/src/estimate.rs
@@ -59,10 +59,7 @@ pub fn estimate(
             }
             Err(error) => {
                 tracing::debug!(%error, %transaction_idx, "Transaction estimation failed");
-                return Err(TransactionExecutionError::ExecutionError {
-                    transaction_index: transaction_idx,
-                    error: error.to_string(),
-                });
+                return Err(TransactionExecutionError::new(transaction_idx, error));
             }
         }
     }

--- a/crates/executor/src/simulate.rs
+++ b/crates/executor/src/simulate.rs
@@ -89,10 +89,7 @@ pub fn simulate(
             }
             Err(error) => {
                 tracing::debug!(%error, %transaction_idx, "Transaction simulation failed");
-                return Err(TransactionExecutionError::ExecutionError {
-                    transaction_index: transaction_idx,
-                    error: error.to_string(),
-                });
+                return Err(TransactionExecutionError::new(transaction_idx, error));
             }
         }
     }
@@ -295,7 +292,7 @@ fn to_trace(
     let maybe_function_invocation = execution_info.execute_call_info.map(Into::into);
     let fee_transfer_invocation = execution_info.fee_transfer_call_info.map(Into::into);
 
-    let trace = match transaction_type {
+    match transaction_type {
         TransactionType::Declare => TransactionTrace::Declare(DeclareTransactionTrace {
             validate_invocation,
             fee_transfer_invocation,
@@ -323,7 +320,5 @@ fn to_trace(
             function_invocation: maybe_function_invocation,
             state_diff,
         }),
-    };
-
-    trace
+    }
 }

--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -174,19 +174,15 @@ pub struct ExecutionResources {
     pub segment_arena_builtin: usize,
 }
 
-impl TryFrom<blockifier::execution::call_info::CallInfo> for FunctionInvocation {
-    type Error = blockifier::transaction::errors::TransactionExecutionError;
-
-    fn try_from(
-        call_info: blockifier::execution::call_info::CallInfo,
-    ) -> Result<Self, Self::Error> {
+impl From<blockifier::execution::call_info::CallInfo> for FunctionInvocation {
+    fn from(call_info: blockifier::execution::call_info::CallInfo) -> Self {
         let messages = ordered_l2_to_l1_messages(&call_info);
 
         let internal_calls = call_info
             .inner_calls
             .into_iter()
-            .map(TryInto::try_into)
-            .collect::<Result<Vec<_>, _>>()?;
+            .map(Into::into)
+            .collect();
 
         let events = call_info
             .execution
@@ -203,7 +199,7 @@ impl TryFrom<blockifier::execution::call_info::CallInfo> for FunctionInvocation 
             .map(IntoFelt::into_felt)
             .collect();
 
-        Ok(Self {
+        Self {
             calldata: call_info
                 .call
                 .calldata
@@ -227,7 +223,7 @@ impl TryFrom<blockifier::execution::call_info::CallInfo> for FunctionInvocation 
             messages,
             result,
             execution_resources: call_info.vm_resources.into(),
-        })
+        }
     }
 }
 

--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -178,11 +178,7 @@ impl From<blockifier::execution::call_info::CallInfo> for FunctionInvocation {
     fn from(call_info: blockifier::execution::call_info::CallInfo) -> Self {
         let messages = ordered_l2_to_l1_messages(&call_info);
 
-        let internal_calls = call_info
-            .inner_calls
-            .into_iter()
-            .map(Into::into)
-            .collect();
+        let internal_calls = call_info.inner_calls.into_iter().map(Into::into).collect();
 
         let events = call_info
             .execution


### PR DESCRIPTION
This PR adds custom formatting for opaque blockifier error variants.

Example before:
```json
{
    "jsonrpc": "2.0",
    "error": {
        "code": 41,
        "message": "Transaction execution error",
        "data": {
            "execution_error": "Transaction validation has failed.",
            "transaction_index": 0
        }
    },
    "id": 1
}
```

After
```json
{
    "jsonrpc": "2.0",
    "error": {
        "code": 41,
        "message": "Transaction execution error",
        "data": {
            "execution_error": "Transaction validation has failed. Execution failed. Failure reason: 0x496e70757420746f6f206c6f6e6720666f7220617267756d656e7473 ('Input too long for arguments').",
            "transaction_index": 0
        }
    },
    "id": 1
}
```