### PR TITLE
fix(rpc): add workaround for gateway not returning deployed contract address

### DIFF
--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -1442,9 +1442,6 @@ mod tests {
                 transaction_hash: transaction_hash!(
                     "06dac1655b34e52a449cfe961188f7cc2b1496bcd36706cedf4935567be29d5b"
                 ),
-                address: contract_address!(
-                    "04e574ea2abd76d3105b3d29de28af0c5a28b889aa465903080167f6b48b1acc"
-                ),
             };
 
             assert_eq!(res, expected);

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -1834,11 +1834,9 @@ pub mod add_transaction {
 
     /// API response for a DEPLOY ACCOUNT transaction
     #[derive(Clone, Debug, serde::Deserialize, PartialEq, Eq)]
-    #[serde(deny_unknown_fields)]
     pub struct DeployAccountResponse {
         pub code: String, // TRANSACTION_RECEIVED
         pub transaction_hash: TransactionHash,
-        pub address: ContractAddress,
     }
 
     #[cfg(test)]

--- a/crates/rpc/src/v02/types.rs
+++ b/crates/rpc/src/v02/types.rs
@@ -448,6 +448,15 @@ pub mod request {
         V3(BroadcastedDeployAccountTransactionV3),
     }
 
+    impl BroadcastedDeployAccountTransaction {
+        pub fn deployed_contract_address(&self) -> ContractAddress {
+            match self {
+                Self::V0V1(tx) => tx.deployed_contract_address(),
+                Self::V3(tx) => tx.deployed_contract_address(),
+            }
+        }
+    }
+
     impl<'de> serde::Deserialize<'de> for BroadcastedDeployAccountTransaction {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where

--- a/crates/rpc/src/v04/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/v04/method/add_deploy_account_transaction.rs
@@ -98,12 +98,15 @@ pub async fn add_deploy_account_transaction(
     context: RpcContext,
     input: AddDeployAccountTransactionInput,
 ) -> Result<AddDeployAccountTransactionOutput, AddDeployAccountTransactionError> {
+    let contract_address = match &input.deploy_account_transaction {
+        Transaction::DeployAccount(tx) => tx.deployed_contract_address(),
+    };
     let Transaction::DeployAccount(tx) = input.deploy_account_transaction;
     let response = add_deploy_account_transaction_impl(&context, tx).await?;
 
     Ok(AddDeployAccountTransactionOutput {
         transaction_hash: response.transaction_hash,
-        contract_address: response.address,
+        contract_address,
     })
 }
 

--- a/crates/rpc/src/v06/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/v06/method/add_deploy_account_transaction.rs
@@ -100,12 +100,15 @@ pub async fn add_deploy_account_transaction(
     context: RpcContext,
     input: AddDeployAccountTransactionInput,
 ) -> Result<AddDeployAccountTransactionOutput, AddDeployAccountTransactionError> {
+    let contract_address = match &input.deploy_account_transaction {
+        Transaction::DeployAccount(tx) => tx.deployed_contract_address(),
+    };
     let Transaction::DeployAccount(tx) = input.deploy_account_transaction;
     let response = add_deploy_account_transaction_impl(&context, tx).await?;
 
     Ok(AddDeployAccountTransactionOutput {
         transaction_hash: response.transaction_hash,
-        contract_address: response.address,
+        contract_address,
     })
 }
 


### PR DESCRIPTION
It looks like the Starknet gateway's `add_transaction` endpoint does not return the address of the deployed contract in the response for DEPLOY_ACCOUNT v3 transactions.

We don't really need that address in the response: it's computed from data available in the transaction so we can also just compute that ourselves.
