### PR TITLE
feat(p2p_proto): remove redundant address fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5742,6 +5742,7 @@ dependencies = [
  "pathfinder-crypto",
  "prost 0.12.1",
  "rand",
+ "rayon",
  "rstest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ num-bigint = { version = "0.4.4", features = ["serde"] }
 primitive-types = "0.12.1"
 pretty_assertions_sorted = "1.2.3"
 rand = "0.8.5"
+rayon = "1.8.0"
 reqwest = { version = "0.11.18", features = ["json"] }
 rstest = "0.18.2"
 semver = "1.0.18"

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -579,6 +579,8 @@ pub fn deployed_contract_address(
 
 #[cfg(test)]
 mod tests {
+    use crate::{felt, CallParam, ClassHash, ContractAddress, ContractAddressSalt};
+
     #[test]
     fn constructor_entry_point() {
         use crate::truncated_keccak;
@@ -642,5 +644,22 @@ mod tests {
                 serde_json::from_str::<BlockId>(r#"{"block_hash": "0xdeadbeef"}"#).unwrap();
             assert_eq!(result, BlockId::Hash(block_hash!("0xdeadbeef")));
         }
+    }
+
+    #[test]
+    fn deployed_contract_address() {
+        let expected_contract_address = ContractAddress(felt!(
+            "0x2fab82e4aef1d8664874e1f194951856d48463c3e6bf9a8c68e234a629a6f50"
+        ));
+        let actual_contract_address = super::deployed_contract_address(
+            std::iter::once(CallParam(felt!(
+                "0x5cd65f3d7daea6c63939d659b8473ea0c5cd81576035a4d34e52fb06840196c"
+            ))),
+            &ContractAddressSalt(felt!("0x0")),
+            &ClassHash(felt!(
+                "0x2338634f11772ea342365abd5be9d9dc8a6f44f159ad782fdebd3db5d969738"
+            )),
+        );
+        assert_eq!(actual_contract_address, expected_contract_address);
     }
 }

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -516,18 +516,13 @@ impl ContractAddress {
         .finalize();
 
         // Contract addresses are _less than_ 2**251 - 256
-        let contract_address =
-            primitive_types::U256::from_big_endian(contract_address.as_be_bytes());
-        let max_address = primitive_types::U256::from_str_radix(
-            "0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00",
-            16,
-        )
-        .unwrap();
-
-        let contract_address = contract_address.rem(max_address);
-        let mut b = [0u8; 32];
-        contract_address.to_big_endian(&mut b);
-        let contract_address = Felt::from_be_slice(&b).unwrap();
+        const MAX_CONTRACT_ADDRESS: Felt =
+            felt!("0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00");
+        let contract_address = if contract_address >= MAX_CONTRACT_ADDRESS {
+            contract_address - MAX_CONTRACT_ADDRESS
+        } else {
+            contract_address
+        };
 
         ContractAddress::new_or_panic(contract_address)
     }

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -488,6 +488,51 @@ macros::felt_newtypes!(
 macros::fmt::thin_display!(BlockNumber);
 macros::fmt::thin_display!(BlockTimestamp);
 
+impl ContractAddress {
+    pub fn deployed_contract_address(
+        constructor_calldata: impl Iterator<Item = CallParam>,
+        contract_address_salt: &ContractAddressSalt,
+        class_hash: &ClassHash,
+    ) -> Self {
+        let constructor_calldata_hash = constructor_calldata
+            .fold(HashChain::default(), |mut h, param| {
+                h.update(param.0);
+                h
+            })
+            .finalize();
+
+        let contract_address = [
+            Felt::from_be_slice(b"STARKNET_CONTRACT_ADDRESS").expect("prefix is convertible"),
+            Felt::ZERO,
+            contract_address_salt.0,
+            class_hash.0,
+            constructor_calldata_hash,
+        ]
+        .into_iter()
+        .fold(HashChain::default(), |mut h, e| {
+            h.update(e);
+            h
+        })
+        .finalize();
+
+        // Contract addresses are _less than_ 2**251 - 256
+        let contract_address =
+            primitive_types::U256::from_big_endian(contract_address.as_be_bytes());
+        let max_address = primitive_types::U256::from_str_radix(
+            "0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00",
+            16,
+        )
+        .unwrap();
+
+        let contract_address = contract_address.rem(max_address);
+        let mut b = [0u8; 32];
+        contract_address.to_big_endian(&mut b);
+        let contract_address = Felt::from_be_slice(&b).unwrap();
+
+        ContractAddress::new_or_panic(contract_address)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum AllowedOrigins {
     Any,
@@ -533,48 +578,6 @@ pub fn calculate_class_commitment_leaf_hash(
         )
         .into(),
     )
-}
-
-pub fn deployed_contract_address(
-    constructor_calldata: impl Iterator<Item = CallParam>,
-    contract_address_salt: &ContractAddressSalt,
-    class_hash: &ClassHash,
-) -> ContractAddress {
-    let constructor_calldata_hash = constructor_calldata
-        .fold(HashChain::default(), |mut h, param| {
-            h.update(param.0);
-            h
-        })
-        .finalize();
-
-    let contract_address = [
-        Felt::from_be_slice(b"STARKNET_CONTRACT_ADDRESS").expect("prefix is convertible"),
-        Felt::ZERO,
-        contract_address_salt.0,
-        class_hash.0,
-        constructor_calldata_hash,
-    ]
-    .into_iter()
-    .fold(HashChain::default(), |mut h, e| {
-        h.update(e);
-        h
-    })
-    .finalize();
-
-    // Contract addresses are _less than_ 2**251 - 256
-    let contract_address = primitive_types::U256::from_big_endian(contract_address.as_be_bytes());
-    let max_address = primitive_types::U256::from_str_radix(
-        "0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00",
-        16,
-    )
-    .unwrap();
-
-    let contract_address = contract_address.rem(max_address);
-    let mut b = [0u8; 32];
-    contract_address.to_big_endian(&mut b);
-    let contract_address = Felt::from_be_slice(&b).unwrap();
-
-    ContractAddress::new_or_panic(contract_address)
 }
 
 #[cfg(test)]
@@ -651,7 +654,7 @@ mod tests {
         let expected_contract_address = ContractAddress(felt!(
             "0x2fab82e4aef1d8664874e1f194951856d48463c3e6bf9a8c68e234a629a6f50"
         ));
-        let actual_contract_address = super::deployed_contract_address(
+        let actual_contract_address = ContractAddress::deployed_contract_address(
             std::iter::once(CallParam(felt!(
                 "0x5cd65f3d7daea6c63939d659b8473ea0c5cd81576035a4d34e52fb06840196c"
             ))),

--- a/crates/crypto/src/algebra/field/felt.rs
+++ b/crates/crypto/src/algebra/field/felt.rs
@@ -269,6 +269,15 @@ impl std::ops::Add for Felt {
     }
 }
 
+impl std::ops::Sub for Felt {
+    type Output = Felt;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        let result = MontFelt::from(self) - MontFelt::from(rhs);
+        Felt::from(result)
+    }
+}
+
 impl From<MontFelt> for Felt {
     fn from(fp: MontFelt) -> Self {
         // safe as BE-bytes representations are the same

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -211,11 +211,11 @@ pub mod transaction_status {
 pub mod transaction {
     use fake::{Dummy, Fake, Faker};
     use pathfinder_common::{
-        AccountDeploymentDataElem, CallParam, CasmHash, ClassHash, ConstructorParam,
-        ContractAddress, ContractAddressSalt, EntryPoint, EthereumAddress, Fee, L1ToL2MessageNonce,
-        L1ToL2MessagePayloadElem, L2ToL1MessagePayloadElem, PaymasterDataElem, ResourceAmount,
-        ResourcePricePerUnit, Tip, TransactionHash, TransactionIndex, TransactionNonce,
-        TransactionSignatureElem, TransactionVersion,
+        deployed_contract_address, AccountDeploymentDataElem, CallParam, CasmHash, ClassHash,
+        ConstructorParam, ContractAddress, ContractAddressSalt, EntryPoint, EthereumAddress, Fee,
+        L1ToL2MessageNonce, L1ToL2MessagePayloadElem, L2ToL1MessagePayloadElem, PaymasterDataElem,
+        ResourceAmount, ResourcePricePerUnit, Tip, TransactionHash, TransactionIndex,
+        TransactionNonce, TransactionSignatureElem, TransactionVersion,
     };
     use pathfinder_crypto::Felt;
     use pathfinder_serde::{
@@ -1361,18 +1361,24 @@ pub mod transaction {
 
     impl<T> Dummy<T> for DeployAccountTransactionV0V1 {
         fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &T, rng: &mut R) -> Self {
-            Self {
-                // TODO verify this is the only realistic value
-                version: TransactionVersion::ONE,
+            let contract_address_salt = Faker.fake_with_rng(rng);
+            let constructor_calldata: Vec<CallParam> = Faker.fake_with_rng(rng);
+            let class_hash = Faker.fake_with_rng(rng);
 
-                contract_address: Faker.fake_with_rng(rng),
+            Self {
+                version: TransactionVersion::ONE,
+                contract_address: deployed_contract_address(
+                    constructor_calldata.iter().copied(),
+                    &contract_address_salt,
+                    &class_hash,
+                ),
                 transaction_hash: Faker.fake_with_rng(rng),
                 max_fee: Faker.fake_with_rng(rng),
                 signature: Faker.fake_with_rng(rng),
                 nonce: Faker.fake_with_rng(rng),
-                contract_address_salt: Faker.fake_with_rng(rng),
-                constructor_calldata: Faker.fake_with_rng(rng),
-                class_hash: Faker.fake_with_rng(rng),
+                contract_address_salt,
+                constructor_calldata,
+                class_hash,
             }
         }
     }
@@ -1402,6 +1408,10 @@ pub mod transaction {
 
     impl<T> Dummy<T> for DeployAccountTransactionV3 {
         fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &T, rng: &mut R) -> Self {
+            let contract_address_salt = Faker.fake_with_rng(rng);
+            let constructor_calldata: Vec<CallParam> = Faker.fake_with_rng(rng);
+            let class_hash = Faker.fake_with_rng(rng);
+
             Self {
                 nonce: Faker.fake_with_rng(rng),
                 nonce_data_availability_mode: Faker.fake_with_rng(rng),
@@ -1410,13 +1420,17 @@ pub mod transaction {
                 tip: Faker.fake_with_rng(rng),
                 paymaster_data: vec![Faker.fake_with_rng(rng)], // TODO p2p allows 1 elem only
 
-                sender_address: Faker.fake_with_rng(rng),
+                sender_address: deployed_contract_address(
+                    constructor_calldata.iter().copied(),
+                    &contract_address_salt,
+                    &class_hash,
+                ),
                 signature: Faker.fake_with_rng(rng),
                 transaction_hash: Faker.fake_with_rng(rng),
                 version: TransactionVersion::THREE,
-                contract_address_salt: Faker.fake_with_rng(rng),
-                constructor_calldata: Faker.fake_with_rng(rng),
-                class_hash: Faker.fake_with_rng(rng),
+                contract_address_salt,
+                constructor_calldata,
+                class_hash,
             }
         }
     }

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -211,11 +211,11 @@ pub mod transaction_status {
 pub mod transaction {
     use fake::{Dummy, Fake, Faker};
     use pathfinder_common::{
-        deployed_contract_address, AccountDeploymentDataElem, CallParam, CasmHash, ClassHash,
-        ConstructorParam, ContractAddress, ContractAddressSalt, EntryPoint, EthereumAddress, Fee,
-        L1ToL2MessageNonce, L1ToL2MessagePayloadElem, L2ToL1MessagePayloadElem, PaymasterDataElem,
-        ResourceAmount, ResourcePricePerUnit, Tip, TransactionHash, TransactionIndex,
-        TransactionNonce, TransactionSignatureElem, TransactionVersion,
+        AccountDeploymentDataElem, CallParam, CasmHash, ClassHash, ConstructorParam,
+        ContractAddress, ContractAddressSalt, EntryPoint, EthereumAddress, Fee, L1ToL2MessageNonce,
+        L1ToL2MessagePayloadElem, L2ToL1MessagePayloadElem, PaymasterDataElem, ResourceAmount,
+        ResourcePricePerUnit, Tip, TransactionHash, TransactionIndex, TransactionNonce,
+        TransactionSignatureElem, TransactionVersion,
     };
     use pathfinder_crypto::Felt;
     use pathfinder_serde::{
@@ -1367,7 +1367,7 @@ pub mod transaction {
 
             Self {
                 version: TransactionVersion::ONE,
-                contract_address: deployed_contract_address(
+                contract_address: ContractAddress::deployed_contract_address(
                     constructor_calldata.iter().copied(),
                     &contract_address_salt,
                     &class_hash,
@@ -1420,7 +1420,7 @@ pub mod transaction {
                 tip: Faker.fake_with_rng(rng),
                 paymaster_data: vec![Faker.fake_with_rng(rng)], // TODO p2p allows 1 elem only
 
-                sender_address: deployed_contract_address(
+                sender_address: ContractAddress::deployed_contract_address(
                     constructor_calldata.iter().copied(),
                     &contract_address_salt,
                     &class_hash,

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -37,7 +37,7 @@ pathfinder-common = { path = "../common" }
 pathfinder-crypto = { path = "../crypto" }
 prost = "0.12.1"
 rand = { workspace = true }
-rayon = "1.8.0"
+rayon = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = "0.10.7"

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -37,6 +37,7 @@ pathfinder-common = { path = "../common" }
 pathfinder-crypto = { path = "../crypto" }
 prost = "0.12.1"
 rand = { workspace = true }
+rayon = "1.8.0"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = "0.10.7"

--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -14,23 +14,23 @@ use p2p_proto::event::EventsRequest;
 use p2p_proto::receipt::{Receipt, ReceiptsRequest};
 use p2p_proto::transaction::TransactionsRequest;
 use pathfinder_common::{
-    event::Event, transaction::TransactionVariant, BlockHash, BlockNumber, ContractAddress,
-    TransactionHash,
+    event::Event,
+    transaction::{DeployAccountTransactionV0V1, DeployAccountTransactionV3, TransactionVariant},
+    BlockHash, BlockNumber, ContractAddress, TransactionHash,
 };
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use tokio::sync::RwLock;
 
-use crate::sync::protocol;
-use crate::{
-    client::{peer_aware, types::StateUpdateWithDefinitions},
-    peers,
+use crate::client::peer_aware;
+use crate::client::types::{
+    MaybeSignedBlockHeader, RawDeployAccountTransaction, StateUpdateWithDefinitions,
 };
+use crate::peers;
+use crate::sync::protocol;
 
 mod parse;
 
 use parse::ParserState;
-
-use super::types::MaybeSignedBlockHeader;
 
 #[derive(Clone, Debug)]
 pub struct Client {
@@ -239,53 +239,18 @@ impl Client {
             match response_receiver {
                 Ok(rx) => {
                     if let Some(parsed) = parse::<parse::transactions::State>(&peer, rx).await {
-                        let deploy_account = parsed.deploy_account;
-                        let mut parsed = parsed.other;
-
                         let (tx, rx) = tokio::sync::oneshot::channel();
 
-                        rayon::spawn(move || {
-                            // Now we can compute the missing addresses
-                            let computed: Vec<_> = deploy_account
-                                .into_par_iter()
-                                .map(|(block_hash, transactions)| {
-                                    (
-                                        block_hash,
-                                        transactions
-                                            .into_par_iter()
-                                            .map(|t| match t {
-                                                TransactionVariant::DeployAccountV0V1(mut x) => {
-                                                    let contract_address =
-                                                        ContractAddress::deployed_contract_address(
-                                                            x.constructor_calldata.iter().copied(),
-                                                            &x.contract_address_salt,
-                                                            &x.class_hash,
-                                                        );
-                                                    x.contract_address = contract_address;
-                                                    TransactionVariant::DeployAccountV0V1(x)
-                                                }
-                                                TransactionVariant::DeployAccountV3(mut x) => {
-                                                    let contract_address =
-                                                        ContractAddress::deployed_contract_address(
-                                                            x.constructor_calldata.iter().copied(),
-                                                            &x.contract_address_salt,
-                                                            &x.class_hash,
-                                                        );
-                                                    x.contract_address = contract_address;
-                                                    TransactionVariant::DeployAccountV3(x)
-                                                }
-                                                _ => unreachable!(),
-                                            })
-                                            .collect::<Vec<_>>(),
-                                    )
-                                })
-                                .collect();
-
-                            // Send the result back to Tokio.
-                            let _ = tx.send(computed);
-                        });
+                        compute_contract_addresses(parsed.deploy_account, tx);
 
                         let computed = rx.await?;
+                        let mut parsed: HashMap<_, _> = parsed
+                            .other
+                            .into_iter()
+                            .map(|(h, txns)| {
+                                (h, txns.into_iter().map(|t| t.into_variant()).collect())
+                            })
+                            .collect();
                         parsed.extend(computed);
 
                         return Ok(parsed);
@@ -381,6 +346,71 @@ impl Client {
             "No valid responses to events request: start {start_block_hash}, n {num_blocks}"
         )
     }
+}
+
+/// Does not block the current thread.
+fn compute_contract_addresses(
+    deploy_account: HashMap<BlockHash, Vec<super::types::RawDeployAccountTransaction>>,
+    tx: tokio::sync::oneshot::Sender<Vec<(BlockHash, Vec<TransactionVariant>)>>,
+) {
+    rayon::spawn(move || {
+        // Now we can compute the missing addresses
+        let computed: Vec<_> = deploy_account
+            .into_par_iter()
+            .map(|(block_hash, transactions)| {
+                (
+                    block_hash,
+                    transactions
+                        .into_par_iter()
+                        .map(|t| match t {
+                            RawDeployAccountTransaction::DeployAccountV0V1(x) => {
+                                let contract_address = ContractAddress::deployed_contract_address(
+                                    x.constructor_calldata.iter().copied(),
+                                    &x.contract_address_salt,
+                                    &x.class_hash,
+                                );
+                                TransactionVariant::DeployAccountV0V1(
+                                    DeployAccountTransactionV0V1 {
+                                        contract_address,
+                                        max_fee: x.max_fee,
+                                        version: x.version,
+                                        signature: x.signature,
+                                        nonce: x.nonce,
+                                        contract_address_salt: x.contract_address_salt,
+                                        constructor_calldata: x.constructor_calldata,
+                                        class_hash: x.class_hash,
+                                    },
+                                )
+                            }
+                            RawDeployAccountTransaction::DeployAccountV3(x) => {
+                                let contract_address = ContractAddress::deployed_contract_address(
+                                    x.constructor_calldata.iter().copied(),
+                                    &x.contract_address_salt,
+                                    &x.class_hash,
+                                );
+                                TransactionVariant::DeployAccountV3(DeployAccountTransactionV3 {
+                                    contract_address,
+                                    signature: x.signature,
+                                    nonce: x.nonce,
+                                    nonce_data_availability_mode: x.nonce_data_availability_mode,
+                                    fee_data_availability_mode: x.fee_data_availability_mode,
+                                    resource_bounds: x.resource_bounds,
+                                    tip: x.tip,
+                                    paymaster_data: x.paymaster_data,
+                                    contract_address_salt: x.contract_address_salt,
+                                    constructor_calldata: x.constructor_calldata,
+                                    class_hash: x.class_hash,
+                                })
+                            }
+                        })
+                        .collect::<Vec<_>>(),
+                )
+            })
+            .collect();
+
+        // Send the result back to Tokio.
+        let _ = tx.send(computed);
+    });
 }
 
 async fn parse<P: Default + ParserState>(

--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -137,10 +137,14 @@ impl Client {
 
                     let mut state = parse::block_header::State::Uninitialized;
                     for part in parts {
-                        if let Err(error) = state.advance(part) {
-                            tracing::debug!(from=%peer, %error, "headers response parsing");
-                            // Try the next peer
-                            break;
+                        let current = std::mem::take(&mut state);
+                        match current.advance(part) {
+                            Ok(next) => state = next,
+                            Err(error) => {
+                                tracing::debug!(from=%peer, %error, "headers response parsing");
+                                // Try the next peer
+                                break;
+                            }
                         }
                     }
 
@@ -236,7 +240,9 @@ impl Client {
 
             match response_receiver {
                 Ok(rx) => {
-                    if let Some(parsed) = parse::<parse::transactions::State>(&peer, rx).await {
+                    if let Some(parsed) =
+                        parse_blocking::<parse::transactions::State>(&peer, rx).await
+                    {
                         return Ok(parsed);
                     }
                 }
@@ -339,9 +345,45 @@ async fn parse<P: Default + ParserState>(
     let mut state = P::default();
 
     while let Some(response) = receiver.next().await {
-        if let Err(error) = state.advance(response) {
-            tracing::debug!(from=%peer, %error, "{} response parsing", std::any::type_name::<P::Dto>());
-            break;
+        let current = std::mem::take(&mut state);
+        match current.advance(response) {
+            Ok(next) => state = next,
+            Err(error) => {
+                tracing::debug!(from=%peer, %error, "{} response parsing", std::any::type_name::<P::Dto>());
+                break;
+            }
+        }
+    }
+
+    state.take_parsed().or_else(|| {
+        tracing::debug!(from=%peer, "empty response or unexpected end of response");
+        None
+    })
+}
+
+/// Use when parsing involves intensive computation, e.g. hashing.
+async fn parse_blocking<P: Default + ParserState + Send + 'static>(
+    peer: &PeerId,
+    mut receiver: mpsc::Receiver<P::Dto>,
+) -> Option<P::Out>
+where
+    P::Dto: Send + 'static,
+{
+    let mut state = P::default();
+
+    while let Some(response) = receiver.next().await {
+        let current = std::mem::take(&mut state);
+        let jh = tokio::task::spawn_blocking(move || current.advance(response));
+        match jh.await {
+            Ok(Ok(next)) => state = next,
+            Ok(Err(error)) => {
+                tracing::debug!(from=%peer, %error, "{} response parsing", std::any::type_name::<P::Dto>());
+                break;
+            }
+            Err(error) => {
+                tracing::debug!(from=%peer, %error, "{} response parsing", std::any::type_name::<P::Dto>());
+                break;
+            }
         }
     }
 

--- a/crates/p2p/src/client/peer_agnostic/parse.rs
+++ b/crates/p2p/src/client/peer_agnostic/parse.rs
@@ -3,16 +3,19 @@ pub(crate) trait ParserState {
     type Inner;
     type Out;
 
-    fn advance(self, item: Self::Dto) -> anyhow::Result<Self>
+    fn advance(&mut self, item: Self::Dto) -> anyhow::Result<()>
     where
         Self: Default + Sized,
     {
-        let next_state = self.transition(item)?;
+        let current_state = std::mem::take(self);
+        let next_state = current_state.transition(item)?;
 
-        if next_state.should_stop() {
+        *self = next_state;
+
+        if self.should_stop() {
             anyhow::bail!("no data or premature end of response")
         } else {
-            Ok(next_state)
+            Ok(())
         }
     }
 

--- a/crates/p2p/src/client/peer_agnostic/parse.rs
+++ b/crates/p2p/src/client/peer_agnostic/parse.rs
@@ -3,19 +3,16 @@ pub(crate) trait ParserState {
     type Inner;
     type Out;
 
-    fn advance(&mut self, item: Self::Dto) -> anyhow::Result<()>
+    fn advance(self, item: Self::Dto) -> anyhow::Result<Self>
     where
         Self: Default + Sized,
     {
-        let current_state = std::mem::take(self);
-        let next_state = current_state.transition(item)?;
+        let next_state = self.transition(item)?;
 
-        *self = next_state;
-
-        if self.should_stop() {
+        if next_state.should_stop() {
             anyhow::bail!("no data or premature end of response")
         } else {
-            Ok(())
+            Ok(next_state)
         }
     }
 

--- a/crates/p2p/src/client/types.rs
+++ b/crates/p2p/src/client/types.rs
@@ -13,11 +13,10 @@ use pathfinder_common::transaction::{
     ResourceBound, ResourceBounds, TransactionVariant,
 };
 use pathfinder_common::{
-    deployed_contract_address, AccountDeploymentDataElem, BlockHash, BlockNumber, BlockTimestamp,
-    CallParam, CasmHash, ClassHash, ConstructorParam, ContractAddress, ContractAddressSalt,
-    ContractNonce, EntryPoint, EventData, EventKey, Fee, GasPrice, SequencerAddress,
-    StarknetVersion, StateCommitment, StorageAddress, StorageValue, TransactionNonce,
-    TransactionSignatureElem, TransactionVersion,
+    AccountDeploymentDataElem, BlockHash, BlockNumber, BlockTimestamp, CallParam, CasmHash,
+    ClassHash, ConstructorParam, ContractAddress, ContractAddressSalt, ContractNonce, EntryPoint,
+    EventData, EventKey, Fee, GasPrice, SequencerAddress, StarknetVersion, StateCommitment,
+    StorageAddress, StorageValue, TransactionNonce, TransactionSignatureElem, TransactionVersion,
 };
 
 /// We don't want to introduce circular dependencies between crates
@@ -269,7 +268,7 @@ impl TryFromDto<p2p_proto::transaction::Transaction> for TransactionVariant {
             }),
             DeployAccountV1(x) => {
                 TransactionVariant::DeployAccountV0V1(DeployAccountTransactionV0V1 {
-                    contract_address: deployed_contract_address(
+                    contract_address: ContractAddress::deployed_contract_address(
                         x.constructor_calldata.iter().map(|x| CallParam(*x)),
                         &ContractAddressSalt(x.address_salt),
                         &ClassHash(x.class_hash.0),
@@ -293,7 +292,7 @@ impl TryFromDto<p2p_proto::transaction::Transaction> for TransactionVariant {
                 })
             }
             DeployAccountV3(x) => TransactionVariant::DeployAccountV3(DeployAccountTransactionV3 {
-                contract_address: deployed_contract_address(
+                contract_address: ContractAddress::deployed_contract_address(
                     x.calldata.iter().map(|x| CallParam(*x)),
                     &ContractAddressSalt(x.address_salt),
                     &ClassHash(x.class_hash.0),

--- a/crates/p2p/src/client/types.rs
+++ b/crates/p2p/src/client/types.rs
@@ -15,8 +15,9 @@ use pathfinder_common::transaction::{
 use pathfinder_common::{
     AccountDeploymentDataElem, BlockHash, BlockNumber, BlockTimestamp, CallParam, CasmHash,
     ClassHash, ConstructorParam, ContractAddress, ContractAddressSalt, ContractNonce, EntryPoint,
-    EventData, EventKey, Fee, GasPrice, SequencerAddress, StarknetVersion, StateCommitment,
-    StorageAddress, StorageValue, TransactionNonce, TransactionSignatureElem, TransactionVersion,
+    EventData, EventKey, Fee, GasPrice, PaymasterDataElem, SequencerAddress, StarknetVersion,
+    StateCommitment, StorageAddress, StorageValue, Tip, TransactionNonce, TransactionSignatureElem,
+    TransactionVersion,
 };
 
 /// We don't want to introduce circular dependencies between crates
@@ -82,6 +83,61 @@ pub struct ContractUpdate {
     /// We don't explicitly know if it's one or the other
     pub class: Option<ClassHash>,
     pub nonce: Option<ContractNonce>,
+}
+
+/// Deployed contract address has not been computed for deploy account transactions.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RawTransactionVariant {
+    DeployAccount(RawDeployAccountTransaction),
+    NonDeployAccount(NonDeployAccountTransaction),
+}
+
+/// Deployed contract address has not been computed.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RawDeployAccountTransaction {
+    DeployAccountV0V1(RawDeployAccountTransactionV0V1),
+    DeployAccountV3(RawDeployAccountTransactionV3),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NonDeployAccountTransaction {
+    DeclareV0(DeclareTransactionV0V1),
+    DeclareV1(DeclareTransactionV0V1),
+    DeclareV2(DeclareTransactionV2),
+    DeclareV3(DeclareTransactionV3),
+    // Regenesis: deploy is a legacy variant and can be removed after regenesis.
+    Deploy(DeployTransaction),
+    InvokeV0(InvokeTransactionV0),
+    InvokeV1(InvokeTransactionV1),
+    InvokeV3(InvokeTransactionV3),
+    L1Handler(L1HandlerTransaction),
+}
+
+/// Deployed contract address has not been computed.
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub struct RawDeployAccountTransactionV0V1 {
+    pub max_fee: Fee,
+    pub version: TransactionVersion,
+    pub signature: Vec<TransactionSignatureElem>,
+    pub nonce: TransactionNonce,
+    pub contract_address_salt: ContractAddressSalt,
+    pub constructor_calldata: Vec<CallParam>,
+    pub class_hash: ClassHash,
+}
+
+/// Deployed contract address has not been computed.
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub struct RawDeployAccountTransactionV3 {
+    pub signature: Vec<TransactionSignatureElem>,
+    pub nonce: TransactionNonce,
+    pub nonce_data_availability_mode: DataAvailabilityMode,
+    pub fee_data_availability_mode: DataAvailabilityMode,
+    pub resource_bounds: ResourceBounds,
+    pub tip: Tip,
+    pub paymaster_data: Vec<PaymasterDataElem>,
+    pub contract_address_salt: ContractAddressSalt,
+    pub constructor_calldata: Vec<CallParam>,
+    pub class_hash: ClassHash,
 }
 
 impl From<pathfinder_common::BlockHeader> for BlockHeader {
@@ -190,7 +246,78 @@ impl From<p2p_proto::state::StateDiff> for StateUpdate {
     }
 }
 
-impl TryFromDto<p2p_proto::transaction::Transaction> for TransactionVariant {
+impl NonDeployAccountTransaction {
+    pub fn into_variant(self) -> TransactionVariant {
+        use NonDeployAccountTransaction::*;
+        match self {
+            DeclareV0(x) => TransactionVariant::DeclareV0(x),
+            DeclareV1(x) => TransactionVariant::DeclareV1(x),
+            DeclareV2(x) => TransactionVariant::DeclareV2(x),
+            DeclareV3(x) => TransactionVariant::DeclareV3(x),
+            Deploy(x) => TransactionVariant::Deploy(x),
+            InvokeV0(x) => TransactionVariant::InvokeV0(x),
+            InvokeV1(x) => TransactionVariant::InvokeV1(x),
+            InvokeV3(x) => TransactionVariant::InvokeV3(x),
+            L1Handler(x) => TransactionVariant::L1Handler(x),
+        }
+    }
+}
+
+impl From<TransactionVariant> for RawTransactionVariant {
+    fn from(x: TransactionVariant) -> Self {
+        use TransactionVariant::*;
+        match x {
+            DeclareV0(x) => Self::NonDeployAccount(NonDeployAccountTransaction::DeclareV0(x)),
+            DeclareV1(x) => Self::NonDeployAccount(NonDeployAccountTransaction::DeclareV1(x)),
+            DeclareV2(x) => Self::NonDeployAccount(NonDeployAccountTransaction::DeclareV2(x)),
+            DeclareV3(x) => Self::NonDeployAccount(NonDeployAccountTransaction::DeclareV3(x)),
+            Deploy(x) => Self::NonDeployAccount(NonDeployAccountTransaction::Deploy(x)),
+            InvokeV0(x) => Self::NonDeployAccount(NonDeployAccountTransaction::InvokeV0(x)),
+            InvokeV1(x) => Self::NonDeployAccount(NonDeployAccountTransaction::InvokeV1(x)),
+            InvokeV3(x) => Self::NonDeployAccount(NonDeployAccountTransaction::InvokeV3(x)),
+            L1Handler(x) => Self::NonDeployAccount(NonDeployAccountTransaction::L1Handler(x)),
+            DeployAccountV0V1(x) => {
+                Self::DeployAccount(RawDeployAccountTransaction::DeployAccountV0V1(x.into()))
+            }
+            DeployAccountV3(x) => {
+                Self::DeployAccount(RawDeployAccountTransaction::DeployAccountV3(x.into()))
+            }
+        }
+    }
+}
+
+impl From<DeployAccountTransactionV0V1> for RawDeployAccountTransactionV0V1 {
+    fn from(x: DeployAccountTransactionV0V1) -> Self {
+        Self {
+            max_fee: x.max_fee,
+            version: x.version,
+            signature: x.signature,
+            nonce: x.nonce,
+            contract_address_salt: x.contract_address_salt,
+            constructor_calldata: x.constructor_calldata,
+            class_hash: x.class_hash,
+        }
+    }
+}
+
+impl From<DeployAccountTransactionV3> for RawDeployAccountTransactionV3 {
+    fn from(x: DeployAccountTransactionV3) -> Self {
+        Self {
+            signature: x.signature,
+            nonce: x.nonce,
+            nonce_data_availability_mode: x.nonce_data_availability_mode,
+            fee_data_availability_mode: x.fee_data_availability_mode,
+            resource_bounds: x.resource_bounds,
+            tip: x.tip,
+            paymaster_data: x.paymaster_data,
+            contract_address_salt: x.contract_address_salt,
+            constructor_calldata: x.constructor_calldata,
+            class_hash: x.class_hash,
+        }
+    }
+}
+
+impl TryFromDto<p2p_proto::transaction::Transaction> for RawTransactionVariant {
     /// ## Important
     ///
     /// This conversion does not compute deployed contract address for deploy account transactions
@@ -203,77 +330,88 @@ impl TryFromDto<p2p_proto::transaction::Transaction> for TransactionVariant {
         use p2p_proto::transaction::Transaction::*;
 
         Ok(match dto {
-            DeclareV0(x) => TransactionVariant::DeclareV0(DeclareTransactionV0V1 {
-                class_hash: ClassHash(x.class_hash.0),
-                max_fee: Fee(x.max_fee),
-                nonce: TransactionNonce::ZERO,
-                sender_address: ContractAddress(x.sender.0),
-                signature: x
-                    .signature
-                    .parts
-                    .into_iter()
-                    .map(TransactionSignatureElem)
-                    .collect(),
-            }),
-            DeclareV1(x) => TransactionVariant::DeclareV1(DeclareTransactionV0V1 {
-                class_hash: ClassHash(x.class_hash.0),
-                max_fee: Fee(x.max_fee),
-                nonce: TransactionNonce(x.nonce),
-                sender_address: ContractAddress(x.sender.0),
-                signature: x
-                    .signature
-                    .parts
-                    .into_iter()
-                    .map(TransactionSignatureElem)
-                    .collect(),
-            }),
-            DeclareV2(x) => TransactionVariant::DeclareV2(DeclareTransactionV2 {
-                class_hash: ClassHash(x.class_hash.0),
-                max_fee: Fee(x.max_fee),
-                nonce: TransactionNonce(x.nonce),
-                sender_address: ContractAddress(x.sender.0),
-                signature: x
-                    .signature
-                    .parts
-                    .into_iter()
-                    .map(TransactionSignatureElem)
-                    .collect(),
-                compiled_class_hash: CasmHash(x.compiled_class_hash),
-            }),
-            DeclareV3(x) => TransactionVariant::DeclareV3(DeclareTransactionV3 {
-                class_hash: ClassHash(x.class_hash.0),
-                nonce: TransactionNonce(x.nonce),
-                nonce_data_availability_mode: DataAvailabilityMode::try_from_dto(x.nonce_domain)?,
-                fee_data_availability_mode: DataAvailabilityMode::try_from_dto(x.fee_domain)?,
-                resource_bounds: ResourceBounds::try_from_dto(x.resource_bounds)?,
-                tip: pathfinder_common::Tip(x.tip.try_into()?),
-                paymaster_data: vec![pathfinder_common::PaymasterDataElem(x.paymaster_data.0)],
-                signature: x
-                    .signature
-                    .parts
-                    .into_iter()
-                    .map(TransactionSignatureElem)
-                    .collect(),
-                account_deployment_data: vec![AccountDeploymentDataElem(
-                    x.account_deployment_data.0,
-                )],
-                sender_address: ContractAddress(x.sender.0),
-                compiled_class_hash: CasmHash(x.compiled_class_hash),
-            }),
-            Deploy(x) => TransactionVariant::Deploy(DeployTransaction {
-                contract_address: ContractAddress(x.address.0),
-                contract_address_salt: ContractAddressSalt(x.address_salt),
-                class_hash: ClassHash(x.class_hash.0),
-                constructor_calldata: x.calldata.into_iter().map(ConstructorParam).collect(),
-                version: match x.version {
-                    0 => TransactionVersion::ZERO,
-                    1 => TransactionVersion::ONE,
-                    _ => anyhow::bail!("Invalid deploy transaction version"),
-                },
-            }),
-            DeployAccountV1(x) => {
-                TransactionVariant::DeployAccountV0V1(DeployAccountTransactionV0V1 {
-                    contract_address: ContractAddress::ZERO,
+            DeclareV0(x) => RawTransactionVariant::NonDeployAccount(
+                NonDeployAccountTransaction::DeclareV0(DeclareTransactionV0V1 {
+                    class_hash: ClassHash(x.class_hash.0),
+                    max_fee: Fee(x.max_fee),
+                    nonce: TransactionNonce::ZERO,
+                    sender_address: ContractAddress(x.sender.0),
+                    signature: x
+                        .signature
+                        .parts
+                        .into_iter()
+                        .map(TransactionSignatureElem)
+                        .collect(),
+                }),
+            ),
+            DeclareV1(x) => RawTransactionVariant::NonDeployAccount(
+                NonDeployAccountTransaction::DeclareV1(DeclareTransactionV0V1 {
+                    class_hash: ClassHash(x.class_hash.0),
+                    max_fee: Fee(x.max_fee),
+                    nonce: TransactionNonce(x.nonce),
+                    sender_address: ContractAddress(x.sender.0),
+                    signature: x
+                        .signature
+                        .parts
+                        .into_iter()
+                        .map(TransactionSignatureElem)
+                        .collect(),
+                }),
+            ),
+            DeclareV2(x) => RawTransactionVariant::NonDeployAccount(
+                NonDeployAccountTransaction::DeclareV2(DeclareTransactionV2 {
+                    class_hash: ClassHash(x.class_hash.0),
+                    max_fee: Fee(x.max_fee),
+                    nonce: TransactionNonce(x.nonce),
+                    sender_address: ContractAddress(x.sender.0),
+                    signature: x
+                        .signature
+                        .parts
+                        .into_iter()
+                        .map(TransactionSignatureElem)
+                        .collect(),
+                    compiled_class_hash: CasmHash(x.compiled_class_hash),
+                }),
+            ),
+            DeclareV3(x) => RawTransactionVariant::NonDeployAccount(
+                NonDeployAccountTransaction::DeclareV3(DeclareTransactionV3 {
+                    class_hash: ClassHash(x.class_hash.0),
+                    nonce: TransactionNonce(x.nonce),
+                    nonce_data_availability_mode: DataAvailabilityMode::try_from_dto(
+                        x.nonce_domain,
+                    )?,
+                    fee_data_availability_mode: DataAvailabilityMode::try_from_dto(x.fee_domain)?,
+                    resource_bounds: ResourceBounds::try_from_dto(x.resource_bounds)?,
+                    tip: pathfinder_common::Tip(x.tip.try_into()?),
+                    paymaster_data: vec![pathfinder_common::PaymasterDataElem(x.paymaster_data.0)],
+                    signature: x
+                        .signature
+                        .parts
+                        .into_iter()
+                        .map(TransactionSignatureElem)
+                        .collect(),
+                    account_deployment_data: vec![AccountDeploymentDataElem(
+                        x.account_deployment_data.0,
+                    )],
+                    sender_address: ContractAddress(x.sender.0),
+                    compiled_class_hash: CasmHash(x.compiled_class_hash),
+                }),
+            ),
+            Deploy(x) => RawTransactionVariant::NonDeployAccount(
+                NonDeployAccountTransaction::Deploy(DeployTransaction {
+                    contract_address: ContractAddress(x.address.0),
+                    contract_address_salt: ContractAddressSalt(x.address_salt),
+                    class_hash: ClassHash(x.class_hash.0),
+                    constructor_calldata: x.calldata.into_iter().map(ConstructorParam).collect(),
+                    version: match x.version {
+                        0 => TransactionVersion::ZERO,
+                        1 => TransactionVersion::ONE,
+                        _ => anyhow::bail!("Invalid deploy transaction version"),
+                    },
+                }),
+            ),
+            DeployAccountV1(x) => RawTransactionVariant::DeployAccount(
+                RawDeployAccountTransaction::DeployAccountV0V1(RawDeployAccountTransactionV0V1 {
                     max_fee: Fee(x.max_fee),
                     version: TransactionVersion::ONE,
                     signature: x
@@ -290,84 +428,97 @@ impl TryFromDto<p2p_proto::transaction::Transaction> for TransactionVariant {
                         .map(CallParam)
                         .collect(),
                     class_hash: ClassHash(x.class_hash.0),
-                })
-            }
-            DeployAccountV3(x) => TransactionVariant::DeployAccountV3(DeployAccountTransactionV3 {
-                contract_address: ContractAddress::ZERO,
-                signature: x
-                    .signature
-                    .parts
-                    .into_iter()
-                    .map(TransactionSignatureElem)
-                    .collect(),
-                nonce: TransactionNonce(x.nonce),
-                nonce_data_availability_mode: DataAvailabilityMode::try_from_dto(x.nonce_domain)?,
-                fee_data_availability_mode: DataAvailabilityMode::try_from_dto(x.fee_domain)?,
-                resource_bounds: ResourceBounds::try_from_dto(x.resource_bounds)?,
-                tip: pathfinder_common::Tip(x.tip.try_into()?),
-                paymaster_data: vec![pathfinder_common::PaymasterDataElem(x.paymaster_data.0)],
-                contract_address_salt: ContractAddressSalt(x.address_salt),
-                constructor_calldata: x.calldata.into_iter().map(CallParam).collect(),
-                class_hash: ClassHash(x.class_hash.0),
-            }),
-            InvokeV0(x) => TransactionVariant::InvokeV0(InvokeTransactionV0 {
-                calldata: x.calldata.into_iter().map(CallParam).collect(),
-                sender_address: ContractAddress(x.address.0),
-                entry_point_selector: EntryPoint(x.entry_point_selector),
-                entry_point_type: None,
-                max_fee: Fee(x.max_fee),
-                signature: x
-                    .signature
-                    .parts
-                    .into_iter()
-                    .map(TransactionSignatureElem)
-                    .collect(),
-            }),
-            InvokeV1(x) => TransactionVariant::InvokeV1(InvokeTransactionV1 {
-                calldata: x.calldata.into_iter().map(CallParam).collect(),
-                sender_address: ContractAddress(x.sender.0),
-                max_fee: Fee(x.max_fee),
-                signature: x
-                    .signature
-                    .parts
-                    .into_iter()
-                    .map(TransactionSignatureElem)
-                    .collect(),
-                nonce: TransactionNonce(x.nonce),
-            }),
-            InvokeV3(x) => TransactionVariant::InvokeV3(InvokeTransactionV3 {
-                signature: x
-                    .signature
-                    .parts
-                    .into_iter()
-                    .map(TransactionSignatureElem)
-                    .collect(),
-                nonce: TransactionNonce(x.nonce),
-                nonce_data_availability_mode: DataAvailabilityMode::try_from_dto(x.nonce_domain)?,
-                fee_data_availability_mode: DataAvailabilityMode::try_from_dto(x.fee_domain)?,
-                resource_bounds: ResourceBounds::try_from_dto(x.resource_bounds)?,
-                tip: pathfinder_common::Tip(x.tip.try_into()?),
-                paymaster_data: vec![pathfinder_common::PaymasterDataElem(x.paymaster_data.0)],
-                account_deployment_data: vec![AccountDeploymentDataElem(
-                    x.account_deployment_data.0,
-                )],
-                calldata: x.calldata.into_iter().map(CallParam).collect(),
-                sender_address: ContractAddress(x.sender.0),
-            }),
-            L1HandlerV0(x) => TransactionVariant::L1Handler(L1HandlerTransaction {
-                contract_address: ContractAddress(x.address.0),
-                entry_point_selector: EntryPoint(x.entry_point_selector),
-                nonce: TransactionNonce(x.nonce),
-                calldata: x.calldata.into_iter().map(CallParam).collect(),
-                // TODO there's a bug in the spec, all available L1 handler transactions up to now (Sep '23)
-                // carry version 0
-                // e.g.
-                // @block 10k
-                // https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction?transactionHash=0x02e42cd5f71a2b09547083f82e267ac2f37ba71e09fa868ffce90d141531c3ba
-                // @block ~261k
-                // https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction?transactionHash=0x02e42cd5f71a2b09547083f82e267ac2f37ba71e09fa868ffce90d141531c3ba
-                version: TransactionVersion::ZERO,
-            }),
+                }),
+            ),
+            DeployAccountV3(x) => RawTransactionVariant::DeployAccount(
+                RawDeployAccountTransaction::DeployAccountV3(RawDeployAccountTransactionV3 {
+                    signature: x
+                        .signature
+                        .parts
+                        .into_iter()
+                        .map(TransactionSignatureElem)
+                        .collect(),
+                    nonce: TransactionNonce(x.nonce),
+                    nonce_data_availability_mode: DataAvailabilityMode::try_from_dto(
+                        x.nonce_domain,
+                    )?,
+                    fee_data_availability_mode: DataAvailabilityMode::try_from_dto(x.fee_domain)?,
+                    resource_bounds: ResourceBounds::try_from_dto(x.resource_bounds)?,
+                    tip: pathfinder_common::Tip(x.tip.try_into()?),
+                    paymaster_data: vec![pathfinder_common::PaymasterDataElem(x.paymaster_data.0)],
+                    contract_address_salt: ContractAddressSalt(x.address_salt),
+                    constructor_calldata: x.calldata.into_iter().map(CallParam).collect(),
+                    class_hash: ClassHash(x.class_hash.0),
+                }),
+            ),
+            InvokeV0(x) => RawTransactionVariant::NonDeployAccount(
+                NonDeployAccountTransaction::InvokeV0(InvokeTransactionV0 {
+                    calldata: x.calldata.into_iter().map(CallParam).collect(),
+                    sender_address: ContractAddress(x.address.0),
+                    entry_point_selector: EntryPoint(x.entry_point_selector),
+                    entry_point_type: None,
+                    max_fee: Fee(x.max_fee),
+                    signature: x
+                        .signature
+                        .parts
+                        .into_iter()
+                        .map(TransactionSignatureElem)
+                        .collect(),
+                }),
+            ),
+            InvokeV1(x) => RawTransactionVariant::NonDeployAccount(
+                NonDeployAccountTransaction::InvokeV1(InvokeTransactionV1 {
+                    calldata: x.calldata.into_iter().map(CallParam).collect(),
+                    sender_address: ContractAddress(x.sender.0),
+                    max_fee: Fee(x.max_fee),
+                    signature: x
+                        .signature
+                        .parts
+                        .into_iter()
+                        .map(TransactionSignatureElem)
+                        .collect(),
+                    nonce: TransactionNonce(x.nonce),
+                }),
+            ),
+            InvokeV3(x) => RawTransactionVariant::NonDeployAccount(
+                NonDeployAccountTransaction::InvokeV3(InvokeTransactionV3 {
+                    signature: x
+                        .signature
+                        .parts
+                        .into_iter()
+                        .map(TransactionSignatureElem)
+                        .collect(),
+                    nonce: TransactionNonce(x.nonce),
+                    nonce_data_availability_mode: DataAvailabilityMode::try_from_dto(
+                        x.nonce_domain,
+                    )?,
+                    fee_data_availability_mode: DataAvailabilityMode::try_from_dto(x.fee_domain)?,
+                    resource_bounds: ResourceBounds::try_from_dto(x.resource_bounds)?,
+                    tip: pathfinder_common::Tip(x.tip.try_into()?),
+                    paymaster_data: vec![pathfinder_common::PaymasterDataElem(x.paymaster_data.0)],
+                    account_deployment_data: vec![AccountDeploymentDataElem(
+                        x.account_deployment_data.0,
+                    )],
+                    calldata: x.calldata.into_iter().map(CallParam).collect(),
+                    sender_address: ContractAddress(x.sender.0),
+                }),
+            ),
+            L1HandlerV0(x) => RawTransactionVariant::NonDeployAccount(
+                NonDeployAccountTransaction::L1Handler(L1HandlerTransaction {
+                    contract_address: ContractAddress(x.address.0),
+                    entry_point_selector: EntryPoint(x.entry_point_selector),
+                    nonce: TransactionNonce(x.nonce),
+                    calldata: x.calldata.into_iter().map(CallParam).collect(),
+                    // TODO there's a bug in the spec, all available L1 handler transactions up to now (Sep '23)
+                    // carry version 0
+                    // e.g.
+                    // @block 10k
+                    // https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction?transactionHash=0x02e42cd5f71a2b09547083f82e267ac2f37ba71e09fa868ffce90d141531c3ba
+                    // @block ~261k
+                    // https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction?transactionHash=0x02e42cd5f71a2b09547083f82e267ac2f37ba71e09fa868ffce90d141531c3ba
+                    version: TransactionVersion::ZERO,
+                }),
+            ),
         })
     }
 }

--- a/crates/p2p/src/client/types.rs
+++ b/crates/p2p/src/client/types.rs
@@ -194,7 +194,7 @@ impl TryFromDto<p2p_proto::transaction::Transaction> for TransactionVariant {
     /// ## Important
     ///
     /// This conversion does not compute deployed contract address for deploy account transactions
-    /// ([`TransactionVariant::DeployAccountTransactionV0V1`] and [`TransactionVariant::DeployAccountTransactionV3`]),
+    /// ([`TransactionVariant::DeployAccountV0V1`] and [`TransactionVariant::DeployAccountV3`]),
     /// filling it with a zero address instead. The caller is responsible for performing the computation after the conversion succeeds.
     fn try_from_dto(dto: p2p_proto::transaction::Transaction) -> anyhow::Result<Self>
     where

--- a/crates/p2p_proto/proto/transaction.proto
+++ b/crates/p2p_proto/proto/transaction.proto
@@ -64,19 +64,16 @@ message Transaction
         starknet.common.Felt252          address_salt = 2;
         repeated starknet.common.Felt252 calldata     = 3;
         uint32                           version      = 4;
-        // FIXME added missing fields
         starknet.common.Address          address      = 5;
     }
 
     message DeployAccountV1 {
-        starknet.common.Felt252          max_fee      = 1;
-        AccountSignature                 signature    = 2;
-        starknet.common.Hash             class_hash   = 3;
-        starknet.common.Felt252          nonce        = 4;
-        starknet.common.Felt252          address_salt = 5;
-        repeated starknet.common.Felt252 calldata     = 6;
-        // FIXME added missing fields
-        starknet.common.Address          address      = 7;
+        starknet.common.Felt252          max_fee              = 1;
+        AccountSignature                 signature            = 2;
+        starknet.common.Hash             class_hash           = 3;
+        starknet.common.Felt252          nonce                = 4;
+        starknet.common.Felt252          address_salt         = 5;
+        repeated starknet.common.Felt252 constructor_calldata = 6;
     }
 
     message DeployAccountV3 {
@@ -90,8 +87,6 @@ message Transaction
         starknet.common.Address          paymaster_data  = 8;
         string                           nonce_domain    = 9;  // rename to nonce_data_availability_mode ?
         string                           fee_domain      = 10; // rename to fee_data_availability_mode ?
-        // FIXME added missing fields
-        starknet.common.Address          address         = 11;
     }
 
     message InvokeV0 {

--- a/crates/p2p_proto/src/transaction.rs
+++ b/crates/p2p_proto/src/transaction.rs
@@ -76,7 +76,6 @@ pub struct Deploy {
     pub class_hash: Hash,
     pub address_salt: Felt,
     pub calldata: Vec<Felt>,
-    // FIXME added missing fields
     pub address: Address,
     pub version: u32,
 }
@@ -89,9 +88,7 @@ pub struct DeployAccountV1 {
     pub class_hash: Hash,
     pub nonce: Felt,
     pub address_salt: Felt,
-    pub calldata: Vec<Felt>,
-    // FIXME added missing field
-    pub address: Address,
+    pub constructor_calldata: Vec<Felt>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ToProtobuf, TryFromProtobuf, Dummy)]
@@ -107,7 +104,6 @@ pub struct DeployAccountV3 {
     pub paymaster_data: Address,
     pub nonce_domain: String,
     pub fee_domain: String,
-    pub address: Address,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ToProtobuf, TryFromProtobuf, Dummy)]

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -45,7 +45,7 @@ pathfinder-serde = { path = "../serde" }
 pathfinder-storage = { path = "../storage" }
 primitive-types = { workspace = true }
 rand = { workspace = true }
-rayon = "1.8.0"
+rayon = { workspace = true }
 reqwest = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/pathfinder/proptest-regressions/p2p_network/sync_handlers/tests.txt
+++ b/crates/pathfinder/proptest-regressions/p2p_network/sync_handlers/tests.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc bc13615220330a9aa3dcbad1f71a6b8c74a7d14e36ffa93a182243c593cc866c # shrinks to (num_blocks, seed, start_block, limit, step, direction) = (1, 8902626232982046058, 0, 1, Step(1), Forward)
+cc 57069d20aea6c1421adac0b72bef7431b6c650f5f41dd6d3b16c2da0121486c3 # shrinks to (num_blocks, seed, start_block, limit, step, direction) = (1, 649405005586826819, 0, 1, Step(1), Forward)

--- a/crates/pathfinder/src/p2p_network/sync_handlers/conv.rs
+++ b/crates/pathfinder/src/p2p_network/sync_handlers/conv.rs
@@ -185,8 +185,7 @@ impl ToProto<p2p_proto::transaction::Transaction> for Transaction {
                 class_hash: Hash(x.class_hash.0),
                 nonce: x.nonce.0,
                 address_salt: x.contract_address_salt.0,
-                calldata: x.constructor_calldata.into_iter().map(|c| c.0).collect(),
-                address: Address(x.contract_address.0),
+                constructor_calldata: x.constructor_calldata.into_iter().map(|c| c.0).collect(),
             }),
             DeployAccountV3(x) => proto::Transaction::DeployAccountV3(proto::DeployAccountV3 {
                 signature: AccountSignature {
@@ -209,7 +208,6 @@ impl ToProto<p2p_proto::transaction::Transaction> for Transaction {
                 ), // TODO
                 nonce_domain: x.nonce_data_availability_mode.to_proto(),
                 fee_domain: x.fee_data_availability_mode.to_proto(),
-                address: Address(x.contract_address.0),
             }),
             InvokeV0(x) => proto::Transaction::InvokeV0(proto::InvokeV0 {
                 max_fee: x.max_fee.0,

--- a/crates/pathfinder/src/p2p_network/sync_handlers/tests.rs
+++ b/crates/pathfinder/src/p2p_network/sync_handlers/tests.rs
@@ -328,7 +328,7 @@ mod prop {
     use crate::p2p_network::sync_handlers::def_into_dto;
     use futures::channel::mpsc;
     use futures::StreamExt;
-    use p2p::client::types::{self as p2p_types, TryFromDto};
+    use p2p::client::types::{self as p2p_types, RawTransactionVariant, TryFromDto};
     use p2p_proto::block::{
         BlockBodiesRequest, BlockBodyMessage, BlockHeadersRequest, BlockHeadersResponse,
         BlockHeadersResponsePart,
@@ -339,7 +339,7 @@ mod prop {
     use p2p_proto::state::{Cairo0Class, Cairo1Class, Class};
     use p2p_proto::transaction::{TransactionsRequest, TransactionsResponseKind};
     use pathfinder_common::event::Event;
-    use pathfinder_common::transaction::{Transaction, TransactionVariant};
+    use pathfinder_common::transaction::Transaction;
     use pathfinder_common::{
         BlockCommitmentSignature, BlockCommitmentSignatureElem, BlockHash, BlockNumber,
         TransactionHash,
@@ -555,7 +555,7 @@ mod prop {
                     (
                         h.number,
                         h.hash,
-                        tr.into_iter().map(|(t, _)| Transaction::from(workaround::for_legacy_l1_handlers(t)).variant).collect::<Vec<_>>()
+                        tr.into_iter().map(|(t, _)| Transaction::from(workaround::for_legacy_l1_handlers(t)).variant.into()).collect::<Vec<_>>()
                     )
             ).collect::<Vec<_>>();
             // Run the handler
@@ -584,7 +584,7 @@ mod prop {
                     (
                         BlockNumber::new(number).unwrap(),
                         BlockHash(hash.0),
-                        transactions.into_iter().map(|t| TransactionVariant::try_from_dto(t).unwrap()).collect::<Vec<_>>()
+                        transactions.into_iter().map(|t| RawTransactionVariant::try_from_dto(t).unwrap()).collect::<Vec<_>>()
                     )
                 }).collect::<Vec<_>>();
 

--- a/crates/rpc/src/v02/types.rs
+++ b/crates/rpc/src/v02/types.rs
@@ -127,9 +127,9 @@ impl From<starknet_gateway_types::reply::transaction::DataAvailabilityMode>
 /// Groups all strictly input types of the RPC API.
 pub mod request {
     use pathfinder_common::{
-        deployed_contract_address, AccountDeploymentDataElem, CallParam, CasmHash, ChainId,
-        ClassHash, ContractAddress, ContractAddressSalt, EntryPoint, Fee, PaymasterDataElem, Tip,
-        TransactionHash, TransactionNonce, TransactionSignatureElem, TransactionVersion,
+        AccountDeploymentDataElem, CallParam, CasmHash, ChainId, ClassHash, ContractAddress,
+        ContractAddressSalt, EntryPoint, Fee, PaymasterDataElem, Tip, TransactionHash,
+        TransactionNonce, TransactionSignatureElem, TransactionVersion,
     };
     use pathfinder_crypto::hash::{HashChain, PoseidonHasher};
     use serde::Deserialize;
@@ -500,7 +500,7 @@ pub mod request {
 
     impl BroadcastedDeployAccountTransactionV0V1 {
         pub fn deployed_contract_address(&self) -> ContractAddress {
-            deployed_contract_address(
+            ContractAddress::deployed_contract_address(
                 self.constructor_calldata.iter().copied(),
                 &self.contract_address_salt,
                 &self.class_hash,
@@ -558,7 +558,7 @@ pub mod request {
 
     impl BroadcastedDeployAccountTransactionV3 {
         pub fn deployed_contract_address(&self) -> ContractAddress {
-            deployed_contract_address(
+            ContractAddress::deployed_contract_address(
                 self.constructor_calldata.iter().copied(),
                 &self.contract_address_salt,
                 &self.class_hash,


### PR DESCRIPTION
I added those fields in anticipation of a spec update but it turns out I didn't notice these fields are [redundant and can just be computed locally](https://github.com/starknet-io/starknet-p2p-specs/pull/23#discussion_r1447011560).

---

Edit: I updated the code to defer computing those addresses after all other parsing is done.