### PR TITLE
feat(load-test): add starknet_getNonce task to load test

### DIFF
--- a/crates/load-test/Cargo.lock
+++ b/crates/load-test/Cargo.lock
@@ -3,17 +3,6 @@
 version = 3
 
 [[package]]
-name = "addchain"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2e69442aa5628ea6951fa33e24efe8313f4321a91bd729fc2f75bdfc858570"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -35,6 +24,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest",
+ "itertools",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.105",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.105",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std",
+ "digest",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -322,6 +375,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.105",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,32 +446,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
-]
-
-[[package]]
-name = "ff"
-version = "0.12.0"
-source = "git+https://github.com/eqlabs/ff?branch=var_time_eq#e4ce228a5da140465a620cb0a455fcb08f23fb52"
-dependencies = [
- "byteorder",
- "ff_derive",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "ff_derive"
-version = "0.12.0"
-source = "git+https://github.com/eqlabs/ff?branch=var_time_eq#e4ce228a5da140465a620cb0a455fcb08f23fb52"
-dependencies = [
- "addchain",
- "cfg-if",
- "num-bigint",
- "num-integer",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.105",
 ]
 
 [[package]]
@@ -878,10 +916,10 @@ name = "load-test"
 version = "0.1.0"
 dependencies = [
  "goose",
+ "pathfinder-crypto",
  "rand",
  "serde",
  "serde_json",
- "stark_hash",
  "tokio",
 ]
 
@@ -984,9 +1022,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.3.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1015,9 +1053,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
 ]
@@ -1089,6 +1127,23 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "pathfinder-crypto"
+version = "0.1.0"
+dependencies = [
+ "ark-ff",
+ "bitvec",
+ "fake",
+ "rand",
+ "serde",
 ]
 
 [[package]]
@@ -1295,6 +1350,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,10 +1416,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.171"
+name = "semver"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+
+[[package]]
+name = "serde"
+version = "1.0.193"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
@@ -1372,9 +1442,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1455,26 +1525,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stark_curve"
-version = "0.1.0"
-dependencies = [
- "bitvec",
- "ff",
-]
-
-[[package]]
-name = "stark_hash"
-version = "0.1.0"
-dependencies = [
- "bitvec",
- "fake",
- "rand",
- "rand_core",
- "serde",
- "stark_curve",
-]
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,12 +1548,6 @@ dependencies = [
  "rustversion",
  "syn 1.0.105",
 ]
-
-[[package]]
-name = "subtle"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -2084,4 +2128,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
 ]

--- a/crates/load-test/src/main.rs
+++ b/crates/load-test/src/main.rs
@@ -74,6 +74,9 @@ fn register_v05(attack: GooseAttack) -> GooseAttack {
         .register_scenario(
             scenario!("v05_get_storage_at").register_transaction(transaction!(task_get_storage_at)),
         )
+        .register_scenario(
+            scenario!("v05_get_nonce").register_transaction(transaction!(task_get_nonce)),
+        )
         // primitive operations that don't use the database
         .register_scenario(
             scenario!("v05_syncing").register_transaction(transaction!(task_syncing)),
@@ -81,7 +84,7 @@ fn register_v05(attack: GooseAttack) -> GooseAttack {
         .register_scenario(
             scenario!("v05_chain_id").register_transaction(transaction!(task_chain_id)),
         )
-        // primitive operation utilizing the Cairo Python subprocesses
+        // primitive operation doing execution
         .register_scenario(scenario!("v05_call").register_transaction(transaction!(task_call)))
         .register_scenario(
             scenario!("v05_estimate_fee").register_transaction(transaction!(task_estimate_fee)),

--- a/crates/load-test/src/requests/v05.rs
+++ b/crates/load-test/src/requests/v05.rs
@@ -267,6 +267,18 @@ pub async fn estimate_fee_for_invoke(
     .await
 }
 
+pub async fn get_nonce(user: &mut GooseUser, contract_address: Felt) -> MethodResult<Felt> {
+    post_jsonrpc_request(
+        user,
+        "starknet_getNonce",
+        json!({
+            "block_id": "pending",
+            "contract_address": contract_address
+        }),
+    )
+    .await
+}
+
 async fn post_jsonrpc_request<T: DeserializeOwned>(
     user: &mut GooseUser,
     method: &str,

--- a/crates/load-test/src/tasks/v05.rs
+++ b/crates/load-test/src/tasks/v05.rs
@@ -1,6 +1,6 @@
 use goose::prelude::*;
-use rand::{Rng, SeedableRng};
 use pathfinder_crypto::Felt;
+use rand::{Rng, SeedableRng};
 
 use crate::requests::v05::*;
 
@@ -258,5 +258,16 @@ pub async fn task_get_storage_at(user: &mut GooseUser) -> TransactionResult {
             .unwrap(),
     )
     .await?;
+    Ok(())
+}
+
+pub async fn task_get_nonce(user: &mut GooseUser) -> TransactionResult {
+    let _ = get_nonce(
+        user,
+        Felt::from_hex_str("0x01b68f7c1bbcaf9017bd8e2f3be124c01525341603e5c76a06870c32e10473c7")
+            .unwrap(),
+    )
+    .await?;
+
     Ok(())
 }


### PR DESCRIPTION
This task does a call to `starknet_getNonce` on the `pending` block. This is a fairly common operation clients do when sending transactions: they first need to determine the current nonce for the account.
