### PR TITLE
feat(rpc): trivial methods using new serialization trait

### DIFF
--- a/crates/rpc/src/dto.rs
+++ b/crates/rpc/src/dto.rs
@@ -1,3 +1,5 @@
 #![allow(unused)]
 
+mod primitives;
 pub mod serialize;
+pub use primitives::*;

--- a/crates/rpc/src/dto/primitives.rs
+++ b/crates/rpc/src/dto/primitives.rs
@@ -4,6 +4,7 @@ use super::serialize::SerializeForVersion;
 
 pub struct Felt<'a>(pub &'a pathfinder_crypto::Felt);
 pub struct BlockHash<'a>(pub &'a pathfinder_common::BlockHash);
+pub struct BlockNumber(pub pathfinder_common::BlockNumber);
 
 mod hex_str {
     use std::borrow::Cow;
@@ -80,6 +81,15 @@ impl SerializeForVersion for BlockHash<'_> {
     }
 }
 
+impl SerializeForVersion for BlockNumber {
+    fn serialize(
+        &self,
+        serializer: serialize::Serializer,
+    ) -> Result<serialize::Ok, serialize::Error> {
+        serializer.serialize_u64(self.0.get())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::dto::serialize::Serializer;
@@ -104,6 +114,15 @@ mod tests {
         let hash = block_hash!("0x1234");
         let expected = Felt(&hash.0).serialize(Default::default()).unwrap();
         let encoded = BlockHash(&hash).serialize(Default::default()).unwrap();
+
+        assert_eq!(encoded, expected);
+    }
+
+    #[test]
+    fn block_number() {
+        let number = pathfinder_common::BlockNumber::new_or_panic(1234);
+        let expected = json!(1234);
+        let encoded = BlockNumber(number).serialize(Default::default()).unwrap();
 
         assert_eq!(encoded, expected);
     }

--- a/crates/rpc/src/dto/primitives.rs
+++ b/crates/rpc/src/dto/primitives.rs
@@ -6,6 +6,7 @@ pub struct SyncStatus<'a>(pub &'a crate::v02::types::syncing::Status);
 
 pub struct Felt<'a>(pub &'a pathfinder_crypto::Felt);
 pub struct BlockHash<'a>(pub &'a pathfinder_common::BlockHash);
+pub struct ChainId<'a>(pub &'a pathfinder_common::ChainId);
 pub struct BlockNumber(pub pathfinder_common::BlockNumber);
 
 mod hex_str {
@@ -99,6 +100,16 @@ impl SerializeForVersion for BlockHash<'_> {
     }
 }
 
+impl SerializeForVersion for ChainId<'_> {
+    fn serialize(
+        &self,
+        serializer: serialize::Serializer,
+    ) -> Result<serialize::Ok, serialize::Error> {
+        let hex_str = hex_str::bytes_to_hex_str_stripped(self.0 .0.as_be_bytes());
+        serializer.serialize_str(&hex_str)
+    }
+}
+
 impl SerializeForVersion for BlockNumber {
     fn serialize(
         &self,
@@ -175,6 +186,15 @@ mod tests {
         });
 
         let encoded = SyncStatus(&status).serialize(s).unwrap();
+
+        assert_eq!(encoded, expected);
+    }
+
+    #[test]
+    fn chain_id() {
+        let uut = ChainId(&pathfinder_common::ChainId(felt!("0x1234")));
+        let expected = json!("0x1234");
+        let encoded = uut.serialize(Default::default()).unwrap();
 
         assert_eq!(encoded, expected);
     }

