### PR TITLE
feat(rpc): RPC version-aware serialization

### DIFF
--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -198,10 +198,10 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
     };
 
     let default_version = match config.rpc_root_version {
-        config::RpcVersion::V04 => pathfinder_rpc::DefaultVersion::V04,
-        config::RpcVersion::V05 => pathfinder_rpc::DefaultVersion::V05,
-        config::RpcVersion::V06 => pathfinder_rpc::DefaultVersion::V06,
-        config::RpcVersion::V07 => pathfinder_rpc::DefaultVersion::V07,
+        config::RpcVersion::V04 => pathfinder_rpc::RpcVersion::V04,
+        config::RpcVersion::V05 => pathfinder_rpc::RpcVersion::V05,
+        config::RpcVersion::V06 => pathfinder_rpc::RpcVersion::V06,
+        config::RpcVersion::V07 => pathfinder_rpc::RpcVersion::V07,
     };
 
     let rpc_server = pathfinder_rpc::RpcServer::new(config.rpc_address, context, default_version);

--- a/crates/rpc/src/dto.rs
+++ b/crates/rpc/src/dto.rs
@@ -1,0 +1,3 @@
+#![allow(unused)]
+
+pub mod serialize;

--- a/crates/rpc/src/dto/serialize.rs
+++ b/crates/rpc/src/dto/serialize.rs
@@ -1,0 +1,233 @@
+use crate::RpcVersion;
+
+#[derive(Copy, Clone)]
+#[cfg_attr(test, derive(Default))]
+pub struct Serializer {
+    pub version: RpcVersion,
+}
+
+pub struct SerializeStruct {
+    pub version: RpcVersion,
+    fields: serde_json::Map<String, Ok>,
+}
+
+type BaseSerializer = serde_json::value::Serializer;
+pub(crate) type Ok = <BaseSerializer as serde::Serializer>::Ok;
+pub(crate) type Error = <BaseSerializer as serde::Serializer>::Error;
+
+pub trait SerializeForVersion {
+    fn serialize(&self, serializer: Serializer) -> Result<Ok, Error>;
+}
+
+// This blanket implementation should be removed once all existing DTOs have been migrated.
+impl<T> SerializeForVersion for T
+where
+    T: serde::Serialize,
+{
+    fn serialize(&self, _serializer: Serializer) -> Result<Ok, Error> {
+        self.serialize(BaseSerializer {})
+    }
+}
+
+impl Serializer {
+    pub fn new(version: RpcVersion) -> Self {
+        Self { version }
+    }
+
+    pub fn serialize(self, value: &dyn SerializeForVersion) -> Result<Ok, Error> {
+        value.serialize(self)
+    }
+
+    pub fn serialize_str(self, value: &str) -> Result<Ok, Error> {
+        use serde::Serializer;
+        BaseSerializer {}.serialize_str(value)
+    }
+
+    pub fn serialize_u64(self, value: u64) -> Result<Ok, Error> {
+        use serde::Serializer;
+        BaseSerializer {}.serialize_u64(value)
+    }
+
+    pub fn serialize_bool(self, value: bool) -> Result<Ok, Error> {
+        use serde::Serializer;
+        BaseSerializer {}.serialize_bool(value)
+    }
+
+    pub fn serialize_struct(self) -> Result<SerializeStruct, Error> {
+        Ok(SerializeStruct {
+            version: self.version,
+            fields: Default::default(),
+        })
+    }
+
+    pub fn serialize_iter(
+        self,
+        len: usize,
+        values: &mut dyn Iterator<Item = impl SerializeForVersion>,
+    ) -> Result<Ok, Error> {
+        use serde::ser::SerializeSeq;
+        use serde::Serializer;
+
+        let mut serializer = BaseSerializer {}.serialize_seq(Some(len))?;
+        for value in values {
+            let value = self.serialize(&value)?;
+            serializer.serialize_element(&value)?;
+        }
+        serializer.end()
+    }
+}
+
+impl SerializeStruct {
+    pub fn serialize_field(
+        &mut self,
+        key: &'static str,
+        value: &dyn SerializeForVersion,
+    ) -> Result<(), Error> {
+        let value = value.serialize(Serializer::new(self.version))?;
+        self.fields.insert(key.to_owned(), value);
+        Ok(())
+    }
+
+    pub fn serialize_iter(
+        &mut self,
+        key: &'static str,
+        len: usize,
+        values: &mut dyn Iterator<Item = impl SerializeForVersion>,
+    ) -> Result<(), Error> {
+        let seq = Serializer::new(self.version).serialize_iter(len, values)?;
+        self.serialize_field(key, &seq)
+    }
+
+    /// Skips serialization if its [`None`].
+    pub fn serialize_optional(
+        &mut self,
+        key: &'static str,
+        value: Option<impl SerializeForVersion>,
+    ) -> Result<(), Error> {
+        if let Some(value) = value {
+            self.serialize_field(key, &value)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn flatten(&mut self, value: &dyn SerializeForVersion) -> Result<(), Error> {
+        let value = value.serialize(Serializer::new(self.version))?;
+
+        if let serde_json::Value::Object(value) = value {
+            for (k, v) in value {
+                self.fields.insert(k, v);
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn end(self) -> Result<Ok, Error> {
+        Ok(serde_json::Value::Object(self.fields))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    mod serialize {
+        use super::*;
+
+        #[test]
+        fn str() {
+            let encoded = Serializer::default().serialize_str("value").unwrap();
+            assert_eq!(encoded, json!("value"));
+        }
+
+        #[test]
+        fn u64() {
+            let encoded = Serializer::default().serialize_u64(123).unwrap();
+            assert_eq!(encoded, json!(123));
+        }
+
+        #[test]
+        fn bool() {
+            let encoded_true = Serializer::default().serialize_bool(true).unwrap();
+            assert_eq!(encoded_true, json!(true));
+
+            let encoded_false = Serializer::default().serialize_bool(false).unwrap();
+            assert_eq!(encoded_false, json!(false));
+        }
+    }
+
+    mod serialize_struct {
+        use super::*;
+
+        #[test]
+        fn version_carries_over() {
+            let uut = Serializer::new(RpcVersion::PathfinderV01)
+                .serialize_struct()
+                .unwrap();
+            assert_eq!(uut.version, RpcVersion::PathfinderV01);
+        }
+
+        #[test]
+        fn optional() {
+            let mut uut = Serializer::default().serialize_struct().unwrap();
+            uut.serialize_optional("missing", None::<u64>).unwrap();
+            uut.serialize_optional("present", Some(200u64)).unwrap();
+            let encoded = uut.end().unwrap();
+            let expected = json!({"present": 200u64});
+
+            assert_eq!(encoded, expected);
+        }
+
+        #[test]
+        fn iter() {
+            let empty = vec![0u64; 0];
+            let count = vec![0u64, 1, 2, 3];
+
+            let mut uut = Serializer::default().serialize_struct().unwrap();
+            uut.serialize_iter("empty", 0, &mut empty.iter()).unwrap();
+            uut.serialize_iter("count", 0, &mut count.iter()).unwrap();
+            let encoded = uut.end().unwrap();
+            let expected = json!({
+                "count": count,
+                "empty": empty,
+            });
+
+            assert_eq!(encoded, expected);
+        }
+
+        #[test]
+        fn flatten() {
+            struct TypeX(u64);
+            impl SerializeForVersion for TypeX {
+                fn serialize(&self, serializer: Serializer) -> Result<Ok, Error> {
+                    let mut serializer = serializer.serialize_struct()?;
+                    serializer.serialize_field("x", &self.0);
+                    serializer.end()
+                }
+            }
+
+            let mut uut = Serializer::default().serialize_struct().unwrap();
+            uut.serialize_field("y", &200u64).unwrap();
+            uut.flatten(&TypeX(300)).unwrap();
+            let encoded = uut.end().unwrap();
+
+            let expected = json!({
+                "x": 300,
+                "y": 200,
+            });
+
+            assert_eq!(encoded, expected);
+        }
+
+        #[test]
+        fn field() {
+            let mut uut = Serializer::default().serialize_struct().unwrap();
+            uut.serialize_field("field", &"value").unwrap();
+            let encoded = uut.end().unwrap();
+            let expected = json!({"field": "value"});
+            assert_eq!(encoded, expected);
+        }
+    }
+}

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -40,10 +40,12 @@ use tower_http::ServiceBuilderExt;
 
 const DEFAULT_MAX_CONNECTIONS: usize = 1024;
 
-pub enum DefaultVersion {
+#[derive(Copy, Clone, Default, PartialEq, PartialOrd)]
+pub enum RpcVersion {
     V04,
     V05,
     V06,
+    #[default]
     V07,
 }
 
@@ -52,11 +54,11 @@ pub struct RpcServer {
     context: RpcContext,
     max_connections: usize,
     cors: Option<CorsLayer>,
-    default_version: DefaultVersion,
+    default_version: RpcVersion,
 }
 
 impl RpcServer {
-    pub fn new(addr: SocketAddr, context: RpcContext, default_version: DefaultVersion) -> Self {
+    pub fn new(addr: SocketAddr, context: RpcContext, default_version: RpcVersion) -> Self {
         Self {
             addr,
             context,
@@ -150,10 +152,10 @@ impl RpcServer {
         let pathfinder_routes = pathfinder::register_routes().build(self.context.clone());
 
         let default_router = match self.default_version {
-            DefaultVersion::V04 => v04_routes.clone(),
-            DefaultVersion::V05 => v05_routes.clone(),
-            DefaultVersion::V06 => v06_routes.clone(),
-            DefaultVersion::V07 => v07_routes.clone(),
+            RpcVersion::V04 => v04_routes.clone(),
+            RpcVersion::V05 => v05_routes.clone(),
+            RpcVersion::V06 => v06_routes.clone(),
+            RpcVersion::V07 => v07_routes.clone(),
         };
 
         let router = axum::Router::new()
@@ -780,7 +782,7 @@ mod tests {
         // of health check. Test that we return success for such queries.
         let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
         let context = RpcContext::for_tests();
-        let (_jh, addr) = RpcServer::new(addr, context, DefaultVersion::V04)
+        let (_jh, addr) = RpcServer::new(addr, context, RpcVersion::V04)
             .spawn()
             .unwrap();
 
@@ -882,7 +884,7 @@ mod tests {
 
         let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
         let context = RpcContext::for_tests();
-        let (_jh, addr) = RpcServer::new(addr, context, DefaultVersion::V04)
+        let (_jh, addr) = RpcServer::new(addr, context, RpcVersion::V04)
             .spawn()
             .unwrap();
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -47,6 +47,19 @@ pub enum RpcVersion {
     V06,
     #[default]
     V07,
+    PathfinderV01,
+}
+
+impl RpcVersion {
+    fn to_str(self) -> &'static str {
+        match self {
+            RpcVersion::V04 => "v0.4",
+            RpcVersion::V05 => "v0.5",
+            RpcVersion::V06 => "v0.6",
+            RpcVersion::V07 => "v0.7",
+            RpcVersion::PathfinderV01 => "v0.1",
+        }
+    }
 }
 
 pub struct RpcServer {
@@ -156,6 +169,9 @@ impl RpcServer {
             RpcVersion::V05 => v05_routes.clone(),
             RpcVersion::V06 => v06_routes.clone(),
             RpcVersion::V07 => v07_routes.clone(),
+            RpcVersion::PathfinderV01 => {
+                anyhow::bail!("Did not expect default RPC version to be Pathfinder v0.1")
+            }
         };
 
         let router = axum::Router::new()

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1,5 +1,6 @@
 //! Starknet node JSON-RPC related modules.
 pub mod context;
+mod dto;
 mod error;
 mod executor;
 mod felt;
@@ -40,7 +41,7 @@ use tower_http::ServiceBuilderExt;
 
 const DEFAULT_MAX_CONNECTIONS: usize = 1024;
 
-#[derive(Copy, Clone, Default, PartialEq, PartialOrd)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, PartialOrd)]
 pub enum RpcVersion {
     V04,
     V05,

--- a/crates/rpc/src/middleware/cors.rs
+++ b/crates/rpc/src/middleware/cors.rs
@@ -19,7 +19,7 @@ pub fn with_allowed_origins(allowed_origins: AllowedOrigins) -> CorsLayer {
 
 #[cfg(test)]
 mod tests {
-    use crate::{context::RpcContext, DefaultVersion, RpcServer};
+    use crate::{context::RpcContext, RpcServer, RpcVersion};
     use http::HeaderValue;
 
     #[tokio::test]
@@ -34,8 +34,7 @@ mod tests {
             (None, None, line!()),
         ] {
             let context = RpcContext::for_tests();
-            let server =
-                RpcServer::new("127.0.0.1:0".parse().unwrap(), context, DefaultVersion::V05);
+            let server = RpcServer::new("127.0.0.1:0".parse().unwrap(), context, RpcVersion::V05);
             let server = match allowed {
                 Some(allowed) => server.with_cors(allowed.into()),
                 None => server,

--- a/crates/rpc/src/pathfinder.rs
+++ b/crates/rpc/src/pathfinder.rs
@@ -4,7 +4,7 @@ pub(crate) mod methods;
 
 #[rustfmt::skip]
 pub fn register_routes() -> RpcRouterBuilder {
-    RpcRouter::builder("v0.1")
+    RpcRouter::builder(crate::RpcVersion::PathfinderV01)
         .register("pathfinder_version",              || { pathfinder_common::consts::VERGEN_GIT_DESCRIBE })
         .register("pathfinder_getProof",             methods::get_proof)
         .register("pathfinder_getTransactionStatus", methods::get_transaction_status)

--- a/crates/rpc/src/v04.rs
+++ b/crates/rpc/src/v04.rs
@@ -9,7 +9,7 @@ use crate::v04::method as v04_method;
 
 #[rustfmt::skip]
 pub fn register_routes() -> RpcRouterBuilder {
-    RpcRouter::builder("v0.4")
+    RpcRouter::builder(crate::RpcVersion::V04)
         .register("starknet_blockHashAndNumber"              , v02_method::block_hash_and_number)
         .register("starknet_blockNumber"                     , v02_method::block_number)
         .register("starknet_call"                            , v02_method::call)

--- a/crates/rpc/src/v05.rs
+++ b/crates/rpc/src/v05.rs
@@ -9,7 +9,7 @@ use crate::v04::method as v04_method;
 
 #[rustfmt::skip]
 pub fn register_routes() -> RpcRouterBuilder {
-    RpcRouter::builder("v0.5")
+    RpcRouter::builder(crate::RpcVersion::V05)
         .register("starknet_blockHashAndNumber"              , v02_method::block_hash_and_number)
         .register("starknet_blockNumber"                     , v02_method::block_number)
         .register("starknet_chainId"                         , v02_method::chain_id)

--- a/crates/rpc/src/v06.rs
+++ b/crates/rpc/src/v06.rs
@@ -10,7 +10,7 @@ use crate::v05::method as v05_method;
 
 #[rustfmt::skip]
 pub fn register_routes() -> RpcRouterBuilder {
-    RpcRouter::builder("v0.6")
+    RpcRouter::builder(crate::RpcVersion::V06)
         .register("starknet_blockHashAndNumber"              , v02_method::block_hash_and_number)
         .register("starknet_blockNumber"                     , v02_method::block_number)
         .register("starknet_chainId"                         , v02_method::chain_id)

--- a/crates/rpc/src/v07.rs
+++ b/crates/rpc/src/v07.rs
@@ -11,7 +11,7 @@ use crate::jsonrpc::{RpcRouter, RpcRouterBuilder};
 
 #[rustfmt::skip]
 pub fn register_routes() -> RpcRouterBuilder {
-    RpcRouter::builder("v0.7")
+    RpcRouter::builder(crate::RpcVersion::V07)
         .register("starknet_blockHashAndNumber",                  v02_method::block_hash_and_number)
         .register("starknet_blockNumber",                         v02_method::block_number)
         .register("starknet_chainId",                             v02_method::chain_id)


### PR DESCRIPTION
This PR adds a new serialization trait which is aware of the RPC version calling it.

This allows DTOs to adapt their serialization to each RPC version, making it much easier to implement and audit RPC specification updates.

This PR only adds the new framework, but doesn't implement it for any specific DTO. Existing methods and DTOs automatically use the new trait due to its blanket impl for `serde::Serialize`.