### PR TITLE
Fix clippy errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
           cargo clean
           rm -rf ~/.cargo/registry
           rm -rf ~/.cargo/git
-      - run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings -D rust_2018_idioms
+      - run: cargo clippy --tests --workspace --all-targets --all-features --locked -- -D warnings -D rust_2018_idioms
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/crates/crypto/src/algebra/curve/mod.rs
+++ b/crates/crypto/src/algebra/curve/mod.rs
@@ -9,7 +9,6 @@ mod params;
 mod projective;
 
 pub use affine::*;
-pub use params::*;
 pub use projective::*;
 
 #[cfg(test)]

--- a/crates/executor/src/pending.rs
+++ b/crates/executor/src/pending.rs
@@ -118,7 +118,7 @@ mod tests {
             _contract_address: starknet_api::core::ContractAddress,
             _key: starknet_api::state::StorageKey,
         ) -> blockifier::state::state_api::StateResult<starknet_api::hash::StarkFelt> {
-            Ok(starknet_api::hash::StarkFelt::try_from(u32::MAX).unwrap())
+            Ok(starknet_api::hash::StarkFelt::from(u32::MAX))
         }
 
         fn get_nonce_at(
@@ -126,7 +126,7 @@ mod tests {
             _contract_address: starknet_api::core::ContractAddress,
         ) -> blockifier::state::state_api::StateResult<starknet_api::core::Nonce> {
             Ok(starknet_api::core::Nonce(
-                starknet_api::hash::StarkFelt::try_from(u32::MAX).unwrap(),
+                starknet_api::hash::StarkFelt::from(u32::MAX),
             ))
         }
 
@@ -135,7 +135,7 @@ mod tests {
             _contract_address: starknet_api::core::ContractAddress,
         ) -> blockifier::state::state_api::StateResult<starknet_api::core::ClassHash> {
             Ok(starknet_api::core::ClassHash(
-                starknet_api::hash::StarkFelt::try_from(u32::MAX).unwrap(),
+                starknet_api::hash::StarkFelt::from(u32::MAX),
             ))
         }
 
@@ -154,7 +154,7 @@ mod tests {
         ) -> blockifier::state::state_api::StateResult<starknet_api::core::CompiledClassHash>
         {
             Ok(starknet_api::core::CompiledClassHash(
-                starknet_api::hash::StarkFelt::try_from(u32::MAX).unwrap(),
+                starknet_api::hash::StarkFelt::from(u32::MAX),
             ))
         }
     }
@@ -175,7 +175,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             nonce,
-            starknet_api::core::Nonce(starknet_api::hash::StarkFelt::try_from(3u8).unwrap(),)
+            starknet_api::core::Nonce(starknet_api::hash::StarkFelt::from(3u8))
         );
 
         // Nonce not set in pending.
@@ -187,7 +187,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             nonce,
-            starknet_api::core::Nonce(starknet_api::hash::StarkFelt::try_from(u32::MAX).unwrap(),)
+            starknet_api::core::Nonce(starknet_api::hash::StarkFelt::from(u32::MAX))
         );
     }
 
@@ -218,10 +218,7 @@ mod tests {
                 ),
             )
             .unwrap();
-        assert_eq!(
-            storage,
-            starknet_api::hash::StarkFelt::try_from(4u8).unwrap()
-        );
+        assert_eq!(storage, starknet_api::hash::StarkFelt::from(4u8));
 
         // Storage not set in pending.
         let storage = uut
@@ -240,10 +237,7 @@ mod tests {
                 ),
             )
             .unwrap();
-        assert_eq!(
-            storage,
-            starknet_api::hash::StarkFelt::try_from(u32::MAX).unwrap()
-        );
+        assert_eq!(storage, starknet_api::hash::StarkFelt::from(u32::MAX));
     }
 
     #[test]
@@ -262,7 +256,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             class_hash,
-            starknet_api::core::ClassHash(starknet_api::hash::StarkFelt::try_from(3u8).unwrap())
+            starknet_api::core::ClassHash(starknet_api::hash::StarkFelt::from(3u8))
         );
 
         // Contract not deployed in pending
@@ -274,9 +268,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             class_hash,
-            starknet_api::core::ClassHash(
-                starknet_api::hash::StarkFelt::try_from(u32::MAX).unwrap()
-            )
+            starknet_api::core::ClassHash(starknet_api::hash::StarkFelt::from(u32::MAX))
         );
     }
 }

--- a/crates/rpc/src/jsonrpc.rs
+++ b/crates/rpc/src/jsonrpc.rs
@@ -7,7 +7,7 @@ pub mod websocket;
 pub use error::RpcError;
 pub use request::RpcRequest;
 pub use response::{RpcResponse, RpcResult};
-pub use router::{rpc_handler, IntoRpcMethod, RpcMethodHandler, RpcRouter, RpcRouterBuilder};
+pub use router::{rpc_handler, RpcRouter, RpcRouterBuilder};
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum RequestId<'a> {

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -16,7 +16,7 @@ use tracing::Instrument;
 use crate::context::RpcContext;
 use crate::jsonrpc::error::RpcError;
 use crate::jsonrpc::request::{RawParams, RpcRequest};
-use crate::jsonrpc::response::{RpcResponse, RpcResult};
+use crate::jsonrpc::{RpcResponse, RpcResult};
 
 #[derive(Clone)]
 pub struct RpcRouter {

--- a/crates/rpc/src/v04/types.rs
+++ b/crates/rpc/src/v04/types.rs
@@ -1,3 +1,4 @@
 mod transaction;
 
+#[allow(unused_imports)]
 pub use transaction::{Transaction, TransactionWithHash};

--- a/crates/rpc/src/v06/types.rs
+++ b/crates/rpc/src/v06/types.rs
@@ -1,6 +1,6 @@
 mod transaction;
 
-pub use transaction::{Transaction, TransactionWithHash};
+pub use transaction::TransactionWithHash;
 
 use crate::felt::RpcFelt;
 use pathfinder_common::{

--- a/crates/storage/src/connection/transaction.rs
+++ b/crates/storage/src/connection/transaction.rs
@@ -446,11 +446,7 @@ mod tests {
             .collect();
         assert_eq!(transactions.len(), receipts.len());
 
-        let body = transactions
-            .into_iter()
-            .zip(receipts)
-            .map(|(t, r)| (t, r))
-            .collect::<Vec<_>>();
+        let body = transactions.into_iter().zip(receipts).collect::<Vec<_>>();
 
         let mut db = crate::Storage::in_memory().unwrap().connection().unwrap();
         let db_tx = db.transaction().unwrap();


### PR DESCRIPTION
Fix clippy errors when running
```
cargo clippy --tests --workspace --all-targets --all-features --locked -- -D warnings -D rust_2018_idioms
```

Also, I added the `--tests` flag to clippy in CI since it's more correct (we want to lint tests as well, and we don't want to be getting "code unused" errors for e.g. re-exports used only by the tests, as was the case in this PR).