### PR TITLE
docs: update RPC spec to v0.7.0-rc2

### DIFF
--- a/doc/rpc/v07/starknet_api_openrpc.json
+++ b/doc/rpc/v07/starknet_api_openrpc.json
@@ -1,7 +1,7 @@
 {
     "openrpc": "1.0.0-rc1",
     "info": {
-        "version": "0.6.0",
+        "version": "0.7.0",
         "title": "StarkNet Node API",
         "license": {}
     },
@@ -381,16 +381,8 @@
             "result": {
                 "name": "result",
                 "schema": {
-                    "oneOf": [
-                        {
-                            "title": "Transaction receipt",
-                            "$ref": "#/components/schemas/TXN_RECEIPT"
-                        },
-                        {
-                            "title": "Pending transaction receipt",
-                            "$ref": "#/components/schemas/PENDING_TXN_RECEIPT"
-                        }
-                    ]
+                    "title": "Transaction receipt with block info",
+                    "$ref": "#/components/schemas/TXN_RECEIPT_WITH_BLOCK_INFO"
                 }
             },
             "errors": [
@@ -1325,7 +1317,7 @@
                 "title": "Storage key",
                 "$comment": "A storage key, represented as a string of hex digits",
                 "description": "A storage key. Represented as up to 62 hex digits, 3 bits, and 5 leading zeroes.",
-                "pattern": "^0x0[0-7]{1}[a-fA-F0-9]{0,62}$"
+                "pattern": "^0x(0|[0-7]{1}[a-fA-F0-9]{0,62}$)"
             },
             "ETH_ADDRESS": {
                 "title": "Ethereum address",
@@ -1418,25 +1410,21 @@
                         "description": "The transactions in this block",
                         "type": "array",
                         "items": {
-                            "title": "transactions in block",
                             "type": "object",
-                            "allOf": [
-                                {
+                            "title": "transaction and receipt",
+                            "properties": {
+                                "transaction": {
                                     "title": "transaction",
                                     "$ref": "#/components/schemas/TXN"
                                 },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "receipt": {
-                                            "title": "receipt",
-                                            "$ref": "#/components/schemas/TXN_RECEIPT"
-                                        }
-                                    },
-                                    "required": [
-                                        "receipt"
-                                    ]
+                                "receipt": {
+                                    "title": "receipt",
+                                    "$ref": "#/components/schemas/TXN_RECEIPT"
                                 }
+                            },
+                            "required": [
+                                "transaction",
+                                "receipt"
                             ]
                         }
                     }
@@ -1512,6 +1500,8 @@
                     "timestamp",
                     "sequencer_address",
                     "l1_gas_price",
+                    "l1_data_gas_price",
+                    "l1_da_mode",
                     "starknet_version"
                 ]
             },
@@ -1540,6 +1530,20 @@
                         "description": "The price of l1 gas in the block",
                         "$ref": "#/components/schemas/RESOURCE_PRICE"
                     },
