### PR TITLE
split contract updates stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6110,6 +6110,7 @@ version = "0.11.2"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "async-stream",
  "async-trait",
  "base64 0.13.1",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ authors = ["Equilibrium Labs <info@equilibrium.co>"]
 [workspace.dependencies]
 anyhow = "1.0.75"
 assert_matches = "1.5.0"
+async-stream = "0.3.5"
 async-trait = "0.1.73"
 axum = { version = "0.6.19", features = ["macros"] }
 base64 = "0.13.1"

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-async-stream = "0.3.5"
+async-stream = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -18,6 +18,7 @@ rpc-full-serde = []
 
 [dependencies]
 anyhow = { workspace = true }
+async-stream = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true, optional = true }
 bitvec = { workspace = true }

--- a/crates/pathfinder/src/sync/p2p.rs
+++ b/crates/pathfinder/src/sync/p2p.rs
@@ -4,9 +4,6 @@ mod receipts;
 mod state_updates;
 mod transactions;
 
-use std::num::NonZeroUsize;
-use std::sync::Arc;
-
 use anyhow::Context;
 use futures::StreamExt;
 use futures::TryStreamExt;
@@ -17,13 +14,11 @@ use p2p_proto::{
     transaction::{TransactionsRequest, TransactionsResponse},
 };
 use pathfinder_common::receipt::Receipt;
-use pathfinder_common::state_update::StateUpdateCounts;
 use pathfinder_common::{transaction::Transaction, BlockHeader};
 use pathfinder_common::{BlockHash, BlockNumber};
 use pathfinder_ethereum::EthereumStateUpdate;
 use pathfinder_storage::Storage;
 use primitive_types::H160;
-use smallvec::SmallVec;
 use tokio::task::spawn_blocking;
 
 use crate::state::block_hash::{
@@ -400,29 +395,16 @@ impl Sync {
 
     async fn sync_state_updates(&self, stop: BlockNumber) -> anyhow::Result<()> {
         let storage = self.storage.clone();
-        let getter = move |start: BlockNumber,
-                           limit: NonZeroUsize|
-              -> anyhow::Result<SmallVec<[StateUpdateCounts; 10]>> {
-            let mut db = storage
-                .connection()
-                .context("Creating database connection")?;
-            let db = db.transaction().context("Creating database transaction")?;
-            let counts = db
-                .state_update_counts(start.into(), limit)
-                .context("Querying state updates")?;
-            Ok(counts)
-        };
-        let getter = Arc::new(getter);
+        let (_, state_update_counts_stream) = futures::channel::mpsc::channel(0); // FIXME: use a real stream
 
         if let Some(start) = state_updates::next_missing(self.storage.clone(), stop)
             .await
             .context("Finding next missing state update")?
         {
-            let getter = getter.clone();
             let result = self
                 .p2p
                 .clone()
-                .contract_updates_stream(start, stop, getter)
+                .contract_updates_stream(start, stop, state_update_counts_stream)
                 .map_err(Into::into)
                 .and_then(state_updates::verify_signature)
                 .try_chunks(100)


### PR DESCRIPTION
Use a separate stream for state update count data. I've experimented quite a bit but couldn't make any reasonable use of stream combinators from `StreamExt` or `TryStreamExt`, so I decided to just replace the getter with a stream.

Fixes #1856 