### PR TITLE
fix(rpc): transaction status not found is an internal error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `starknet_getEvents` does not return a continuation token if not all events from the last block fit into the result page.
+- `starknet_getTransactionStatus` reports gateway errors as `TxnNotFound`. These are now reported as internal errors.
 
 ## [0.11.1] - 2024-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `starknet_getEvents` does not return a continuation token if not all events from the last block fit into the result page.
 - `starknet_getTransactionStatus` reports gateway errors as `TxnNotFound`. These are now reported as internal errors.
+
+## [0.11.2] - 2024-03-07
+
+### Fixed
+
+- `starknet_getEvents` does not return a continuation token if not all events from the last block fit into the result page.
 
 ## [0.11.1] - 2024-03-01
 


### PR DESCRIPTION
`starknet_getTransactionStatus` does some incorrect error mapping, which this PR corrects.

1. Gateway's `NotReceived` status is incorrectly mapped to an internal error instead of `TxnNotFound`.
2. All gateway errors are incorrect mapped to `TxnNotFound`. These are now an internal error.