### PR TITLE
fix(rpc/v06): fix price unit in transaction receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - v0.5 `starknet_simulateTransactions` returns internal error instead of `ContractError` for reverted transactions.
-- v0.6 `starknet_getTransactionReceipt` now returns EXECUTION_RESOURCES properties as numbers. The `segment_arena_builtin` resource has been added.
+- v0.6 `starknet_getTransactionReceipt`
+  - `EXECUTION_RESOURCES` fields are hex-strings instead of integers
+  - `segment_arena_builtin` resource is missing
+  - v3 transaction price unit type is `STRK` instead of `FRI`
 
 ### Changed
 

--- a/crates/rpc/src/v06/method/estimate_fee.rs
+++ b/crates/rpc/src/v06/method/estimate_fee.rs
@@ -4,6 +4,7 @@ use serde_with::serde_as;
 
 use crate::{
     context::RpcContext, error::ApplicationError, v02::types::request::BroadcastedTransaction,
+    v06::types::PriceUnit,
 };
 use pathfinder_common::BlockId;
 
@@ -104,23 +105,6 @@ impl From<pathfinder_executor::types::FeeEstimate> for FeeEstimate {
             gas_price: value.gas_price,
             overall_fee: value.overall_fee,
             unit: value.unit.into(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, serde::Serialize, PartialEq, Eq)]
-pub enum PriceUnit {
-    #[serde(rename = "WEI")]
-    Wei,
-    #[serde(rename = "FRI")]
-    Fri,
-}
-
-impl From<pathfinder_executor::types::PriceUnit> for PriceUnit {
-    fn from(value: pathfinder_executor::types::PriceUnit) -> Self {
-        match value {
-            pathfinder_executor::types::PriceUnit::Wei => Self::Wei,
-            pathfinder_executor::types::PriceUnit::Fri => Self::Fri,
         }
     }
 }

--- a/crates/rpc/src/v06/method/estimate_message_fee.rs
+++ b/crates/rpc/src/v06/method/estimate_message_fee.rs
@@ -230,7 +230,7 @@ mod tests {
     };
     use tempfile::tempdir;
 
-    use crate::v06::method::estimate_fee::PriceUnit;
+    use crate::v06::types::PriceUnit;
 
     use super::*;
 

--- a/crates/rpc/src/v06/method/simulate_transactions.rs
+++ b/crates/rpc/src/v06/method/simulate_transactions.rs
@@ -155,6 +155,7 @@ pub mod dto {
     use crate::felt::RpcFelt;
     use crate::v03::method::get_state_update::types::StateDiff;
     use crate::v05::method::call::FunctionCall;
+    use crate::v06::types::PriceUnit;
 
     use super::*;
 
@@ -185,23 +186,6 @@ pub mod dto {
                 gas_price: value.gas_price,
                 overall_fee: value.overall_fee,
                 unit: value.unit.into(),
-            }
-        }
-    }
-
-    #[derive(Clone, Debug, serde::Serialize, PartialEq, Eq)]
-    pub enum PriceUnit {
-        #[serde(rename = "WEI")]
-        Wei,
-        #[serde(rename = "FRI")]
-        Fri,
-    }
-
-    impl From<pathfinder_executor::types::PriceUnit> for PriceUnit {
-        fn from(value: pathfinder_executor::types::PriceUnit) -> Self {
-            match value {
-                pathfinder_executor::types::PriceUnit::Wei => Self::Wei,
-                pathfinder_executor::types::PriceUnit::Fri => Self::Fri,
             }
         }
     }
@@ -649,6 +633,7 @@ pub(crate) mod tests {
     use crate::v03::method::get_state_update::types::{DeployedContract, Nonce, StateDiff};
     pub(crate) use crate::v04::method::simulate_transactions::tests::setup_storage;
     use crate::v05::method::call::FunctionCall;
+    use crate::v06::types::PriceUnit;
     use pathfinder_common::{felt, macro_prelude::*, ClassHash, StorageValue, TransactionVersion};
     use starknet_gateway_test_fixtures::class_definitions::{
         DUMMY_ACCOUNT_CLASS_HASH, ERC20_CONTRACT_DEFINITION_CLASS_HASH,


### PR DESCRIPTION
`starknet_getTransactionReceipt` was still returning STRK as the fee token type for v3 transactions.