### PR TITLE
Change jsonrpc `data` field to a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `starknet_getEvents` incorrectly evaluates empty sub-lists in key filters for pending events.
+- For `UNEXPECTED_ERROR`, change the `data` field into a `string` to comply with the spec.
 
 ## [0.10.3] - 2024-01-04
 

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -199,9 +199,7 @@ impl ApplicationError {
                 "limit": limit,
                 "requested": requested,
             })),
-            ApplicationError::UnexpectedError { data } => Some(json!({
-                "error": data,
-            })),
+            ApplicationError::UnexpectedError { data } => Some(json!(data)),
             ApplicationError::ProofLimitExceeded { limit, requested } => Some(json!({
                 "limit": limit,
                 "requested": requested,


### PR DESCRIPTION
For spec compliance, change the `data` field of our jsonrpc errors into a string. It used to be an object.

Fixes https://github.com/eqlabs/pathfinder/issues/1685.
