### PR TITLE
fix: sync restarts leave a zombie task behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `starknet_getTransactionStatus` reports gateway errors as `TxnNotFound`. These are now reported as internal errors.
+- Sync process leaves a zombie task behind each time it restarts, wasting resources.
 
 ## [0.11.2] - 2024-03-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `starknet_getTransactionStatus` reports gateway errors as `TxnNotFound`. These are now reported as internal errors.
 - Sync process leaves a zombie task behind each time it restarts, wasting resources.
 
+### Changed
+
+- Default sync poll reduced from 5s to 2s. This is more appropriate given the lower block times on mainnet.
+
 ## [0.11.2] - 2024-03-07
 
 ### Fixed

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -124,7 +124,7 @@ Examples:
     #[arg(
         long = "sync.poll-interval",
         long_help = "New block poll interval in seconds",
-        default_value = "5",
+        default_value = "2",
         env = "PATHFINDER_HEAD_POLL_INTERVAL_SECONDS"
     )]
     poll_interval: std::num::NonZeroU64,

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -1,6 +1,6 @@
 use crate::state::block_hash::{verify_block_hash, VerifyResult};
 use crate::state::sync::class::{download_class, DownloadedClass};
-use crate::state::sync::{pending, SyncEvent};
+use crate::state::sync::SyncEvent;
 use anyhow::{anyhow, Context};
 use pathfinder_common::state_update::ContractClassUpdate;
 use pathfinder_common::{
@@ -105,7 +105,7 @@ where
         storage,
     } = context;
 
-    let mut pending_handle = None;
+    // let mut pending_handle = None;
 
     'outer: loop {
         // Get the next block from L2.
@@ -143,24 +143,6 @@ where
                     break (block, commitments, state_update)
                 }
                 DownloadBlock::AtHead => {
-                    const PENDING_POLL_INTERVAL: std::time::Duration =
-                        std::time::Duration::from_secs(2);
-
-                    if cfg!(feature = "p2p") {
-                        // Not implemented yet for P2P
-                        tracing::info!("Skipping the pending blocks polling");
-                        tokio::time::sleep(PENDING_POLL_INTERVAL).await;
-                    } else if pending_handle.is_none() {
-                        tracing::info!("At head of chain, enabling polling of pending data");
-                        pending_handle = Some(tokio::spawn(pending::poll_pending(
-                            tx_event.clone(),
-                            sequencer.clone(),
-                            PENDING_POLL_INTERVAL,
-                            storage.clone(),
-                        )));
-                    }
-
-
                     // Wait for the latest block to change.
                     if latest
                         .wait_for(|(_, hash)| hash != &head.unwrap_or_default().1)

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -105,8 +105,6 @@ where
         storage,
     } = context;
 
-    // let mut pending_handle = None;
-
     'outer: loop {
         // Get the next block from L2.
         let (next, head_meta) = match &head {

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -22,8 +22,8 @@ pub async fn poll_pending<S: GatewayApi + Clone + Send + 'static>(
     loop {
         let t_fetch = Instant::now();
 
-        let latest = { latest.borrow().clone() }.0.get();
-        let current = { current.borrow().clone() }.0.get();
+        let latest = { latest.borrow().0.get() };
+        let current = { current.borrow().0.get() };
 
         if latest.abs_diff(current) > 6 {
             tracing::debug!(%latest, %current, "Not in sync yet; skipping pending block download");

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -22,8 +22,8 @@ pub async fn poll_pending<S: GatewayApi + Clone + Send + 'static>(
     loop {
         let t_fetch = Instant::now();
 
-        let latest = { latest.borrow().0.get() };
-        let current = { current.borrow().0.get() };
+        let latest = latest.borrow().0.get();
+        let current = current.borrow().0.get();
 
         if latest.abs_diff(current) > 6 {
             tracing::debug!(%latest, %current, "Not in sync yet; skipping pending block download");


### PR DESCRIPTION
This PR separates pending producer from the L2 producer.

The pending producer task is now always running, but only emits pending data when local sync is within 6 blocks of the latest on chain block.

I've also create a separate task which exclusively tracks the gateways latest block ID. This feeds both the sync status and the L2 producer now, reducing the number of these calls we make.

I'm a bit unsure of these changes -- the code feels brittle.

Fixes #1864 