### PR TITLE
fix(pathfinder): exit gracefully on INT/TERM signal

### DIFF
--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -64,7 +64,7 @@ starknet-gateway-types = { path = "../gateway-types" }
 tempfile = "3.8"
 thiserror = "1.0.48"
 time = { version = "0.3.28", features = ["macros"] }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal"] }
 tokio-stream = "0.1.14"
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.17", features = [

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -17,6 +17,7 @@ use std::net::SocketAddr;
 use std::num::NonZeroU32;
 use std::path::PathBuf;
 use std::sync::{atomic::AtomicBool, Arc};
+use tokio::signal::unix::{signal, SignalKind};
 use tracing::info;
 
 use crate::config::NetworkConfig;
@@ -251,6 +252,9 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
 
     tokio::spawn(update::poll_github_for_releases());
 
+    let mut term_signal = signal(SignalKind::terminate())?;
+    let mut int_signal = signal(SignalKind::interrupt())?;
+
     // We are now ready.
     readiness.store(true, std::sync::atomic::Ordering::Relaxed);
 
@@ -261,22 +265,31 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
                 Ok(task_result) => tracing::error!("Sync process ended unexpected with: {:?}", task_result),
                 Err(err) => tracing::error!("Sync process ended unexpected; failed to join task handle: {:?}", err),
             }
+            anyhow::bail!("Unexpected shutdown");
         }
         result = rpc_handle => {
             match result {
                 Ok(_) => tracing::error!("RPC server process ended unexpectedly"),
                 Err(err) => tracing::error!(error=%err, "RPC server process ended unexpectedly"),
             }
+            anyhow::bail!("Unexpected shutdown");
         }
         result = p2p_handle => {
             match result {
                 Ok(_) => tracing::error!("P2P process ended unexpectedly"),
                 Err(err) => tracing::error!(error=%err, "P2P process ended unexpectedly"),
             }
+            anyhow::bail!("Unexpected shutdown");
+        }
+        _ = term_signal.recv() => {
+            tracing::info!("TERM signal received, exiting gracefully");
+            Ok(())
+        }
+        _ = int_signal.recv() => {
+            tracing::info!("INT signal received, exiting gracefully");
+            Ok(())
         }
     }
-
-    anyhow::bail!("Unexpected shutdown");
 }
 
 #[cfg(feature = "tokio-console")]


### PR DESCRIPTION
So that the SQLite DB is properly closed and we don't leave WAL and SHM files behind.
