### PR TITLE
feat(pathfinder): switch memory allocator to jemalloc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `starknet_getEvents` implementation is now using a much simpler implementation that no longer relies on SQLite queries. In general this leads to more consistent query times and a roughly 20% smaller database.
   - The migration step involves computing Bloom filters for all blocks and dropping database tables no longer needed. This takes more than one hour for a mainnet database.
   - The new `storage.event-bloom-filter-cache-size`, `rpc.get-events-max-blocks-to-scan` and `rpc.get-events-max-bloom-filters-to-load` arguments control some aspects of the algorithm.
+- The memory allocator used by pathfinder has been changed to jemalloc, leading to improved JSON-RPC performance.
 
 ## [0.10.6] - 2024-02-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4501,6 +4501,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
+name = "jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6101,10 +6121,10 @@ dependencies = [
  "futures",
  "http",
  "ipnet",
+ "jemallocator",
  "lazy_static",
  "metrics",
  "metrics-exporter-prometheus",
- "mimalloc",
  "mockall",
  "p2p",
  "p2p_proto",

--- a/crates/load-test/Cargo.lock
+++ b/crates/load-test/Cargo.lock
@@ -1137,7 +1137,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pathfinder-crypto"
-version = "0.1.0"
+version = "0.11.0-rc0"
 dependencies = [
  "ark-ff",
  "bitvec",

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -34,10 +34,10 @@ console-subscriber = { version = "0.1.10", optional = true }
 fake = { workspace = true }
 futures = { workspace = true }
 ipnet = { workspace = true }
+jemallocator = "0.5.4"
 lazy_static = { workspace = true }
 metrics = { workspace = true }
 metrics-exporter-prometheus = "0.11.0"
-mimalloc = { version = "0.1.39", default-features = false }
 p2p = { path = "../p2p", optional = true }
 p2p_proto = { path = "../p2p_proto", optional = true }
 pathfinder-common = { path = "../common" }

--- a/crates/pathfinder/examples/re_execute.rs
+++ b/crates/pathfinder/examples/re_execute.rs
@@ -1,7 +1,6 @@
 use std::num::NonZeroU32;
 
 use anyhow::Context;
-use mimalloc::MiMalloc;
 use pathfinder_common::receipt::Receipt;
 use pathfinder_common::transaction::Transaction;
 use pathfinder_common::{BlockHeader, BlockNumber, ChainId};
@@ -9,11 +8,11 @@ use pathfinder_executor::ExecutionState;
 use pathfinder_storage::{BlockId, JournalMode, Storage};
 use rayon::prelude::*;
 
-// Due to the amount of JSON parsing that gets done during execution we use an alternate
-// allocator here: mimalloc. According to benchmarks re_execute performs roughly 25% better
-// when using mimalloc.
+// The Cairo VM allocates felts on the stack, so during execution it's making
+// a huge number of allocations. We get roughly two times better execution
+// performance by using jemalloc (compared to the Linux glibc allocator).
 #[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 /// Re-execute transactions in a range of blocks.
 ///

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -2,7 +2,6 @@
 
 use anyhow::Context;
 use metrics_exporter_prometheus::PrometheusBuilder;
-use mimalloc::MiMalloc;
 
 use pathfinder_common::{consts::VERGEN_GIT_DESCRIBE, BlockNumber, Chain, ChainId, EthereumChain};
 use pathfinder_ethereum::{EthereumApi, EthereumClient};
@@ -25,8 +24,11 @@ use crate::config::NetworkConfig;
 mod config;
 mod update;
 
+// The Cairo VM allocates felts on the stack, so during execution it's making
+// a huge number of allocations. We get roughly two times better execution
+// performance by using jemalloc (compared to the Linux glibc allocator).
 #[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 fn main() -> anyhow::Result<()> {
     tokio::runtime::Builder::new_multi_thread()


### PR DESCRIPTION
Compared to mimalloc, jemalloc seems to have even better performance with the Cairo VM.

With the `v06_scripted_mainnet_without_huge_calls` scenario in load-test we seem to get ~23% better performance with jemalloc.