### PR TITLE
docs: typo in contributing documentation

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -18,7 +18,7 @@ Keeping these points in mind will increase the odds of a successful PR:
 - Have an accurate description of your changes and intentions with the PR.
 - Code comments should describe the **why** and not the **how**.
 - New features should have reasonable tests.
-- Ensure CI is happy. CI will run automatically when the PR is opened. This includes checks checks for
+- Ensure CI is happy. CI will run automatically when the PR is opened. This includes checks for
   - formatting (`cargo fmt`)
   - linting (`cargo clippy`)
   - testing (`cargo test`)


### PR DESCRIPTION
I've corrected a small typo in the `contributing.md` file, where the word "checks" was mistakenly duplicated. This change is intended to improve the clarity and readability of the documentation.

**Details:**
- **File:** `contributing.md`
- **Change:** Removed the redundant word "checks" from the guidelines section.

**Commit ID:** a8a6430d7743cad99c6b9e9ca9a310cd4b9eb761

Here's the quick diff:
```diff
- Ensure CI is happy. CI will run automatically when the PR is opened. This includes checks checks for
+ Ensure CI is happy. CI will run automatically when the PR is opened. This includes checks for
```
