### PR TITLE
Initial p2p sync implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,6 +527,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "async-task"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5739,6 +5761,7 @@ name = "p2p"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "base64 0.13.1",
  "clap",

--- a/crates/common/src/header.rs
+++ b/crates/common/src/header.rs
@@ -1,8 +1,5 @@
-use crate::{
-    BlockHash, BlockNumber, BlockTimestamp, ClassCommitment, EventCommitment, GasPrice,
-    SequencerAddress, StarknetVersion, StateCommitment, StateUpdate, StorageCommitment,
-    TransactionCommitment,
-};
+use crate::prelude::*;
+use crate::BlockCommitmentSignature;
 use fake::Dummy;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Dummy)]
@@ -22,6 +19,12 @@ pub struct BlockHeader {
     pub transaction_commitment: TransactionCommitment,
     pub transaction_count: usize,
     pub event_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct SignedBlockHeader {
+    pub header: BlockHeader,
+    pub signature: BlockCommitmentSignature,
 }
 
 pub struct BlockHeaderBuilder(BlockHeader);

--- a/crates/common/src/header.rs
+++ b/crates/common/src/header.rs
@@ -27,6 +27,17 @@ pub struct SignedBlockHeader {
     pub signature: BlockCommitmentSignature,
 }
 
+impl SignedBlockHeader {
+    /// Returns true if the signature is correct for the block header.
+    ///
+    /// Note that this does not imply that a given state diff is correct.
+    /// TODO: improve this documentation somehow.
+    pub fn verify_signature(&self) -> bool {
+        // TODO: implement this.
+        true
+    }
+}
+
 pub struct BlockHeaderBuilder(BlockHeader);
 
 impl BlockHeader {
@@ -49,6 +60,10 @@ impl BlockHeader {
         StateUpdate::default()
             .with_block_hash(self.hash)
             .with_state_commitment(self.state_commitment)
+    }
+
+    pub fn verify_hash(&self) -> bool {
+        todo!();
     }
 }
 

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -25,7 +25,7 @@ pub mod trie;
 pub use signature::BlockCommitmentSignature;
 pub use state_update::StateUpdate;
 
-pub use header::{BlockHeader, BlockHeaderBuilder};
+pub use header::{BlockHeader, BlockHeaderBuilder, SignedBlockHeader};
 
 impl ContractAddress {
     /// The contract at 0x1 is special. It was never deployed and therefore

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -254,6 +254,10 @@ impl BlockNumber {
             Some(*self - 1)
         }
     }
+
+    pub fn is_zero(&self) -> bool {
+        self == &Self::GENESIS
+    }
 }
 
 impl std::ops::Add<u64> for BlockNumber {

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -10,6 +10,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+async-stream = "0.3.5"
 async-trait = { workspace = true }
 base64 = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }

--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -17,9 +17,9 @@ use p2p_proto::transaction::TransactionsRequest;
 use pathfinder_common::{
     event::Event,
     transaction::{DeployAccountTransactionV0V1, DeployAccountTransactionV3, TransactionVariant},
-    BlockHash, BlockNumber, ContractAddress, TransactionHash,
+    BlockHash, BlockNumber, ContractAddress, SignedBlockHeader, TransactionHash,
 };
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use tokio::sync::RwLock;
 
 use crate::client::peer_aware;
@@ -116,6 +116,86 @@ impl Client {
         };
         peers.shuffle(&mut rand::thread_rng());
         peers
