### PR TITLE
Report RPC input parsing errors

### DIFF
--- a/crates/rpc/src/jsonrpc/error.rs
+++ b/crates/rpc/src/jsonrpc/error.rs
@@ -5,7 +5,7 @@ use serde_json::{json, Value};
 
 #[derive(Debug)]
 pub enum RpcError {
-    ParseError,
+    ParseError(String),
     InvalidRequest(String),
     MethodNotFound,
     InvalidParams(String),
@@ -30,7 +30,7 @@ impl RpcError {
     pub fn code(&self) -> i32 {
         // From the json-rpc specification: https://www.jsonrpc.org/specification#error_object
         match self {
-            RpcError::ParseError => -32700,
+            RpcError::ParseError(..) => -32700,
             RpcError::InvalidRequest(..) => -32600,
             RpcError::MethodNotFound { .. } => -32601,
             RpcError::InvalidParams(..) => -32602,
@@ -42,7 +42,7 @@ impl RpcError {
 
     pub fn message(&self) -> Cow<'_, str> {
         match self {
-            RpcError::ParseError => "Parse error".into(),
+            RpcError::ParseError(..) => "Parse error".into(),
             RpcError::InvalidRequest(..) => "Invalid request".into(),
             RpcError::MethodNotFound { .. } => "Method not found".into(),
             RpcError::InvalidParams(..) => "Invalid params".into(),
@@ -63,14 +63,12 @@ impl RpcError {
             })),
             RpcError::ApplicationError(e) => e.data(),
             RpcError::InternalError(_) => None,
-            RpcError::ParseError => None,
-            RpcError::InvalidRequest(e) => Some(json!({
-                "reason": e
-            })),
             RpcError::MethodNotFound => None,
-            RpcError::InvalidParams(e) => Some(json!({
-                "reason": e
-            })),
+            RpcError::ParseError(e) | RpcError::InvalidRequest(e) | RpcError::InvalidParams(e) => {
+                Some(json!({
+                    "reason": e
+                }))
+            }
         }
     }
 }

--- a/crates/rpc/src/jsonrpc/response.rs
+++ b/crates/rpc/src/jsonrpc/response.rs
@@ -13,10 +13,12 @@ pub struct RpcResponse<'a> {
 }
 
 impl<'a> RpcResponse<'a> {
-    pub const PARSE_ERROR: Self = Self {
-        output: Err(RpcError::ParseError),
-        id: RequestId::Null,
-    };
+    pub const fn parse_error(error: String) -> RpcResponse<'a> {
+        Self {
+            output: Err(RpcError::ParseError(error)),
+            id: RequestId::Null,
+        }
+    }
 
     pub const fn invalid_request(error: String) -> RpcResponse<'a> {
         Self {


### PR DESCRIPTION
Report more detailed RPC errors for syntactically invalid inputs. Fixes https://github.com/eqlabs/pathfinder/issues/1623.
