### PR TITLE
feat(rpc): expose parsing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Request payload is now logged before execution begins.
   - Logs now include `x-request-id` header value which can be used to correlate with client requests/responses.
   - Batch logs also include the index within a batch.
+- RPC parsing errors now expose the failure reason as part of the errors `data` field.
 
 ### Fixed
 

--- a/crates/rpc/src/jsonrpc/request.rs
+++ b/crates/rpc/src/jsonrpc/request.rs
@@ -48,7 +48,7 @@ impl<'a> RawParams<'a> {
     pub fn deserialize<T: Deserialize<'a>>(self) -> Result<T, RpcError> {
         let s = self.0.map(|x| x.get()).unwrap_or_default();
 
-        serde_json::from_str::<T>(s).map_err(|_| RpcError::InvalidParams)
+        serde_json::from_str::<T>(s).map_err(|e| RpcError::InvalidParams(e.to_string()))
     }
 }
 


### PR DESCRIPTION
This PR exposes the error reason for RPC parsing errors via the error's `data` property.

Currently users simply receive `"Invalid params"` or `"Invalid request"` which can be difficult to track down what exactly is wrong in complicated json structures. typos, wrong field names are all difficult to spot.

This PR surfaces the core serde parsing error in an attempt to help.

Here are some downsides to the current implementation

- `serde_json::Error` does not implement serialize so we have to use `to_string` before serializing
- `serde` errors are terrible when combined with untagged enums. Essentially just says "data matched no known enum variant".
- Errors may at times be confusing as we use helper structs for some serde which can be visible in the error message.

Open question: should the error string be truncated to some length for safety? This should probably happen both at the point where `to_string()` is invoked and at the error serialization step.

Lastly, this PR is probably not *required* so I'm happy to drop this entirely as well.