### PR TITLE
fix(storage/event): fix handling of page overflow for last block in range

### DIFF
--- a/crates/storage/src/connection/event.rs
+++ b/crates/storage/src/connection/event.rs
@@ -670,7 +670,7 @@ mod tests {
     }
 
     #[test]
-    fn get_events_by_key_v03() {
+    fn get_events_by_key() {
         let (storage, test_data) = test_utils::setup_test_storage();
         let emitted_events = test_data.events;
         let mut connection = storage.connection().unwrap();
@@ -914,7 +914,7 @@ mod tests {
     }
 
     #[test]
-    fn get_events_by_key_v03_with_paging() {
+    fn get_events_by_key_with_paging() {
         let (storage, test_data) = test_utils::setup_test_storage();
         let emitted_events = test_data.events;
         let mut connection = storage.connection().unwrap();

--- a/crates/storage/src/connection/event.rs
+++ b/crates/storage/src/connection/event.rs
@@ -120,11 +120,6 @@ pub(super) fn get_events(
             break ScanResult::Done;
         }
 
-        // Stop if we have a page of events plus an extra one to decide if we're on the last page.
-        if emitted_events.len() > filter.page_size {
-            break ScanResult::PageFull;
-        }
-
         // Check bloom filter
         if !key_filter_is_empty || filter.contract_address.is_some() {
             let bloom = load_bloom(tx, reorg_counter, block_number)?;
@@ -167,6 +162,11 @@ pub(super) fn get_events(
             BlockScanResult::Done { new_offset } => {
                 offset = new_offset;
             }
+        }
+
+        // Stop if we have a page of events plus an extra one to decide if we're on the last page.
+        if emitted_events.len() > filter.page_size {
+            break ScanResult::PageFull;
         }
 
         block_number += 1;
@@ -593,6 +593,69 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
+            events,
+            PageOfEvents {
+                events: expected_events.to_vec(),
+                continuation_token: None,
+            }
+        );
+    }
+
+    #[test]
+    fn get_events_up_to_block_with_paging() {
+        let (storage, test_data) = test_utils::setup_test_storage();
+        let emitted_events = test_data.events;
+        let mut connection = storage.connection().unwrap();
+        let tx = connection.transaction().unwrap();
+
+        let filter = EventFilter {
+            from_block: None,
+            to_block: Some(BlockNumber::new_or_panic(1)),
+            contract_address: None,
+            keys: vec![],
+            page_size: test_utils::EVENTS_PER_BLOCK + 1,
+            offset: 0,
+        };
+
+        let expected_events = &emitted_events[..test_utils::EVENTS_PER_BLOCK + 1];
+        let events = get_events(
+            &tx,
+            &filter,
+            *MAX_BLOCKS_TO_SCAN,
+            *MAX_BLOOM_FILTERS_TO_LOAD,
+        )
+        .unwrap();
+        pretty_assertions_sorted::assert_eq!(
+            events,
+            PageOfEvents {
+                events: expected_events.to_vec(),
+                continuation_token: Some(ContinuationToken {
+                    block_number: BlockNumber::new_or_panic(1),
+                    offset: 1
+                }),
+            }
+        );
+
+        // test continuation token
+        let filter = EventFilter {
+            from_block: Some(events.continuation_token.unwrap().block_number),
+            to_block: Some(BlockNumber::new_or_panic(1)),
+            contract_address: None,
+            keys: vec![],
+            page_size: test_utils::EVENTS_PER_BLOCK + 1,
+            offset: events.continuation_token.unwrap().offset,
+        };
+
+        let expected_events =
+            &emitted_events[test_utils::EVENTS_PER_BLOCK + 1..test_utils::EVENTS_PER_BLOCK * 2];
+        let events = get_events(
+            &tx,
+            &filter,
+            *MAX_BLOCKS_TO_SCAN,
+            *MAX_BLOOM_FILTERS_TO_LOAD,
+        )
+        .unwrap();
+        pretty_assertions_sorted::assert_eq!(
             events,
             PageOfEvents {
                 events: expected_events.to_vec(),

--- a/crates/storage/src/connection/event.rs
+++ b/crates/storage/src/connection/event.rs
@@ -61,13 +61,6 @@ pub struct PageOfEvents {
     pub continuation_token: Option<ContinuationToken>,
 }
 
-#[derive(Debug, PartialEq)]
-pub struct KeyFilterResult<'a> {
-    pub base_query: &'static str,
-    pub where_statement: &'static str,
-    pub param: (&'static str, rusqlite::types::ToSqlOutput<'a>),
-}
-
 pub(super) fn insert_block_events<'a>(
     tx: &Transaction<'_>,
     block_number: BlockNumber,


### PR DESCRIPTION
Previously we did the is-page-full check _after_ increasing the current block number and checking if we're out of the range in the filter.

This causes the code to behave like it's done scanning the block range even if not all events from the last block fit into the page.

This change fixes the issue by moving the check right after the potentially page-filling `scan_block_into()` call.

Closes #1844 