### PR TITLE
feat(p2p): add low watermark for outbound connections

### DIFF
--- a/crates/p2p/src/behaviour.rs
+++ b/crates/p2p/src/behaviour.rs
@@ -484,6 +484,13 @@ impl Behaviour {
         self.peers.iter()
     }
 
+    pub fn num_outbound_peers(&self) -> usize {
+        self.peers
+            .iter()
+            .filter(|(_, peer)| peer.is_outbound())
+            .count()
+    }
+
     /// Number of inbound non-relayed peers.
     fn num_inbound_direct_peers(&self) -> usize {
         self.peers

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -82,6 +82,9 @@ pub struct Config {
     pub max_inbound_direct_peers: usize,
     /// Maximum number of relayed peers.
     pub max_inbound_relayed_peers: usize,
+    /// The minimum number of peers to maintain. If the number of outbound peers drops below this
+    /// number, the node will attempt to connect to more peers.
+    pub low_watermark: usize,
     /// How long to prevent evicted peers from reconnecting.
     pub eviction_timeout: Duration,
     pub ip_whitelist: Vec<IpNet>,
@@ -98,7 +101,7 @@ impl Default for BootstrapConfig {
     fn default() -> Self {
         Self {
             start_offset: Duration::from_secs(5),
-            period: Duration::from_secs(10 * 60),
+            period: Duration::from_secs(2 * 60),
         }
     }
 }
@@ -216,7 +219,7 @@ pub enum Event {
 #[derive(Debug)]
 pub enum TestEvent {
     NewListenAddress(Multiaddr),
-    PeriodicBootstrapCompleted(Result<PeerId, PeerId>),
+    KademliaBootstrapCompleted(Result<PeerId, PeerId>),
     StartProvidingCompleted(Result<RecordKey, RecordKey>),
     ConnectionEstablished { outbound: bool, remote: PeerId },
     ConnectionClosed { remote: PeerId },

--- a/crates/p2p/src/peers.rs
+++ b/crates/p2p/src/peers.rs
@@ -26,6 +26,10 @@ impl Peer {
         matches!(self.direction, Direction::Inbound)
     }
 
+    pub fn is_outbound(&self) -> bool {
+        matches!(self.direction, Direction::Outbound)
+    }
+
     pub fn is_relayed(&self) -> bool {
         self.addr
             .as_ref()

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -357,7 +357,7 @@ Example:
         long_help = "The maximum number of inbound direct (non-relayed) connections.",
         value_name = "MAX_INBOUND_DIRECT_CONNECTIONS",
         env = "PATHFINDER_MAX_INBOUND_DIRECT_CONNECTIONS",
-        default_value = "35"
+        default_value = "30"
     )]
     max_inbound_direct_connections: u32,
 
@@ -366,9 +366,18 @@ Example:
         long_help = "The maximum number of inbound relayed connections.",
         value_name = "MAX_INBOUND_RELAYED_CONNECTIONS",
         env = "PATHFINDER_MAX_INBOUND_RELAYED_CONNECTIONS",
-        default_value = "15"
+        default_value = "30"
     )]
     max_inbound_relayed_connections: u32,
+
+    #[arg(
+        long = "p2p.low-watermark",
+        long_help = "The minimum number of outbound peers to maintain. If the number of outbound peers drops below this number, the node will attempt to connect to more peers.",
+        value_name = "LOW_WATERMARK",
+        env = "PATHFINDER_LOW_WATERMARK",
+        default_value = "20"
+    )]
+    low_watermark: u32,
 
     #[arg(
         long = "p2p.ip-whitelist",
@@ -550,6 +559,7 @@ pub struct P2PConfig {
     pub max_inbound_direct_connections: usize,
     pub max_inbound_relayed_connections: usize,
     pub ip_whitelist: Vec<IpNet>,
+    pub low_watermark: usize,
 }
 
 #[cfg(not(feature = "p2p"))]
@@ -642,6 +652,7 @@ impl P2PConfig {
             bootstrap_addresses: parse_multiaddr_vec(args.bootstrap_addresses),
             predefined_peers: parse_multiaddr_vec(args.predefined_peers),
             ip_whitelist: args.ip_whitelist,
+            low_watermark: 0,
         }
     }
 }

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -386,6 +386,7 @@ async fn start_p2p(
             relay_connection_timeout: Duration::from_secs(10),
             max_inbound_direct_peers: config.max_inbound_direct_connections,
             max_inbound_relayed_peers: config.max_inbound_relayed_connections,
+            low_watermark: config.low_watermark,
             ip_whitelist: config.ip_whitelist,
             bootstrap: Default::default(),
             eviction_timeout: Duration::from_secs(15 * 60),


### PR DESCRIPTION
Instead of always doing periodic Kademlia bootstrap, only bootstrap if the number of outbound connections is below a _low watermark_ value.

Keep track of ongoing Kademlia bootstraps and finish early if they're taking too long. This might seem controversial but these should never last more than a few minutes, and I was having issues during testing where the bootstrap would hang and the test would only be able to progress if the previous bootstrap was aborted. We don't want to get into this situation in production.

Part of https://github.com/eqlabs/pathfinder/issues/1711.