+                    "l1_data_gas_price": {
+                        "title": "L1 data gas price",
+                        "description": "The price of l1 data gas in the block",
+                        "$ref": "#/components/schemas/RESOURCE_PRICE"
+                    },
+                    "l1_da_mode": {
+                        "title": "L1 da mode",
+                        "type": "string",
+                        "description": "specifies whether the data of this block is published via blob data or calldata",
+                        "enum": [
+                            "BLOB",
+                            "CALLDATA"
+                        ]
+                    },
                     "starknet_version": {
                         "title": "Starknet version",
                         "description": "Semver of the current Starknet protocol",
@@ -1551,6 +1555,8 @@
                     "timestamp",
                     "sequencer_address",
                     "l1_gas_price",
+                    "l1_data_gas_price",
+                    "l1_da_mode",
                     "starknet_version"
                 ],
                 "not": {
@@ -2836,73 +2842,104 @@
                 ]
             },
             "COMMON_RECEIPT_PROPERTIES": {
-                "title": "Common receipt properties",
-                "description": "Common properties for a transaction receipt",
-                "type": "object",
-                "properties": {
-                    "transaction_hash": {
-                        "title": "Transaction hash",
-                        "$ref": "#/components/schemas/TXN_HASH",
-                        "description": "The hash identifying the transaction"
+                "allOf": [
+                    {
+                        "title": "Common receipt properties",
+                        "description": "Common properties for a transaction receipt",
+                        "type": "object",
+                        "properties": {
+                            "transaction_hash": {
+                                "title": "Transaction hash",
+                                "$ref": "#/components/schemas/TXN_HASH",
+                                "description": "The hash identifying the transaction"
+                            },
+                            "actual_fee": {
+                                "title": "Actual fee",
+                                "$ref": "#/components/schemas/FEE_PAYMENT",
+                                "description": "The fee that was charged by the sequencer"
+                            },
+                            "finality_status": {
+                                "title": "Finality status",
+                                "description": "finality status of the tx",
+                                "$ref": "#/components/schemas/TXN_FINALITY_STATUS"
+                            },
+                            "messages_sent": {
+                                "type": "array",
+                                "title": "Messages sent",
+                                "items": {
+                                    "$ref": "#/components/schemas/MSG_TO_L1"
+                                }
+                            },
+                            "events": {
+                                "description": "The events emitted as part of this transaction",
+                                "title": "Events",
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/EVENT"
+                                }
+                            },
+                            "execution_resources": {
+                                "title": "Execution resources",
+                                "description": "The resources consumed by the transaction",
+                                "$ref": "#/components/schemas/EXECUTION_RESOURCES"
+                            }
+                        },
+                        "required": [
+                            "transaction_hash",
+                            "actual_fee",
+                            "finality_status",
+                            "messages_sent",
+                            "events",
+                            "execution_resources"
+                        ]
                     },
-                    "actual_fee": {
-                        "title": "Actual fee",
-                        "$ref": "#/components/schemas/FEE_PAYMENT",
-                        "description": "The fee that was charged by the sequencer"
-                    },
-                    "execution_status": {
-                        "title": "Execution status",
-                        "$ref": "#/components/schemas/TXN_EXECUTION_STATUS"
-                    },
-                    "finality_status": {
-                        "title": "Finality status",
-                        "$ref": "#/components/schemas/TXN_FINALITY_STATUS"
-                    },
-                    "block_hash": {
-                        "title": "Block hash",
-                        "$ref": "#/components/schemas/BLOCK_HASH"
-                    },
-                    "block_number": {
-                        "title": "Block number",
-                        "$ref": "#/components/schemas/BLOCK_NUMBER"
-                    },
-                    "messages_sent": {
-                        "type": "array",
-                        "title": "Messages sent",
-                        "items": {
-                            "$ref": "#/components/schemas/MSG_TO_L1"
-                        }
-                    },
-                    "revert_reason": {
-                        "title": "Revert reason",
-                        "name": "revert reason",
-                        "description": "the revert reason for the failed execution",
-                        "type": "string"
-                    },
-                    "events": {
-                        "description": "The events emitted as part of this transaction",
-                        "title": "Events",
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/EVENT"
-                        }
-                    },
-                    "execution_resources": {
-                        "title": "Execution resources",
-                        "description": "The resources consumed by the transaction",
-                        "$ref": "#/components/schemas/EXECUTION_RESOURCES"
+                    {
+                        "oneOf": [
+                            {
+                                "title": "Successful Common receipt properties",
+                                "description": "Common properties for a transaction receipt that was executed successfully",
+                                "type": "object",
+                                "properties": {
+                                    "execution_status": {
+                                        "title": "Execution status",
+                                        "type": "string",
+                                        "enum": [
+                                            "SUCCEEDED"
+                                        ],
+                                        "description": "The execution status of the transaction"
+                                    }
+                                },
+                                "required": [
+                                    "execution_status"
+                                ]
+                            },
+                            {
+                                "title": "Reverted Common receipt properties",
+                                "description": "Common properties for a transaction receipt that was reverted",
+                                "type": "object",
+                                "properties": {
+                                    "execution_status": {
+                                        "title": "Execution status",
+                                        "type": "string",
+                                        "enum": [
+                                            "REVERTED"
+                                        ],
+                                        "description": "The execution status of the transaction"
+                                    },
+                                    "revert_reason": {
+                                        "title": "Revert reason",
+                                        "name": "revert reason",
+                                        "description": "the revert reason for the failed execution",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "execution_status",
+                                    "revert_reason"
+                                ]
+                            }
+                        ]
                     }
-                },
-                "required": [
-                    "transaction_hash",
-                    "actual_fee",
-                    "finality_status",
-                    "execution_status",
-                    "block_hash",
-                    "block_number",
-                    "messages_sent",
-                    "events",
-                    "execution_resources"
                 ]
             },
             "INVOKE_TXN_RECEIPT": {
@@ -2927,31 +2964,6 @@
                     {
                         "title": "Common receipt properties",
                         "$ref": "#/components/schemas/COMMON_RECEIPT_PROPERTIES"
-                    }
-                ]
-            },
-            "PENDING_INVOKE_TXN_RECEIPT": {
-                "title": "Invoke Transaction Receipt",
-                "allOf": [
-                    {
-                        "title": "Type",
-                        "type": "object",
-                        "properties": {
-                            "type": {
-                                "title": "Type",
-                                "type": "string",
-                                "enum": [
-                                    "INVOKE"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "type"
-                        ]
-                    },
-                    {
-                        "title": "Common receipt properties",
-                        "$ref": "#/components/schemas/PENDING_COMMON_RECEIPT_PROPERTIES"
                     }
                 ]
             },
@@ -2980,68 +2992,12 @@
                     }
                 ]
             },
