### PR TITLE
fix(rpc): trace caching oversight

### DIFF
--- a/crates/executor/src/simulate.rs
+++ b/crates/executor/src/simulate.rs
@@ -118,7 +118,7 @@ pub fn simulate(
 
 pub fn trace(
     mut execution_state: ExecutionState<'_>,
-    cache: &TraceCache,
+    cache: TraceCache,
     block_hash: BlockHash,
     transactions: Vec<Transaction>,
     charge_fee: bool,

--- a/crates/rpc/src/v05/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v05/method/trace_block_transactions.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use pathfinder_common::{BlockId, TransactionHash};
-use pathfinder_executor::{ExecutionState, TransactionExecutionError};
+use pathfinder_executor::{ExecutionState, TraceCache, TransactionExecutionError};
 use serde::{Deserialize, Serialize};
 use starknet_gateway_client::GatewayApi;
 use starknet_gateway_types::trace::TransactionTrace as GatewayTxTrace;
@@ -146,7 +146,7 @@ pub async fn trace_block_transactions(
         let mut db = storage.connection()?;
         let db = db.transaction()?;
 
-        let (header, transactions) = match input.block_id {
+        let (header, transactions, cache) = match input.block_id {
             BlockId::Pending => {
                 let pending = context
                     .pending_data
@@ -156,7 +156,12 @@ pub async fn trace_block_transactions(
                 let header = pending.header();
                 let transactions = pending.block.transactions.clone();
 
-                (header, transactions)
+                (
+                    header,
+                    transactions,
+                    // Can't use caching for pending blocks since they have no block hash.
+                    TraceCache::default(),
+                )
             }
             other => {
                 let block_id = other.try_into().expect("Only pending should fail");
@@ -168,7 +173,7 @@ pub async fn trace_block_transactions(
                     .transactions_for_block(block_id)?
                     .context("Transaction data missing")?;
 
-                (header, transactions)
+                (header, transactions, context.cache.clone())
             }
         };
 
@@ -201,8 +206,7 @@ pub async fn trace_block_transactions(
 
         let hash = header.hash;
         let state = ExecutionState::trace(&db, context.chain_id, header, None);
-        let traces =
-            pathfinder_executor::trace(state, &context.cache, hash, transactions, true, true)?;
+        let traces = pathfinder_executor::trace(state, cache, hash, transactions, true, true)?;
 
         let result = traces
             .into_iter()

--- a/crates/rpc/src/v05/method/trace_transaction.rs
+++ b/crates/rpc/src/v05/method/trace_transaction.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use pathfinder_common::TransactionHash;
-use pathfinder_executor::{ExecutionState, TransactionExecutionError};
+use pathfinder_executor::{ExecutionState, TraceCache, TransactionExecutionError};
 use serde::{Deserialize, Serialize};
 use starknet_gateway_client::GatewayApi;
 
@@ -120,7 +120,7 @@ pub async fn trace_transaction(
             .get(&db)
             .context("Querying pending data")?;
 
-        let (header, transactions) = if let Some(pending_tx) = pending
+        let (header, transactions, cache) = if let Some(pending_tx) = pending
             .block
             .transactions
             .iter()
@@ -139,7 +139,13 @@ pub async fn trace_transaction(
                 return Ok(LocalExecution::Unsupported(pending_tx.clone()));
             }
 
-            (header, pending.block.transactions.clone())
+            (
+                header,
+                pending.block.transactions.clone(),
+                // Can't use cache for pending transactions since they are in a pending block, which
+                // has no block hash.
+                TraceCache::default(),
+            )
         } else {
             let block_hash = db
                 .transaction_block_hash(input.transaction_hash)?
@@ -171,7 +177,7 @@ pub async fn trace_transaction(
                 .context("Fetching block transactions")?
                 .context("Block transactions missing")?;
 
-            (header, transactions.clone())
+            (header, transactions.clone(), context.cache.clone())
         };
 
         let hash = header.hash;
@@ -182,7 +188,7 @@ pub async fn trace_transaction(
             .map(|transaction| compose_executor_transaction(transaction, &db))
             .collect::<Result<Vec<_>, _>>()?;
 
-        pathfinder_executor::trace(state, &context.cache, hash, transactions, true, true)
+        pathfinder_executor::trace(state, cache, hash, transactions, true, true)
             .map_err(TraceTransactionError::from)
             .and_then(|txs| {
                 txs.into_iter()

--- a/crates/rpc/src/v06/method/trace_transaction.rs
+++ b/crates/rpc/src/v06/method/trace_transaction.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use pathfinder_common::TransactionHash;
-use pathfinder_executor::{ExecutionState, TransactionExecutionError};
+use pathfinder_executor::{ExecutionState, TraceCache, TransactionExecutionError};
 use serde::{Deserialize, Serialize};
 use starknet_gateway_client::GatewayApi;
 
@@ -125,7 +125,7 @@ pub async fn trace_transaction(
             .get(&db)
             .context("Querying pending data")?;
 
-        let (header, transactions) = if let Some(pending_tx) = pending
+        let (header, transactions, cache) = if let Some(pending_tx) = pending
             .block
             .transactions
             .iter()
@@ -144,7 +144,12 @@ pub async fn trace_transaction(
                 return Ok(LocalExecution::Unsupported(pending_tx.clone()));
             }
 
-            (header, pending.block.transactions.clone())
+            (
+                header,
+                pending.block.transactions.clone(),
+                // Can't use the cache for pending blocks since they have no block hash.
+                TraceCache::default(),
+            )
         } else {
             let block_hash = db
                 .transaction_block_hash(input.transaction_hash)?
@@ -176,7 +181,7 @@ pub async fn trace_transaction(
                 .context("Fetching block transactions")?
                 .context("Block transactions missing")?;
 
-            (header, transactions.clone())
+            (header, transactions.clone(), context.cache.clone())
         };
 
         let hash = header.hash;
@@ -187,7 +192,7 @@ pub async fn trace_transaction(
             .map(|transaction| compose_executor_transaction(transaction, &db))
             .collect::<Result<Vec<_>, _>>()?;
 
-        pathfinder_executor::trace(state, &context.cache, hash, transactions, true, true)
+        pathfinder_executor::trace(state, cache, hash, transactions, true, true)
             .map_err(TraceTransactionError::from)
             .and_then(|txs| {
                 txs.into_iter()


### PR DESCRIPTION
The trace caching code uses `pending.hash` for caching, which is set to zero. So tracing pending blocks and transactions was completely broken.

The fix is hacky, but all this code is getting refactored by @Mirko-von-Leipzig anyway, so it doesn't really matter.

Also worth noting: to avoid mistakes like this in the future it might make sense to turn `pending.hash` into an `Option`, since logically pending blocks _don't_ have a hash (their hash is not zero - they don't have one).