### PR TITLE
fix(rpc/v06): fix execution resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - v0.5 `starknet_simulateTransactions` returns internal error instead of `ContractError` for reverted transactions.
+- v0.6 `starknet_getTransactionReceipt` now returns EXECUTION_RESOURCES properties as numbers. The `segment_arena_builtin` resource has been added.
 
 ### Changed
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -222,7 +222,7 @@ pub mod test_utils {
     use pathfinder_storage::{BlockId, Storage};
     use primitive_types::H160;
     use starknet_gateway_types::reply::transaction::{
-        DeployTransaction, EntryPointType, ExecutionResources, InvokeTransaction,
+        BuiltinCounters, DeployTransaction, EntryPointType, ExecutionResources, InvokeTransaction,
         InvokeTransactionV0, Receipt, Transaction,
     };
     use starknet_gateway_types::reply::transaction::{ExecutionStatus, L2ToL1Message};
@@ -463,9 +463,13 @@ pub mod test_utils {
             actual_fee: None,
             events: vec![],
             execution_resources: Some(ExecutionResources {
-                builtin_instance_counter: Default::default(),
-                n_memory_holes: 0,
-                n_steps: 0,
+                builtin_instance_counter: BuiltinCounters {
+                    output_builtin: 33,
+                    pedersen_builtin: 32,
+                    ..Default::default()
+                },
+                n_memory_holes: 5,
+                n_steps: 10,
             }),
             l1_to_l2_consumed_message: None,
             l2_to_l1_messages: vec![],

--- a/crates/rpc/src/v05/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v05/method/get_transaction_receipt.rs
@@ -14,11 +14,10 @@ pub async fn get_transaction_receipt(
 mod tests {
     use super::*;
     use pathfinder_common::{macro_prelude::*, BlockNumber, Fee};
-    use starknet_gateway_types::reply::transaction::ExecutionResources;
     use v06::types::*;
 
     #[tokio::test]
-    async fn v05_gas_check() {
+    async fn check_v05_representation() {
         let context = RpcContext::for_tests();
         let input = v06::GetTransactionReceiptInput {
             transaction_hash: transaction_hash_bytes!(b"txn 0"),
@@ -27,6 +26,7 @@ mod tests {
         let result = super::get_transaction_receipt(context, input)
             .await
             .unwrap();
+
         assert_eq!(
             result,
             MaybePendingTransactionReceipt::Normal(TransactionReceipt::Invoke(
@@ -45,10 +45,62 @@ mod tests {
                         execution_status: ExecutionStatus::Succeeded,
                         finality_status: FinalityStatus::AcceptedOnL1,
                         revert_reason: None,
-                        execution_resources: ExecutionResources::default().into(),
+                        execution_resources: ExecutionResourcesProperties::V05(
+                            ExecutionResourcesPropertiesV05 {
+                                steps: 10,
+                                memory_holes: 5,
+                                pedersen_builtin_applications: 32,
+                                ..Default::default()
+                            }
+                        ),
                     }
                 }
             ))
         )
+    }
+
+    #[tokio::test]
+    async fn json_output() {
+        let context = RpcContext::for_tests_with_pending().await;
+        let input = v06::GetTransactionReceiptInput {
+            transaction_hash: transaction_hash_bytes!(b"txn 0"),
+        };
+
+        let receipt = get_transaction_receipt(context.clone(), input)
+            .await
+            .unwrap();
+
+        let receipt = serde_json::to_value(receipt).unwrap();
+
+        let expected = serde_json::json!({
+            "transaction_hash": transaction_hash_bytes!(b"txn 0"),
+            "actual_fee": "0x0",
+            "execution_resources": {
+                "steps": "0xa",
+                "memory_holes": "0x5",
+                "range_check_builtin_applications": "0x0",
+                "pedersen_builtin_applications": "0x20",
+                "poseidon_builtin_applications": "0x0",
+                "ec_op_builtin_applications": "0x0",
+                "ecdsa_builtin_applications": "0x0",
+                "bitwise_builtin_applications": "0x0",
+                "keccak_builtin_applications": "0x0"
+            },
+            "execution_status": "SUCCEEDED",
+            "finality_status": "ACCEPTED_ON_L1",
+            "block_hash": block_hash_bytes!(b"genesis"),
+            "block_number": 0,
+            "messages_sent": [],
+            "events": [
+                {
+                    "data": [event_data_bytes!(b"event 0 data")],
+                    "from_address": contract_address_bytes!(b"event 0 from addr"),
+                    "keys": [event_key_bytes!(b"event 0 key")]
+                }
+            ],
+            "type": "INVOKE",
+        });
+
+        assert_eq!(receipt, expected);
     }
 }


### PR DESCRIPTION
The values are expected to be numbers, not hex-encoded strings.

This PR also adds the `segment_arena_builtin` counter that was previously missing.

Only `steps` is required now so we're skipping serialization for other zero-valued counters.