-            "PENDING_DECLARE_TXN_RECEIPT": {
-                "title": "Declare Transaction Receipt",
-                "allOf": [
-                    {
-                        "title": "Declare txn receipt",
-                        "type": "object",
-                        "properties": {
-                            "type": {
-                                "title": "Declare",
-                                "type": "string",
-                                "enum": [
-                                    "DECLARE"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "type"
-                        ]
-                    },
-                    {
-                        "title": "Common receipt properties",
-                        "$ref": "#/components/schemas/PENDING_COMMON_RECEIPT_PROPERTIES"
-                    }
-                ]
-            },
             "DEPLOY_ACCOUNT_TXN_RECEIPT": {
                 "title": "Deploy Account Transaction Receipt",
                 "allOf": [
                     {
                         "title": "Common receipt properties",
                         "$ref": "#/components/schemas/COMMON_RECEIPT_PROPERTIES"
-                    },
-                    {
-                        "title": "DeployAccount txn receipt",
-                        "type": "object",
-                        "properties": {
-                            "type": {
-                                "title": "Deploy account",
-                                "type": "string",
-                                "enum": [
-                                    "DEPLOY_ACCOUNT"
-                                ]
-                            },
-                            "contract_address": {
-                                "title": "Contract address",
-                                "description": "The address of the deployed contract",
-                                "$ref": "#/components/schemas/FELT"
-                            }
-                        },
-                        "required": [
-                            "type",
-                            "contract_address"
-                        ]
-                    }
-                ]
-            },
-            "PENDING_DEPLOY_ACCOUNT_TXN_RECEIPT": {
-                "title": "Deploy Account Transaction Receipt",
-                "allOf": [
-                    {
-                        "title": "Common receipt properties",
-                        "$ref": "#/components/schemas/PENDING_COMMON_RECEIPT_PROPERTIES"
                     },
                     {
                         "title": "DeployAccount txn receipt",
@@ -3130,38 +3086,6 @@
                     }
                 ]
             },
-            "PENDING_L1_HANDLER_TXN_RECEIPT": {
-                "title": "L1 Handler Transaction Receipt",
-                "description": "receipt for l1 handler transaction",
-                "allOf": [
-                    {
-                        "title": "Transaction type",
-                        "type": "object",
-                        "properties": {
-                            "type": {
-                                "title": "type",
-                                "type": "string",
-                                "enum": [
-                                    "L1_HANDLER"
-                                ]
-                            },
-                            "message_hash": {
-                                "title": "Message hash",
-                                "description": "The message hash as it appears on the L1 core contract",
-                                "$ref": "#/components/schemas/NUM_AS_HEX"
-                            }
-                        },
-                        "required": [
-                            "type",
-                            "message_hash"
-                        ]
-                    },
-                    {
-                        "title": "Common receipt properties",
-                        "$ref": "#/components/schemas/PENDING_COMMON_RECEIPT_PROPERTIES"
-                    }
-                ]
-            },
             "TXN_RECEIPT": {
                 "title": "Transaction Receipt",
                 "oneOf": [
@@ -3187,91 +3111,29 @@
                     }
                 ]
             },
-            "PENDING_TXN_RECEIPT": {
-                "title": "Transaction Receipt",
-                "oneOf": [
+            "TXN_RECEIPT_WITH_BLOCK_INFO": {
+                "title": "Transaction receipt with block info",
+                "allOf": [
                     {
-                        "title": "Pending Invoke transaction receipt",
-                        "$ref": "#/components/schemas/PENDING_INVOKE_TXN_RECEIPT"
+                        "title": "Transaction receipt",
+                        "$ref": "#/components/schemas/TXN_RECEIPT"
                     },
                     {
-                        "title": "Pending L1 handler transaction receipt",
-                        "$ref": "#/components/schemas/PENDING_L1_HANDLER_TXN_RECEIPT"
-                    },
-                    {
-                        "title": "Pending Declare transaction receipt",
-                        "$ref": "#/components/schemas/PENDING_DECLARE_TXN_RECEIPT"
-                    },
-                    {
-                        "title": "Pending Deploy account transaction receipt",
-                        "$ref": "#/components/schemas/PENDING_DEPLOY_ACCOUNT_TXN_RECEIPT"
+                        "type": "object",
+                        "properties": {
+                            "block_hash": {
+                                "title": "Block hash",
+                                "$ref": "#/components/schemas/BLOCK_HASH",
+                                "description": "If this field is missing, it means the receipt belongs to the pending block"
+                            },
+                            "block_number": {
+                                "title": "Block number",
+                                "$ref": "#/components/schemas/BLOCK_NUMBER",
+                                "description": "If this field is missing, it means the receipt belongs to the pending block"
+                            }
+                        }
                     }
                 ]
-            },
-            "PENDING_COMMON_RECEIPT_PROPERTIES": {
-                "title": "Pending common receipt properties",
-                "description": "Common properties for a pending transaction receipt",
-                "type": "object",
-                "properties": {
-                    "transaction_hash": {
-                        "title": "Transaction hash",
-                        "$ref": "#/components/schemas/TXN_HASH",
-                        "description": "The hash identifying the transaction"
-                    },
-                    "actual_fee": {
-                        "title": "Actual fee",
-                        "$ref": "#/components/schemas/FEE_PAYMENT",
-                        "description": "The fee that was charged by the sequencer"
-                    },
-                    "messages_sent": {
-                        "type": "array",
-                        "title": "Messages sent",
-                        "items": {
-                            "$ref": "#/components/schemas/MSG_TO_L1"
-                        }
-                    },
-                    "events": {
-                        "description": "The events emitted as part of this transaction",
-                        "title": "Events",
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/EVENT"
-                        }
-                    },
-                    "revert_reason": {
-                        "title": "Revert reason",
-                        "name": "revert reason",
-                        "description": "the revert reason for the failed execution",
-                        "type": "string"
-                    },
-                    "finality_status": {
-                        "title": "Finality status",
-                        "type": "string",
-                        "enum": [
-                            "ACCEPTED_ON_L2"
-                        ],
-                        "description": "The finality status of the transaction"
-                    },
-                    "execution_status": {
-                        "title": "Execution status",
-                        "$ref": "#/components/schemas/TXN_EXECUTION_STATUS"
-                    },
-                    "execution_resources": {
-                        "title": "Execution resources",
-                        "description": "The resources consumed by the transaction",
-                        "$ref": "#/components/schemas/EXECUTION_RESOURCES"
-                    }
-                },
-                "required": [
-                    "transaction_hash",
-                    "actual_fee",
-                    "messages_sent",
-                    "events",
-                    "finality_status",
-                    "execution_status",
-                    "execution_resources"
-                ],
-                "additionalProperties": false
             },
             "MSG_TO_L1": {
                 "title": "Message to L1",

--- a/doc/rpc/v07/starknet_trace_api_openrpc.json
+++ b/doc/rpc/v07/starknet_trace_api_openrpc.json
@@ -1,7 +1,7 @@
 {
     "openrpc": "1.0.0-rc1",
     "info": {
-        "version": "0.6.0",
+        "version": "0.7.0",
         "title": "StarkNet Trace API",
         "license": {}
     },
@@ -171,7 +171,10 @@
                                                 "description": "the revert reason for the failed execution",
                                                 "type": "string"
                                             }
-                                        }
+                                        },
+                                        "required": [
+                                            "revert_reason"
+                                        ]
                                     }
                                 ]
                             },
