### PR TITLE
WIP: refactor: unify felt macros

### DIFF
--- a/crates/common/src/macros.rs
+++ b/crates/common/src/macros.rs
@@ -137,6 +137,18 @@ macro_rules! felt_newtypes {
                 }
             }
 
+            impl From<&'static str> for $target {
+                fn from(value: &'static str) -> Self {
+                    Self(pathfinder_crypto::Felt::from_hex_str(value).unwrap())
+                }
+            }
+
+            impl<const N: usize> From<&'static [u8; N]> for $target {
+                fn from(value: &'static [u8; N]) -> Self {
+                    Self(pathfinder_crypto::Felt::from_be_slice(value).unwrap())
+                }
+            }
+
             $crate::macros::fmt::thin_debug!($target);
             $crate::macros::fmt::thin_display!($target);
         }
@@ -189,6 +201,18 @@ macro_rules! felt_newtypes {
             impl From<crate::macros::MacroFelt> for $target {
                 fn from(value: crate::macros::MacroFelt) -> Self {
                     Self::new_or_panic(pathfinder_crypto::Felt::from(value))
+                }
+            }
+
+            impl From<&'static str> for $target {
+                fn from(value: &'static str) -> Self {
+                    Self(pathfinder_crypto::Felt::from_hex_str(value).unwrap())
+                }
+            }
+
+            impl<const N: usize> From<&'static [u8; N]> for $target {
+                fn from(value: &'static [u8; N]) -> Self {
+                    Self(pathfinder_crypto::Felt::from_be_slice(value).unwrap())
                 }
             }
 
@@ -359,13 +383,32 @@ mod tests {
     use super::*;
 
     #[test]
-    fn felt2_examples() {
+    fn macro_felt_example() {
         let single: pathfinder_crypto::Felt = felt2!("0xABCD");
         let vector: Vec<pathfinder_crypto::Felt> = felt2!["0x1", "0x2", "0x4xxx"];
 
         let tx = crate::transaction::InvokeTransactionV3 {
             signature: felt2!["0xAAAA", "0xBBBB"],
             nonce: felt2!("0xABCD"),
+            nonce_data_availability_mode: todo!(),
+            fee_data_availability_mode: todo!(),
+            resource_bounds: todo!(),
+            tip: todo!(),
+            paymaster_data: todo!(),
+            account_deployment_data: todo!(),
+            calldata: todo!(),
+            sender_address: todo!(),
+        };
+    }
+
+    #[test]
+    fn static_from_example() {
+        let single: pathfinder_crypto::Felt = felt2!("0xABCD");
+        let vector: Vec<pathfinder_crypto::Felt> = felt2!["0x1", "0x2", "0x4xxx"];
+
+        let tx = crate::transaction::InvokeTransactionV3 {
+            signature: vec!["0xAAAA".into(), "0xBBBB".into()],
+            nonce: b"abcdefasd".into(),
             nonce_data_availability_mode: todo!(),
             fee_data_availability_mode: todo!(),
             resource_bounds: todo!(),


### PR DESCRIPTION
This PR unifies all Felt newtype macros into a single one (well two including bytes variant).

I was getting annoyed creating fixtures for transactions so I tried some things.

Instead of `transaction_hash!` and `transaction_hash_bytes!` we would only have `felt!` and `felt_bytes!`.

Also included is the ability for `felt!` to generate a vector if supplied with multiple strings. This can be made a separate macro 🤷 Doesn't matter much.

### How it works

The vector portion is a bit more complicated - its not really the focus here so I'll just gloss over it by saying it uses the tt-muncher and push-down accumulate macro patterns.

The unifying macro operates the same as the original but performs two additional casts. These are required because we don't allow `From<Felt> for T` (since this would weaken type safety via `.into`). The intermediete type `MacroFelt(Felt)` implements `From<MacroFelt> for T` for all the newtypes.

This lets the macro essentially do `MacroFelt(Felt("0x1234")).into()`.

### Benefits

The macro now relies on type inference. Since we only use this only for creating test fixtures this isn't an issue (and is actually a benefit).

The vector macro usage is actually really nice, since you now don't have to repeat `call_param_elem!` like a madman.

Just one macro.

Less code.

I've included a basic usage example.

### Downsides

I haven't figured out how to get compile time checks to work for the vector variant. As in `felt2!["0x1", "0xxxxxx"]` will fail at runtime.

`MacroFelt` may have to be public for the macro to be used outside of the crate.

### Remaining work

- [ ] clean up macro and reorganise code
- [ ] ensure `MacroFelt` doesn't leak out
- [ ] replace existing macro instances
- [ ] remove existing macro

Opening for critique / feedback / judgement before I do any actual hard work of replacing all existing macro instances.


## Secondary alternative

I've added a second commit demonstrating essentially the same thing except we (ab)use static to enforce that only constant literals can be used. This requires no macros which is really nice.

This adds `Felt::from(&'static str)` and `Felt::from(&'static [u8; N])` which enables using
```rust
let nonce: ContractNonce = "0xABCD".into();
let nonce: ContractNonce = b"byte literal".into();
```

One could use this and still add support for vectors if we wanted, like `felt_vec!` to not repeat into everywhere in the vec. Doesn't matter much though.