### PR TITLE
feat(rpc): upgrade blockifier to 0.5.0-rc.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6236,6 +6236,8 @@ dependencies = [
  "pathfinder-crypto",
  "pathfinder-storage",
  "primitive-types",
+ "semver",
+ "serde_json",
  "starknet-gateway-types",
  "starknet_api",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "blockifier"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15e4988ff074f3402a7ee245461bb3834fd631df73d8f62b0729a326d0be53b"
+checksum = "7619ae814dc5224dff007fe33693982e6684c11d9cabba23cfe5a5b21c340dac"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -890,10 +890,10 @@ dependencies = [
  "ark-secp256r1",
  "cached",
  "cairo-felt 0.9.1",
- "cairo-lang-casm 2.6.0-rc.0",
+ "cairo-lang-casm 2.6.0-rc.1",
  "cairo-lang-runner",
  "cairo-lang-starknet-classes",
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-utils 2.6.0-rc.1",
  "cairo-vm",
  "derive_more",
  "indexmap 2.2.1",
@@ -1095,11 +1095,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c609f2d50a308006b0c04a3e1f9eda79fc4b6cc7d5cdb128c45ae020af7391"
+checksum = "7b0946e77ad3088c0e3b46f685ed0cf59810138abc285b112bd2386d9dba51cd"
 dependencies = [
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-utils 2.6.0-rc.1",
  "indoc 2.0.4",
  "num-bigint",
  "num-traits 0.2.17",
@@ -1184,22 +1184,22 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d0e519f55e16aca12c48330b058e84368fa0a2751bc6322f63e474e98039bd"
+checksum = "05e6b8cf598402a9fb70a84ec599e16c66ba6f28930ac34edfdf00251b4f54db"
 dependencies = [
  "anyhow",
- "cairo-lang-defs 2.6.0-rc.0",
- "cairo-lang-diagnostics 2.6.0-rc.0",
- "cairo-lang-filesystem 2.6.0-rc.0",
- "cairo-lang-lowering 2.6.0-rc.0",
- "cairo-lang-parser 2.6.0-rc.0",
- "cairo-lang-project 2.6.0-rc.0",
- "cairo-lang-semantic 2.6.0-rc.0",
- "cairo-lang-sierra 2.6.0-rc.0",
- "cairo-lang-sierra-generator 2.6.0-rc.0",
- "cairo-lang-syntax 2.6.0-rc.0",
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-defs 2.6.0-rc.1",
+ "cairo-lang-diagnostics 2.6.0-rc.1",
+ "cairo-lang-filesystem 2.6.0-rc.1",
+ "cairo-lang-lowering 2.6.0-rc.1",
+ "cairo-lang-parser 2.6.0-rc.1",
+ "cairo-lang-project 2.6.0-rc.1",
+ "cairo-lang-semantic 2.6.0-rc.1",
+ "cairo-lang-sierra 2.6.0-rc.1",
+ "cairo-lang-sierra-generator 2.6.0-rc.1",
+ "cairo-lang-syntax 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0-rc.1",
  "salsa",
  "smol_str 0.2.1",
  "thiserror",
@@ -1223,11 +1223,11 @@ checksum = "c99d41a14f98521c617c0673a0faa41fd00029d32106a4643e1291a1813340a7"
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28f52797c69c11cfe7099747eccdf837ecd71ff17ef443f45dff743426a7163"
+checksum = "6c2f336e086ea0c55a2d8db410b358a881e2910bd6cadd79059ee66666334a61"
 dependencies = [
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-utils 2.6.0-rc.1",
 ]
 
 [[package]]
@@ -1284,16 +1284,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65986f560d3c1ac573ac26e9d9e000ad95f82b64b7d1f4b49005608049c8c09"
+checksum = "47344ed1dd561da66d415b0d9c20f83c900d9956b86e36dc52abfed7f1ea2dc2"
 dependencies = [
- "cairo-lang-debug 2.6.0-rc.0",
- "cairo-lang-diagnostics 2.6.0-rc.0",
- "cairo-lang-filesystem 2.6.0-rc.0",
- "cairo-lang-parser 2.6.0-rc.0",
- "cairo-lang-syntax 2.6.0-rc.0",
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-debug 2.6.0-rc.1",
+ "cairo-lang-diagnostics 2.6.0-rc.1",
+ "cairo-lang-filesystem 2.6.0-rc.1",
+ "cairo-lang-parser 2.6.0-rc.1",
+ "cairo-lang-syntax 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0-rc.1",
  "itertools 0.11.0",
  "salsa",
  "smol_str 0.2.1",
@@ -1335,13 +1335,13 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a9e688f43671b7cb397bcb4fbdb55158633369a1f5ae4e61ea42207eb371d63"
+checksum = "9a43cb751b873725f7b9b4eee0161673b082f698d2436ee5ecda93b271219690"
 dependencies = [
- "cairo-lang-debug 2.6.0-rc.0",
- "cairo-lang-filesystem 2.6.0-rc.0",
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-debug 2.6.0-rc.1",
+ "cairo-lang-filesystem 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0-rc.1",
  "itertools 0.11.0",
 ]
 
@@ -1381,11 +1381,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c516416fe6b202df2d94611e984b6177ac87f8553b17765f9430608132f5645"
+checksum = "418c5a172ef9a6c193dc03142148c3c2047a7f44175b9faaa75a0945261b1d7c"
 dependencies = [
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-utils 2.6.0-rc.1",
  "good_lp",
 ]
 
@@ -1430,12 +1430,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd837ab31b831e9f7b8376ff83f77fff01ad5a6a7bd23bf146bcfaad62d4b039"
+checksum = "feaf3b3beedb8ce3cabdb8a7777431d04b507bc264add66e18dd4ecc66e1d67b"
 dependencies = [
- "cairo-lang-debug 2.6.0-rc.0",
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-debug 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0-rc.1",
  "path-clean 1.0.1",
  "salsa",
  "serde",
@@ -1517,19 +1517,19 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae6a996bd5f5c6f1ac6f961c507d2d841c9ecfbd6aa645a74140907d8a13280"
+checksum = "bdb288727186146a68871d70d8c1f8de34db21195ff432fb5d90c9363adb038c"
 dependencies = [
- "cairo-lang-debug 2.6.0-rc.0",
- "cairo-lang-defs 2.6.0-rc.0",
- "cairo-lang-diagnostics 2.6.0-rc.0",
- "cairo-lang-filesystem 2.6.0-rc.0",
- "cairo-lang-parser 2.6.0-rc.0",
- "cairo-lang-proc-macros 2.6.0-rc.0",
- "cairo-lang-semantic 2.6.0-rc.0",
- "cairo-lang-syntax 2.6.0-rc.0",
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-debug 2.6.0-rc.1",
+ "cairo-lang-defs 2.6.0-rc.1",
+ "cairo-lang-diagnostics 2.6.0-rc.1",
+ "cairo-lang-filesystem 2.6.0-rc.1",
+ "cairo-lang-parser 2.6.0-rc.1",
+ "cairo-lang-proc-macros 2.6.0-rc.1",
+ "cairo-lang-semantic 2.6.0-rc.1",
+ "cairo-lang-syntax 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0-rc.1",
  "id-arena",
  "itertools 0.11.0",
  "log",
@@ -1600,15 +1600,15 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ead70afebbb01898f7a1d29e3bfb91ee545c29446680ccbb66f5c51f1741313"
+checksum = "9613127cee21b8c45f0e42016b22a5bca08721ed3750d342d25662cfa9acd16a"
 dependencies = [
- "cairo-lang-diagnostics 2.6.0-rc.0",
- "cairo-lang-filesystem 2.6.0-rc.0",
- "cairo-lang-syntax 2.6.0-rc.0",
- "cairo-lang-syntax-codegen 2.6.0-rc.0",
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-diagnostics 2.6.0-rc.1",
+ "cairo-lang-filesystem 2.6.0-rc.1",
+ "cairo-lang-syntax 2.6.0-rc.1",
+ "cairo-lang-syntax-codegen 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0-rc.1",
  "colored",
  "itertools 0.11.0",
  "num-bigint",
@@ -1676,16 +1676,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ecdc7986014341e0165a027105e612985c32a7bcd2f7c0fc4cd6197b37eb67"
+checksum = "e231acf33b6c8c2ec0e491f42d9fa60f5b8d68f69ad87ed783970eeb59b16818"
 dependencies = [
- "cairo-lang-defs 2.6.0-rc.0",
- "cairo-lang-diagnostics 2.6.0-rc.0",
- "cairo-lang-filesystem 2.6.0-rc.0",
- "cairo-lang-parser 2.6.0-rc.0",
- "cairo-lang-syntax 2.6.0-rc.0",
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-defs 2.6.0-rc.1",
+ "cairo-lang-diagnostics 2.6.0-rc.1",
+ "cairo-lang-filesystem 2.6.0-rc.1",
+ "cairo-lang-parser 2.6.0-rc.1",
+ "cairo-lang-syntax 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0-rc.1",
  "indent",
  "indoc 2.0.4",
  "itertools 0.11.0",
@@ -1726,11 +1726,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5629126ebb5347cdad42fa7388535118521b4f68419f957728fe53760a726e83"
+checksum = "03d11dd056948249102687d1152ef1fec418c562128a74e0ee77c627446424bc"
 dependencies = [
- "cairo-lang-debug 2.6.0-rc.0",
+ "cairo-lang-debug 2.6.0-rc.1",
  "quote",
  "syn 2.0.48",
 ]
@@ -1774,12 +1774,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60125ce673e4c453ffe532ba15b295a0664334c4af666e43ab94ecaa2915fa8a"
+checksum = "27d557c942c12cc372c46319a83c253bc2fbe14282f122e4577b77022c8faf97"
 dependencies = [
- "cairo-lang-filesystem 2.6.0-rc.0",
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-filesystem 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0-rc.1",
  "serde",
  "smol_str 0.2.1",
  "thiserror",
@@ -1788,23 +1788,24 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runner"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d269f3b2fe2613cb70f72f4a2c7928d119232766a83ffc7bbb3fb0aba2c74b"
+checksum = "18585650b961dada1311844d1a279f3fa9fce14445057210d99000672b09edb6"
 dependencies = [
  "ark-ff",
  "ark-secp256k1",
  "ark-secp256r1",
  "ark-std",
  "cairo-felt 0.9.1",
- "cairo-lang-casm 2.6.0-rc.0",
- "cairo-lang-sierra 2.6.0-rc.0",
- "cairo-lang-sierra-ap-change 2.6.0-rc.0",
- "cairo-lang-sierra-generator 2.6.0-rc.0",
- "cairo-lang-sierra-to-casm 2.6.0-rc.0",
+ "cairo-lang-casm 2.6.0-rc.1",
+ "cairo-lang-lowering 2.6.0-rc.1",
+ "cairo-lang-sierra 2.6.0-rc.1",
+ "cairo-lang-sierra-ap-change 2.6.0-rc.1",
+ "cairo-lang-sierra-generator 2.6.0-rc.1",
+ "cairo-lang-sierra-to-casm 2.6.0-rc.1",
  "cairo-lang-sierra-type-size",
- "cairo-lang-starknet 2.6.0-rc.0",
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-starknet 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0-rc.1",
  "cairo-vm",
  "itertools 0.11.0",
  "keccak",
@@ -1887,19 +1888,19 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0773a59a843e532aea274efaa7be499b6953a1aaeb0d64c8b8c11109ba1da2c4"
+checksum = "4805057e20661751822c30ec57f2082e9a6a4b8f4c743d3142ae7e557e34fbdd"
 dependencies = [
- "cairo-lang-debug 2.6.0-rc.0",
- "cairo-lang-defs 2.6.0-rc.0",
- "cairo-lang-diagnostics 2.6.0-rc.0",
- "cairo-lang-filesystem 2.6.0-rc.0",
- "cairo-lang-parser 2.6.0-rc.0",
- "cairo-lang-plugins 2.6.0-rc.0",
- "cairo-lang-proc-macros 2.6.0-rc.0",
- "cairo-lang-syntax 2.6.0-rc.0",
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-debug 2.6.0-rc.1",
+ "cairo-lang-defs 2.6.0-rc.1",
+ "cairo-lang-diagnostics 2.6.0-rc.1",
+ "cairo-lang-filesystem 2.6.0-rc.1",
+ "cairo-lang-parser 2.6.0-rc.1",
+ "cairo-lang-plugins 2.6.0-rc.1",
+ "cairo-lang-proc-macros 2.6.0-rc.1",
+ "cairo-lang-syntax 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0-rc.1",
  "id-arena",
  "indoc 2.0.4",
  "itertools 0.11.0",
@@ -1979,13 +1980,13 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f06cf259fa7022e55f4a997c691510728119a3a2025e8fd9a8d18d3871b91259"
+checksum = "a5ef37c891ea0ab18d818fd74ceea6a865685c93a1c7a4ace1301909ba87bb82"
 dependencies = [
  "anyhow",
  "cairo-felt 0.9.1",
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-utils 2.6.0-rc.1",
  "const-fnv1a-hash",
  "convert_case 0.6.0",
  "derivative",
@@ -2042,14 +2043,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927b7624e3e6c45552a70b50760706b49939f4eec24ad03359dd9a3de383e58d"
+checksum = "c830940809184a4cf74b70b8ca3e479272fbc91c9b7fbd0e1ab00c49a6f4f809"
 dependencies = [
- "cairo-lang-eq-solver 2.6.0-rc.0",
- "cairo-lang-sierra 2.6.0-rc.0",
+ "cairo-lang-eq-solver 2.6.0-rc.1",
+ "cairo-lang-sierra 2.6.0-rc.1",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-utils 2.6.0-rc.1",
  "itertools 0.11.0",
  "num-traits 0.2.17",
  "thiserror",
@@ -2094,14 +2095,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce6e6355cb8f06714879a031d9c85e80d4261468e93a3c62b440b4804518e43"
+checksum = "0b99b1095e496a5060607c2aac7c0487843a38166b4882efb98244d588e9fbb1"
 dependencies = [
- "cairo-lang-eq-solver 2.6.0-rc.0",
- "cairo-lang-sierra 2.6.0-rc.0",
+ "cairo-lang-eq-solver 2.6.0-rc.1",
+ "cairo-lang-sierra 2.6.0-rc.1",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-utils 2.6.0-rc.1",
  "itertools 0.11.0",
  "num-traits 0.2.17",
  "thiserror",
@@ -2185,20 +2186,20 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "085979b1238d59a2d0feebca864ddbd91854f6c057c96cf904ee5e7229e6590a"
+checksum = "4ab0d0990afbdad473e45a55979e8ca959f6e20a98455c52e57a2817b587c084"
 dependencies = [
- "cairo-lang-debug 2.6.0-rc.0",
- "cairo-lang-defs 2.6.0-rc.0",
- "cairo-lang-diagnostics 2.6.0-rc.0",
- "cairo-lang-filesystem 2.6.0-rc.0",
- "cairo-lang-lowering 2.6.0-rc.0",
- "cairo-lang-parser 2.6.0-rc.0",
- "cairo-lang-semantic 2.6.0-rc.0",
- "cairo-lang-sierra 2.6.0-rc.0",
- "cairo-lang-syntax 2.6.0-rc.0",
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-debug 2.6.0-rc.1",
+ "cairo-lang-defs 2.6.0-rc.1",
+ "cairo-lang-diagnostics 2.6.0-rc.1",
+ "cairo-lang-filesystem 2.6.0-rc.1",
+ "cairo-lang-lowering 2.6.0-rc.1",
+ "cairo-lang-parser 2.6.0-rc.1",
+ "cairo-lang-semantic 2.6.0-rc.1",
+ "cairo-lang-sierra 2.6.0-rc.1",
+ "cairo-lang-syntax 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0-rc.1",
  "itertools 0.11.0",
  "num-bigint",
  "once_cell",
@@ -2275,18 +2276,18 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048b7e1627faddfcde39bc4bfaca81ef88fa01c984e17f322195a3598632bcd1"
+checksum = "95cef15ac7c317f2d3d494a594f2d35465e182400656e5a9cbb7d0cffc0fd227"
 dependencies = [
  "assert_matches",
  "cairo-felt 0.9.1",
- "cairo-lang-casm 2.6.0-rc.0",
- "cairo-lang-sierra 2.6.0-rc.0",
- "cairo-lang-sierra-ap-change 2.6.0-rc.0",
- "cairo-lang-sierra-gas 2.6.0-rc.0",
+ "cairo-lang-casm 2.6.0-rc.1",
+ "cairo-lang-sierra 2.6.0-rc.1",
+ "cairo-lang-sierra-ap-change 2.6.0-rc.1",
+ "cairo-lang-sierra-gas 2.6.0-rc.1",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-utils 2.6.0-rc.1",
  "indoc 2.0.4",
  "itertools 0.11.0",
  "num-bigint",
@@ -2296,12 +2297,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5b15790a43e099efa6631b0a3a956feed3079ed5f6b8bb853bc9747c3eb305"
+checksum = "c3407dee40282408638acb476f4f8a4821fbd8c68eb6d1194a213a7de28e375a"
 dependencies = [
- "cairo-lang-sierra 2.6.0-rc.0",
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-sierra 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0-rc.1",
 ]
 
 [[package]]
@@ -2426,24 +2427,24 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fff12ebd720839dd1d51ac776b53e2ad7b898d5bc28c3998d17f380da85c8a9"
+checksum = "f04b3700cb2bc4d44f9e6b0e81de38501cd601db95ffe97469a06a80ea91b798"
 dependencies = [
  "anyhow",
  "cairo-felt 0.9.1",
- "cairo-lang-compiler 2.6.0-rc.0",
- "cairo-lang-defs 2.6.0-rc.0",
- "cairo-lang-diagnostics 2.6.0-rc.0",
- "cairo-lang-filesystem 2.6.0-rc.0",
- "cairo-lang-lowering 2.6.0-rc.0",
- "cairo-lang-plugins 2.6.0-rc.0",
- "cairo-lang-semantic 2.6.0-rc.0",
- "cairo-lang-sierra 2.6.0-rc.0",
- "cairo-lang-sierra-generator 2.6.0-rc.0",
+ "cairo-lang-compiler 2.6.0-rc.1",
+ "cairo-lang-defs 2.6.0-rc.1",
+ "cairo-lang-diagnostics 2.6.0-rc.1",
+ "cairo-lang-filesystem 2.6.0-rc.1",
+ "cairo-lang-lowering 2.6.0-rc.1",
+ "cairo-lang-plugins 2.6.0-rc.1",
+ "cairo-lang-semantic 2.6.0-rc.1",
+ "cairo-lang-sierra 2.6.0-rc.1",
+ "cairo-lang-sierra-generator 2.6.0-rc.1",
  "cairo-lang-starknet-classes",
- "cairo-lang-syntax 2.6.0-rc.0",
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-syntax 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0-rc.1",
  "const_format",
  "indent",
  "indoc 2.0.4",
@@ -2457,15 +2458,15 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet-classes"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e306eeaf4766fc701a74e727c1a88c2c5d2b40748d07d0548ec8e0b0ca11dec6"
+checksum = "19152cb8a07c399d72e11bde4bc0c6b10db5c716e621b498b89573a00c517d0c"
 dependencies = [
  "cairo-felt 0.9.1",
- "cairo-lang-casm 2.6.0-rc.0",
- "cairo-lang-sierra 2.6.0-rc.0",
- "cairo-lang-sierra-to-casm 2.6.0-rc.0",
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-casm 2.6.0-rc.1",
+ "cairo-lang-sierra 2.6.0-rc.1",
+ "cairo-lang-sierra-to-casm 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0-rc.1",
  "convert_case 0.6.0",
  "itertools 0.11.0",
  "num-bigint",
@@ -2527,13 +2528,13 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5fb36c2d85254af7e33b130809cea8969150bbe8df03c51876b546224704a3"
+checksum = "1293b76a4f6711178dafd5a65b35de5289ef7737f1d4fb9c2cd5f25a36da2d1f"
 dependencies = [
- "cairo-lang-debug 2.6.0-rc.0",
- "cairo-lang-filesystem 2.6.0-rc.0",
- "cairo-lang-utils 2.6.0-rc.0",
+ "cairo-lang-debug 2.6.0-rc.1",
+ "cairo-lang-filesystem 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0-rc.1",
  "num-bigint",
  "num-traits 0.2.17",
  "salsa",
@@ -2577,9 +2578,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5784bda479025abf46e895def0672d04634c7a5b8820279617d03778a6110321"
+checksum = "e6211d20dc94543416f96b55c785273ab92180a58602121194ab5cb8282d1744"
 dependencies = [
  "genco",
  "xshell",
@@ -2636,9 +2637,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.6.0-rc.0"
+version = "2.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d812e9b5472c7f10cd3c8e9155d4532bc251e5352a7d1d646934c20fa0dc8bdb"
+checksum = "db4ce2f99f15869184146f8223b2d09b0d93679cb2bea5465c96b981cecb40b6"
 dependencies = [
  "hashbrown 0.14.3",
  "indexmap 2.2.1",
@@ -6177,7 +6178,7 @@ dependencies = [
  "cairo-lang-starknet 1.0.0-alpha.6",
  "cairo-lang-starknet 1.0.0-rc0",
  "cairo-lang-starknet 1.1.1",
- "cairo-lang-starknet 2.6.0-rc.0",
+ "cairo-lang-starknet 2.6.0-rc.1",
  "cairo-lang-starknet-classes",
  "pathfinder-common",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ async-trait = "0.1.73"
 axum = { version = "0.6.19", features = ["macros"] }
 base64 = "0.13.1"
 bitvec = "1.0.1"
-blockifier = "=0.5.0-rc.1"
+blockifier = "=0.5.0-rc.3"
 bytes = "1.4.0"
 cached = "0.44.0"
 # This one needs to match the version used by blockifier

--- a/crates/common/src/header.rs
+++ b/crates/common/src/header.rs
@@ -116,6 +116,16 @@ impl BlockHeaderBuilder {
         self
     }
 
+    pub fn with_eth_l1_data_gas_price(mut self, eth_l1_data_gas_price: GasPrice) -> Self {
+        self.0.eth_l1_data_gas_price = eth_l1_data_gas_price;
+        self
+    }
+
+    pub fn with_strk_l1_data_gas_price(mut self, strk_l1_data_gas_price: GasPrice) -> Self {
+        self.0.strk_l1_data_gas_price = strk_l1_data_gas_price;
+        self
+    }
+
     pub fn with_sequencer_address(mut self, sequencer_address: SequencerAddress) -> Self {
         self.0.sequencer_address = sequencer_address;
         self

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -9,11 +9,11 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-cairo-lang-starknet-classes = "=2.6.0-rc.0"
+cairo-lang-starknet-classes = "=2.6.0-rc.1"
 casm-compiler-v1_0_0-alpha6 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-alpha.6" }
 casm-compiler-v1_0_0-rc0 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-rc0" }
 casm-compiler-v1_1_1 = { package = "cairo-lang-starknet", version = "=1.1.1" }
-casm-compiler-v2 = { package = "cairo-lang-starknet", version = "=2.6.0-rc.0" }
+casm-compiler-v2 = { package = "cairo-lang-starknet", version = "=2.6.0-rc.1" }
 pathfinder-common = { path = "../common" }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -17,6 +17,8 @@ pathfinder-common = { path = "../common" }
 pathfinder-crypto = { path = "../crypto" }
 pathfinder-storage = { path = "../storage" }
 primitive-types = { workspace = true, features = ["serde"] }
+semver = { workspace = true }
+serde_json = { workspace = true }
 starknet-gateway-types = { path = "../gateway-types" }
 starknet_api = { workspace = true }
 tokio = { workspace = true }

--- a/crates/executor/resources/versioned_constants_13_0.json
+++ b/crates/executor/resources/versioned_constants_13_0.json
@@ -1,0 +1,394 @@
+{
+    "gateway": {
+        "max_calldata_length": 4000,
+        "max_contract_bytecode_size": 61440
+    },
+    "invoke_tx_max_n_steps": 3000000,
+    "max_recursion_depth": 50,
+    "os_constants": {
+        "nop_entry_point_offset": -1,
+        "entry_point_type_external": 0,
+        "entry_point_type_l1_handler": 1,
+        "entry_point_type_constructor": 2,
+        "l1_handler_version": 0,
+        "sierra_array_len_bound": 4294967296,
+        "constructor_entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+        "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+        "validate_entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+        "validate_declare_entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
+        "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
+        "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+        "default_entry_point_selector": 0,
+        "block_hash_contract_address": 1,
+        "stored_block_hash_buffer": 10,
+        "step_gas_cost": 100,
+        "range_check_gas_cost": 70,
+        "memory_hole_gas_cost": 10,
+        "initial_gas_cost": {
+            "step_gas_cost": 100000000
+        },
+        "entry_point_initial_budget": {
+            "step_gas_cost": 100
+        },
+        "syscall_base_gas_cost": {
+            "step_gas_cost": 100
+        },
+        "entry_point_gas_cost": {
+            "entry_point_initial_budget": 1,
+            "step_gas_cost": 500
+        },
+        "fee_transfer_gas_cost": {
+            "entry_point_gas_cost": 1,
+            "step_gas_cost": 100
+        },
+        "transaction_gas_cost": {
+            "entry_point_gas_cost": 2,
+            "fee_transfer_gas_cost": 1,
+            "step_gas_cost": 100
+        },
+        "call_contract_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 10,
+            "entry_point_gas_cost": 1
+        },
+        "deploy_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 200,
+            "entry_point_gas_cost": 1
+        },
+        "get_block_hash_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 50
+        },
+        "get_execution_info_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 10
+        },
+        "library_call_gas_cost": {
+            "call_contract_gas_cost": 1
+        },
+        "replace_class_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 50
+        },
+        "storage_read_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 50
+        },
+        "storage_write_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 50
+        },
+        "emit_event_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 10
+        },
+        "send_message_to_l1_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 50
+        },
+        "secp256k1_add_gas_cost": {
+            "step_gas_cost": 406,
+            "range_check_gas_cost": 29
+        },
+        "secp256k1_get_point_from_x_gas_cost": {
+            "step_gas_cost": 391,
+            "range_check_gas_cost": 30,
+            "memory_hole_gas_cost": 20
+        },
+        "secp256k1_get_xy_gas_cost": {
+            "step_gas_cost": 239,
+            "range_check_gas_cost": 11,
+            "memory_hole_gas_cost": 40
+        },
+        "secp256k1_mul_gas_cost": {
+            "step_gas_cost": 76401,
+            "range_check_gas_cost": 7045
+        },
+        "secp256k1_new_gas_cost": {
+            "step_gas_cost": 475,
+            "range_check_gas_cost": 35,
+            "memory_hole_gas_cost": 40
+        },
+        "secp256r1_add_gas_cost": {
+            "step_gas_cost": 589,
+            "range_check_gas_cost": 57
+        },
+        "secp256r1_get_point_from_x_gas_cost": {
+            "step_gas_cost": 510,
+            "range_check_gas_cost": 44,
+            "memory_hole_gas_cost": 20
+        },
+        "secp256r1_get_xy_gas_cost": {
+            "step_gas_cost": 241,
+            "range_check_gas_cost": 11,
+            "memory_hole_gas_cost": 40
+        },
+        "secp256r1_mul_gas_cost": {
+            "step_gas_cost": 125240,
+            "range_check_gas_cost": 13961
+        },
+        "secp256r1_new_gas_cost": {
+            "step_gas_cost": 594,
+            "range_check_gas_cost": 49,
+            "memory_hole_gas_cost": 40
+        },
+        "keccak_gas_cost": {
+            "syscall_base_gas_cost": 1
+        },
+        "keccak_round_cost_gas_cost": 180000,
+        "error_block_number_out_of_range": "Block number out of range",
+        "error_out_of_gas": "Out of gas",
+        "error_invalid_input_len": "Invalid input length",
+        "error_invalid_argument": "Invalid argument",
+        "validated": "VALID",
+        "l1_gas": "L1_GAS",
+        "l2_gas": "L2_GAS",
+        "l1_gas_index": 0,
+        "l2_gas_index": 1
+    },
+    "os_resources": {
+        "execute_syscalls": {
+            "CallContract": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 19
+                },
+                "n_memory_holes": 0,
+                "n_steps": 691
+            },
+            "DelegateCall": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 19
+                },
+                "n_memory_holes": 0,
+                "n_steps": 713
+            },
+            "DelegateL1Handler": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 15
+                },
+                "n_memory_holes": 0,
+                "n_steps": 692
+            },
+            "Deploy": {
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 7,
+                    "range_check_builtin": 18
+                },
+                "n_memory_holes": 0,
+                "n_steps": 944
+            },
+            "EmitEvent": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 19
+            },
+            "GetBlockHash": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 2
+                },
+                "n_memory_holes": 0,
+                "n_steps": 74
+            },
+            "GetBlockNumber": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 40
+            },
+            "GetBlockTimestamp": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 38
+            },
+            "GetCallerAddress": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 32
+            },
+            "GetContractAddress": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 36
+            },
+            "GetExecutionInfo": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 29
+            },
+            "GetSequencerAddress": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 34
+            },
+            "GetTxInfo": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 29
+            },
+            "GetTxSignature": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 44
+            },
+            "Keccak": {
+                "builtin_instance_counter": {
+                    "bitwise_builtin": 6,
+                    "keccak_builtin": 1,
+                    "range_check_builtin": 56
+                },
+                "n_memory_holes": 0,
+                "n_steps": 381
+            },
+            "LibraryCall": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 19
+                },
+                "n_memory_holes": 0,
+                "n_steps": 680
+            },
+            "LibraryCallL1Handler": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 15
+                },
+                "n_memory_holes": 0,
+                "n_steps": 659
+            },
+            "ReplaceClass": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 73
+            },
+            "Secp256k1Add": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 29
+                },
+                "n_memory_holes": 0,
+                "n_steps": 406
+            },
+            "Secp256k1GetPointFromX": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 30
+                },
+                "n_memory_holes": 20,
+                "n_steps": 391
+            },
+            "Secp256k1GetXy": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 11
+                },
+                "n_memory_holes": 40,
+                "n_steps": 239
+            },
+            "Secp256k1Mul": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 7045
+                },
+                "n_memory_holes": 0,
+                "n_steps": 76401
+            },
+            "Secp256k1New": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 35
+                },
+                "n_memory_holes": 40,
+                "n_steps": 475
+            },
+            "Secp256r1Add": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 57
+                },
+                "n_memory_holes": 0,
+                "n_steps": 589
+            },
+            "Secp256r1GetPointFromX": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 44
+                },
+                "n_memory_holes": 20,
+                "n_steps": 510
+            },
+            "Secp256r1GetXy": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 11
+                },
+                "n_memory_holes": 40,
+                "n_steps": 241
+            },
+            "Secp256r1Mul": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 13961
+                },
+                "n_memory_holes": 0,
+                "n_steps": 125240
+            },
+            "Secp256r1New": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 49
+                },
+                "n_memory_holes": 40,
+                "n_steps": 594
+            },
+            "SendMessageToL1": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 84
+            },
+            "StorageRead": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 44
+            },
+            "StorageWrite": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 46
+            }
+        },
+        "execute_txs_inner": {
+            "Declare": {
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 15,
+                    "range_check_builtin": 63
+                },
+                "n_memory_holes": 0,
+                "n_steps": 2711
+            },
+            "DeployAccount": {
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 23,
+                    "range_check_builtin": 83
+                },
+                "n_memory_holes": 0,
+                "n_steps": 3628
+            },
+            "InvokeFunction": {
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 16,
+                    "range_check_builtin": 80
+                },
+                "n_memory_holes": 0,
+                "n_steps": 3382
+            },
+            "L1Handler": {
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 11,
+                    "range_check_builtin": 17
+                },
+                "n_memory_holes": 0,
+                "n_steps": 1069
+            }
+        }
+    },
+    "validate_max_n_steps": 1000000,
+    "vm_resource_fee_cost": {
+        "bitwise_builtin": 0.32,
+        "ec_op_builtin": 5.12,
+        "ecdsa_builtin": 10.24,
+        "keccak_builtin": 10.24,
+        "n_steps": 0.005,
+        "output_builtin": 0,
+        "pedersen_builtin": 0.16,
+        "poseidon_builtin": 0.16,
+        "range_check_builtin": 0.08
+    }
+}

