### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ acl = private
 You can then download a compressed database using the command:
 
 ```shell
-rclone copy -P pathfinder-snapshots:pathfinder-snapshots/testnet_0.9.0_880310.sqlite.zst .
+rclone copy -P pathfinder-snapshots:pathfinder-snapshots/testnet_0.9.0_880310.sqlite.zst
 ```
 
 ### Uncompressing database snapshots


### PR DESCRIPTION
Remove the identifier "."

Short description of what this PR does.

Excess identifier, no meaning.

A longer description, include motivation and intent if possible. Detail any caveats or follow-up steps still required.

As the number of  blocks increases, users running nodes are facing the issue of insufficient primary disk space. At this time, it is necessary to mount an additional disk and move the operation to a disk with larger space. Then this line of code has its own error. Excessive meaningless identifiers will cause `Command copy needs 2 arguments maximum: you provided 3 non flag arguments: ["pathfinder-snapshots:pathfinder-snapshots/mainnet_0.9.0_309113.sqlite.zst" "." "/mnt/starknet"]`

Conclusion: 
Remove identifiers, reduce workload, and allow developers to quickly move on to the next step.

Delete once completed:
- [ ] link any issues closed by this pull-request
- [ ] add all user-facing changes to `CHANGELOG.md`
