### PR TITLE
fix(p2p): properly pass the `ip_whitelist` flag

### DIFF
--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -88,24 +88,6 @@ pub struct Config {
     pub bootstrap: BootstrapConfig,
 }
 
-impl Config {
-    pub fn new(
-        max_inbound_direct_peers: usize,
-        max_inbound_relay_peers: usize,
-        bootstrap: BootstrapConfig,
-    ) -> Self {
-        Self {
-            direct_connection_timeout: Duration::from_secs(30),
-            relay_connection_timeout: Duration::from_secs(10),
-            max_inbound_direct_peers,
-            max_inbound_relayed_peers: max_inbound_relay_peers,
-            ip_whitelist: vec!["::/0".parse().unwrap(), "0.0.0.0/0".parse().unwrap()],
-            bootstrap,
-            eviction_timeout: Duration::from_secs(15 * 60),
-        }
-    }
-}
-
 #[derive(Copy, Clone, Debug)]
 pub struct BootstrapConfig {
     pub start_offset: Duration,

--- a/crates/p2p/src/tests.rs
+++ b/crates/p2p/src/tests.rs
@@ -82,7 +82,15 @@ impl TestPeer {
 impl Default for TestPeer {
     fn default() -> Self {
         Self::new(
-            Config::new(10, 10, Default::default()),
+            Config {
+                direct_connection_timeout: Duration::from_secs(30),
+                relay_connection_timeout: Duration::from_secs(10),
+                max_inbound_direct_peers: 10,
+                max_inbound_relayed_peers: 10,
+                ip_whitelist: vec!["::/0".parse().unwrap(), "0.0.0.0/0".parse().unwrap()],
+                bootstrap: Default::default(),
+                eviction_timeout: Duration::from_secs(15 * 60),
+            },
             Keypair::generate_ed25519(),
         )
     }

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -549,6 +549,7 @@ pub struct P2PConfig {
     pub predefined_peers: Vec<Multiaddr>,
     pub max_inbound_direct_connections: usize,
     pub max_inbound_relayed_connections: usize,
+    pub ip_whitelist: Vec<IpNet>,
 }
 
 #[cfg(not(feature = "p2p"))]
@@ -640,6 +641,7 @@ impl P2PConfig {
             listen_on: args.listen_on,
             bootstrap_addresses: parse_multiaddr_vec(args.bootstrap_addresses),
             predefined_peers: parse_multiaddr_vec(args.predefined_peers),
+            ip_whitelist: args.ip_whitelist,
         }
     }
 }

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -348,7 +348,7 @@ async fn start_p2p(
     use p2p::libp2p::identity::Keypair;
     use pathfinder_lib::p2p_network::{client::HybridClient, P2PContext};
     use serde::Deserialize;
-    use std::path::Path;
+    use std::{path::Path, time::Duration};
     use zeroize::Zeroizing;
 
     #[derive(Clone, Deserialize)]
@@ -381,11 +381,15 @@ async fn start_p2p(
     };
 
     let context = P2PContext {
-        cfg: p2p::Config::new(
-            config.max_inbound_direct_connections,
-            config.max_inbound_relayed_connections,
-            Default::default(),
-        ),
+        cfg: p2p::Config {
+            direct_connection_timeout: Duration::from_secs(30),
+            relay_connection_timeout: Duration::from_secs(10),
+            max_inbound_direct_peers: config.max_inbound_direct_connections,
+            max_inbound_relayed_peers: config.max_inbound_relayed_connections,
+            ip_whitelist: config.ip_whitelist,
+            bootstrap: Default::default(),
+            eviction_timeout: Duration::from_secs(15 * 60),
+        },
         chain_id,
         storage,
         proxy: config.proxy,


### PR DESCRIPTION
Properly pass the `ip_whitelist` flag from CLI into `p2p`. Remove `Config::new` since the idea is that `Config` is just a data struct that the client should provide values for.