### PR TITLE
chore: testnet only release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.10.3-rc0] - 2023-12-14
+
 ### Changed
 
-- Fee estimations are now in-line with the new reduced values for Starknet 0.13.0.
-
-## [0.10.2] - 2023-12-13
+- Fee estimations are now compatible with starknet v0.13 and *incompatible* with starknet v0.12.3.
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5869,7 +5869,7 @@ checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
 name = "pathfinder"
-version = "0.10.2"
+version = "0.10.3-rc0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pathfinder"
-version = "0.10.2"
+version = "0.10.3-rc0"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }


### PR DESCRIPTION
This is release prep for pricing compatibility with starknet v0.13. It **should not** be used on mainnet until v0.13 has been released there.