### PR TITLE
feat(executor): rework handling of pending state update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `EXECUTION_RESOURCES` fields are hex-strings instead of integers
   - `segment_arena_builtin` resource is missing
   - v3 transaction price unit type is `STRK` instead of `FRI`
-  - v3 transaction hashes are computed incorrectly when using the "query" flag, causing validation errors.
+  - v3 transaction hashes are computed incorrectly when using the "query" flag, causing validation errors
+- Execution performance for calls involving the `pending` blocks is much better for trivial calls (like `balanceOf`).
 
 ### Changed
 

--- a/crates/executor/src/execution_state.rs
+++ b/crates/executor/src/execution_state.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::state_reader::PathfinderStateReader;
 use crate::IntoStarkFelt;
 use anyhow::Context;
@@ -15,7 +17,7 @@ pub struct ExecutionState<'tx> {
     pub chain_id: ChainId,
     pub header: BlockHeader,
     execute_on_parent_state: bool,
-    pending_state: Option<StateUpdate>,
+    pending_state: Option<Arc<StateUpdate>>,
 }
 
 impl<'tx> ExecutionState<'tx> {
@@ -73,7 +75,7 @@ impl<'tx> ExecutionState<'tx> {
         transaction: &'tx pathfinder_storage::Transaction<'tx>,
         chain_id: ChainId,
         header: BlockHeader,
-        pending_state: Option<StateUpdate>,
+        pending_state: Option<Arc<StateUpdate>>,
     ) -> Self {
         Self {
             transaction,
@@ -88,7 +90,7 @@ impl<'tx> ExecutionState<'tx> {
         transaction: &'tx pathfinder_storage::Transaction<'tx>,
         chain_id: ChainId,
         header: BlockHeader,
-        pending_state: Option<StateUpdate>,
+        pending_state: Option<Arc<StateUpdate>>,
     ) -> Self {
         Self {
             transaction,

--- a/crates/load-test/src/requests/v05.rs
+++ b/crates/load-test/src/requests/v05.rs
@@ -223,7 +223,6 @@ pub async fn call(
     contract_address: Felt,
     call_data: &[&str],
     entry_point_selector: &str,
-    at_block: Felt,
 ) -> MethodResult<Vec<String>> {
     post_jsonrpc_request(
         user,
@@ -234,7 +233,7 @@ pub async fn call(
                 "calldata": call_data,
                 "entry_point_selector": entry_point_selector,
             },
-            "block_id": {"block_hash": at_block},
+            "block_id": "pending",
         }),
     )
     .await

--- a/crates/load-test/src/tasks/v05.rs
+++ b/crates/load-test/src/tasks/v05.rs
@@ -156,23 +156,16 @@ pub async fn task_syncing(user: &mut GooseUser) -> TransactionResult {
 }
 
 pub async fn task_call(user: &mut GooseUser) -> TransactionResult {
-    // call a test contract deployed in block 0
-    // https://voyager.online/contract/0x06ee3440b08a9c805305449ec7f7003f27e9f7e287b83610952ec36bdc5a6bae
     call(
         user,
-        Felt::from_hex_str("0x06ee3440b08a9c805305449ec7f7003f27e9f7e287b83610952ec36bdc5a6bae")
+        Felt::from_hex_str("0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7")
             .unwrap(),
         &[
-            // address
-            "0x01e2cd4b3588e8f6f9c4e89fb0e293bf92018c96d7a93ee367d29a284223b6ff",
-            // value
-            "0x071d1e9d188c784a0bde95c1d508877a0d93e9102b37213d1e13f3ebc54a7751",
+            // account contract address
+            "0x05d7b537d7f0a56230cbd085ed1f7f40662df13718192c321a6b871f161acb7d",
         ],
-        // "set_value" entry point
-        "0x3d7905601c217734671143d457f0db37f7f8883112abd34b92c4abfeafde0c3",
-        // hash of mainnet block 0
-        Felt::from_hex_str("0x47c3637b57c2b079b93c61539950c17e868a28f46cdef28f88521067f21e943")
-            .unwrap(),
+        // "balanceOf" entry point
+        "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e",
     )
     .await?;
     Ok(())

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -74,7 +74,7 @@ pub struct SyncContext<G, E> {
     pub sequencer: G,
     pub state: Arc<SyncState>,
     pub head_poll_interval: Duration,
-    pub pending_data: WatchSender<Arc<PendingData>>,
+    pub pending_data: WatchSender<PendingData>,
     pub block_validation_mode: l2::BlockValidationMode,
     pub websocket_txs: Option<TopicBroadcasters>,
     pub block_cache_size: usize,
@@ -323,7 +323,7 @@ where
 struct ConsumerContext {
     pub storage: Storage,
     pub state: Arc<SyncState>,
-    pub pending_data: WatchSender<Arc<PendingData>>,
+    pub pending_data: WatchSender<PendingData>,
     pub verify_tree_hashes: bool,
     pub websocket_txs: Option<TopicBroadcasters>,
 }
@@ -533,11 +533,11 @@ async fn consumer(mut events: Receiver<SyncEvent>, context: ConsumerContext) -> 
 
                 if pending.0.parent_hash == hash {
                     let data = PendingData {
-                        block: pending.0,
-                        state_update: pending.1,
+                        block: pending.0.into(),
+                        state_update: pending.1.into(),
                         number: number + 1,
                     };
-                    pending_data.send_replace(Arc::new(data));
+                    pending_data.send_replace(data);
                     tracing::debug!("Updated pending data");
                 }
             }

--- a/crates/rpc/src/context.rs
+++ b/crates/rpc/src/context.rs
@@ -31,7 +31,7 @@ impl RpcContext {
         sync_status: Arc<SyncState>,
         chain_id: ChainId,
         sequencer: SequencerClient,
-        pending_data: tokio_watch::Receiver<Arc<PendingData>>,
+        pending_data: tokio_watch::Receiver<PendingData>,
         batch_concurrency_limit: NonZeroUsize,
     ) -> Self {
         let pending_data = PendingWatcher::new(pending_data);
@@ -92,7 +92,7 @@ impl RpcContext {
         }
     }
 
-    pub fn with_pending_data(self, pending_data: tokio_watch::Receiver<Arc<PendingData>>) -> Self {
+    pub fn with_pending_data(self, pending_data: tokio_watch::Receiver<PendingData>) -> Self {
         let pending_data = PendingWatcher::new(pending_data);
         Self {
             pending_data,
@@ -107,7 +107,7 @@ impl RpcContext {
         let pending_data = super::test_utils::create_pending_data(context.storage.clone()).await;
 
         let (tx, rx) = tokio_watch::channel(Default::default());
-        tx.send(Arc::new(pending_data)).unwrap();
+        tx.send(pending_data).unwrap();
 
         context.with_pending_data(rx)
     }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -754,8 +754,8 @@ pub mod test_utils {
         .unwrap();
 
         PendingData {
-            block,
-            state_update,
+            block: block.into(),
+            state_update: state_update.into(),
             number: latest.number + 1,
         }
     }

--- a/crates/rpc/src/v03/method/get_state_update.rs
+++ b/crates/rpc/src/v03/method/get_state_update.rs
@@ -30,8 +30,9 @@ pub async fn get_state_update(
                 .pending_data
                 .get(&tx)
                 .context("Query pending data")?
-                .state_update
-                .clone();
+                .state_update;
+
+            let state_update = (*state_update).clone();
 
             return Ok(state_update.into());
         }
@@ -571,12 +572,8 @@ mod tests {
             block_id: BlockId::Pending,
         };
 
-        let expected: StateUpdate = context
-            .pending_data
-            .get_unchecked()
-            .state_update
-            .clone()
-            .into();
+        let expected = context.pending_data.get_unchecked().state_update;
+        let expected = (*expected).clone().into();
 
         let result = get_state_update(context, input).await.unwrap();
 

--- a/crates/rpc/src/v04/method/get_block_with_tx_hashes.rs
+++ b/crates/rpc/src/v04/method/get_block_with_tx_hashes.rs
@@ -38,8 +38,8 @@ pub async fn get_block_with_tx_hashes(
                     .pending_data
                     .get(&transaction)
                     .context("Querying pending data")?
-                    .block
-                    .clone();
+                    .block;
+                let block = (*block).clone();
 
                 return Ok(types::Block::from_sequencer(block.into()));
             }

--- a/crates/rpc/src/v04/method/get_block_with_txs.rs
+++ b/crates/rpc/src/v04/method/get_block_with_txs.rs
@@ -38,8 +38,8 @@ pub async fn get_block_with_txs(
                 .pending_data
                 .get(&transaction)
                 .context("Querying pending data")?
-                .block
-                .clone();
+                .block;
+            let block = (*block).clone();
 
             return Ok(types::Block::from_sequencer(block.into()));
         }

--- a/crates/rpc/src/v05/method/call.rs
+++ b/crates/rpc/src/v05/method/call.rs
@@ -278,8 +278,7 @@ mod tests {
             let pending_data = pending_data_with_update(
                 last_block_header,
                 StateUpdate::default().with_storage_update(contract_address, test_key, new_value),
-            )
-            .await;
+            );
 
             let (_tx, rx) = tokio::sync::watch::channel(pending_data);
             let context = context.with_pending_data(rx);
@@ -321,8 +320,7 @@ mod tests {
                 StateUpdate::default()
                     .with_deployed_contract(new_contract_address, CONTRACT_DEFINITION_CLASS_HASH)
                     .with_storage_update(new_contract_address, test_key, new_value),
-            )
-            .await;
+            );
             let (_tx, rx) = tokio::sync::watch::channel(pending_data);
             let context = context.with_pending_data(rx);
 
@@ -374,8 +372,7 @@ mod tests {
                     .with_declared_sierra_class(sierra_hash, casm_hash)
                     .with_deployed_contract(new_contract_address, ClassHash(sierra_hash.0))
                     .with_storage_update(new_contract_address, storage_key, storage_value),
-            )
-            .await;
+            );
             let (_tx, rx) = tokio::sync::watch::channel(pending_data);
             let context = context.with_pending_data(rx);
 
@@ -391,7 +388,7 @@ mod tests {
             assert_eq!(result, CallOutput(vec![CallResultValue(storage_value.0)]));
         }
 
-        async fn pending_data_with_update(
+        fn pending_data_with_update(
             last_block_header: BlockHeader,
             state_update: StateUpdate,
         ) -> PendingData {

--- a/crates/rpc/src/v05/method/call.rs
+++ b/crates/rpc/src/v05/method/call.rs
@@ -176,7 +176,6 @@ mod tests {
     }
 
     mod in_memory {
-        use std::sync::Arc;
 
         use super::*;
 
@@ -282,7 +281,7 @@ mod tests {
             )
             .await;
 
-            let (_tx, rx) = tokio::sync::watch::channel(Arc::new(pending_data));
+            let (_tx, rx) = tokio::sync::watch::channel(pending_data);
             let context = context.with_pending_data(rx);
 
             // unchanged on latest block
@@ -324,7 +323,7 @@ mod tests {
                     .with_storage_update(new_contract_address, test_key, new_value),
             )
             .await;
-            let (_tx, rx) = tokio::sync::watch::channel(Arc::new(pending_data));
+            let (_tx, rx) = tokio::sync::watch::channel(pending_data);
             let context = context.with_pending_data(rx);
 
             let input = CallInput {
@@ -377,7 +376,7 @@ mod tests {
                     .with_storage_update(new_contract_address, storage_key, storage_value),
             )
             .await;
-            let (_tx, rx) = tokio::sync::watch::channel(Arc::new(pending_data));
+            let (_tx, rx) = tokio::sync::watch::channel(pending_data);
             let context = context.with_pending_data(rx);
 
             let input = CallInput {
@@ -407,8 +406,9 @@ mod tests {
                     transaction_receipts: vec![],
                     transactions: vec![],
                     starknet_version: last_block_header.starknet_version,
-                },
-                state_update,
+                }
+                .into(),
+                state_update: state_update.into(),
                 number: last_block_header.number + 1,
             }
         }

--- a/crates/rpc/src/v05/method/get_block_with_tx_hashes.rs
+++ b/crates/rpc/src/v05/method/get_block_with_tx_hashes.rs
@@ -38,8 +38,8 @@ pub async fn get_block_with_tx_hashes(
                     .pending_data
                     .get(&transaction)
                     .context("Querying pending data")?
-                    .block
-                    .clone();
+                    .block;
+                let block = (*block).clone();
 
                 return Ok(types::Block::from_sequencer(block.into()));
             }

--- a/crates/rpc/src/v05/method/get_block_with_txs.rs
+++ b/crates/rpc/src/v05/method/get_block_with_txs.rs
@@ -39,8 +39,8 @@ pub async fn get_block_with_txs(
                     .pending_data
                     .get(&transaction)
                     .context("Querying pending data")?
-                    .block
-                    .clone();
+                    .block;
+                let block = (*block).clone();
 
                 return Ok(types::Block::from_sequencer(block.into()));
             }

--- a/crates/rpc/src/v05/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v05/method/trace_block_transactions.rs
@@ -248,10 +248,9 @@ pub async fn trace_block_transactions(
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::sync::Arc;
 
     use pathfinder_common::{
-        block_hash, felt, BlockHeader, ChainId, GasPrice, SierraHash, StateUpdate, TransactionIndex,
+        block_hash, felt, BlockHeader, ChainId, GasPrice, SierraHash, TransactionIndex,
     };
     use starknet_gateway_types::reply::transaction::{ExecutionStatus, Receipt};
 
@@ -462,13 +461,13 @@ pub(crate) mod tests {
         };
 
         let pending_data = crate::pending::PendingData {
-            block: pending_block,
-            state_update: StateUpdate::default(),
+            block: pending_block.into(),
+            state_update: Default::default(),
             number: last_block_header.number + 1,
         };
 
         let (tx, rx) = tokio::sync::watch::channel(Default::default());
-        tx.send(Arc::new(pending_data)).unwrap();
+        tx.send(pending_data).unwrap();
 
         let context = context.with_pending_data(rx);
 

--- a/crates/rpc/src/v06/method/get_block_with_tx_hashes.rs
+++ b/crates/rpc/src/v06/method/get_block_with_tx_hashes.rs
@@ -38,8 +38,8 @@ pub async fn get_block_with_tx_hashes(
                     .pending_data
                     .get(&transaction)
                     .context("Querying pending data")?
-                    .block
-                    .clone();
+                    .block;
+                let block = (*block).clone();
 
                 return Ok(types::Block::from_sequencer(block.into()));
             }

--- a/crates/rpc/src/v06/method/get_block_with_txs.rs
+++ b/crates/rpc/src/v06/method/get_block_with_txs.rs
@@ -39,8 +39,8 @@ pub async fn get_block_with_txs(
                     .pending_data
                     .get(&transaction)
                     .context("Querying pending data")?
-                    .block
-                    .clone();
+                    .block;
+                let block = (*block).clone();
 
                 return Ok(types::Block::from_sequencer(block.into()));
             }

--- a/crates/rpc/src/v06/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v06/method/trace_block_transactions.rs
@@ -269,10 +269,8 @@ pub async fn trace_block_transactions(
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::sync::Arc;
-
     use pathfinder_common::{
-        block_hash, felt, BlockHeader, ChainId, GasPrice, SierraHash, StateUpdate, TransactionIndex,
+        block_hash, felt, BlockHeader, ChainId, GasPrice, SierraHash, TransactionIndex,
     };
     use starknet_gateway_types::reply::transaction::{ExecutionStatus, Receipt};
 
@@ -483,13 +481,13 @@ pub(crate) mod tests {
         };
 
         let pending_data = crate::pending::PendingData {
-            block: pending_block,
-            state_update: StateUpdate::default(),
+            block: pending_block.into(),
+            state_update: Default::default(),
             number: last_block_header.number + 1,
         };
 
         let (tx, rx) = tokio::sync::watch::channel(Default::default());
-        tx.send(Arc::new(pending_data)).unwrap();
+        tx.send(pending_data).unwrap();
 
         let context = context.with_pending_data(rx);
 


### PR DESCRIPTION
This PR changes how we apply pending state updates to the executor state and improves execution performance for trivial calls involving the `pending` block by a factor of 10.

---

Some background: our executor has been applying updates in the pending state to the `CachedState` object we've constructed. This object stores these updates in-memory and returns the updated values it has in its "cache" when queried during exectution. There is some missing functionality on the `State` trait though: we can't explicitly set nonces: the only operation exposed is `increment_nonce()`... As a workaround we've been fetching current `latest` nonces for each contract and determined how many times we'd need to call `increment_nonce()` to get to the desired value.

Unfortunately this does not scale well: this is essentially one extra storage lookup per contract updated in the pending block...

This PR changes how we get the changes in the pending state update into our execution state. It implements a state reader for the pending state update that wraps our `PathfinderStateReader` looking up things in storage. This way we're not limited by the API exposed by `CachedState` and can just return the correct nonce values for contracts updated in the pending state.

To be able to do this there are some changes required to `PendingData`: instead of having a single `Arc` around the `PendingData` structure now the pending block and state update are individually an `Arc` so that they can be passed around individually.

The PR also fixes an oversight in `StateUpdate::storage_value()` where system contract updates were not properly returned.