### PR TITLE
chore: Fix clippy warnings when running with no `p2p` feature enabled

### DIFF
--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -730,6 +730,7 @@ impl DebugConfig {
 }
 
 impl Config {
+    #[cfg_attr(not(feature = "p2p"), allow(clippy::unit_arg))]
     pub fn parse() -> Self {
         let cli = Cli::parse();
 


### PR DESCRIPTION
When running bare `cargo clippy` the tool complains about the unit arg which is used when the `p2p` feature is disabled. As the CI runs clippy with all features the warning is not visible there.

This patch silences clippy's `unit_arg` lint but only of the `p2p` feature is enabled.

Short description of what this PR does.

---------------------------

There are no issues nor a changelog entry since this is a really minor change that would only be noticed by developers.

Thanks for your time! :wave: 