### PR TITLE
refactor(pathfinder): remove `lru` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6088,7 +6088,6 @@ dependencies = [
  "http",
  "ipnet",
  "lazy_static",
- "lru 0.11.1",
  "metrics",
  "metrics-exporter-prometheus",
  "mimalloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ base64 = "0.13.1"
 bitvec = "1.0.1"
 blockifier = "=0.4.0"
 bytes = "1.4.0"
+cached = "0.44.0"
 # This one needs to match the version used by blockifier
 cairo-vm = "=0.8.3"
 clap = "4.1.13"

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 blockifier = { workspace = true }
-cached = "0.44.0"
+cached = { workspace = true }
 cairo-vm = { workspace = true }
 lazy_static = { workspace = true }
 pathfinder-common = { path = "../common" }

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -29,7 +29,6 @@ fake = { workspace = true }
 futures = { workspace = true }
 ipnet = { workspace = true }
 lazy_static = { workspace = true }
-lru = "0.11.1"
 metrics = { workspace = true }
 metrics-exporter-prometheus = "0.11.0"
 mimalloc = { version = "0.1.39", default-features = false }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -13,7 +13,7 @@ base64 = { workspace = true }
 bincode = "2.0.0-rc.3"
 bitvec = { workspace = true }
 bloomfilter = "1.0.12"
-cached = "0.44.0"
+cached = { workspace = true }
 const_format = { workspace = true }
 data-encoding = "2.4.0"
 fake = { workspace = true }


### PR DESCRIPTION
First I wanted to replace `lru` with `cached` since we use `cached` everywhere else. Then I noticed that `cached` actually doesn't have some of the functions that are being used, but this cache was specifically just for 2 elements which is really simple. So I ended up using a `VecDeque`.

Closes https://github.com/eqlabs/pathfinder/issues/1725.