--- a/crates/rpc/src/dto/primitives.rs
+++ b/crates/rpc/src/dto/primitives.rs
@@ -1,0 +1,99 @@
+mod hex_str {
+    use std::borrow::Cow;
+
+    const LUT: [u8; 16] = *b"0123456789abcdef";
+
+    pub fn bytes_to_hex_str_stripped(data: &[u8]) -> Cow<'static, str> {
+        // Skip empty bytes
+        let zero_count = data.iter().take_while(|b| **b == 0).count();
+        let data = &data[zero_count..];
+
+        if data.is_empty() {
+            return Cow::from("0x0");
+        }
+
+        // Is the most significant nibble zero? We need to skip it if it is.
+        // Index is safe since we just checked that it is non-empty.
+        let zero_nibble = (0xF0 & data[0]) == 0;
+        to_hex_str(data, zero_nibble).into()
+    }
+
+    pub fn bytes_to_hex_str_full(data: &[u8]) -> String {
+        to_hex_str(data, false)
+    }
+
+    #[inline]
+    fn to_hex_str(data: &[u8], skip_first_nibble: bool) -> String {
+        let count = if skip_first_nibble {
+            data.len() * 2 - 1
+        } else {
+            data.len() * 2
+        };
+        let mut buf = vec![0; 2 + count];
+        buf[0] = b'0';
+        buf[1] = b'x';
+
+        // Handle the first byte separately as we may need to skip the first nibble.
+        let (offset, data) = if skip_first_nibble {
+            buf[2] = LUT[data[0] as usize & 0x0f];
+            (3, &data[1..])
+        } else {
+            (2, data)
+        };
+
+        // Same small lookup table is ~25% faster than hex::encode_from_slice 🤷
+        for (i, b) in data.iter().enumerate() {
+            let idx = *b as usize;
+            let pos = offset + i * 2;
+            buf[pos] = LUT[(idx & 0xf0) >> 4];
+            buf[pos + 1] = LUT[idx & 0x0f];
+        }
+
+        // SAFETY: we only insert hex digits.
+        unsafe { String::from_utf8_unchecked(buf) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod hex_str {
+        use super::super::hex_str::*;
+
+        #[test]
+        fn zero() {
+            let data = 0x0u16.to_be_bytes();
+            assert_eq!(&bytes_to_hex_str_full(&data), "0x0000");
+            assert_eq!(&bytes_to_hex_str_stripped(&data), "0x0");
+        }
+
+        #[test]
+        fn leading_zeros_even() {
+            let data = 0x12u16.to_be_bytes();
+            assert_eq!(&bytes_to_hex_str_full(&data), "0x0012");
+            assert_eq!(&bytes_to_hex_str_stripped(&data), "0x12");
+        }
+
+        #[test]
+        fn leading_zeros_odd() {
+            let data = 0x1u16.to_be_bytes();
+            assert_eq!(&bytes_to_hex_str_full(&data), "0x0001");
+            assert_eq!(&bytes_to_hex_str_stripped(&data), "0x1");
+        }
+
+        #[test]
+        fn multibyte_odd() {
+            let data = 0x12345u32.to_be_bytes();
+            assert_eq!(&bytes_to_hex_str_full(&data), "0x00012345");
+            assert_eq!(&bytes_to_hex_str_stripped(&data), "0x12345");
+        }
+
+        #[test]
+        fn multibyte_even() {
+            let data = 0x123456u32.to_be_bytes();
+            assert_eq!(&bytes_to_hex_str_full(&data), "0x00123456");
+            assert_eq!(&bytes_to_hex_str_stripped(&data), "0x123456");
+        }
+    }
+}

--- a/crates/rpc/src/dto/primitives.rs
+++ b/crates/rpc/src/dto/primitives.rs
@@ -1,3 +1,9 @@
+use crate::dto::serialize;
+
+use super::serialize::SerializeForVersion;
+
+pub struct Felt<'a>(pub &'a pathfinder_crypto::Felt);
+
 mod hex_str {
     use std::borrow::Cow;
 
@@ -54,9 +60,34 @@ mod hex_str {
     }
 }
 