--- a/crates/executor/src/execution_state.rs
+++ b/crates/executor/src/execution_state.rs
@@ -19,6 +19,44 @@ pub const ETH_FEE_TOKEN_ADDRESS: ContractAddress =
 pub const STRK_FEE_TOKEN_ADDRESS: ContractAddress =
     contract_address!("0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d");
 
+mod versioned_constants {
+    use pathfinder_common::StarknetVersion;
+
+    use super::VersionedConstants;
+
+    const BLOCKIFIER_VERSIONED_CONSTANTS_JSON_0_13_0: &[u8] =
+        include_bytes!("../resources/versioned_constants_13_0.json");
+
+    const STARKNET_VERSION_MATCHING_LATEST_BLOCKIFIER: semver::Version =
+        semver::Version::new(0, 13, 1);
+
+    lazy_static::lazy_static! {
+        pub static ref BLOCKIFIER_VERSIONED_CONSTANTS_0_13_0: VersionedConstants =
+            serde_json::from_slice(BLOCKIFIER_VERSIONED_CONSTANTS_JSON_0_13_0).unwrap();
+    }
+
+    pub(super) fn for_version(
+        version: &StarknetVersion,
+    ) -> anyhow::Result<&'static VersionedConstants> {
+        let versioned_constants = match version.parse_as_semver()? {
+            Some(version) => {
+                // Right now we only properly support two versions: 0.13.0 and 0.13.1.
+                // We use 0.13.0 for all blocks _before_ 0.13.1.
+                if version < STARKNET_VERSION_MATCHING_LATEST_BLOCKIFIER {
+                    &BLOCKIFIER_VERSIONED_CONSTANTS_0_13_0
+                } else {
+                    VersionedConstants::latest_constants()
+                }
+            }
+            // The default for blocks that don't have a version number.
+            // This is supposed to be the _oldest_ version we support.
+            None => &BLOCKIFIER_VERSIONED_CONSTANTS_0_13_0,
+        };
+
+        Ok(versioned_constants)
+    }
+}
+
 pub struct ExecutionState<'tx> {
     transaction: &'tx pathfinder_storage::Transaction<'tx>,
     pub chain_id: ChainId,
