### PR TITLE
feat(p2p): outbound peer eviction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5913,6 +5913,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "sha3",
  "test-log",
  "tokio",
  "tracing",

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -43,6 +43,7 @@ rayon = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = "0.10.7"
+sha3 = { workspace = true }
 tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread", "sync"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }

--- a/crates/p2p/src/client/peer_aware.rs
+++ b/crates/p2p/src/client/peer_aware.rs
@@ -179,6 +179,18 @@ impl Client {
         receiver.await.expect("Sender not to be dropped")
     }
 
+    /// Mark a peer as not useful.
+    ///
+    /// These peers will be candidates for outbound peer eviction.
+    pub async fn not_useful(&self, peer_id: PeerId) {
+        let (sender, receiver) = oneshot::channel();
+        self.sender
+            .send(Command::NotUseful { peer_id, sender })
+            .await
+            .expect("Command receiver not to be dropped");
+        receiver.await.expect("Sender not to be dropped")
+    }
+
     #[cfg(test)]
     pub(crate) fn for_test(&self) -> test_utils::Client {
         test_utils::Client::new(self.sender.clone())

--- a/crates/p2p/src/peers.rs
+++ b/crates/p2p/src/peers.rs
@@ -48,7 +48,8 @@ impl Peer {
 
     pub fn connected_at(&self) -> Option<Instant> {
         match self.connectivity {
-            Connectivity::Connected { connected_at } => Some(connected_at),
+            Connectivity::Connected { connected_at, .. } => Some(connected_at),
+            Connectivity::Disconnecting { connected_at, .. } => connected_at,
             Connectivity::Disconnected { connected_at, .. } => connected_at,
             Connectivity::Dialing => None,
         }
@@ -61,6 +62,10 @@ pub enum Connectivity {
     Connected {
         /// When the peer was connected.
         connected_at: Instant,
+    },
+    Disconnecting {
+        /// When the peer was connected, if he was connected.
+        connected_at: Option<Instant>,
     },
     Disconnected {
         /// When the peer was connected, if he was connected.

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -371,6 +371,15 @@ Example:
     max_inbound_relayed_connections: u32,
 
     #[arg(
+        long = "p2p.max-outbound-connections",
+        long_help = "The maximum number of outbound connections.",
+        value_name = "MAX_OUTBOUND_CONNECTIONS",
+        env = "PATHFINDER_MAX_OUTBOUND_CONNECTIONS",
+        default_value = "50"
+    )]
+    max_outbound_connections: u32,
+
+    #[arg(
         long = "p2p.low-watermark",
         long_help = "The minimum number of outbound peers to maintain. If the number of outbound peers drops below this number, the node will attempt to connect to more peers.",
         value_name = "LOW_WATERMARK",
@@ -558,6 +567,7 @@ pub struct P2PConfig {
     pub predefined_peers: Vec<Multiaddr>,
     pub max_inbound_direct_connections: usize,
     pub max_inbound_relayed_connections: usize,
+    pub max_outbound_connections: usize,
     pub ip_whitelist: Vec<IpNet>,
     pub low_watermark: usize,
 }
@@ -646,6 +656,7 @@ impl P2PConfig {
                 .max_inbound_relayed_connections
                 .try_into()
                 .unwrap(),
+            max_outbound_connections: args.max_outbound_connections.try_into().unwrap(),
             proxy: args.proxy,
             identity_config_file: args.identity_config_file,
             listen_on: args.listen_on,

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -386,6 +386,7 @@ async fn start_p2p(
             relay_connection_timeout: Duration::from_secs(10),
             max_inbound_direct_peers: config.max_inbound_direct_connections,
             max_inbound_relayed_peers: config.max_inbound_relayed_connections,
+            max_outbound_peers: config.max_outbound_connections,
             low_watermark: config.low_watermark,
             ip_whitelist: config.ip_whitelist,
             bootstrap: Default::default(),


### PR DESCRIPTION
Evict outbound peers for which `useful = false` when a new outbound connection is attempted. Did this first because it's simpler than inbound peer eviction.

Part of https://github.com/eqlabs/pathfinder/issues/1711.