### PR TITLE
feat(gateway): specialize pending block

### DIFF
--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -19,11 +19,14 @@ pub trait GatewayApi: Sync {
         unimplemented!();
     }
 
-    async fn block(&self, block: BlockId) -> Result<reply::MaybePendingBlock, SequencerError> {
+    async fn block_deprecated(
+        &self,
+        block: BlockId,
+    ) -> Result<reply::MaybePendingBlock, SequencerError> {
         unimplemented!();
     }
 
-    async fn block_without_retry(
+    async fn block_without_retry_deprecated(
         &self,
         block: BlockId,
     ) -> Result<reply::MaybePendingBlock, SequencerError> {
@@ -58,7 +61,7 @@ pub trait GatewayApi: Sync {
         unimplemented!();
     }
 
-    async fn state_update(&self, block: BlockId) -> Result<StateUpdate, SequencerError> {
+    async fn state_update_deprecated(&self, block: BlockId) -> Result<StateUpdate, SequencerError> {
         unimplemented!();
     }
 
@@ -124,15 +127,18 @@ impl<T: GatewayApi + Sync + Send> GatewayApi for std::sync::Arc<T> {
         self.as_ref().pending_block().await
     }
 
-    async fn block(&self, block: BlockId) -> Result<reply::MaybePendingBlock, SequencerError> {
-        self.as_ref().block(block).await
-    }
-
-    async fn block_without_retry(
+    async fn block_deprecated(
         &self,
         block: BlockId,
     ) -> Result<reply::MaybePendingBlock, SequencerError> {
-        self.as_ref().block_without_retry(block).await
+        self.as_ref().block_deprecated(block).await
+    }
+
+    async fn block_without_retry_deprecated(
+        &self,
+        block: BlockId,
+    ) -> Result<reply::MaybePendingBlock, SequencerError> {
+        self.as_ref().block_without_retry_deprecated(block).await
     }
 
     async fn block_header(
@@ -163,8 +169,8 @@ impl<T: GatewayApi + Sync + Send> GatewayApi for std::sync::Arc<T> {
         self.as_ref().transaction(transaction_hash).await
     }
 
-    async fn state_update(&self, block: BlockId) -> Result<StateUpdate, SequencerError> {
-        self.as_ref().state_update(block).await
+    async fn state_update_deprecated(&self, block: BlockId) -> Result<StateUpdate, SequencerError> {
+        self.as_ref().state_update_deprecated(block).await
     }
 
     async fn state_update_with_block(
@@ -338,7 +344,7 @@ impl Client {
         };
         // unwrap is safe as `block_hash` is always present for non-pending blocks.
         let genesis_hash = self
-            .block(BlockNumber::GENESIS.into())
+            .block_deprecated(BlockNumber::GENESIS.into())
             .await?
             .as_block()
             .expect("Genesis block should not be pending")
@@ -378,12 +384,15 @@ impl GatewayApi for Client {
     }
 
     #[tracing::instrument(skip(self))]
-    async fn block(&self, block: BlockId) -> Result<reply::MaybePendingBlock, SequencerError> {
+    async fn block_deprecated(
+        &self,
+        block: BlockId,
+    ) -> Result<reply::MaybePendingBlock, SequencerError> {
         self.block_with_retry_behaviour(block, self.retry).await
     }
 
     #[tracing::instrument(skip(self))]
-    async fn block_without_retry(
+    async fn block_without_retry_deprecated(
         &self,
         block: BlockId,
     ) -> Result<reply::MaybePendingBlock, SequencerError> {
@@ -458,7 +467,7 @@ impl GatewayApi for Client {
     }
 
     #[tracing::instrument(skip(self))]
-    async fn state_update(&self, block: BlockId) -> Result<StateUpdate, SequencerError> {
+    async fn state_update_deprecated(&self, block: BlockId) -> Result<StateUpdate, SequencerError> {
         let state_update: reply::StateUpdate = self
             .feeder_gateway_request()
             .get_state_update()
@@ -832,7 +841,7 @@ mod tests {
         let url = Url::parse(&url).unwrap();
         let client = Client::with_base_url(url).unwrap();
 
-        let _ = client.block(BlockId::Latest).await;
+        let _ = client.block_deprecated(BlockId::Latest).await;
         shutdown_tx.send(()).unwrap();
         server_handle.await.unwrap();
     }
@@ -853,11 +862,11 @@ mod tests {
                 ),
             ]);
             let by_hash = client
-                .block(BlockId::from(GENESIS_BLOCK_HASH))
+                .block_deprecated(BlockId::from(GENESIS_BLOCK_HASH))
                 .await
                 .unwrap();
             let by_number = client
-                .block(BlockId::from(GENESIS_BLOCK_NUMBER))
+                .block_deprecated(BlockId::from(GENESIS_BLOCK_NUMBER))
                 .await
                 .unwrap();
             assert_eq!(by_hash, by_number);
@@ -876,14 +885,14 @@ mod tests {
                 ),
             ]);
             let by_hash = client
-                .block(
+                .block_deprecated(
                     block_hash!("040ffdbd9abbc4fc64652c50db94a29bce65c183316f304a95df624de708e746")
                         .into(),
                 )
                 .await
                 .unwrap();
             let by_number = client
-                .block(BlockNumber::new_or_panic(231579).into())
+                .block_deprecated(BlockNumber::new_or_panic(231579).into())
                 .await
                 .unwrap();
             assert_eq!(by_hash, by_number);
@@ -901,7 +910,7 @@ mod tests {
                 "/feeder_gateway/get_block?blockNumber=latest",
                 (v0_9_0::block::NUMBER_231579, 200),
             )]);
-            client.block(BlockId::Latest).await.unwrap();
+            client.block_deprecated(BlockId::Latest).await.unwrap();
         }
 
         #[tokio::test]
@@ -910,7 +919,7 @@ mod tests {
                 "/feeder_gateway/get_block?blockNumber=pending",
                 (v0_9_0::block::PENDING, 200),
             )]);
-            client.block(BlockId::Pending).await.unwrap();
+            client.block_deprecated(BlockId::Pending).await.unwrap();
         }
 
         #[test_log::test(tokio::test)]
@@ -920,7 +929,7 @@ mod tests {
                 response_from(KnownStarknetErrorCode::BlockNotFound),
             )]);
             let error = client
-                .block(BlockId::from(INVALID_BLOCK_HASH))
+                .block_deprecated(BlockId::from(INVALID_BLOCK_HASH))
                 .await
                 .unwrap_err();
             assert_matches!(
@@ -936,7 +945,7 @@ mod tests {
                 response_from(KnownStarknetErrorCode::BlockNotFound),
             )]);
             let error = client
-                .block(BlockId::from(INVALID_BLOCK_NUMBER))
+                .block_deprecated(BlockId::from(INVALID_BLOCK_NUMBER))
                 .await
                 .unwrap_err();
             assert_matches!(
@@ -963,7 +972,7 @@ mod tests {
             let expected_version = StarknetVersion::new(0, 9, 1);
 
             let version = client
-                .block(BlockNumber::new_or_panic(300000).into())
+                .block_deprecated(BlockNumber::new_or_panic(300000).into())
                 .await
                 .unwrap()
                 .as_block()
@@ -971,7 +980,7 @@ mod tests {
                 .starknet_version;
             assert_eq!(version, expected_version);
 
-            let block = client.block(BlockId::Pending).await.unwrap();
+            let block = client.block_deprecated(BlockId::Pending).await.unwrap();
             assert_matches!(block, MaybePendingBlock::Pending(_));
         }
     }
@@ -1071,11 +1080,11 @@ mod tests {
                 ),
             ]);
             let by_number = client
