### PR TITLE
feat(gateway-types): add transaction hash calculation for 0.7 L1_HANDLER transactions

### DIFF
--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -522,18 +522,12 @@ async fn download_block(
 
             rayon::spawn(move || {
                 let result = block.transactions.par_iter().enumerate().try_for_each(|(i, txn)| {
-                        match verify(txn, chain_id, block_number) {
+                        match verify(txn, chain_id) {
                             starknet_gateway_types::transaction_hash::VerifyResult::Match => {}
                             starknet_gateway_types::transaction_hash::VerifyResult::Mismatch(actual) =>
                                 anyhow::bail!("Transaction hash mismatch: block {block_number} idx {i} expected {} calculated {}",
                                     txn.hash(),
                                     actual),
-                            starknet_gateway_types::transaction_hash::VerifyResult::NotVerifiable => {
-                                tracing::trace!(
-                                    "Skipping transaction verification: block {block_number} idx {i} hash {}",
-                                    txn.hash()
-                                )
-                            }
                         };
                         Ok(())
                     }).map(|_| block);


### PR DESCRIPTION
Starknet 0.7 introduced L1_HANDLER transactions and added a nonce to these transactions. This means that the transaction hash calculation already uses the `l1_handler` prefix, but it still does not include a transaction version in the hash -- so effectively it's another legacy variant.

This change makes it possible to remove the non-verifiable block range for transaction hashes.
