### PR TITLE
feat: v0.11.0 preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.11.0] - 2024-02-27
 
 ### Changed
 
@@ -15,10 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The migration step involves computing Bloom filters for all blocks and dropping database tables no longer needed. This takes more than one hour for a mainnet database.
   - The new `storage.event-bloom-filter-cache-size`, `rpc.get-events-max-blocks-to-scan` and `rpc.get-events-max-bloom-filters-to-load` arguments control some aspects of the algorithm.
 - The memory allocator used by pathfinder has been changed to jemalloc, leading to improved JSON-RPC performance.
+- Improved poseidon hash performance.
+- Default RPC version changed to v0.6.
+
 
 ### Added
 
+- Support for Starknet v0.13.1.
+- Support for RPC v0.7.
 - The request timeout for gateway and feeder-gateway queries is now configurable using `gateway.request-timeout` (`"PATHFINDER_GATEWAY_REQUEST_TIMEOUT"`).
+
+### Fixed
+
+- Websocket control frames aren't handled.
 
 ## [0.10.6] - 2024-02-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5923,7 +5923,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p2p"
-version = "0.11.0-rc0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5959,7 +5959,7 @@ dependencies = [
 
 [[package]]
 name = "p2p_proto"
-version = "0.11.0-rc0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fake",
@@ -5977,7 +5977,7 @@ dependencies = [
 
 [[package]]
 name = "p2p_proto_derive"
-version = "0.11.0-rc0"
+version = "0.11.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5986,7 +5986,7 @@ dependencies = [
 
 [[package]]
 name = "p2p_stream"
-version = "0.11.0-rc0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6104,7 +6104,7 @@ checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
 name = "pathfinder"
-version = "0.11.0-rc0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -6169,7 +6169,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-common"
-version = "0.11.0-rc0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-compiler"
-version = "0.11.0-rc0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "cairo-lang-starknet 1.0.0-alpha.6",
@@ -6209,7 +6209,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-crypto"
-version = "0.11.0-rc0"
+version = "0.11.0"
 dependencies = [
  "ark-ff",
  "assert_matches",
@@ -6225,7 +6225,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-ethereum"
-version = "0.11.0-rc0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6245,7 +6245,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-executor"
-version = "0.11.0-rc0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "blockifier",
@@ -6266,7 +6266,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-merkle-tree"
-version = "0.11.0-rc0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -6282,7 +6282,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-retry"
-version = "0.11.0-rc0"
+version = "0.11.0"
 dependencies = [
  "tokio",
  "tokio-retry",
@@ -6290,7 +6290,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-rpc"
-version = "0.11.0-rc0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -6339,7 +6339,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-serde"
-version = "0.11.0-rc0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "num-bigint",
@@ -6354,7 +6354,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-storage"
-version = "0.11.0-rc0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -7991,7 +7991,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-gateway-client"
-version = "0.11.0-rc0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -8025,7 +8025,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-gateway-test-fixtures"
-version = "0.11.0-rc0"
+version = "0.11.0"
 dependencies = [
  "pathfinder-common",
  "pathfinder-crypto",
@@ -8033,7 +8033,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-gateway-types"
-version = "0.11.0-rc0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ codegen-units = 1
 lto = true
 
 [workspace.package]
-version = "0.11.0-rc0"
+version = "0.11.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.74"

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -81,7 +81,7 @@ Examples:
     #[arg(
         long = "rpc.root-version",
         long_help = "Version of the JSON-RPC API to serve on the / (root) path",
-        default_value = "v05",
+        default_value = "v06",
         env = "PATHFINDER_RPC_ROOT_VERSION"
     )]
     rpc_root_version: RpcVersion,


### PR DESCRIPTION
This PR updates the changelog and bumps the crate version for v0.11.0 release. In addition, also changes the default RPC version to v0.6.