### PR TITLE
fix(rpc/pending): properly default L1 DA mode and data gas prices in case pending is missing

### DIFF
--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -82,6 +82,7 @@ impl PendingWatcher {
                     timestamp: latest.timestamp,
                     parent_hash: latest.hash,
                     starknet_version: latest.starknet_version,
+                    l1_da_mode: Some(latest.l1_da_mode.into()),
                     // This shouldn't have an impact anywhere as the RPC methods should
                     // know this is a pending block. But rather safe than sorry.
                     status: Status::Pending,
@@ -105,7 +106,7 @@ impl PendingWatcher {
 #[cfg(test)]
 mod tests {
 
-    use pathfinder_common::macro_prelude::*;
+    use pathfinder_common::{macro_prelude::*, L1DataAvailabilityMode};
     use pathfinder_common::{BlockHeader, BlockTimestamp, GasPrice};
 
     use super::*;
@@ -175,6 +176,7 @@ mod tests {
             .child_builder()
             .with_eth_l1_gas_price(GasPrice(1234))
             .with_strk_l1_gas_price(GasPrice(3377))
+            .with_l1_da_mode(L1DataAvailabilityMode::Blob)
             .with_timestamp(BlockTimestamp::new_or_panic(6777))
             .finalize_with_hash(block_hash_bytes!(b"latest hash"));
 
@@ -188,6 +190,7 @@ mod tests {
             block: PendingBlock {
                 eth_l1_gas_price_implementation_detail: Some(latest.eth_l1_gas_price),
                 strk_l1_gas_price_implementation_detail: Some(latest.strk_l1_gas_price),
+                l1_da_mode: Some(latest.l1_da_mode.into()),
                 timestamp: latest.timestamp,
                 parent_hash: latest.hash,
                 starknet_version: latest.starknet_version,

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use pathfinder_common::{BlockHeader, BlockNumber, StateUpdate};
 use pathfinder_storage::Transaction;
-use starknet_gateway_types::reply::{PendingBlock, Status};
+use starknet_gateway_types::reply::{GasPrices, PendingBlock, Status};
 
 use tokio::sync::watch::Receiver as WatchReceiver;
 
@@ -79,6 +79,10 @@ impl PendingWatcher {
                 block: PendingBlock {
                     eth_l1_gas_price_implementation_detail: Some(latest.eth_l1_gas_price),
                     strk_l1_gas_price_implementation_detail: Some(latest.strk_l1_gas_price),
+                    l1_data_gas_price: Some(GasPrices {
+                        price_in_wei: latest.eth_l1_data_gas_price,
+                        price_in_fri: latest.strk_l1_data_gas_price,
+                    }),
                     timestamp: latest.timestamp,
                     parent_hash: latest.hash,
                     starknet_version: latest.starknet_version,
@@ -176,6 +180,8 @@ mod tests {
             .child_builder()
             .with_eth_l1_gas_price(GasPrice(1234))
             .with_strk_l1_gas_price(GasPrice(3377))
+            .with_eth_l1_data_gas_price(GasPrice(9999))
+            .with_strk_l1_data_gas_price(GasPrice(8888))
             .with_l1_da_mode(L1DataAvailabilityMode::Blob)
             .with_timestamp(BlockTimestamp::new_or_panic(6777))
             .finalize_with_hash(block_hash_bytes!(b"latest hash"));
@@ -190,6 +196,10 @@ mod tests {
             block: PendingBlock {
                 eth_l1_gas_price_implementation_detail: Some(latest.eth_l1_gas_price),
                 strk_l1_gas_price_implementation_detail: Some(latest.strk_l1_gas_price),
+                l1_data_gas_price: Some(GasPrices {
+                    price_in_wei: latest.eth_l1_data_gas_price,
+                    price_in_fri: latest.strk_l1_data_gas_price,
+                }),
                 l1_da_mode: Some(latest.l1_da_mode.into()),
                 timestamp: latest.timestamp,
                 parent_hash: latest.hash,


### PR DESCRIPTION
On Starknet there are (short) periods where there is no pending block: right after the pending block was promoted to latest.

In these periods pathfinder uses values (like gas prices and timestamp) from the latest block for starknet_estimateFee and starknet_simulateTransactions.

Unfortunately pathfinder did not properly initialize pending L1 DA mode and L1 data gas prices in these cases and just defaulted to using CALLDATA mode until a proper pending block is published by the feeder gateway. This PR fixes that by taking the values 

Closes #1869
