### PR TITLE
feat(executor): enable L1 blob data availability mode for execution

### DIFF
--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -15,7 +15,7 @@ pub use call::call;
 pub use class::{parse_casm_definition, parse_deprecated_class_definition};
 pub use error::{CallError, TransactionExecutionError};
 pub use estimate::estimate;
-pub use execution_state::{ExecutionState, ETH_FEE_TOKEN_ADDRESS};
+pub use execution_state::{ExecutionState, L1BlobDataAvailability, ETH_FEE_TOKEN_ADDRESS};
 pub use felt::{IntoFelt, IntoStarkFelt};
 pub use simulate::{simulate, trace, TraceCache};
 

--- a/crates/pathfinder/examples/re_execute.rs
+++ b/crates/pathfinder/examples/re_execute.rs
@@ -85,9 +85,9 @@ fn main() -> anyhow::Result<()> {
         .par_bridge()
         .for_each_with(storage, |storage, block| execute(storage, chain_id, block));
 
-    let elapsed = start_time.elapsed().as_millis();
+    let elapsed = start_time.elapsed();
 
-    tracing::debug!(%num_transactions, %elapsed, "Finished");
+    tracing::info!(%num_transactions, ?elapsed, "Finished");
 
     Ok(())
 }

--- a/crates/pathfinder/examples/re_execute.rs
+++ b/crates/pathfinder/examples/re_execute.rs
@@ -187,7 +187,9 @@ fn execute(storage: &mut Storage, chain_id: ChainId, work: Work) {
                     if gas_diff > (actual_gas_consumed * 2 / 10)
                         || data_gas_diff > (actual_data_gas_consumed * 2 / 10)
                     {
-                        tracing::warn!(block_number=%work.header.number, transaction_hash=%receipt.transaction_hash, %estimated_gas_consumed, %actual_gas_consumed, estimated_fee=%estimate.overall_fee, %actual_fee, "Estimation mismatch");
+                        tracing::warn!(block_number=%work.header.number, transaction_hash=%receipt.transaction_hash, %estimated_gas_consumed, %actual_gas_consumed, %estimated_data_gas_consumed, %actual_data_gas_consumed, estimated_fee=%estimate.overall_fee, %actual_fee, "Estimation mismatch");
+                    } else {
+                        tracing::debug!(block_number=%work.header.number, transaction_hash=%receipt.transaction_hash, %estimated_gas_consumed, %actual_gas_consumed, %estimated_data_gas_consumed, %actual_data_gas_consumed, estimated_fee=%estimate.overall_fee, %actual_fee, "Estimation matches");
                     }
                 }
             }

--- a/crates/pathfinder/examples/re_execute.rs
+++ b/crates/pathfinder/examples/re_execute.rs
@@ -146,9 +146,9 @@ fn execute(storage: &mut Storage, chain_id: ChainId, work: Work) {
         }
     };
 
