### PR TITLE
fix(sync): don't error out of `poll_pending` task

### DIFF
--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -71,7 +71,7 @@ pub async fn poll_pending<S: GatewayApi + Clone + Send + 'static>(
                 .send(SyncEvent::Pending((block, state_update)))
                 .await
             {
-                tracing::error!("Event channel closed, this shouldn't happen: {}", e);
+                tracing::error!(error=%e, "Event channel closed unexpectedly. Ending pending stream.");
                 break;
             }
         }


### PR DESCRIPTION
Make sure `poll_pending` doesn't error when `pending_block` returns an error.

Fixes https://github.com/eqlabs/pathfinder/issues/1789.
