### PR TITLE
Backport gateway-api-key support into v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.10.2-api_key] - 2023-12-22
+
+### Added
+
+- `gateway-api-key API_KEY` configuration option. If enabled, each time a request is sent to the Starknet gateway or the feeder gateway a `X-Throttling-Bypass: API_KEY` header will be set.
+
 ## [0.10.2] - 2023-12-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3382,6 +3382,7 @@ checksum = "9af7b0c58ac9d03169e27f080616ce9f64004edca3d2ef4147a811c21b23b319"
 dependencies = [
  "dummy",
  "rand",
+ "serde_json",
  "unidecode",
 ]
 
@@ -7706,9 +7707,11 @@ dependencies = [
  "async-trait",
  "base64 0.13.1",
  "bytes",
+ "fake",
  "flate2",
  "futures",
  "http",
+ "httpmock",
  "lazy_static",
  "metrics",
  "mockall",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ flate2 = "1.0.27"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 hex = "0.4.3"
 http = "0.2.9"
+httpmock = "0.7.0-rc.1"
 lazy_static = "1.4.0"
 metrics = "0.20.1"
 num-bigint = { version = "0.4.4", features = ["serde"] }

--- a/crates/ethereum/Cargo.toml
+++ b/crates/ethereum/Cargo.toml
@@ -23,5 +23,5 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-httpmock = "0.7.0-rc.1"
+httpmock = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }

--- a/crates/gateway-client/Cargo.toml
+++ b/crates/gateway-client/Cargo.toml
@@ -32,7 +32,9 @@ warp = { version = "0.3.5" }
 [dev-dependencies]
 assert_matches = { workspace = true }
 base64 = { workspace = true }
+fake = { workspace = true }
 flate2 = { workspace = true }
+httpmock = { workspace = true }
 lazy_static = { workspace = true }
 pathfinder-crypto = { path = "../crypto" }
 pretty_assertions = { workspace = true }

--- a/crates/gateway-types/Cargo.toml
+++ b/crates/gateway-types/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-fake = { workspace = true }
+fake = { workspace = true, features = ["serde_json"] }
 lazy_static = { workspace = true }
 pathfinder-common = { path = "../common" }
 pathfinder-crypto = { path = "../crypto" }

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -197,6 +197,14 @@ This should only be enabled for debugging purposes as it adds substantial proces
         action=ArgAction::Set
     )]
     is_rpc_enabled: bool,
+
+    #[arg(
+        long = "gateway-api-key",
+        value_name = "API_KEY",
+        long_help = "Specify an API key for both the Starknet feeder gateway and gateway.",
+        env = "PATHFINDER_GATEWAY_API_KEY"
+    )]
+    gateway_api_key: Option<String>,
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq)]
@@ -438,6 +446,7 @@ pub struct Config {
     pub rpc_batch_concurrency_limit: NonZeroUsize,
     pub is_sync_enabled: bool,
     pub is_rpc_enabled: bool,
+    pub gateway_api_key: Option<String>,
 }
 
 pub struct Ethereum {
@@ -613,6 +622,7 @@ impl Config {
             rpc_batch_concurrency_limit: cli.rpc_batch_concurrency_limit,
             is_sync_enabled: cli.is_sync_enabled,
             is_rpc_enabled: cli.is_rpc_enabled,
+            gateway_api_key: cli.gateway_api_key,
         }
     }
 }

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -94,10 +94,13 @@ async fn async_main() -> anyhow::Result<()> {
             .context("Starting monitoring task")?;
     }
 
-    let pathfinder_context =
-        PathfinderContext::configure_and_proxy_check(network, config.data_directory)
-            .await
-            .context("Configuring pathfinder")?;
+    let pathfinder_context = PathfinderContext::configure_and_proxy_check(
+        network,
+        config.data_directory,
+        config.gateway_api_key,
+    )
+    .await
+    .context("Configuring pathfinder")?;
 
     verify_networks(pathfinder_context.network, ethereum.chain)?;
 
