### PR TITLE
chore(rpc/v07): add Invoke v3 test to `starknet_simulateTransactions`

### DIFF
--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -15,7 +15,9 @@ pub use call::call;
 pub use class::{parse_casm_definition, parse_deprecated_class_definition};
 pub use error::{CallError, TransactionExecutionError};
 pub use estimate::estimate;
-pub use execution_state::{ExecutionState, L1BlobDataAvailability, ETH_FEE_TOKEN_ADDRESS};
+pub use execution_state::{
+    ExecutionState, L1BlobDataAvailability, ETH_FEE_TOKEN_ADDRESS, STRK_FEE_TOKEN_ADDRESS,
+};
 pub use felt::{IntoFelt, IntoStarkFelt};
 pub use simulate::{simulate, trace, TraceCache};
 

--- a/crates/rpc/src/test_setup.rs
+++ b/crates/rpc/src/test_setup.rs
@@ -77,8 +77,17 @@ pub async fn test_storage<F: FnOnce(StateUpdate) -> StateUpdate>(
         .with_deployed_contract(account_contract_address, DUMMY_ACCOUNT_CLASS_HASH)
         .with_deployed_contract(universal_deployer_address, universal_deployer_class_hash)
         .with_deployed_contract(pathfinder_executor::ETH_FEE_TOKEN_ADDRESS, erc20_class_hash)
+        .with_deployed_contract(
+            pathfinder_executor::STRK_FEE_TOKEN_ADDRESS,
+            erc20_class_hash,
+        )
         .with_storage_update(
             pathfinder_executor::ETH_FEE_TOKEN_ADDRESS,
+            account_balance_key,
+            storage_value!("0x10000000000000000000000000000"),
+        )
+        .with_storage_update(
+            pathfinder_executor::STRK_FEE_TOKEN_ADDRESS,
             account_balance_key,
             storage_value!("0x10000000000000000000000000000"),
         );

--- a/crates/rpc/src/v04/method/simulate_transactions.rs
+++ b/crates/rpc/src/v04/method/simulate_transactions.rs
@@ -718,6 +718,12 @@ pub(crate) mod tests {
             class_hash!("0x06f38fb91ddbf325a0625533576bb6f6eafd9341868a9ec3faa4b01ce6c4f4dc");
 
         pub mod input {
+            use pathfinder_common::{ResourceAmount, ResourcePricePerUnit, Tip};
+
+            use crate::v02::types::{
+                request::BroadcastedInvokeTransactionV3, ResourceBound, ResourceBounds,
+            };
+
             use super::*;
 
             pub fn declare(account_contract_address: ContractAddress) -> BroadcastedTransaction {
@@ -778,6 +784,39 @@ pub(crate) mod tests {
                         version: TransactionVersion::ONE,
                         max_fee: MAX_FEE,
                         signature: vec![],
+                        sender_address: account_contract_address,
+                        calldata: vec![
+                            CallParam(*DEPLOYED_CONTRACT_ADDRESS.get()),
+                            // Entry point selector for the called contract, i.e. AccountCallArray::selector
+                            CallParam(EntryPoint::hashed(b"get_data").0),
+                            // Length of the call data for the called contract, i.e. AccountCallArray::data_len
+                            call_param!("0"),
+                        ],
+                    },
+                ))
+            }
+
+            pub fn invoke_v3(account_contract_address: ContractAddress) -> BroadcastedTransaction {
+                BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V3(
+                    BroadcastedInvokeTransactionV3 {
+                        version: TransactionVersion::THREE,
+                        signature: vec![],
+                        nonce: transaction_nonce!("0x3"),
+                        resource_bounds: ResourceBounds {
+                            l1_gas: ResourceBound {
+                                max_amount: ResourceAmount(10000),
+                                max_price_per_unit: ResourcePricePerUnit(100000000),
+                            },
+                            l2_gas: ResourceBound {
+                                max_amount: ResourceAmount(10000),
+                                max_price_per_unit: ResourcePricePerUnit(100000000),
+                            },
+                        },
+                        tip: Tip(0),
+                        paymaster_data: vec![],
+                        account_deployment_data: vec![],
+                        nonce_data_availability_mode: crate::v02::types::DataAvailabilityMode::L1,
+                        fee_data_availability_mode: crate::v02::types::DataAvailabilityMode::L1,
                         sender_address: account_contract_address,
                         calldata: vec![
                             CallParam(*DEPLOYED_CONTRACT_ADDRESS.get()),


### PR DESCRIPTION
This PR adds an additional Invoke v3 transaction using STRK for fee payment to the JSON-RPC 0.7.0 `starknet_simulateTransactions` tests.