### PR TITLE
fix: align `UNEXPECTED_ERROR` message with other nodes

### DIFF
--- a/crates/gateway-types/src/error.rs
+++ b/crates/gateway-types/src/error.rs
@@ -29,7 +29,7 @@ impl std::error::Error for StarknetError {}
 
 impl std::fmt::Display for StarknetError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{self:?}")
+        write!(f, "{}", self.message)
     }
 }
 

--- a/crates/rpc/src/v04/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v04/method/add_declare_transaction.rs
@@ -350,9 +350,11 @@ mod tests {
 
             #[test]
             fn unexpected_error_message() {
-                use starknet_gateway_types::error::{StarknetError, StarknetErrorCode, KnownStarknetErrorCode};
-                let starknet_error = SequencerError::StarknetError(StarknetError { 
-                    code: StarknetErrorCode::Known(KnownStarknetErrorCode::TransactionLimitExceeded), 
+                use starknet_gateway_types::error::{
+                    KnownStarknetErrorCode, StarknetError, StarknetErrorCode,
+                };
+                let starknet_error = SequencerError::StarknetError(StarknetError {
+                    code: StarknetErrorCode::Known(KnownStarknetErrorCode::TransactionLimitExceeded),
                     message: "StarkNet Alpha throughput limit reached, please wait a few minutes and try again.".to_string() 
                 });
 

--- a/crates/rpc/src/v04/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v04/method/add_declare_transaction.rs
@@ -347,6 +347,28 @@ mod tests {
                 };
                 assert_eq!(input, expected);
             }
+
+            #[test]
+            fn unexpected_error_message() {
+                use starknet_gateway_types::error::{StarknetError, StarknetErrorCode, KnownStarknetErrorCode};
+                let starknet_error = SequencerError::StarknetError(StarknetError { 
+                    code: StarknetErrorCode::Known(KnownStarknetErrorCode::TransactionLimitExceeded), 
+                    message: "StarkNet Alpha throughput limit reached, please wait a few minutes and try again.".to_string() 
+                });
+
+                let error = AddDeclareTransactionError::from(starknet_error);
+                let error = crate::error::ApplicationError::from(error);
+                let error = crate::jsonrpc::RpcError::from(error);
+                let error = serde_json::to_value(error).unwrap();
+
+                let expected = json!({
+                    "code": 63,
+                    "message": "An unexpected error occurred",
+                    "data": "StarkNet Alpha throughput limit reached, please wait a few minutes and try again."
+                });
+
+                assert_eq!(error, expected);
+            }
         }
 
         mod v2 {

--- a/crates/rpc/src/v04/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/v04/method/add_invoke_transaction.rs
@@ -213,6 +213,32 @@ mod tests {
             };
             assert_eq!(input, expected);
         }
+
+        #[test]
+        fn unexpected_error_message() {
+            use starknet_gateway_types::error::{
+                KnownStarknetErrorCode, StarknetError, StarknetErrorCode,
+            };
+            let starknet_error = SequencerError::StarknetError(StarknetError {
+                code: StarknetErrorCode::Known(KnownStarknetErrorCode::TransactionLimitExceeded),
+                message:
+                    "StarkNet Alpha throughput limit reached, please wait a few minutes and try again."
+                        .to_string(),
+            });
+
+            let error = AddInvokeTransactionError::from(starknet_error);
+            let error = crate::error::ApplicationError::from(error);
+            let error = crate::jsonrpc::RpcError::from(error);
+            let error = serde_json::to_value(error).unwrap();
+
+            let expected = serde_json::json!({
+                "code": 63,
+                "message": "An unexpected error occurred",
+                "data": "StarkNet Alpha throughput limit reached, please wait a few minutes and try again."
+            });
+
+            assert_eq!(error, expected);
+        }
     }
 
     #[tokio::test]

--- a/crates/rpc/src/v06/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v06/method/add_declare_transaction.rs
@@ -352,9 +352,11 @@ mod tests {
 
             #[test]
             fn unexpected_error_message() {
-                use starknet_gateway_types::error::{StarknetError, StarknetErrorCode, KnownStarknetErrorCode};
-                let starknet_error = SequencerError::StarknetError(StarknetError { 
-                    code: StarknetErrorCode::Known(KnownStarknetErrorCode::TransactionLimitExceeded), 
+                use starknet_gateway_types::error::{
+                    KnownStarknetErrorCode, StarknetError, StarknetErrorCode,
+                };
+                let starknet_error = SequencerError::StarknetError(StarknetError {
+                    code: StarknetErrorCode::Known(KnownStarknetErrorCode::TransactionLimitExceeded),
                     message: "StarkNet Alpha throughput limit reached, please wait a few minutes and try again.".to_string() 
                 });
 

--- a/crates/rpc/src/v06/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v06/method/add_declare_transaction.rs
@@ -349,6 +349,28 @@ mod tests {
                 };
                 assert_eq!(input, expected);
             }
+
+            #[test]
+            fn unexpected_error_message() {
+                use starknet_gateway_types::error::{StarknetError, StarknetErrorCode, KnownStarknetErrorCode};
+                let starknet_error = SequencerError::StarknetError(StarknetError { 
+                    code: StarknetErrorCode::Known(KnownStarknetErrorCode::TransactionLimitExceeded), 
+                    message: "StarkNet Alpha throughput limit reached, please wait a few minutes and try again.".to_string() 
+                });
+
+                let error = AddDeclareTransactionError::from(starknet_error);
+                let error = crate::error::ApplicationError::from(error);
+                let error = crate::jsonrpc::RpcError::from(error);
+                let error = serde_json::to_value(error).unwrap();
+
+                let expected = json!({
+                    "code": 63,
+                    "message": "An unexpected error occurred",
+                    "data": "StarkNet Alpha throughput limit reached, please wait a few minutes and try again."
+                });
+
+                assert_eq!(error, expected);
+            }
         }
 
         mod v2 {

--- a/crates/rpc/src/v06/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/v06/method/add_deploy_account_transaction.rs
@@ -224,6 +224,32 @@ mod tests {
         assert_eq!(input, get_input());
     }
 
+    #[test]
+    fn unexpected_error_message() {
+        use starknet_gateway_types::error::{
+            KnownStarknetErrorCode, StarknetError, StarknetErrorCode,
+        };
+        let starknet_error = SequencerError::StarknetError(StarknetError {
+            code: StarknetErrorCode::Known(KnownStarknetErrorCode::TransactionLimitExceeded),
+            message:
+                "StarkNet Alpha throughput limit reached, please wait a few minutes and try again."
+                    .to_string(),
+        });
+
+        let error = AddDeployAccountTransactionError::from(starknet_error);
+        let error = crate::error::ApplicationError::from(error);
+        let error = crate::jsonrpc::RpcError::from(error);
+        let error = serde_json::to_value(error).unwrap();
+
+        let expected = serde_json::json!({
+            "code": 63,
+            "message": "An unexpected error occurred",
+            "data": "StarkNet Alpha throughput limit reached, please wait a few minutes and try again."
+        });
+
+        assert_eq!(error, expected);
+    }
+
     fn get_input() -> AddDeployAccountTransactionInput {
         AddDeployAccountTransactionInput {
             deploy_account_transaction: Transaction::DeployAccount(

--- a/crates/rpc/src/v06/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/v06/method/add_invoke_transaction.rs
@@ -277,9 +277,11 @@ mod tests {
 
         #[test]
         fn unexpected_error_message() {
-            use starknet_gateway_types::error::{StarknetError, StarknetErrorCode, KnownStarknetErrorCode};
-            let starknet_error = SequencerError::StarknetError(StarknetError { 
-                code: StarknetErrorCode::Known(KnownStarknetErrorCode::TransactionLimitExceeded), 
+            use starknet_gateway_types::error::{
+                KnownStarknetErrorCode, StarknetError, StarknetErrorCode,
+            };
+            let starknet_error = SequencerError::StarknetError(StarknetError {
+                code: StarknetErrorCode::Known(KnownStarknetErrorCode::TransactionLimitExceeded),
                 message: "StarkNet Alpha throughput limit reached, please wait a few minutes and try again.".to_string() 
             });
 

--- a/crates/rpc/src/v06/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/v06/method/add_invoke_transaction.rs
@@ -274,6 +274,28 @@ mod tests {
             };
             assert_eq!(input, expected);
         }
+
+        #[test]
+        fn unexpected_error_message() {
+            use starknet_gateway_types::error::{StarknetError, StarknetErrorCode, KnownStarknetErrorCode};
+            let starknet_error = SequencerError::StarknetError(StarknetError { 
+                code: StarknetErrorCode::Known(KnownStarknetErrorCode::TransactionLimitExceeded), 
+                message: "StarkNet Alpha throughput limit reached, please wait a few minutes and try again.".to_string() 
+            });
+
+            let error = AddInvokeTransactionError::from(starknet_error);
+            let error = crate::error::ApplicationError::from(error);
+            let error = crate::jsonrpc::RpcError::from(error);
+            let error = serde_json::to_value(error).unwrap();
+
+            let expected = json!({
+                "code": 63,
+                "message": "An unexpected error occurred",
+                "data": "StarkNet Alpha throughput limit reached, please wait a few minutes and try again."
+            });
+
+            assert_eq!(error, expected);
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Changes the starknet display fmt from struct debug to message.

See the attached bug issue for details.

Closes #1750 
