### PR TITLE
feat(pathfinder): use the mimalloc memory allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4443,9 +4443,9 @@ checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d058a81af0d1c22d7a1c948576bee6d673f7af3c0f35564abd6c81122f513d"
+checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
 dependencies = [
  "cc",
  "libc",
@@ -5196,9 +5196,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.38"
+version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972e5f23f6716f62665760b0f4cbf592576a80c7b879ba9beaafc0e558894127"
+checksum = "fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c"
 dependencies = [
  "libmimalloc-sys",
 ]

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -29,6 +29,7 @@ lazy_static = { workspace = true }
 lru = "0.11.1"
 metrics = { workspace = true }
 metrics-exporter-prometheus = "0.11.0"
+mimalloc = { version = "0.1.39", default-features = false }
 p2p = { path = "../p2p", optional = true }
 p2p_proto = { path = "../p2p_proto", optional = true }
 pathfinder-common = { path = "../common" }
@@ -74,7 +75,6 @@ crossbeam-channel = "0.5.8"
 fake = { workspace = true }
 flate2 = { workspace = true }
 http = { workspace = true }
-mimalloc = { version = "0.1.38", default-features = false }
 mockall = "0.11.4"
 pathfinder-common = { path = "../common", features = ["full-serde"] }
 pathfinder-compiler = { path = "../compiler" }

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -2,6 +2,8 @@
 
 use anyhow::Context;
 use metrics_exporter_prometheus::PrometheusBuilder;
+use mimalloc::MiMalloc;
+
 use pathfinder_common::{consts::VERGEN_GIT_DESCRIBE, BlockNumber, Chain, ChainId, EthereumChain};
 use pathfinder_ethereum::{EthereumApi, EthereumClient};
 use pathfinder_lib::state::SyncContext;
@@ -24,6 +26,9 @@ use crate::config::NetworkConfig;
 
 mod config;
 mod update;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 fn main() -> anyhow::Result<()> {
     tokio::runtime::Builder::new_multi_thread()


### PR DESCRIPTION
Cairo VM performance seems to be hugely affected by memory allocator performance since it tends to allocate lot of small objects. This change switches our global allocator to mimalloc which was shown to improve execution performance of `starknet_call` calls invoking StarkGate `balanceOf` by 40%.
