### PR TITLE
config option to set peers explicitly

### DIFF
--- a/crates/crypto/src/algebra/curve/mod.rs
+++ b/crates/crypto/src/algebra/curve/mod.rs
@@ -9,7 +9,7 @@ mod params;
 mod projective;
 
 pub use affine::*;
-pub use params::*;
+
 pub use projective::*;
 
 #[cfg(test)]

--- a/crates/executor/src/pending.rs
+++ b/crates/executor/src/pending.rs
@@ -118,7 +118,7 @@ mod tests {
             _contract_address: starknet_api::core::ContractAddress,
             _key: starknet_api::state::StorageKey,
         ) -> blockifier::state::state_api::StateResult<starknet_api::hash::StarkFelt> {
-            Ok(starknet_api::hash::StarkFelt::try_from(u32::MAX).unwrap())
+            Ok(starknet_api::hash::StarkFelt::from(u32::MAX))
         }
 
         fn get_nonce_at(
@@ -126,7 +126,7 @@ mod tests {
             _contract_address: starknet_api::core::ContractAddress,
         ) -> blockifier::state::state_api::StateResult<starknet_api::core::Nonce> {
             Ok(starknet_api::core::Nonce(
-                starknet_api::hash::StarkFelt::try_from(u32::MAX).unwrap(),
+                starknet_api::hash::StarkFelt::from(u32::MAX),
             ))
         }
 
@@ -135,7 +135,7 @@ mod tests {
             _contract_address: starknet_api::core::ContractAddress,
         ) -> blockifier::state::state_api::StateResult<starknet_api::core::ClassHash> {
             Ok(starknet_api::core::ClassHash(
-                starknet_api::hash::StarkFelt::try_from(u32::MAX).unwrap(),
+                starknet_api::hash::StarkFelt::from(u32::MAX),
             ))
         }
 
@@ -154,7 +154,7 @@ mod tests {
         ) -> blockifier::state::state_api::StateResult<starknet_api::core::CompiledClassHash>
         {
             Ok(starknet_api::core::CompiledClassHash(
-                starknet_api::hash::StarkFelt::try_from(u32::MAX).unwrap(),
+                starknet_api::hash::StarkFelt::from(u32::MAX),
             ))
         }
     }
@@ -175,7 +175,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             nonce,
-            starknet_api::core::Nonce(starknet_api::hash::StarkFelt::try_from(3u8).unwrap(),)
+            starknet_api::core::Nonce(starknet_api::hash::StarkFelt::from(3u8),)
         );
 
         // Nonce not set in pending.
@@ -187,7 +187,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             nonce,
-            starknet_api::core::Nonce(starknet_api::hash::StarkFelt::try_from(u32::MAX).unwrap(),)
+            starknet_api::core::Nonce(starknet_api::hash::StarkFelt::from(u32::MAX),)
         );
     }
 
@@ -218,10 +218,7 @@ mod tests {
                 ),
             )
             .unwrap();
-        assert_eq!(
-            storage,
-            starknet_api::hash::StarkFelt::try_from(4u8).unwrap()
-        );
+        assert_eq!(storage, starknet_api::hash::StarkFelt::from(4u8));
 
         // Storage not set in pending.
         let storage = uut
@@ -240,10 +237,7 @@ mod tests {
                 ),
             )
             .unwrap();
-        assert_eq!(
-            storage,
-            starknet_api::hash::StarkFelt::try_from(u32::MAX).unwrap()
-        );
+        assert_eq!(storage, starknet_api::hash::StarkFelt::from(u32::MAX));
     }
 
     #[test]
@@ -262,7 +256,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             class_hash,
-            starknet_api::core::ClassHash(starknet_api::hash::StarkFelt::try_from(3u8).unwrap())
+            starknet_api::core::ClassHash(starknet_api::hash::StarkFelt::from(3u8))
         );
 
         // Contract not deployed in pending