-                .state_update(BlockId::from(GENESIS_BLOCK_NUMBER))
+                .state_update_deprecated(BlockId::from(GENESIS_BLOCK_NUMBER))
                 .await
                 .unwrap();
             let by_hash = client
-                .state_update(BlockId::from(GENESIS_BLOCK_HASH))
+                .state_update_deprecated(BlockId::from(GENESIS_BLOCK_HASH))
                 .await
                 .unwrap();
 
@@ -1095,11 +1104,11 @@ mod tests {
                 ),
             ]);
             let by_number = client
-                .state_update(BlockNumber::new_or_panic(315700).into())
+                .state_update_deprecated(BlockNumber::new_or_panic(315700).into())
                 .await
                 .unwrap();
             let by_hash = client
-                .state_update(
+                .state_update_deprecated(
                     block_hash!("017e4297ba605d22babb8c4e59a965b00e0487cd1e3ff63f99dbc7fe33e4fd03")
                         .into(),
                 )
@@ -1120,7 +1129,7 @@ mod tests {
                 response_from(KnownStarknetErrorCode::BlockNotFound),
             )]);
             let error = client
-                .state_update(BlockId::from(INVALID_BLOCK_NUMBER))
+                .state_update_deprecated(BlockId::from(INVALID_BLOCK_NUMBER))
                 .await
                 .unwrap_err();
             assert_matches!(
@@ -1136,7 +1145,7 @@ mod tests {
                 response_from(KnownStarknetErrorCode::BlockNotFound),
             )]);
             let error = client