+impl SerializeForVersion for Felt<'_> {
+    fn serialize(
+        &self,
+        serializer: serialize::Serializer,
+    ) -> Result<serialize::Ok, serialize::Error> {
+        let hex_str = hex_str::bytes_to_hex_str_stripped(self.0.as_be_bytes());
+        serializer.serialize_str(&hex_str)
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use crate::dto::serialize::Serializer;
+
     use super::*;
+
+    use pathfinder_common::macro_prelude::*;
+    use pretty_assertions_sorted::assert_eq;
+    use serde_json::json;
+
+    #[test]
+    fn felt() {
+        let uut = Felt(&felt!("0x1234"));
+        let expected = json!("0x1234");
+        let encoded = uut.serialize(Default::default()).unwrap();
+
+        assert_eq!(encoded, expected);
+    }
 
     mod hex_str {
         use super::super::hex_str::*;

--- a/crates/rpc/src/dto/primitives.rs
+++ b/crates/rpc/src/dto/primitives.rs
@@ -2,6 +2,8 @@ use crate::dto::serialize;
 
 use super::serialize::SerializeForVersion;
 
+pub struct SyncStatus<'a>(pub &'a crate::v02::types::syncing::Status);
+
 pub struct Felt<'a>(pub &'a pathfinder_crypto::Felt);
 pub struct BlockHash<'a>(pub &'a pathfinder_common::BlockHash);
 pub struct BlockNumber(pub pathfinder_common::BlockNumber);
@@ -59,6 +61,22 @@ mod hex_str {
 
         // SAFETY: we only insert hex digits.
         unsafe { String::from_utf8_unchecked(buf) }
+    }
+}
+
+impl SerializeForVersion for SyncStatus<'_> {
+    fn serialize(
+        &self,
+        serializer: serialize::Serializer,
+    ) -> Result<serialize::Ok, serialize::Error> {
+        let mut serializer = serializer.serialize_struct()?;
+        serializer.serialize_field("starting_block_hash", &BlockHash(&self.0.starting.hash))?;
+        serializer.serialize_field("starting_block_num", &BlockNumber(self.0.starting.number))?;
+        serializer.serialize_field("current_block_hash", &BlockHash(&self.0.current.hash))?;
+        serializer.serialize_field("current_block_num", &BlockNumber(self.0.current.number))?;
+        serializer.serialize_field("highest_block_hash", &BlockHash(&self.0.highest.hash))?;
+        serializer.serialize_field("highest_block_num", &BlockNumber(self.0.highest.number))?;
+        serializer.end()
     }
 }
 
@@ -123,6 +141,40 @@ mod tests {
         let number = pathfinder_common::BlockNumber::new_or_panic(1234);
         let expected = json!(1234);
         let encoded = BlockNumber(number).serialize(Default::default()).unwrap();
+
+        assert_eq!(encoded, expected);
+    }
+
+    #[test]
+    fn sync_status() {
+        use crate::v02::types::syncing::NumberedBlock;
+        let status = crate::v02::types::syncing::Status {
+            starting: NumberedBlock {
+                number: pathfinder_common::BlockNumber::GENESIS,
+                hash: block_hash!("0x123"),
+            },
+            current: NumberedBlock {
+                number: pathfinder_common::BlockNumber::GENESIS + 20,
+                hash: block_hash!("0x456"),
+            },
+            highest: NumberedBlock {
+                number: pathfinder_common::BlockNumber::GENESIS + 300,
+                hash: block_hash!("0x789"),
+            },
+        };
+
+        let s = Serializer::default();
+
+        let expected = json!({
+           "starting_block_hash": BlockHash(&status.starting.hash).serialize(s).unwrap(),
+           "current_block_hash": BlockHash(&status.current.hash).serialize(s).unwrap(),
+           "highest_block_hash": BlockHash(&status.highest.hash).serialize(s).unwrap(),
+           "starting_block_num": BlockNumber(status.starting.number).serialize(s).unwrap(),
+           "current_block_num": BlockNumber(status.current.number).serialize(s).unwrap(),
+           "highest_block_num": BlockNumber(status.highest.number).serialize(s).unwrap(),
+        });
+
+        let encoded = SyncStatus(&status).serialize(s).unwrap();
 
         assert_eq!(encoded, expected);
     }

