### PR TITLE
chore: make tests faster

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ inherits = "release"
 codegen-units = 1
 lto = true
 
+[profile.dev.package.flate2]
+opt-level = 3
+
 [workspace.package]
 version = "0.11.0"
 edition = "2021"

--- a/justfile
+++ b/justfile
@@ -2,7 +2,14 @@ default:
     just --summary --unsorted
 
 test $RUST_BACKTRACE="1" *args="":
-    cargo nextest run --no-fail-fast --all-targets --all-features --workspace --locked {{args}}
+    cargo nextest run --no-fail-fast --all-targets --all-features --workspace --locked \
+    -E 'not test(/^p2p_network::sync_handlers::tests::prop/)' \
+    {{args}}
+
+proptest $RUST_BACKTRACE="1" *args="":
+    cargo nextest run --no-fail-fast --all-targets --all-features --workspace --locked \
+    -E 'test(/^p2p_network::sync_handlers::tests::prop/)' \
+    {{args}}
 
 build:
     cargo build --workspace --all-targets


### PR DESCRIPTION
flate2 1.0.28 built unoptimized is significantly slower than before an unsafe unsoundness was fixed. This unnecessarily slows down some of our tests which use `flate2` during test setup. (For more info please check https://github.com/rust-lang/flate2-rs/issues/395)

This PR makes sure that `flate2` is optimized even for a `dev` build.

In addition, `just test` now skips running the p2p proptests which take a long time to run. You can explicitly run those using `just proptest`.