@@ -489,40 +492,41 @@ mod pathfinder_context {
         pub async fn configure_and_proxy_check(
             cfg: NetworkConfig,
             data_directory: PathBuf,
+            api_key: Option<String>,
         ) -> anyhow::Result<Self> {
             let context = match cfg {
                 NetworkConfig::Mainnet => Self {
                     network: Chain::Mainnet,
                     network_id: ChainId::MAINNET,
-                    gateway: GatewayClient::mainnet(),
+                    gateway: GatewayClient::mainnet().with_api_key(api_key),
                     database: data_directory.join("mainnet.sqlite"),
                     l1_core_address: H160::from(core_addr::MAINNET),
                 },
                 NetworkConfig::GoerliTestnet => Self {
                     network: Chain::GoerliTestnet,
                     network_id: ChainId::GOERLI_TESTNET,
-                    gateway: GatewayClient::goerli_testnet(),
+                    gateway: GatewayClient::goerli_testnet().with_api_key(api_key),
                     database: data_directory.join("goerli.sqlite"),
                     l1_core_address: H160::from(core_addr::GOERLI_TESTNET),
                 },
                 NetworkConfig::GoerliIntegration => Self {
                     network: Chain::GoerliIntegration,
                     network_id: ChainId::GOERLI_INTEGRATION,
-                    gateway: GatewayClient::goerli_integration(),
+                    gateway: GatewayClient::goerli_integration().with_api_key(api_key),
                     database: data_directory.join("integration.sqlite"),
                     l1_core_address: H160::from(core_addr::GOERLI_INTEGRATION),
                 },
                 NetworkConfig::SepoliaTestnet => Self {
                     network: Chain::SepoliaTestnet,
                     network_id: ChainId::SEPOLIA_TESTNET,
-                    gateway: GatewayClient::sepolia_testnet(),
+                    gateway: GatewayClient::sepolia_testnet().with_api_key(api_key),
                     database: data_directory.join("testnet-sepolia.sqlite"),
                     l1_core_address: H160::from(core_addr::SEPOLIA_TESTNET),
                 },
                 NetworkConfig::SepoliaIntegration => Self {
                     network: Chain::SepoliaIntegration,
                     network_id: ChainId::SEPOLIA_INTEGRATION,
-                    gateway: GatewayClient::sepolia_integration(),
+                    gateway: GatewayClient::sepolia_integration().with_api_key(api_key),
                     database: data_directory.join("integration-sepolia.sqlite"),
                     l1_core_address: H160::from(core_addr::SEPOLIA_INTEGRATION),
                 },
@@ -530,9 +534,15 @@ mod pathfinder_context {
                     gateway,
                     feeder_gateway,
                     chain_id,
-                } => Self::configure_custom(gateway, feeder_gateway, chain_id, data_directory)
-                    .await
-                    .context("Configuring custom network")?,
+                } => Self::configure_custom(
+                    gateway,
+                    feeder_gateway,
+                    chain_id,
+                    data_directory,
+                    api_key,
+                )
+                .await
+                .context("Configuring custom network")?,
             };
 
             Ok(context)
@@ -546,12 +556,14 @@ mod pathfinder_context {
             feeder: Url,
             chain_id: String,
             data_directory: PathBuf,
+            api_key: Option<String>,
         ) -> anyhow::Result<Self> {
             use pathfinder_crypto::Felt;
             use starknet_gateway_client::GatewayApi;
 
-            let gateway =
-                GatewayClient::with_urls(gateway, feeder).context("Creating gateway client")?;
+            let gateway = GatewayClient::with_urls(gateway, feeder)
+                .context("Creating gateway client")?
+                .with_api_key(api_key);
 
             let network_id =
                 ChainId(Felt::from_be_slice(chain_id.as_bytes()).context("Parsing chain ID")?);


### PR DESCRIPTION
### Important

This branch will NOT be merged into `main`. It should not be removed as it is the base for (EDIT) [v0.10.2-apikey](https://github.com/eqlabs/pathfinder/releases/tag/v0.10.2-apikey) release.