### PR TITLE
fix(storage/events): add upper bounds on queries used to select strategy

### DIFF
--- a/crates/storage/src/connection/event.rs
+++ b/crates/storage/src/connection/event.rs
@@ -14,8 +14,8 @@ pub const KEY_FILTER_LIMIT: usize = 256;
 const KEY_FILTER_COST_LIMIT: usize = 1_000_000;
 const KEY_FILTER_WEIGHT: usize = 50;
 
-const KEY_FILTER_UPPER_BOUND: usize = KEY_FILTER_COST_LIMIT / KEY_FILTER_WEIGHT;
-const RANGE_FILTER_UPPER_BOUND: usize = KEY_FILTER_COST_LIMIT;
+const KEY_FILTER_UPPER_BOUND: usize = KEY_FILTER_COST_LIMIT / KEY_FILTER_WEIGHT + 1;
+const RANGE_FILTER_UPPER_BOUND: usize = KEY_FILTER_COST_LIMIT + 1;
 
 pub struct EventFilter<K: KeyFilter> {
     pub from_block: Option<BlockNumber>,


### PR DESCRIPTION
Since we already have a cost limit on the event queries there's no point in counting the exact number of matching events by the keys or range.

It's sufficient to be able to count up to reaching a limit where the cost would be too much anyway.

This avoids issues with queries using keys of which there are a few hundred million events in the database.

