### PR TITLE
fix(rpc): remove direct dependency on `blockifier`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6273,7 +6273,6 @@ dependencies = [
  "assert_matches",
  "axum",
  "base64 0.13.1",
- "blockifier",
  "bytes",
  "flate2",
  "futures",

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -22,4 +22,5 @@ pub use simulate::{simulate, trace, TraceCache};
 // re-export blockifier transaction type since it's exposed on our API
 pub use blockifier::transaction::account_transaction::AccountTransaction;
 pub use blockifier::transaction::transaction_execution::Transaction;
+pub use blockifier::transaction::transactions::ClassInfo;
 pub use transaction::transaction_hash;

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -11,7 +11,6 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 axum = { workspace = true, features = ["ws", "headers"] }
 base64 = { workspace = true }
-blockifier = { workspace = true }
 flate2 = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }

--- a/crates/rpc/src/executor.rs
+++ b/crates/rpc/src/executor.rs
@@ -3,10 +3,9 @@ use crate::v02::types::request::BroadcastedInvokeTransaction;
 use crate::v02::types::request::BroadcastedTransaction;
 use crate::v02::types::SierraContractClass;
 use anyhow::Context;
-use blockifier::transaction::transactions::ClassInfo;
 use pathfinder_common::transaction::TransactionVariant;
 use pathfinder_common::ChainId;
-use pathfinder_executor::IntoStarkFelt;
+use pathfinder_executor::{ClassInfo, IntoStarkFelt};
 use starknet_api::core::PatriciaKey;
 
 pub enum ExecutionStateError {


### PR DESCRIPTION
We're already exposing some types from blockifier (like the transaction type) on our executor API. This PR does the same for `CallInfo` and removes the direct dependency on blockifier from the RPC crate.

Closes #1783 

