### PR TITLE
ci: periodically refresh cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,8 @@ jobs:
           rm -rf ~/.cargo/registry
           rm -rf ~/.cargo/git
       - name: Compile unit tests
-        run: cargo nextest run --all-targets --all-features --workspace --locked --no-run --timings
+        # --build-jobs 1 as we are constantly OOMing during compilation.
+        run: cargo nextest run --all-targets --all-features --workspace --locked --no-run --timings --build-jobs 1
       - name: Run unit tests
         run: timeout 10m cargo nextest run --no-fail-fast --all-targets --all-features --workspace --locked
       - name: Store timings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Daily cron job used to clear and rebuild cache (https://github.com/Swatinem/rust-cache/issues/181).
+  schedule:
+    - cron: '0 0 * * *'
 
 # Limits workflow concurrency to only the latest commit in the PR.
 concurrency:
@@ -36,6 +39,12 @@ jobs:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - uses: Noelware/setup-protoc@1.1.0
       - uses: taiki-e/install-action@nextest
+      - name: Clear cache
+        if: github.event_name =='schedule'
+        run: |
+          cargo clean
+          rm -rf ~/.cargo/registry
+          rm -rf ~/.cargo/git
       - name: Compile unit tests
         run: cargo nextest run --all-targets --all-features --workspace --locked --no-run --timings
       - name: Run unit tests
@@ -58,6 +67,12 @@ jobs:
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - uses: Noelware/setup-protoc@1.1.0
+      - name: Clear cache
+        if: github.event_name =='schedule'
+        run: |
+          cargo clean
+          rm -rf ~/.cargo/registry
+          rm -rf ~/.cargo/git
       - run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings -D rust_2018_idioms
 
   rustfmt:
@@ -80,6 +95,9 @@ jobs:
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - uses: Noelware/setup-protoc@1.1.0
+      - name: Clear cache
+        if: github.event_name =='schedule'
+        run: cargo clean
       - run: cargo doc --no-deps --document-private-items
 
   dep-sort:


### PR DESCRIPTION
This PR periodically clears our rust-cache which otherwise grows indefinitely.

For context see this [rust-cache issue](https://github.com/Swatinem/rust-cache/issues/181).

In addition, this PR restricts the test compilation to single threaded in the hope that it reduces the odds of going OOM and failing the run. This is (probably) the cause of many CI failures which timeout after 30+ minutes.

Note: I haven't tested this cache refresh idea. The concept is to still use the caching action but then to delete it all. And build from scratch instead, and then the action will re-upload the fresh cache.