### PR TITLE
feat(p2p): peer management cli config checks

### DIFF
--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -673,7 +673,7 @@ impl P2PConfig {
             Cli::command()
                 .error(
                     ErrorKind::ValueValidation,
-                    "p2p.low-watermark must be less than or equal to max_outbound_connections",
+                    "p2p.low-watermark must be less than or equal to p2p.max_outbound_connections",
                 )
                 .exit()
         }


### PR DESCRIPTION
Adds the following config checks:
- max_inbound_direct_connections >= 25 or equal to zero.
- max_inbound_relayed_connections >= 25 or equal to zero.
- low_watermark <= max_outbound_connections.

Fixes an invalid config for `p2p.ip-whitelist` :see_no_evil: 

Closes #1711.
