### PR TITLE
feat(p2p): prevent evicted peers from reconnecting too quickly

### DIFF
--- a/crates/p2p/src/peers.rs
+++ b/crates/p2p/src/peers.rs
@@ -46,6 +46,7 @@ impl Peer {
         })
     }
 
+    /// The connection time of the peer, if he is connected.
     pub fn connected_at(&self) -> Option<Instant> {
         match self.connectivity {
             Connectivity::Connected { connected_at, .. } => Some(connected_at),


### PR DESCRIPTION
Prevent evicted peers from reconnecting too quickly.

Part of https://github.com/eqlabs/pathfinder/issues/1711.