@@ -373,7 +376,7 @@
                             },
                             "execution_resources": {
                                 "title": "Computation resources",
-                                "description": "Resources consumed by the internal call",
+                                "description": "Resources consumed by the internal call. This is named execution_resources for legacy reasons",
                                 "$ref": "#/components/schemas/COMPUTATION_RESOURCES"
                             }
                         },

--- a/doc/rpc/v07/starknet_write_api.json
+++ b/doc/rpc/v07/starknet_write_api.json
@@ -1,206 +1,145 @@
 {
     "openrpc": "1.0.0-rc1",
     "info": {
-        "version": "0.6.0",
-        "title": "StarkNet Node Write API",
+        "version": "0.7.0",
+        "title": "StarkNet Trace API",
         "license": {}
     },
     "servers": [],
     "methods": [
         {
-            "name": "starknet_addInvokeTransaction",
-            "summary": "Submit a new transaction to be added to the chain",
+            "name": "starknet_traceTransaction",
+            "summary": "For a given executed transaction, return the trace of its execution, including internal calls",
+            "description": "Returns the execution trace of the transaction designated by the input hash",
             "params": [
                 {
-                    "name": "invoke_transaction",
-                    "description": "The information needed to invoke the function (or account, for version 1 transactions)",
+                    "name": "transaction_hash",
+                    "summary": "The hash of the transaction to trace",
                     "required": true,
                     "schema": {
-                        "$ref": "#/components/schemas/BROADCASTED_INVOKE_TXN"
+                        "$ref": "./starknet_api_openrpc.json#/components/schemas/TXN_HASH"
                     }
                 }
             ],
             "result": {
-                "name": "result",
-                "description": "The result of the transaction submission",
+                "name": "trace",
+                "description": "The function call trace of the transaction designated by the given hash",
                 "schema": {
-                    "type": "object",
-                    "properties": {
-                        "transaction_hash": {
-                            "title": "The hash of the invoke transaction",
-                            "$ref": "#/components/schemas/TXN_HASH"
-                        }
-                    },
-                    "required": [
-                        "transaction_hash"
-                    ]
+                    "$ref": "#/components/schemas/TRANSACTION_TRACE"
                 }
             },
             "errors": [
                 {
-                    "$ref": "#/components/errors/INSUFFICIENT_ACCOUNT_BALANCE"
+                    "$ref": "#/components/errors/TXN_HASH_NOT_FOUND"
                 },
                 {
-                    "$ref": "#/components/errors/INSUFFICIENT_MAX_FEE"
-                },
-                {
-                    "$ref": "#/components/errors/INVALID_TRANSACTION_NONCE"
-                },
-                {
-                    "$ref": "#/components/errors/VALIDATION_FAILURE"
-                },
-                {
-                    "$ref": "#/components/errors/NON_ACCOUNT"
-                },
-                {
-                    "$ref": "#/components/errors/DUPLICATE_TX"
-                },
-                {
-                    "$ref": "#/components/errors/UNSUPPORTED_TX_VERSION"
-                },
-                {
-                    "$ref": "#/components/errors/UNEXPECTED_ERROR"
+                    "$ref": "#/components/errors/NO_TRACE_AVAILABLE"
                 }
             ]
         },
         {
-            "name": "starknet_addDeclareTransaction",
-            "summary": "Submit a new class declaration transaction",
+            "name": "starknet_simulateTransactions",
+            "summary": "Simulate a given sequence of transactions on the requested state, and generate the execution traces. Note that some of the transactions may revert, in which case no error is thrown, but revert details can be seen on the returned trace object. . Note that some of the transactions may revert, this will be reflected by the revert_error property in the trace. Other types of failures (e.g. unexpected error or failure in the validation phase) will result in TRANSACTION_EXECUTION_ERROR.",
             "params": [
                 {
-                    "name": "declare_transaction",
-                    "description": "Declare transaction required to declare a new class on Starknet",
+                    "name": "block_id",
+                    "description": "The hash of the requested block, or number (height) of the requested block, or a block tag, for the block referencing the state or call the transaction on.",
                     "required": true,
                     "schema": {
-                        "title": "Declare transaction",
-                        "$ref": "#/components/schemas/BROADCASTED_DECLARE_TXN"
+                        "$ref": "#/components/schemas/BLOCK_ID"
+                    }
+                },
+                {
+                    "name": "transactions",
+                    "description": "The transactions to simulate",
+                    "required": true,
+                    "schema": {
+                        "type": "array",
+                        "description": "a sequence of transactions to simulate, running each transaction on the state resulting from applying all the previous ones",
+                        "items": {
+                            "$ref": "#/components/schemas/BROADCASTED_TXN"
+                        }
+                    }
+                },
+                {
+                    "name": "simulation_flags",
+                    "description": "describes what parts of the transaction should be executed",
+                    "required": true,
+                    "schema": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SIMULATION_FLAG"
+                        }
                     }
                 }
             ],
             "result": {
-                "name": "result",
-                "description": "The result of the transaction submission",
+                "name": "simulated_transactions",
+                "description": "The execution trace and consuemd resources of the required transactions",
                 "schema": {
-                    "type": "object",
-                    "properties": {
-                        "transaction_hash": {
-                            "title": "The hash of the declare transaction",
-                            "$ref": "#/components/schemas/TXN_HASH"
-                        },
-                        "class_hash": {
-                            "title": "The hash of the declared class",
-                            "$ref": "#/components/schemas/FELT"
+                    "type": "array",
+                    "items": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "transaction_trace": {
+                                    "title": "the transaction's trace",
+                                    "$ref": "#/components/schemas/TRANSACTION_TRACE"
+                                },
+                                "fee_estimation": {
+                                    "title": "the transaction's resources and fee",
+                                    "$ref": "#/components/schemas/FEE_ESTIMATE"
+                                }
+                            }
                         }
-                    },
-                    "required": [
-                        "transaction_hash",
-                        "class_hash"
-                    ]
+                    }
                 }
             },
             "errors": [
                 {
-                    "$ref": "#/components/errors/CLASS_ALREADY_DECLARED"
+                    "$ref": "#/components/errors/BLOCK_NOT_FOUND"
                 },
                 {
-                    "$ref": "#/components/errors/COMPILATION_FAILED"
-                },
-                {
-                    "$ref": "#/components/errors/COMPILED_CLASS_HASH_MISMATCH"
-                },
-                {
-                    "$ref": "#/components/errors/INSUFFICIENT_ACCOUNT_BALANCE"
-                },
-                {
-                    "$ref": "#/components/errors/INSUFFICIENT_MAX_FEE"
-                },
-                {
-                    "$ref": "#/components/errors/INVALID_TRANSACTION_NONCE"
-                },
-                {
-                    "$ref": "#/components/errors/VALIDATION_FAILURE"
-                },
-                {
-                    "$ref": "#/components/errors/NON_ACCOUNT"
-                },
-                {
-                    "$ref": "#/components/errors/DUPLICATE_TX"
-                },
-                {
-                    "$ref": "#/components/errors/CONTRACT_CLASS_SIZE_IS_TOO_LARGE"
-                },
-                {
-                    "$ref": "#/components/errors/UNSUPPORTED_TX_VERSION"
-                },
-                {
-                    "$ref": "#/components/errors/UNSUPPORTED_CONTRACT_CLASS_VERSION"
-                },
-                {
-                    "$ref": "#/components/errors/UNEXPECTED_ERROR"
+                    "$ref": "#/components/errors/TRANSACTION_EXECUTION_ERROR"
                 }
             ]
         },
         {
-            "name": "starknet_addDeployAccountTransaction",
-            "summary": "Submit a new deploy account transaction",
+            "name": "starknet_traceBlockTransactions",
+            "summary": "Retrieve traces for all transactions in the given block",
+            "description": "Returns the execution traces of all transactions included in the given block",
             "params": [
                 {
-                    "name": "deploy_account_transaction",
-                    "description": "The deploy account transaction",
+                    "name": "block_id",
+                    "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
                     "required": true,
                     "schema": {
-                        "$ref": "#/components/schemas/BROADCASTED_DEPLOY_ACCOUNT_TXN"
+                        "$ref": "#/components/schemas/BLOCK_ID"
                     }
                 }
             ],
             "result": {
-                "name": "result",
-                "description": "The result of the transaction submission",
+                "name": "traces",
+                "description": "The traces of all transactions in the block",
                 "schema": {
-                    "type": "object",
-                    "properties": {
-                        "transaction_hash": {
-                            "title": "The hash of the deploy transaction",
-                            "$ref": "#/components/schemas/TXN_HASH"
-                        },
-                        "contract_address": {
-                            "title": "The address of the new contract",
-                            "$ref": "#/components/schemas/FELT"
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "description": "A single pair of transaction hash and corresponding trace",
+                        "properties": {
+                            "transaction_hash": {
+                                "$ref": "#/components/schemas/FELT"
+                            },
+                            "trace_root": {
+                                "$ref": "#/components/schemas/TRANSACTION_TRACE"
+                            }
                         }
-                    },
-                    "required": [
-                        "transaction_hash",
-                        "contract_address"
-                    ]
+                    }
                 }
             },
             "errors": [
                 {
-                    "$ref": "#/components/errors/INSUFFICIENT_ACCOUNT_BALANCE"
-                },
-                {
-                    "$ref": "#/components/errors/INSUFFICIENT_MAX_FEE"
-                },
-                {
-                    "$ref": "#/components/errors/INVALID_TRANSACTION_NONCE"
-                },
-                {
-                    "$ref": "#/components/errors/VALIDATION_FAILURE"
-                },
-                {
-                    "$ref": "#/components/errors/NON_ACCOUNT"
-                },
-                {
-                    "$ref": "#/components/errors/CLASS_HASH_NOT_FOUND"
-                },
-                {
-                    "$ref": "#/components/errors/DUPLICATE_TX"
-                },
-                {
-                    "$ref": "#/components/errors/UNSUPPORTED_TX_VERSION"
-                },
-                {
-                    "$ref": "#/components/errors/UNEXPECTED_ERROR"
+                    "$ref": "#/components/errors/BLOCK_NOT_FOUND"
                 }
             ]
         }
