### PR TITLE
chore: drop default rpc log level to trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `x-request-id` header to RPC responses. If the request does not have the header set then an ID is generated. This can be used to identify a specific caller's request/response within the node's logs. Duplicate IDs are possible since they can be set by the caller, so we recommend making your's identifiable with a prefix or using a GUID.
-- Improved tracing for RPC requests. These are all logged on `debug` level under the `pathfinder_rpc` module. Additional information can also be obtained from `tower_http` module. These can be enabled by appending `pathfinder_rpc=debug,tower_http=debug` to `RUST_LOG` environment variable.
+- Improved tracing for RPC requests. These are all logged on `trace` level under the `pathfinder_rpc` module. Additional information can also be obtained from `tower_http` module. These can be enabled by appending `pathfinder_rpc=trace,tower_http=trace` to `RUST_LOG` environment variable.
   - Request payload is now logged before execution begins.
   - Logs now include `x-request-id` header value which can be used to correlate with client requests/responses.
   - Batch logs also include the index within a batch.

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -70,7 +70,7 @@ impl RpcRouter {
 
     /// Parses and executes a request. Returns [None] if its a notification.
     async fn run_request<'a>(&self, request: &'a str) -> Option<RpcResponse<'a>> {
-        tracing::debug!(%request, "Running request");
+        tracing::trace!(%request, "Running request");
 
         let Ok(request) = serde_json::from_str::<RpcRequest<'_>>(request) else {
             return Some(RpcResponse::INVALID_REQUEST);

--- a/crates/rpc/src/middleware/tracing.rs
+++ b/crates/rpc/src/middleware/tracing.rs
@@ -1,11 +1,15 @@
 use tower_http::classify::{ServerErrorsAsFailures, SharedClassifier};
-use tower_http::trace::TraceLayer;
+use tower_http::trace::{DefaultOnEos, DefaultOnRequest, DefaultOnResponse, TraceLayer};
+use tracing::Level;
 
 pub(crate) fn trace_layer(
 ) -> TraceLayer<SharedClassifier<ServerErrorsAsFailures>, RequestHeaderSpan> {
     tower_http::trace::TraceLayer::new_for_http()
         // Records request ID header value in the span.
         .make_span_with(RequestHeaderSpan)
+        .on_request(DefaultOnRequest::default().level(Level::TRACE))
+        .on_response(DefaultOnResponse::default().level(Level::TRACE))
+        .on_eos(DefaultOnEos::default().level(Level::TRACE))
 }
 
 #[derive(Copy, Clone)]


### PR DESCRIPTION
Debug level is a bit too spammy since one often enables `pathfinder=debug` which unfortunately also enables the rpc logs at the same level.

The tracing spans are left at debug level which I think is fine?