+    }
+
+    pub fn header_stream(
+        self,
+        start: BlockNumber,
+        stop: BlockNumber,
+        reverse: bool,
+    ) -> impl futures::Stream<Item = PeerData<SignedBlockHeader>> {
+        let (mut start, stop, direction) = match reverse {
+            true => (stop, start, Direction::Backward),
+            false => (start, stop, Direction::Forward),
+        };
+
+        async_stream::stream! {
+            // Loop which refreshes peer set once we exhaust it.
+            loop {
+                let peers = self
+                    .get_update_peers_with_sync_capability(protocol::Headers::NAME)
+                    .await;
+
+                // Attempt each peer.
+                'next_peer: for peer in peers {
+                    let limit = start.get().max(stop.get()) - start.get().min(stop.get());
+
+                    let request = BlockHeadersRequest {
+                        iteration: Iteration {
+                            start: start.get().into(),
+                            direction,
+                            limit,
+                            step: 1.into(),
+                        },
+                    };
+
+                    let responses = match self.inner.send_headers_sync_request(peer, request).await
+                    {
+                        Ok(x) => x,
+                        Err(error) => {
+                            // Failed to establish connection, try next peer.
+                            tracing::debug!(%peer, reason=%error, "Headers request failed");
+                            continue 'next_peer;
+                        }
+                    };
+
+                    let mut responses = responses
+                        .flat_map(|response| futures::stream::iter(response.parts))
+                        .chunks(2)
+                        .scan((), |(), chunk| async { parse::handle_signed_header_chunk(chunk) })
+                        .boxed();
+
+                    while let Some(signed_header) = responses.next().await {
+                        let signed_header = match signed_header {
+                            Ok(signed_header) => signed_header,
+                            Err(error) => {
+                                tracing::debug!(%peer, %error, "Header stream failed");
+                                continue 'next_peer;
+                            }
+                        };
+
+                        // Small sanity check. We cannot reliably check the hash here,
+                        // its easier for the caller to ensure it matches expectations.
+                        if signed_header.header.number != start {
+                            tracing::debug!(%peer, "Wrong block number");
+                            continue 'next_peer;
+                        }
+
+                        start = match direction {
+                            Direction::Forward => start + 1,
+                            // unwrap_or_default is safe as this is the genesis edge case,
+                            // at which point the loop will complete at the end of this iteration.
+                            Direction::Backward => start.parent().unwrap_or_default(),
+                        };
+
+
+                        yield PeerData::new(peer, signed_header);
+                    }
+
+                    // TODO: track how much and how fast this peer responded with i.e. don't let them drip feed us etc.
+                }
+            }
+        }
     }
 
     pub async fn block_headers(

--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -33,6 +33,19 @@ mod parse;
 
 use parse::ParserState;
 
+/// Data received from a specific peer.
+#[derive(Debug)]
+pub struct PeerData<T> {
+    pub peer: PeerId,
+    pub data: T,
+}
+
+impl<T> PeerData<T> {
+    pub fn new(peer: PeerId, data: T) -> Self {
+        Self { peer, data }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Client {
     inner: peer_aware::Client,

--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -188,7 +188,6 @@ impl Client {
                             Direction::Backward => start.parent().unwrap_or_default(),
                         };
 
-
                         yield PeerData::new(peer, signed_header);
                     }
 

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -31,6 +31,7 @@ mod test_utils;
 mod tests;
 mod transport;
 
+pub use client::peer_agnostic::PeerData;
 pub use libp2p;
 pub use peers::Peers;
 pub use sync::protocol::PROTOCOLS;

--- a/crates/pathfinder/src/lib.rs
+++ b/crates/pathfinder/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod monitoring;
 pub mod state;
+mod sync;
 
 #[cfg(feature = "p2p")]
 pub mod p2p_network;

--- a/crates/pathfinder/src/sync.rs
+++ b/crates/pathfinder/src/sync.rs
@@ -1,2 +1,3 @@
 #[cfg(feature = "p2p")]
+#[allow(dead_code)]
 mod p2p;

--- a/crates/pathfinder/src/sync.rs
+++ b/crates/pathfinder/src/sync.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "p2p")]
+mod p2p;

--- a/crates/pathfinder/src/sync/p2p.rs
+++ b/crates/pathfinder/src/sync/p2p.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code, unused_variables)]
 mod headers;
 
 use anyhow::Context;

