### PR TITLE
ci: bump package MSRV to 1.76

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ opt-level = 3
 version = "0.11.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-rust-version = "1.74"
+rust-version = "1.76"
 authors = ["Equilibrium Labs <info@equilibrium.co>"]
 
 [workspace.dependencies]


### PR DESCRIPTION
Fix the daily MSRV CI workflow failures by bumping the MSRV.

No longer compiles on 1.74 (current MSRV) as we use `Result::inspect_err`.
