### PR TITLE
feat(v0.6): drop `-rc5` for `starknet_specVersion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - v0.5 `starknet_simulateTransactions` returns internal error instead of `ContractError` for reverted transactions.
 
+### Changed
+
+- JSON-RPC v0.6 now serves `0.6.0` for `starknet_specVersion`.
+
 ## [0.10.1] - 2023-12-05
 
 ### Fixed

--- a/crates/rpc/src/v06.rs
+++ b/crates/rpc/src/v06.rs
@@ -40,7 +40,7 @@ pub fn register_routes() -> RpcRouterBuilder {
         .register("starknet_getTransactionByHash"            , method::get_transaction_by_hash)
         .register("starknet_getTransactionReceipt"           , method::get_transaction_receipt)
         .register("starknet_simulateTransactions"            , method::simulate_transactions)
-        .register("starknet_specVersion"                     , || "0.6.0-rc5")
+        .register("starknet_specVersion"                     , || "0.6.0")
         .register("starknet_traceBlockTransactions"          , method::trace_block_transactions)
         .register("starknet_traceTransaction"                , method::trace_transaction)
 


### PR DESCRIPTION
The stable relase is now available and made no difference from `rc5`.