--- a/crates/pathfinder/src/sync/p2p.rs
+++ b/crates/pathfinder/src/sync/p2p.rs
@@ -1,0 +1,346 @@
+mod headers;
+
+use anyhow::Context;
+use pathfinder_common::{BlockHash, BlockNumber};
+use pathfinder_ethereum::EthereumStateUpdate;
+use pathfinder_storage::Storage;
+use primitive_types::H160;
+use tokio::task::spawn_blocking;
+
+use p2p::client::peer_agnostic::Client as P2PClient;
+
+/// Provides P2P sync capability for blocks secured by L1.
+pub struct Sync {
+    storage: Storage,
+    p2p: P2PClient,
+    // TODO: merge these two inside the client.
+    eth_client: pathfinder_ethereum::EthereumClient,
+    eth_address: H160,
+}
+
+impl Sync {
+    pub fn new(
+        storage: Storage,
+        p2p: P2PClient,
+        ethereum: (pathfinder_ethereum::EthereumClient, H160),
+    ) -> Self {
+        Self {
+            storage,
+            p2p,
+            eth_client: ethereum.0,
+            eth_address: ethereum.1,
+        }
+    }
+
+    /// Syncs using p2p until the latest Ethereum checkpoint.
+    pub async fn run(&self) -> anyhow::Result<()> {
+        use pathfinder_ethereum::EthereumApi;
+        let checkpoint = self
+            .eth_client
+            .get_starknet_state(&self.eth_address)
+            .await
+            .context("Fetching latest L1 checkpoint")?;
+
+        let local_state = LocalState::from_db(self.storage.clone(), checkpoint.clone())
+            .await
+            .context("Querying local state")?;
+
+        // Ensure our local state is consistent with the L1 checkpoint.
+        CheckpointAnalysis::analyse(&local_state, &checkpoint)
+            .handle(self.storage.clone())
+            .await
+            .context("Analysing local storage against L1 checkpoint")?;
+
+        // Persist checkpoint as new L1 anchor. This must be done first to protect against an interrupted sync process.
+        // Subsequent syncs will use this value to rollback against. Persisting it later would result in more data than
+        // necessary being rolled back (potentially all data if the header sync process is frequently interrupted), so this
+        // ensures sync will progress even under bad conditions.
+        let anchor = checkpoint;
+        persist_anchor(self.storage.clone(), anchor.clone())
+            .await
+            .context("Persisting new Ethereum anchor")?;
+
+        // Sync missing headers in reverse chronological order, from the new anchor to genesis.
+        self.sync_headers(anchor).await.context("Syncing headers")?;
+
+        // Sync the rest of the data in chronological order.
+
+        Ok(())
+    }
+
+    /// Syncs all headers in reverse chronological order, from the anchor point
+    /// back to genesis. Fills in any gaps left by previous header syncs.
+    ///
+    /// As sync goes backwards from a known L1 anchor block, this method can
+    /// guarantee that all sync'd headers are secured by L1.
+    ///
+    /// No guarantees are made about any headers newer than the anchor.
+    async fn sync_headers(&self, anchor: EthereumStateUpdate) -> anyhow::Result<()> {
+        while let Some(gap) =
+            headers::next_gap(self.storage.clone(), anchor.block_number, anchor.block_hash)
+                .await
+                .context("Finding next gap in header chain")?
+        {
+            use futures::StreamExt;
+            use futures::TryStreamExt;
+
+            // TODO: create a tracing scope for this gap start, stop.
+
+            tracing::info!("Syncing headers");
+
+            // TODO: consider .inspect_ok(tracing::trace!) for each stage.
+            let result = self
+                .p2p
+                .clone()
+                // TODO: consider buffering in the client to reduce request latency.
+                .header_stream(gap.head, gap.tail, true)
+                .scan((gap.head, gap.head_hash, false), headers::check_continuity)
+                // TODO: rayon scope this.
+                .and_then(headers::verify)
+                // chunk so that persisting to storage can be batched.
+                .try_chunks(1024)
+                // TODO: Pull out remaining data from try_chunks error.
+                //       try_chunks::Error is a tuple of Err(data, error) so we
+                //       should re-stream that as Ok(data), Err(error). Right now
+                //       we just map to Err(error).
+                .map_err(|e| e.1)
+                .and_then(|x| headers::persist(x, self.storage.clone()))
+                .inspect_ok(|x| tracing::info!(tail=%x.data.header.number, "Header chunk synced"))
+                // Drive stream to completion.
+                .try_fold((), |_state, _x| std::future::ready(Ok(())))
+                .await;
+
+            match result {
+                Ok(()) => {
+                    tracing::info!("Syncing headers complete");
+                }
+                Err(error) => {
+                    if let Some(peer_data) = error.peer_id_and_data() {
+                        // TODO: punish peer.
+                        tracing::debug!(
+                            peer=%peer_data.peer, block=%peer_data.data.header.number, %error,
+                            "Error while streaming headers"
+                        );
+                    } else {
+                        tracing::debug!(%error, "Error while streaming headers");
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Performs [analysis](Self::analyse) of the [LocalState] by comparing it with a given L1 checkpoint, and
+/// and [handles](Self::handle) the result.
+enum CheckpointAnalysis {
+    /// The checkpoint hash does not match the local L1 anchor, indicating an inconsistency with the Ethereum source
+    /// with the one used by the previous sync.
+    HashMismatchWithAnchor {
+        block: BlockNumber,
+        checkpoint: BlockHash,
+        anchor: BlockHash,
+    },
+    /// The checkpoint is older than the local anchor, indicating an inconsistency in the Ethereum source between
+    /// this sync and the previous sync.
+    PredatesAnchor {
+        checkpoint: BlockNumber,
+        anchor: BlockNumber,
+    },
+    /// The checkpoint exceeds the local chain. As such, the local chain should be rolled back to its anchor as we
+    /// cannot be confident in any of the local data not verified by L1.
+    ExceedsLocalChain {
+        local: BlockNumber,
+        checkpoint: BlockNumber,
+        anchor: Option<BlockNumber>,
+    },
+    /// The checkpoint hash does not match the local chain data. The local chain should be rolled back to its anchor.
+    HashMismatchWithLocalChain {
+        block: BlockNumber,
+        local: BlockHash,
+        checkpoint: BlockHash,
+        anchor: Option<BlockNumber>,
+    },
+    /// Local data is consistent with the checkpoint, no action required.
+    Consistent,
+}
+
+impl CheckpointAnalysis {
+    /// Analyse [LocalState] by checking it for consistency against the given L1 checkpoint.
+    ///
+    /// For more information on the potential inconsistencies see the [CheckpointAnalysis] variants.
+    fn analyse(local_state: &LocalState, checkpoint: &EthereumStateUpdate) -> CheckpointAnalysis {
+        // Checkpoint is older than or inconsistent with our local L1 anchor.
+        if let Some(anchor) = &local_state.anchor {
+            if checkpoint.block_number < anchor.block_number {
+                return CheckpointAnalysis::PredatesAnchor {
+                    checkpoint: checkpoint.block_number,
+                    anchor: anchor.block_number,
+                };
+            }
+            if checkpoint.block_number == anchor.block_number
+                && checkpoint.block_hash != anchor.block_hash
+            {
+                return CheckpointAnalysis::HashMismatchWithAnchor {
+                    block: anchor.block_number,
+                    checkpoint: checkpoint.block_hash,
+                    anchor: anchor.block_hash,
+                };
+            }
+        }
+
+        // Is local data not secured by an anchor potentially invalid?
+        if let Some(latest) = local_state.latest_header {
+            if checkpoint.block_number > latest.0 {
+                return CheckpointAnalysis::ExceedsLocalChain {
+                    local: latest.0,
+                    checkpoint: checkpoint.block_number,
+                    anchor: local_state.anchor.as_ref().map(|x| x.block_number),
+                };
+            } else if let Some((_, hash)) = local_state.checkpoint {
+                if hash != checkpoint.block_hash {
+                    return CheckpointAnalysis::HashMismatchWithLocalChain {
+                        block: checkpoint.block_number,
+                        local: hash,
+                        checkpoint: checkpoint.block_hash,
+                        anchor: local_state.anchor.as_ref().map(|x| x.block_number),
+                    };
+                }
+            }
+        }
+
+        CheckpointAnalysis::Consistent
+    }
+
+    /// Handles the [checkpoint analysis](Self::analyse) [result](Self).
+    ///
+    /// Returns an error for [PredatesAnchor](Self::PredatesAnchor) and
+    /// [HashMismatchWithAnchor](Self::HashMismatchWithAnchor) since these indicate an inconsistency with the Ethereum
+    /// source - making all data suspect.
+    ///
+    /// Rolls back local state to the anchor for [ExceedsLocalChain](Self::ExceedsLocalChain) and
+    /// [HashMismatchWithLocalChain](Self::HashMismatchWithLocalChain) conditions.
+    ///
+    /// Does nothing for [Consistent](Self::Consistent). This leaves any insecure local data intact. Always rolling
+    /// back to the L1 anchor would result in a poor user experience if restarting frequently as each restart would
+    /// purge new data.
+    async fn handle(self, storage: Storage) -> anyhow::Result<()> {
+        match self {
+            CheckpointAnalysis::HashMismatchWithAnchor {
+                block,
+                checkpoint,
+                anchor,
+            } => {
+                tracing::error!(
+                    %block, %checkpoint, %anchor,
+                    "Ethereum checkpoint's hash did not match the local Ethereum anchor. This indicates a serious inconsistency in the Ethereum source used by this sync and the previous sync."
+                );
+                anyhow::bail!("Ethereum checkpoint hash did not match local anchor.");
+            }
+            CheckpointAnalysis::PredatesAnchor { checkpoint, anchor } => {
+                // TODO: or consider this valid. If so, then we should continue sync but use the local anchor instead of the checkpoint.
+                tracing::error!(
+                    %checkpoint, %anchor,
+                    "Ethereum checkpoint is older than the local anchor. This indicates a serious inconsistency in the Ethereum source used by this sync and the previous sync."
+                );
+                anyhow::bail!("Ethereum checkpoint hash did not match local anchor.");
+            }
+            CheckpointAnalysis::ExceedsLocalChain {
+                local,
+                checkpoint,
+                anchor,
+            } => {
+                tracing::info!(
+                    %local, anchor=%anchor.unwrap_or_default(), %checkpoint,
+                    "Rolling back local chain to latest anchor point. Local data is potentially invalid as the Ethereum checkpoint is newer the local chain."
+                );
+                rollback_to_anchor(storage, anchor)
+                    .await
+                    .context("Rolling back chain state to L1 anchor")?;
+            }
+            CheckpointAnalysis::HashMismatchWithLocalChain {
+                block,
+                local,
+                checkpoint,
+                anchor,
+            } => {
+                tracing::info!(
+                    %block, %local, %checkpoint, ?anchor,
+                    "Rolling back local chain to latest anchor point. Local data is invalid as it did not match the Ethereum checkpoint's hash."
+                );
+                rollback_to_anchor(storage, anchor)
+                    .await
+                    .context("Rolling back chain state to L1 anchor")?;
+            }
+            CheckpointAnalysis::Consistent => {
+                tracing::info!("Ethereum checkpoint is consistent with local data");
+            }
+        };
+
+        Ok(())
+    }
+}
+
+struct LocalState {
+    latest_header: Option<(BlockNumber, BlockHash)>,
+    anchor: Option<EthereumStateUpdate>,
+    checkpoint: Option<(BlockNumber, BlockHash)>,
+}
+
+impl LocalState {
+    async fn from_db(storage: Storage, checkpoint: EthereumStateUpdate) -> anyhow::Result<Self> {
+        // TODO: this should include header gaps.
+        spawn_blocking(move || {
+            let mut db = storage
+                .connection()
+                .context("Creating database connection")?;
+            let db = db.transaction().context("Creating database transaction")?;
+
+            let latest_header = db
+                .block_id(pathfinder_storage::BlockId::Latest)
+                .context("Querying latest header")?;
+
+            let checkpoint = db
+                .block_id(checkpoint.block_number.into())
+                .context("Querying checkpoint header")?;
+
+            let anchor = db.latest_l1_state().context("Querying latest L1 anchor")?;
+
+            Ok(LocalState {
+                latest_header,
+                checkpoint,
+                anchor,
+            })
+        })
+        .await
+        .context("Joining blocking task")?
+    }
+}
+
+/// Rolls back local chain-state until the given anchor point, making it the tip of the local chain. If this is ['None']
+/// then all data will be rolled back.
+async fn rollback_to_anchor(storage: Storage, anchor: Option<BlockNumber>) -> anyhow::Result<()> {
+    spawn_blocking(move || {
+        todo!("Rollback storage to anchor point");
+    })
+    .await
+    .context("Joining blocking task")?
+}
+
+async fn persist_anchor(storage: Storage, anchor: EthereumStateUpdate) -> anyhow::Result<()> {
+    spawn_blocking(move || {
+        let mut db = storage
+            .connection()
+            .context("Creating database connection")?;
+        let db = db.transaction().context("Creating database transaction")?;
+        db.upsert_l1_state(&anchor).context("Inserting anchor")?;
+        // TODO: this is a bit dodgy, but is used by the sync process. However it destroys
+        //       some RPC assumptions which we should be aware of.
+        db.update_l1_l2_pointer(Some(anchor.block_number))
+            .context("Updating L1-L2 pointer")?;
+        db.commit().context("Committing database transaction")?;
+        Ok(())
+    })
+    .await
+    .context("Joining blocking task")?
+}

--- a/crates/pathfinder/src/sync/p2p.rs
+++ b/crates/pathfinder/src/sync/p2p.rs
@@ -132,7 +132,7 @@ impl Sync {
     }
 }
 
-/// Performs [analysis](Self::analyse) of the [LocalState] by comparing it with a given L1 checkpoint, and
+/// Performs [analysis](Self::analyse) of the [LocalState] by comparing it with a given L1 checkpoint,
 /// and [handles](Self::handle) the result.
 enum CheckpointAnalysis {
     /// The checkpoint hash does not match the local L1 anchor, indicating an inconsistency with the Ethereum source

--- a/crates/pathfinder/src/sync/p2p/headers.rs
+++ b/crates/pathfinder/src/sync/p2p/headers.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code, unused_variables)]
 use anyhow::Context;
 use p2p::PeerData;
 use pathfinder_common::{BlockHash, BlockNumber, SignedBlockHeader};
@@ -41,7 +42,7 @@ pub(super) async fn next_gap(
         let gap_head = if head_exists {
             // Find the next header that exists, but whose parent does not.
             let Some(gap_head) = db
-                .next_ancestor_without_parent(head.into())
+                .next_ancestor_without_parent(head)
                 .context("Querying head of gap")?
             else {
                 // No headers are missing so no gap found.
@@ -153,9 +154,9 @@ pub(super) async fn persist(
         let tx = db.transaction().context("Creating database transaction")?;
 
         for SignedBlockHeader { header, signature } in signed_headers.iter().map(|x| &x.data) {
-            tx.insert_block_header(&header)
+            tx.insert_block_header(header)
                 .context("Persisting block header")?;
-            tx.insert_signature(header.number, &signature)
+            tx.insert_signature(header.number, signature)
                 .context("Persisting block signature")?;
         }
 

--- a/crates/pathfinder/src/sync/p2p/headers.rs
+++ b/crates/pathfinder/src/sync/p2p/headers.rs
@@ -1,0 +1,168 @@
+use anyhow::Context;
+use p2p::PeerData;
+use pathfinder_common::{BlockHash, BlockNumber, SignedBlockHeader};
+use pathfinder_storage::Storage;
+use tokio::task::spawn_blocking;
+
+type SignedHeaderResult = Result<PeerData<SignedBlockHeader>, HeaderSyncError>;
+
+/// Describes a gap in the stored headers.
+///
+/// Both head and tail form part of the gap i.e. it is an inclusive range.
+pub(super) struct HeaderGap {
+    /// Freshest block height of the gap.
+    pub head: BlockNumber,
+    /// Hash of the gap's head block. Used to validate the header chain data received.
+    pub head_hash: BlockHash,
+    /// Oldest block height of the gap.
+    pub tail: BlockNumber,
+    /// Oldest block's parent's hash. Used to link any received data to the existing local
+    /// chain data.
+    pub tail_parent_hash: BlockHash,
+}
+
+/// Returns the first [HeaderGap] in headers, searching from the given block backwards.
+pub(super) async fn next_gap(
+    storage: Storage,
+    head: BlockNumber,
+    head_hash: BlockHash,
+) -> anyhow::Result<Option<HeaderGap>> {
+    spawn_blocking(move || {
+        let mut db = storage
+            .connection()
+            .context("Creating database connection")?;
+        let db = db.transaction().context("Creating database transaction")?;
+
+        // It's possible for the head block to be the head of the gap. This can occur when
+        // called with the L1 anchor which has not been synced yet.
+        let head_exists = db
+            .block_exists(head.into())
+            .context("Checking if search head exists locally")?;
+        let gap_head = if head_exists {
+            // Find the next header that exists, but whose parent does not.
+            let Some(gap_head) = db
+                .next_ancestor_without_parent(head.into())
+                .context("Querying head of gap")?
+            else {
+                // No headers are missing so no gap found.
+                return Ok(None);
+            };
+
+            gap_head
+        } else {
+            // Start of search is already missing so it becomes the head of the gap.
+            (head, head_hash)
+        };
+
+        let gap_tail = db
+            .next_ancestor(gap_head.0)
+            .context("Querying tail of gap")?
+            // By this point we are certain there is a gap, so the tail automatically becomes genesis
+            // if no actual tail block is found.
+            .unwrap_or_default();
+
+        Ok(Some(HeaderGap {
+            head: gap_head.0,
+            head_hash: gap_head.1,
+            tail: gap_tail.0 + 1,
+            tail_parent_hash: gap_tail.1,
+        }))
+    })
+    .await
+    .context("Joining blocking task")?
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(super) enum HeaderSyncError {
+    #[error(transparent)]
+    DatabaseError(#[from] anyhow::Error),
+    #[error("Signature verification failed")]
+    BadSignature(PeerData<SignedBlockHeader>),
+    #[error("Block hash verification failed")]
+    BadBlockHash(PeerData<SignedBlockHeader>),
+    #[error("Discontinuity in header chain")]
+    Discontinuity(PeerData<SignedBlockHeader>),
+}
+
+impl HeaderSyncError {
+    pub fn peer_id_and_data(&self) -> Option<&PeerData<SignedBlockHeader>> {
+        match self {
+            HeaderSyncError::DatabaseError(_) => None,
+            HeaderSyncError::BadSignature(x) => Some(x),
+            HeaderSyncError::BadBlockHash(x) => Some(x),
+            HeaderSyncError::Discontinuity(x) => Some(x),
+        }
+    }
+}
+
+/// Ensures the header block ID matches expectations.
+///
+/// Intended for use with [scan](futures::StreamExt::scan) which is why
+/// its function signature is a bit strange.
+pub(super) fn check_continuity(
+    expected: &mut (BlockNumber, BlockHash, bool),
+    input: PeerData<SignedBlockHeader>,
+) -> impl futures::Future<Output = Option<SignedHeaderResult>> {
+    if expected.2 {
+        return std::future::ready(None);
+    }
+
+    let header = &input.data.header;
+    let is_correct = header.number == expected.0 && header.hash == expected.1;
+
+    // Update expectation.
+    expected.0 = header.number;
+    expected.1 = header.hash;
+
+    let result = if is_correct {
+        Some(Ok(input))
+    } else {
+        expected.2 = true;
+        Some(Err(HeaderSyncError::Discontinuity(input)))
+    };
+
+    std::future::ready(result)
+}
+
+/// Verifies the block hash and signature.
+pub(super) async fn verify(signed_header: PeerData<SignedBlockHeader>) -> SignedHeaderResult {
+    tokio::task::spawn_blocking(move || {
+        if !signed_header.data.verify_signature() {
+            return Err(HeaderSyncError::BadSignature(signed_header));
+        }
+
+        if !signed_header.data.header.verify_hash() {
+            return Err(HeaderSyncError::BadBlockHash(signed_header));
+        }
+
+        Ok(signed_header)
+    })
+    .await
+    .expect("Task should not crash")
+}
+
+/// Writes the headers to storage.
+pub(super) async fn persist(
+    mut signed_headers: Vec<PeerData<SignedBlockHeader>>,
+    storage: Storage,
+) -> SignedHeaderResult {
+    tokio::task::spawn_blocking(move || {
+        let mut db = storage
+            .connection()
+            .context("Creating database connection")?;
+        let tx = db.transaction().context("Creating database transaction")?;
+
+        for SignedBlockHeader { header, signature } in signed_headers.iter().map(|x| &x.data) {
+            tx.insert_block_header(&header)
+                .context("Persisting block header")?;
+            tx.insert_signature(header.number, &signature)
+                .context("Persisting block signature")?;
+        }
+
+        tx.commit().context("Committing database transaction")?;
+
+        Ok(signed_headers.pop().expect("Headers should not be empty"))
+    })
+    .await
+    .expect("Task should not crash")
+}

--- a/crates/storage/src/connection.rs
+++ b/crates/storage/src/connection.rs
@@ -118,6 +118,26 @@ impl<'inner> Transaction<'inner> {
         block::block_header(self, block)
     }
 
+    /// Returns the closest ancestor header that is in storage.
+    ///
+    /// i.e. returns the latest header with number < target.
+    pub fn next_ancestor(
+        &self,
+        block: BlockNumber,
+    ) -> anyhow::Result<Option<(BlockNumber, BlockHash)>> {
+        block::next_ancestor(self, block)
+    }
+
+    /// Searches in reverse chronological order for a block that exists in storage, but whose parent does not.
+    ///
+    /// Note that target is included in the search.
+    pub fn next_ancestor_without_parent(
+        &self,
+        block: BlockNumber,
+    ) -> anyhow::Result<Option<(BlockNumber, BlockHash)>> {
+        block::next_ancestor_without_parent(self, block)
+    }
+
     /// Removes all data related to this block.
     ///
     /// This includes block header, block body and state update information.


### PR DESCRIPTION
Initial stab at a p2p sync implementation. This only implements the header sync portion and is not yet connected to the binary at all.

#### Note

This has changed significantly from the original demo. The original used tasks connected via channels whereas this new design uses streams and stream adapters which I think is much easier to read.

## Design

The driving idea is that we can speed up disk IO by only syncing one type of data at a time e.g. only block headers, then transaction data etc. This has the additional advantage of keeping processing simple since much less needs to be done by a single process.

This PR implements the sync skeleton and then the header sync portion of it.

## Nomenclature

I use two "definitions" throughout the code and comments:
1. **checkpoint** An L1 starknet checkpoint aka `EthereumStateUpdate`
2. **anchor** The latest checkpoint used locally for sync purposes. This acts as an "anchor" for the rest of the sync process.

## Design

To keep things simple and easy to reason about, but also secure, the sync process will only consider blocks that are secured by L1. This enables the following algorithm:

1. Fetch the latest checkpoint from L1.
2. Clean up any local data that is invalidated by the new checkpoint.
3. Sync headers in reverse chronological order from checkpoint to genesis. Since we use the checkpoint as a known anchor position, and sync in reverse we can guarantee the security of the synced headers.
4. Sync the rest of the data in chronological order, using the headers for security.

Data is also persisted to disk in chunks.

## Known issues

This only syncs up to the latest L1 checkpoint, so this might leave a rather large gap of unsynced blocks still. I don't think we should worry about that at this stage. I prefer having a more secure sync, supplemented by using a non-sync approach for the rest. Ideally the gap would be small enough that we can reach the tip of L2 from the L1 checkpoint in one swoop.

There is a missing loop, which should repeat the overall sync procedure as after the first iteration we will again be behind the next L1 checkpoint. But that's easy to add.

RPC will be dodgy while this sync happens, but I think that's fine.

We need to be careful about any storage invariants we may break during sync. But if we find any such cases, we should prefer adjusting storage instead of malforming p2p sync to fit it.

## Current status

- [x] header sync PoC skeleton
- [x] header sync details
- [ ] body sync
- [ ] optimisations (only in the final iteration)

However I think to keep the PR manageable this is a good place to stop for now.