### PR TITLE
fix: update of outdated links

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -49,7 +49,7 @@ pub struct ContractClass {
 impl EntryPoint {
     /// Returns a new EntryPoint which has been truncated to fit from Keccak256 digest of input.
     ///
-    /// See: <https://starknet.io/documentation/contracts/#function_selector>
+    /// See: <https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/contract-classes/>
     pub fn hashed(input: &[u8]) -> Self {
         use sha3::Digest;
         EntryPoint(truncated_keccak(<[u8; 32]>::from(sha3::Keccak256::digest(

--- a/crates/pathfinder/src/state/block_hash.rs
+++ b/crates/pathfinder/src/state/block_hash.rs
@@ -449,7 +449,7 @@ pub fn calculate_event_commitment(transaction_receipts: &[Receipt]) -> Result<Ev
 
 /// Calculate the hash of an event.
 ///
-/// See the [documentation](https://docs.starknet.io/docs/Events/starknet-events#event-hash)
+/// See the [documentation](https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/starknet-events/#event_hash)
 /// for details.
 fn calculate_event_hash(event: &Event) -> Felt {
     let mut keys_hash = HashChain::default();

--- a/doc/rpc/v03/starknet_api_openrpc.json
+++ b/doc/rpc/v03/starknet_api_openrpc.json
@@ -2728,7 +2728,7 @@
                 "properties": {
                     "gas_consumed": {
                         "title": "Gas consumed",
-                        "description": "The Ethereum gas cost of the transaction (see https://docs.starknet.io/docs/Fees/fee-mechanism for more info)",
+                        "description": "The Ethereum gas cost of the transaction (see https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/fee-mechanism/fee-mechanism for more info)",
                         "$ref": "#/components/schemas/NUM_AS_HEX"
                     },
                     "gas_price": {

--- a/doc/rpc/v03/starknet_api_openrpc.json
+++ b/doc/rpc/v03/starknet_api_openrpc.json
@@ -2728,7 +2728,7 @@
                 "properties": {
                     "gas_consumed": {
                         "title": "Gas consumed",
-                        "description": "The Ethereum gas cost of the transaction (see https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/fee-mechanism/fee-mechanism for more info)",
+                        "description": "The Ethereum gas cost of the transaction (see https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/fee-mechanism/ for more info)",
                         "$ref": "#/components/schemas/NUM_AS_HEX"
                     },
                     "gas_price": {

--- a/doc/rpc/v04/starknet_api_openrpc.json
+++ b/doc/rpc/v04/starknet_api_openrpc.json
@@ -2954,7 +2954,7 @@
                 "properties": {
                     "gas_consumed": {
                         "title": "Gas consumed",
-                        "description": "The Ethereum gas cost of the transaction (see https://docs.starknet.io/docs/Fees/fee-mechanism for more info)",
+                        "description": "The Ethereum gas cost of the transaction (see https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/fee-mechanism/ for more info)",
                         "$ref": "#/components/schemas/NUM_AS_HEX"
                     },
                     "gas_price": {

--- a/doc/rpc/v05/starknet_api_openrpc.json
+++ b/doc/rpc/v05/starknet_api_openrpc.json
@@ -3204,7 +3204,7 @@
                 "properties": {
                     "gas_consumed": {
                         "title": "Gas consumed",
-                        "description": "The Ethereum gas cost of the transaction (see https://docs.starknet.io/docs/Fees/fee-mechanism for more info)",
+                        "description": "The Ethereum gas cost of the transaction (see https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/fee-mechanism/ for more info)",
                         "$ref": "#/components/schemas/NUM_AS_HEX"
                     },
                     "gas_price": {

--- a/doc/rpc/v06/starknet_api_openrpc.json
+++ b/doc/rpc/v06/starknet_api_openrpc.json
@@ -3655,7 +3655,7 @@
                 "properties": {
                     "gas_consumed": {
                         "title": "Gas consumed",
-                        "description": "The Ethereum gas cost of the transaction (see https://docs.starknet.io/docs/Fees/fee-mechanism for more info)",
+                        "description": "The Ethereum gas cost of the transaction (see https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/fee-mechanism/ for more info)",
                         "$ref": "#/components/schemas/FELT"
                     },
                     "gas_price": {


### PR DESCRIPTION
This PR updates the outdated links pointing to Starknet documentation. Outdated links are replaced with working links and it is ensured, that links reference the same topic as the original links.