--- a/crates/rpc/src/dto/primitives.rs
+++ b/crates/rpc/src/dto/primitives.rs
@@ -3,6 +3,7 @@ use crate::dto::serialize;
 use super::serialize::SerializeForVersion;
 
 pub struct Felt<'a>(pub &'a pathfinder_crypto::Felt);
+pub struct BlockHash<'a>(pub &'a pathfinder_common::BlockHash);
 
 mod hex_str {
     use std::borrow::Cow;
@@ -70,6 +71,15 @@ impl SerializeForVersion for Felt<'_> {
     }
 }
 
+impl SerializeForVersion for BlockHash<'_> {
+    fn serialize(
+        &self,
+        serializer: serialize::Serializer,
+    ) -> Result<serialize::Ok, serialize::Error> {
+        serializer.serialize(&Felt(&self.0 .0))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::dto::serialize::Serializer;
@@ -85,6 +95,15 @@ mod tests {
         let uut = Felt(&felt!("0x1234"));
         let expected = json!("0x1234");
         let encoded = uut.serialize(Default::default()).unwrap();
+
+        assert_eq!(encoded, expected);
+    }
+
+    #[test]
+    fn block_hash() {
+        let hash = block_hash!("0x1234");
+        let expected = Felt(&hash.0).serialize(Default::default()).unwrap();
+        let encoded = BlockHash(&hash).serialize(Default::default()).unwrap();
 
         assert_eq!(encoded, expected);
     }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -5,6 +5,7 @@ mod error;
 mod executor;
 mod felt;
 mod jsonrpc;
+pub(crate) mod method;
 pub mod middleware;
 mod pathfinder;
 mod pending;

--- a/crates/rpc/src/method.rs
+++ b/crates/rpc/src/method.rs
@@ -1,3 +1,5 @@
+pub mod block_number;
 pub mod syncing;
 
+pub use block_number::block_number;
 pub use syncing::syncing;

--- a/crates/rpc/src/method.rs
+++ b/crates/rpc/src/method.rs
@@ -1,0 +1,3 @@
+pub mod syncing;
+
+pub use syncing::syncing;

--- a/crates/rpc/src/method.rs
+++ b/crates/rpc/src/method.rs
@@ -1,5 +1,7 @@
+pub mod block_hash_and_number;
 pub mod block_number;
 pub mod syncing;
 
+pub use block_hash_and_number::block_hash_and_number;
 pub use block_number::block_number;
 pub use syncing::syncing;

--- a/crates/rpc/src/method.rs
+++ b/crates/rpc/src/method.rs
@@ -1,7 +1,9 @@
 pub mod block_hash_and_number;
 pub mod block_number;
+pub mod chain_id;
 pub mod syncing;
 
 pub use block_hash_and_number::block_hash_and_number;
 pub use block_number::block_number;
+pub use chain_id::chain_id;
 pub use syncing::syncing;

--- a/crates/rpc/src/method/block_hash_and_number.rs
+++ b/crates/rpc/src/method/block_hash_and_number.rs
@@ -1,0 +1,42 @@
+use crate::context::RpcContext;
+use anyhow::Context;
+use pathfinder_storage::BlockId;
+
+pub struct Output {
+    number: pathfinder_common::BlockNumber,
+    hash: pathfinder_common::BlockHash,
+}
+
+crate::error::generate_rpc_error_subset!(Error: NoBlocks);
+
+pub async fn block_hash_and_number(context: RpcContext) -> Result<Output, Error> {
+    let span = tracing::Span::current();
+
+    let jh = tokio::task::spawn_blocking(move || {
+        let _g = span.enter();
+        let mut db = context
+            .storage
+            .connection()
+            .context("Opening database connection")?;
+        let tx = db.transaction().context("Opening database transaction")?;
+
+        tx.block_id(BlockId::Latest)
+            .context("Reading latest block number and hash from database")?
+            .map(|(number, hash)| Output { number, hash })
+            .ok_or(Error::NoBlocks)
+    });
+
+    jh.await.context("Database read panic or shutting down")?
+}
+
+impl crate::dto::serialize::SerializeForVersion for Output {
+    fn serialize(
+        &self,
+        serializer: crate::dto::serialize::Serializer,
+    ) -> Result<crate::dto::serialize::Ok, crate::dto::serialize::Error> {
+        let mut serializer = serializer.serialize_struct()?;
+        serializer.serialize_field("block_hash", &crate::dto::BlockHash(&self.hash))?;
+        serializer.serialize_field("block_number", &crate::dto::BlockNumber(self.number))?;
+        serializer.end()
+    }
+}

--- a/crates/rpc/src/method/block_number.rs
+++ b/crates/rpc/src/method/block_number.rs
@@ -1,0 +1,36 @@
+use crate::context::RpcContext;
+use anyhow::Context;
+use pathfinder_storage::BlockId;
+
+pub struct Output(pathfinder_common::BlockNumber);
+
+crate::error::generate_rpc_error_subset!(Error: NoBlocks);
+
+pub async fn block_number(context: RpcContext) -> Result<Output, Error> {
+    let span = tracing::Span::current();
+
+    let jh = tokio::task::spawn_blocking(move || {
+        let _g = span.enter();
+        let mut db = context
+            .storage
+            .connection()
+            .context("Opening database connection")?;
+        let tx = db.transaction().context("Opening database transaction")?;
+
+        tx.block_id(BlockId::Latest)
+            .context("Reading latest block number from database")?
+            .map(|(block_number, _)| Output(block_number))
+            .ok_or(Error::NoBlocks)
+    });
+
+    jh.await.context("Database read panic or shutting down")?
+}
+
+impl crate::dto::serialize::SerializeForVersion for Output {
+    fn serialize(
+        &self,
+        serializer: crate::dto::serialize::Serializer,
+    ) -> Result<crate::dto::serialize::Ok, crate::dto::serialize::Error> {
+        serializer.serialize(&crate::dto::BlockNumber(self.0))
+    }
+}

--- a/crates/rpc/src/method/chain_id.rs
+++ b/crates/rpc/src/method/chain_id.rs
@@ -1,0 +1,18 @@
+use crate::context::RpcContext;
+
+crate::error::generate_rpc_error_subset!(Error);
+
+pub struct Output(pathfinder_common::ChainId);
+
+pub async fn chain_id(context: RpcContext) -> Result<Output, Error> {
+    Ok(Output(context.chain_id))
+}
+
+impl crate::dto::serialize::SerializeForVersion for Output {
+    fn serialize(
+        &self,
+        serializer: crate::dto::serialize::Serializer,
+    ) -> Result<crate::dto::serialize::Ok, crate::dto::serialize::Error> {
+        serializer.serialize(&crate::dto::ChainId(&self.0))
+    }
+}

--- a/crates/rpc/src/method/syncing.rs
+++ b/crates/rpc/src/method/syncing.rs
@@ -1,0 +1,24 @@
+use crate::{context::RpcContext, v02::types::syncing::Syncing};
+
+crate::error::generate_rpc_error_subset!(Error);
+
+pub struct Output(Syncing);
+
+pub async fn syncing(context: RpcContext) -> Result<Output, Error> {
+    // Scoped so I don't have to think too hard about mutex guard drop semantics.
+    let value = { context.sync_status.status.read().await.clone() };
+
+    Ok(Output(value))
+}
+
+impl crate::dto::serialize::SerializeForVersion for Output {
+    fn serialize(
+        &self,
+        serializer: crate::dto::serialize::Serializer,
+    ) -> Result<crate::dto::serialize::Ok, crate::dto::serialize::Error> {
+        match self.0 {
+            Syncing::False(_) => serializer.serialize_bool(false),
+            Syncing::Status(status) => serializer.serialize(&crate::dto::SyncStatus(&status)),
+        }
+    }
+}

--- a/crates/rpc/src/v07.rs
+++ b/crates/rpc/src/v07.rs
@@ -3,7 +3,6 @@ pub mod method;
 
 use crate::v02::method as v02_method;
 use crate::v03::method as v03_method;
-use crate::v04::method as v04_method;
 use crate::v05::method as v05_method;
 use crate::v06::method as v06_method;
 
@@ -25,7 +24,7 @@ pub fn register_routes() -> RpcRouterBuilder {
         .register("starknet_getEvents",                           v03_method::get_events)
         .register("starknet_getStateUpdate",                      v03_method::get_state_update)
 
-        .register("starknet_syncing",                             v04_method::syncing)
+        .register("starknet_syncing",                             crate::method::syncing)
 
         .register("starknet_call",                                v05_method::call)
         .register("starknet_getTransactionStatus",                v05_method::get_transaction_status)

--- a/crates/rpc/src/v07.rs
+++ b/crates/rpc/src/v07.rs
@@ -12,7 +12,7 @@ use crate::jsonrpc::{RpcRouter, RpcRouterBuilder};
 pub fn register_routes() -> RpcRouterBuilder {
     RpcRouter::builder(crate::RpcVersion::V07)
         .register("starknet_blockHashAndNumber",                  v02_method::block_hash_and_number)
-        .register("starknet_blockNumber",                         v02_method::block_number)
+        .register("starknet_blockNumber",                         crate::method::block_number)
         .register("starknet_chainId",                             v02_method::chain_id)
         .register("starknet_getBlockTransactionCount",            v02_method::get_block_transaction_count)
         .register("starknet_getClass",                            v02_method::get_class)

--- a/crates/rpc/src/v07.rs
+++ b/crates/rpc/src/v07.rs
@@ -11,7 +11,7 @@ use crate::jsonrpc::{RpcRouter, RpcRouterBuilder};
 #[rustfmt::skip]
 pub fn register_routes() -> RpcRouterBuilder {
     RpcRouter::builder(crate::RpcVersion::V07)
-        .register("starknet_blockHashAndNumber",                  v02_method::block_hash_and_number)
+        .register("starknet_blockHashAndNumber",                  crate::method::block_hash_and_number)
         .register("starknet_blockNumber",                         crate::method::block_number)
         .register("starknet_chainId",                             v02_method::chain_id)
         .register("starknet_getBlockTransactionCount",            v02_method::get_block_transaction_count)

--- a/crates/rpc/src/v07.rs
+++ b/crates/rpc/src/v07.rs
@@ -13,7 +13,7 @@ pub fn register_routes() -> RpcRouterBuilder {
     RpcRouter::builder(crate::RpcVersion::V07)
         .register("starknet_blockHashAndNumber",                  crate::method::block_hash_and_number)
         .register("starknet_blockNumber",                         crate::method::block_number)
-        .register("starknet_chainId",                             v02_method::chain_id)
+        .register("starknet_chainId",                             crate::method::chain_id)
         .register("starknet_getBlockTransactionCount",            v02_method::get_block_transaction_count)
         .register("starknet_getClass",                            v02_method::get_class)
         .register("starknet_getClassAt",                          v02_method::get_class_at)


### PR DESCRIPTION
Implements some of the simpler RPC methods using the new trait.

Note that this explicly targets RPC v0.7-rc2 only. No backwards compatibility yet - let's fully support v0.7 and then we can work backwards. This let's us skip work for v0.4 and v0.5 if we manage to remove them before this work gets there.

------------------------

Particular review focus should be on the correctness of the DTO serialization ito inner types being used. i.e. ensure that if the spec says `BLOCK_HASH` is a `FELT` then the serialization implementation should use `serialize(&Felt(...))`. 

There isn't really a super easy way to enforce this apart from rigorous manual auditing when adding/updating DTOs.

------------------------

Adds DTO implementations for:
```
FELT
BLOCK_HASH
BLOCK_NUMBER
SYNC_STATUS
CHAIN_ID
```
and implements methods
```
starknet_blockHashAndNumber
starknet_blockNumber
starknet_chainId
starknet_syncing
```

Part of #1830