### PR TITLE
fix(gateway): add transactions should not timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `starknet_getEvents` does not return a continuation token if not all events from the last block fit into the result page.
+- `starknet_addXXX` requests to the gateway use the configured gateway timeout, often causing these to timeout while waiting for 
+  a gateway response. These instead now use a much longer timeout.
 
 ## [0.11.1] - 2024-03-01
 

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -441,7 +441,10 @@ impl GatewayApi for Client {
         self.gateway_request()
             .add_transaction()
             .with_retry(false)
-            .post_with_json(&request::add_transaction::AddTransaction::Invoke(invoke))
+            .post_with_json(
+                &request::add_transaction::AddTransaction::Invoke(invoke),
+                Some(Duration::MAX),
+            )
             .await
     }
 
@@ -461,7 +464,10 @@ impl GatewayApi for Client {
             // mainnet requires a token (but testnet does not so its optional).
             .with_optional_token(token.as_deref())
             .with_retry(false)
-            .post_with_json(&request::add_transaction::AddTransaction::Declare(declare))
+            .post_with_json(
+                &request::add_transaction::AddTransaction::Declare(declare),
+                Some(Duration::MAX),
+            )
             .await
     }
 
@@ -477,9 +483,10 @@ impl GatewayApi for Client {
         self.gateway_request()
             .add_transaction()
             .with_retry(false)
-            .post_with_json(&request::add_transaction::AddTransaction::DeployAccount(
-                deploy,
-            ))
+            .post_with_json(
+                &request::add_transaction::AddTransaction::DeployAccount(deploy),
+                Some(Duration::MAX),
+            )
             .await
     }
 


### PR DESCRIPTION
This PR removes the timeout from the RPC write transaction submissions to the gateway.

This is done in a somewhat clumsy fashion by adding a timeout to those methods and setting it to `MAX` to override the builtin timeout from the client.

Ideally we would refactor this to make all of these things much simpler again.

Unsure how to test this properly.

Fixes #1839 