### PR TITLE
chore(github): upgrade docker/metadata-action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Determine Docker image metadata
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: eqlabs/pathfinder
       - name: Checkout sources


### PR DESCRIPTION
So that we avoid a warning about the Node 20 upgrade: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

