### PR TITLE
Ensure that peers use meaningful protocols

### DIFF
--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -71,10 +71,11 @@ pub fn new(
     let (event_sender, event_receiver) = mpsc::channel(1);
 
     (
-        Client::new(command_sender, local_peer_id),
+        Client::new(command_sender.clone(), local_peer_id),
         event_receiver,
         MainLoop::new(
             swarm,
+            command_sender,
             command_receiver,
             event_sender,
             peers,
@@ -191,6 +192,7 @@ enum Command {
         new_block: NewBlock,
         sender: EmptyResultSender,
     },
+    CheckProtocols(PeerId),
     /// For testing purposes only
     _Test(TestCommand),
 }


### PR DESCRIPTION
I wanted to close connections when protocol negotiation fails, but I think libp2p does that already. Then I realized that some protocols can basically waste connections: e.g. a peer who only connects to ping is not useful at all.

So my idea is: some reasonable time after a peer connection is established, check that they are using at least one of the protocols which move the chain forward. Otherwise close the peer connection. LMK if this makes sense or not, and if I'm checking the right protocols.

After I'm sure this makes sense I will open another PR with tests.

Part of #1670.