@@ -75,12 +113,14 @@ impl<'tx> ExecutionState<'tx> {
             None
         };
 
+        let versioned_constants = versioned_constants::for_version(&self.header.starknet_version)?;
+
         let block_context = pre_process_block(
             &mut cached_state,
             old_block_number_and_hash,
             block_info,
             chain_info,
-            VersionedConstants::latest_constants().to_owned(),
+            versioned_constants.to_owned(),
         )?;
 
         Ok((cached_state, block_context))

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -20,7 +20,7 @@ pub use felt::{IntoFelt, IntoStarkFelt};
 pub use simulate::{simulate, trace, TraceCache};
 
 // re-export blockifier transaction type since it's exposed on our API
+pub use blockifier::execution::contract_class::ClassInfo;
 pub use blockifier::transaction::account_transaction::AccountTransaction;
 pub use blockifier::transaction::transaction_execution::Transaction;
-pub use blockifier::transaction::transactions::ClassInfo;
 pub use transaction::transaction_hash;

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -28,7 +28,7 @@ async-trait = { workspace = true }
 base64 = { workspace = true, optional = true }
 bitvec = { workspace = true }
 bytes = { workspace = true }
-cairo-lang-starknet-classes = { version = "=2.6.0-rc.0", optional = true }
+cairo-lang-starknet-classes = { version = "=2.6.0-rc.1", optional = true }
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
 console-subscriber = { version = "0.1.10", optional = true }
 fake = { workspace = true }

