### PR TITLE
ci(docker): don't tag prereleases as latest

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -86,9 +86,11 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Pull image
         run: docker pull eqlabs/pathfinder:snapshot-${{ github.sha }}
-      - name: Tag image
-        run: |
-          docker tag eqlabs/pathfinder:snapshot-${{ github.sha }} eqlabs/pathfinder:latest
-          docker tag eqlabs/pathfinder:snapshot-${{ github.sha }} eqlabs/pathfinder:${{ github.event.release.tag_name }}
+      - name: Tag image with release name
+        run: docker tag eqlabs/pathfinder:snapshot-${{ github.sha }} eqlabs/pathfinder:${{ github.event.release.tag_name }}
+        # Only tag the image as 'latest' if its a release i.e. not a prerelease.
+      - name: Tag image with 'latest'
+        if: ${{ !github.event.release.prerelease }}
+        run: docker tag eqlabs/pathfinder:snapshot-${{ github.sha }} eqlabs/pathfinder:latest
       - name: Push image tags
         run: docker push --all-tags eqlabs/pathfinder


### PR DESCRIPTION
Tested on my own fork.

Github also has an additional checkbox to mark a release as latest -- but I couldn't find that information in the github event.