### PR TITLE
fix(executor): always provide old block number and hash to `pre_process_block()`

### DIFF
--- a/crates/executor/src/execution_state.rs
+++ b/crates/executor/src/execution_state.rs
@@ -94,9 +94,7 @@ impl<'tx> ExecutionState<'tx> {
 
         // Perform system contract updates if we are executing ontop of a parent block.
         // Currently this is only the block hash from 10 blocks ago.
-        let old_block_number_and_hash = if self.execute_on_parent_state
-            && self.header.number.get() >= 10
-        {
+        let old_block_number_and_hash = if self.header.number.get() >= 10 {
             let block_number_whose_hash_becomes_available =
                 pathfinder_common::BlockNumber::new_or_panic(self.header.number.get() - 10);
             let block_hash = self


### PR DESCRIPTION

Previously we did an optimization here: if we were using state from the end of a block then the state already had the system contract updates applied so we skipped looking up the block hash.

Now blockifier's `pre_process_block` requires that we always supply this value for blocks > 10, leading to errors with `starknet_call`, `starknet_estimateFee` and `starknet_simulateTransactions` for block height > 10.
