### PR TITLE
fix(rpc): handle WebSocket control frames

### DIFF
--- a/crates/rpc/src/jsonrpc/websocket/logic.rs
+++ b/crates/rpc/src/jsonrpc/websocket/logic.rs
@@ -127,7 +127,11 @@ async fn read(
 
     loop {
         let request = match receiver.next().await {
-            Some(Ok(x)) => x.into_data(),
+            Some(Ok(Message::Text(x))) => x.into_bytes(),
+            Some(Ok(Message::Binary(x))) => x,
+            Some(Ok(Message::Ping(_)))
+            | Some(Ok(Message::Pong(_)))
+            | Some(Ok(Message::Close(_))) => continue,
             // Both of these are client disconnects according to the axum example
             // https://docs.rs/axum/0.6.20/axum/extract/ws/index.html#example
             Some(Err(e)) => {


### PR DESCRIPTION
Pathfinder treats WebSocket control frames (ping/pong/close) as data frames (text/binary). When it receives ping frames, it tries to parse non-data empty messages and outputs errors like these:
```
$ wscat -c ...
Connected (press CTRL+C to quit)
< {"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request","data":{"reason":"EOF while parsing a value at line 1 column 0"}},"id":null}
< {"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request","data":{"reason":"EOF while parsing a value at line 1 column 0"}},"id":null}
< {"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request","data":{"reason":"EOF while parsing a value at line 1 column 0"}},"id":null}
>
```