-    match pathfinder_executor::estimate(execution_state, transactions, false) {
-        Ok(fee_estimates) => {
-            for (estimate, receipt) in fee_estimates.iter().zip(work.receipts.iter()) {
+    match pathfinder_executor::simulate(execution_state, transactions, false, false) {
+        Ok(simulations) => {
+            for (simulation, receipt) in simulations.iter().zip(work.receipts.iter()) {
                 if let Some(actual_fee) = receipt.actual_fee {
                     let actual_fee =
                         u128::from_be_bytes(actual_fee.0.to_be_bytes()[16..].try_into().unwrap());
@@ -157,6 +157,8 @@ fn execute(storage: &mut Storage, chain_id: ChainId, work: Work) {
                     if actual_fee == 0 {
                         continue;
                     }
+
+                    let estimate = &simulation.fee_estimation;
 
                     let (gas_price, data_gas_price) = match estimate.unit {
                         pathfinder_executor::types::PriceUnit::Wei => (

--- a/crates/pathfinder/examples/re_execute.rs
+++ b/crates/pathfinder/examples/re_execute.rs
@@ -95,6 +95,7 @@ fn main() -> anyhow::Result<()> {
 fn get_chain_id(tx: &pathfinder_storage::Transaction<'_>) -> anyhow::Result<ChainId> {
     use pathfinder_common::consts::{
         GOERLI_INTEGRATION_GENESIS_HASH, GOERLI_TESTNET_GENESIS_HASH, MAINNET_GENESIS_HASH,
+        SEPOLIA_INTEGRATION_GENESIS_HASH, SEPOLIA_TESTNET_GENESIS_HASH,
     };
 
     let (_, genesis_hash) = tx
@@ -106,6 +107,8 @@ fn get_chain_id(tx: &pathfinder_storage::Transaction<'_>) -> anyhow::Result<Chai
         MAINNET_GENESIS_HASH => ChainId::MAINNET,
         GOERLI_TESTNET_GENESIS_HASH => ChainId::GOERLI_TESTNET,
         GOERLI_INTEGRATION_GENESIS_HASH => ChainId::GOERLI_INTEGRATION,
+        SEPOLIA_TESTNET_GENESIS_HASH => ChainId::SEPOLIA_TESTNET,
+        SEPOLIA_INTEGRATION_GENESIS_HASH => ChainId::SEPOLIA_INTEGRATION,
         _ => anyhow::bail!("Unknown chain"),
     };
 

--- a/crates/rpc/src/test_setup.rs
+++ b/crates/rpc/src/test_setup.rs
@@ -53,8 +53,9 @@ pub async fn test_storage<F: FnOnce(StateUpdate) -> StateUpdate>(
         .with_timestamp(BlockTimestamp::new_or_panic(1))
         .with_eth_l1_gas_price(GasPrice(1))
         .with_strk_l1_gas_price(GasPrice(2))
-        .with_eth_l1_data_gas_price(GasPrice(1))
+        .with_eth_l1_data_gas_price(GasPrice(2))
         .with_strk_l1_data_gas_price(GasPrice(2))
+        .with_l1_da_mode(pathfinder_common::L1DataAvailabilityMode::Blob)
         .with_sequencer_address(sequencer_address!(
             "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8"
         ))

--- a/crates/rpc/src/v05/method/call.rs
+++ b/crates/rpc/src/v05/method/call.rs
@@ -3,7 +3,7 @@ use crate::error::ApplicationError;
 use crate::felt::RpcFelt;
 use anyhow::Context;
 use pathfinder_common::{BlockId, CallParam, CallResultValue, ContractAddress, EntryPoint};
-use pathfinder_executor::ExecutionState;
+use pathfinder_executor::{ExecutionState, L1BlobDataAvailability};
 
 #[derive(Debug)]
 pub enum CallError {
@@ -109,7 +109,13 @@ pub async fn call(context: RpcContext, input: CallInput) -> Result<CallOutput, C
             }
         };
 
-        let state = ExecutionState::simulation(&db, context.chain_id, header, pending);
+        let state = ExecutionState::simulation(
+            &db,
+            context.chain_id,
+            header,
+            pending,
+            L1BlobDataAvailability::Disabled,
+        );
 
         let result = pathfinder_executor::call(
             state,

--- a/crates/rpc/src/v05/method/estimate_fee.rs
+++ b/crates/rpc/src/v05/method/estimate_fee.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use pathfinder_executor::ExecutionState;
+use pathfinder_executor::{ExecutionState, L1BlobDataAvailability};
 use serde_with::serde_as;
 
 use crate::{
@@ -127,7 +127,13 @@ pub async fn estimate_fee(
             }
         };
 
-        let state = ExecutionState::simulation(&db, context.chain_id, header, pending);
+        let state = ExecutionState::simulation(
+            &db,
+            context.chain_id,
+            header,
+            pending,
+            L1BlobDataAvailability::Disabled,
+        );
 
         let transactions = input
             .request

--- a/crates/rpc/src/v05/method/simulate_transactions.rs
+++ b/crates/rpc/src/v05/method/simulate_transactions.rs
@@ -5,7 +5,9 @@ use crate::{
 use anyhow::Context;
 use pathfinder_common::{BlockId, CallParam, EntryPoint};
 use pathfinder_crypto::Felt;
-use pathfinder_executor::{types::TransactionSimulation, TransactionExecutionError};
+use pathfinder_executor::{
+    types::TransactionSimulation, L1BlobDataAvailability, TransactionExecutionError,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Debug)]
@@ -123,8 +125,13 @@ pub async fn simulate_transactions(
             }
         };
 
-        let state =
-            pathfinder_executor::ExecutionState::simulation(&db, context.chain_id, header, pending);
+        let state = pathfinder_executor::ExecutionState::simulation(
+            &db,
+            context.chain_id,
+            header,
+            pending,
+            L1BlobDataAvailability::Disabled,
+        );
 
         let transactions = input
             .transactions

--- a/crates/rpc/src/v06/method/estimate_fee.rs
+++ b/crates/rpc/src/v06/method/estimate_fee.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use pathfinder_executor::ExecutionState;
+use pathfinder_executor::{ExecutionState, L1BlobDataAvailability};
 use serde_with::serde_as;
 
 use crate::{
@@ -143,7 +143,13 @@ pub async fn estimate_fee(
             }
         };
 
-        let state = ExecutionState::simulation(&db, context.chain_id, header, pending);
+        let state = ExecutionState::simulation(
+            &db,
+            context.chain_id,
+            header,
+            pending,
+            L1BlobDataAvailability::Disabled,
+        );
 
         let skip_validate = input
             .simulation_flags

--- a/crates/rpc/src/v06/method/estimate_message_fee.rs
+++ b/crates/rpc/src/v06/method/estimate_message_fee.rs
@@ -5,7 +5,7 @@ use pathfinder_common::{
     BlockId, CallParam, ChainId, ContractAddress, EntryPoint, EthereumAddress, TransactionNonce,
 };
 use pathfinder_crypto::Felt;
-use pathfinder_executor::{ExecutionState, IntoStarkFelt};
+use pathfinder_executor::{ExecutionState, IntoStarkFelt, L1BlobDataAvailability};
 use starknet_api::core::PatriciaKey;
 
 use crate::{context::RpcContext, error::ApplicationError, v06::method::estimate_fee::FeeEstimate};
@@ -129,7 +129,13 @@ pub(crate) async fn estimate_message_fee_impl(
             return Err(EstimateMessageFeeError::ContractNotFound);
         }
 
-        let state = ExecutionState::simulation(&db, context.chain_id, header, pending);
+        let state = ExecutionState::simulation(
+            &db,
+            context.chain_id,
+            header,
+            pending,
+            L1BlobDataAvailability::Disabled,
+        );
 
         let transaction = create_executor_transaction(input, context.chain_id)?;
 

--- a/crates/rpc/src/v06/method/simulate_transactions.rs
+++ b/crates/rpc/src/v06/method/simulate_transactions.rs
@@ -5,7 +5,9 @@ use crate::{
 use anyhow::Context;
 use pathfinder_common::{BlockId, CallParam, EntryPoint};
 use pathfinder_crypto::Felt;
-use pathfinder_executor::{types::TransactionSimulation, TransactionExecutionError};
+use pathfinder_executor::{
+    types::TransactionSimulation, L1BlobDataAvailability, TransactionExecutionError,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Debug)]
@@ -126,8 +128,13 @@ pub async fn simulate_transactions(
             }
         };
 
-        let state =
-            pathfinder_executor::ExecutionState::simulation(&db, context.chain_id, header, pending);
+        let state = pathfinder_executor::ExecutionState::simulation(
+            &db,
+            context.chain_id,
+            header,
+            pending,
+            L1BlobDataAvailability::Disabled,
+        );
 
         let transactions = input
             .transactions


### PR DESCRIPTION
If the block has its `l1_da_mode` set to blob we now enable using it in the block context for blockifier.

Pre-v0.7 JSON-RPC estimate/simulate methods purpusefully disable this feature even if the block we're executing on has it enabled. This is because these methods do not return `data_gas_consumed` so `resource_bounds` would not be initialized properly based on that partial fee estimate.

Since we don't have JSON-RPC 0.7 methods using this feature I have only tested this feature using the `re_execute` tool on Sepolia integration.

Partially implements #1782