### PR TITLE
fix(rpc/v05/simulate_transactions): fix error code for reverted transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Logs now include `x-request-id` header value which can be used to correlate with client requests/responses.
   - Batch logs also include the index within a batch.
 
+### Fixed
+
+- v0.5 `starknet_simulateTransactions` returns internal error instead of `ContractError` for reverted transactions.
+
 ## [0.10.1] - 2023-12-05
 
 ### Fixed

--- a/crates/rpc/src/v05/method/simulate_transactions.rs
+++ b/crates/rpc/src/v05/method/simulate_transactions.rs
@@ -140,10 +140,9 @@ pub async fn simulate_transactions(
             .filter_map(pathfinder_executor::types::TransactionSimulation::revert_reason)
             .next()
         {
-            Some(revert_reason) => Err(SimulateTransactionError::Custom(anyhow::anyhow!(
-                "Transaction reverted: {}",
-                revert_reason
-            ))),
+            Some(revert_reason) => Err(SimulateTransactionError::ContractErrorV05 {
+                revert_error: revert_reason.to_owned(),
+            }),
             None => {
                 let txs = txs.into_iter().map(Into::into).collect();
                 Ok(SimulateTransactionOutput(txs))


### PR DESCRIPTION
The error code for reverted transactions should be CONTRACT_ERROR, since in the 0.5.1 JSON-RPC specification that error code has the revert reason as additional data.

Closes #1626
