### PR TITLE
feat(rpc): add rpc version override http header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `X-Pathfinder-RPC-Version-Override` optional request HTTP header that overrides the RPC spec version to be used for the specitic RPC call. When not provided or invalid the pre-definded spec version is going to be used (based on HTTP path).
+- `X-Pathfinder-RPC-Version-Override` optional request HTTP header that overrides the RPC spec version to be used for the specitic RPC call. When not provided or invalid the pre-defined spec version is going to be used (based on HTTP path).
   - Starknet RPC spec versions: `v0.4`, `v0.5`, `v0.6`, `v0.7` for Starknet RPC spec version.
   - Pathfinder extended RPC spec versions: `v0.1` (such does not change the behavior at this point, because there is only a single version of Pathfinder extended RPC spec).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `starknet_estimateFee` and `starknet_simulateTransactions` can return fee estimates below the minimum fee expected by the sequencer for trivial transactions.
 
+### Added
+
+- `X-Pathfinder-RPC-Version-Override` optional request HTTP header that overrides the RPC spec version to be used for the specitic RPC call. When not provided or invalid the pre-definded spec version is going to be used (based on HTTP path).
+  - Starknet RPC spec versions: `v0.4`, `v0.5`, `v0.6`, `v0.7` for Starknet RPC spec version.
+  - Pathfinder extended RPC spec versions: `v0.1` (such does not change the behavior at this point, because there is only a single version of Pathfinder extended RPC spec).
+
 ## [0.11.3] - 2024-03-13
 
 ### Fixed

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -78,7 +78,11 @@ impl RpcRouter {
     }
 
     /// Parses and executes a request. Returns [None] if its a notification.
-    async fn run_request<'a>(&self, request: &'a str, version: &'a RpcVersion) -> Option<RpcResponse<'a>> {
+    async fn run_request<'a>(
+        &self,
+        request: &'a str,
+        version: &'a RpcVersion,
+    ) -> Option<RpcResponse<'a>> {
         tracing::trace!(%request, "Running request");
 
         let request = match serde_json::from_str::<RpcRequest<'_>>(request) {
@@ -175,7 +179,8 @@ pub async fn rpc_handler(
         body: axum::body::Bytes,
         headers: http::HeaderMap,
     ) -> impl axum::response::IntoResponse {
-        let version = headers.get(RPC_VERSION_OVERRIDE_HEADER)
+        let version = headers
+            .get(RPC_VERSION_OVERRIDE_HEADER)
             .and_then(|v| v.to_str().ok())
             .and_then(RpcVersion::from_str)
             .unwrap_or(state.version);

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -70,7 +70,7 @@ impl RpcVersion {
             "v0.6" => Some(RpcVersion::V06),
             "v0.7" => Some(RpcVersion::V07),
             "v0.1" => Some(RpcVersion::PathfinderV01),
-            _ => None
+            _ => None,
         }
     }
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -62,6 +62,17 @@ impl RpcVersion {
             RpcVersion::PathfinderV01 => "v0.1",
         }
     }
+
+    fn from_str(version: &str) -> Option<Self> {
+        match version {
+            "v0.4" => Some(RpcVersion::V04),
+            "v0.5" => Some(RpcVersion::V05),
+            "v0.6" => Some(RpcVersion::V06),
+            "v0.7" => Some(RpcVersion::V07),
+            "v0.1" => Some(RpcVersion::PathfinderV01),
+            _ => None
+        }
+    }
 }
 
 pub struct RpcServer {


### PR DESCRIPTION
NOTE: This is just a suggestion, not even a strong one. I believe such per-request RPC spec version definition can be useful when RPC provider does not provide a way to query multiple RPC versions by single endpoint. Example: currently Infura exposes `0.5.1` spec version, and there is no easy way to process `0.6.0` request/response (or I just failed to find one) even though Pathfinder has the capabilities to process such requests/responses.

---

This PR allows defining desired RPC spec version per request.

When provided with HTTP request headers, the request is going to be processed according to the provided version override. When not provided, the pre-defined version is going to be used (the one derived from the HTTP request path).

Example:

```
curl ...
-H 'X-Pathfinder-RPC-Version-Override: v0.6'
$URL
```
