### PR TITLE
update README.md: actualize info about JSON-RPC API versions and paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,13 +240,16 @@ This can be used to interact with a custom Starknet gateway, or to use a gateway
 
 You can interact with Starknet using the JSON-RPC API. Pathfinder supports the official Starknet RPC API and in addition supplements this with its own pathfinder specific extensions such as `pathfinder_getProof`.
 
-Currently pathfinder supports `v0.3`, `v0.4`, and `v0.5` versions of the Starknet JSON-RPC specification.
+Currently, pathfinder supports `v0.4`, `v0.5`, and `v0.6` versions of the Starknet JSON-RPC specification.
 The `path` of the URL used to access the JSON-RPC server determines which version of the API is served:
 
-- the `v0.3.0` API is exposed on the `/rpc/v0.3` and `/rpc/v0_3` path
-- the `v0.4.0` API is exposed on the `/`, `/rpc/v0.4` and `/rpc/v0_4` path
-- the `v0.5.1` API is exposed on the `/rpc/v0.5` and `/rpc/v0_5` path
+- the `v0.4.0` API is exposed on the `/rpc/v0.4` and `/rpc/v0_4` path
+- the `v0.5.1` API is exposed on the `/`, `/rpc/v0.5` and `/rpc/v0_5` path
+- the `v0.6.0` API is exposed on the `/rpc/v0_6` path
 - the pathfinder extension API is exposed on `/rpc/pathfinder/v0.1`
+- websocket API is exposed on the `/ws` path
+
+Version of the API, which is served on the root (`/`) path, can be configured via the pathfinder parameter `--rpc.root-version` (or the `RPC_ROOT_VERSION` environment variable).
 
 Note that the pathfinder extension is versioned separately from the Starknet specification itself.
 


### PR DESCRIPTION
PR is updates available API versions and paths after 0.10.0 version, added info about available WS path 