@@ -208,91 +147,366 @@
     "components": {
         "contentDescriptors": {},
         "schemas": {
-            "NUM_AS_HEX": {
-                "title": "An integer number in hex format (0x...)",
-                "type": "string",
-                "pattern": "^0x[a-fA-F0-9]+$"
+            "TRANSACTION_TRACE": {
+                "oneOf": [
+                    {
+                        "name": "INVOKE_TXN_TRACE",
+                        "type": "object",
+                        "description": "the execution trace of an invoke transaction",
+                        "properties": {
+                            "validate_invocation": {
+                                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+                            },
+                            "execute_invocation": {
+                                "description": "the trace of the __execute__ call or constructor call, depending on the transaction type (none for declare transactions)",
+                                "oneOf": [
+                                    {
+                                        "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "revert_reason": {
+                                                "name": "revert reason",
+                                                "description": "the revert reason for the failed execution",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "revert_reason"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "fee_transfer_invocation": {
+                                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+                            },
+                            "state_diff": {
+                                "title": "state_diff",
+                                "description": "the state diffs induced by the transaction",
+                                "$ref": "#/components/schemas/STATE_DIFF"
+                            },
+                            "execution_resources": {
+                                "title": "Execution resources",
+                                "description": "the resources consumed by the transaction, includes both computation and data",
+                                "$ref": "#/components/schemas/EXECUTION_RESOURCES"
+                            },
+                            "type": {
+                                "title": "Type",
+                                "type": "string",
+                                "enum": [
+                                    "INVOKE"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "type",
+                            "execute_invocation",
+                            "execution_resources"
+                        ]
+                    },
+                    {
+                        "name": "DECLARE_TXN_TRACE",
+                        "type": "object",
+                        "description": "the execution trace of a declare transaction",
+                        "properties": {
+                            "validate_invocation": {
+                                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+                            },
+                            "fee_transfer_invocation": {
+                                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+                            },
+                            "state_diff": {
+                                "title": "state_diff",
+                                "description": "the state diffs induced by the transaction",
+                                "$ref": "#/components/schemas/STATE_DIFF"
+                            },
+                            "execution_resources": {
+                                "title": "Execution resources",
+                                "description": "the resources consumed by the transaction, includes both computation and data",
+                                "$ref": "#/components/schemas/EXECUTION_RESOURCES"
+                            },
+                            "type": {
+                                "title": "Type",
+                                "type": "string",
+                                "enum": [
+                                    "DECLARE"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "type",
+                            "execution_resources"
+                        ]
+                    },
+                    {
+                        "name": "DEPLOY_ACCOUNT_TXN_TRACE",
+                        "type": "object",
+                        "description": "the execution trace of a deploy account transaction",
+                        "properties": {
+                            "validate_invocation": {
+                                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+                            },
+                            "constructor_invocation": {
+                                "description": "the trace of the __execute__ call or constructor call, depending on the transaction type (none for declare transactions)",
+                                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+                            },
+                            "fee_transfer_invocation": {
+                                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+                            },
+                            "state_diff": {
+                                "title": "state_diff",
+                                "description": "the state diffs induced by the transaction",
+                                "$ref": "#/components/schemas/STATE_DIFF"
+                            },
+                            "execution_resources": {
+                                "title": "Execution resources",
+                                "description": "the resources consumed by the transaction, includes both computation and data",
+                                "$ref": "#/components/schemas/EXECUTION_RESOURCES"
+                            },
+                            "type": {
+                                "title": "Type",
+                                "type": "string",
+                                "enum": [
+                                    "DEPLOY_ACCOUNT"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "type",
+                            "execution_resources",
+                            "constructor_invocation"
+                        ]
+                    },
+                    {
+                        "name": "L1_HANDLER_TXN_TRACE",
+                        "type": "object",
+                        "description": "the execution trace of an L1 handler transaction",
+                        "properties": {
+                            "function_invocation": {
+                                "description": "the trace of the __execute__ call or constructor call, depending on the transaction type (none for declare transactions)",
+                                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+                            },
+                            "state_diff": {
+                                "title": "state_diff",
+                                "description": "the state diffs induced by the transaction",
+                                "$ref": "#/components/schemas/STATE_DIFF"
+                            },
+                            "type": {
+                                "title": "Type",
+                                "type": "string",
+                                "enum": [
+                                    "L1_HANDLER"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "type",
+                            "function_invocation"
+                        ]
+                    }
+                ]
             },
-            "SIGNATURE": {
-                "$ref": "./starknet_api_openrpc.json#/components/schemas/SIGNATURE"
+            "SIMULATION_FLAG": {
+                "type": "string",
+                "enum": [
+                    "SKIP_VALIDATE",
+                    "SKIP_FEE_CHARGE"
+                ],
+                "description": "Flags that indicate how to simulate a given transaction. By default, the sequencer behavior is replicated locally (enough funds are expected to be in the account, and fee will be deducted from the balance before the simulation of the next transaction). To skip the fee charge, use the SKIP_FEE_CHARGE flag."
+            },
+            "NESTED_CALL": {
+                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+            },
+            "FUNCTION_INVOCATION": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/FUNCTION_CALL"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "caller_address": {
+                                "title": "Caller Address",
+                                "description": "The address of the invoking contract. 0 for the root invocation",
+                                "$ref": "#/components/schemas/FELT"
+                            },
+                            "class_hash": {
+                                "title": "Class hash",
+                                "description": "The hash of the class being called",
+                                "$ref": "#/components/schemas/FELT"
+                            },
+                            "entry_point_type": {
+                                "$ref": "#/components/schemas/ENTRY_POINT_TYPE"
+                            },
+                            "call_type": {
+                                "$ref": "#/components/schemas/CALL_TYPE"
+                            },
+                            "result": {
+                                "title": "Invocation Result",
+                                "description": "The value returned from the function invocation",
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/FELT"
+                                }
+                            },
+                            "calls": {
+                                "title": "Nested Calls",
+                                "description": "The calls made by this invocation",
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/NESTED_CALL"
+                                }
+                            },
+                            "events": {
+                                "title": "Invocation Events",
+                                "description": "The events emitted in this invocation",
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/ORDERED_EVENT"
+                                }
+                            },
+                            "messages": {
+                                "title": "L1 Messages",
+                                "description": "The messages sent by this invocation to L1",
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/ORDERED_MESSAGE"
+                                }
+                            },
+                            "execution_resources": {
+                                "title": "Computation resources",
+                                "description": "Resources consumed by the internal call. This is named execution_resources for legacy reasons",
+                                "$ref": "#/components/schemas/COMPUTATION_RESOURCES"
+                            }
+                        },
+                        "required": [
+                            "caller_address",
+                            "class_hash",
+                            "entry_point_type",
+                            "call_type",
+                            "result",
+                            "calls",
+                            "events",
+                            "messages",
+                            "execution_resources"
+                        ]
+                    }
+                ]
+            },
+            "ENTRY_POINT_TYPE": {
+                "type": "string",
+                "enum": [
+                    "EXTERNAL",
+                    "L1_HANDLER",
+                    "CONSTRUCTOR"
+                ]
+            },
+            "CALL_TYPE": {
+                "type": "string",
+                "enum": [
+                    "LIBRARY_CALL",
+                    "CALL",
+                    "DELEGATE"
+                ]
+            },
+            "ORDERED_EVENT": {
+                "type": "object",
+                "title": "orderedEvent",
+                "description": "an event alongside its order within the transaction",
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "order": {
+                                "title": "order",
+                                "description": "the order of the event within the transaction",
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    {
+                        "$ref": "#/components/schemas/EVENT"
+                    }
+                ]
+            },
+            "ORDERED_MESSAGE": {
+                "type": "object",
+                "title": "orderedMessage",
+                "description": "a message alongside its order within the transaction",
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "order": {
+                                "title": "order",
+                                "description": "the order of the message within the transaction",
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    {
+                        "$ref": "#/components/schemas/MSG_TO_L1"
+                    }
+                ]
             },
             "FELT": {
                 "$ref": "./starknet_api_openrpc.json#/components/schemas/FELT"
             },
-            "TXN_HASH": {
-                "$ref": "./starknet_api_openrpc.json#/components/schemas/TXN_HASH"
-            },
-            "BROADCASTED_INVOKE_TXN": {
-                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BROADCASTED_INVOKE_TXN"
-            },
-            "BROADCASTED_DECLARE_TXN": {
-                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BROADCASTED_DECLARE_TXN"
-            },
-            "BROADCASTED_DEPLOY_ACCOUNT_TXN": {
-                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BROADCASTED_DEPLOY_ACCOUNT_TXN"
-            },
             "FUNCTION_CALL": {
                 "$ref": "./starknet_api_openrpc.json#/components/schemas/FUNCTION_CALL"
+            },
+            "EVENT": {
+                "$ref": "./starknet_api_openrpc.json#/components/schemas/EVENT_CONTENT"
+            },
+            "MSG_TO_L1": {
+                "$ref": "./starknet_api_openrpc.json#/components/schemas/MSG_TO_L1"
+            },
+            "BLOCK_ID": {
+                "$ref": "./starknet_api_openrpc.json#/components/schemas/BLOCK_ID"
+            },
+            "FEE_ESTIMATE": {
+                "$ref": "./starknet_api_openrpc.json#/components/schemas/FEE_ESTIMATE"
+            },
+            "BROADCASTED_TXN": {
+                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BROADCASTED_TXN"
+            },
+            "STATE_DIFF": {
+                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/STATE_DIFF"
+            },
+            "COMPUTATION_RESOURCES": {
+                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/COMPUTATION_RESOURCES"
+            },
+            "EXECUTION_RESOURCES": {
+                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/EXECUTION_RESOURCES"
             }
         },
         "errors": {
-            "CLASS_HASH_NOT_FOUND": {
-                "code": 28,
-                "message": "Class hash not found"
+            "NO_TRACE_AVAILABLE": {
+                "code": 10,
+                "message": "No trace available for transaction",
+                "data": {
+                    "type": "object",
+                    "description": "Extra information on why trace is not available. Either it wasn't executed yet (RECEIVED), or the transaction failed (REJECTED)",
+                    "properties": {
+                        "status": {
+                            "type": "string",
+                            "enum": [
+                                "RECEIVED",
+                                "REJECTED"
+                            ]
+                        }
+                    }
+                }
             },
-            "CLASS_ALREADY_DECLARED": {
-                "code": 51,
-                "message": "Class already declared"
+            "TXN_HASH_NOT_FOUND": {
+                "$ref": "./api/starknet_api_openrpc.json#/components/errors/TXN_HASH_NOT_FOUND"
             },
-            "INVALID_TRANSACTION_NONCE": {
-                "code": 52,
-                "message": "Invalid transaction nonce"
+            "BLOCK_NOT_FOUND": {
+                "$ref": "./api/starknet_api_openrpc.json#/components/errors/BLOCK_NOT_FOUND"
             },
-            "INSUFFICIENT_MAX_FEE": {
-                "code": 53,
-                "message": "Max fee is smaller than the minimal transaction cost (validation plus fee transfer)"
-            },
-            "INSUFFICIENT_ACCOUNT_BALANCE": {
-                "code": 54,
-                "message": "Account balance is smaller than the transaction's max_fee"
-            },
-            "VALIDATION_FAILURE": {
-                "code": 55,
-                "message": "Account validation failed",
-                "data": "string"
-            },
-            "COMPILATION_FAILED": {
-                "code": 56,
-                "message": "Compilation failed"
-            },
-            "CONTRACT_CLASS_SIZE_IS_TOO_LARGE": {
-                "code": 57,
-                "message": "Contract class size it too large"
-            },
-            "NON_ACCOUNT": {
-                "code": 58,
-                "message": "Sender address in not an account contract"
-            },
-            "DUPLICATE_TX": {
-                "code": 59,
-                "message": "A transaction with the same hash already exists in the mempool"
-            },
-            "COMPILED_CLASS_HASH_MISMATCH": {
-                "code": 60,
-                "message": "the compiled class hash did not match the one supplied in the transaction"
-            },
-            "UNSUPPORTED_TX_VERSION": {
-                "code": 61,
-                "message": "the transaction version is not supported"
-            },
-            "UNSUPPORTED_CONTRACT_CLASS_VERSION": {
-                "code": 62,
-                "message": "the contract class version is not supported"
-            },
-            "UNEXPECTED_ERROR": {
-                "code": 63,
-                "message": "An unexpected error occurred",
-                "data": "string"
+            "TRANSACTION_EXECUTION_ERROR": {
+                "$ref": "./api/starknet_api_openrpc.json#/components/errors/TRANSACTION_EXECUTION_ERROR"
             }
         }
     }


### PR DESCRIPTION
The current docs are from some older commit. These updated spec docs are required for auditing the RPC rework.

Files copied verbatim from the spec repo at the v0.7.0-rc2 tag.