### PR TITLE
feat(gateway-client): use a more aggressive request timeout and retry strategy

### DIFF
--- a/crates/gateway-client/src/builder.rs
+++ b/crates/gateway-client/src/builder.rs
@@ -397,8 +397,8 @@ where
     use std::num::NonZeroU64;
 
     Retry::exponential(future_factory, NonZeroU64::new(2).unwrap())
-        .factor(NonZeroU64::new(15).unwrap())
-        .max_delay(std::time::Duration::from_secs(10 * 60))
+        .factor(NonZeroU64::new(1).unwrap())
+        .max_delay(std::time::Duration::from_secs(10))
         .when(retry_condition)
         .await
 }
@@ -594,9 +594,9 @@ mod tests {
             );
 
             // The retry loops forever, so wrap it in a timeout and check the counter.
-            // 5 retries = 465s
-            // 6 retries = 945s
-            tokio::time::timeout(Duration::from_secs(500), fut)
+            // 4 retries = 2 + 4 + 8 + 10 = 24 seconds
+            // 5 retries = 2 + 4 + 8 + 10 + 10 = 34 seconds
+            tokio::time::timeout(Duration::from_secs(30), fut)
                 .await
                 .unwrap_err();
 

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -285,7 +285,7 @@ impl Client {
 
         Ok(Self {
             inner: reqwest::Client::builder()
-                .timeout(Duration::from_secs(120))
+                .timeout(Duration::from_secs(5))
                 .user_agent(pathfinder_common::consts::USER_AGENT)
                 .build()?,
             gateway,

--- a/crates/retry/src/lib.rs
+++ b/crates/retry/src/lib.rs
@@ -118,9 +118,7 @@ impl From<Strategy> for MaybeLimited {
                 .unwrap_or(u64::MAX),
         );
         let backoff = match s.max_delay {
-            Some(max_delay) => {
-                backoff.max_delay(max_delay.checked_mul(FACTOR).unwrap_or(Duration::MAX))
-            }
+            Some(max_delay) => backoff.max_delay(max_delay),
             None => backoff,
         };
 


### PR DESCRIPTION
 Individual requests to the feeder gateway can sometimes take a long time to complete (we've observed ~30s for polling the pending block). These requests potentially block our progress with syncing. In these cases it can be generally better to just time out the request more aggressively (after just 5 seconds) and retry.

The retry strategy also requires some tuning for the lower request timeout to be effective. The initial delay is 2s, then it doubles every time up to 10s.