### PR TITLE
feat(rpc): improve logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added `x-request-id` header to RPC responses. If the request does not have the header set then an ID is generated. This can be used to identify a specific caller's request/response within the node's logs. Duplicate IDs are possible since they can be set by the caller, so we recommend making your's identifiable with a prefix or using a GUID.
+- Improved tracing for RPC requests. These are all logged on `debug` level under the `pathfinder_rpc` module. Additional information can also be obtained from `tower_http` module. These can be enabled by appending `pathfinder_rpc=debug,tower_http=debug` to `RUST_LOG` environment variable.
+  - Request payload is now logged before execution begins.
+  - Logs now include `x-request-id` header value which can be used to correlate with client requests/responses.
+  - Batch logs also include the index within a batch.
+
 ## [0.10.1] - 2023-12-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8319,9 +8319,11 @@ dependencies = [
  "http-body",
  "http-range-header",
  "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -8608,6 +8610,15 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "valuable"

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -49,7 +49,9 @@ tower = { version = "0.4.13", default-features = false, features = [
 tower-http = { version = "0.4.0", default-features = false, features = [
     "cors",
     "limit",
+    "request-id",
     "trace",
+    "util",
 ] }
 tracing = { workspace = true }
 zstd = { workspace = true }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -36,6 +36,7 @@ use std::{net::SocketAddr, result::Result};
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tower_http::cors::CorsLayer;
+use tower_http::ServiceBuilderExt;
 
 const DEFAULT_MAX_CONNECTIONS: usize = 1024;
 
@@ -121,11 +122,13 @@ impl RpcServer {
             // This is required by axum -- axum doesn't deal with Result, errors
             // must be responses as well.
             .layer(HandleErrorLayer::new(handle_middleware_errors))
+            // make sure to set request ids before the request reaches `TraceLayer`
+            .set_x_request_id(middleware::request_id::RequestIdSource::default())
             .concurrency_limit(self.max_connections)
             .layer(DefaultBodyLimit::max(REQUEST_MAX_SIZE))
             .timeout(REQUEST_TIMEOUT)
-            .layer(tower_http::trace::TraceLayer::new_for_http())
-            .option_layer(self.cors);
+            .option_layer(self.cors)
+            .propagate_x_request_id();
 
         /// Returns success for requests with an empty body without reading
         /// the entire body.

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -127,6 +127,7 @@ impl RpcServer {
             .concurrency_limit(self.max_connections)
             .layer(DefaultBodyLimit::max(REQUEST_MAX_SIZE))
             .timeout(REQUEST_TIMEOUT)
+            .layer(middleware::tracing::trace_layer())
             .option_layer(self.cors)
             .propagate_x_request_id();
 

--- a/crates/rpc/src/middleware.rs
+++ b/crates/rpc/src/middleware.rs
@@ -1,2 +1,3 @@
 pub mod cors;
 pub(crate) mod request_id;
+pub(crate) mod tracing;

--- a/crates/rpc/src/middleware.rs
+++ b/crates/rpc/src/middleware.rs
@@ -1,1 +1,2 @@
 pub mod cors;
+pub(crate) mod request_id;

--- a/crates/rpc/src/middleware/request_id.rs
+++ b/crates/rpc/src/middleware/request_id.rs
@@ -1,0 +1,24 @@
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+
+// A `MakeRequestId` that increments an atomic counter
+#[derive(Clone, Default)]
+pub(crate) struct RequestIdSource {
+    counter: Arc<AtomicU64>,
+}
+
+impl tower_http::request_id::MakeRequestId for RequestIdSource {
+    fn make_request_id<B>(
+        &mut self,
+        _: &http::Request<B>,
+    ) -> Option<tower_http::request_id::RequestId> {
+        let request_id = self
+            .counter
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            .to_string()
+            .parse()
+            .unwrap();
+
+        Some(tower_http::request_id::RequestId::new(request_id))
+    }
+}

--- a/crates/rpc/src/middleware/tracing.rs
+++ b/crates/rpc/src/middleware/tracing.rs
@@ -1,0 +1,36 @@
+use tower_http::classify::{ServerErrorsAsFailures, SharedClassifier};
+use tower_http::trace::TraceLayer;
+
+pub(crate) fn trace_layer(
+) -> TraceLayer<SharedClassifier<ServerErrorsAsFailures>, RequestHeaderSpan> {
+    tower_http::trace::TraceLayer::new_for_http()
+        // Records request ID header value in the span.
+        .make_span_with(RequestHeaderSpan)
+}
+
+#[derive(Copy, Clone)]
+pub(crate) struct RequestHeaderSpan;
+
+impl<B> tower_http::trace::MakeSpan<B> for RequestHeaderSpan {
+    fn make_span(&mut self, request: &http::Request<B>) -> tracing::Span {
+        let x_request_id = request
+            .headers()
+            .get("x-request-id")
+            .and_then(|x| x.to_str().ok());
+
+        if let Some(x_request_id) = x_request_id {
+            tracing::debug_span!(
+                "request",
+                uri = %request.uri(),
+                version = ?request.version(),
+                ?x_request_id,
+            )
+        } else {
+            tracing::debug_span!(
+                "request",
+                uri = %request.uri(),
+                version = ?request.version(),
+            )
+        }
+    }
+}


### PR DESCRIPTION
This PR improves the RPC logging situation. 

We lost the ability to log request bodies when we moved to our own json-rpc framework. This PR adds this back and also adds `x-request-id` header which can be used to correlate specific requests from clients.

Note that I also removed the HTTP method from the trace fields - since this is almost always POST I thought it is just clutter..

The following logs were obtained with `RUST_LOG=pathfinder_rpc=debug,tower_http=debug`.

Before
```
DEBUG request{method=POST uri=/ version=HTTP/1.1}: tower_http::trace::on_request: started processing request
DEBUG request{method=POST uri=/ version=HTTP/1.1}: tower_http::trace::on_response: finished processing request latency=0 ms status=200
```

After
```
DEBUG request{uri=/ version=HTTP/1.1 x_request_id="0"}: tower_http::trace::on_request: started processing request
DEBUG request{uri=/ version=HTTP/1.1 x_request_id="0"}: pathfinder_rpc::jsonrpc::router: Running request request={"id":0,"jsonrpc":"2.0","method":"starknet_syncing"}
DEBUG request{uri=/ version=HTTP/1.1 x_request_id="0"}: tower_http::trace::on_response: finished processing request latency=0 ms status=200
```

Batch after
```
DEBUG request{uri=/ version=HTTP/1.1 x_request_id="0"}: tower_http::trace::on_request: started processing request
DEBUG request{uri=/ version=HTTP/1.1 x_request_id="0"}:batch{idx=0}: pathfinder_rpc::jsonrpc::router: Running request request={"id":0,"jsonrpc":"2.0","method":"starknet_syncing"}
DEBUG request{uri=/ version=HTTP/1.1 x_request_id="0"}:batch{idx=1}: pathfinder_rpc::jsonrpc::router: Running request request={"id":1,"jsonrpc":"2.0","method":"starknet_syncing"}
DEBUG request{uri=/ version=HTTP/1.1 x_request_id="0"}: tower_http::trace::on_response: finished processing request latency=0 ms status=200
```