### PR TITLE
fix(rpc/get_events): fix pending events key filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- `starknet_getEvents` incorrectly evaluates empty sub-lists in key filters for pending events.
+
 ## [0.10.3] - 2024-01-04
 
 ### Added

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -635,7 +635,10 @@ pub mod test_utils {
                     Event {
                         data: vec![],
                         from_address: contract_address!("0xabcddddddd"),
-                        keys: vec![event_key_bytes!(b"pending key")],
+                        keys: vec![
+                            event_key_bytes!(b"pending key"),
+                            event_key_bytes!(b"second pending key"),
+                        ],
                     },
                     Event {
                         data: vec![],

--- a/crates/rpc/src/v03/method/get_events.rs
+++ b/crates/rpc/src/v03/method/get_events.rs
@@ -113,6 +113,12 @@ pub async fn get_events(
     }
 
     let storage = context.storage.clone();
+
+    // truncate empty key lists from the end of the key filter
+    let mut keys = request.keys.clone();
+    if let Some(last_non_empty) = keys.iter().rposition(|keys| !keys.is_empty()) {
+        keys.truncate(last_non_empty + 1);
+    }
     let keys = V03KeyFilter::new(request.keys.clone());
 
     // blocking task to perform database event query
@@ -420,14 +426,15 @@ fn append_pending_events(
                 return true;
             }
 
-            let keys_to_check = std::cmp::min(keys.len(), event.keys.len());
+            if event.keys.len() < keys.len() {
+                return false;
+            }
 
             event
                 .keys
                 .iter()
                 .zip(keys.iter())
-                .take(keys_to_check)
-                .all(|(key, filter)| filter.contains(key))
+                .all(|(key, filter)| filter.is_empty() || filter.contains(key))
         })
         .skip(skip)
         // We need to take an extra event to determine is_last_page.
@@ -1042,6 +1049,42 @@ mod tests {
             let result = get_events(context.clone(), input.clone()).await.unwrap();
             assert_eq!(result.events, &all[0..1]);
             assert_eq!(result.continuation_token, None);
+        }
+
+        #[tokio::test]
+        async fn key_matching() {
+            let context = RpcContext::for_tests_with_pending().await;
+
+            let mut input = GetEventsInput {
+                filter: EventFilter {
+                    from_block: Some(BlockId::Pending),
+                    to_block: Some(BlockId::Pending),
+                    address: None,
+                    keys: vec![],
+                    chunk_size: 1024,
+                    continuation_token: None,
+                },
+            };
+
+            let all = get_events(context.clone(), input.clone())
+                .await
+                .unwrap()
+                .events;
+            assert_eq!(all.len(), 3);
+
+            input.filter.keys = vec![vec![event_key_bytes!(b"pending key 2")]];
+            let events = get_events(context.clone(), input.clone())
+                .await
+                .unwrap()
+                .events;
+            assert_eq!(events, &all[2..3]);
+
+            input.filter.keys = vec![vec![], vec![event_key_bytes!(b"second pending key")]];
+            let events = get_events(context.clone(), input.clone())
+                .await
+                .unwrap()
+                .events;
+            assert_eq!(events, &all[1..2]);
         }
     }
 }

--- a/crates/rpc/src/v04/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v04/method/get_transaction_receipt.rs
@@ -608,7 +608,10 @@ mod tests {
                             Event {
                                 data: vec![],
                                 from_address: contract_address!("0xabcddddddd"),
-                                keys: vec![event_key_bytes!(b"pending key")],
+                                keys: vec![
+                                    event_key_bytes!(b"pending key"),
+                                    event_key_bytes!(b"second pending key")
+                                ],
                             },
                             Event {
                                 data: vec![],

--- a/crates/rpc/src/v06/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v06/method/get_transaction_receipt.rs
@@ -947,7 +947,10 @@ mod tests {
                             Event {
                                 data: vec![],
                                 from_address: contract_address!("0xabcddddddd"),
-                                keys: vec![event_key_bytes!(b"pending key")],
+                                keys: vec![
+                                    event_key_bytes!(b"pending key"),
+                                    event_key_bytes!(b"second pending key")
+                                ],
                             },
                             Event {
                                 data: vec![],


### PR DESCRIPTION
Empty lists in the key filter array were not handled correctly: these are supposed to match all events, but the code was treating them as non-matching.

Closes #1666 