### PR TITLE
Mirko/unify rpc tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6259,6 +6259,7 @@ dependencies = [
  "axum",
  "base64 0.13.1",
  "bytes",
+ "cached",
  "flate2",
  "futures",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ base64 = "0.13.1"
 bitvec = "1.0.1"
 blockifier = "=0.4.0"
 bytes = "1.4.0"
+cached = "0.44.0"
 # This one needs to match the version used by blockifier
 cairo-vm = "=0.8.3"
 clap = "4.1.13"

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 blockifier = { workspace = true }
-cached = "0.44.0"
+cached = { workspace = true }
 cairo-vm = { workspace = true }
 lazy_static = { workspace = true }
 pathfinder-common = { path = "../common" }

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -19,7 +19,7 @@ pub use error::{CallError, TransactionExecutionError};
 pub use estimate::estimate;
 pub use execution_state::ExecutionState;
 pub use felt::{IntoFelt, IntoStarkFelt};
-pub use simulate::{simulate, trace, TraceCache};
+pub use simulate::{simulate, trace, BlockTrace, TraceCache};
 
 // re-export blockifier transaction type since it's exposed on our API
 pub use blockifier::transaction::account_transaction::AccountTransaction;

--- a/crates/executor/src/simulate.rs
+++ b/crates/executor/src/simulate.rs
@@ -116,6 +116,8 @@ pub fn simulate(
     Ok(simulations)
 }
 
+pub type BlockTrace = Vec<(TransactionHash, TransactionTrace)>;
+
 pub fn trace(
     mut execution_state: ExecutionState<'_>,
     cache: &TraceCache,
@@ -123,7 +125,7 @@ pub fn trace(
     transactions: Vec<Transaction>,
     charge_fee: bool,
     validate: bool,
-) -> Result<Vec<(TransactionHash, TransactionTrace)>, TransactionExecutionError> {
+) -> Result<BlockTrace, TransactionExecutionError> {
     let (mut state, block_context) = execution_state.starknet_state()?;
 
     let cached = { cache.0.lock().unwrap().cache_get(&block_hash).cloned() };

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -11,6 +11,7 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 axum = { workspace = true, features = ["ws", "headers"] }
 base64 = { workspace = true }
+cached = { workspace = true }
 flate2 = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }

--- a/crates/rpc/src/context.rs
+++ b/crates/rpc/src/context.rs
@@ -2,6 +2,7 @@ use crate::gas_price;
 pub use crate::jsonrpc::websocket::WebsocketContext;
 use crate::pending::PendingData;
 use crate::pending::PendingWatcher;
+use crate::trace::BlockTraceCache;
 use crate::SyncState;
 use pathfinder_common::ChainId;
 use pathfinder_executor::TraceCache;
@@ -21,6 +22,7 @@ pub struct RpcConfig {
 
 #[derive(Clone)]
 pub struct RpcContext {
+    pub trace_cache: BlockTraceCache,
     pub cache: TraceCache,
     pub storage: Storage,
     pub execution_storage: Storage,
@@ -45,6 +47,7 @@ impl RpcContext {
     ) -> Self {
         let pending_data = PendingWatcher::new(pending_data);
         Self {
+            trace_cache: BlockTraceCache::new(128),
             cache: Default::default(),
             storage,
             execution_storage,

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -10,6 +10,7 @@ mod pathfinder;
 mod pending;
 #[cfg(test)]
 mod test_setup;
+mod trace;
 pub mod v02;
 pub mod v03;
 pub mod v04;

--- a/crates/rpc/src/trace.rs
+++ b/crates/rpc/src/trace.rs
@@ -1,0 +1,126 @@
+use std::sync::{Arc, Mutex};
+
+use anyhow::Context;
+use cached::{Cached, SizedCache};
+
+use pathfinder_common::{BlockHash, ChainId};
+use pathfinder_executor::{BlockTrace, ExecutionState, TransactionExecutionError};
+use starknet_gateway_types::reply::transaction::Transaction;
+
+use crate::{
+    compose_executor_transaction,
+    executor::VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEWAY,
+    PendingData,
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum TraceError {
+    #[error("Block not found")]
+    BlockNotFound,
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+    #[error("Transaction execution failed")]
+    ExecutionError(TransactionExecutionError),
+    #[error("Starknet version not supported")]
+    VersionNotSupported(Vec<Transaction>),
+}
+
+#[derive(Debug, Clone)]
+pub struct BlockTraceCache(Arc<Mutex<SizedCache<BlockHash, Arc<BlockTrace>>>>);
+
+impl BlockTraceCache {
+    pub fn new(size: usize) -> Self {
+        Self(Arc::new(Mutex::new(SizedCache::with_size(size))))
+    }
+}
+
+pub fn trace_block(
+    cache: &BlockTraceCache,
+    block: BlockHash,
+    db: &pathfinder_storage::Transaction<'_>,
+    chain_id: ChainId,
+) -> Result<Arc<BlockTrace>, TraceError> {
+    if let Some(cached) = cache.0.lock().unwrap().cache_get(&block).cloned() {
+        tracing::trace!("Trace cache hit");
+        return Ok(cached);
+    } else {
+        tracing::trace!("Trace cache miss");
+    }
+
+    let header = db
+        .block_header(block.into())
+        .context("Fetching block header")?
+        .ok_or(TraceError::BlockNotFound)?;
+
+    let transactions = db
+        .transaction_data_for_block(block.into())
+        .context("Fetching transactions for block")?
+        .ok_or(TraceError::BlockNotFound)?
+        .into_iter()
+        .map(|(tx, _)| tx)
+        .collect();
+
+    let version = header
+        .starknet_version
+        .parse_as_semver()
+        .context("Parsing starknet version")?
+        .unwrap_or(semver::Version::new(0, 0, 0));
+    if version < VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEWAY {
+        return Err(TraceError::VersionNotSupported(transactions));
+    }
+
+    let transactions = transactions
+        .into_iter()
+        .map(|tx| compose_executor_transaction(&tx, db))
+        .collect::<Result<_, _>>()
+        .context("Mapping transactions")?;
+    let state = ExecutionState::trace(&db, chain_id, header, None);
+    // TODO: remove cache from execution trace.
+    let traces =
+        pathfinder_executor::trace(state, &Default::default(), block, transactions, true, true)
+            .map_err(|e| TraceError::ExecutionError(e))?;
+    let traces = Arc::new(traces);
+
+    cache.0.lock().unwrap().cache_set(block, traces.clone());
+
+    Ok(traces)
+}
+
+pub fn trace_pending_block(
+    pending: PendingData,
+    db: &pathfinder_storage::Transaction<'_>,
+    chain_id: ChainId,
+) -> Result<Arc<BlockTrace>, TraceError> {
+    let header = pending.header();
+
+    let version = header
+        .starknet_version
+        .parse_as_semver()
+        .context("Parsing starknet version")?
+        .unwrap_or(semver::Version::new(0, 0, 0));
+    if version < VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEWAY {
+        return Err(TraceError::VersionNotSupported(
+            pending.block.transactions.clone(),
+        ));
+    }
+
+    let transactions = pending
+        .block
+        .transactions
+        .iter()
+        .map(|tx| compose_executor_transaction(tx, db))
+        .collect::<Result<_, _>>()
+        .context("Mapping transactions")?;
+    let state = ExecutionState::trace(&db, chain_id, header, None);
+    // TODO: remove cache from execution trace.
+    let traces = pathfinder_executor::trace(
+        state,
+        &Default::default(),
+        Default::default(),
+        transactions,
+        true,
+        true,
+    )
+    .map_err(|e| TraceError::ExecutionError(e))?;
+    Ok(Arc::new(traces))
+}


### PR DESCRIPTION
Concentrates the various trace implementations into a single place.

Currently only used by rpc v0.6 trace block transactions.
