### PR TITLE
feat(rpc/v0.7): add methods impacted by receipt DTOs

### DIFF
--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -828,7 +828,6 @@ mod tests {
         "starknet_getTransactionStatus",
         "starknet_estimateFee",
         "starknet_estimateMessageFee",
-        "starknet_getBlockWithTxs",
         "starknet_getTransactionByBlockIdAndIndex",
         "starknet_getTransactionByHash",
     ])]

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -828,7 +828,6 @@ mod tests {
         "starknet_getTransactionStatus",
         "starknet_estimateFee",
         "starknet_estimateMessageFee",
-        "starknet_getBlockWithTxHashes",
         "starknet_getBlockWithTxs",
         "starknet_getTransactionByBlockIdAndIndex",
         "starknet_getTransactionByHash",

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -832,7 +832,6 @@ mod tests {
         "starknet_getBlockWithTxs",
         "starknet_getTransactionByBlockIdAndIndex",
         "starknet_getTransactionByHash",
-        "starknet_getTransactionReceipt",
     ])]
     #[case::v0_7_trace("/rpc/v0_7", "v07/starknet_trace_api_openrpc.json", &[
         "starknet_simulateTransactions",

--- a/crates/rpc/src/v07.rs
+++ b/crates/rpc/src/v07.rs
@@ -29,7 +29,7 @@ pub fn register_routes() -> RpcRouterBuilder {
         // .register("starknet_addInvokeTransaction"            , method::add_invoke_transaction)
         // .register("starknet_estimateFee"                     , method::estimate_fee)
         // .register("starknet_estimateMessageFee"              , method::estimate_message_fee)
-        // .register("starknet_getBlockWithTxHashes"            , method::get_block_with_tx_hashes)
+        .register("starknet_getBlockWithTxHashes",                method::get_block_with_tx_hashes)
         // .register("starknet_getBlockWithTxs"                 , method::get_block_with_txs)
         // .register("starknet_getTransactionByBlockIdAndIndex" , method::get_transaction_by_block_id_and_index)
         // .register("starknet_getTransactionByHash"            , method::get_transaction_by_hash)

--- a/crates/rpc/src/v07.rs
+++ b/crates/rpc/src/v07.rs
@@ -33,7 +33,7 @@ pub fn register_routes() -> RpcRouterBuilder {
         // .register("starknet_getBlockWithTxs"                 , method::get_block_with_txs)
         // .register("starknet_getTransactionByBlockIdAndIndex" , method::get_transaction_by_block_id_and_index)
         // .register("starknet_getTransactionByHash"            , method::get_transaction_by_hash)
-        // .register("starknet_getTransactionReceipt"           , method::get_transaction_receipt)
+        .register("starknet_getTransactionReceipt",               method::get_transaction_receipt)
         // .register("starknet_simulateTransactions"            , method::simulate_transactions)
         .register("starknet_specVersion",                         || "0.7.0-rc0")
         // .register("starknet_traceBlockTransactions"          , method::trace_block_transactions)

--- a/crates/rpc/src/v07.rs
+++ b/crates/rpc/src/v07.rs
@@ -30,7 +30,7 @@ pub fn register_routes() -> RpcRouterBuilder {
         // .register("starknet_estimateFee"                     , method::estimate_fee)
         // .register("starknet_estimateMessageFee"              , method::estimate_message_fee)
         .register("starknet_getBlockWithTxHashes",                method::get_block_with_tx_hashes)
-        // .register("starknet_getBlockWithTxs"                 , method::get_block_with_txs)
+        .register("starknet_getBlockWithTxs",                     method::get_block_with_txs)
         // .register("starknet_getTransactionByBlockIdAndIndex" , method::get_transaction_by_block_id_and_index)
         // .register("starknet_getTransactionByHash"            , method::get_transaction_by_hash)
         .register("starknet_getTransactionReceipt",               method::get_transaction_receipt)

--- a/crates/rpc/src/v07/method.rs
+++ b/crates/rpc/src/v07/method.rs
@@ -1,5 +1,7 @@
 mod get_block_with_receipts;
+mod get_block_with_tx_hashes;
 mod get_transaction_receipt;
 
 pub(crate) use get_block_with_receipts::get_block_with_receipts;
+pub(crate) use get_block_with_tx_hashes::get_block_with_tx_hashes;
 pub(crate) use get_transaction_receipt::get_transaction_receipt;

--- a/crates/rpc/src/v07/method.rs
+++ b/crates/rpc/src/v07/method.rs
@@ -1,7 +1,9 @@
 mod get_block_with_receipts;
 mod get_block_with_tx_hashes;
+mod get_block_with_txs;
 mod get_transaction_receipt;
 
 pub(crate) use get_block_with_receipts::get_block_with_receipts;
 pub(crate) use get_block_with_tx_hashes::get_block_with_tx_hashes;
+pub(crate) use get_block_with_txs::get_block_with_txs;
 pub(crate) use get_transaction_receipt::get_transaction_receipt;

--- a/crates/rpc/src/v07/method.rs
+++ b/crates/rpc/src/v07/method.rs
@@ -1,3 +1,5 @@
 mod get_block_with_receipts;
+mod get_transaction_receipt;
 
 pub(crate) use get_block_with_receipts::get_block_with_receipts;
+pub(crate) use get_transaction_receipt::get_transaction_receipt;

--- a/crates/rpc/src/v07/method/get_block_with_tx_hashes.rs
+++ b/crates/rpc/src/v07/method/get_block_with_tx_hashes.rs
@@ -1,0 +1,98 @@
+use crate::context::RpcContext;
+use crate::v02::types::reply::BlockStatus;
+use crate::v07::dto;
+use pathfinder_common::TransactionHash;
+
+use anyhow::Context;
+use pathfinder_common::BlockId;
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Input {
+    block_id: BlockId,
+}
+
+#[derive(serde::Serialize)]
+#[serde(untagged)]
+pub enum Output {
+    Full(BlockWithTxHashes),
+    Pending(PendingBlockWithTxHashes),
+}
+
+#[derive(serde::Serialize)]
+pub struct BlockWithTxHashes {
+    #[serde(flatten)]
+    header: dto::header::Header,
+    status: BlockStatus,
+    transactions: Vec<TransactionHash>,
+}
+
+#[derive(serde::Serialize)]
+pub struct PendingBlockWithTxHashes {
+    #[serde(flatten)]
+    header: dto::header::PendingHeader,
+    status: BlockStatus,
+    transactions: Vec<TransactionHash>,
+}
+
+crate::error::generate_rpc_error_subset!(Error: BlockNotFound);
+
+/// Get block information with transaction hashes given the block id
+pub async fn get_block_with_tx_hashes(context: RpcContext, input: Input) -> Result<Output, Error> {
+    let span = tracing::Span::current();
+
+    tokio::task::spawn_blocking(move || {
+        let _g = span.enter();
+        let mut connection = context
+            .storage
+            .connection()
+            .context("Opening database connection")?;
+
+        let transaction = connection
+            .transaction()
+            .context("Creating database transaction")?;
+
+        let block_id = match input.block_id {
+            BlockId::Pending => {
+                let pending = context
+                    .pending_data
+                    .get(&transaction)
+                    .context("Querying pending data")?;
+
+                let transactions = pending.block.transactions.iter().map(|t| t.hash).collect();
+
+                return Ok(Output::Pending(PendingBlockWithTxHashes {
+                    header: pending.header().into(),
+                    status: BlockStatus::Pending,
+                    transactions,
+                }));
+            }
+            other => other.try_into().expect("Only pending cast should fail"),
+        };
+
+        let header = transaction
+            .block_header(block_id)
+            .context("Reading block from database")?
+            .ok_or(Error::BlockNotFound)?;
+
+        let l1_accepted = transaction.block_is_l1_accepted(header.number.into())?;
+        let status = if l1_accepted {
+            BlockStatus::AcceptedOnL1
+        } else {
+            BlockStatus::AcceptedOnL2
+        };
+
+        let transactions = transaction
+            .transaction_hashes_for_block(header.number.into())
+            .context("Reading transaction hashes")?
+            .context("Transaction hashes missing")?;
+
+        Ok(Output::Full(BlockWithTxHashes {
+            header: header.into(),
+            status,
+            transactions,
+        }))
+    })
+    .await
+    .context("Joining blocking task")?
+}

--- a/crates/rpc/src/v07/method/get_block_with_txs.rs
+++ b/crates/rpc/src/v07/method/get_block_with_txs.rs
@@ -1,0 +1,108 @@
+use crate::context::RpcContext;
+use crate::v02::types::reply::BlockStatus;
+use crate::v06::types::TransactionWithHash;
+use crate::v07::dto;
+
+use anyhow::Context;
+use pathfinder_common::BlockId;
+use serde::Serialize;
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Input {
+    block_id: BlockId,
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum Output {
+    Full(BlockWithTxs),
+    Pending(PendingBlockWithTxs),
+}
+
+#[derive(Serialize)]
+pub struct BlockWithTxs {
+    #[serde(flatten)]
+    header: dto::header::Header,
+    status: BlockStatus,
+    transactions: Vec<TransactionWithHash>,
+}
+
+#[derive(Serialize)]
+pub struct PendingBlockWithTxs {
+    #[serde(flatten)]
+    header: dto::header::PendingHeader,
+    status: BlockStatus,
+    transactions: Vec<TransactionWithHash>,
+}
+
+crate::error::generate_rpc_error_subset!(Error: BlockNotFound);
+
+/// Get block information with full transactions given the block id
+pub async fn get_block_with_txs(context: RpcContext, input: Input) -> Result<Output, Error> {
+    let span = tracing::Span::current();
+
+    tokio::task::spawn_blocking(move || {
+        let _g = span.enter();
+        let mut connection = context
+            .storage
+            .connection()
+            .context("Opening database connection")?;
+
+        let transaction = connection
+            .transaction()
+            .context("Creating database transaction")?;
+
+        let block_id = match input.block_id {
+            BlockId::Pending => {
+                let pending = context
+                    .pending_data
+                    .get(&transaction)
+                    .context("Querying pending data")?;
+
+                let transactions = pending
+                    .block
+                    .transactions
+                    .iter()
+                    .cloned()
+                    .map(Into::into)
+                    .collect();
+
+                return Ok(Output::Pending(PendingBlockWithTxs {
+                    header: pending.header().into(),
+                    status: BlockStatus::Pending,
+                    transactions,
+                }));
+            }
+            other => other.try_into().expect("Only pending cast should fail"),
+        };
+
+        let header = transaction
+            .block_header(block_id)
+            .context("Reading block from database")?
+            .ok_or(Error::BlockNotFound)?;
+
+        let l1_accepted = transaction.block_is_l1_accepted(header.number.into())?;
+        let status = if l1_accepted {
+            BlockStatus::AcceptedOnL1
+        } else {
+            BlockStatus::AcceptedOnL2
+        };
+
+        let transactions = transaction
+            .transactions_for_block(header.number.into())
+            .context("Reading transactions from database")?
+            .context("Transaction data missing")?
+            .into_iter()
+            .map(Into::into)
+            .collect();
+
+        Ok(Output::Full(BlockWithTxs {
+            header: header.into(),
+            status,
+            transactions,
+        }))
+    })
+    .await
+    .context("Joining blocking task")?
+}

--- a/crates/rpc/src/v07/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v07/method/get_transaction_receipt.rs
@@ -1,0 +1,87 @@
+use crate::context::RpcContext;
+use crate::v06::method::get_transaction_receipt::types::FinalityStatus;
+use crate::v07::dto;
+use anyhow::Context;
+use pathfinder_common::TransactionHash;
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Input {
+    pub transaction_hash: TransactionHash,
+}
+
+#[derive(serde::Serialize)]
+#[serde(untagged)]
+pub enum Output {
+    Full(dto::receipt::TxnReceipt),
+    Pending(dto::receipt::PendingTxnReceipt),
+}
+
+crate::error::generate_rpc_error_subset!(Error: TxnHashNotFound);
+
+pub async fn get_transaction_receipt(context: RpcContext, input: Input) -> Result<Output, Error> {
+    let span = tracing::Span::current();
+
+    tokio::task::spawn_blocking(move || {
+        let _g = span.enter();
+        let mut db = context
+            .storage
+            .connection()
+            .context("Opening database connection")?;
+
+        let db_tx = db.transaction().context("Creating database transaction")?;
+
+        // Check pending transactions.
+        let pending = context
+            .pending_data
+            .get(&db_tx)
+            .context("Querying pending data")?;
+
+        if let Some((transaction, receipt)) = pending
+            .block
+            .transactions
+            .iter()
+            .zip(pending.block.transaction_receipts.iter())
+            .find_map(|(t, r)| (t.hash == input.transaction_hash).then(|| (t.clone(), r.clone())))
+        {
+            let receipt = dto::receipt::PendingTxnReceipt::from_common(
+                &transaction,
+                receipt,
+                FinalityStatus::AcceptedOnL2,
+            );
+
+            return Ok(Output::Pending(receipt));
+        }
+
+        let (transaction, receipt, block_hash) = db_tx
+            .transaction_with_receipt(input.transaction_hash)
+            .context("Reading transaction receipt from database")?
+            .ok_or(Error::TxnHashNotFound)?;
+
+        let block_number = db_tx
+            .block_id(block_hash.into())
+            .context("Querying block number")?
+            .context("Block number info missing")?
+            .0;
+
+        let l1_accepted = db_tx
+            .block_is_l1_accepted(block_number.into())
+            .context("Querying block status")?;
+
+        let finality_status = if l1_accepted {
+            FinalityStatus::AcceptedOnL1
+        } else {
+            FinalityStatus::AcceptedOnL2
+        };
+
+        Ok(Output::Full(dto::receipt::TxnReceipt::from_common(
+            &transaction,
+            receipt,
+            block_hash,
+            block_number,
+            finality_status,
+        )))
+    })
+    .await
+    .context("Joining blocking task")?
+}


### PR DESCRIPTION
This PR adds RPC v0.7 implementations for 
- `starknet_getBlockWithTxs`
- `starknet_getBlockWithTxHashes`
- `starknet_getTransactionReceipt`

The implementations are largely just copied over from the v0.6 implementations, but with some additions to account for the new v0.7 DTOs.

This PR is light on tests - I thought these are simple enough, and covered by v0.6 tests and the DTO tests themselves. However, let me know if I should transfer the v0.6 tests over.

Closes #1801, closes #1802, closes #1803.