--- a/crates/rpc/src/v04/method/simulate_transactions.rs
+++ b/crates/rpc/src/v04/method/simulate_transactions.rs
@@ -5,7 +5,7 @@ pub(crate) mod tests {
         BroadcastedInvokeTransaction, BroadcastedInvokeTransactionV1,
     };
     use crate::v02::types::ContractClass;
-    use pathfinder_common::{macro_prelude::*, Fee};
+    use pathfinder_common::{macro_prelude::*, Fee, StarknetVersion};
     use pathfinder_common::{
         //felt,
         BlockHeader,
@@ -115,7 +115,9 @@ pub(crate) mod tests {
         }
     }
 
-    pub(crate) async fn setup_storage() -> (
+    pub(crate) async fn setup_storage_with_starknet_version(
+        version: StarknetVersion,
+    ) -> (
         Storage,
         BlockHeader,
         ContractAddress,
@@ -127,7 +129,7 @@ pub(crate) mod tests {
 
         // set test storage variable
         let (storage, last_block_header, account_contract_address, universal_deployer_address) =
-            crate::test_setup::test_storage(|state_update| {
+            crate::test_setup::test_storage(version, |state_update| {
                 state_update.with_storage_update(
                     fixtures::DEPLOYED_CONTRACT_ADDRESS,
                     test_storage_key,
@@ -143,5 +145,15 @@ pub(crate) mod tests {
             universal_deployer_address,
             test_storage_value,
         )
+    }
+
+    pub(crate) async fn setup_storage() -> (
+        Storage,
+        BlockHeader,
+        ContractAddress,
+        ContractAddress,
+        StorageValue,
+    ) {
+        setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 0)).await
     }
 }

--- a/crates/rpc/src/v05/method/estimate_fee.rs
+++ b/crates/rpc/src/v05/method/estimate_fee.rs
@@ -348,26 +348,26 @@ pub(crate) mod tests {
             };
             let result = estimate_fee(context, input).await.unwrap();
             let declare_expected = FeeEstimate {
-                gas_consumed: 26571.into(),
+                gas_consumed: 2768.into(),
                 gas_price: 1.into(),
-                overall_fee: 26571.into(),
+                overall_fee: 2768.into(),
             };
             let deploy_expected = FeeEstimate {
-                gas_consumed: 3008.into(),
+                gas_consumed: 3020.into(),
                 gas_price: 1.into(),
-                overall_fee: 3008.into(),
+                overall_fee: 3020.into(),
             };
             let invoke_expected = FeeEstimate {
-                gas_consumed: 1664.into(),
+                gas_consumed: 1674.into(),
                 gas_price: 1.into(),
-                overall_fee: 1664.into(),
+                overall_fee: 1674.into(),
             };
             let invoke_v0_expected = FeeEstimate {
-                gas_consumed: 872.into(),
+                gas_consumed: 880.into(),
                 gas_price: 1.into(),
-                overall_fee: 872.into(),
+                overall_fee: 880.into(),
             };
-            pretty_assertions_sorted::assert_eq!(
+            assert_eq!(
                 result,
                 vec![
                     declare_expected,

--- a/crates/rpc/src/v05/method/estimate_message_fee.rs
+++ b/crates/rpc/src/v05/method/estimate_message_fee.rs
@@ -183,14 +183,14 @@ mod tests {
     #[tokio::test]
     async fn test_estimate_message_fee() {
         let expected = FeeEstimate {
-            gas_consumed: 16299.into(),
+            gas_consumed: 16302.into(),
             gas_price: 1.into(),
-            overall_fee: 16299.into(),
+            overall_fee: 16302.into(),
         };
 
         let rpc = setup(Setup::Full).await.expect("RPC context");
         let result = estimate_message_fee(rpc, input()).await.expect("result");
-        pretty_assertions_sorted::assert_eq!(result, expected);
+        assert_eq!(result, expected);
     }
 
     #[tokio::test]

--- a/crates/rpc/src/v05/method/simulate_transactions.rs
+++ b/crates/rpc/src/v05/method/simulate_transactions.rs
@@ -584,9 +584,9 @@ pub(crate) mod tests {
             SimulatedTransaction {
                 fee_estimation:
                     FeeEstimate {
-                        gas_consumed: 2213.into(),
+                        gas_consumed: 2222.into(),
                         gas_price: 1.into(),
-                        overall_fee: 2213.into(),
+                        overall_fee: 2222.into(),
                     }
                 ,
                 transaction_trace:
@@ -809,7 +809,7 @@ pub(crate) mod tests {
             use super::dto::*;
             use super::*;
 
-            const DECLARE_GAS_CONSUMED: u64 = 26571;
+            const DECLARE_GAS_CONSUMED: u64 = 2768;
 
             pub fn declare(
                 account_contract_address: ContractAddress,
@@ -902,7 +902,7 @@ pub(crate) mod tests {
                     storage_entries: vec![
                         StorageEntry {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffff9835")
+                            value: storage_value!("0x000000000000000000000000000000000000fffffffffffffffffffffffff530")
                         },
                         StorageEntry {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
@@ -966,7 +966,7 @@ pub(crate) mod tests {
                 }
             }
 
-            const UNIVERSAL_DEPLOYER_GAS_CONSUMED: u64 = 3008;
+            const UNIVERSAL_DEPLOYER_GAS_CONSUMED: u64 = 3020;
 
             pub fn universal_deployer(
                 account_contract_address: ContractAddress,
@@ -1089,7 +1089,7 @@ pub(crate) mod tests {
                     storage_entries: vec![
                         StorageEntry {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffff8c75")
+                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffffe964")
                         },
                         StorageEntry {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
@@ -1263,7 +1263,7 @@ pub(crate) mod tests {
                 }
             }
 
-            const INVOKE_GAS_CONSUMED: u64 = 1664;
+            const INVOKE_GAS_CONSUMED: u64 = 1674;
 
             pub fn invoke(
                 account_contract_address: ContractAddress,
@@ -1368,7 +1368,7 @@ pub(crate) mod tests {
                     storage_entries: vec![
                         StorageEntry {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffff85f5")
+                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffffe2da")
                         },
                         StorageEntry {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),

--- a/crates/rpc/src/v05/method/simulate_transactions.rs
+++ b/crates/rpc/src/v05/method/simulate_transactions.rs
@@ -694,7 +694,7 @@ pub(crate) mod tests {
 
         let result = simulate_transactions(context, input).await.unwrap();
 
-        const DECLARE_GAS_CONSUMED: u64 = 17116;
+        const DECLARE_GAS_CONSUMED: u64 = 1666;
         use super::dto::*;
         use crate::v03::method::get_state_update::types::{StorageDiff, StorageEntry};
 
@@ -762,7 +762,7 @@ pub(crate) mod tests {
                             storage_entries: vec![
                                 StorageEntry {
                                     key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                                    value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffffbd24")
+                                    value: storage_value!("0x000000000000000000000000000000000000fffffffffffffffffffffffff97e")
                                 },
                                 StorageEntry {
                                     key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),

--- a/crates/rpc/src/v06/method/estimate_fee.rs
+++ b/crates/rpc/src/v06/method/estimate_fee.rs
@@ -409,37 +409,37 @@ pub(crate) mod tests {
             };
             let result = estimate_fee(context, input).await.unwrap();
             let declare_expected = FeeEstimate {
-                gas_consumed: 26571.into(),
+                gas_consumed: 2768.into(),
                 gas_price: 1.into(),
-                overall_fee: 26571.into(),
+                overall_fee: 2768.into(),
                 unit: PriceUnit::Wei,
             };
             let deploy_expected = FeeEstimate {
-                gas_consumed: 3008.into(),
+                gas_consumed: 3020.into(),
                 gas_price: 1.into(),
-                overall_fee: 3008.into(),
+                overall_fee: 3020.into(),
                 unit: PriceUnit::Wei,
             };
             let invoke_expected = FeeEstimate {
-                gas_consumed: 1664.into(),
+                gas_consumed: 1674.into(),
                 gas_price: 1.into(),
-                overall_fee: 1664.into(),
+                overall_fee: 1674.into(),
                 unit: PriceUnit::Wei,
             };
             let invoke_v0_expected = FeeEstimate {
-                gas_consumed: 872.into(),
+                gas_consumed: 880.into(),
                 gas_price: 1.into(),
-                overall_fee: 872.into(),
+                overall_fee: 880.into(),
                 unit: PriceUnit::Wei,
             };
             let invoke_v3_expected = FeeEstimate {
-                gas_consumed: 1664.into(),
+                gas_consumed: 1674.into(),
                 // STRK gas price is 2
                 gas_price: 2.into(),
-                overall_fee: 3328.into(),
+                overall_fee: 3348.into(),
                 unit: PriceUnit::Fri,
             };
-            pretty_assertions_sorted::assert_eq!(
+            assert_eq!(
                 result,
                 vec![
                     declare_expected,

--- a/crates/rpc/src/v06/method/estimate_message_fee.rs
+++ b/crates/rpc/src/v06/method/estimate_message_fee.rs
@@ -364,15 +364,15 @@ mod tests {
     #[tokio::test]
     async fn test_estimate_message_fee() {
         let expected = FeeEstimate {
-            gas_consumed: 16299.into(),
+            gas_consumed: 16302.into(),
             gas_price: 1.into(),
-            overall_fee: 16299.into(),
+            overall_fee: 16302.into(),
             unit: PriceUnit::Wei,
         };
 
         let rpc = setup(Setup::Full).await.expect("RPC context");
         let result = estimate_message_fee(rpc, input()).await.expect("result");
-        pretty_assertions_sorted::assert_eq!(result, expected);
+        assert_eq!(result, expected);
     }
 
     #[tokio::test]

--- a/crates/rpc/src/v06/method/simulate_transactions.rs
+++ b/crates/rpc/src/v06/method/simulate_transactions.rs
@@ -828,7 +828,7 @@ pub(crate) mod tests {
                             messages: vec![],
                             result: vec![felt!("0x1")],
                             execution_resources: ExecutionResources {
-                                steps: 525,
+                                steps: 936,
                                 memory_holes: 59,
                                 range_check_builtin_applications: 21,
                                 pedersen_builtin_applications: 4,
@@ -1050,7 +1050,7 @@ pub(crate) mod tests {
                     messages: vec![],
                     result: vec![felt!("0x1")],
                     execution_resources: ExecutionResources {
-                        steps: 525,
+                        steps: 936,
                         memory_holes: 59,
                         range_check_builtin_applications: 21,
                         pedersen_builtin_applications: 4,
@@ -1322,9 +1322,10 @@ pub(crate) mod tests {
                                 *DEPLOYED_CONTRACT_ADDRESS.get(),
                             ],
                             execution_resources: ExecutionResources {
-                                steps: 125,
+                                steps: 1120,
                                 memory_holes: 2,
-                                range_check_builtin_applications: 2,
+                                range_check_builtin_applications: 20,
+                                pedersen_builtin_applications: 7,
                                 ..Default::default()
                             },
                         }
@@ -1354,9 +1355,10 @@ pub(crate) mod tests {
                         *DEPLOYED_CONTRACT_ADDRESS.get(),
                     ],
                     execution_resources: ExecutionResources {
-                        steps: 164,
+                        steps: 1850,
                         memory_holes: 2,
-                        range_check_builtin_applications: 3,
+                        range_check_builtin_applications: 40,
+                        pedersen_builtin_applications: 7,
                         ..Default::default()
                     },
                 }
@@ -1397,7 +1399,7 @@ pub(crate) mod tests {
                     messages: vec![],
                     result: vec![felt!("0x1")],
                     execution_resources: ExecutionResources {
-                        steps: 525,
+                        steps: 936,
                         memory_holes: 59,
                         range_check_builtin_applications: 21,
                         pedersen_builtin_applications: 4,
@@ -1574,7 +1576,7 @@ pub(crate) mod tests {
                         messages: vec![],
                         result: vec![test_storage_value.0],
                         execution_resources: ExecutionResources {
-                            steps: 78,
+                            steps: 122,
                             range_check_builtin_applications: 2,
                             ..Default::default()
                         },
@@ -1595,8 +1597,8 @@ pub(crate) mod tests {
                     messages: vec![],
                     result: vec![test_storage_value.0],
                     execution_resources: ExecutionResources {
-                        steps: 117,
-                        range_check_builtin_applications: 3,
+                        steps: 852,
+                        range_check_builtin_applications: 22,
                         ..Default::default()
                     },
                 }
@@ -1636,7 +1638,7 @@ pub(crate) mod tests {
                     messages: vec![],
                     result: vec![felt!("0x1")],
                     execution_resources: ExecutionResources {
-                        steps: 525,
+                        steps: 936,
                         memory_holes: 59,
                         range_check_builtin_applications: 21,
                         pedersen_builtin_applications: 4,

--- a/crates/rpc/src/v06/method/simulate_transactions.rs
+++ b/crates/rpc/src/v06/method/simulate_transactions.rs
@@ -669,9 +669,9 @@ pub(crate) mod tests {
             SimulatedTransaction {
                 fee_estimation:
                     FeeEstimate {
-                        gas_consumed: 2213.into(),
+                        gas_consumed: 2222.into(),
                         gas_price: 1.into(),
-                        overall_fee: 2213.into(),
+                        overall_fee: 2222.into(),
                         unit: PriceUnit::Wei,
                     }
                 ,
@@ -783,7 +783,7 @@ pub(crate) mod tests {
 
         let result = simulate_transactions(context, input).await.unwrap();
 
-        const DECLARE_GAS_CONSUMED: u64 = 17116;
+        const DECLARE_GAS_CONSUMED: u64 = 1666;
         use super::dto::*;
         use crate::v03::method::get_state_update::types::{StorageDiff, StorageEntry};
 
@@ -828,9 +828,9 @@ pub(crate) mod tests {
                             messages: vec![],
                             result: vec![felt!("0x1")],
                             execution_resources: ExecutionResources {
-                                steps: 1354,
+                                steps: 525,
                                 memory_holes: 59,
-                                range_check_builtin_applications: 31,
+                                range_check_builtin_applications: 21,
                                 pedersen_builtin_applications: 4,
                                 ..Default::default()
                             },
@@ -863,7 +863,7 @@ pub(crate) mod tests {
                             storage_entries: vec![
                                 StorageEntry {
                                     key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                                    value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffffbd24")
+                                    value: storage_value!("0x000000000000000000000000000000000000fffffffffffffffffffffffff97e")
                                 },
                                 StorageEntry {
                                     key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
@@ -910,7 +910,7 @@ pub(crate) mod tests {
             use super::dto::*;
             use super::*;
 
-            const DECLARE_GAS_CONSUMED: u64 = 26571;
+            const DECLARE_GAS_CONSUMED: u64 = 2768;
 
             pub fn declare(
                 account_contract_address: ContractAddress,
@@ -1006,7 +1006,7 @@ pub(crate) mod tests {
                     storage_entries: vec![
                         StorageEntry {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffff9835")
+                            value: storage_value!("0x000000000000000000000000000000000000fffffffffffffffffffffffff530")
                         },
                         StorageEntry {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
@@ -1050,9 +1050,9 @@ pub(crate) mod tests {
                     messages: vec![],
                     result: vec![felt!("0x1")],
                     execution_resources: ExecutionResources {
-                        steps: 1354,
+                        steps: 525,
                         memory_holes: 59,
-                        range_check_builtin_applications: 31,
+                        range_check_builtin_applications: 21,
                         pedersen_builtin_applications: 4,
                         ..Default::default()
                     },
@@ -1081,7 +1081,7 @@ pub(crate) mod tests {
                 }
             }
 
-            const UNIVERSAL_DEPLOYER_GAS_CONSUMED: u64 = 3008;
+            const UNIVERSAL_DEPLOYER_GAS_CONSUMED: u64 = 3020;
 
             pub fn universal_deployer(
                 account_contract_address: ContractAddress,
@@ -1207,7 +1207,7 @@ pub(crate) mod tests {
                     storage_entries: vec![
                         StorageEntry {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffff8c75")
+                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffffe964")
                         },
                         StorageEntry {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
@@ -1322,10 +1322,9 @@ pub(crate) mod tests {
                                 *DEPLOYED_CONTRACT_ADDRESS.get(),
                             ],
                             execution_resources: ExecutionResources {
-                                steps: 1262,
+                                steps: 125,
                                 memory_holes: 2,
-                                range_check_builtin_applications: 23,
-                                pedersen_builtin_applications: 7,
+                                range_check_builtin_applications: 2,
                                 ..Default::default()
                             },
                         }
@@ -1355,10 +1354,9 @@ pub(crate) mod tests {
                         *DEPLOYED_CONTRACT_ADDRESS.get(),
                     ],
                     execution_resources: ExecutionResources {
-                        steps: 2061,
+                        steps: 164,
                         memory_holes: 2,
-                        range_check_builtin_applications: 44,
-                        pedersen_builtin_applications: 7,
+                        range_check_builtin_applications: 3,
                         ..Default::default()
                     },
                 }
@@ -1399,16 +1397,16 @@ pub(crate) mod tests {
                     messages: vec![],
                     result: vec![felt!("0x1")],
                     execution_resources: ExecutionResources {
-                        steps: 1354,
+                        steps: 525,
                         memory_holes: 59,
-                        range_check_builtin_applications: 31,
+                        range_check_builtin_applications: 21,
                         pedersen_builtin_applications: 4,
                         ..Default::default()
                     },
                 }
             }
 
-            const INVOKE_GAS_CONSUMED: u64 = 1664;
+            const INVOKE_GAS_CONSUMED: u64 = 1674;
 
             pub fn invoke(
                 account_contract_address: ContractAddress,
@@ -1516,7 +1514,7 @@ pub(crate) mod tests {
                     storage_entries: vec![
                         StorageEntry {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffff85f5")
+                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffffe2da")
                         },
                         StorageEntry {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
@@ -1576,8 +1574,8 @@ pub(crate) mod tests {
                         messages: vec![],
                         result: vec![test_storage_value.0],
                         execution_resources: ExecutionResources {
-                            steps: 165,
-                            range_check_builtin_applications: 3,
+                            steps: 78,
+                            range_check_builtin_applications: 2,
                             ..Default::default()
                         },
                     }],
@@ -1597,8 +1595,8 @@ pub(crate) mod tests {
                     messages: vec![],
                     result: vec![test_storage_value.0],
                     execution_resources: ExecutionResources {
-                        steps: 964,
-                        range_check_builtin_applications: 24,
+                        steps: 117,
+                        range_check_builtin_applications: 3,
                         ..Default::default()
                     },
                 }
@@ -1638,9 +1636,9 @@ pub(crate) mod tests {
                     messages: vec![],
                     result: vec![felt!("0x1")],
                     execution_resources: ExecutionResources {
-                        steps: 1354,
+                        steps: 525,
                         memory_holes: 59,
-                        range_check_builtin_applications: 31,
+                        range_check_builtin_applications: 21,
                         pedersen_builtin_applications: 4,
                         ..Default::default()
                     },

--- a/crates/rpc/src/v06/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v06/method/trace_block_transactions.rs
@@ -305,15 +305,15 @@ pub(crate) mod tests {
         ];
 
         let traces = vec![
-            fixtures::expected_output::declare(account_contract_address, &last_block_header)
+            fixtures::expected_output_0_13_0::declare(account_contract_address, &last_block_header)
                 .transaction_trace,
-            fixtures::expected_output::universal_deployer(
+            fixtures::expected_output_0_13_0::universal_deployer(
                 account_contract_address,
                 &last_block_header,
                 universal_deployer_address,
             )
             .transaction_trace,
-            fixtures::expected_output::invoke(
+            fixtures::expected_output_0_13_0::invoke(
                 account_contract_address,
                 &last_block_header,
                 test_storage_value,
@@ -445,15 +445,15 @@ pub(crate) mod tests {
         ];
 
         let traces = vec![
-            fixtures::expected_output::declare(account_contract_address, &last_block_header)
+            fixtures::expected_output_0_13_0::declare(account_contract_address, &last_block_header)
                 .transaction_trace,
-            fixtures::expected_output::universal_deployer(
+            fixtures::expected_output_0_13_0::universal_deployer(
                 account_contract_address,
                 &last_block_header,
                 universal_deployer_address,
             )
             .transaction_trace,
-            fixtures::expected_output::invoke(
+            fixtures::expected_output_0_13_0::invoke(
                 account_contract_address,
                 &last_block_header,
                 test_storage_value,


### PR DESCRIPTION
This PR upgrades blockifier and the Cairo compiler to the most recent version.

This version of blockifier is adding support for VersionedConstants for Starknet 0.13.0, so the executor code was updated to use the constants appropriate for the Starknet version of the block we're doing execution on.

Some simulation tests for Starknet 0.13.0 had to be updated: even though fee estimates match, transaction traces now report resource use for syscalls too, thus causing differences in `execution_resources`.

A new test for testing Starknet 0.13.1 fee estimation & traces has been added to JSON-RPC 0.6 `starknet_simulateTransactions`.

Closes: #1769 