### PR TITLE
fix(rpc): fix transaction hash calculation for query only transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Transaction hash calculation for transactions using the "query version" flag is broken for `starknet_estimateFee` and `starknet_simulateTransactions`.
+
 ## [0.11.0] - 2024-02-27
 
 ### Changed

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -206,6 +206,14 @@ impl TransactionVersion {
         self.0.as_be_bytes()[15] & 0b0000_0001 != 0
     }
 
+    pub fn with_query_only(self, query_only: bool) -> Self {
+        if query_only {
+            self.with_query_version()
+        } else {
+            Self(self.without_query_version().into())
+        }
+    }
+
     pub const ZERO: Self = Self(Felt::ZERO);
     pub const ONE: Self = Self(Felt::from_u64(1));
     pub const TWO: Self = Self(Felt::from_u64(2));


### PR DESCRIPTION
A recent refactor broke transaction hash calculation for BroadcastedTransaction instances with the query flag set in their version field.

The common `TransactionVariant` type cannot represent the "query only" flag so we were losing that bit of information when converting the broadcasted transaction type to perform hash calculation.

This change adds a `query_only` flag to the hash calculation itself, as that is the only place we should care about the value of this flag.
