### PR TITLE
feat(rpc/v0.7): `starknet_getBlockWithReceipts`

### DIFF
--- a/crates/common/src/receipt.rs
+++ b/crates/common/src/receipt.rs
@@ -16,10 +16,10 @@ impl Receipt {
         matches!(self.execution_status, ExecutionStatus::Reverted { .. })
     }
 
-    pub fn revert_reason(&self) -> Option<String> {
+    pub fn revert_reason(&self) -> Option<&str> {
         match &self.execution_status {
             ExecutionStatus::Succeeded => None,
-            ExecutionStatus::Reverted { reason } => Some(reason.clone()),
+            ExecutionStatus::Reverted { reason } => Some(reason.as_str()),
         }
     }
 }

--- a/crates/pathfinder/src/p2p_network/sync_handlers/conv.rs
+++ b/crates/pathfinder/src/p2p_network/sync_handlers/conv.rs
@@ -191,7 +191,11 @@ impl ToDto<p2p_proto::transaction::Transaction> for Transaction {
 impl ToDto<p2p_proto::receipt::Receipt> for (Transaction, Receipt) {
     fn to_dto(self) -> p2p_proto::receipt::Receipt {
         use p2p_proto::receipt::Receipt::{Declare, Deploy, DeployAccount, Invoke, L1Handler};
-        let revert_reason = self.1.revert_reason().unwrap_or_default();
+        let revert_reason = self
+            .1
+            .revert_reason()
+            .map(|x| x.to_owned())
+            .unwrap_or_default();
         let common = ReceiptCommon {
             transaction_hash: Hash(self.1.transaction_hash.0),
             actual_fee: self.1.actual_fee.unwrap_or_default().0,

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -833,7 +833,6 @@ mod tests {
         "starknet_getTransactionByBlockIdAndIndex",
         "starknet_getTransactionByHash",
         "starknet_getTransactionReceipt",
-        "starknet_getBlockWithReceipts",
     ])]
     #[case::v0_7_trace("/rpc/v0_7", "v07/starknet_trace_api_openrpc.json", &[
         "starknet_simulateTransactions",

--- a/crates/rpc/src/v06/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v06/method/get_transaction_receipt.rs
@@ -470,7 +470,7 @@ pub mod types {
                 unit: fee_unit,
             };
 
-            let revert_reason = receipt.revert_reason();
+            let revert_reason = receipt.revert_reason().map(|x| x.to_owned());
 
             let common = CommonTransactionReceiptProperties {
                 transaction_hash: receipt.transaction_hash,
@@ -611,7 +611,7 @@ pub mod types {
                 unit: fee_unit,
             };
 
-            let revert_reason = receipt.revert_reason();
+            let revert_reason = receipt.revert_reason().map(|x| x.to_owned());
 
             let common = CommonPendingTransactionReceiptProperties {
                 transaction_hash: receipt.transaction_hash,

--- a/crates/rpc/src/v06/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v06/method/get_transaction_receipt.rs
@@ -404,7 +404,7 @@ pub mod types {
         }
     }
 
-    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+    #[derive(Copy, Clone, Debug, Serialize, PartialEq, Eq)]
     #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
     #[cfg_attr(any(test, feature = "rpc-full-serde"), derive(serde::Deserialize))]
     pub enum FinalityStatus {

--- a/crates/rpc/src/v07.rs
+++ b/crates/rpc/src/v07.rs
@@ -1,3 +1,4 @@
+pub mod dto;
 use crate::jsonrpc::{RpcRouter, RpcRouterBuilder};
 
 #[rustfmt::skip]

--- a/crates/rpc/src/v07.rs
+++ b/crates/rpc/src/v07.rs
@@ -1,4 +1,6 @@
 pub mod dto;
+pub mod method;
+
 use crate::jsonrpc::{RpcRouter, RpcRouterBuilder};
 
 #[rustfmt::skip]
@@ -33,9 +35,10 @@ pub fn register_routes() -> RpcRouterBuilder {
         // .register("starknet_getTransactionByHash"            , method::get_transaction_by_hash)
         // .register("starknet_getTransactionReceipt"           , method::get_transaction_receipt)
         // .register("starknet_simulateTransactions"            , method::simulate_transactions)
-        .register("starknet_specVersion"                     , || "0.7.0-rc0")
+        .register("starknet_specVersion",                         || "0.7.0-rc0")
         // .register("starknet_traceBlockTransactions"          , method::trace_block_transactions)
         // .register("starknet_traceTransaction"                , method::trace_transaction)
+        .register("starknet_getBlockWithReceipts",                method::get_block_with_receipts)
 
-        .register("pathfinder_getProof"                      , crate::pathfinder::methods::get_proof)
+        .register("pathfinder_getProof",                          crate::pathfinder::methods::get_proof)
 }

--- a/crates/rpc/src/v07/dto.rs
+++ b/crates/rpc/src/v07/dto.rs
@@ -1,0 +1,1 @@
+pub(crate) mod header;

--- a/crates/rpc/src/v07/dto.rs
+++ b/crates/rpc/src/v07/dto.rs
@@ -1,1 +1,2 @@
 pub(crate) mod header;
+pub(crate) mod receipt;

--- a/crates/rpc/src/v07/dto/header.rs
+++ b/crates/rpc/src/v07/dto/header.rs
@@ -1,0 +1,223 @@
+use pathfinder_common::prelude::*;
+use serde::Serialize;
+use serde_with::serde_as;
+
+#[serde_as]
+#[derive(Serialize)]
+pub struct Header {
+    block_hash: BlockHash,
+    parent_hash: BlockHash,
+    block_number: BlockNumber,
+    new_root: StateCommitment,
+    timestamp: BlockTimestamp,
+    sequencer_address: SequencerAddress,
+    l1_gas_price: ResourcePrice,
+    starknet_version: StarknetVersion,
+    l1_data_gas_price: ResourcePrice,
+    l1_da_mode: L1DaMode,
+}
+
+impl From<pathfinder_common::BlockHeader> for Header {
+    fn from(value: pathfinder_common::BlockHeader) -> Self {
+        let l1_gas_price = ResourcePrice {
+            price_in_wei: value.eth_l1_gas_price,
+            price_in_fri: value.strk_l1_gas_price,
+        };
+        let l1_data_gas_price = ResourcePrice {
+            price_in_wei: value.eth_l1_data_gas_price,
+            price_in_fri: value.strk_l1_data_gas_price,
+        };
+
+        Self {
+            block_hash: value.hash,
+            parent_hash: value.parent_hash,
+            block_number: value.number,
+            new_root: value.state_commitment,
+            timestamp: value.timestamp,
+            sequencer_address: value.sequencer_address,
+            l1_gas_price,
+            starknet_version: value.starknet_version,
+            l1_data_gas_price,
+            l1_da_mode: value.l1_da_mode.into(),
+        }
+    }
+}
+
+#[serde_as]
+#[derive(Serialize)]
+pub struct PendingHeader {
+    parent_hash: BlockHash,
+    timestamp: BlockTimestamp,
+    sequencer_address: SequencerAddress,
+    l1_gas_price: ResourcePrice,
+    starknet_version: StarknetVersion,
+    l1_data_gas_price: ResourcePrice,
+    l1_da_mode: L1DaMode,
+}
+
+impl From<pathfinder_common::BlockHeader> for PendingHeader {
+    fn from(value: pathfinder_common::BlockHeader) -> Self {
+        let l1_gas_price = ResourcePrice {
+            price_in_wei: value.eth_l1_gas_price,
+            price_in_fri: value.strk_l1_gas_price,
+        };
+        let l1_data_gas_price = ResourcePrice {
+            price_in_wei: value.eth_l1_data_gas_price,
+            price_in_fri: value.strk_l1_data_gas_price,
+        };
+
+        Self {
+            parent_hash: value.parent_hash,
+            timestamp: value.timestamp,
+            sequencer_address: value.sequencer_address,
+            l1_gas_price,
+            starknet_version: value.starknet_version,
+            l1_data_gas_price,
+            l1_da_mode: value.l1_da_mode.into(),
+        }
+    }
+}
+
+#[serde_as]
+#[derive(Serialize)]
+struct ResourcePrice {
+    #[serde_as(as = "pathfinder_serde::GasPriceAsHexStr")]
+    pub price_in_wei: GasPrice,
+    #[serde_as(as = "pathfinder_serde::GasPriceAsHexStr")]
+    pub price_in_fri: GasPrice,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum L1DaMode {
+    Blob,
+    Calldata,
+}
+
+impl From<pathfinder_common::L1DataAvailabilityMode> for L1DaMode {
+    fn from(value: pathfinder_common::L1DataAvailabilityMode) -> Self {
+        match value {
+            pathfinder_common::L1DataAvailabilityMode::Calldata => Self::Calldata,
+            pathfinder_common::L1DataAvailabilityMode::Blob => Self::Blob,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pathfinder_common::{
+        macro_prelude::*, BlockNumber, BlockTimestamp, GasPrice, StarknetVersion,
+    };
+    use pretty_assertions_sorted::assert_eq;
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn pending_header() {
+        let expected = json!({
+            "parent_hash": "0x2",
+            "timestamp": 4,
+            "sequencer_address": "0x9",
+            "l1_gas_price": {
+                "price_in_wei": "0x5",
+                "price_in_fri": "0x6",
+            },
+            "l1_data_gas_price": {
+                "price_in_wei": "0x7",
+                "price_in_fri": "0x8",
+            },
+            "l1_da_mode": "CALLDATA",
+            "starknet_version": "0.11.1"
+        });
+
+        let uut = pathfinder_common::BlockHeader {
+            parent_hash: block_hash!("0x2"),
+            timestamp: BlockTimestamp::new_or_panic(4),
+            eth_l1_gas_price: GasPrice(0x5),
+            strk_l1_gas_price: GasPrice(0x6),
+            eth_l1_data_gas_price: GasPrice(0x7),
+            strk_l1_data_gas_price: GasPrice(0x8),
+            sequencer_address: sequencer_address!("0x9"),
+            starknet_version: StarknetVersion::new(0, 11, 1),
+            l1_da_mode: pathfinder_common::L1DataAvailabilityMode::Calldata,
+            ..Default::default()
+        };
+        let uut = PendingHeader::from(uut);
+
+        let encoded = serde_json::to_value(uut).unwrap();
+
+        assert_eq!(encoded, expected);
+    }
+
+    #[test]
+    fn header() {
+        let expected = json!({
+            "block_hash": "0x1",
+            "parent_hash": "0x2",
+            "block_number": 3,
+            "new_root": "0x10",
+            "timestamp": 4,
+            "sequencer_address": "0x9",
+            "l1_gas_price": {
+                "price_in_wei": "0x5",
+                "price_in_fri": "0x6",
+            },
+            "l1_data_gas_price": {
+                "price_in_wei": "0x7",
+                "price_in_fri": "0x8",
+            },
+            "l1_da_mode": "CALLDATA",
+            "starknet_version": "0.11.1"
+        });
+
+        let uut = pathfinder_common::BlockHeader {
+            hash: block_hash!("0x1"),
+            parent_hash: block_hash!("0x2"),
+            number: BlockNumber::new_or_panic(3),
+            timestamp: BlockTimestamp::new_or_panic(4),
+            eth_l1_gas_price: GasPrice(0x5),
+            strk_l1_gas_price: GasPrice(0x6),
+            eth_l1_data_gas_price: GasPrice(0x7),
+            strk_l1_data_gas_price: GasPrice(0x8),
+            sequencer_address: sequencer_address!("0x9"),
+            state_commitment: state_commitment!("0x10"),
+            starknet_version: StarknetVersion::new(0, 11, 1),
+            l1_da_mode: pathfinder_common::L1DataAvailabilityMode::Calldata,
+            ..Default::default()
+        };
+        let uut = Header::from(uut);
+
+        let encoded = serde_json::to_value(uut).unwrap();
+
+        assert_eq!(encoded, expected);
+    }
+
+    #[test]
+    fn l1_data_availability_mode() {
+        let calldata = L1DaMode::from(pathfinder_common::L1DataAvailabilityMode::Calldata);
+        let encoded = serde_json::to_value(calldata).unwrap();
+        assert_eq!(encoded, json!("CALLDATA"));
+
+        let blob = L1DaMode::from(pathfinder_common::L1DataAvailabilityMode::Blob);
+        let encoded = serde_json::to_value(blob).unwrap();
+        assert_eq!(encoded, json!("BLOB"));
+    }
+
+    #[test]
+    fn resource_price() {
+        let expected = json!({
+            "price_in_fri": "0x123",
+            "price_in_wei": "0x456",
+        });
+
+        let uut = ResourcePrice {
+            price_in_wei: GasPrice(0x456),
+            price_in_fri: GasPrice(0x123),
+        };
+
+        let encoded = serde_json::to_value(uut).unwrap();
+
+        assert_eq!(encoded, expected);
+    }
+}

--- a/crates/rpc/src/v07/dto/receipt.rs
+++ b/crates/rpc/src/v07/dto/receipt.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+use crate::v06::method::get_transaction_receipt::types::ExecutionResourcesPropertiesV06;
+
+#[derive(Serialize)]
+pub struct ComputationResources(ExecutionResourcesPropertiesV06);
+
+impl From<pathfinder_common::receipt::ExecutionResources> for ComputationResources {
+    fn from(value: pathfinder_common::receipt::ExecutionResources) -> Self {
+        Self(ExecutionResourcesPropertiesV06 {
+            steps: value.n_steps,
+            memory_holes: value.n_memory_holes,
+            range_check_builtin_applications: value.builtin_instance_counter.range_check_builtin,
+            pedersen_builtin_applications: value.builtin_instance_counter.pedersen_builtin,
+            poseidon_builtin_applications: value.builtin_instance_counter.poseidon_builtin,
+            ec_op_builtin_applications: value.builtin_instance_counter.ec_op_builtin,
+            ecdsa_builtin_applications: value.builtin_instance_counter.ecdsa_builtin,
+            bitwise_builtin_applications: value.builtin_instance_counter.bitwise_builtin,
+            keccak_builtin_applications: value.builtin_instance_counter.keccak_builtin,
+            segment_arena_builtin: value.builtin_instance_counter.segment_arena_builtin,
+        })
+    }
+}

--- a/crates/rpc/src/v07/dto/receipt.rs
+++ b/crates/rpc/src/v07/dto/receipt.rs
@@ -21,3 +21,17 @@ impl From<pathfinder_common::receipt::ExecutionResources> for ComputationResourc
         })
     }
 }
+
+#[derive(Serialize)]
+pub struct ExecutionResources {
+    #[serde(flatten)]
+    computation_resources: ComputationResources,
+    data_availability: DataResources,
+}
+
+#[derive(Serialize)]
+/// An object embedded within EXECUTION_RESOURCES.
+struct DataResources {
+    l1_gas: u64,
+    l1_data_gas: u64,
+}

--- a/crates/rpc/src/v07/dto/receipt.rs
+++ b/crates/rpc/src/v07/dto/receipt.rs
@@ -1,13 +1,77 @@
+use pathfinder_serde::H256AsNoLeadingZerosHexStr;
 use serde::Serialize;
 
-use crate::v06::method::get_transaction_receipt::types::ExecutionResourcesPropertiesV06;
+use pathfinder_common::prelude::*;
+
+use crate::v06::method::get_transaction_receipt::types as v06;
+
+#[serde_with::serde_as]
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
+#[allow(unused)]
+pub enum TxnReceipt {
+    Invoke {
+        #[serde(flatten)]
+        common: CommonReceiptProperties,
+    },
+    L1Handler {
+        #[serde_as(as = "H256AsNoLeadingZerosHexStr")]
+        message_hash: primitive_types::H256,
+        #[serde(flatten)]
+        common: CommonReceiptProperties,
+    },
+    Declare {
+        #[serde(flatten)]
+        common: CommonReceiptProperties,
+    },
+    Deploy {
+        contract_address: ContractAddress,
+        #[serde(flatten)]
+        common: CommonReceiptProperties,
+    },
+    DeployAccount {
+        contract_address: ContractAddress,
+        #[serde(flatten)]
+        common: CommonReceiptProperties,
+    },
+}
+
+#[serde_with::serde_as]
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum PendingTxnReceipt {
+    Invoke {
+        #[serde(flatten)]
+        common: CommonPendingReceiptProperties,
+    },
+    L1Handler {
+        #[serde_as(as = "H256AsNoLeadingZerosHexStr")]
+        message_hash: primitive_types::H256,
+        #[serde(flatten)]
+        common: CommonPendingReceiptProperties,
+    },
+    Declare {
+        #[serde(flatten)]
+        common: CommonPendingReceiptProperties,
+    },
+    Deploy {
+        contract_address: ContractAddress,
+        #[serde(flatten)]
+        common: CommonPendingReceiptProperties,
+    },
+    DeployAccount {
+        contract_address: ContractAddress,
+        #[serde(flatten)]
+        common: CommonPendingReceiptProperties,
+    },
+}
 
 #[derive(Serialize)]
-pub struct ComputationResources(ExecutionResourcesPropertiesV06);
+pub struct ComputationResources(v06::ExecutionResourcesPropertiesV06);
 
 impl From<pathfinder_common::receipt::ExecutionResources> for ComputationResources {
     fn from(value: pathfinder_common::receipt::ExecutionResources) -> Self {
-        Self(ExecutionResourcesPropertiesV06 {
+        Self(v06::ExecutionResourcesPropertiesV06 {
             steps: value.n_steps,
             memory_holes: value.n_memory_holes,
             range_check_builtin_applications: value.builtin_instance_counter.range_check_builtin,
@@ -29,9 +93,202 @@ pub struct ExecutionResources {
     data_availability: DataResources,
 }
 
+impl From<pathfinder_common::receipt::ExecutionResources> for ExecutionResources {
+    fn from(value: pathfinder_common::receipt::ExecutionResources) -> Self {
+        Self {
+            data_availability: value.data_availability.clone().into(),
+            computation_resources: value.into(),
+        }
+    }
+}
+
 #[derive(Serialize)]
 /// An object embedded within EXECUTION_RESOURCES.
 struct DataResources {
-    l1_gas: u64,
-    l1_data_gas: u64,
+    l1_gas: u128,
+    l1_data_gas: u128,
+}
+
+impl From<pathfinder_common::receipt::ExecutionDataAvailability> for DataResources {
+    fn from(value: pathfinder_common::receipt::ExecutionDataAvailability) -> Self {
+        Self {
+            l1_gas: value.l1_gas,
+            l1_data_gas: value.l1_data_gas,
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct CommonReceiptProperties {
+    pub transaction_hash: TransactionHash,
+    pub actual_fee: FeePayment,
+    pub block_hash: BlockHash,
+    pub block_number: BlockNumber,
+    pub messages_sent: Vec<v06::MessageToL1>,
+    pub events: Vec<v06::Event>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revert_reason: Option<String>,
+    pub execution_resources: ExecutionResources,
+    pub execution_status: v06::ExecutionStatus,
+    pub finality_status: v06::FinalityStatus,
+}
+
+#[derive(Serialize)]
+pub struct CommonPendingReceiptProperties {
+    pub transaction_hash: TransactionHash,
+    pub actual_fee: FeePayment,
+    pub messages_sent: Vec<v06::MessageToL1>,
+    pub events: Vec<v06::Event>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revert_reason: Option<String>,
+    pub execution_status: v06::ExecutionStatus,
+    pub execution_resources: ExecutionResources,
+    pub finality_status: v06::FinalityStatus,
+}
+
+#[derive(Serialize)]
+struct FeePayment {
+    amount: Fee,
+    unit: PriceUnit,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum PriceUnit {
+    Wei,
+    Fri,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pathfinder_common::macro_prelude::*;
+
+    use pretty_assertions_sorted::assert_eq;
+
+    #[test]
+    fn txn_receipt() {
+        let expected = serde_json::json!({
+            "transaction_hash": "0x1",
+            "block_hash": "0x3",
+            "actual_fee": {
+                "amount": "0x123",
+                "unit": "WEI",
+            },
+            "block_number": 4,
+            "messages_sent": [],
+            "events": [],
+            "execution_resources": {
+                "steps": 10,
+                "data_availability": {
+                    "l1_gas": 0,
+                    "l1_data_gas": 0,
+                }
+            },
+            "execution_status": "SUCCEEDED",
+            "finality_status": "ACCEPTED_ON_L2",
+            "type": "INVOKE",
+        });
+
+        let uut = TxnReceipt::Invoke {
+            common: CommonReceiptProperties {
+                transaction_hash: transaction_hash!("0x1"),
+                actual_fee: FeePayment {
+                    amount: fee!("0x123"),
+                    unit: PriceUnit::Wei,
+                },
+                block_hash: block_hash!("0x3"),
+                block_number: BlockNumber::new_or_panic(4),
+                messages_sent: vec![],
+                events: vec![],
+                revert_reason: None,
+                execution_resources: ExecutionResources {
+                    computation_resources: ComputationResources(
+                        v06::ExecutionResourcesPropertiesV06 {
+                            steps: 10,
+                            memory_holes: 0,
+                            range_check_builtin_applications: 0,
+                            pedersen_builtin_applications: 0,
+                            poseidon_builtin_applications: 0,
+                            ec_op_builtin_applications: 0,
+                            ecdsa_builtin_applications: 0,
+                            bitwise_builtin_applications: 0,
+                            keccak_builtin_applications: 0,
+                            segment_arena_builtin: 0,
+                        },
+                    ),
+                    data_availability: DataResources {
+                        l1_gas: 0,
+                        l1_data_gas: 0,
+                    },
+                },
+                execution_status: v06::ExecutionStatus::Succeeded,
+                finality_status: v06::FinalityStatus::AcceptedOnL2,
+            },
+        };
+
+        let encoded = serde_json::to_value(uut).unwrap();
+
+        assert_eq!(encoded, expected);
+    }
+    #[test]
+    fn pending_txn_receipt() {
+        let expected = serde_json::json!({
+            "transaction_hash": "0x1",
+            "actual_fee": {
+                "amount": "0x123",
+                "unit": "WEI",
+            },
+            "messages_sent": [],
+            "events": [],
+            "execution_resources": {
+                "steps": 10,
+                "data_availability": {
+                    "l1_gas": 0,
+                    "l1_data_gas": 0,
+                }
+            },
+            "execution_status": "SUCCEEDED",
+            "finality_status": "ACCEPTED_ON_L2",
+            "type": "INVOKE",
+        });
+
+        let uut = PendingTxnReceipt::Invoke {
+            common: CommonPendingReceiptProperties {
+                transaction_hash: transaction_hash!("0x1"),
+                actual_fee: FeePayment {
+                    amount: fee!("0x123"),
+                    unit: PriceUnit::Wei,
+                },
+                messages_sent: vec![],
+                events: vec![],
+                revert_reason: None,
+                execution_resources: ExecutionResources {
+                    computation_resources: ComputationResources(
+                        v06::ExecutionResourcesPropertiesV06 {
+                            steps: 10,
+                            memory_holes: 0,
+                            range_check_builtin_applications: 0,
+                            pedersen_builtin_applications: 0,
+                            poseidon_builtin_applications: 0,
+                            ec_op_builtin_applications: 0,
+                            ecdsa_builtin_applications: 0,
+                            bitwise_builtin_applications: 0,
+                            keccak_builtin_applications: 0,
+                            segment_arena_builtin: 0,
+                        },
+                    ),
+                    data_availability: DataResources {
+                        l1_gas: 0,
+                        l1_data_gas: 0,
+                    },
+                },
+                execution_status: v06::ExecutionStatus::Succeeded,
+                finality_status: v06::FinalityStatus::AcceptedOnL2,
+            },
+        };
+
+        let encoded = serde_json::to_value(uut).unwrap();
+        assert_eq!(encoded, expected);
+    }
 }

--- a/crates/rpc/src/v07/method.rs
+++ b/crates/rpc/src/v07/method.rs
@@ -1,0 +1,3 @@
+mod get_block_with_receipts;
+
+pub(crate) use get_block_with_receipts::get_block_with_receipts;

--- a/crates/rpc/src/v07/method/get_block_with_receipts.rs
+++ b/crates/rpc/src/v07/method/get_block_with_receipts.rs
@@ -1,0 +1,436 @@
+use anyhow::Context;
+use pathfinder_common::BlockId;
+
+use crate::{context::RpcContext, v07::dto};
+
+#[derive(serde::Serialize)]
+#[serde(untagged)]
+pub(crate) enum Output {
+    Full(dto::receipt::BlockWithReceipts),
+    Pending(dto::receipt::PendingBlockWithReceipts),
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Input {
+    pub block_id: BlockId,
+}
+
+crate::error::generate_rpc_error_subset!(Error: BlockNotFound);
+
+pub async fn get_block_with_receipts(context: RpcContext, input: Input) -> Result<Output, Error> {
+    let span = tracing::Span::current();
+    tokio::task::spawn_blocking(move || {
+        let _g = span.enter();
+        let mut db = context
+            .storage
+            .connection()
+            .context("Creating database connection")?;
+
+        let db = db.transaction().context("Creating database transaction")?;
+
+        let block_id = match input.block_id {
+            BlockId::Pending => {
+                let pending = context
+                    .pending_data
+                    .get(&db)
+                    .context("Querying pending data")?;
+
+                return Ok(Output::Pending(pending.into()));
+            }
+            other => other.try_into().expect("Only pending cast should fail"),
+        };
+
+        let header = db
+            .block_header(block_id)
+            .context("Fetching block header")?
+            .ok_or(Error::BlockNotFound)?;
+
+        let body = db
+            .transaction_data_for_block(block_id)
+            .context("Fetching transaction data")?
+            .context("Transaction data missing")?;
+
+        let is_l1_accepted = db
+            .block_is_l1_accepted(block_id)
+            .context("Fetching block finality")?;
+
+        Ok(Output::Full(dto::receipt::BlockWithReceipts::from_common(
+            header,
+            body,
+            is_l1_accepted,
+        )))
+    })
+    .await
+    .context("Joining blocking task")?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions_sorted::assert_eq;
+    use serde::Serialize;
+
+    #[tokio::test]
+    async fn pending() {
+        let context = RpcContext::for_tests_with_pending().await;
+        let input = Input {
+            block_id: BlockId::Pending,
+        };
+
+        let output = get_block_with_receipts(context.clone(), input)
+            .await
+            .unwrap()
+            .serialize(serde_json::value::Serializer)
+            .unwrap();
+
+        let expected = serde_json::json!({
+            "l1_da_mode": "CALLDATA",
+            "l1_data_gas_price": {
+                "price_in_fri": "0x7374726b206461746761737072696365",
+                "price_in_wei": "0x6461746761737072696365",
+            },
+            "l1_gas_price": {
+                "price_in_fri": "0x7374726b20676173207072696365",
+                "price_in_wei": "0x676173207072696365",
+            },
+            "parent_hash": "0x6c6174657374",
+            "sequencer_address": "0x70656e64696e672073657175656e6365722061646472657373",
+            "starknet_version": "0.11.0",
+            "timestamp": 1234567,
+            "transactions": [
+                {
+                    "receipt": {
+                        "actual_fee": {
+                            "amount": "0x0",
+                            "unit": "WEI",
+                        },
+                        "events": [
+                            {
+                                "data": [],
+                                "from_address": "0xabcddddddd",
+                                "keys": [
+                                    "0x70656e64696e67206b6579",
+                                ],
+                            },
+                            {
+                                "data": [],
+                                "from_address": "0xabcddddddd",
+                                "keys": [
+                                    "0x70656e64696e67206b6579",
+                                    "0x7365636f6e642070656e64696e67206b6579",
+                                ],
+                            },
+                            {
+                                "data": [],
+                                "from_address": "0xabcaaaaaaa",
+                                "keys": [
+                                    "0x70656e64696e67206b65792032",
+                                ],
+                            },
+                        ],
+                        "execution_resources": {
+                            "data_availability": {
+                                "l1_data_gas": 0,
+                                "l1_gas": 0
+                            },
+                            "steps": 0
+                        },
+                        "execution_status": "SUCCEEDED",
+                        "finality_status": "ACCEPTED_ON_L2",
+                        "messages_sent": [],
+                        "transaction_hash": "0x70656e64696e6720747820686173682030",
+                        "type": "INVOKE",
+                    },
+                    "transaction": {
+                        "calldata": [],
+                        "contract_address": "0x70656e64696e6720636f6e747261637420616464722030",
+                        "entry_point_selector": "0x656e74727920706f696e742030",
+                        "max_fee": "0x0",
+                        "signature": [],
+                        "transaction_hash": "0x70656e64696e6720747820686173682030",
+                        "type": "INVOKE",
+                        "version": "0x0",
+                    },
+                },
+                {
+                    "receipt": {
+                        "actual_fee": {
+                            "amount": "0x0",
+                            "unit": "WEI",
+                        },
+                        "contract_address": "0x1122355",
+                        "events": [],
+                        "execution_resources": {
+                            "data_availability": {
+                                "l1_data_gas": 0,
+                                "l1_gas": 0
+                            },
+                            "steps": 0
+                        },
+                        "execution_status": "SUCCEEDED",
+                        "finality_status": "ACCEPTED_ON_L2",
+                        "messages_sent": [],
+                        "transaction_hash": "0x70656e64696e6720747820686173682031",
+                        "type": "DEPLOY",
+                    },
+                    "transaction": {
+                        "class_hash": "0x70656e64696e6720636c61737320686173682031",
+                        "constructor_calldata": [],
+                        "contract_address_salt": "0x73616c7479",
+                        "transaction_hash": "0x70656e64696e6720747820686173682031",
+                        "type": "DEPLOY",
+                        "version": "0x0",
+                    },
+                },
+                {
+                    "receipt": {
+                        "actual_fee": {
+                            "amount": "0x0",
+                            "unit": "WEI",
+                        },
+                        "events": [],
+                        "execution_resources": {
+                            "data_availability": {
+                                "l1_data_gas": 0,
+                                "l1_gas": 0
+                            },
+                            "steps": 0
+                        },
+                        "execution_status": "REVERTED",
+                        "finality_status": "ACCEPTED_ON_L2",
+                        "messages_sent": [],
+                        "revert_reason": "Reverted!",
+                        "transaction_hash": "0x70656e64696e67207265766572746564",
+                        "type": "INVOKE",
+                    },
+                    "transaction": {
+                        "calldata": [],
+                        "contract_address": "0x70656e64696e6720636f6e747261637420616464722030",
+                        "entry_point_selector": "0x656e74727920706f696e742030",
+                        "max_fee": "0x0",
+                        "signature": [],
+                        "transaction_hash": "0x70656e64696e67207265766572746564",
+                        "type": "INVOKE",
+                        "version": "0x0",
+                    },
+                },
+            ],
+        });
+
+        assert_eq!(output, expected);
+    }
+
+    #[tokio::test]
+    async fn latest() {
+        let context = RpcContext::for_tests_with_pending().await;
+        let input = Input {
+            block_id: BlockId::Latest,
+        };
+
+        let output = get_block_with_receipts(context.clone(), input)
+            .await
+            .unwrap()
+            .serialize(serde_json::value::Serializer)
+            .unwrap();
+
+        let expected = serde_json::json!({
+            "block_hash": "0x6c6174657374",
+            "block_number": 2,
+            "l1_da_mode": "CALLDATA",
+            "l1_data_gas_price": {
+                "price_in_fri": "0x0",
+                "price_in_wei": "0x0",
+            },
+            "l1_gas_price": {
+                "price_in_fri": "0x0",
+                "price_in_wei": "0x2",
+            },
+            "new_root": "0x57b695c82af81429fdc8966088b0196105dfb5aa22b54cbc86fc95dc3b3ece1",
+            "parent_hash": "0x626c6f636b2031",
+            "sequencer_address": "0x2",
+            "starknet_version": "",
+            "status": "ACCEPTED_ON_L2",
+            "timestamp": 2,
+            "transactions": [
+                {
+                    "receipt": {
+                        "actual_fee": {
+                            "amount": "0x0",
+                            "unit": "WEI",
+                        },
+                        "events": [],
+                        "execution_resources": {
+                            "data_availability": {
+                                "l1_data_gas": 0,
+                                "l1_gas": 0,
+                            },
+                            "memory_holes": 5,
+                            "pedersen_builtin_applications": 32,
+                            "steps": 10,
+                        },
+                        "execution_status": "SUCCEEDED",
+                        "finality_status": "ACCEPTED_ON_L2",
+                        "messages_sent": [],
+                        "transaction_hash": "0x74786e2033",
+                        "type": "INVOKE",
+                    },
+                    "transaction": {
+                        "calldata": [],
+                        "contract_address": "0x636f6e74726163742031",
+                        "entry_point_selector": "0x0",
+                        "max_fee": "0x0",
+                        "signature": [],
+                        "transaction_hash": "0x74786e2033",
+                        "type": "INVOKE",
+                        "version": "0x0",
+                    },
+                },
+                {
+                    "receipt": {
+                        "actual_fee": {
+                            "amount": "0x0",
+                            "unit": "WEI",
+                        },
+                        "events": [],
+                        "execution_resources": {
+                            "data_availability": {
+                                "l1_data_gas": 0,
+                                "l1_gas": 0,
+                            },
+                            "memory_holes": 5,
+                            "pedersen_builtin_applications": 32,
+                            "steps": 10,
+                        },
+                        "execution_status": "SUCCEEDED",
+                        "finality_status": "ACCEPTED_ON_L2",
+                        "messages_sent": [],
+                        "transaction_hash": "0x74786e2034",
+                        "type": "INVOKE",
+                    },
+                    "transaction": {
+                        "calldata": [],
+                        "contract_address": "0x0",
+                        "entry_point_selector": "0x0",
+                        "max_fee": "0x0",
+                        "signature": [],
+                        "transaction_hash": "0x74786e2034",
+                        "type": "INVOKE",
+                        "version": "0x0",
+                    },
+                },
+                {
+                    "receipt": {
+                        "actual_fee": {
+                            "amount": "0x0",
+                            "unit": "WEI",
+                        },
+                        "events": [],
+                        "execution_resources": {
+                            "data_availability": {
+                                "l1_data_gas": 0,
+                                "l1_gas": 0,
+                            },
+                            "memory_holes": 5,
+                            "pedersen_builtin_applications": 32,
+                            "steps": 10,
+                        },
+                        "execution_status": "SUCCEEDED",
+                        "finality_status": "ACCEPTED_ON_L2",
+                        "messages_sent": [],
+                        "transaction_hash": "0x74786e2035",
+                        "type": "INVOKE",
+                    },
+                    "transaction": {
+                        "calldata": [],
+                        "contract_address": "0x636f6e74726163742031",
+                        "entry_point_selector": "0x0",
+                        "max_fee": "0x0",
+                        "signature": [],
+                        "transaction_hash": "0x74786e2035",
+                        "type": "INVOKE",
+                        "version": "0x0",
+                    },
+                },
+                {
+                    "receipt": {
+                        "actual_fee": {
+                            "amount": "0x0",
+                            "unit": "WEI",
+                        },
+                        "events": [],
+                        "execution_resources": {
+                            "data_availability": {
+                                "l1_data_gas": 0,
+                                "l1_gas": 0,
+                            },
+                            "memory_holes": 5,
+                            "pedersen_builtin_applications": 32,
+                            "steps": 10,
+                        },
+                        "execution_status": "SUCCEEDED",
+                        "finality_status": "ACCEPTED_ON_L2",
+                        "messages_sent": [
+                            {
+                                "from_address": "0xcafebabe",
+                                "payload": [
+                                    "0x1",
+                                    "0x2",
+                                    "0x3",
+                                ],
+                                "to_address": "0x0",
+                            },
+                        ],
+                        "transaction_hash": "0x74786e2036",
+                        "type": "INVOKE",
+                    },
+                    "transaction": {
+                        "calldata": [],
+                        "contract_address": "0x636f6e74726163742031",
+                        "entry_point_selector": "0x0",
+                        "max_fee": "0x0",
+                        "signature": [],
+                        "transaction_hash": "0x74786e2036",
+                        "type": "INVOKE",
+                        "version": "0x0",
+                    },
+                },
+                {
+                    "receipt": {
+                        "actual_fee": {
+                            "amount": "0x0",
+                            "unit": "WEI",
+                        },
+                        "events": [],
+                        "execution_resources": {
+                            "data_availability": {
+                                "l1_data_gas": 0,
+                                "l1_gas": 0,
+                            },
+                            "memory_holes": 5,
+                            "pedersen_builtin_applications": 32,
+                            "steps": 10,
+                        },
+                        "execution_status": "REVERTED",
+                        "finality_status": "ACCEPTED_ON_L2",
+                        "messages_sent": [],
+                        "revert_reason": "Reverted because",
+                        "transaction_hash": "0x74786e207265766572746564",
+                        "type": "INVOKE",
+                    },
+                    "transaction": {
+                        "calldata": [],
+                        "contract_address": "0x636f6e74726163742031",
+                        "entry_point_selector": "0x0",
+                        "max_fee": "0x0",
+                        "signature": [],
+                        "transaction_hash": "0x74786e207265766572746564",
+                        "type": "INVOKE",
+                        "version": "0x0",
+                    },
+                },
+            ],
+        });
+        assert_eq!(output, expected);
+    }
+}


### PR DESCRIPTION
Implements `starknet_getblockwithreceipts` for RPC v0.7.

This PR adds DTOs for all new and updated components (afaict) for RPC v0.7.0-rc1 + an additional upcoming fix that will become rc2.

This PR *does not* implement any other methods which need to be changed for v0.7 due to the type changes.

Closes #1774, closes #1771, closes #1772.