@@ -274,9 +268,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             class_hash,
-            starknet_api::core::ClassHash(
-                starknet_api::hash::StarkFelt::try_from(u32::MAX).unwrap()
-            )
+            starknet_api::core::ClassHash(starknet_api::hash::StarkFelt::from(u32::MAX))
         );
     }
 }

--- a/crates/p2p/src/main_loop.rs
+++ b/crates/p2p/src/main_loop.rs
@@ -7,7 +7,7 @@ use libp2p::gossipsub::{self, IdentTopic};
 use libp2p::identify;
 use libp2p::kad::{self, BootstrapError, BootstrapOk, QueryId, QueryResult};
 use libp2p::multiaddr::Protocol;
-use libp2p::swarm::dial_opts::{DialOpts, PeerCondition};
+use libp2p::swarm::dial_opts::DialOpts;
 use libp2p::swarm::SwarmEvent;
 use libp2p::PeerId;
 use p2p_proto::block::{BlockBodiesResponse, BlockHeadersResponse};
@@ -704,8 +704,6 @@ impl MainLoop {
                         // and we haven't started dialing yet.
                         DialOpts::peer_id(peer_id)
                             .addresses(vec![addr.clone()])
-                            .condition(PeerCondition::Disconnected)
-                            .extend_addresses_through_behaviour() // TODO not sure if we need it
                             .build(),
                     ) {
                         Ok(_) => {

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -303,7 +303,7 @@ struct P2PCli {
     listen_on: Multiaddr,
     #[arg(
         long = "p2p.bootstrap-addresses",
-        long_help = r#"Comma separated list of multiaddresses to use as bootstrap nodes. The list cannot be empty. Each multiaddress must contain the peer ID of the node.
+        long_help = r#"Comma separated list of multiaddresses to use as bootstrap nodes. Each multiaddress must contain a peer ID. At least one bootstrap node or predefined peer has to be specified.
 
 Example:
     '/ip4/127.0.0.1/9001/p2p/12D3KooWBEkKyufuqCMoZLRhVzq4xdHxVWhhYeBpjw92GSyZ6xaN,/ip4/127.0.0.1/9002/p2p/12D3KooWBEkKyufuqCMoZLRhVzq4xdHxVWhhYeBpjw92GSyZ6xaN'"#,
@@ -314,7 +314,7 @@ Example:
 
     #[arg(
         long = "p2p.predefined-peers",
-        long_help = r#"Comma separated list of multiaddresses to use as peers apart from peers discovered via DHT discovery. The list is optional. Each multiaddress must contain the peer ID of the node.
+        long_help = r#"Comma separated list of multiaddresses to use as peers apart from peers discovered via DHT discovery. Each multiaddress must contain a peer ID.
 
 Example:
     '/ip4/127.0.0.1/9003/p2p/12D3KooWBEkKyufuqCMoZLRhVzq4xdHxVWhhYeBpjw92GSyZ6xaP,/ip4/127.0.0.1/9004/p2p/12D3KooWBEkKyufuqCMoZLRhVzq4xdHxVWhhYeBpjw92GSyZ6xaR'"#,
@@ -487,6 +487,7 @@ pub struct P2PConfig {
     pub identity_config_file: Option<std::path::PathBuf>,
     pub listen_on: Multiaddr,
     pub bootstrap_addresses: Vec<Multiaddr>,
+    pub predefined_peers: Vec<Multiaddr>,
 }
 
 #[cfg(not(feature = "p2p"))]
@@ -555,31 +556,36 @@ impl P2PConfig {
         use p2p::libp2p::multiaddr::Result;
         use std::str::FromStr;
 
+        let parse_multiaddr_vec = |multiaddrs: Vec<String>| -> Vec<Multiaddr> {
+            multiaddrs
+                .into_iter()
+                .map(|addr| Multiaddr::from_str(&addr))
+                .collect::<Result<Vec<_>>>()
+                .unwrap_or_else(|error| {
+                    Cli::command()
+                        .error(ErrorKind::ValueValidation, error)
+                        .exit()
+                })
+        };
+
+        let bootstrap_addresses = parse_multiaddr_vec(args.bootstrap_addresses);
+        let predefined_peers = parse_multiaddr_vec(args.predefined_peers);
+
+        if bootstrap_addresses.is_empty() && predefined_peers.is_empty() {
+            Cli::command()
+                .error(
+                    ErrorKind::ValueValidation,
+                    "Specify at least one bootstrap address or one predefined peer.",
+                )
+                .exit()
+        }
+
         Self {
             proxy: args.proxy,
             identity_config_file: args.identity_config_file,
             listen_on: args.listen_on,
-            bootstrap_addresses: {
-                let x = args
-                    .bootstrap_addresses
-                    .into_iter()
-                    .map(|addr| Multiaddr::from_str(&addr))
-                    .collect::<Result<Vec<_>>>()
-                    .unwrap_or_else(|error| {
-                        Cli::command()
-                            .error(ErrorKind::ValueValidation, error)
-                            .exit()
-                    });
-                x.is_empty().then(|| {
-                    Cli::command()
-                        .error(
-                            ErrorKind::ValueValidation,
-                            "Specify at least one bootstrap address.",
-                        )
-                        .exit()
-                });
-                x
-            },
+            bootstrap_addresses,
+            predefined_peers,
         }
     }
 }

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -303,7 +303,7 @@ struct P2PCli {
     listen_on: Multiaddr,
     #[arg(
         long = "p2p.bootstrap-addresses",
-        long_help = r#"Comma separated list of multiaddresses to use as bootstrap nodes. Each multiaddress must contain a peer ID. At least one bootstrap node or predefined peer has to be specified.
+        long_help = r#"Comma separated list of multiaddresses to use as bootstrap nodes. Each multiaddress must contain a peer ID.
 
 Example:
     '/ip4/127.0.0.1/9001/p2p/12D3KooWBEkKyufuqCMoZLRhVzq4xdHxVWhhYeBpjw92GSyZ6xaN,/ip4/127.0.0.1/9002/p2p/12D3KooWBEkKyufuqCMoZLRhVzq4xdHxVWhhYeBpjw92GSyZ6xaN'"#,
@@ -568,24 +568,12 @@ impl P2PConfig {
                 })
         };
 
-        let bootstrap_addresses = parse_multiaddr_vec(args.bootstrap_addresses);
-        let predefined_peers = parse_multiaddr_vec(args.predefined_peers);
-
-        if bootstrap_addresses.is_empty() && predefined_peers.is_empty() {
-            Cli::command()
-                .error(
-                    ErrorKind::ValueValidation,
-                    "Specify at least one bootstrap address or one predefined peer.",
-                )
-                .exit()
-        }
-
         Self {
             proxy: args.proxy,
             identity_config_file: args.identity_config_file,
             listen_on: args.listen_on,
-            bootstrap_addresses,
-            predefined_peers,
+            bootstrap_addresses: parse_multiaddr_vec(args.bootstrap_addresses),
+            predefined_peers: parse_multiaddr_vec(args.predefined_peers),
         }
     }
 }

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -303,11 +303,25 @@ struct P2PCli {
     listen_on: Multiaddr,
     #[arg(
         long = "p2p.bootstrap-addresses",
-        long_help = "Comma separated list of multiaddresses to use as bootstrap nodes. The list cannot be empty.",
+        long_help = r#"Comma separated list of multiaddresses to use as bootstrap nodes. The list cannot be empty. Each multiaddress must contain the peer ID of the node.
+
+Example:
+    '/ip4/127.0.0.1/9001/p2p/12D3KooWBEkKyufuqCMoZLRhVzq4xdHxVWhhYeBpjw92GSyZ6xaN,/ip4/127.0.0.1/9002/p2p/12D3KooWBEkKyufuqCMoZLRhVzq4xdHxVWhhYeBpjw92GSyZ6xaN'"#,
         value_name = "MULTIADDRESS_LIST",
         env = "PATHFINDER_P2P_BOOTSTRAP_ADDRESSES"
     )]
     bootstrap_addresses: Vec<String>,
