### PR TITLE
Add CLI args for inbound connection limits

### DIFF
--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -101,13 +101,13 @@ pub struct LimitsConfig {
     pub max_inbound_relay_peers: usize,
 }
 
-impl Default for LimitsConfig {
-    fn default() -> Self {
+impl LimitsConfig {
+    pub fn new(max_inbound_direct_peers: usize, max_inbound_relay_peers: usize) -> Self {
         Self {
             direct_connection_timeout: Duration::from_secs(30),
             relay_connection_timeout: Duration::from_secs(10),
-            max_inbound_direct_peers: 35,
-            max_inbound_relay_peers: 15,
+            max_inbound_direct_peers,
+            max_inbound_relay_peers,
         }
     }
 }

--- a/crates/p2p/src/tests.rs
+++ b/crates/p2p/src/tests.rs
@@ -103,7 +103,7 @@ impl Default for TestPeer {
     fn default() -> Self {
         Self::new(
             Default::default(),
-            Default::default(),
+            LimitsConfig::new(10, 10),
             Keypair::generate_ed25519(),
         )
     }
@@ -248,7 +248,8 @@ async fn periodic_bootstrap() {
     let limits_cfg = LimitsConfig {
         direct_connection_timeout: Duration::from_millis(50),
         relay_connection_timeout: Duration::from_millis(50),
-        ..Default::default()
+        max_inbound_direct_peers: 10,
+        max_inbound_relay_peers: 10,
     };
     let mut boot = TestPeer::new(periodic_cfg, limits_cfg, Keypair::generate_ed25519());
     let mut peer1 = TestPeer::new(periodic_cfg, limits_cfg, Keypair::generate_ed25519());
@@ -315,7 +316,8 @@ async fn reconnect_too_quickly() {
     let limits_cfg = LimitsConfig {
         direct_connection_timeout: CONNECTION_TIMEOUT,
         relay_connection_timeout: Duration::from_millis(500),
-        ..Default::default()
+        max_inbound_direct_peers: 10,
+        max_inbound_relay_peers: 10,
     };
 
     let mut peer1 = TestPeer::new(periodic_cfg, limits_cfg, Keypair::generate_ed25519());
@@ -410,7 +412,8 @@ async fn duplicate_connection() {
     let limits_cfg = LimitsConfig {
         direct_connection_timeout: CONNECTION_TIMEOUT,
         relay_connection_timeout: Duration::from_millis(500),
-        ..Default::default()
+        max_inbound_direct_peers: 10,
+        max_inbound_relay_peers: 10,
     };
     let keypair = Keypair::generate_ed25519();
     let mut peer1 = TestPeer::new(periodic_cfg, limits_cfg, keypair.clone());
@@ -491,7 +494,7 @@ async fn max_inbound_connections() {
         direct_connection_timeout: CONNECTION_TIMEOUT,
         relay_connection_timeout: Duration::from_millis(500),
         max_inbound_direct_peers: 2,
-        ..Default::default()
+        max_inbound_relay_peers: 0,
     };
     let mut peer1 = TestPeer::new(periodic_cfg, limits_cfg, Keypair::generate_ed25519());
     let mut peer2 = TestPeer::new(periodic_cfg, limits_cfg, Keypair::generate_ed25519());

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -322,6 +322,24 @@ Example:
         env = "PATHFINDER_P2P_PREDEFINED_PEERS"
     )]
     predefined_peers: Vec<String>,
+
+    #[arg(
+        long = "p2p.max-inbound-direct-connections",
+        long_help = "The maximum number of inbound direct (non-relayed) connections.",
+        value_name = "MAX_INBOUND_DIRECT_CONNECTIONS",
+        env = "PATHFINDER_MAX_INBOUND_DIRECT_CONNECTIONS",
+        default_value = "35"
+    )]
+    max_inbound_direct_connections: u32,
+
+    #[arg(
+        long = "p2p.max-inbound-relayed-connections",
+        long_help = "The maximum number of inbound relayed connections.",
+        value_name = "MAX_INBOUND_RELAYED_CONNECTIONS",
+        env = "PATHFINDER_MAX_INBOUND_RELAYED_CONNECTIONS",
+        default_value = "15"
+    )]
+    max_inbound_relayed_connections: u32,
 }
 
 #[cfg(feature = "p2p")]
@@ -488,6 +506,8 @@ pub struct P2PConfig {
     pub listen_on: Multiaddr,
     pub bootstrap_addresses: Vec<Multiaddr>,
     pub predefined_peers: Vec<Multiaddr>,
+    pub max_inbound_direct_connections: usize,
+    pub max_inbound_relayed_connections: usize,
 }
 
 #[cfg(not(feature = "p2p"))]
@@ -569,6 +589,11 @@ impl P2PConfig {
         };
 
         Self {
+            max_inbound_direct_connections: args.max_inbound_direct_connections.try_into().unwrap(),
+            max_inbound_relayed_connections: args
+                .max_inbound_relayed_connections
+                .try_into()
+                .unwrap(),
             proxy: args.proxy,
             identity_config_file: args.identity_config_file,
             listen_on: args.listen_on,

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -370,6 +370,10 @@ async fn start_p2p(
     };
 
     let context = P2PContext {
+        limits_cfg: p2p::LimitsConfig::new(
+            config.max_inbound_direct_connections,
+            config.max_inbound_relayed_connections,
+        ),
         chain_id,
         storage,
         proxy: config.proxy,

--- a/crates/pathfinder/src/p2p_network.rs
+++ b/crates/pathfinder/src/p2p_network.rs
@@ -23,6 +23,7 @@ pub type P2PNetworkHandle = (
 );
 
 pub struct P2PContext {
+    pub limits_cfg: p2p::LimitsConfig,
     pub chain_id: ChainId,
     pub storage: Storage,
     pub proxy: bool,
@@ -35,6 +36,7 @@ pub struct P2PContext {
 #[tracing::instrument(name = "p2p", skip_all)]
 pub async fn start(context: P2PContext) -> anyhow::Result<P2PNetworkHandle> {
     let P2PContext {
+        limits_cfg,
         chain_id,
         storage,
         proxy,
@@ -52,7 +54,7 @@ pub async fn start(context: P2PContext) -> anyhow::Result<P2PNetworkHandle> {
         keypair,
         peers.clone(),
         Default::default(),
-        Default::default(),
+        limits_cfg,
         chain_id,
     );
 


### PR DESCRIPTION
Add some CLI knobs to control the P2P limits that I recently added.

Part of #1670.