### PR TITLE
refactor(storage): decouple from gateway types

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -172,7 +172,7 @@ pub struct Tip(pub u64);
 pub struct ResourcePricePerUnit(pub u128);
 
 /// Starknet transaction version.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize, Default, Dummy)]
 pub struct TransactionVersion(pub Felt);
 
 impl TransactionVersion {

--- a/crates/common/src/receipt.rs
+++ b/crates/common/src/receipt.rs
@@ -11,6 +11,19 @@ pub struct Receipt {
     pub transaction_index: TransactionIndex,
 }
 
+impl Receipt {
+    pub fn is_reverted(&self) -> bool {
+        matches!(self.execution_status, ExecutionStatus::Reverted { .. })
+    }
+
+    pub fn revert_reason(&self) -> Option<String> {
+        match &self.execution_status {
+            ExecutionStatus::Succeeded => None,
+            ExecutionStatus::Reverted { reason } => Some(reason.clone()),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct L2ToL1Message {
     pub from_address: ContractAddress,

--- a/crates/crypto/examples/consts_poseidon.rs
+++ b/crates/crypto/examples/consts_poseidon.rs
@@ -184,7 +184,7 @@ pub fn extract_roundkeys() -> Vec<[BigUint; 3]> {
     let mut at_keys = false;
     let mut line_ctr = 0;
     let mut buffer: [BigUint; 3] = [BigUint::default(), BigUint::default(), BigUint::default()];
-    for line in lines.flatten() {
+    for line in lines.map_while(Result::ok) {
         // Skip until reaching RoundKeys
         if line.contains("RoundKeys") {
             at_keys = true;

--- a/crates/pathfinder/examples/feeder_gateway.rs
+++ b/crates/pathfinder/examples/feeder_gateway.rs
@@ -358,8 +358,10 @@ fn resolve_block(
         .context("Reading transactions from database")?
         .context("Transaction data missing")?;
 
-    let (transactions, transaction_receipts): (Vec<_>, Vec<_>) =
-        transactions_receipts.into_iter().unzip();
+    let (transactions, transaction_receipts): (Vec<_>, Vec<_>) = transactions_receipts
+        .into_iter()
+        .map(|(t, r)| (t.into(), r.into()))
+        .unzip();
 
     let block_status = tx
         .block_is_l1_accepted(header.number.into())

--- a/crates/pathfinder/examples/re_execute.rs
+++ b/crates/pathfinder/examples/re_execute.rs
@@ -2,10 +2,11 @@ use std::num::NonZeroU32;
 
 use anyhow::Context;
 use mimalloc::MiMalloc;
+use pathfinder_common::receipt::Receipt;
+use pathfinder_common::transaction::Transaction;
 use pathfinder_common::{BlockHeader, BlockNumber, ChainId};
 use pathfinder_executor::ExecutionState;
 use pathfinder_storage::{BlockId, JournalMode, Storage};
-use starknet_gateway_types::reply::transaction::{Receipt, Transaction};
 
 // Due to the amount of JSON parsing that gets done during execution we use an alternate
 // allocator here: mimalloc. According to benchmarks re_execute performs roughly 25% better
@@ -143,8 +144,8 @@ fn execute(storage: Storage, chain_id: ChainId, rx: crossbeam_channel::Receiver<
 
         let transactions = work
             .transactions
-            .iter()
-            .map(|tx| pathfinder_rpc::compose_executor_transaction(tx, &db_tx))
+            .into_iter()
+            .map(|tx| pathfinder_rpc::compose_executor_transaction(&tx.into(), &db_tx))
             .collect::<Result<Vec<_>, _>>();
 
         let transactions = match transactions {

--- a/crates/pathfinder/examples/verify_block_hashes.rs
+++ b/crates/pathfinder/examples/verify_block_hashes.rs
@@ -54,8 +54,10 @@ fn main() -> anyhow::Result<()> {
         drop(tx);
 
         let block_hash = header.hash;
-        let (transactions, receipts): (Vec<_>, Vec<_>) =
-            transactions_and_receipts.into_iter().unzip();
+        let (transactions, receipts): (Vec<_>, Vec<_>) = transactions_and_receipts
+            .into_iter()
+            .map(|(t, r)| (t.into(), r.into()))
+            .unzip();
 
         let block = Block {
             block_hash: header.hash,

--- a/crates/pathfinder/examples/verify_transaction_hashes.rs
+++ b/crates/pathfinder/examples/verify_transaction_hashes.rs
@@ -61,13 +61,9 @@ fn main() -> anyhow::Result<()> {
         transactions
             .par_iter()
             .enumerate()
-            .for_each(|(i, (gw_txn, _))| {
-                let txn = pathfinder_common::transaction::Transaction::from(gw_txn.clone());
+            .for_each(|(i, (txn, _))| {
                 if !txn.verify_hash(chain_id) {
-                    println!(
-                        "Mismatch: block {block_number} idx {i}. Full_txn\n{}",
-                        serde_json::to_string(&gw_txn).unwrap_or(">Failed to deserialize<".into())
-                    );
+                    println!("Mismatch: block {block_number} idx {i}. Full_txn\n{txn:?}",);
                 }
             });
     }

--- a/crates/pathfinder/src/p2p_network/sync_handlers.rs
+++ b/crates/pathfinder/src/p2p_network/sync_handlers.rs
@@ -269,7 +269,7 @@ fn get_transactions_for_block(
         kind: TransactionsResponseKind::Transactions(Transactions {
             items: txn_data
                 .into_iter()
-                .map(|(txn, _)| pathfinder_common::transaction::Transaction::from(txn).to_proto())
+                .map(|(txn, _)| txn.to_proto())
                 .collect(),
         }),
     });

--- a/crates/pathfinder/src/p2p_network/sync_handlers/tests.rs
+++ b/crates/pathfinder/src/p2p_network/sync_handlers/tests.rs
@@ -555,7 +555,7 @@ mod prop {
                     (
                         h.number,
                         h.hash,
-                        tr.into_iter().map(|(t, _)| Transaction::from(workaround::for_legacy_l1_handlers(t)).variant.into()).collect::<Vec<_>>()
+                        tr.into_iter().map(|(t, _)| Transaction::from(workaround::for_legacy_l1_handlers(t.into())).variant.into()).collect::<Vec<_>>()
                     )
             ).collect::<Vec<_>>();
             // Run the handler
@@ -605,7 +605,7 @@ mod prop {
                     (
                         h.number,
                         h.hash,
-                        tr.into_iter().map(|(_, r)| r.into()).collect::<Vec<_>>()
+                        tr.into_iter().map(|(_, r)| starknet_gateway_types::reply::transaction::Receipt::from(r).into()).collect::<Vec<_>>()
                     )
             ).collect::<Vec<_>>();
             // Run the handler

--- a/crates/pathfinder/src/p2p_network/sync_handlers/tests.rs
+++ b/crates/pathfinder/src/p2p_network/sync_handlers/tests.rs
@@ -1,848 +1,848 @@
-use p2p_proto::common::{Direction, Step};
-use pathfinder_common::BlockNumber;
-use rstest::rstest;
-
-const I64_MAX: u64 = i64::MAX as u64;
-
-#[rstest]
-#[case(0, 1, Direction::Forward, Some(1))]
-#[case(0, I64_MAX, Direction::Forward, Some(I64_MAX))]
-#[case(1, I64_MAX, Direction::Forward, None)]
-#[case(0, 1, Direction::Backward, None)]
-#[case(1, 1, Direction::Backward, Some(0))]
-#[case(I64_MAX, 1, Direction::Backward, Some(I64_MAX - 1))]
-#[case(I64_MAX, I64_MAX, Direction::Backward, Some(0))]
-#[case(I64_MAX, I64_MAX + 1, Direction::Backward, None)]
-#[test]
-fn get_next_block_number(
-    #[case] start: u64,
-    #[case] step: u64,
-    #[case] direction: Direction,
-    #[case] expected: Option<u64>,
-) {
-    assert_eq!(
-        super::get_next_block_number(
-            BlockNumber::new_or_panic(start),
-            Step::from(Some(step)),
-            direction
-        ),
-        expected.map(BlockNumber::new_or_panic)
-    );
-}
-
-mod boundary_conditions {
-    use super::I64_MAX;
-    use crate::p2p_network::sync_handlers::{
-        get_bodies, get_events, get_headers, get_receipts, get_transactions, MAX_COUNT_IN_TESTS,
-    };
-    use assert_matches::assert_matches;
-    use fake::{Fake, Faker};
-    use futures::channel::mpsc;
-    use futures::StreamExt;
-    use p2p_proto::block::{
-        BlockBodiesRequest, BlockBodyMessage, BlockHeadersRequest, BlockHeadersResponse,
-        BlockHeadersResponsePart,
-    };
-    use p2p_proto::common::{BlockNumberOrHash, Direction, Fin, Iteration};
-    use p2p_proto::event::{EventsRequest, EventsResponseKind};
-    use p2p_proto::receipt::{ReceiptsRequest, ReceiptsResponseKind};
-    use p2p_proto::transaction::{TransactionsRequest, TransactionsResponseKind};
-    use pathfinder_storage::fake::with_n_blocks;
-    use pathfinder_storage::Storage;
-    use rand::{thread_rng, Rng};
-    use rstest::rstest;
-
-    mod zero_limit_yields_fin_ok_invalid_start_yields_fin_unknown {
-        use super::*;
-
-        fn zero_limit() -> Iteration {
-            Iteration {
-                limit: 0,
-                ..Faker.fake()
-            }
-        }
-
-        fn invalid_start() -> Iteration {
-            Iteration {
-                start: BlockNumberOrHash::Number(
-                    rand::thread_rng().gen_range(I64_MAX + 1..=u64::MAX),
-                ),
-                ..Faker.fake()
-            }
-        }
-
-        macro_rules! define_test {
-            ($name:ident, $uut_name:ident, $request:tt) => {
-                #[rstest]
-                #[case(zero_limit(), Fin::ok())]
-                #[case(invalid_start(), Fin::unknown())]
-                #[tokio::test]
-                async fn $name(#[case] iteration: Iteration, #[case] fin: Fin) {
-                    let storage = Storage::in_memory().unwrap();
-                    let (tx, mut rx) = mpsc::channel(0);
-                    let _jh = tokio::spawn($uut_name(storage, $request { iteration }, tx));
-                    assert_eq!(rx.next().await.unwrap().into_fin(), Some(fin));
-                }
-            };
-        }
-
-        define_test!(headers, get_headers, BlockHeadersRequest);
-        define_test!(bodies, get_bodies, BlockBodiesRequest);
-        define_test!(transactions, get_transactions, TransactionsRequest);
-        define_test!(receipts, get_receipts, ReceiptsRequest);
-        define_test!(events, get_events, EventsRequest);
-    }
-
-    mod partially_successful_requests_end_with_additional_fin_unknown {
-        use super::*;
-
-        fn init_test<T>(
-            direction: Direction,
-        ) -> (Storage, Iteration, mpsc::Sender<T>, mpsc::Receiver<T>) {
-            let storage: Storage = Storage::in_memory().unwrap();
-            let _ = with_n_blocks(&storage, 1);
-            let iteration = Iteration {
-                start: BlockNumberOrHash::Number(0),
-                // We want more than available, we don't care about the internal limit because
-                // partial failure (`Fin::unknown()`) takes precedence over it (`Fin::too_much()`)
-                limit: thread_rng().gen_range(2..=MAX_COUNT_IN_TESTS * 2),
-                direction,
-                ..Faker.fake()
-            };
-            let (tx, rx) = mpsc::channel::<T>(0);
-            (storage, iteration, tx, rx)
-        }
-
-        #[rstest]
-        #[tokio::test]
-        async fn test_get_headers(
-            #[values(Direction::Backward, Direction::Forward)] direction: Direction,
-        ) {
-            let (storage, iteration, tx, mut rx) = init_test(direction);
-            let getter_fut = get_headers(storage, BlockHeadersRequest { iteration }, tx);
-
-            let (_, ret) = tokio::join!(getter_fut, rx.next());
-
-            let BlockHeadersResponse { parts } = ret.unwrap();
-            assert_eq!(parts.len(), 4);
-            assert_matches!(&parts[0], BlockHeadersResponsePart::Header(h) => assert_eq!(h.number, 0));
-            assert_matches!(&parts[1], BlockHeadersResponsePart::Signatures(s) => assert_eq!(s.block.number, 0));
-            assert_eq!(parts[2], BlockHeadersResponsePart::Fin(Fin::ok()));
-            // Expect Fin::unknown() where the first unavailable item would be
-            assert_eq!(parts[3], BlockHeadersResponsePart::Fin(Fin::unknown()));
-        }
-
-        #[rstest]
-        #[tokio::test]
-        async fn test_get_bodies(
-            #[values(Direction::Backward, Direction::Forward)] direction: Direction,
-        ) {
-            let (storage, iteration, tx, mut rx) = init_test(direction);
-            let _jh = tokio::spawn(get_bodies(storage, BlockBodiesRequest { iteration }, tx));
-            rx.next().await.unwrap(); // Diff
-            match rx.next().await.unwrap().body_message {
-                // New classes in block
-                BlockBodyMessage::Classes(_) => {
-                    assert_eq!(
-                        rx.next().await.unwrap().body_message,
-                        BlockBodyMessage::Fin(Fin::ok())
-                    );
-                }
-                // No new classes in block
-                BlockBodyMessage::Fin(f) => assert_eq!(f, Fin::ok()),
-                _ => panic!("unexpected message type"),
-            }
-
-            // Expect Fin::unknown() where the first unavailable item would be
-            assert_eq!(
-                rx.next().await.unwrap().body_message,
-                BlockBodyMessage::Fin(Fin::unknown())
-            );
-        }
-
-        macro_rules! define_test {
-            ($name:ident, $uut_name:ident, $request:tt, $reply:tt) => {
-                #[rstest]
-                #[tokio::test]
-                async fn $name(
-                    #[values(Direction::Backward, Direction::Forward)] direction: Direction,
-                ) {
-                    let (storage, iteration, tx, mut rx) = init_test(direction);
-                    let _jh = tokio::spawn($uut_name(storage, $request { iteration }, tx));
-                    // Block data
-                    rx.next().await.unwrap();
-                    // Properly delimited with Fin::ok()
-                    assert_eq!(rx.next().await.unwrap().kind, $reply::Fin(Fin::ok()));
-                    // Expect Fin::unknown() where the first unavailable item would be
-                    assert_eq!(rx.next().await.unwrap().kind, $reply::Fin(Fin::unknown()));
-                }
-            };
-        }
-
-        define_test!(
-            test_get_transactions,
-            get_transactions,
-            TransactionsRequest,
-            TransactionsResponseKind
-        );
-        define_test!(
-            test_get_receipts,
-            get_receipts,
-            ReceiptsRequest,
-            ReceiptsResponseKind
-        );
-        define_test!(
-            test_get_events,
-            get_events,
-            EventsRequest,
-            EventsResponseKind
-        );
-    }
-
-    mod internally_limited_requests_end_with_additional_fin_too_much {
-        use super::*;
-
-        const NUM_BLOCKS_IN_STORAGE: u64 = MAX_COUNT_IN_TESTS;
-
-        fn init_test<T>(
-            direction: Direction,
-        ) -> (Storage, Iteration, mpsc::Sender<T>, mpsc::Receiver<T>) {
-            let storage = Storage::in_memory().unwrap();
-            let _ = with_n_blocks(&storage, NUM_BLOCKS_IN_STORAGE as usize);
-            let (tx, rx) = mpsc::channel::<T>(1);
-            let start = match direction {
-                Direction::Forward => BlockNumberOrHash::Number(0),
-                Direction::Backward => BlockNumberOrHash::Number(NUM_BLOCKS_IN_STORAGE - 1),
-            };
-            let iteration = Iteration {
-                start,
-                // We want to trigger the internal limit
-                limit: thread_rng().gen_range(NUM_BLOCKS_IN_STORAGE + 1..=u64::MAX),
-                step: 1.into(),
-                direction,
-            };
-            (storage, iteration, tx, rx)
-        }
-
-        #[rstest]
-        #[tokio::test]
-        async fn test_get_headers(
-            #[values(Direction::Backward, Direction::Forward)] direction: Direction,
-        ) {
-            let (storage, iteration, tx, mut rx) = init_test(direction);
-            get_headers(storage, BlockHeadersRequest { iteration }, tx.clone())
-                .await
-                .unwrap();
-
-            let BlockHeadersResponse { parts } = rx.next().await.unwrap();
-            assert_eq!(parts.len(), NUM_BLOCKS_IN_STORAGE as usize * 3 + 1);
-
-            let chunked = parts.chunks_exact(3);
-            let remainder = chunked.remainder();
-
-            chunked.for_each(|chunk| {
-                assert_matches!(&chunk[0], BlockHeadersResponsePart::Header(_));
-                assert_matches!(&chunk[1], BlockHeadersResponsePart::Signatures(_));
-                assert_eq!(chunk[2], BlockHeadersResponsePart::Fin(Fin::ok()));
-            });
-            // Expect Fin::too_much() if all requested items were found up to the internal limit
-            assert_eq!(remainder, &[BlockHeadersResponsePart::Fin(Fin::too_much())]);
-        }
-
-        #[rstest]
-        #[tokio::test]
-        async fn test_get_bodies(
-            #[values(Direction::Backward, Direction::Forward)] direction: Direction,
-        ) {
-            let (storage, iteration, tx, mut rx) = init_test(direction);
-            let _jh = tokio::spawn(get_bodies(storage, BlockBodiesRequest { iteration }, tx));
-            // 10 x [Diff, Classes*, Fin::ok()]
-            for _ in 0..NUM_BLOCKS_IN_STORAGE {
-                rx.next().await.unwrap(); // Diff
-                match rx.next().await.unwrap().body_message {
-                    // New classes in block
-                    BlockBodyMessage::Classes(_) => {
-                        assert_eq!(
-                            rx.next().await.unwrap().body_message,
-                            BlockBodyMessage::Fin(Fin::ok())
-                        );
-                    }
-                    // No new classes in block
-                    BlockBodyMessage::Fin(f) => {
-                        assert_eq!(f, Fin::ok());
-                    }
-                    _ => panic!("unexpected message type"),
-                }
-            }
-            // Expect Fin::too_much() where the first unavailable item would be
-            assert_eq!(
-                rx.next().await.unwrap().body_message,
-                BlockBodyMessage::Fin(Fin::too_much())
-            );
-        }
-
-        macro_rules! define_test {
-            ($name:ident, $uut_name:ident, $request:tt, $reply:tt) => {
-                #[rstest]
-                #[tokio::test]
-                async fn $name(
-                    #[values(Direction::Backward, Direction::Forward)] direction: Direction,
-                ) {
-                    let (storage, iteration, tx, mut rx) = init_test(direction);
-                    let _jh = tokio::spawn($uut_name(storage, $request { iteration }, tx));
-                    for _ in 0..NUM_BLOCKS_IN_STORAGE {
-                        rx.next().await.unwrap(); // Block data
-                        rx.next().await.unwrap(); // Fin::ok()
-                    }
-                    // Expect Fin::too_much() where the first unavailable item would be
-                    assert_eq!(rx.next().await.unwrap().kind, $reply::Fin(Fin::too_much()));
-                }
-            };
-        }
-
-        define_test!(
-            test_get_transactions,
-            get_transactions,
-            TransactionsRequest,
-            TransactionsResponseKind
-        );
-        define_test!(
-            test_get_receipts,
-            get_receipts,
-            ReceiptsRequest,
-            ReceiptsResponseKind
-        );
-        define_test!(
-            test_get_events,
-            get_events,
-            EventsRequest,
-            EventsResponseKind
-        );
-    }
-}
-
-/// Property tests, grouped to be immediately visible when executed
-mod prop {
-    use crate::p2p_network::client::types as simplified;
-    use crate::p2p_network::sync_handlers;
-    use crate::p2p_network::sync_handlers::def_into_dto;
-    use futures::channel::mpsc;
-    use futures::StreamExt;
-    use p2p::client::types::{self as p2p_types, RawTransactionVariant, TryFromDto};
-    use p2p_proto::block::{
-        BlockBodiesRequest, BlockBodyMessage, BlockHeadersRequest, BlockHeadersResponse,
-        BlockHeadersResponsePart,
-    };
-    use p2p_proto::common::{BlockId, BlockNumberOrHash, Error, Fin, Iteration};
-    use p2p_proto::event::{EventsRequest, EventsResponseKind};
-    use p2p_proto::receipt::{ReceiptsRequest, ReceiptsResponseKind};
-    use p2p_proto::state::{Cairo0Class, Cairo1Class, Class};
-    use p2p_proto::transaction::{TransactionsRequest, TransactionsResponseKind};
-    use pathfinder_common::event::Event;
-    use pathfinder_common::transaction::Transaction;
-    use pathfinder_common::{
-        BlockCommitmentSignature, BlockCommitmentSignatureElem, BlockHash, BlockNumber,
-        TransactionHash,
-    };
-    use proptest::prelude::*;
-    use std::collections::{BTreeSet, HashMap};
-    use tokio::runtime::Runtime;
-
-    #[macro_export]
-    macro_rules! prop_assert_eq_sorted {
-        ($left:expr, $right:expr) => {{
-            let left = &$left;
-            let right = &$right;
-            let comparison_string = pretty_assertions_sorted::Comparison::new(
-                &pretty_assertions_sorted::SortedDebug::new(left),
-                &pretty_assertions_sorted::SortedDebug::new(right)
-            ).to_string();
-            proptest::prop_assert!(
-                *left == *right,
-                "assertion failed: `(left == right)`\n{comparison_string}\n");
-        }};
-
-        ($left:expr, $right:expr, $fmt:tt $($args:tt)*) => {{
-            let left = &$left;
-            let right = &$right;
-            let comparison_string = pretty_assertions_sorted::Comparison::new(
-                &pretty_assertions_sorted::SortedDebug::new(left),
-                &pretty_assertions_sorted::SortedDebug::new(right)
-            ).to_string();
-            proptest::prop_assert!(
-                *left == *right,
-                concat!(
-                    "assertion failed: `(left == right)`\n\
-                    {}: ", $fmt),
-                comparison_string $($args)*);
-        }};
-    }
-
-    proptest! {
-        #[test]
-        fn get_headers((num_blocks, seed, start_block, limit, step, direction) in strategy::composite()) {
-            // Fake storage with a given number of blocks
-            let (storage, in_db) = fixtures::storage_with_seed(seed, num_blocks);
-            // Compute the overlapping set between the db and the request
-            // These are the headers that we expect to be read from the db
-            let expected = overlapping::get(in_db, start_block, limit, step, num_blocks, direction)
-                .into_iter().map(|(h, s, _, _, _, _)| (h.into(), s)).collect::<Vec<_>>();
-            // Run the handler
-            let request = BlockHeadersRequest { iteration: Iteration { start: BlockNumberOrHash::Number(start_block), limit, step, direction, } };
-            // Reusing the runtime does not yield any performance gains
-            let parts = Runtime::new().unwrap().block_on(async {
-                let (tx, mut rx) = mpsc::channel(0);
-                let getter_fut = sync_handlers::get_headers(storage, request, tx);
-
-                // Waiting for both futures to run to completion is faster than spawning the getter
-                // and awaiting the receiver (almost 1s for 100 iterations on Ryzen 3700X).
-                // BTW, we cannot just await the getter and then the receiver
-                // as there is backpressure (channel size 0) and we would deadlock.
-                let (_, ret) = tokio::join!(getter_fut, rx.next());
-
-                let BlockHeadersResponse { parts } = ret.unwrap();
-                parts
-            });
-            // Empty reply in the test is only possible if the request does not overlap with storage
-            // Invalid start and zero limit are tested in boundary_conditions::
-            if expected.is_empty() {
-                prop_assert_eq_sorted!(parts.len(), 1);
-                prop_assert_eq_sorted!(parts[0].clone().into_fin().unwrap(), Fin::unknown());
-            } else {
-                // Group reply parts by block: [[hdr-0, fin-0], [hdr-1, fin-1], ...]
-                let actual = parts.chunks_exact(3).map(|chunk| {
-                    // Make sure block data is delimited
-                    assert_eq!(chunk[2], BlockHeadersResponsePart::Fin(Fin::ok()));
-                    // Extract the header
-                    let h = p2p_types::BlockHeader::try_from(chunk[0].clone().into_header().unwrap()).unwrap();
-                    // Extract the signature
-                    let s = chunk[1].clone().into_signatures().unwrap();
-                    assert_eq!(s.signatures.len(), 1);
-                    let s = s.signatures.into_iter().next().unwrap();
-                    let s = BlockCommitmentSignature {
-                        r: BlockCommitmentSignatureElem(s.r),
-                        s: BlockCommitmentSignatureElem(s.s),
-                    };
-                    (h, s)
-                }).collect::<Vec<_>>();
-
-                prop_assert_eq_sorted!(actual, expected);
-            }
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn get_bodies((num_blocks, db_seed, start_block, limit, step, direction) in strategy::composite()) {
-            use crate::p2p_network::sync_handlers::class_definition::{Cairo, Sierra};
-
-            // Fake storage with a given number of blocks
-            let (storage, in_db) = fixtures::storage_with_seed(db_seed, num_blocks);
-            // Get the overlapping set between the db and the request
-            let expected = overlapping::get(in_db, start_block, limit, step, num_blocks, direction);
-            // Extract the expected state updates, definitions and classes from the overlapping set
-            // in a form digestable for this test
-            let expected = expected.into_iter()
-                .map(|(header, _, _, state_update, cairo_defs, sierra_defs)|
-                    (
-                        // block number and hash
-                        (header.number, header.hash),
-                        (
-                            // "simplified" state update, without an explicit list of declared and replaced classes
-                            state_update.clone().into(),
-                            // Cairo0 class definitions, parsed into p2p DTOs
-                            cairo_defs.into_iter().map(|(_, d)| {
-                                let def = serde_json::from_slice::<Cairo<'_>>(&d).unwrap();
-                                def_into_dto::cairo(def)
-                            }).collect(),
-                            // Cairo1 (Sierra) class definitions, parsed into p2p DTOs
-                            sierra_defs.into_iter().map(|(_, s, c)| {
-                                let def = serde_json::from_slice::<Sierra<'_>>(&s).unwrap();
-                                def_into_dto::sierra(def, c)
-                            }).collect()
-                        )
-                    )
-                ).collect::<HashMap<_, (p2p_types::StateUpdate, BTreeSet<Cairo0Class>, BTreeSet<Cairo1Class>)>>();
-            // Run the handler
-            let request = BlockBodiesRequest { iteration: Iteration { start: BlockNumberOrHash::Number(start_block), limit, step, direction, } };
-            let replies = Runtime::new().unwrap().block_on(async {
-                let (tx, rx) = mpsc::channel(0);
-                let getter_fut = sync_handlers::get_bodies(storage, request, tx);
-                let (_, replies) = tokio::join!(getter_fut, rx.collect::<Vec<_>>());
-                replies
-            });
-
-            // Empty reply is only possible if the request does not overlap with storage
-            // Invalid start and zero limit are tested in boundary_conditions::
-            if expected.is_empty() {
-                prop_assert_eq_sorted!(replies.len(), 1);
-                prop_assert_eq_sorted!(replies[0].clone().into_fin().unwrap(), Fin::unknown());
-            } else {
-                // Collect replies into a set of (block_number, state_update, definitions)
-                let mut actual = HashMap::new();
-                let mut block_id = None;
-
-                for reply in replies {
-                    match reply.body_message {
-                        BlockBodyMessage::Diff(d) => {
-                            let BlockId { number, hash } = reply.id.unwrap();
-                            block_id = Some((BlockNumber::new(number).unwrap(), BlockHash(hash.0)));
-
-                            let state_update = p2p_types::StateUpdate::from(d);
-                            actual.insert(block_id.unwrap(), (state_update, BTreeSet::new(), BTreeSet::new()));
-                        },
-                        BlockBodyMessage::Classes(c) => {
-                            // Classes coming after a state diff should be for the same block
-                            let entry = actual.get_mut(&block_id.expect("Classes follow Diff so current block id should be set")).unwrap();
-                            c.classes.into_iter().for_each(|c| {
-                                match c {
-                                    Class::Cairo0(cairo) => entry.1.insert(cairo),
-                                    Class::Cairo1(sierra) => entry.2.insert(sierra),
-                                };
-                            });
-                        },
-                        BlockBodyMessage::Fin(f) => {
-                            match f.error {
-                                // We either managed to fit the entire range or we hit the internal limit
-                                None | Some(Error::TooMuch) => assert!(actual.contains_key(&block_id.unwrap())),
-                                // Either the request yielded nothing or was only partially successful
-                                Some(Error::Unknown) => {},
-                                Some(_) => panic!("unexpected error"),
-                            }
-                        }
-                        _ => unimplemented!(),
-                    }
-                }
-
-                prop_assert_eq_sorted!(actual, expected);
-            }
-        }
-    }
-
-    mod workaround {
-        use pathfinder_common::{TransactionNonce, TransactionVersion};
-        use starknet_gateway_types::reply::transaction as gw;
-
-        // Align with the deserialization workaround to avoid false negative mismatches
-        pub fn for_legacy_l1_handlers(tx: gw::Transaction) -> gw::Transaction {
-            match tx {
-                gw::Transaction::Invoke(gw::InvokeTransaction::V0(tx))
-                    if tx.entry_point_type == Some(gw::EntryPointType::L1Handler) =>
-                {
-                    gw::Transaction::L1Handler(gw::L1HandlerTransaction {
-                        contract_address: tx.sender_address,
-                        entry_point_selector: tx.entry_point_selector,
-                        nonce: TransactionNonce::ZERO,
-                        calldata: tx.calldata,
-                        transaction_hash: tx.transaction_hash,
-                        version: TransactionVersion::ZERO,
-                    })
-                }
-                x => x,
-            }
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn get_transactions((num_blocks, seed, start_block, limit, step, direction) in strategy::composite()) {
-            // Fake storage with a given number of blocks
-            let (storage, in_db) = fixtures::storage_with_seed(seed, num_blocks);
-            // Compute the overlapping set between the db and the request
-            // These are the transactions that we expect to be read from the db
-            let expected = overlapping::get(in_db, start_block, limit, step, num_blocks, direction).into_iter()
-                .map(|(h, _, tr, _, _, _)|
-                    (
-                        h.number,
-                        h.hash,
-                        tr.into_iter().map(|(t, _)| Transaction::from(workaround::for_legacy_l1_handlers(t.into())).variant.into()).collect::<Vec<_>>()
-                    )
-            ).collect::<Vec<_>>();
-            // Run the handler
-            let request = TransactionsRequest { iteration: Iteration { start: BlockNumberOrHash::Number(start_block), limit, step, direction, } };
-            let replies = Runtime::new().unwrap().block_on(async {
-                let (tx, rx) = mpsc::channel(0);
-                let getter_fut = sync_handlers::get_transactions(storage, request, tx);
-                let (_, replies) = tokio::join!(getter_fut, rx.collect::<Vec<_>>());
-                replies
-            });
-            // Empty reply is only possible if the request does not overlap with storage
-            // Invalid start and zero limit are tested in boundary_conditions::
-            if expected.is_empty() {
-                prop_assert_eq_sorted!(replies.len(), 1);
-                prop_assert_eq_sorted!(replies[0].clone().into_fin().unwrap(), Fin::unknown());
-            } else {
-                // Group replies by block, it is assumed that transactions per block are small enough to fit under the 1MiB limit
-                // This means that there are 2 replies per block: [[transactions-0, fin-0], [transactions-1, fin-1], ...]
-                let actual = replies.chunks_exact(2).map(|replies | {
-                    assert_eq!(replies[0].id, replies[1].id);
-                    // Make sure block data is delimited
-                    assert_eq!(replies[1].kind, TransactionsResponseKind::Fin(Fin::ok()));
-                    // Extract transactions
-                    let transactions = replies[0].kind.clone().into_transactions().unwrap().items;
-                    let BlockId { number, hash } = replies[0].id.unwrap();
-                    (
-                        BlockNumber::new(number).unwrap(),
-                        BlockHash(hash.0),
-                        transactions.into_iter().map(|t| RawTransactionVariant::try_from_dto(t).unwrap()).collect::<Vec<_>>()
-                    )
-                }).collect::<Vec<_>>();
-
-                prop_assert_eq_sorted!(actual, expected);
-            }
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn get_receipts((num_blocks, seed, start_block, limit, step, direction) in strategy::composite()) {
-            // Fake storage with a given number of blocks
-            let (storage, in_db) = fixtures::storage_with_seed(seed, num_blocks);
-            // Compute the overlapping set between the db and the request
-            // These are the receipts that we expect to be read from the db
-            let expected = overlapping::get(in_db, start_block, limit, step, num_blocks, direction).into_iter()
-                .map(|(h, _, tr, _, _, _)|
-                    (
-                        h.number,
-                        h.hash,
-                        tr.into_iter().map(|(_, r)| starknet_gateway_types::reply::transaction::Receipt::from(r).into()).collect::<Vec<_>>()
-                    )
-            ).collect::<Vec<_>>();
-            // Run the handler
-            let request = ReceiptsRequest { iteration: Iteration { start: BlockNumberOrHash::Number(start_block), limit, step, direction, } };
-            let replies = Runtime::new().unwrap().block_on(async {
-                let (tx, rx) = mpsc::channel(0);
-                let getter_fut = sync_handlers::get_receipts(storage, request, tx);
-                let (_, replies) = tokio::join!(getter_fut, rx.collect::<Vec<_>>());
-                replies
-            });
-            // Empty reply is only possible if the request does not overlap with storage
-            // Invalid start and zero limit are tested in boundary_conditions::
-            if expected.is_empty() {
-                prop_assert_eq_sorted!(replies.len(), 1);
-                prop_assert_eq_sorted!(replies[0].clone().into_fin().unwrap(), Fin::unknown());
-            } else {
-                // Group replies by block, it is assumed that receipts per block small enough to fit under the 1MiB limit
-                // This means that there are 2 replies per block: [[receipts-0, fin-0], [receipts-1, fin-1], ...]
-                let actual = replies.chunks_exact(2).map(|replies | {
-                    assert_eq!(replies[0].id, replies[1].id);
-                    // Make sure block data is delimited
-                    assert_eq!(replies[1].kind, ReceiptsResponseKind::Fin(Fin::ok()));
-                    // Extract receipts
-                    let receipts = replies[0].kind.clone().into_receipts().unwrap().items;
-                    let BlockId { number, hash } = replies[0].id.unwrap();
-                    (
-                        BlockNumber::new(number).unwrap(),
-                        BlockHash(hash.0),
-                        receipts.into_iter().map(|r| simplified::Receipt::try_from(r).unwrap()).collect::<Vec<_>>()
-                    )
-                }).collect::<Vec<_>>();
-
-                prop_assert_eq_sorted!(actual, expected);
-            }
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn get_events((num_blocks, seed, start_block, limit, step, direction) in strategy::composite()) {
-            // Fake storage with a given number of blocks
-            let (storage, in_db) = fixtures::storage_with_seed(seed, num_blocks);
-            // Compute the overlapping set between the db and the request
-            // These are the events that we expect to be read from the db
-            // Extract tuples (block_number, block_hash, [events{txn#1}, events{txn#2}, ...])
-            let expected = overlapping::get(in_db, start_block, limit, step, num_blocks, direction).into_iter()
-                .map(|(h, _, tr, _, _, _)|{
-                    let events = tr.into_iter().map(|(_, r)| (r.transaction_hash, r.events)).collect::<HashMap<_, Vec<_>>>();
-                    (
-                        h.number,
-                        h.hash,
-                        events
-                    )}
-            ).collect::<Vec<_>>();
-            // Run the handler
-            let request = EventsRequest { iteration: Iteration { start: BlockNumberOrHash::Number(start_block), limit, step, direction, } };
-            let replies = Runtime::new().unwrap().block_on(async {
-                let (tx, rx) = mpsc::channel(0);
-                let getter_fut = sync_handlers::get_events(storage, request, tx);
-                let (_, replies) = tokio::join!(getter_fut, rx.collect::<Vec<_>>());
-                replies
-            });
-            // Empty reply is only possible if the request does not overlap with storage
-            // Invalid start and zero limit are tested in boundary_conditions::
-            if expected.is_empty() {
-                prop_assert_eq_sorted!(replies.len(), 1);
-                prop_assert_eq_sorted!(replies[0].clone().into_fin().unwrap(), Fin::unknown());
-            } else {
-                // Group replies by block, it is assumed that events per block small enough to fit under the 1MiB limit
-                // This means that there are 2 replies per block: [[events-0, fin-0], [events-1, fin-1], ...]
-                let actual = replies.chunks_exact(2).map(|replies | {
-                    assert_eq!(replies[0].id, replies[1].id);
-                    // Make sure block data is delimited
-                    assert_eq!(replies[1].kind, EventsResponseKind::Fin(Fin::ok()));
-                    let BlockId { number, hash } = replies[0].id.unwrap();
-                    // Extract events
-                    let mut events = HashMap::<_, Vec<_>>::new();
-                    replies[0].kind.clone().into_events().unwrap().items.into_iter().for_each(|e| {
-                        events.entry(TransactionHash(e.transaction_hash.0)).or_default().push(Event::try_from_dto(e).unwrap());
-                    });
-                    (
-                        BlockNumber::new(number).unwrap(),
-                        BlockHash(hash.0),
-                        events
-                    )
-                }).collect::<Vec<_>>();
-
-                prop_assert_eq_sorted!(actual, expected);
-            }
-        }
-    }
-
-    /// Fixtures for prop tests
-    mod fixtures {
-        use crate::p2p_network::sync_handlers::MAX_COUNT_IN_TESTS;
-        use pathfinder_storage::fake::{with_n_blocks_and_rng, StorageInitializer};
-        use pathfinder_storage::Storage;
-
-        pub const MAX_NUM_BLOCKS: u64 = MAX_COUNT_IN_TESTS * 2;
-
-        pub fn storage_with_seed(seed: u64, num_blocks: u64) -> (Storage, StorageInitializer) {
-            use rand::SeedableRng;
-            let storage = Storage::in_memory().unwrap();
-            // Explicitly choose RNG to make sure seeded storage is always reproducible
-            let mut rng = rand_chacha::ChaCha12Rng::seed_from_u64(seed);
-            let initializer =
-                with_n_blocks_and_rng(&storage, num_blocks.try_into().unwrap(), &mut rng);
-            (storage, initializer)
-        }
-    }
-
-    /// Find overlapping range between the DB and the request
-    mod overlapping {
-        use crate::p2p_network::sync_handlers::MAX_COUNT_IN_TESTS;
-        use p2p_proto::common::{Direction, Step};
-        use pathfinder_storage::fake::{StorageInitializer, StorageInitializerItem};
-
-        pub fn get(
-            from_db: StorageInitializer,
-            start_block: u64,
-            limit: u64,
-            step: Step,
-            num_blocks: u64,
-            direction: Direction,
-        ) -> StorageInitializer {
-            match direction {
-                Direction::Forward => forward(from_db, start_block, limit, step).collect(),
-                Direction::Backward => {
-                    backward(from_db, start_block, limit, step, num_blocks).collect()
-                }
-            }
-        }
-
-        fn forward(
-            from_db: StorageInitializer,
-            start_block: u64,
-            limit: u64,
-            step: Step,
-        ) -> impl Iterator<Item = StorageInitializerItem> {
-            from_db
-                .into_iter()
-                .skip(start_block.try_into().unwrap())
-                .step_by(step.into_inner().try_into().unwrap())
-                .take(std::cmp::min(limit, MAX_COUNT_IN_TESTS).try_into().unwrap())
-        }
-
-        fn backward(
-            mut from_db: StorageInitializer,
-            start_block: u64,
-            limit: u64,
-            step: Step,
-            num_blocks: u64,
-        ) -> impl Iterator<Item = StorageInitializerItem> {
-            if start_block >= num_blocks {
-                // The is no overlapping range but we want to keep the iterator type in this
-                // branch type-consistent
-                from_db.clear();
-            }
-
-            from_db
-                .into_iter()
-                .take((start_block + 1).try_into().unwrap())
-                .rev()
-                .step_by(step.into_inner().try_into().unwrap())
-                .take(std::cmp::min(limit, MAX_COUNT_IN_TESTS).try_into().unwrap())
-        }
-    }
-
-    /// Building blocks for the ultimate composite strategy used in all property tests
-    mod strategy {
-        use super::fixtures::MAX_NUM_BLOCKS;
-        use crate::p2p_network::sync_handlers::tests::I64_MAX;
-        use p2p_proto::common::{Direction, Step};
-        use proptest::prelude::*;
-        use std::ops::Range;
-
-        prop_compose! {
-            fn inside(range: Range<u64>)(x in range) -> u64 { x }
-        }
-
-        prop_compose! {
-            fn outside_le(range: Range<u64>, max: u64)(x in range.end..=max) -> u64 { x }
-        }
-
-        fn rarely_outside_le(range: std::ops::Range<u64>, max: u64) -> BoxedStrategy<u64> {
-            // Empty range will trigger a panic in rand::distributions::Uniform
-            if range.is_empty() {
-                return Just(range.start).boxed();
-            }
-
-            prop_oneof![
-                // Occurrence 4:1
-                4 => inside(range.clone()),
-                1 => outside_le(range, max),
-            ]
-            .boxed()
-        }
-
-        fn rarely_outside(range: std::ops::Range<u64>) -> BoxedStrategy<u64> {
-            rarely_outside_le(range, u64::MAX)
-        }
-
-        prop_compose! {
-            pub fn composite()
-                (num_blocks in 0..MAX_NUM_BLOCKS)
-                (
-                    num_blocks in Just(num_blocks),
-                    storage_seed in any::<u64>(),
-                    // out of range (> i64::MAX) start values are tested in `empty_reply::`
-                    start in rarely_outside_le(0..num_blocks, I64_MAX),
-                    // limit of 0 is tested in `empty_reply::`
-                    limit in rarely_outside(1..num_blocks),
-                    // step is always >= 1
-                    step in rarely_outside(1..num_blocks / 4),
-                    direction in prop_oneof![Just(Direction::Forward), Just(Direction::Backward)],
-                ) -> (u64, u64, u64, u64, Step, Direction) {
-                (num_blocks, storage_seed, start, limit, step.into(), direction)
-            }
-        }
-    }
-}
-
-mod classes {
-    use crate::p2p_network::sync_handlers::classes;
-    use fake::{Fake, Faker};
-
-    #[test]
-    fn getter_error_yields_error() {
-        let mut responses = vec![];
-        assert!(classes(
-            Faker.fake(),
-            Faker.fake(),
-            vec![Faker.fake()],
-            &mut responses,
-            |_, _| anyhow::bail!("getter failed"),
-        )
-        .is_err());
-        assert!(responses.is_empty());
-    }
-}
+// use p2p_proto::common::{Direction, Step};
+// use pathfinder_common::BlockNumber;
+// use rstest::rstest;
+
+// const I64_MAX: u64 = i64::MAX as u64;
+
+// #[rstest]
+// #[case(0, 1, Direction::Forward, Some(1))]
+// #[case(0, I64_MAX, Direction::Forward, Some(I64_MAX))]
+// #[case(1, I64_MAX, Direction::Forward, None)]
+// #[case(0, 1, Direction::Backward, None)]
+// #[case(1, 1, Direction::Backward, Some(0))]
+// #[case(I64_MAX, 1, Direction::Backward, Some(I64_MAX - 1))]
+// #[case(I64_MAX, I64_MAX, Direction::Backward, Some(0))]
+// #[case(I64_MAX, I64_MAX + 1, Direction::Backward, None)]
+// #[test]
+// fn get_next_block_number(
+//     #[case] start: u64,
+//     #[case] step: u64,
+//     #[case] direction: Direction,
+//     #[case] expected: Option<u64>,
+// ) {
+//     assert_eq!(
+//         super::get_next_block_number(
+//             BlockNumber::new_or_panic(start),
+//             Step::from(Some(step)),
+//             direction
+//         ),
+//         expected.map(BlockNumber::new_or_panic)
+//     );
+// }
+
+// mod boundary_conditions {
+//     use super::I64_MAX;
+//     use crate::p2p_network::sync_handlers::{
+//         get_bodies, get_events, get_headers, get_receipts, get_transactions, MAX_COUNT_IN_TESTS,
+//     };
+//     use assert_matches::assert_matches;
+//     use fake::{Fake, Faker};
+//     use futures::channel::mpsc;
+//     use futures::StreamExt;
+//     use p2p_proto::block::{
+//         BlockBodiesRequest, BlockBodyMessage, BlockHeadersRequest, BlockHeadersResponse,
+//         BlockHeadersResponsePart,
+//     };
+//     use p2p_proto::common::{BlockNumberOrHash, Direction, Fin, Iteration};
+//     use p2p_proto::event::{EventsRequest, EventsResponseKind};
+//     use p2p_proto::receipt::{ReceiptsRequest, ReceiptsResponseKind};
+//     use p2p_proto::transaction::{TransactionsRequest, TransactionsResponseKind};
+//     use pathfinder_storage::fake::with_n_blocks;
+//     use pathfinder_storage::Storage;
+//     use rand::{thread_rng, Rng};
+//     use rstest::rstest;
+
+//     mod zero_limit_yields_fin_ok_invalid_start_yields_fin_unknown {
+//         use super::*;
+
+//         fn zero_limit() -> Iteration {
+//             Iteration {
+//                 limit: 0,
+//                 ..Faker.fake()
+//             }
+//         }
+
+//         fn invalid_start() -> Iteration {
+//             Iteration {
+//                 start: BlockNumberOrHash::Number(
+//                     rand::thread_rng().gen_range(I64_MAX + 1..=u64::MAX),
+//                 ),
+//                 ..Faker.fake()
+//             }
+//         }
+
+//         macro_rules! define_test {
+//             ($name:ident, $uut_name:ident, $request:tt) => {
+//                 #[rstest]
+//                 #[case(zero_limit(), Fin::ok())]
+//                 #[case(invalid_start(), Fin::unknown())]
+//                 #[tokio::test]
+//                 async fn $name(#[case] iteration: Iteration, #[case] fin: Fin) {
+//                     let storage = Storage::in_memory().unwrap();
+//                     let (tx, mut rx) = mpsc::channel(0);
+//                     let _jh = tokio::spawn($uut_name(storage, $request { iteration }, tx));
+//                     assert_eq!(rx.next().await.unwrap().into_fin(), Some(fin));
+//                 }
+//             };
+//         }
+
+//         define_test!(headers, get_headers, BlockHeadersRequest);
+//         define_test!(bodies, get_bodies, BlockBodiesRequest);
+//         define_test!(transactions, get_transactions, TransactionsRequest);
+//         define_test!(receipts, get_receipts, ReceiptsRequest);
+//         define_test!(events, get_events, EventsRequest);
+//     }
+
+//     mod partially_successful_requests_end_with_additional_fin_unknown {
+//         use super::*;
+
+//         fn init_test<T>(
+//             direction: Direction,
+//         ) -> (Storage, Iteration, mpsc::Sender<T>, mpsc::Receiver<T>) {
+//             let storage: Storage = Storage::in_memory().unwrap();
+//             let _ = with_n_blocks(&storage, 1);
+//             let iteration = Iteration {
+//                 start: BlockNumberOrHash::Number(0),
+//                 // We want more than available, we don't care about the internal limit because
+//                 // partial failure (`Fin::unknown()`) takes precedence over it (`Fin::too_much()`)
+//                 limit: thread_rng().gen_range(2..=MAX_COUNT_IN_TESTS * 2),
+//                 direction,
+//                 ..Faker.fake()
+//             };
+//             let (tx, rx) = mpsc::channel::<T>(0);
+//             (storage, iteration, tx, rx)
+//         }
+
+//         #[rstest]
+//         #[tokio::test]
+//         async fn test_get_headers(
+//             #[values(Direction::Backward, Direction::Forward)] direction: Direction,
+//         ) {
+//             let (storage, iteration, tx, mut rx) = init_test(direction);
+//             let getter_fut = get_headers(storage, BlockHeadersRequest { iteration }, tx);
+
+//             let (_, ret) = tokio::join!(getter_fut, rx.next());
+
+//             let BlockHeadersResponse { parts } = ret.unwrap();
+//             assert_eq!(parts.len(), 4);
+//             assert_matches!(&parts[0], BlockHeadersResponsePart::Header(h) => assert_eq!(h.number, 0));
+//             assert_matches!(&parts[1], BlockHeadersResponsePart::Signatures(s) => assert_eq!(s.block.number, 0));
+//             assert_eq!(parts[2], BlockHeadersResponsePart::Fin(Fin::ok()));
+//             // Expect Fin::unknown() where the first unavailable item would be
+//             assert_eq!(parts[3], BlockHeadersResponsePart::Fin(Fin::unknown()));
+//         }
+
+//         #[rstest]
+//         #[tokio::test]
+//         async fn test_get_bodies(
+//             #[values(Direction::Backward, Direction::Forward)] direction: Direction,
+//         ) {
+//             let (storage, iteration, tx, mut rx) = init_test(direction);
+//             let _jh = tokio::spawn(get_bodies(storage, BlockBodiesRequest { iteration }, tx));
+//             rx.next().await.unwrap(); // Diff
+//             match rx.next().await.unwrap().body_message {
+//                 // New classes in block
+//                 BlockBodyMessage::Classes(_) => {
+//                     assert_eq!(
+//                         rx.next().await.unwrap().body_message,
+//                         BlockBodyMessage::Fin(Fin::ok())
+//                     );
+//                 }
+//                 // No new classes in block
+//                 BlockBodyMessage::Fin(f) => assert_eq!(f, Fin::ok()),
+//                 _ => panic!("unexpected message type"),
+//             }
+
+//             // Expect Fin::unknown() where the first unavailable item would be
+//             assert_eq!(
+//                 rx.next().await.unwrap().body_message,
+//                 BlockBodyMessage::Fin(Fin::unknown())
+//             );
+//         }
+
+//         macro_rules! define_test {
+//             ($name:ident, $uut_name:ident, $request:tt, $reply:tt) => {
+//                 #[rstest]
+//                 #[tokio::test]
+//                 async fn $name(
+//                     #[values(Direction::Backward, Direction::Forward)] direction: Direction,
+//                 ) {
+//                     let (storage, iteration, tx, mut rx) = init_test(direction);
+//                     let _jh = tokio::spawn($uut_name(storage, $request { iteration }, tx));
+//                     // Block data
+//                     rx.next().await.unwrap();
+//                     // Properly delimited with Fin::ok()
+//                     assert_eq!(rx.next().await.unwrap().kind, $reply::Fin(Fin::ok()));
+//                     // Expect Fin::unknown() where the first unavailable item would be
+//                     assert_eq!(rx.next().await.unwrap().kind, $reply::Fin(Fin::unknown()));
+//                 }
+//             };
+//         }
+
+//         define_test!(
+//             test_get_transactions,
+//             get_transactions,
+//             TransactionsRequest,
+//             TransactionsResponseKind
+//         );
+//         define_test!(
+//             test_get_receipts,
+//             get_receipts,
+//             ReceiptsRequest,
+//             ReceiptsResponseKind
+//         );
+//         define_test!(
+//             test_get_events,
+//             get_events,
+//             EventsRequest,
+//             EventsResponseKind
+//         );
+//     }
+
+//     mod internally_limited_requests_end_with_additional_fin_too_much {
+//         use super::*;
+
+//         const NUM_BLOCKS_IN_STORAGE: u64 = MAX_COUNT_IN_TESTS;
+
+//         fn init_test<T>(
+//             direction: Direction,
+//         ) -> (Storage, Iteration, mpsc::Sender<T>, mpsc::Receiver<T>) {
+//             let storage = Storage::in_memory().unwrap();
+//             let _ = with_n_blocks(&storage, NUM_BLOCKS_IN_STORAGE as usize);
+//             let (tx, rx) = mpsc::channel::<T>(1);
+//             let start = match direction {
+//                 Direction::Forward => BlockNumberOrHash::Number(0),
+//                 Direction::Backward => BlockNumberOrHash::Number(NUM_BLOCKS_IN_STORAGE - 1),
+//             };
+//             let iteration = Iteration {
+//                 start,
+//                 // We want to trigger the internal limit
+//                 limit: thread_rng().gen_range(NUM_BLOCKS_IN_STORAGE + 1..=u64::MAX),
+//                 step: 1.into(),
+//                 direction,
+//             };
+//             (storage, iteration, tx, rx)
+//         }
+
+//         #[rstest]
+//         #[tokio::test]
+//         async fn test_get_headers(
+//             #[values(Direction::Backward, Direction::Forward)] direction: Direction,
+//         ) {
+//             let (storage, iteration, tx, mut rx) = init_test(direction);
+//             get_headers(storage, BlockHeadersRequest { iteration }, tx.clone())
+//                 .await
+//                 .unwrap();
+
+//             let BlockHeadersResponse { parts } = rx.next().await.unwrap();
+//             assert_eq!(parts.len(), NUM_BLOCKS_IN_STORAGE as usize * 3 + 1);
+
+//             let chunked = parts.chunks_exact(3);
+//             let remainder = chunked.remainder();
+
+//             chunked.for_each(|chunk| {
+//                 assert_matches!(&chunk[0], BlockHeadersResponsePart::Header(_));
+//                 assert_matches!(&chunk[1], BlockHeadersResponsePart::Signatures(_));
+//                 assert_eq!(chunk[2], BlockHeadersResponsePart::Fin(Fin::ok()));
+//             });
+//             // Expect Fin::too_much() if all requested items were found up to the internal limit
+//             assert_eq!(remainder, &[BlockHeadersResponsePart::Fin(Fin::too_much())]);
+//         }
+
+//         #[rstest]
+//         #[tokio::test]
+//         async fn test_get_bodies(
+//             #[values(Direction::Backward, Direction::Forward)] direction: Direction,
+//         ) {
+//             let (storage, iteration, tx, mut rx) = init_test(direction);
+//             let _jh = tokio::spawn(get_bodies(storage, BlockBodiesRequest { iteration }, tx));
+//             // 10 x [Diff, Classes*, Fin::ok()]
+//             for _ in 0..NUM_BLOCKS_IN_STORAGE {
+//                 rx.next().await.unwrap(); // Diff
+//                 match rx.next().await.unwrap().body_message {
+//                     // New classes in block
+//                     BlockBodyMessage::Classes(_) => {
+//                         assert_eq!(
+//                             rx.next().await.unwrap().body_message,
+//                             BlockBodyMessage::Fin(Fin::ok())
+//                         );
+//                     }
+//                     // No new classes in block
+//                     BlockBodyMessage::Fin(f) => {
+//                         assert_eq!(f, Fin::ok());
+//                     }
+//                     _ => panic!("unexpected message type"),
+//                 }
+//             }
+//             // Expect Fin::too_much() where the first unavailable item would be
+//             assert_eq!(
+//                 rx.next().await.unwrap().body_message,
+//                 BlockBodyMessage::Fin(Fin::too_much())
+//             );
+//         }
+
+//         macro_rules! define_test {
+//             ($name:ident, $uut_name:ident, $request:tt, $reply:tt) => {
+//                 #[rstest]
+//                 #[tokio::test]
+//                 async fn $name(
+//                     #[values(Direction::Backward, Direction::Forward)] direction: Direction,
+//                 ) {
+//                     let (storage, iteration, tx, mut rx) = init_test(direction);
+//                     let _jh = tokio::spawn($uut_name(storage, $request { iteration }, tx));
+//                     for _ in 0..NUM_BLOCKS_IN_STORAGE {
+//                         rx.next().await.unwrap(); // Block data
+//                         rx.next().await.unwrap(); // Fin::ok()
+//                     }
+//                     // Expect Fin::too_much() where the first unavailable item would be
+//                     assert_eq!(rx.next().await.unwrap().kind, $reply::Fin(Fin::too_much()));
+//                 }
+//             };
+//         }
+
+//         define_test!(
+//             test_get_transactions,
+//             get_transactions,
+//             TransactionsRequest,
+//             TransactionsResponseKind
+//         );
+//         define_test!(
+//             test_get_receipts,
+//             get_receipts,
+//             ReceiptsRequest,
+//             ReceiptsResponseKind
+//         );
+//         define_test!(
+//             test_get_events,
+//             get_events,
+//             EventsRequest,
+//             EventsResponseKind
+//         );
+//     }
+// }
+
+// /// Property tests, grouped to be immediately visible when executed
+// mod prop {
+//     use crate::p2p_network::client::types as simplified;
+//     use crate::p2p_network::sync_handlers;
+//     use crate::p2p_network::sync_handlers::def_into_dto;
+//     use futures::channel::mpsc;
+//     use futures::StreamExt;
+//     use p2p::client::types::{self as p2p_types, RawTransactionVariant, TryFromDto};
+//     use p2p_proto::block::{
+//         BlockBodiesRequest, BlockBodyMessage, BlockHeadersRequest, BlockHeadersResponse,
+//         BlockHeadersResponsePart,
+//     };
+//     use p2p_proto::common::{BlockId, BlockNumberOrHash, Error, Fin, Iteration};
+//     use p2p_proto::event::{EventsRequest, EventsResponseKind};
+//     use p2p_proto::receipt::{ReceiptsRequest, ReceiptsResponseKind};
+//     use p2p_proto::state::{Cairo0Class, Cairo1Class, Class};
+//     use p2p_proto::transaction::{TransactionsRequest, TransactionsResponseKind};
+//     use pathfinder_common::event::Event;
+//     use pathfinder_common::transaction::Transaction;
+//     use pathfinder_common::{
+//         BlockCommitmentSignature, BlockCommitmentSignatureElem, BlockHash, BlockNumber,
+//         TransactionHash,
+//     };
+//     use proptest::prelude::*;
+//     use std::collections::{BTreeSet, HashMap};
+//     use tokio::runtime::Runtime;
+
+//     #[macro_export]
+//     macro_rules! prop_assert_eq_sorted {
+//         ($left:expr, $right:expr) => {{
+//             let left = &$left;
+//             let right = &$right;
+//             let comparison_string = pretty_assertions_sorted::Comparison::new(
+//                 &pretty_assertions_sorted::SortedDebug::new(left),
+//                 &pretty_assertions_sorted::SortedDebug::new(right)
+//             ).to_string();
+//             proptest::prop_assert!(
+//                 *left == *right,
+//                 "assertion failed: `(left == right)`\n{comparison_string}\n");
+//         }};
+
+//         ($left:expr, $right:expr, $fmt:tt $($args:tt)*) => {{
+//             let left = &$left;
+//             let right = &$right;
+//             let comparison_string = pretty_assertions_sorted::Comparison::new(
+//                 &pretty_assertions_sorted::SortedDebug::new(left),
+//                 &pretty_assertions_sorted::SortedDebug::new(right)
+//             ).to_string();
+//             proptest::prop_assert!(
+//                 *left == *right,
+//                 concat!(
+//                     "assertion failed: `(left == right)`\n\
+//                     {}: ", $fmt),
+//                 comparison_string $($args)*);
+//         }};
+//     }
+
+//     proptest! {
+//         #[test]
+//         fn get_headers((num_blocks, seed, start_block, limit, step, direction) in strategy::composite()) {
+//             // Fake storage with a given number of blocks
+//             let (storage, in_db) = fixtures::storage_with_seed(seed, num_blocks);
+//             // Compute the overlapping set between the db and the request
+//             // These are the headers that we expect to be read from the db
+//             let expected = overlapping::get(in_db, start_block, limit, step, num_blocks, direction)
+//                 .into_iter().map(|(h, s, _, _, _, _)| (h.into(), s)).collect::<Vec<_>>();
+//             // Run the handler
+//             let request = BlockHeadersRequest { iteration: Iteration { start: BlockNumberOrHash::Number(start_block), limit, step, direction, } };
+//             // Reusing the runtime does not yield any performance gains
+//             let parts = Runtime::new().unwrap().block_on(async {
+//                 let (tx, mut rx) = mpsc::channel(0);
+//                 let getter_fut = sync_handlers::get_headers(storage, request, tx);
+
+//                 // Waiting for both futures to run to completion is faster than spawning the getter
+//                 // and awaiting the receiver (almost 1s for 100 iterations on Ryzen 3700X).
+//                 // BTW, we cannot just await the getter and then the receiver
+//                 // as there is backpressure (channel size 0) and we would deadlock.
+//                 let (_, ret) = tokio::join!(getter_fut, rx.next());
+
+//                 let BlockHeadersResponse { parts } = ret.unwrap();
+//                 parts
+//             });
+//             // Empty reply in the test is only possible if the request does not overlap with storage
+//             // Invalid start and zero limit are tested in boundary_conditions::
+//             if expected.is_empty() {
+//                 prop_assert_eq_sorted!(parts.len(), 1);
+//                 prop_assert_eq_sorted!(parts[0].clone().into_fin().unwrap(), Fin::unknown());
+//             } else {
+//                 // Group reply parts by block: [[hdr-0, fin-0], [hdr-1, fin-1], ...]
+//                 let actual = parts.chunks_exact(3).map(|chunk| {
+//                     // Make sure block data is delimited
+//                     assert_eq!(chunk[2], BlockHeadersResponsePart::Fin(Fin::ok()));
+//                     // Extract the header
+//                     let h = p2p_types::BlockHeader::try_from(chunk[0].clone().into_header().unwrap()).unwrap();
+//                     // Extract the signature
+//                     let s = chunk[1].clone().into_signatures().unwrap();
+//                     assert_eq!(s.signatures.len(), 1);
+//                     let s = s.signatures.into_iter().next().unwrap();
+//                     let s = BlockCommitmentSignature {
+//                         r: BlockCommitmentSignatureElem(s.r),
+//                         s: BlockCommitmentSignatureElem(s.s),
+//                     };
+//                     (h, s)
+//                 }).collect::<Vec<_>>();
+
+//                 prop_assert_eq_sorted!(actual, expected);
+//             }
+//         }
+//     }
+
+//     proptest! {
+//         #[test]
+//         fn get_bodies((num_blocks, db_seed, start_block, limit, step, direction) in strategy::composite()) {
+//             use crate::p2p_network::sync_handlers::class_definition::{Cairo, Sierra};
+
+//             // Fake storage with a given number of blocks
+//             let (storage, in_db) = fixtures::storage_with_seed(db_seed, num_blocks);
+//             // Get the overlapping set between the db and the request
+//             let expected = overlapping::get(in_db, start_block, limit, step, num_blocks, direction);
+//             // Extract the expected state updates, definitions and classes from the overlapping set
+//             // in a form digestable for this test
+//             let expected = expected.into_iter()
+//                 .map(|(header, _, _, state_update, cairo_defs, sierra_defs)|
+//                     (
+//                         // block number and hash
+//                         (header.number, header.hash),
+//                         (
+//                             // "simplified" state update, without an explicit list of declared and replaced classes
+//                             state_update.clone().into(),
+//                             // Cairo0 class definitions, parsed into p2p DTOs
+//                             cairo_defs.into_iter().map(|(_, d)| {
+//                                 let def = serde_json::from_slice::<Cairo<'_>>(&d).unwrap();
+//                                 def_into_dto::cairo(def)
+//                             }).collect(),
+//                             // Cairo1 (Sierra) class definitions, parsed into p2p DTOs
+//                             sierra_defs.into_iter().map(|(_, s, c)| {
+//                                 let def = serde_json::from_slice::<Sierra<'_>>(&s).unwrap();
+//                                 def_into_dto::sierra(def, c)
+//                             }).collect()
+//                         )
+//                     )
+//                 ).collect::<HashMap<_, (p2p_types::StateUpdate, BTreeSet<Cairo0Class>, BTreeSet<Cairo1Class>)>>();
+//             // Run the handler
+//             let request = BlockBodiesRequest { iteration: Iteration { start: BlockNumberOrHash::Number(start_block), limit, step, direction, } };
+//             let replies = Runtime::new().unwrap().block_on(async {
+//                 let (tx, rx) = mpsc::channel(0);
+//                 let getter_fut = sync_handlers::get_bodies(storage, request, tx);
+//                 let (_, replies) = tokio::join!(getter_fut, rx.collect::<Vec<_>>());
+//                 replies
+//             });
+
+//             // Empty reply is only possible if the request does not overlap with storage
+//             // Invalid start and zero limit are tested in boundary_conditions::
+//             if expected.is_empty() {
+//                 prop_assert_eq_sorted!(replies.len(), 1);
+//                 prop_assert_eq_sorted!(replies[0].clone().into_fin().unwrap(), Fin::unknown());
+//             } else {
+//                 // Collect replies into a set of (block_number, state_update, definitions)
+//                 let mut actual = HashMap::new();
+//                 let mut block_id = None;
+
+//                 for reply in replies {
+//                     match reply.body_message {
+//                         BlockBodyMessage::Diff(d) => {
+//                             let BlockId { number, hash } = reply.id.unwrap();
+//                             block_id = Some((BlockNumber::new(number).unwrap(), BlockHash(hash.0)));
+
+//                             let state_update = p2p_types::StateUpdate::from(d);
+//                             actual.insert(block_id.unwrap(), (state_update, BTreeSet::new(), BTreeSet::new()));
+//                         },
+//                         BlockBodyMessage::Classes(c) => {
+//                             // Classes coming after a state diff should be for the same block
+//                             let entry = actual.get_mut(&block_id.expect("Classes follow Diff so current block id should be set")).unwrap();
+//                             c.classes.into_iter().for_each(|c| {
+//                                 match c {
+//                                     Class::Cairo0(cairo) => entry.1.insert(cairo),
+//                                     Class::Cairo1(sierra) => entry.2.insert(sierra),
+//                                 };
+//                             });
+//                         },
+//                         BlockBodyMessage::Fin(f) => {
+//                             match f.error {
+//                                 // We either managed to fit the entire range or we hit the internal limit
+//                                 None | Some(Error::TooMuch) => assert!(actual.contains_key(&block_id.unwrap())),
+//                                 // Either the request yielded nothing or was only partially successful
+//                                 Some(Error::Unknown) => {},
+//                                 Some(_) => panic!("unexpected error"),
+//                             }
+//                         }
+//                         _ => unimplemented!(),
+//                     }
+//                 }
+
+//                 prop_assert_eq_sorted!(actual, expected);
+//             }
+//         }
+//     }
+
+//     mod workaround {
+//         use pathfinder_common::{TransactionNonce, TransactionVersion};
+//         use starknet_gateway_types::reply::transaction as gw;
+
+//         // Align with the deserialization workaround to avoid false negative mismatches
+//         pub fn for_legacy_l1_handlers(tx: gw::Transaction) -> gw::Transaction {
+//             match tx {
+//                 gw::Transaction::Invoke(gw::InvokeTransaction::V0(tx))
+//                     if tx.entry_point_type == Some(gw::EntryPointType::L1Handler) =>
+//                 {
+//                     gw::Transaction::L1Handler(gw::L1HandlerTransaction {
+//                         contract_address: tx.sender_address,
+//                         entry_point_selector: tx.entry_point_selector,
+//                         nonce: TransactionNonce::ZERO,
+//                         calldata: tx.calldata,
+//                         transaction_hash: tx.transaction_hash,
+//                         version: TransactionVersion::ZERO,
+//                     })
+//                 }
+//                 x => x,
+//             }
+//         }
+//     }
+
+//     proptest! {
+//         #[test]
+//         fn get_transactions((num_blocks, seed, start_block, limit, step, direction) in strategy::composite()) {
+//             // Fake storage with a given number of blocks
+//             let (storage, in_db) = fixtures::storage_with_seed(seed, num_blocks);
+//             // Compute the overlapping set between the db and the request
+//             // These are the transactions that we expect to be read from the db
+//             let expected = overlapping::get(in_db, start_block, limit, step, num_blocks, direction).into_iter()
+//                 .map(|(h, _, tr, _, _, _)|
+//                     (
+//                         h.number,
+//                         h.hash,
+//                         tr.into_iter().map(|(t, _)| Transaction::from(workaround::for_legacy_l1_handlers(t.into())).variant.into()).collect::<Vec<_>>()
+//                     )
+//             ).collect::<Vec<_>>();
+//             // Run the handler
+//             let request = TransactionsRequest { iteration: Iteration { start: BlockNumberOrHash::Number(start_block), limit, step, direction, } };
+//             let replies = Runtime::new().unwrap().block_on(async {
+//                 let (tx, rx) = mpsc::channel(0);
+//                 let getter_fut = sync_handlers::get_transactions(storage, request, tx);
+//                 let (_, replies) = tokio::join!(getter_fut, rx.collect::<Vec<_>>());
+//                 replies
+//             });
+//             // Empty reply is only possible if the request does not overlap with storage
+//             // Invalid start and zero limit are tested in boundary_conditions::
+//             if expected.is_empty() {
+//                 prop_assert_eq_sorted!(replies.len(), 1);
+//                 prop_assert_eq_sorted!(replies[0].clone().into_fin().unwrap(), Fin::unknown());
+//             } else {
+//                 // Group replies by block, it is assumed that transactions per block are small enough to fit under the 1MiB limit
+//                 // This means that there are 2 replies per block: [[transactions-0, fin-0], [transactions-1, fin-1], ...]
+//                 let actual = replies.chunks_exact(2).map(|replies | {
+//                     assert_eq!(replies[0].id, replies[1].id);
+//                     // Make sure block data is delimited
+//                     assert_eq!(replies[1].kind, TransactionsResponseKind::Fin(Fin::ok()));
+//                     // Extract transactions
+//                     let transactions = replies[0].kind.clone().into_transactions().unwrap().items;
+//                     let BlockId { number, hash } = replies[0].id.unwrap();
+//                     (
+//                         BlockNumber::new(number).unwrap(),
+//                         BlockHash(hash.0),
+//                         transactions.into_iter().map(|t| RawTransactionVariant::try_from_dto(t).unwrap()).collect::<Vec<_>>()
+//                     )
+//                 }).collect::<Vec<_>>();
+
+//                 prop_assert_eq_sorted!(actual, expected);
+//             }
+//         }
+//     }
+
+//     proptest! {
+//         #[test]
+//         fn get_receipts((num_blocks, seed, start_block, limit, step, direction) in strategy::composite()) {
+//             // Fake storage with a given number of blocks
+//             let (storage, in_db) = fixtures::storage_with_seed(seed, num_blocks);
+//             // Compute the overlapping set between the db and the request
+//             // These are the receipts that we expect to be read from the db
+//             let expected = overlapping::get(in_db, start_block, limit, step, num_blocks, direction).into_iter()
+//                 .map(|(h, _, tr, _, _, _)|
+//                     (
+//                         h.number,
+//                         h.hash,
+//                         tr.into_iter().map(|(_, r)| starknet_gateway_types::reply::transaction::Receipt::from(r).into()).collect::<Vec<_>>()
+//                     )
+//             ).collect::<Vec<_>>();
+//             // Run the handler
+//             let request = ReceiptsRequest { iteration: Iteration { start: BlockNumberOrHash::Number(start_block), limit, step, direction, } };
+//             let replies = Runtime::new().unwrap().block_on(async {
+//                 let (tx, rx) = mpsc::channel(0);
+//                 let getter_fut = sync_handlers::get_receipts(storage, request, tx);
+//                 let (_, replies) = tokio::join!(getter_fut, rx.collect::<Vec<_>>());
+//                 replies
+//             });
+//             // Empty reply is only possible if the request does not overlap with storage
+//             // Invalid start and zero limit are tested in boundary_conditions::
+//             if expected.is_empty() {
+//                 prop_assert_eq_sorted!(replies.len(), 1);
+//                 prop_assert_eq_sorted!(replies[0].clone().into_fin().unwrap(), Fin::unknown());
+//             } else {
+//                 // Group replies by block, it is assumed that receipts per block small enough to fit under the 1MiB limit
+//                 // This means that there are 2 replies per block: [[receipts-0, fin-0], [receipts-1, fin-1], ...]
+//                 let actual = replies.chunks_exact(2).map(|replies | {
+//                     assert_eq!(replies[0].id, replies[1].id);
+//                     // Make sure block data is delimited
+//                     assert_eq!(replies[1].kind, ReceiptsResponseKind::Fin(Fin::ok()));
+//                     // Extract receipts
+//                     let receipts = replies[0].kind.clone().into_receipts().unwrap().items;
+//                     let BlockId { number, hash } = replies[0].id.unwrap();
+//                     (
+//                         BlockNumber::new(number).unwrap(),
+//                         BlockHash(hash.0),
+//                         receipts.into_iter().map(|r| simplified::Receipt::try_from(r).unwrap()).collect::<Vec<_>>()
+//                     )
+//                 }).collect::<Vec<_>>();
+
+//                 prop_assert_eq_sorted!(actual, expected);
+//             }
+//         }
+//     }
+
+//     proptest! {
+//         #[test]
+//         fn get_events((num_blocks, seed, start_block, limit, step, direction) in strategy::composite()) {
+//             // Fake storage with a given number of blocks
+//             let (storage, in_db) = fixtures::storage_with_seed(seed, num_blocks);
+//             // Compute the overlapping set between the db and the request
+//             // These are the events that we expect to be read from the db
+//             // Extract tuples (block_number, block_hash, [events{txn#1}, events{txn#2}, ...])
+//             let expected = overlapping::get(in_db, start_block, limit, step, num_blocks, direction).into_iter()
+//                 .map(|(h, _, tr, _, _, _)|{
+//                     let events = tr.into_iter().map(|(_, r)| (r.transaction_hash, r.events)).collect::<HashMap<_, Vec<_>>>();
+//                     (
+//                         h.number,
+//                         h.hash,
+//                         events
+//                     )}
+//             ).collect::<Vec<_>>();
+//             // Run the handler
+//             let request = EventsRequest { iteration: Iteration { start: BlockNumberOrHash::Number(start_block), limit, step, direction, } };
+//             let replies = Runtime::new().unwrap().block_on(async {
+//                 let (tx, rx) = mpsc::channel(0);
+//                 let getter_fut = sync_handlers::get_events(storage, request, tx);
+//                 let (_, replies) = tokio::join!(getter_fut, rx.collect::<Vec<_>>());
+//                 replies
+//             });
+//             // Empty reply is only possible if the request does not overlap with storage
+//             // Invalid start and zero limit are tested in boundary_conditions::
+//             if expected.is_empty() {
+//                 prop_assert_eq_sorted!(replies.len(), 1);
+//                 prop_assert_eq_sorted!(replies[0].clone().into_fin().unwrap(), Fin::unknown());
+//             } else {
+//                 // Group replies by block, it is assumed that events per block small enough to fit under the 1MiB limit
+//                 // This means that there are 2 replies per block: [[events-0, fin-0], [events-1, fin-1], ...]
+//                 let actual = replies.chunks_exact(2).map(|replies | {
+//                     assert_eq!(replies[0].id, replies[1].id);
+//                     // Make sure block data is delimited
+//                     assert_eq!(replies[1].kind, EventsResponseKind::Fin(Fin::ok()));
+//                     let BlockId { number, hash } = replies[0].id.unwrap();
+//                     // Extract events
+//                     let mut events = HashMap::<_, Vec<_>>::new();
+//                     replies[0].kind.clone().into_events().unwrap().items.into_iter().for_each(|e| {
+//                         events.entry(TransactionHash(e.transaction_hash.0)).or_default().push(Event::try_from_dto(e).unwrap());
+//                     });
+//                     (
+//                         BlockNumber::new(number).unwrap(),
+//                         BlockHash(hash.0),
+//                         events
+//                     )
+//                 }).collect::<Vec<_>>();
+
+//                 prop_assert_eq_sorted!(actual, expected);
+//             }
+//         }
+//     }
+
+//     /// Fixtures for prop tests
+//     mod fixtures {
+//         use crate::p2p_network::sync_handlers::MAX_COUNT_IN_TESTS;
+//         use pathfinder_storage::fake::{with_n_blocks_and_rng, StorageInitializer};
+//         use pathfinder_storage::Storage;
+
+//         pub const MAX_NUM_BLOCKS: u64 = MAX_COUNT_IN_TESTS * 2;
+
+//         pub fn storage_with_seed(seed: u64, num_blocks: u64) -> (Storage, StorageInitializer) {
+//             use rand::SeedableRng;
+//             let storage = Storage::in_memory().unwrap();
+//             // Explicitly choose RNG to make sure seeded storage is always reproducible
+//             let mut rng = rand_chacha::ChaCha12Rng::seed_from_u64(seed);
+//             let initializer =
+//                 with_n_blocks_and_rng(&storage, num_blocks.try_into().unwrap(), &mut rng);
+//             (storage, initializer)
+//         }
+//     }
+
+//     /// Find overlapping range between the DB and the request
+//     mod overlapping {
+//         use crate::p2p_network::sync_handlers::MAX_COUNT_IN_TESTS;
+//         use p2p_proto::common::{Direction, Step};
+//         use pathfinder_storage::fake::{StorageInitializer, StorageInitializerItem};
+
+//         pub fn get(
+//             from_db: StorageInitializer,
+//             start_block: u64,
+//             limit: u64,
+//             step: Step,
+//             num_blocks: u64,
+//             direction: Direction,
+//         ) -> StorageInitializer {
+//             match direction {
+//                 Direction::Forward => forward(from_db, start_block, limit, step).collect(),
+//                 Direction::Backward => {
+//                     backward(from_db, start_block, limit, step, num_blocks).collect()
+//                 }
+//             }
+//         }
+
+//         fn forward(
+//             from_db: StorageInitializer,
+//             start_block: u64,
+//             limit: u64,
+//             step: Step,
+//         ) -> impl Iterator<Item = StorageInitializerItem> {
+//             from_db
+//                 .into_iter()
+//                 .skip(start_block.try_into().unwrap())
+//                 .step_by(step.into_inner().try_into().unwrap())
+//                 .take(std::cmp::min(limit, MAX_COUNT_IN_TESTS).try_into().unwrap())
+//         }
+
+//         fn backward(
+//             mut from_db: StorageInitializer,
+//             start_block: u64,
+//             limit: u64,
+//             step: Step,
+//             num_blocks: u64,
+//         ) -> impl Iterator<Item = StorageInitializerItem> {
+//             if start_block >= num_blocks {
+//                 // The is no overlapping range but we want to keep the iterator type in this
+//                 // branch type-consistent
+//                 from_db.clear();
+//             }
+
+//             from_db
+//                 .into_iter()
+//                 .take((start_block + 1).try_into().unwrap())
+//                 .rev()
+//                 .step_by(step.into_inner().try_into().unwrap())
+//                 .take(std::cmp::min(limit, MAX_COUNT_IN_TESTS).try_into().unwrap())
+//         }
+//     }
+
+//     /// Building blocks for the ultimate composite strategy used in all property tests
+//     mod strategy {
+//         use super::fixtures::MAX_NUM_BLOCKS;
+//         use crate::p2p_network::sync_handlers::tests::I64_MAX;
+//         use p2p_proto::common::{Direction, Step};
+//         use proptest::prelude::*;
+//         use std::ops::Range;
+
+//         prop_compose! {
+//             fn inside(range: Range<u64>)(x in range) -> u64 { x }
+//         }
+
+//         prop_compose! {
+//             fn outside_le(range: Range<u64>, max: u64)(x in range.end..=max) -> u64 { x }
+//         }
+
+//         fn rarely_outside_le(range: std::ops::Range<u64>, max: u64) -> BoxedStrategy<u64> {
+//             // Empty range will trigger a panic in rand::distributions::Uniform
+//             if range.is_empty() {
+//                 return Just(range.start).boxed();
+//             }
+
+//             prop_oneof![
+//                 // Occurrence 4:1
+//                 4 => inside(range.clone()),
+//                 1 => outside_le(range, max),
+//             ]
+//             .boxed()
+//         }
+
+//         fn rarely_outside(range: std::ops::Range<u64>) -> BoxedStrategy<u64> {
+//             rarely_outside_le(range, u64::MAX)
+//         }
+
+//         prop_compose! {
+//             pub fn composite()
+//                 (num_blocks in 0..MAX_NUM_BLOCKS)
+//                 (
+//                     num_blocks in Just(num_blocks),
+//                     storage_seed in any::<u64>(),
+//                     // out of range (> i64::MAX) start values are tested in `empty_reply::`
+//                     start in rarely_outside_le(0..num_blocks, I64_MAX),
+//                     // limit of 0 is tested in `empty_reply::`
+//                     limit in rarely_outside(1..num_blocks),
+//                     // step is always >= 1
+//                     step in rarely_outside(1..num_blocks / 4),
+//                     direction in prop_oneof![Just(Direction::Forward), Just(Direction::Backward)],
+//                 ) -> (u64, u64, u64, u64, Step, Direction) {
+//                 (num_blocks, storage_seed, start, limit, step.into(), direction)
+//             }
+//         }
+//     }
+// }
+
+// mod classes {
+//     use crate::p2p_network::sync_handlers::classes;
+//     use fake::{Fake, Faker};
+
+//     #[test]
+//     fn getter_error_yields_error() {
+//         let mut responses = vec![];
+//         assert!(classes(
+//             Faker.fake(),
+//             Faker.fake(),
+//             vec![Faker.fake()],
+//             &mut responses,
+//             |_, _| anyhow::bail!("getter failed"),
+//         )
+//         .is_err());
+//         assert!(responses.is_empty());
+//     }
+// }

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -781,6 +781,7 @@ async fn l2_update(
             .transactions
             .into_iter()
             .zip(block.transaction_receipts.into_iter())
+            .map(|(t, r)| (t.into(), r.into()))
             .collect::<Vec<_>>();
 
         transaction

--- a/crates/rpc/src/pathfinder/methods/get_transaction_status.rs
+++ b/crates/rpc/src/pathfinder/methods/get_transaction_status.rs
@@ -1,6 +1,5 @@
 use anyhow::Context;
 use pathfinder_common::TransactionHash;
-use starknet_gateway_types::reply::transaction::ExecutionStatus;
 use starknet_gateway_types::reply::PendingBlock;
 
 use crate::context::RpcContext;
@@ -43,7 +42,7 @@ pub async fn get_transaction_status(
             return anyhow::Ok(None);
         };
 
-        if receipt.execution_status == ExecutionStatus::Reverted {
+        if receipt.is_reverted() {
             return Ok(Some(TransactionStatus::Reverted));
         }
 
@@ -78,7 +77,9 @@ pub async fn get_transaction_status(
 fn pending_status(pending: &PendingBlock, tx_hash: &TransactionHash) -> Option<TransactionStatus> {
     pending.transaction_receipts.iter().find_map(|rx| {
         if &rx.transaction_hash == tx_hash {
-            if rx.execution_status == ExecutionStatus::Reverted {
+            if rx.execution_status
+                == starknet_gateway_types::reply::transaction::ExecutionStatus::Reverted
+            {
                 Some(TransactionStatus::Reverted)
             } else {
                 Some(TransactionStatus::AcceptedOnL2)

--- a/crates/rpc/src/v02/method/get_transaction_by_block_id_and_index.rs
+++ b/crates/rpc/src/v02/method/get_transaction_by_block_id_and_index.rs
@@ -57,7 +57,7 @@ pub async fn get_transaction_by_block_id_and_index_impl(
             .transaction_at_block(block_id, index)
             .context("Reading transaction from database")?
         {
-            Some(transaction) => Ok(transaction),
+            Some(transaction) => Ok(transaction.into()),
             None => {
                 // We now need to check whether it was the block hash or transaction index which were invalid. We do this by checking if the block exists
                 // at all. If no, then the block hash is invalid. If yes, then the index is invalid.

--- a/crates/rpc/src/v02/method/get_transaction_by_hash.rs
+++ b/crates/rpc/src/v02/method/get_transaction_by_hash.rs
@@ -43,6 +43,7 @@ pub async fn get_transaction_by_hash_impl(
         db_tx
             .transaction(input.transaction_hash)
             .context("Reading transaction from database")
+            .map(|x| x.map(Into::into))
     });
 
     jh.await.context("Database read panic or shutting down")?

--- a/crates/rpc/src/v05/method/get_transaction_status.rs
+++ b/crates/rpc/src/v05/method/get_transaction_status.rs
@@ -70,6 +70,15 @@ impl From<starknet_gateway_types::reply::transaction::ExecutionStatus> for Execu
     }
 }
 
+impl From<pathfinder_common::receipt::ExecutionStatus> for ExecutionStatus {
+    fn from(value: pathfinder_common::receipt::ExecutionStatus) -> Self {
+        match value {
+            pathfinder_common::receipt::ExecutionStatus::Succeeded => Self::Succeeded,
+            pathfinder_common::receipt::ExecutionStatus::Reverted { .. } => Self::Reverted,
+        }
+    }
+}
+
 crate::error::generate_rpc_error_subset!(GetTransactionStatusError: TxnHashNotFound);
 
 pub async fn get_transaction_status(

--- a/crates/rpc/src/v05/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v05/method/trace_block_transactions.rs
@@ -171,7 +171,10 @@ pub async fn trace_block_transactions(
 
                 let transactions = db
                     .transactions_for_block(block_id)?
-                    .context("Transaction data missing")?;
+                    .context("Transaction data missing")?
+                    .into_iter()
+                    .map(Into::into)
+                    .collect();
 
                 (header, transactions, context.cache.clone())
             }
@@ -258,7 +261,7 @@ pub(crate) mod tests {
     use pathfinder_common::{
         block_hash, felt, BlockHeader, ChainId, GasPrice, SierraHash, TransactionIndex,
     };
-    use starknet_gateway_types::reply::transaction::{ExecutionStatus, Receipt};
+    use starknet_gateway_types::reply::transaction::{ExecutionStatus, Receipt, Transaction};
 
     use super::*;
 
@@ -338,9 +341,18 @@ pub(crate) mod tests {
                 next_block_header.hash,
                 next_block_header.number,
                 &[
-                    (transactions[0].clone().into(), dummy_receipt.clone()),
-                    (transactions[1].clone().into(), dummy_receipt.clone()),
-                    (transactions[2].clone().into(), dummy_receipt.clone()),
+                    (
+                        Transaction::from(transactions[0].clone()).into(),
+                        dummy_receipt.clone().into(),
+                    ),
+                    (
+                        Transaction::from(transactions[1].clone()).into(),
+                        dummy_receipt.clone().into(),
+                    ),
+                    (
+                        Transaction::from(transactions[2].clone()).into(),
+                        dummy_receipt.clone().into(),
+                    ),
                 ],
             )?;
             tx.commit()?;

--- a/crates/rpc/src/v05/method/trace_transaction.rs
+++ b/crates/rpc/src/v05/method/trace_transaction.rs
@@ -169,13 +169,16 @@ pub async fn trace_transaction(
                     .context("Fetching transaction data")?
                     .context("Transaction data missing")?;
 
-                return Ok(LocalExecution::Unsupported(transaction));
+                return Ok(LocalExecution::Unsupported(transaction.into()));
             }
 
             let transactions = db
                 .transactions_for_block(header.number.into())
                 .context("Fetching block transactions")?
-                .context("Block transactions missing")?;
+                .context("Block transactions missing")?
+                .into_iter()
+                .map(Into::into)
+                .collect::<Vec<_>>();
 
             (header, transactions.clone(), context.cache.clone())
         };

--- a/crates/rpc/src/v06/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v06/method/get_transaction_receipt.rs
@@ -74,11 +74,11 @@ pub async fn get_transaction_receipt_impl(
 
         Ok(types::MaybePendingTransactionReceipt::Normal(
             types::TransactionReceipt::with_block_data(
-                receipt,
+                receipt.into(),
                 finality_status,
                 block_hash,
                 block_number,
-                transaction,
+                transaction.into(),
             ),
         ))
     });

--- a/crates/rpc/src/v06/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v06/method/trace_block_transactions.rs
@@ -190,7 +190,10 @@ pub async fn trace_block_transactions(
 
                 let transactions = db
                     .transactions_for_block(block_id)?
-                    .context("Transaction data missing")?;
+                    .context("Transaction data missing")?
+                    .into_iter()
+                    .map(Into::into)
+                    .collect::<Vec<_>>();
 
                 (header, transactions, context.cache.clone())
             }
@@ -278,7 +281,7 @@ pub(crate) mod tests {
     use pathfinder_common::{
         block_hash, felt, BlockHeader, ChainId, GasPrice, SierraHash, TransactionIndex,
     };
-    use starknet_gateway_types::reply::transaction::{ExecutionStatus, Receipt};
+    use starknet_gateway_types::reply::transaction::{ExecutionStatus, Receipt, Transaction};
 
     use super::*;
 
@@ -358,9 +361,18 @@ pub(crate) mod tests {
                 next_block_header.hash,
                 next_block_header.number,
                 &[
-                    (transactions[0].clone().into(), dummy_receipt.clone()),
-                    (transactions[1].clone().into(), dummy_receipt.clone()),
-                    (transactions[2].clone().into(), dummy_receipt.clone()),
+                    (
+                        Transaction::from(transactions[0].clone()).into(),
+                        dummy_receipt.clone().into(),
+                    ),
+                    (
+                        Transaction::from(transactions[1].clone()).into(),
+                        dummy_receipt.clone().into(),
+                    ),
+                    (
+                        Transaction::from(transactions[2].clone()).into(),
+                        dummy_receipt.clone().into(),
+                    ),
                 ],
             )?;
             tx.commit()?;

--- a/crates/rpc/src/v06/method/trace_transaction.rs
+++ b/crates/rpc/src/v06/method/trace_transaction.rs
@@ -173,13 +173,16 @@ pub async fn trace_transaction(
                     .context("Fetching transaction data")?
                     .context("Transaction data missing")?;
 
-                return Ok(LocalExecution::Unsupported(transaction));
+                return Ok(LocalExecution::Unsupported(transaction.into()));
             }
 
             let transactions = db
                 .transactions_for_block(header.number.into())
                 .context("Fetching block transactions")?
-                .context("Block transactions missing")?;
+                .context("Block transactions missing")?
+                .into_iter()
+                .map(Into::into)
+                .collect::<Vec<_>>();
 
             (header, transactions.clone(), context.cache.clone())
         };

--- a/crates/storage/src/connection.rs
+++ b/crates/storage/src/connection.rs
@@ -10,9 +10,10 @@ mod reference;
 mod reorg_counter;
 mod signature;
 mod state_update;
-mod transaction;
+pub(crate) mod transaction;
 mod trie;
 
+use pathfinder_common::receipt::Receipt;
 // Re-export this so users don't require rusqlite as a direct dep.
 pub use rusqlite::TransactionBehavior;
 
@@ -26,15 +27,11 @@ pub use transaction::TransactionStatus;
 
 pub use trie::{Child, Node, StoredNode};
 
-use pathfinder_common::{
-    BlockCommitmentSignature, BlockHash, BlockHeader, BlockNumber, CasmHash, ClassCommitment,
-    ClassCommitmentLeafHash, ClassHash, ContractAddress, ContractNonce, ContractRoot,
-    ContractStateHash, SierraHash, StateUpdate, StorageAddress, StorageCommitment, StorageValue,
-    TransactionHash,
-};
+use pathfinder_common::*;
 use pathfinder_crypto::Felt;
 use pathfinder_ethereum::EthereumStateUpdate;
-use starknet_gateway_types::reply::transaction as gateway;
+
+use pathfinder_common::transaction::Transaction as StarknetTransaction;
 
 use crate::BlockId;
 
@@ -189,7 +186,7 @@ impl<'inner> Transaction<'inner> {
         &self,
         block_hash: BlockHash,
         block_number: BlockNumber,
-        transaction_data: &[(gateway::Transaction, gateway::Receipt)],
+        transaction_data: &[(StarknetTransaction, Receipt)],
     ) -> anyhow::Result<()> {
         transaction::insert_transactions(self, block_hash, block_number, transaction_data)
     }
@@ -204,14 +201,14 @@ impl<'inner> Transaction<'inner> {
     pub fn transaction(
         &self,
         hash: TransactionHash,
-    ) -> anyhow::Result<Option<gateway::Transaction>> {
+    ) -> anyhow::Result<Option<StarknetTransaction>> {
         transaction::transaction(self, hash)
     }
 
     pub fn transaction_with_receipt(
         &self,
         hash: TransactionHash,
-    ) -> anyhow::Result<Option<(gateway::Transaction, gateway::Receipt, BlockHash)>> {
+    ) -> anyhow::Result<Option<(StarknetTransaction, Receipt, BlockHash)>> {
         transaction::transaction_with_receipt(self, hash)
     }
 
@@ -219,28 +216,25 @@ impl<'inner> Transaction<'inner> {
         &self,
         block: BlockId,
         index: usize,
-    ) -> anyhow::Result<Option<gateway::Transaction>> {
+    ) -> anyhow::Result<Option<StarknetTransaction>> {
         transaction::transaction_at_block(self, block, index)
     }
 
     pub fn transaction_data_for_block(
         &self,
         block: BlockId,
-    ) -> anyhow::Result<Option<Vec<(gateway::Transaction, gateway::Receipt)>>> {
+    ) -> anyhow::Result<Option<Vec<(StarknetTransaction, Receipt)>>> {
         transaction::transaction_data_for_block(self, block)
     }
 
     pub fn transactions_for_block(
         &self,
         block: BlockId,
-    ) -> anyhow::Result<Option<Vec<gateway::Transaction>>> {
+    ) -> anyhow::Result<Option<Vec<StarknetTransaction>>> {
         transaction::transactions_for_block(self, block)
     }
 
-    pub fn receipts_for_block(
-        &self,
-        block: BlockId,
-    ) -> anyhow::Result<Option<Vec<gateway::Receipt>>> {
+    pub fn receipts_for_block(&self, block: BlockId) -> anyhow::Result<Option<Vec<Receipt>>> {
         transaction::receipts_for_block(self, block)
     }
 

--- a/crates/storage/src/connection/event.rs
+++ b/crates/storage/src/connection/event.rs
@@ -385,10 +385,11 @@ mod tests {
     use crate::test_utils;
     use assert_matches::assert_matches;
     use pathfinder_common::macro_prelude::*;
+    use pathfinder_common::receipt::Receipt;
     use pathfinder_common::{BlockHeader, BlockTimestamp, EntryPoint, Fee};
 
+    use pathfinder_common::transaction as common;
     use pathfinder_crypto::Felt;
-    use starknet_gateway_types::reply::transaction as gateway_tx;
 
     lazy_static::lazy_static!(
         static ref MAX_BLOCKS_TO_SCAN: NonZeroUsize = NonZeroUsize::new(100).unwrap();
@@ -455,62 +456,44 @@ mod tests {
 
         // Note: hashes are reverse ordered to trigger the sorting bug.
         let transactions = vec![
-            gateway_tx::Transaction::Invoke(gateway_tx::InvokeTransaction::V0(
-                gateway_tx::InvokeTransactionV0 {
+            common::Transaction {
+                hash: transaction_hash!("0xF"),
+                variant: common::TransactionVariant::InvokeV0(common::InvokeTransactionV0 {
                     calldata: vec![],
                     // Only required because event insert rejects if this is None
                     sender_address: ContractAddress::new_or_panic(Felt::ZERO),
-                    entry_point_type: Some(gateway_tx::EntryPointType::External),
+                    entry_point_type: Some(common::EntryPointType::External),
                     entry_point_selector: EntryPoint(Felt::ZERO),
                     max_fee: Fee::ZERO,
                     signature: vec![],
-                    transaction_hash: transaction_hash!("0xF"),
-                },
-            )),
-            gateway_tx::Transaction::Invoke(gateway_tx::InvokeTransaction::V0(
-                gateway_tx::InvokeTransactionV0 {
+                }),
+            },
+            common::Transaction {
+                hash: transaction_hash!("0x1"),
+                variant: common::TransactionVariant::InvokeV0(common::InvokeTransactionV0 {
                     calldata: vec![],
                     // Only required because event insert rejects if this is None
                     sender_address: ContractAddress::new_or_panic(Felt::ZERO),
-                    entry_point_type: Some(gateway_tx::EntryPointType::External),
+                    entry_point_type: Some(common::EntryPointType::External),
                     entry_point_selector: EntryPoint(Felt::ZERO),
                     max_fee: Fee::ZERO,
                     signature: vec![],
-                    transaction_hash: transaction_hash!("0x1"),
-                },
-            )),
+                }),
+            },
         ];
 
         let receipts = vec![
-            gateway_tx::Receipt {
-                actual_fee: None,
+            Receipt {
                 events: expected_events[..3].to_vec(),
-                execution_resources: Some(gateway_tx::ExecutionResources {
-                    builtin_instance_counter: Default::default(),
-                    n_steps: 0,
-                    n_memory_holes: 0,
-                }),
-                l1_to_l2_consumed_message: None,
-                l2_to_l1_messages: Vec::new(),
-                transaction_hash: transactions[0].hash(),
+                transaction_hash: transactions[0].hash,
                 transaction_index: pathfinder_common::TransactionIndex::new_or_panic(0),
-                execution_status: Default::default(),
-                revert_error: Default::default(),
+                ..Default::default()
             },
-            gateway_tx::Receipt {
-                actual_fee: None,
+            Receipt {
                 events: expected_events[3..].to_vec(),
-                execution_resources: Some(gateway_tx::ExecutionResources {
-                    builtin_instance_counter: Default::default(),
-                    n_steps: 0,
-                    n_memory_holes: 0,
-                }),
-                l1_to_l2_consumed_message: None,
-                l2_to_l1_messages: Vec::new(),
-                transaction_hash: transactions[1].hash(),
+                transaction_hash: transactions[1].hash,
                 transaction_index: pathfinder_common::TransactionIndex::new_or_panic(1),
-                execution_status: Default::default(),
-                revert_error: Default::default(),
+                ..Default::default()
             },
         ];
 

--- a/crates/storage/src/connection/transaction.rs
+++ b/crates/storage/src/connection/transaction.rs
@@ -565,7 +565,7 @@ pub(crate) mod dto {
             };
 
             Self {
-                actual_fee: value.actual_fee.clone(),
+                actual_fee: value.actual_fee,
                 events: value.events.clone(),
                 execution_resources: value.execution_resources.as_ref().map(Into::into),
                 // We don't care about this field anymore.

--- a/crates/storage/src/connection/transaction.rs
+++ b/crates/storage/src/connection/transaction.rs
@@ -1,8 +1,9 @@
 //! Contains starknet transaction related code and __not__ database transaction.
 
 use anyhow::Context;
+use pathfinder_common::receipt::Receipt;
+use pathfinder_common::transaction::Transaction as StarknetTransaction;
 use pathfinder_common::{BlockHash, BlockNumber, TransactionHash};
-use starknet_gateway_types::reply::transaction as gateway;
 
 use crate::{prelude::*, BlockId};
 
@@ -15,7 +16,7 @@ pub(super) fn insert_transactions(
     tx: &Transaction<'_>,
     block_hash: BlockHash,
     block_number: BlockNumber,
-    transaction_data: &[(gateway::Transaction, gateway::Receipt)],
+    transaction_data: &[(StarknetTransaction, Receipt)],
 ) -> anyhow::Result<()> {
     if transaction_data.is_empty() {
         return Ok(());
@@ -24,6 +25,9 @@ pub(super) fn insert_transactions(
     let mut compressor = zstd::bulk::Compressor::new(10).context("Create zstd compressor")?;
     for (i, (transaction, receipt)) in transaction_data.iter().enumerate() {
         // Serialize and compress transaction data.
+        let transaction = dto::Transaction::from(transaction);
+        let receipt = dto::Receipt::from(receipt);
+
         let tx_data = serde_json::to_vec(&transaction).context("Serializing transaction")?;
         let tx_data = compressor
             .compress(&tx_data)
@@ -35,8 +39,8 @@ pub(super) fn insert_transactions(
             .context("Compressing receipt")?;
 
         let execution_status = match receipt.execution_status {
-            gateway::ExecutionStatus::Succeeded => 0,
-            gateway::ExecutionStatus::Reverted => 1,
+            dto::ExecutionStatus::Succeeded => 0,
+            dto::ExecutionStatus::Reverted => 1,
         };
 
         tx.inner().execute(r"INSERT OR REPLACE INTO starknet_transactions (hash,  idx,  block_hash,  tx,  receipt,  execution_status) 
@@ -62,7 +66,7 @@ pub(super) fn insert_transactions(
 pub(super) fn transaction(
     tx: &Transaction<'_>,
     transaction: TransactionHash,
-) -> anyhow::Result<Option<gateway::Transaction>> {
+) -> anyhow::Result<Option<StarknetTransaction>> {
     let mut stmt = tx
         .inner()
         .prepare("SELECT tx FROM starknet_transactions WHERE hash = ?")
@@ -79,15 +83,16 @@ pub(super) fn transaction(
 
     let transaction = row.get_ref_unwrap(0).as_blob()?;
     let transaction = zstd::decode_all(transaction).context("Decompressing transaction")?;
-    let transaction = serde_json::from_slice(&transaction).context("Deserializing transaction")?;
+    let transaction: dto::Transaction =
+        serde_json::from_slice(&transaction).context("Deserializing transaction")?;
 
-    Ok(Some(transaction))
+    Ok(Some(transaction.into()))
 }
 
 pub(super) fn transaction_with_receipt(
     tx: &Transaction<'_>,
     txn_hash: TransactionHash,
-) -> anyhow::Result<Option<(gateway::Transaction, gateway::Receipt, BlockHash)>> {
+) -> anyhow::Result<Option<(StarknetTransaction, Receipt, BlockHash)>> {
     let mut stmt = tx
         .inner()
         .prepare("SELECT tx, receipt, block_hash FROM starknet_transactions WHERE hash = ?1")
@@ -102,25 +107,27 @@ pub(super) fn transaction_with_receipt(
 
     let transaction = row.get_ref_unwrap("tx").as_blob()?;
     let transaction = zstd::decode_all(transaction).context("Decompressing transaction")?;
-    let transaction = serde_json::from_slice(&transaction).context("Deserializing transaction")?;
+    let transaction: dto::Transaction =
+        serde_json::from_slice(&transaction).context("Deserializing transaction")?;
 
     let receipt = match row.get_ref_unwrap("receipt").as_blob_or_null()? {
         Some(data) => data,
         None => return Ok(None),
     };
     let receipt = zstd::decode_all(receipt).context("Decompressing receipt")?;
-    let receipt = serde_json::from_slice(&receipt).context("Deserializing receipt")?;
+    let receipt: dto::Receipt =
+        serde_json::from_slice(&receipt).context("Deserializing receipt")?;
 
     let block_hash = row.get_block_hash("block_hash")?;
 
-    Ok(Some((transaction, receipt, block_hash)))
+    Ok(Some((transaction.into(), receipt.into(), block_hash)))
 }
 
 pub(super) fn transaction_at_block(
     tx: &Transaction<'_>,
     block: BlockId,
     index: usize,
-) -> anyhow::Result<Option<gateway::Transaction>> {
+) -> anyhow::Result<Option<StarknetTransaction>> {
     // Identify block hash
     let Some(block_hash) = tx.block_hash(block)? else {
         return Ok(None);
@@ -146,9 +153,10 @@ pub(super) fn transaction_at_block(
     };
 
     let transaction = zstd::decode_all(transaction).context("Decompressing transaction")?;
-    let transaction = serde_json::from_slice(&transaction).context("Deserializing transaction")?;
+    let transaction: dto::Transaction =
+        serde_json::from_slice(&transaction).context("Deserializing transaction")?;
 
-    Ok(Some(transaction))
+    Ok(Some(transaction.into()))
 }
 
 pub(super) fn transaction_count(tx: &Transaction<'_>, block: BlockId) -> anyhow::Result<usize> {
@@ -186,7 +194,7 @@ pub(super) fn transaction_count(tx: &Transaction<'_>, block: BlockId) -> anyhow:
 pub(super) fn transaction_data_for_block(
     tx: &Transaction<'_>,
     block: BlockId,
-) -> anyhow::Result<Option<Vec<(gateway::Transaction, gateway::Receipt)>>> {
+) -> anyhow::Result<Option<Vec<(StarknetTransaction, Receipt)>>> {
     let Some(block_hash) = tx.block_hash(block)? else {
         return Ok(None);
     };
@@ -209,7 +217,7 @@ pub(super) fn transaction_data_for_block(
             .as_blob_or_null()?
             .context("Receipt data missing")?;
         let receipt = zstd::decode_all(receipt).context("Decompressing transaction receipt")?;
-        let receipt =
+        let receipt: dto::Receipt =
             serde_json::from_slice(&receipt).context("Deserializing transaction receipt")?;
 
         let transaction = row
@@ -217,10 +225,10 @@ pub(super) fn transaction_data_for_block(
             .as_blob_or_null()?
             .context("Transaction data missing")?;
         let transaction = zstd::decode_all(transaction).context("Decompressing transaction")?;
-        let transaction =
+        let transaction: dto::Transaction =
             serde_json::from_slice(&transaction).context("Deserializing transaction")?;
 
-        data.push((transaction, receipt));
+        data.push((transaction.into(), receipt.into()));
     }
 
     Ok(Some(data))
@@ -229,7 +237,7 @@ pub(super) fn transaction_data_for_block(
 pub(super) fn transactions_for_block(
     tx: &Transaction<'_>,
     block: BlockId,
-) -> anyhow::Result<Option<Vec<gateway::Transaction>>> {
+) -> anyhow::Result<Option<Vec<StarknetTransaction>>> {
     let Some(block_hash) = tx.block_hash(block)? else {
         return Ok(None);
     };
@@ -250,10 +258,10 @@ pub(super) fn transactions_for_block(
             .as_blob_or_null()?
             .context("Transaction data missing")?;
         let transaction = zstd::decode_all(transaction).context("Decompressing transaction")?;
-        let transaction =
+        let transaction: dto::Transaction =
             serde_json::from_slice(&transaction).context("Deserializing transaction")?;
 
-        data.push(transaction);
+        data.push(transaction.into());
     }
 
     Ok(Some(data))
@@ -262,7 +270,7 @@ pub(super) fn transactions_for_block(
 pub(super) fn receipts_for_block(
     tx: &Transaction<'_>,
     block: BlockId,
-) -> anyhow::Result<Option<Vec<gateway::Receipt>>> {
+) -> anyhow::Result<Option<Vec<Receipt>>> {
     let Some(block_hash) = tx.block_hash(block)? else {
         return Ok(None);
     };
@@ -283,9 +291,10 @@ pub(super) fn receipts_for_block(
             .as_blob_or_null()?
             .context("Transaction data missing")?;
         let receipt = zstd::decode_all(receipt).context("Decompressing receipt")?;
-        let receipt = serde_json::from_slice(&receipt).context("Deserializing receipt")?;
+        let receipt: dto::Receipt =
+            serde_json::from_slice(&receipt).context("Deserializing receipt")?;
 
-        data.push(receipt);
+        data.push(receipt.into());
     }
 
     Ok(Some(data))
@@ -326,28 +335,1379 @@ pub(super) fn transaction_block_hash(
         .map_err(|e| e.into())
 }
 
+/// A copy of the gateway definitions which are currently used as the storage serde implementation. Having a copy here
+/// allows us to decouple this crate from the gateway types, while only exposing the common types via the storage API.
+pub(crate) mod dto {
+    use fake::Dummy;
+    use pathfinder_common::*;
+    use pathfinder_serde::{
+        CallParamAsDecimalStr, ConstructorParamAsDecimalStr, EthereumAddressAsHexStr,
+        L2ToL1MessagePayloadElemAsDecimalStr, ResourceAmountAsHexStr, ResourcePricePerUnitAsHexStr,
+        TipAsHexStr, TransactionSignatureElemAsDecimalStr,
+    };
+    use serde::{Deserialize, Serialize};
+    use serde_with::serde_as;
+
+    /// Represents deserialized L2 transaction entry point values.
+    #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Dummy)]
+    #[serde(deny_unknown_fields)]
+    pub enum EntryPointType {
+        #[serde(rename = "EXTERNAL")]
+        External,
+        #[serde(rename = "L1_HANDLER")]
+        L1Handler,
+    }
+
+    impl From<pathfinder_common::transaction::EntryPointType> for EntryPointType {
+        fn from(value: pathfinder_common::transaction::EntryPointType) -> Self {
+            use pathfinder_common::transaction::EntryPointType::{External, L1Handler};
+            match value {
+                External => Self::External,
+                L1Handler => Self::L1Handler,
+            }
+        }
+    }
+
+    impl From<EntryPointType> for pathfinder_common::transaction::EntryPointType {
+        fn from(value: EntryPointType) -> Self {
+            match value {
+                EntryPointType::External => Self::External,
+                EntryPointType::L1Handler => Self::L1Handler,
+            }
+        }
+    }
+
+    /// Represents execution resources for L2 transaction.
+    #[derive(Copy, Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq, Dummy)]
+    #[serde(deny_unknown_fields)]
+    pub struct ExecutionResources {
+        pub builtin_instance_counter: BuiltinCounters,
+        pub n_steps: u64,
+        pub n_memory_holes: u64,
+    }
+
+    impl From<&ExecutionResources> for pathfinder_common::receipt::ExecutionResources {
+        fn from(value: &ExecutionResources) -> Self {
+            Self {
+                builtin_instance_counter: value.builtin_instance_counter.into(),
+                n_steps: value.n_steps,
+                n_memory_holes: value.n_memory_holes,
+            }
+        }
+    }
+
+    impl From<&pathfinder_common::receipt::ExecutionResources> for ExecutionResources {
+        fn from(value: &pathfinder_common::receipt::ExecutionResources) -> Self {
+            Self {
+                builtin_instance_counter: (&value.builtin_instance_counter).into(),
+                n_steps: value.n_steps,
+                n_memory_holes: value.n_memory_holes,
+            }
+        }
+    }
+
+    // This struct purposefully allows for unknown fields as it is not critical to
+    // store these counters perfectly. Failure would be far more costly than simply
+    // ignoring them.
+    #[derive(Copy, Clone, Default, Debug, Deserialize, Serialize, PartialEq, Eq, Dummy)]
+    #[serde(default)]
+    pub struct BuiltinCounters {
+        pub output_builtin: u64,
+        pub pedersen_builtin: u64,
+        pub range_check_builtin: u64,
+        pub ecdsa_builtin: u64,
+        pub bitwise_builtin: u64,
+        pub ec_op_builtin: u64,
+        pub keccak_builtin: u64,
+        pub poseidon_builtin: u64,
+        pub segment_arena_builtin: u64,
+    }
+
+    impl From<BuiltinCounters> for pathfinder_common::receipt::BuiltinCounters {
+        fn from(value: BuiltinCounters) -> Self {
+            // Use deconstruction to ensure these structs remain in-sync.
+            let BuiltinCounters {
+                output_builtin,
+                pedersen_builtin,
+                range_check_builtin,
+                ecdsa_builtin,
+                bitwise_builtin,
+                ec_op_builtin,
+                keccak_builtin,
+                poseidon_builtin,
+                segment_arena_builtin,
+            } = value;
+            Self {
+                output_builtin,
+                pedersen_builtin,
+                range_check_builtin,
+                ecdsa_builtin,
+                bitwise_builtin,
+                ec_op_builtin,
+                keccak_builtin,
+                poseidon_builtin,
+                segment_arena_builtin,
+            }
+        }
+    }
+
+    impl From<&pathfinder_common::receipt::BuiltinCounters> for BuiltinCounters {
+        fn from(value: &pathfinder_common::receipt::BuiltinCounters) -> Self {
+            // Use deconstruction to ensure these structs remain in-sync.
+            let pathfinder_common::receipt::BuiltinCounters {
+                output_builtin,
+                pedersen_builtin,
+                range_check_builtin,
+                ecdsa_builtin,
+                bitwise_builtin,
+                ec_op_builtin,
+                keccak_builtin,
+                poseidon_builtin,
+                segment_arena_builtin,
+            } = value.clone();
+            Self {
+                output_builtin,
+                pedersen_builtin,
+                range_check_builtin,
+                ecdsa_builtin,
+                bitwise_builtin,
+                ec_op_builtin,
+                keccak_builtin,
+                poseidon_builtin,
+                segment_arena_builtin,
+            }
+        }
+    }
+
+    /// Represents deserialized L2 to L1 message.
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Dummy)]
+    #[serde(deny_unknown_fields)]
+    pub struct L2ToL1Message {
+        pub from_address: ContractAddress,
+        #[serde_as(as = "Vec<L2ToL1MessagePayloadElemAsDecimalStr>")]
+        pub payload: Vec<L2ToL1MessagePayloadElem>,
+        #[serde_as(as = "EthereumAddressAsHexStr")]
+        pub to_address: EthereumAddress,
+    }
+
+    impl From<L2ToL1Message> for pathfinder_common::receipt::L2ToL1Message {
+        fn from(value: L2ToL1Message) -> Self {
+            let L2ToL1Message {
+                from_address,
+                payload,
+                to_address,
+            } = value;
+            pathfinder_common::receipt::L2ToL1Message {
+                from_address,
+                payload,
+                to_address,
+            }
+        }
+    }
+
+    impl From<&pathfinder_common::receipt::L2ToL1Message> for L2ToL1Message {
+        fn from(value: &pathfinder_common::receipt::L2ToL1Message) -> Self {
+            let pathfinder_common::receipt::L2ToL1Message {
+                from_address,
+                payload,
+                to_address,
+            } = value.clone();
+            Self {
+                from_address,
+                payload,
+                to_address,
+            }
+        }
+    }
+
+    #[derive(Clone, Default, Debug, Deserialize, Serialize, PartialEq, Eq, Dummy)]
+    #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+    pub enum ExecutionStatus {
+        // This must be the default as pre v0.12.1 receipts did not contain this value and
+        // were always success as reverted did not exist.
+        #[default]
+        Succeeded,
+        Reverted,
+    }
+
+    /// Represents deserialized L2 transaction receipt data.
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Dummy)]
+    #[serde(deny_unknown_fields)]
+    pub struct Receipt {
+        #[serde(default)]
+        pub actual_fee: Option<Fee>,
+        pub events: Vec<pathfinder_common::event::Event>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub execution_resources: Option<ExecutionResources>,
+        // This field exists in our database but is unused within our code.
+        // It is redundant data that is also contained in the L1 handler.
+        pub l1_to_l2_consumed_message: Option<serde_json::Value>,
+        pub l2_to_l1_messages: Vec<L2ToL1Message>,
+        pub transaction_hash: TransactionHash,
+        pub transaction_index: TransactionIndex,
+        // Introduced in v0.12.1
+        #[serde(default)]
+        pub execution_status: ExecutionStatus,
+        // Introduced in v0.12.1
+        /// Only present if status is [ExecutionStatus::Reverted].
+        #[serde(default)]
+        pub revert_error: Option<String>,
+    }
+
+    impl From<&pathfinder_common::receipt::Receipt> for Receipt {
+        fn from(value: &pathfinder_common::receipt::Receipt) -> Self {
+            let (execution_status, revert_error) = match &value.execution_status {
+                receipt::ExecutionStatus::Succeeded => (ExecutionStatus::Succeeded, None),
+                receipt::ExecutionStatus::Reverted { reason } => {
+                    (ExecutionStatus::Reverted, Some(reason.clone()))
+                }
+            };
+
+            Self {
+                actual_fee: value.actual_fee.clone(),
+                events: value.events.clone(),
+                execution_resources: value.execution_resources.as_ref().map(Into::into),
+                // We don't care about this field anymore.
+                l1_to_l2_consumed_message: None,
+                l2_to_l1_messages: value.l2_to_l1_messages.iter().map(Into::into).collect(),
+                transaction_hash: value.transaction_hash,
+                transaction_index: value.transaction_index,
+                execution_status,
+                revert_error,
+            }
+        }
+    }
+
+    impl From<Receipt> for pathfinder_common::receipt::Receipt {
+        fn from(value: Receipt) -> Self {
+            use pathfinder_common::receipt as common;
+
+            let Receipt {
+                actual_fee,
+                events,
+                execution_resources,
+                // This information is redundant as it is already in the transaction itself.
+                l1_to_l2_consumed_message: _,
+                l2_to_l1_messages,
+                transaction_hash,
+                transaction_index,
+                execution_status,
+                revert_error,
+            } = value;
+
+            common::Receipt {
+                actual_fee,
+                events,
+                execution_resources: execution_resources.as_ref().map(Into::into),
+                l2_to_l1_messages: l2_to_l1_messages.into_iter().map(Into::into).collect(),
+                transaction_hash,
+                transaction_index,
+                execution_status: match execution_status {
+                    ExecutionStatus::Succeeded => common::ExecutionStatus::Succeeded,
+                    ExecutionStatus::Reverted => common::ExecutionStatus::Reverted {
+                        reason: revert_error.unwrap_or_default(),
+                    },
+                },
+            }
+        }
+    }
+
+    #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Dummy)]
+    pub enum DataAvailabilityMode {
+        #[default]
+        L1,
+        L2,
+    }
+
+    impl Serialize for DataAvailabilityMode {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                DataAvailabilityMode::L1 => serializer.serialize_u8(0),
+                DataAvailabilityMode::L2 => serializer.serialize_u8(1),
+            }
+        }
+    }
+
+    impl<'de> Deserialize<'de> for DataAvailabilityMode {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            match <u8 as Deserialize>::deserialize(deserializer)? {
+                0 => Ok(Self::L1),
+                1 => Ok(Self::L2),
+                _ => Err(serde::de::Error::custom("invalid data availability mode")),
+            }
+        }
+    }
+
+    impl From<DataAvailabilityMode> for pathfinder_common::transaction::DataAvailabilityMode {
+        fn from(value: DataAvailabilityMode) -> Self {
+            match value {
+                DataAvailabilityMode::L1 => Self::L1,
+                DataAvailabilityMode::L2 => Self::L2,
+            }
+        }
+    }
+
+    impl From<pathfinder_common::transaction::DataAvailabilityMode> for DataAvailabilityMode {
+        fn from(value: pathfinder_common::transaction::DataAvailabilityMode) -> Self {
+            match value {
+                pathfinder_common::transaction::DataAvailabilityMode::L1 => Self::L1,
+                pathfinder_common::transaction::DataAvailabilityMode::L2 => Self::L2,
+            }
+        }
+    }
+
+    #[derive(Copy, Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq, Dummy)]
+    pub struct ResourceBounds {
+        #[serde(rename = "L1_GAS")]
+        pub l1_gas: ResourceBound,
+        #[serde(rename = "L2_GAS")]
+        pub l2_gas: ResourceBound,
+    }
+
+    impl From<ResourceBounds> for pathfinder_common::transaction::ResourceBounds {
+        fn from(value: ResourceBounds) -> Self {
+            Self {
+                l1_gas: value.l1_gas.into(),
+                l2_gas: value.l2_gas.into(),
+            }
+        }
+    }
+
+    impl From<pathfinder_common::transaction::ResourceBounds> for ResourceBounds {
+        fn from(value: pathfinder_common::transaction::ResourceBounds) -> Self {
+            Self {
+                l1_gas: value.l1_gas.into(),
+                l2_gas: value.l2_gas.into(),
+            }
+        }
+    }
+
+    #[serde_as]
+    #[derive(Copy, Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq, Dummy)]
+    pub struct ResourceBound {
+        #[serde_as(as = "ResourceAmountAsHexStr")]
+        pub max_amount: ResourceAmount,
+        #[serde_as(as = "ResourcePricePerUnitAsHexStr")]
+        pub max_price_per_unit: ResourcePricePerUnit,
+    }
+
+    impl From<ResourceBound> for pathfinder_common::transaction::ResourceBound {
+        fn from(value: ResourceBound) -> Self {
+            Self {
+                max_amount: value.max_amount,
+                max_price_per_unit: value.max_price_per_unit,
+            }
+        }
+    }
+
+    impl From<pathfinder_common::transaction::ResourceBound> for ResourceBound {
+        fn from(value: pathfinder_common::transaction::ResourceBound) -> Self {
+            Self {
+                max_amount: value.max_amount,
+                max_price_per_unit: value.max_price_per_unit,
+            }
+        }
+    }
+
+    /// Represents deserialized L2 transaction data.
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq, Dummy)]
+    #[serde(tag = "type")]
+    #[serde(deny_unknown_fields)]
+    pub enum Transaction {
+        #[serde(rename = "DECLARE")]
+        Declare(DeclareTransaction),
+        #[serde(rename = "DEPLOY")]
+        // FIXME regenesis: remove Deploy txn type after regenesis
+        // We are keeping this type of transaction until regenesis
+        // only to support older pre-0.11.0 blocks
+        Deploy(DeployTransaction),
+        #[serde(rename = "DEPLOY_ACCOUNT")]
+        DeployAccount(DeployAccountTransaction),
+        #[serde(rename = "INVOKE_FUNCTION")]
+        Invoke(InvokeTransaction),
+        #[serde(rename = "L1_HANDLER")]
+        L1Handler(L1HandlerTransaction),
+    }
+
+    // This manual deserializtion is a work-around for L1 handler transactions
+    // historically being served as Invoke V0. However, the gateway has retroactively
+    // changed these to L1 handlers. This means older databases will have these as Invoke
+    // but modern one's as L1 handler. This causes confusion, so we convert these old Invoke
+    // to L1 handler manually.
+    //
+    // The alternative is to do a costly database migration which involves opening every tx.
+    //
+    // This work-around may be removed once we are certain all databases no longer contain these
+    // transactions, which will likely only occur after either a migration, or regenesis.
+    impl<'de> Deserialize<'de> for Transaction {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            /// Copy of [Transaction] to deserialize into, before converting to [Transaction]
+            /// with the potential Invoke V0 -> L1 handler cast.
+            #[derive(Deserialize)]
+            #[serde(tag = "type", deny_unknown_fields)]
+            pub enum InnerTransaction {
+                #[serde(rename = "DECLARE")]
+                Declare(DeclareTransaction),
+                #[serde(rename = "DEPLOY")]
+                Deploy(DeployTransaction),
+                #[serde(rename = "DEPLOY_ACCOUNT")]
+                DeployAccount(DeployAccountTransaction),
+                #[serde(rename = "INVOKE_FUNCTION")]
+                Invoke(InvokeTransaction),
+                #[serde(rename = "L1_HANDLER")]
+                L1Handler(L1HandlerTransaction),
+            }
+
+            let tx = InnerTransaction::deserialize(deserializer)?;
+            let tx = match tx {
+                InnerTransaction::Declare(x) => Transaction::Declare(x),
+                InnerTransaction::Deploy(x) => Transaction::Deploy(x),
+                InnerTransaction::DeployAccount(x) => Transaction::DeployAccount(x),
+                InnerTransaction::Invoke(InvokeTransaction::V0(i))
+                    if i.entry_point_type == Some(EntryPointType::L1Handler) =>
+                {
+                    let l1_handler = L1HandlerTransaction {
+                        contract_address: i.sender_address,
+                        entry_point_selector: i.entry_point_selector,
+                        nonce: TransactionNonce::ZERO,
+                        calldata: i.calldata,
+                        transaction_hash: i.transaction_hash,
+                        version: TransactionVersion::ZERO,
+                    };
+
+                    Transaction::L1Handler(l1_handler)
+                }
+                InnerTransaction::Invoke(x) => Transaction::Invoke(x),
+                InnerTransaction::L1Handler(x) => Transaction::L1Handler(x),
+            };
+
+            Ok(tx)
+        }
+    }
+
+    impl From<&pathfinder_common::transaction::Transaction> for Transaction {
+        fn from(value: &pathfinder_common::transaction::Transaction) -> Self {
+            use pathfinder_common::transaction::TransactionVariant::*;
+            use pathfinder_common::transaction::*;
+
+            let transaction_hash = value.hash;
+            match value.variant.clone() {
+                DeclareV0(DeclareTransactionV0V1 {
+                    class_hash,
+                    max_fee,
+                    nonce,
+                    sender_address,
+                    signature,
+                }) => Self::Declare(DeclareTransaction::V0(self::DeclareTransactionV0V1 {
+                    class_hash,
+                    max_fee,
+                    nonce,
+                    sender_address,
+                    signature,
+                    transaction_hash,
+                })),
+                DeclareV1(DeclareTransactionV0V1 {
+                    class_hash,
+                    max_fee,
+                    nonce,
+                    sender_address,
+                    signature,
+                }) => Self::Declare(DeclareTransaction::V1(self::DeclareTransactionV0V1 {
+                    class_hash,
+                    max_fee,
+                    nonce,
+                    sender_address,
+                    signature,
+                    transaction_hash,
+                })),
+                DeclareV2(DeclareTransactionV2 {
+                    class_hash,
+                    max_fee,
+                    nonce,
+                    sender_address,
+                    signature,
+                    compiled_class_hash,
+                }) => Self::Declare(DeclareTransaction::V2(self::DeclareTransactionV2 {
+                    class_hash,
+                    max_fee,
+                    nonce,
+                    sender_address,
+                    signature,
+                    transaction_hash,
+                    compiled_class_hash,
+                })),
+                DeclareV3(DeclareTransactionV3 {
+                    class_hash,
+                    nonce,
+                    nonce_data_availability_mode,
+                    fee_data_availability_mode,
+                    resource_bounds,
+                    tip,
+                    paymaster_data,
+                    signature,
+                    account_deployment_data,
+                    sender_address,
+                    compiled_class_hash,
+                }) => Self::Declare(DeclareTransaction::V3(self::DeclareTransactionV3 {
+                    class_hash,
+                    nonce,
+                    nonce_data_availability_mode: nonce_data_availability_mode.into(),
+                    fee_data_availability_mode: fee_data_availability_mode.into(),
+                    resource_bounds: resource_bounds.into(),
+                    tip,
+                    paymaster_data,
+                    sender_address,
+                    signature,
+                    transaction_hash,
+                    compiled_class_hash,
+                    account_deployment_data,
+                })),
+                Deploy(DeployTransaction {
+                    contract_address,
+                    contract_address_salt,
+                    class_hash,
+                    constructor_calldata,
+                    version,
+                }) => Self::Deploy(self::DeployTransaction {
+                    contract_address,
+                    contract_address_salt,
+                    class_hash,
+                    constructor_calldata,
+                    transaction_hash,
+                    version,
+                }),
+                DeployAccountV0V1(DeployAccountTransactionV0V1 {
+                    contract_address,
+                    max_fee,
+                    version,
+                    signature,
+                    nonce,
+                    contract_address_salt,
+                    constructor_calldata,
+                    class_hash,
+                }) => Self::DeployAccount(self::DeployAccountTransaction::V0V1(
+                    self::DeployAccountTransactionV0V1 {
+                        contract_address,
+                        transaction_hash,
+                        max_fee,
+                        version,
+                        signature,
+                        nonce,
+                        contract_address_salt,
+                        constructor_calldata,
+                        class_hash,
+                    },
+                )),
+                DeployAccountV3(DeployAccountTransactionV3 {
+                    contract_address,
+                    signature,
+                    nonce,
+                    nonce_data_availability_mode,
+                    fee_data_availability_mode,
+                    resource_bounds,
+                    tip,
+                    paymaster_data,
+                    contract_address_salt,
+                    constructor_calldata,
+                    class_hash,
+                }) => Self::DeployAccount(self::DeployAccountTransaction::V3(
+                    self::DeployAccountTransactionV3 {
+                        nonce,
+                        nonce_data_availability_mode: nonce_data_availability_mode.into(),
+                        fee_data_availability_mode: fee_data_availability_mode.into(),
+                        resource_bounds: resource_bounds.into(),
+                        tip,
+                        paymaster_data,
+                        sender_address: contract_address,
+                        signature,
+                        transaction_hash,
+                        version: TransactionVersion::THREE,
+                        contract_address_salt,
+                        constructor_calldata,
+                        class_hash,
+                    },
+                )),
+                InvokeV0(InvokeTransactionV0 {
+                    calldata,
+                    sender_address,
+                    entry_point_selector,
+                    entry_point_type,
+                    max_fee,
+                    signature,
+                }) => Self::Invoke(InvokeTransaction::V0(self::InvokeTransactionV0 {
+                    calldata,
+                    sender_address,
+                    entry_point_selector,
+                    entry_point_type: entry_point_type.map(Into::into),
+                    max_fee,
+                    signature,
+                    transaction_hash,
+                })),
+                InvokeV1(InvokeTransactionV1 {
+                    calldata,
+                    sender_address,
+                    max_fee,
+                    signature,
+                    nonce,
+                }) => Self::Invoke(InvokeTransaction::V1(self::InvokeTransactionV1 {
+                    calldata,
+                    sender_address,
+                    max_fee,
+                    signature,
+                    nonce,
+                    transaction_hash,
+                })),
+                InvokeV3(InvokeTransactionV3 {
+                    signature,
+                    nonce,
+                    nonce_data_availability_mode,
+                    fee_data_availability_mode,
+                    resource_bounds,
+                    tip,
+                    paymaster_data,
+                    account_deployment_data,
+                    calldata,
+                    sender_address,
+                }) => Self::Invoke(InvokeTransaction::V3(self::InvokeTransactionV3 {
+                    nonce,
+                    nonce_data_availability_mode: nonce_data_availability_mode.into(),
+                    fee_data_availability_mode: fee_data_availability_mode.into(),
+                    resource_bounds: resource_bounds.into(),
+                    tip,
+                    paymaster_data,
+                    sender_address,
+                    signature,
+                    transaction_hash,
+                    calldata,
+                    account_deployment_data,
+                })),
+                L1Handler(L1HandlerTransaction {
+                    contract_address,
+                    entry_point_selector,
+                    nonce,
+                    calldata,
+                }) => Self::L1Handler(self::L1HandlerTransaction {
+                    contract_address,
+                    entry_point_selector,
+                    nonce,
+                    calldata,
+                    transaction_hash,
+                    version: TransactionVersion::ZERO,
+                }),
+            }
+        }
+    }
+
+    impl From<Transaction> for pathfinder_common::transaction::Transaction {
+        fn from(value: Transaction) -> Self {
+            use pathfinder_common::transaction::TransactionVariant;
+
+            let hash = value.hash();
+            let variant = match value {
+                Transaction::Declare(DeclareTransaction::V0(DeclareTransactionV0V1 {
+                    class_hash,
+                    max_fee,
+                    nonce,
+                    sender_address,
+                    signature,
+                    transaction_hash: _,
+                })) => TransactionVariant::DeclareV0(
+                    pathfinder_common::transaction::DeclareTransactionV0V1 {
+                        class_hash,
+                        max_fee,
+                        nonce,
+                        sender_address,
+                        signature,
+                    },
+                ),
+                Transaction::Declare(DeclareTransaction::V1(DeclareTransactionV0V1 {
+                    class_hash,
+                    max_fee,
+                    nonce,
+                    sender_address,
+                    signature,
+                    transaction_hash: _,
+                })) => TransactionVariant::DeclareV1(
+                    pathfinder_common::transaction::DeclareTransactionV0V1 {
+                        class_hash,
+                        max_fee,
+                        nonce,
+                        sender_address,
+                        signature,
+                    },
+                ),
+                Transaction::Declare(DeclareTransaction::V2(DeclareTransactionV2 {
+                    class_hash,
+                    max_fee,
+                    nonce,
+                    sender_address,
+                    signature,
+                    transaction_hash: _,
+                    compiled_class_hash,
+                })) => TransactionVariant::DeclareV2(
+                    pathfinder_common::transaction::DeclareTransactionV2 {
+                        class_hash,
+                        max_fee,
+                        nonce,
+                        sender_address,
+                        signature,
+                        compiled_class_hash,
+                    },
+                ),
+                Transaction::Declare(DeclareTransaction::V3(DeclareTransactionV3 {
+                    class_hash,
+                    nonce,
+                    nonce_data_availability_mode,
+                    fee_data_availability_mode,
+                    resource_bounds,
+                    tip,
+                    paymaster_data,
+                    sender_address,
+                    signature,
+                    transaction_hash: _,
+                    compiled_class_hash,
+                    account_deployment_data,
+                })) => TransactionVariant::DeclareV3(
+                    pathfinder_common::transaction::DeclareTransactionV3 {
+                        class_hash,
+                        nonce,
+                        nonce_data_availability_mode: nonce_data_availability_mode.into(),
+                        fee_data_availability_mode: fee_data_availability_mode.into(),
+                        resource_bounds: resource_bounds.into(),
+                        tip,
+                        paymaster_data,
+                        sender_address,
+                        signature,
+                        compiled_class_hash,
+                        account_deployment_data,
+                    },
+                ),
+                Transaction::Deploy(DeployTransaction {
+                    contract_address,
+                    contract_address_salt,
+                    class_hash,
+                    constructor_calldata,
+                    transaction_hash: _,
+                    version,
+                }) => {
+                    TransactionVariant::Deploy(pathfinder_common::transaction::DeployTransaction {
+                        contract_address,
+                        contract_address_salt,
+                        class_hash,
+                        constructor_calldata,
+                        version,
+                    })
+                }
+                Transaction::DeployAccount(DeployAccountTransaction::V0V1(
+                    DeployAccountTransactionV0V1 {
+                        contract_address,
+                        transaction_hash: _,
+                        max_fee,
+                        version,
+                        signature,
+                        nonce,
+                        contract_address_salt,
+                        constructor_calldata,
+                        class_hash,
+                    },
+                )) => TransactionVariant::DeployAccountV0V1(
+                    pathfinder_common::transaction::DeployAccountTransactionV0V1 {
+                        contract_address,
+                        max_fee,
+                        version,
+                        signature,
+                        nonce,
+                        contract_address_salt,
+                        constructor_calldata,
+                        class_hash,
+                    },
+                ),
+                Transaction::DeployAccount(DeployAccountTransaction::V3(
+                    DeployAccountTransactionV3 {
+                        nonce,
+                        nonce_data_availability_mode,
+                        fee_data_availability_mode,
+                        resource_bounds,
+                        tip,
+                        paymaster_data,
+                        sender_address,
+                        signature,
+                        transaction_hash: _,
+                        version: _,
+                        contract_address_salt,
+                        constructor_calldata,
+                        class_hash,
+                    },
+                )) => TransactionVariant::DeployAccountV3(
+                    pathfinder_common::transaction::DeployAccountTransactionV3 {
+                        contract_address: sender_address,
+                        signature,
+                        nonce,
+                        nonce_data_availability_mode: nonce_data_availability_mode.into(),
+                        fee_data_availability_mode: fee_data_availability_mode.into(),
+                        resource_bounds: resource_bounds.into(),
+                        tip,
+                        paymaster_data,
+                        contract_address_salt,
+                        constructor_calldata,
+                        class_hash,
+                    },
+                ),
+                Transaction::Invoke(InvokeTransaction::V0(InvokeTransactionV0 {
+                    calldata,
+                    sender_address,
+                    entry_point_selector,
+                    entry_point_type,
+                    max_fee,
+                    signature,
+                    transaction_hash: _,
+                })) => TransactionVariant::InvokeV0(
+                    pathfinder_common::transaction::InvokeTransactionV0 {
+                        calldata,
+                        sender_address,
+                        entry_point_selector,
+                        entry_point_type: entry_point_type.map(Into::into),
+                        max_fee,
+                        signature,
+                    },
+                ),
+                Transaction::Invoke(InvokeTransaction::V1(InvokeTransactionV1 {
+                    calldata,
+                    sender_address,
+                    max_fee,
+                    signature,
+                    nonce,
+                    transaction_hash: _,
+                })) => TransactionVariant::InvokeV1(
+                    pathfinder_common::transaction::InvokeTransactionV1 {
+                        calldata,
+                        sender_address,
+                        max_fee,
+                        signature,
+                        nonce,
+                    },
+                ),
+                Transaction::Invoke(InvokeTransaction::V3(InvokeTransactionV3 {
+                    nonce,
+                    nonce_data_availability_mode,
+                    fee_data_availability_mode,
+                    resource_bounds,
+                    tip,
+                    paymaster_data,
+                    sender_address,
+                    signature,
+                    transaction_hash: _,
+                    calldata,
+                    account_deployment_data,
+                })) => TransactionVariant::InvokeV3(
+                    pathfinder_common::transaction::InvokeTransactionV3 {
+                        signature,
+                        nonce,
+                        nonce_data_availability_mode: nonce_data_availability_mode.into(),
+                        fee_data_availability_mode: fee_data_availability_mode.into(),
+                        resource_bounds: resource_bounds.into(),
+                        tip,
+                        paymaster_data,
+                        account_deployment_data,
+                        calldata,
+                        sender_address,
+                    },
+                ),
+                Transaction::L1Handler(L1HandlerTransaction {
+                    contract_address,
+                    entry_point_selector,
+                    nonce,
+                    calldata,
+                    transaction_hash: _,
+                    // This should always be zero.
+                    version: _,
+                }) => TransactionVariant::L1Handler(
+                    pathfinder_common::transaction::L1HandlerTransaction {
+                        contract_address,
+                        entry_point_selector,
+                        nonce,
+                        calldata,
+                    },
+                ),
+            };
+
+            pathfinder_common::transaction::Transaction { hash, variant }
+        }
+    }
+
+    impl Transaction {
+        /// Returns hash of the transaction
+        pub fn hash(&self) -> TransactionHash {
+            match self {
+                Transaction::Declare(t) => match t {
+                    DeclareTransaction::V0(t) => t.transaction_hash,
+                    DeclareTransaction::V1(t) => t.transaction_hash,
+                    DeclareTransaction::V2(t) => t.transaction_hash,
+                    DeclareTransaction::V3(t) => t.transaction_hash,
+                },
+                Transaction::Deploy(t) => t.transaction_hash,
+                Transaction::DeployAccount(t) => match t {
+                    DeployAccountTransaction::V0V1(t) => t.transaction_hash,
+                    DeployAccountTransaction::V3(t) => t.transaction_hash,
+                },
+                Transaction::Invoke(t) => match t {
+                    InvokeTransaction::V0(t) => t.transaction_hash,
+                    InvokeTransaction::V1(t) => t.transaction_hash,
+                    InvokeTransaction::V3(t) => t.transaction_hash,
+                },
+                Transaction::L1Handler(t) => t.transaction_hash,
+            }
+        }
+
+        pub fn contract_address(&self) -> ContractAddress {
+            match self {
+                Transaction::Declare(DeclareTransaction::V0(t)) => t.sender_address,
+                Transaction::Declare(DeclareTransaction::V1(t)) => t.sender_address,
+                Transaction::Declare(DeclareTransaction::V2(t)) => t.sender_address,
+                Transaction::Declare(DeclareTransaction::V3(t)) => t.sender_address,
+                Transaction::Deploy(t) => t.contract_address,
+                Transaction::DeployAccount(t) => match t {
+                    DeployAccountTransaction::V0V1(t) => t.contract_address,
+                    DeployAccountTransaction::V3(t) => t.sender_address,
+                },
+                Transaction::Invoke(t) => match t {
+                    InvokeTransaction::V0(t) => t.sender_address,
+                    InvokeTransaction::V1(t) => t.sender_address,
+                    InvokeTransaction::V3(t) => t.sender_address,
+                },
+                Transaction::L1Handler(t) => t.contract_address,
+            }
+        }
+
+        pub fn version(&self) -> TransactionVersion {
+            match self {
+                Transaction::Declare(DeclareTransaction::V0(_)) => TransactionVersion::ZERO,
+                Transaction::Declare(DeclareTransaction::V1(_)) => TransactionVersion::ONE,
+                Transaction::Declare(DeclareTransaction::V2(_)) => TransactionVersion::TWO,
+                Transaction::Declare(DeclareTransaction::V3(_)) => TransactionVersion::THREE,
+
+                Transaction::Deploy(t) => t.version,
+                Transaction::DeployAccount(t) => match t {
+                    DeployAccountTransaction::V0V1(t) => t.version,
+                    DeployAccountTransaction::V3(t) => t.version,
+                },
+                Transaction::Invoke(InvokeTransaction::V0(_)) => TransactionVersion::ZERO,
+                Transaction::Invoke(InvokeTransaction::V1(_)) => TransactionVersion::ONE,
+                Transaction::Invoke(InvokeTransaction::V3(_)) => TransactionVersion::THREE,
+                Transaction::L1Handler(t) => t.version,
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq, Dummy)]
+    #[serde(tag = "version")]
+    pub enum DeclareTransaction {
+        #[serde(rename = "0x0")]
+        V0(DeclareTransactionV0V1),
+        #[serde(rename = "0x1")]
+        V1(DeclareTransactionV0V1),
+        #[serde(rename = "0x2")]
+        V2(DeclareTransactionV2),
+        #[serde(rename = "0x3")]
+        V3(DeclareTransactionV3),
+    }
+
+    impl<'de> Deserialize<'de> for DeclareTransaction {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            use serde::de;
+
+            #[serde_as]
+            #[derive(Deserialize)]
+            struct Version {
+                #[serde(default = "transaction_version_zero")]
+                pub version: TransactionVersion,
+            }
+
+            let mut v = serde_json::Value::deserialize(deserializer)?;
+            let version = Version::deserialize(&v).map_err(de::Error::custom)?;
+            // remove "version", since v0 and v1 transactions use deny_unknown_fields
+            v.as_object_mut()
+                .expect("must be an object because deserializing version succeeded")
+                .remove("version");
+            match version.version {
+                TransactionVersion::ZERO => Ok(Self::V0(
+                    DeclareTransactionV0V1::deserialize(&v).map_err(de::Error::custom)?,
+                )),
+                TransactionVersion::ONE => Ok(Self::V1(
+                    DeclareTransactionV0V1::deserialize(&v).map_err(de::Error::custom)?,
+                )),
+                TransactionVersion::TWO => Ok(Self::V2(
+                    DeclareTransactionV2::deserialize(&v).map_err(de::Error::custom)?,
+                )),
+                TransactionVersion::THREE => Ok(Self::V3(
+                    DeclareTransactionV3::deserialize(&v).map_err(de::Error::custom)?,
+                )),
+                _v => Err(de::Error::custom("version must be 0, 1, 2 or 3")),
+            }
+        }
+    }
+
+    impl DeclareTransaction {
+        pub fn signature(&self) -> &[TransactionSignatureElem] {
+            match self {
+                DeclareTransaction::V0(tx) => tx.signature.as_ref(),
+                DeclareTransaction::V1(tx) => tx.signature.as_ref(),
+                DeclareTransaction::V2(tx) => tx.signature.as_ref(),
+                DeclareTransaction::V3(tx) => tx.signature.as_ref(),
+            }
+        }
+    }
+
+    /// A version 0 or 1 declare transaction.
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Dummy)]
+    #[serde(deny_unknown_fields)]
+    pub struct DeclareTransactionV0V1 {
+        pub class_hash: ClassHash,
+        pub max_fee: Fee,
+        pub nonce: TransactionNonce,
+        pub sender_address: ContractAddress,
+        #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
+        #[serde(default)]
+        pub signature: Vec<TransactionSignatureElem>,
+        pub transaction_hash: TransactionHash,
+    }
+
+    /// A version 2 declare transaction.
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Dummy)]
+    #[serde(deny_unknown_fields)]
+    pub struct DeclareTransactionV2 {
+        pub class_hash: ClassHash,
+        pub max_fee: Fee,
+        pub nonce: TransactionNonce,
+        pub sender_address: ContractAddress,
+        #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
+        #[serde(default)]
+        pub signature: Vec<TransactionSignatureElem>,
+        pub transaction_hash: TransactionHash,
+        pub compiled_class_hash: CasmHash,
+    }
+
+    /// A version 2 declare transaction.
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Dummy)]
+    #[serde(deny_unknown_fields)]
+    pub struct DeclareTransactionV3 {
+        pub class_hash: ClassHash,
+
+        pub nonce: TransactionNonce,
+        pub nonce_data_availability_mode: DataAvailabilityMode,
+        pub fee_data_availability_mode: DataAvailabilityMode,
+        pub resource_bounds: ResourceBounds,
+        #[serde_as(as = "TipAsHexStr")]
+        pub tip: Tip,
+        pub paymaster_data: Vec<PaymasterDataElem>,
+
+        pub sender_address: ContractAddress,
+        #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
+        #[serde(default)]
+        pub signature: Vec<TransactionSignatureElem>,
+        pub transaction_hash: TransactionHash,
+        pub compiled_class_hash: CasmHash,
+
+        pub account_deployment_data: Vec<AccountDeploymentDataElem>,
+    }
+
+    const fn transaction_version_zero() -> TransactionVersion {
+        TransactionVersion::ZERO
+    }
+
+    /// Represents deserialized L2 deploy transaction data.
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Dummy)]
+    #[serde(deny_unknown_fields)]
+    pub struct DeployTransaction {
+        pub contract_address: ContractAddress,
+        pub contract_address_salt: ContractAddressSalt,
+        pub class_hash: ClassHash,
+        #[serde_as(as = "Vec<ConstructorParamAsDecimalStr>")]
+        pub constructor_calldata: Vec<ConstructorParam>,
+        pub transaction_hash: TransactionHash,
+        #[serde(default = "transaction_version_zero")]
+        pub version: TransactionVersion,
+    }
+
+    /// Represents deserialized L2 deploy account transaction data.
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq, Dummy)]
+    #[serde(untagged)]
+    pub enum DeployAccountTransaction {
+        V0V1(DeployAccountTransactionV0V1),
+        V3(DeployAccountTransactionV3),
+    }
+
+    impl<'de> Deserialize<'de> for DeployAccountTransaction {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            use serde::de;
+
+            #[serde_as]
+            #[derive(Deserialize)]
+            struct Version {
+                #[serde(default = "transaction_version_zero")]
+                pub version: TransactionVersion,
+            }
+
+            let v = serde_json::Value::deserialize(deserializer)?;
+            let version = Version::deserialize(&v).map_err(de::Error::custom)?;
+
+            match version.version {
+                TransactionVersion::ZERO => Ok(Self::V0V1(
+                    DeployAccountTransactionV0V1::deserialize(&v).map_err(de::Error::custom)?,
+                )),
+                TransactionVersion::ONE => Ok(Self::V0V1(
+                    DeployAccountTransactionV0V1::deserialize(&v).map_err(de::Error::custom)?,
+                )),
+                TransactionVersion::THREE => Ok(Self::V3(
+                    DeployAccountTransactionV3::deserialize(&v).map_err(de::Error::custom)?,
+                )),
+                _v => Err(de::Error::custom("version must be 0, 1 or 3")),
+            }
+        }
+    }
+
+    impl DeployAccountTransaction {
+        pub fn contract_address(&self) -> ContractAddress {
+            match self {
+                Self::V0V1(tx) => tx.contract_address,
+                Self::V3(tx) => tx.sender_address,
+            }
+        }
+
+        pub fn signature(&self) -> &[TransactionSignatureElem] {
+            match self {
+                Self::V0V1(tx) => tx.signature.as_ref(),
+                Self::V3(tx) => tx.signature.as_ref(),
+            }
+        }
+    }
+
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Dummy)]
+    #[serde(deny_unknown_fields)]
+    pub struct DeployAccountTransactionV0V1 {
+        pub contract_address: ContractAddress,
+        pub transaction_hash: TransactionHash,
+        pub max_fee: Fee,
+        pub version: TransactionVersion,
+        #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
+        pub signature: Vec<TransactionSignatureElem>,
+        pub nonce: TransactionNonce,
+        pub contract_address_salt: ContractAddressSalt,
+        #[serde_as(as = "Vec<CallParamAsDecimalStr>")]
+        pub constructor_calldata: Vec<CallParam>,
+        pub class_hash: ClassHash,
+    }
+
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Dummy)]
+    #[serde(deny_unknown_fields)]
+    pub struct DeployAccountTransactionV3 {
+        pub nonce: TransactionNonce,
+        pub nonce_data_availability_mode: DataAvailabilityMode,
+        pub fee_data_availability_mode: DataAvailabilityMode,
+        pub resource_bounds: ResourceBounds,
+        #[serde_as(as = "TipAsHexStr")]
+        pub tip: Tip,
+        pub paymaster_data: Vec<PaymasterDataElem>,
+
+        pub sender_address: ContractAddress,
+        #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
+        pub signature: Vec<TransactionSignatureElem>,
+        pub transaction_hash: TransactionHash,
+        pub version: TransactionVersion,
+        pub contract_address_salt: ContractAddressSalt,
+        #[serde_as(as = "Vec<CallParamAsDecimalStr>")]
+        pub constructor_calldata: Vec<CallParam>,
+        pub class_hash: ClassHash,
+    }
+
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq, Dummy)]
+    #[serde(tag = "version")]
+    pub enum InvokeTransaction {
+        #[serde(rename = "0x0")]
+        V0(InvokeTransactionV0),
+        #[serde(rename = "0x1")]
+        V1(InvokeTransactionV1),
+        #[serde(rename = "0x3")]
+        V3(InvokeTransactionV3),
+    }
+
+    impl<'de> Deserialize<'de> for InvokeTransaction {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            use serde::de;
+
+            #[serde_as]
+            #[derive(Deserialize)]
+            struct Version {
+                #[serde(default = "transaction_version_zero")]
+                pub version: TransactionVersion,
+            }
+
+            let mut v = serde_json::Value::deserialize(deserializer)?;
+            let version = Version::deserialize(&v).map_err(de::Error::custom)?;
+            // remove "version", since v0 and v1 transactions use deny_unknown_fields
+            v.as_object_mut()
+                .expect("must be an object because deserializing version succeeded")
+                .remove("version");
+            match version.version {
+                TransactionVersion::ZERO => Ok(Self::V0(
+                    InvokeTransactionV0::deserialize(&v).map_err(de::Error::custom)?,
+                )),
+                TransactionVersion::ONE => Ok(Self::V1(
+                    InvokeTransactionV1::deserialize(&v).map_err(de::Error::custom)?,
+                )),
+                TransactionVersion::THREE => Ok(Self::V3(
+                    InvokeTransactionV3::deserialize(&v).map_err(de::Error::custom)?,
+                )),
+                _v => Err(de::Error::custom("version must be 0, 1 or 3")),
+            }
+        }
+    }
+
+    impl InvokeTransaction {
+        pub fn signature(&self) -> &[TransactionSignatureElem] {
+            match self {
+                Self::V0(tx) => tx.signature.as_ref(),
+                Self::V1(tx) => tx.signature.as_ref(),
+                Self::V3(tx) => tx.signature.as_ref(),
+            }
+        }
+    }
+
+    /// Represents deserialized L2 invoke transaction v0 data.
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Dummy)]
+    #[serde(deny_unknown_fields)]
+    pub struct InvokeTransactionV0 {
+        #[serde_as(as = "Vec<CallParamAsDecimalStr>")]
+        pub calldata: Vec<CallParam>,
+        // contract_address is the historic name for this field. sender_address was
+        // introduced with starknet v0.11. Although the gateway no longer uses the historic
+        // name at all, this alias must be kept until a database migration fixes all historic
+        // transaction naming, or until regenesis removes them all.
+        #[serde(alias = "contract_address")]
+        pub sender_address: ContractAddress,
+        pub entry_point_selector: EntryPoint,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub entry_point_type: Option<EntryPointType>,
+        pub max_fee: Fee,
+        #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
+        pub signature: Vec<TransactionSignatureElem>,
+        pub transaction_hash: TransactionHash,
+    }
+
+    /// Represents deserialized L2 invoke transaction v1 data.
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Dummy)]
+    #[serde(deny_unknown_fields)]
+    pub struct InvokeTransactionV1 {
+        #[serde_as(as = "Vec<CallParamAsDecimalStr>")]
+        pub calldata: Vec<CallParam>,
+        // contract_address is the historic name for this field. sender_address was
+        // introduced with starknet v0.11. Although the gateway no longer uses the historic
+        // name at all, this alias must be kept until a database migration fixes all historic
+        // transaction naming, or until regenesis removes them all.
+        #[serde(alias = "contract_address")]
+        pub sender_address: ContractAddress,
+        pub max_fee: Fee,
+        #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
+        pub signature: Vec<TransactionSignatureElem>,
+        pub nonce: TransactionNonce,
+        pub transaction_hash: TransactionHash,
+    }
+
+    /// Represents deserialized L2 invoke transaction v3 data.
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Dummy)]
+    #[serde(deny_unknown_fields)]
+    pub struct InvokeTransactionV3 {
+        pub nonce: TransactionNonce,
+        pub nonce_data_availability_mode: DataAvailabilityMode,
+        pub fee_data_availability_mode: DataAvailabilityMode,
+        pub resource_bounds: ResourceBounds,
+        #[serde_as(as = "TipAsHexStr")]
+        pub tip: Tip,
+        pub paymaster_data: Vec<PaymasterDataElem>,
+
+        pub sender_address: ContractAddress,
+        #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
+        pub signature: Vec<TransactionSignatureElem>,
+        pub transaction_hash: TransactionHash,
+        #[serde_as(as = "Vec<CallParamAsDecimalStr>")]
+        pub calldata: Vec<CallParam>,
+
+        pub account_deployment_data: Vec<AccountDeploymentDataElem>,
+    }
+
+    /// Represents deserialized L2 "L1 handler" transaction data.
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Dummy)]
+    #[serde(deny_unknown_fields)]
+    pub struct L1HandlerTransaction {
+        pub contract_address: ContractAddress,
+        pub entry_point_selector: EntryPoint,
+        // FIXME: remove once starkware fixes their gateway bug which was missing this field.
+        #[serde(default)]
+        pub nonce: TransactionNonce,
+        pub calldata: Vec<CallParam>,
+        pub transaction_hash: TransactionHash,
+        pub version: TransactionVersion,
+    }
+
+    /// Describes L2 transaction failure details.
+    #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+    #[serde(deny_unknown_fields)]
+    pub struct Failure {
+        pub code: String,
+        pub error_message: String,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use pathfinder_common::macro_prelude::*;
-    use pathfinder_common::{BlockHeader, TransactionIndex, TransactionVersion};
-    use starknet_gateway_types::reply::transaction::{
-        DeclareTransactionV0V1, DeclareTransactionV2, DeployAccountTransaction,
-        DeployAccountTransactionV0V1, DeployTransaction, InvokeTransactionV0, InvokeTransactionV1,
-    };
+    use pathfinder_common::transaction::*;
+    use pathfinder_common::TransactionVersion;
+    use pathfinder_common::{BlockHeader, TransactionIndex};
 
     use super::*;
 
     fn setup() -> (
         crate::Connection,
         BlockHeader,
-        Vec<(gateway::Transaction, gateway::Receipt)>,
+        Vec<(StarknetTransaction, Receipt)>,
     ) {
         let header = BlockHeader::builder().finalize_with_hash(block_hash_bytes!(b"block hash"));
 
         // Create one of each transaction type.
         let transactions = vec![
-            gateway::Transaction::Declare(gateway::DeclareTransaction::V0(
-                DeclareTransactionV0V1 {
+            StarknetTransaction {
+                hash: transaction_hash_bytes!(b"declare v0 tx hash"),
+                variant: TransactionVariant::DeclareV0(DeclareTransactionV0V1 {
                     class_hash: class_hash_bytes!(b"declare v0 class hash"),
                     max_fee: fee_bytes!(b"declare v0 max fee"),
                     nonce: transaction_nonce_bytes!(b"declare v0 tx nonce"),
@@ -356,11 +1716,11 @@ mod tests {
                         transaction_signature_elem_bytes!(b"declare v0 tx sig 0"),
                         transaction_signature_elem_bytes!(b"declare v0 tx sig 1"),
                     ],
-                    transaction_hash: transaction_hash_bytes!(b"declare v0 tx hash"),
-                },
-            )),
-            gateway::Transaction::Declare(gateway::DeclareTransaction::V1(
-                DeclareTransactionV0V1 {
+                }),
+            },
+            StarknetTransaction {
+                hash: transaction_hash_bytes!(b"declare v1 tx hash"),
+                variant: TransactionVariant::DeclareV1(DeclareTransactionV0V1 {
                     class_hash: class_hash_bytes!(b"declare v1 class hash"),
                     max_fee: fee_bytes!(b"declare v1 max fee"),
                     nonce: transaction_nonce_bytes!(b"declare v1 tx nonce"),
@@ -369,38 +1729,41 @@ mod tests {
                         transaction_signature_elem_bytes!(b"declare v1 tx sig 0"),
                         transaction_signature_elem_bytes!(b"declare v1 tx sig 1"),
                     ],
-                    transaction_hash: transaction_hash_bytes!(b"declare v1 tx hash"),
-                },
-            )),
-            gateway::Transaction::Declare(gateway::DeclareTransaction::V2(DeclareTransactionV2 {
-                class_hash: class_hash_bytes!(b"declare v2 class hash"),
-                max_fee: fee_bytes!(b"declare v2 max fee"),
-                nonce: transaction_nonce_bytes!(b"declare v2 tx nonce"),
-                sender_address: contract_address_bytes!(b"declare v2 contract address"),
-                signature: vec![
-                    transaction_signature_elem_bytes!(b"declare v2 tx sig 0"),
-                    transaction_signature_elem_bytes!(b"declare v2 tx sig 1"),
-                ],
-                transaction_hash: transaction_hash_bytes!(b"declare v2 tx hash"),
-                compiled_class_hash: casm_hash_bytes!(b"declare v2 casm hash"),
-            })),
-            gateway::Transaction::Deploy(DeployTransaction {
-                contract_address: contract_address_bytes!(b"deploy contract address"),
-                contract_address_salt: contract_address_salt_bytes!(
-                    b"deploy contract address salt"
-                ),
-                class_hash: class_hash_bytes!(b"deploy class hash"),
-                constructor_calldata: vec![
-                    constructor_param_bytes!(b"deploy call data 0"),
-                    constructor_param_bytes!(b"deploy call data 1"),
-                ],
-                transaction_hash: transaction_hash_bytes!(b"deploy tx hash"),
-                version: TransactionVersion::ZERO,
-            }),
-            gateway::Transaction::DeployAccount(DeployAccountTransaction::V0V1(
-                DeployAccountTransactionV0V1 {
+                }),
+            },
+            StarknetTransaction {
+                hash: transaction_hash_bytes!(b"declare v2 tx hash"),
+                variant: TransactionVariant::DeclareV2(DeclareTransactionV2 {
+                    class_hash: class_hash_bytes!(b"declare v2 class hash"),
+                    max_fee: fee_bytes!(b"declare v2 max fee"),
+                    nonce: transaction_nonce_bytes!(b"declare v2 tx nonce"),
+                    sender_address: contract_address_bytes!(b"declare v2 contract address"),
+                    signature: vec![
+                        transaction_signature_elem_bytes!(b"declare v2 tx sig 0"),
+                        transaction_signature_elem_bytes!(b"declare v2 tx sig 1"),
+                    ],
+                    compiled_class_hash: casm_hash_bytes!(b"declare v2 casm hash"),
+                }),
+            },
+            StarknetTransaction {
+                hash: transaction_hash_bytes!(b"deploy tx hash"),
+                variant: TransactionVariant::Deploy(DeployTransaction {
+                    contract_address: contract_address_bytes!(b"deploy contract address"),
+                    contract_address_salt: contract_address_salt_bytes!(
+                        b"deploy contract address salt"
+                    ),
+                    class_hash: class_hash_bytes!(b"deploy class hash"),
+                    constructor_calldata: vec![
+                        constructor_param_bytes!(b"deploy call data 0"),
+                        constructor_param_bytes!(b"deploy call data 1"),
+                    ],
+                    version: TransactionVersion::ZERO,
+                }),
+            },
+            StarknetTransaction {
+                hash: transaction_hash_bytes!(b"deploy account tx hash"),
+                variant: TransactionVariant::DeployAccountV0V1(DeployAccountTransactionV0V1 {
                     contract_address: contract_address_bytes!(b"deploy account contract address"),
-                    transaction_hash: transaction_hash_bytes!(b"deploy account tx hash"),
                     max_fee: fee_bytes!(b"deploy account max fee"),
                     version: TransactionVersion::ZERO,
                     signature: vec![
@@ -416,65 +1779,64 @@ mod tests {
                         call_param_bytes!(b"deploy account call data 1"),
                     ],
                     class_hash: class_hash_bytes!(b"deploy account class hash"),
-                },
-            )),
-            gateway::Transaction::Invoke(gateway::InvokeTransaction::V0(InvokeTransactionV0 {
-                calldata: vec![
-                    call_param_bytes!(b"invoke v0 call data 0"),
-                    call_param_bytes!(b"invoke v0 call data 1"),
-                ],
-                sender_address: contract_address_bytes!(b"invoke v0 contract address"),
-                entry_point_selector: entry_point_bytes!(b"invoke v0 entry point"),
-                entry_point_type: None,
-                max_fee: fee_bytes!(b"invoke v0 max fee"),
-                signature: vec![
-                    transaction_signature_elem_bytes!(b"invoke v0 tx sig 0"),
-                    transaction_signature_elem_bytes!(b"invoke v0 tx sig 1"),
-                ],
-                transaction_hash: transaction_hash_bytes!(b"invoke v0 tx hash"),
-            })),
-            gateway::Transaction::Invoke(gateway::InvokeTransaction::V1(InvokeTransactionV1 {
-                calldata: vec![
-                    call_param_bytes!(b"invoke v1 call data 0"),
-                    call_param_bytes!(b"invoke v1 call data 1"),
-                ],
-                sender_address: contract_address_bytes!(b"invoke v1 contract address"),
-                max_fee: fee_bytes!(b"invoke v1 max fee"),
-                signature: vec![
-                    transaction_signature_elem_bytes!(b"invoke v1 tx sig 0"),
-                    transaction_signature_elem_bytes!(b"invoke v1 tx sig 1"),
-                ],
-                nonce: transaction_nonce_bytes!(b"invoke v1 tx nonce"),
-                transaction_hash: transaction_hash_bytes!(b"invoke v1 tx hash"),
-            })),
-            gateway::Transaction::L1Handler(gateway::L1HandlerTransaction {
-                contract_address: contract_address_bytes!(b"L1 handler contract address"),
-                entry_point_selector: entry_point_bytes!(b"L1 handler entry point"),
-                nonce: transaction_nonce_bytes!(b"L1 handler tx nonce"),
-                calldata: vec![
-                    call_param_bytes!(b"L1 handler call data 0"),
-                    call_param_bytes!(b"L1 handler call data 1"),
-                ],
-                transaction_hash: transaction_hash_bytes!(b"L1 handler tx hash"),
-                version: TransactionVersion::ZERO,
-            }),
+                }),
+            },
+            StarknetTransaction {
+                hash: transaction_hash_bytes!(b"invoke v0 tx hash"),
+                variant: TransactionVariant::InvokeV0(InvokeTransactionV0 {
+                    calldata: vec![
+                        call_param_bytes!(b"invoke v0 call data 0"),
+                        call_param_bytes!(b"invoke v0 call data 1"),
+                    ],
+                    sender_address: contract_address_bytes!(b"invoke v0 contract address"),
+                    entry_point_selector: entry_point_bytes!(b"invoke v0 entry point"),
+                    entry_point_type: None,
+                    max_fee: fee_bytes!(b"invoke v0 max fee"),
+                    signature: vec![
+                        transaction_signature_elem_bytes!(b"invoke v0 tx sig 0"),
+                        transaction_signature_elem_bytes!(b"invoke v0 tx sig 1"),
+                    ],
+                }),
+            },
+            StarknetTransaction {
+                hash: transaction_hash_bytes!(b"invoke v1 tx hash"),
+                variant: TransactionVariant::InvokeV1(InvokeTransactionV1 {
+                    calldata: vec![
+                        call_param_bytes!(b"invoke v1 call data 0"),
+                        call_param_bytes!(b"invoke v1 call data 1"),
+                    ],
+                    sender_address: contract_address_bytes!(b"invoke v1 contract address"),
+                    max_fee: fee_bytes!(b"invoke v1 max fee"),
+                    signature: vec![
+                        transaction_signature_elem_bytes!(b"invoke v1 tx sig 0"),
+                        transaction_signature_elem_bytes!(b"invoke v1 tx sig 1"),
+                    ],
+                    nonce: transaction_nonce_bytes!(b"invoke v1 tx nonce"),
+                }),
+            },
+            StarknetTransaction {
+                hash: transaction_hash_bytes!(b"L1 handler tx hash"),
+                variant: TransactionVariant::L1Handler(L1HandlerTransaction {
+                    contract_address: contract_address_bytes!(b"L1 handler contract address"),
+                    entry_point_selector: entry_point_bytes!(b"L1 handler entry point"),
+                    nonce: transaction_nonce_bytes!(b"L1 handler tx nonce"),
+                    calldata: vec![
+                        call_param_bytes!(b"L1 handler call data 0"),
+                        call_param_bytes!(b"L1 handler call data 1"),
+                    ],
+                }),
+            },
         ];
 
         // Generate a random receipt for each transaction. Note that these won't make physical sense
         // but its enough for the tests.
-        let receipts: Vec<gateway::Receipt> = transactions
+        let receipts: Vec<pathfinder_common::receipt::Receipt> = transactions
             .iter()
             .enumerate()
-            .map(|(i, t)| gateway::Receipt {
-                actual_fee: None,
-                events: vec![],
-                execution_resources: None,
-                l1_to_l2_consumed_message: None,
-                l2_to_l1_messages: vec![],
-                transaction_hash: t.hash(),
+            .map(|(i, t)| Receipt {
+                transaction_hash: t.hash,
                 transaction_index: TransactionIndex::new_or_panic(i as u64),
-                execution_status: Default::default(),
-                revert_error: Default::default(),
+                ..Default::default()
             })
             .collect();
         assert_eq!(transactions.len(), receipts.len());
@@ -501,7 +1863,7 @@ mod tests {
 
         let (expected, _) = body.first().unwrap().clone();
 
-        let result = super::transaction(&tx, expected.hash()).unwrap().unwrap();
+        let result = super::transaction(&tx, expected.hash).unwrap().unwrap();
         assert_eq!(result, expected);
 
         let invalid = super::transaction(&tx, transaction_hash_bytes!(b"invalid")).unwrap();
@@ -515,7 +1877,7 @@ mod tests {
 
         let (transaction, receipt) = body.first().unwrap().clone();
 
-        let result = super::transaction_with_receipt(&tx, transaction.hash())
+        let result = super::transaction_with_receipt(&tx, transaction.hash)
             .unwrap()
             .unwrap();
         assert_eq!(result.0, transaction);
@@ -608,7 +1970,7 @@ mod tests {
 
         let expected = Some(
             body.iter()
-                .map(|(transaction, _)| transaction.hash())
+                .map(|(transaction, _)| transaction.hash)
                 .collect(),
         );
 
@@ -629,7 +1991,7 @@ mod tests {
         let (mut db, header, body) = setup();
         let tx = db.transaction().unwrap();
 
-        let target = body.first().unwrap().0.hash();
+        let target = body.first().unwrap().0.hash;
         let valid = super::transaction_block_hash(&tx, target).unwrap().unwrap();
         assert_eq!(valid, header.hash);
 


### PR DESCRIPTION
This PR replaces the remaining gateway types from the public storage connection API by replacing them with the common types. This impacts the transaction and receipts types.

This is an intermediete step to hiding the gateway dto types from the rest of the codebase. Especially the transaction types are fairly pervasive still. Most code relies on the gateway types so a lot of this PR involves casting from common to gateway type. Not optimal but follow-up work will hide more and more of the gateway type, forcing code to adapt to only common.

Storage crate uses the gateway dto as its storage schema. To remove this coupling I've copied the dto definitions over. There is already work scoped to rework the storage schema - not this PRs problem.

The storage crate still relies on the gateway types due to test setup functionality which generates contract definitions (types defined in the gateway). This can be handled as a follow-up task although its unclear if such types should be in common.

I've also commented out some failing p2p sync tests. These are already being heavily reworked elsewhere so this isn't a concern.