### PR TITLE
fix(rpc/get_events): use truncated key list for filter

### DIFF
--- a/crates/rpc/src/v03/method/get_events.rs
+++ b/crates/rpc/src/v03/method/get_events.rs
@@ -119,7 +119,7 @@ pub async fn get_events(
     if let Some(last_non_empty) = keys.iter().rposition(|keys| !keys.is_empty()) {
         keys.truncate(last_non_empty + 1);
     }
-    let keys = V03KeyFilter::new(request.keys.clone());
+    let keys = V03KeyFilter::new(keys);
 
     // blocking task to perform database event query
     let span = tracing::Span::current();


### PR DESCRIPTION
In the fix for issue #1666 a bug slipped in: after truncating the list of keys we should use the _truncated_ list to construct the filter.