+
+    #[arg(
+        long = "p2p.predefined-peers",
+        long_help = r#"Comma separated list of multiaddresses to use as peers apart from peers discovered via DHT discovery. The list is optional. Each multiaddress must contain the peer ID of the node.
+
+Example:
+    '/ip4/127.0.0.1/9003/p2p/12D3KooWBEkKyufuqCMoZLRhVzq4xdHxVWhhYeBpjw92GSyZ6xaP,/ip4/127.0.0.1/9004/p2p/12D3KooWBEkKyufuqCMoZLRhVzq4xdHxVWhhYeBpjw92GSyZ6xaR'"#,
+        value_name = "MULTIADDRESS_LIST",
+        env = "PATHFINDER_P2P_PREDEFINED_PEERS"
+    )]
+    predefined_peers: Vec<String>,
 }
 
 #[cfg(feature = "p2p")]

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -382,6 +382,7 @@ async fn start_p2p(
         keypair,
         listen_on: config.listen_on,
         bootstrap_addresses: config.bootstrap_addresses,
+        predefined_peers: config.predefined_peers,
     };
 
     let (_p2p_peers, p2p_client, head_receiver, p2p_handle) =

--- a/crates/rpc/src/jsonrpc.rs
+++ b/crates/rpc/src/jsonrpc.rs
@@ -6,8 +6,8 @@ pub mod websocket;
 
 pub use error::RpcError;
 pub use request::RpcRequest;