-                .state_update(BlockId::from(INVALID_BLOCK_HASH))
+                .state_update_deprecated(BlockId::from(INVALID_BLOCK_HASH))
                 .await
                 .unwrap_err();
             assert_matches!(
@@ -1151,7 +1160,10 @@ mod tests {
                 "/feeder_gateway/get_state_update?blockNumber=latest",
                 (v0_11_0::state_update::NUMBER_315700, 200),
             )]);
-            client.state_update(BlockId::Latest).await.unwrap();
+            client
+                .state_update_deprecated(BlockId::Latest)
+                .await
+                .unwrap();
         }
 
         #[tokio::test]
@@ -1160,7 +1172,10 @@ mod tests {
                 "/feeder_gateway/get_state_update?blockNumber=pending",
                 (v0_11_0::state_update::PENDING, 200),
             )]);
-            client.state_update(BlockId::Pending).await.unwrap();
+            client
+                .state_update_deprecated(BlockId::Pending)
+                .await
+                .unwrap();
         }
     }
 

--- a/crates/gateway-client/tests/metrics.rs
+++ b/crates/gateway-client/tests/metrics.rs
@@ -17,7 +17,7 @@ async fn all_counter_types_including_tags() {
     with_method(
         "get_block",
         |client, x| async move {
-            let _ = client.block(x).await;
+            let _ = client.block_deprecated(x).await;
         },
         (v0_9_0::block::GENESIS.to_owned(), 200),
     )
@@ -25,7 +25,7 @@ async fn all_counter_types_including_tags() {
     with_method(
         "get_state_update",
         |client, x| async move {
-            let _ = client.state_update(x).await;
+            let _ = client.state_update_deprecated(x).await;
         },
         (v0_11_0::state_update::GENESIS.to_owned(), 200),
     )

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -660,18 +660,16 @@ async fn verify_database(
         match (network, db_network) {
             (Chain::Custom, _) => {
                 // Verify against gateway.
-                let gateway_block = gateway_client
-                    .block(BlockNumber::GENESIS.into())
+                let (_, gateway_hash) = gateway_client
+                    .block_header(BlockNumber::GENESIS.into())
                     .await
-                    .context("Downloading genesis block from gateway for database verification")?
-                    .as_block()
-                    .context("Genesis block should not be pending")?;
+                    .context("Downloading genesis block from gateway for database verification")?;
 
                 anyhow::ensure!(
-                    database_genesis == gateway_block.block_hash,
+                    database_genesis == gateway_hash,
                     "Database genesis block does not match gateway. {} != {}",
                     database_genesis,
-                    gateway_block.block_hash
+                    gateway_hash
                 );
             }
             (network, db_network) => anyhow::ensure!(

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -4,11 +4,9 @@ pub mod l2;
 mod pending;
 
 use anyhow::Context;
-use pathfinder_common::{
-    BlockCommitmentSignature, BlockHash, BlockHeader, BlockNumber, CasmHash, Chain, ChainId,
-    ClassCommitment, ClassHash, EventCommitment, GasPrice, SequencerAddress, SierraHash,
-    StateCommitment, StateUpdate, StorageCommitment, TransactionCommitment,
-};
+use pathfinder_common::prelude::*;
+use pathfinder_common::BlockCommitmentSignature;
+use pathfinder_common::Chain;
 use pathfinder_crypto::Felt;
 use pathfinder_ethereum::{EthereumApi, EthereumStateUpdate};
 use pathfinder_merkle_tree::contract_state::update_contract_state;
@@ -62,7 +60,7 @@ pub enum SyncEvent {
         casm_hash: CasmHash,
     },
     /// A new L2 pending update was polled.
-    Pending(Box<(PendingBlock, StateUpdate)>),
+    Pending((Arc<PendingBlock>, Arc<StateUpdate>)),
 }
 
 pub struct SyncContext<G, E> {
@@ -565,8 +563,8 @@ async fn consumer(mut events: Receiver<SyncEvent>, context: ConsumerContext) -> 
 
                 if pending.0.parent_hash == hash {
                     let data = PendingData {
-                        block: pending.0.into(),
-                        state_update: pending.1.into(),
+                        block: pending.0,
+                        state_update: pending.1,
                         number: number + 1,
                     };
                     pending_data.send_replace(data);

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -439,14 +439,12 @@ async fn download_block(
     sequencer: &impl GatewayApi,
     mode: BlockValidationMode,
 ) -> anyhow::Result<DownloadBlock> {
-    use starknet_gateway_types::{
-        error::KnownStarknetErrorCode::BlockNotFound, reply::MaybePendingBlock,
-    };
+    use starknet_gateway_types::error::KnownStarknetErrorCode::BlockNotFound;
 
-    let result = sequencer.state_update_with_block(block_number.into()).await;
+    let result = sequencer.state_update_with_block(block_number).await;
 
     let result = match result {
-        Ok((MaybePendingBlock::Block(block), state_update)) => {
+        Ok((block, state_update)) => {
             let block = Box::new(block);
             let state_update = Box::new(state_update);
 
@@ -494,9 +492,6 @@ async fn download_block(
                     block.status
                 )),
             }
-        }
-        Ok((MaybePendingBlock::Pending(_), _)) => {
-            anyhow::bail!("Sequencer returned `pending` block")
         }
         Err(SequencerError::StarknetError(err)) if err.code == BlockNotFound.into() => {
             // This would occur if we queried past the head of the chain. We now need to check that
@@ -936,8 +931,8 @@ mod tests {
         fn expect_state_update_with_block(
             mock: &mut MockGatewayApi,
             seq: &mut mockall::Sequence,
-            block: BlockId,
-            returned_result: Result<(reply::MaybePendingBlock, StateUpdate), SequencerError>,
+            block: BlockNumber,
+            returned_result: Result<(reply::Block, StateUpdate), SequencerError>,
         ) {
             use mockall::predicate::eq;
 
@@ -1017,8 +1012,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK0_NUMBER.into(),
-                    Ok((BLOCK0.clone().into(), STATE_UPDATE0.clone())),
+                    BLOCK0_NUMBER,
+                    Ok((BLOCK0.clone(), STATE_UPDATE0.clone())),
                 );
                 expect_class_by_hash(
                     &mut mock,
@@ -1036,8 +1031,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK1_NUMBER.into(),
-                    Ok((BLOCK1.clone().into(), STATE_UPDATE1.clone())),
+                    BLOCK1_NUMBER,
+                    Ok((BLOCK1.clone(), STATE_UPDATE1.clone())),
                 );
                 expect_class_by_hash(
                     &mut mock,
@@ -1055,7 +1050,7 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK2_NUMBER.into(),
+                    BLOCK2_NUMBER,
                     Err(block_not_found()),
                 );
                 expect_signature(
@@ -1105,8 +1100,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK1_NUMBER.into(),
-                    Ok((BLOCK1.clone().into(), STATE_UPDATE1.clone())),
+                    BLOCK1_NUMBER,
+                    Ok((BLOCK1.clone(), STATE_UPDATE1.clone())),
                 );
                 expect_class_by_hash(
                     &mut mock,
@@ -1125,7 +1120,7 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK2_NUMBER.into(),
+                    BLOCK2_NUMBER,
                     Err(block_not_found()),
                 );
                 expect_signature(
@@ -1189,8 +1184,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK0_NUMBER.into(),
-                    Ok((block.into(), STATE_UPDATE0.clone())),
+                    BLOCK0_NUMBER,
+                    Ok((block, STATE_UPDATE0.clone())),
                 );
                 expect_signature(
                     &mut mock,
@@ -1231,8 +1226,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK0_NUMBER.into(),
-                    Ok((BLOCK0.clone().into(), STATE_UPDATE0.clone())),
+                    BLOCK0_NUMBER,
+                    Ok((BLOCK0.clone(), STATE_UPDATE0.clone())),
                 );
                 expect_class_by_hash(
                     &mut mock,
@@ -1251,7 +1246,7 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK1_NUMBER.into(),
+                    BLOCK1_NUMBER,
                     Err(block_not_found()),
                 );
                 expect_signature(
@@ -1275,8 +1270,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK0_NUMBER.into(),
-                    Ok((BLOCK0_V2.clone().into(), STATE_UPDATE0_V2.clone())),
+                    BLOCK0_NUMBER,
+                    Ok((BLOCK0_V2.clone(), STATE_UPDATE0_V2.clone())),
                 );
                 expect_class_by_hash(
                     &mut mock,
@@ -1295,7 +1290,7 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK1_NUMBER.into(),
+                    BLOCK1_NUMBER,
                     Err(block_not_found()),
                 );
                 expect_signature(
@@ -1374,8 +1369,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK0_NUMBER.into(),
-                    Ok((BLOCK0.clone().into(), STATE_UPDATE0.clone())),
+                    BLOCK0_NUMBER,
+                    Ok((BLOCK0.clone(), STATE_UPDATE0.clone())),
                 );
                 expect_class_by_hash(
                     &mut mock,
@@ -1393,8 +1388,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK1_NUMBER.into(),
-                    Ok((BLOCK1.clone().into(), STATE_UPDATE1.clone())),
+                    BLOCK1_NUMBER,
+                    Ok((BLOCK1.clone(), STATE_UPDATE1.clone())),
                 );
                 expect_class_by_hash(
                     &mut mock,
@@ -1412,8 +1407,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK2_NUMBER.into(),
-                    Ok((BLOCK2.clone().into(), STATE_UPDATE2.clone())),
+                    BLOCK2_NUMBER,
+                    Ok((BLOCK2.clone(), STATE_UPDATE2.clone())),
                 );
                 expect_signature(
                     &mut mock,
@@ -1425,7 +1420,7 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK3_NUMBER.into(),
+                    BLOCK3_NUMBER,
                     Err(block_not_found()),
                 );
                 expect_signature(
@@ -1448,14 +1443,14 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK1_NUMBER.into(),
-                    Ok((block1_v2.clone().into(), STATE_UPDATE1_V2.clone())),
+                    BLOCK1_NUMBER,
+                    Ok((block1_v2.clone(), STATE_UPDATE1_V2.clone())),
                 );
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK0_NUMBER.into(),
-                    Ok((BLOCK0_V2.clone().into(), STATE_UPDATE0_V2.clone())),
+                    BLOCK0_NUMBER,
+                    Ok((BLOCK0_V2.clone(), STATE_UPDATE0_V2.clone())),
                 );
 
                 // Once the L2 sync task has found where reorg occurred,
@@ -1464,8 +1459,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK0_NUMBER.into(),
-                    Ok((BLOCK0_V2.clone().into(), STATE_UPDATE0_V2.clone())),
+                    BLOCK0_NUMBER,
+                    Ok((BLOCK0_V2.clone(), STATE_UPDATE0_V2.clone())),
                 );
                 expect_class_by_hash(
                     &mut mock,
@@ -1483,8 +1478,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK1_NUMBER.into(),
-                    Ok((block1_v2.clone().into(), STATE_UPDATE1_V2.clone())),
+                    BLOCK1_NUMBER,
+                    Ok((block1_v2.clone(), STATE_UPDATE1_V2.clone())),
                 );
                 expect_signature(
                     &mut mock,
@@ -1498,7 +1493,7 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK2_NUMBER.into(),
+                    BLOCK2_NUMBER,
                     Err(block_not_found()),
                 );
                 expect_signature(
@@ -1624,8 +1619,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK0_NUMBER.into(),
-                    Ok((BLOCK0.clone().into(), STATE_UPDATE0.clone())),
+                    BLOCK0_NUMBER,
+                    Ok((BLOCK0.clone(), STATE_UPDATE0.clone())),
                 );
                 expect_class_by_hash(
                     &mut mock,
@@ -1643,8 +1638,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK1_NUMBER.into(),
-                    Ok((BLOCK1.clone().into(), STATE_UPDATE1.clone())),
+                    BLOCK1_NUMBER,
+                    Ok((BLOCK1.clone(), STATE_UPDATE1.clone())),
                 );
                 expect_class_by_hash(
                     &mut mock,
@@ -1662,8 +1657,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK2_NUMBER.into(),
-                    Ok((BLOCK2.clone().into(), STATE_UPDATE2.clone())),
+                    BLOCK2_NUMBER,
+                    Ok((BLOCK2.clone(), STATE_UPDATE2.clone())),
                 );
                 expect_signature(
                     &mut mock,
@@ -1675,8 +1670,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK3_NUMBER.into(),
-                    Ok((block3.clone().into(), STATE_UPDATE3.clone())),
+                    BLOCK3_NUMBER,
+                    Ok((block3.clone(), STATE_UPDATE3.clone())),
                 );
                 expect_signature(
                     &mut mock,
@@ -1688,7 +1683,7 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK4_NUMBER.into(),
+                    BLOCK4_NUMBER,
                     Err(block_not_found()),
                 );
                 expect_signature(
@@ -1711,20 +1706,20 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK2_NUMBER.into(),
-                    Ok((block2_v2.clone().into(), STATE_UPDATE2_V2.clone())),
+                    BLOCK2_NUMBER,
+                    Ok((block2_v2.clone(), STATE_UPDATE2_V2.clone())),
                 );
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK1_NUMBER.into(),
-                    Ok((block1_v2.clone().into(), STATE_UPDATE1_V2.clone())),
+                    BLOCK1_NUMBER,
+                    Ok((block1_v2.clone(), STATE_UPDATE1_V2.clone())),
                 );
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK0_NUMBER.into(),
-                    Ok((BLOCK0.clone().into(), STATE_UPDATE0.clone())),
+                    BLOCK0_NUMBER,
+                    Ok((BLOCK0.clone(), STATE_UPDATE0.clone())),
                 );
 
                 // Finally the L2 sync task is downloading the new blocks once it knows where to start again
@@ -1732,8 +1727,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK1_NUMBER.into(),
-                    Ok((block1_v2.clone().into(), STATE_UPDATE1_V2.clone())),
+                    BLOCK1_NUMBER,
+                    Ok((block1_v2.clone(), STATE_UPDATE1_V2.clone())),
                 );
                 expect_signature(
                     &mut mock,
@@ -1745,8 +1740,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK2_NUMBER.into(),
-                    Ok((block2_v2.clone().into(), STATE_UPDATE2_V2.clone())),
+                    BLOCK2_NUMBER,
+                    Ok((block2_v2.clone(), STATE_UPDATE2_V2.clone())),
                 );
                 expect_signature(
                     &mut mock,
@@ -1758,7 +1753,7 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK3_NUMBER.into(),
+                    BLOCK3_NUMBER,
                     Err(block_not_found()),
                 );
                 expect_signature(
@@ -1852,8 +1847,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK0_NUMBER.into(),
-                    Ok((BLOCK0.clone().into(), STATE_UPDATE0.clone())),
+                    BLOCK0_NUMBER,
+                    Ok((BLOCK0.clone(), STATE_UPDATE0.clone())),
                 );
                 expect_class_by_hash(
                     &mut mock,
@@ -1871,8 +1866,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK1_NUMBER.into(),
-                    Ok((BLOCK1.clone().into(), STATE_UPDATE1.clone())),
+                    BLOCK1_NUMBER,
+                    Ok((BLOCK1.clone(), STATE_UPDATE1.clone())),
                 );
                 expect_class_by_hash(
                     &mut mock,
@@ -1890,8 +1885,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK2_NUMBER.into(),
-                    Ok((BLOCK2.clone().into(), STATE_UPDATE2.clone())),
+                    BLOCK2_NUMBER,
+                    Ok((BLOCK2.clone(), STATE_UPDATE2.clone())),
                 );
                 expect_signature(
                     &mut mock,
@@ -1903,7 +1898,7 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK3_NUMBER.into(),
+                    BLOCK3_NUMBER,
                     Err(block_not_found()),
                 );
                 expect_signature(
@@ -1926,8 +1921,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK1_NUMBER.into(),
-                    Ok((BLOCK1.clone().into(), STATE_UPDATE1.clone())),
+                    BLOCK1_NUMBER,
+                    Ok((BLOCK1.clone(), STATE_UPDATE1.clone())),
                 );
 
                 // Finally the L2 sync task is downloading the new blocks once it knows where to start again
@@ -1935,8 +1930,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK2_NUMBER.into(),
-                    Ok((block2_v2.clone().into(), STATE_UPDATE2_V2.clone())),
+                    BLOCK2_NUMBER,
+                    Ok((block2_v2.clone(), STATE_UPDATE2_V2.clone())),
                 );
                 expect_signature(
                     &mut mock,
@@ -1949,7 +1944,7 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK3_NUMBER.into(),
+                    BLOCK3_NUMBER,
                     Err(block_not_found()),
                 );
                 expect_signature(
@@ -2049,8 +2044,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK0_NUMBER.into(),
-                    Ok((BLOCK0.clone().into(), STATE_UPDATE0.clone())),
+                    BLOCK0_NUMBER,
+                    Ok((BLOCK0.clone(), STATE_UPDATE0.clone())),
                 );
                 expect_class_by_hash(
                     &mut mock,
@@ -2069,8 +2064,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK1_NUMBER.into(),
-                    Ok((BLOCK1.clone().into(), STATE_UPDATE1.clone())),
+                    BLOCK1_NUMBER,
+                    Ok((BLOCK1.clone(), STATE_UPDATE1.clone())),
                 );
                 expect_class_by_hash(
                     &mut mock,
@@ -2088,8 +2083,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK2_NUMBER.into(),
-                    Ok((block2.clone().into(), STATE_UPDATE2.clone())),
+                    BLOCK2_NUMBER,
+                    Ok((block2.clone(), STATE_UPDATE2.clone())),
                 );
                 expect_signature(
                     &mut mock,
@@ -2103,8 +2098,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK0_NUMBER.into(),
-                    Ok((BLOCK0.clone().into(), STATE_UPDATE0.clone())),
+                    BLOCK0_NUMBER,
+                    Ok((BLOCK0.clone(), STATE_UPDATE0.clone())),
                 );
 
                 // Finally the L2 sync task is downloading the new blocks once it knows where to start again
@@ -2112,8 +2107,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK1_NUMBER.into(),
-                    Ok((block1_v2.clone().into(), STATE_UPDATE1_V2.clone())),
+                    BLOCK1_NUMBER,
+                    Ok((block1_v2.clone(), STATE_UPDATE1_V2.clone())),
                 );
                 expect_signature(
                     &mut mock,
@@ -2125,8 +2120,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK2_NUMBER.into(),
-                    Ok((block2.clone().into(), STATE_UPDATE2.clone())),
+                    BLOCK2_NUMBER,
+                    Ok((block2.clone(), STATE_UPDATE2.clone())),
                 );
                 expect_signature(
                     &mut mock,
@@ -2139,7 +2134,7 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK3_NUMBER.into(),
+                    BLOCK3_NUMBER,
                     Err(block_not_found()),
                 );
                 expect_signature(
@@ -2201,8 +2196,8 @@ mod tests {
                 expect_state_update_with_block(
                     &mut mock,
                     &mut seq,
-                    BLOCK0_NUMBER.into(),
-                    Ok((BLOCK0.clone().into(), STATE_UPDATE0.clone())),
+                    BLOCK0_NUMBER,
+                    Ok((BLOCK0.clone(), STATE_UPDATE0.clone())),
                 );
                 expect_signature(
                     &mut mock,

--- a/crates/rpc/src/gas_price.rs
+++ b/crates/rpc/src/gas_price.rs
@@ -69,7 +69,7 @@ impl Cached {
         match self
             .gateway
             // Don't indefinitely retry as this could block the RPC request.
-            .block_without_retry(pathfinder_common::BlockId::Pending)
+            .block_without_retry_deprecated(pathfinder_common::BlockId::Pending)
             .await
         {
             Ok(block) => match block {


### PR DESCRIPTION
Separates gateway queries for pending and full block data.

This simplifies the `MaybePendingBlock` deserialization by side-stepping the issue entirely.

Note that this PR does not actually remove the type - and indeed it is still actively relied on by some of the gateway methods. However these methods are only used in tests which should be replaced by tests for the actually-in-use methods.

I decided to not actually do this work in order to reduce the rebase breakage.

There is one exception to this - the gas price still uses the deprecated method, however I believe this file/function is no longer used? If it is, then this PR requires a bit more work to add a non-retry method alternative.