-pub use response::{RpcResponse, RpcResult};
-pub use router::{rpc_handler, IntoRpcMethod, RpcMethodHandler, RpcRouter, RpcRouterBuilder};
+pub use response::RpcResponse;
+pub use router::{rpc_handler, RpcRouter, RpcRouterBuilder};
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum RequestId<'a> {

--- a/crates/rpc/src/v04/method/pending_transactions.rs
+++ b/crates/rpc/src/v04/method/pending_transactions.rs
@@ -40,7 +40,7 @@ pub async fn pending_transactions(
 
 #[cfg(test)]
 mod tests {
-    use crate::v04::types::Transaction;
+    use crate::v04::types::transaction::Transaction;
 
     use super::*;
     use pathfinder_common::macro_prelude::*;

--- a/crates/rpc/src/v04/types.rs
+++ b/crates/rpc/src/v04/types.rs
@@ -1,3 +1,3 @@
-mod transaction;
+pub(crate) mod transaction;
 
-pub use transaction::{Transaction, TransactionWithHash};
+pub use transaction::TransactionWithHash;

--- a/crates/rpc/src/v06/types.rs
+++ b/crates/rpc/src/v06/types.rs
@@ -1,6 +1,6 @@
 mod transaction;
 
-pub use transaction::{Transaction, TransactionWithHash};
+pub use transaction::TransactionWithHash;
 
 use crate::felt::RpcFelt;
 use pathfinder_common::{

--- a/crates/storage/src/connection/transaction.rs
+++ b/crates/storage/src/connection/transaction.rs
@@ -446,11 +446,7 @@ mod tests {
             .collect();
         assert_eq!(transactions.len(), receipts.len());
 
-        let body = transactions
-            .into_iter()
-            .zip(receipts)
-            .map(|(t, r)| (t, r))
-            .collect::<Vec<_>>();
+        let body = transactions.into_iter().zip(receipts).collect::<Vec<_>>();
 
         let mut db = crate::Storage::in_memory().unwrap().connection().unwrap();
         let db_tx = db.transaction().unwrap();


### PR DESCRIPTION
This PR:
- adds the `p2p.predefined-peers` config option, which is a list of peers that we'd like to dial and add to the dht immediately after starting pathfinder; it's an addition to how the node used to work, which is using bootstrap nodes and periodic node discovery (rebootstraping)
- removes the requirement of setting at least one bootstrap node when starting pathfinder
- fixes #1655 