### PR TITLE
chore: workspace all the deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4501,9 +4501,6 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "is-terminal"
@@ -8304,7 +8301,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6159ab4116165c99fc88cce31f99fa2c9dbe08d3691cb38da02fc3b45f357d2b"
 dependencies = [
  "test-log-macros",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ authors = ["Equilibrium Labs <info@equilibrium.co>"]
 anyhow = "1.0.75"
 assert_matches = "1.5.0"
 async-trait = "0.1.73"
-axum = { version = "0.6.19", features = ["macros"] }
+axum = "0.6.19"
 base64 = "0.13.1"
 bitvec = "1.0.1"
 blockifier = "=0.5.0"
@@ -56,21 +56,21 @@ cairo-vm = "=0.9.2"
 clap = "4.1.13"
 const_format = "0.2.31"
 criterion = "0.5.1"
-fake = { version = "2.8.0", features = ["derive"] }
+fake = "2.8.0"
 flate2 = "1.0.27"
-futures = { version = "0.3", default-features = false, features = ["std"] }
+futures = { version = "0.3", default-features = false }
 hex = "0.4.3"
 http = "0.2.9"
 httpmock = "0.7.0-rc.1"
-ipnet = { version = "2.9.0", features = ["serde"] }
+ipnet = "2.9.0"
 lazy_static = "1.4.0"
 metrics = "0.20.1"
-num-bigint = { version = "0.4.4", features = ["serde"] }
+num-bigint = "0.4.4"
 primitive-types = "0.12.1"
 pretty_assertions_sorted = "1.2.3"
 rand = "0.8.5"
 rayon = "1.8.0"
-reqwest = { version = "0.11.18", features = ["json"] }
+reqwest = "0.11.18"
 rstest = "0.18.2"
 semver = "1.0.18"
 serde = "1.0.192"
@@ -80,11 +80,60 @@ sha3 = "0.10"
 smallvec = "1.13.1"
 # This one needs to match the version used by blockifier
 starknet_api = "=0.10.0"
-test-log = { version = "0.2.12", default-features = false, features = [
-    "trace",
-] }
+test-log = { version = "0.2.12", default-features = false }
 thiserror = "1.0.48"
-tokio = "1.29.1"
+tokio = "1.32.0"
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-zstd = { version = "0.12.4", features = ["pkg-config"] }
+tracing-subscriber = "0.3.17"
+zstd = "0.12.4"
+ark-ff = "0.4.2"
+async-stream = "0.3.5"
+bincode = "2.0.0-rc.3"
+bloomfilter = "1.0.12"
+cairo-lang-starknet-classes = "=2.6.0"
+casm-compiler-v1_0_0-alpha6 = { git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-alpha.6" }
+casm-compiler-v1_0_0-rc0 = { git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-rc0" }
+casm-compiler-v1_1_1 = "=1.1.1"
+casm-compiler-v2 = "=2.6.0"
+console-subscriber = "0.1.10"
+const-decoder = "0.3.0"
+data-encoding = "2.4.0"
+env_logger = "0.10.0"
+ff = "0.13"
+futures-bounded = "0.2.1"
+hyper = "0.14.27"
+jemallocator = "0.5.4"
+keccak-hash = "0.10.0"
+libp2p = { version = "0.53.0", default-features = false }
+libp2p-identity = "0.2.2"
+libp2p-plaintext = "0.41.0"
+libp2p-swarm-test = "0.3.0"
+metrics-exporter-prometheus = "0.11.0"
+mime = "0.3"
+mockall = "0.11.4"
+paste = "1.0.14"
+proc-macro2 = "1.0.66"
+proptest = "1.2.0"
+prost = "0.12.1"
+prost-build = "0.12.1"
+prost-types = "0.12.1"
+quote = "1.0"
+r2d2 = "0.8.10"
+r2d2_sqlite = "0.21.0"
+rand_chacha = "0.3.1"
+rusqlite = "0.28.0"
+sha2 = "0.10.7"
+syn = "1.0"
+tempfile = "3.8"
+time = "0.3.28"
+tokio-retry = "0.3.0"
+tokio-stream = "0.1.14"
+tokio-tungstenite = "0.20"
+tower = { version = "0.4.13", default-features = false }
+tower-http = { version = "0.4.0", default-features = false }
+unsigned-varint = "0.8.0"
+url = "2.4.1"
+vergen = { version = "8", default-features = false }
+void = "1.0.2"
+warp = "0.3.5"
+zeroize = "1.6.0"

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -16,7 +16,7 @@ bitvec = { workspace = true }
 fake = { workspace = true }
 metrics = { workspace = true }
 num-bigint = { workspace = true }
-paste = "1.0.14"
+paste = { workspace = true }
 pathfinder-crypto = { path = "../crypto" }
 primitive-types = { workspace = true, features = ["serde"] }
 rand = { workspace = true }
@@ -34,7 +34,4 @@ thiserror = { workspace = true }
 rstest = { workspace = true }
 
 [build-dependencies]
-vergen = { version = "8", default-features = false, features = [
-    "git",
-    "gitcl",
-] }
+vergen = { workspace = true, features = ["git", "gitcl"] }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -13,7 +13,7 @@ full-serde = []
 [dependencies]
 anyhow = { workspace = true }
 bitvec = { workspace = true }
-fake = { workspace = true }
+fake = { workspace = true, features = ["derive"] }
 metrics = { workspace = true }
 num-bigint = { workspace = true }
 paste = { workspace = true }

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-cairo-lang-starknet-classes = "=2.6.0"
+cairo-lang-starknet-classes = { workspace = true }
 casm-compiler-v1_0_0-alpha6 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-alpha.6" }
 casm-compiler-v1_0_0-rc0 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-rc0" }
 casm-compiler-v1_1_1 = { package = "cairo-lang-starknet", version = "=1.1.1" }

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -20,10 +20,10 @@ rand = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]
-ark-ff = { version = "0.4.2", features = ["std", "asm"] }
+ark-ff = { workspace = true, features = ["std", "asm"] }
 assert_matches = { workspace = true }
 criterion = { workspace = true }
-ff = { version = "0.13", features = ["derive"] }
+ff = { workspace = true, features = ["derive"] }
 num-bigint = { workspace = true }
 pretty_assertions_sorted = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/ethereum/Cargo.toml
+++ b/crates/ethereum/Cargo.toml
@@ -10,9 +10,9 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-const-decoder = "0.3.0"
+const-decoder = { workspace = true }
 hex = { workspace = true }
-keccak-hash = "0.10.0"
+keccak-hash = { workspace = true }
 pathfinder-common = { path = "../common" }
 pathfinder-crypto = { path = "../crypto" }
 primitive-types = { workspace = true }

--- a/crates/ethereum/Cargo.toml
+++ b/crates/ethereum/Cargo.toml
@@ -16,7 +16,7 @@ keccak-hash = { workspace = true }
 pathfinder-common = { path = "../common" }
 pathfinder-crypto = { path = "../crypto" }
 primitive-types = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/crates/gateway-client/Cargo.toml
+++ b/crates/gateway-client/Cargo.toml
@@ -14,7 +14,7 @@ bytes = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 metrics = { workspace = true }
-mockall = { version = "0.11.4" }
+mockall = { workspace = true }
 pathfinder-common = { path = "../common" }
 pathfinder-retry = { path = "../retry" }
 pathfinder-serde = { path = "../serde" }
@@ -27,7 +27,7 @@ serde_json = { workspace = true, features = [
 starknet-gateway-types = { path = "../gateway-types" }
 tokio = { workspace = true, features = ["macros", "test-util"] }
 tracing = { workspace = true }
-warp = { version = "0.3.5" }
+warp = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -10,55 +10,39 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-async-stream = "0.3.5"
+async-stream = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
 futures = { workspace = true }
 ipnet = { workspace = true }
-libp2p = { version = "0.53.0", default-features = false, features = [
-    "autonat",
-    "dcutr",
-    "dns",
-    "gossipsub",
-    "identify",
-    "kad",
-    "macros",
-    "noise",
-    "ping",
-    "relay",
-    "request-response",
-    "serde",
-    "tcp",
-    "tokio",
-    "yamux",
-] }
+libp2p = { workspace = true, features = ["autonat", "dcutr", "dns", "gossipsub", "identify", "kad", "macros", "noise", "ping", "relay", "request-response", "serde", "tcp", "tokio", "yamux"] }
 p2p_proto = { path = "../p2p_proto" }
 p2p_stream = { path = "../p2p_stream" }
 pathfinder-common = { path = "../common" }
 pathfinder-crypto = { path = "../crypto" }
-prost = "0.12.1"
+prost = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-sha2 = "0.10.7"
+sha2 = { workspace = true }
 sha3 = { workspace = true }
 smallvec = { workspace = true }
-tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread", "sync"] }
-tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-unsigned-varint = { version = "0.8.0", features = ["futures"] }
-void = "1.0.2"
-zeroize = "1.6.0"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+unsigned-varint = { workspace = true, features = ["futures"] }
+void = { workspace = true }
+zeroize = { workspace = true }
 
 [dev-dependencies]
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
-env_logger = "0.10.0"
+env_logger = { workspace = true }
 fake = { workspace = true }
 hex = { workspace = true }
 rand = { workspace = true }
 rstest = { workspace = true }
 test-log = { workspace = true }
-tokio = { version = "1.32.0", features = ["test-util"] }
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+tokio = { workspace = true, features = ["test-util"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/crates/p2p_proto/Cargo.toml
+++ b/crates/p2p_proto/Cargo.toml
@@ -10,13 +10,13 @@ build = "build.rs"
 [dependencies]
 anyhow = { workspace = true }
 fake = { workspace = true, features = ["serde_json"] }
-libp2p-identity = { version = "0.2.2", features = ["peerid"] }
+libp2p-identity = { workspace = true, features = ["peerid"] }
 p2p_proto_derive = { path = "../p2p_proto_derive" }
 pathfinder-common = { path = "../common" }
 pathfinder-crypto = { path = "../crypto" }
 primitive-types = { workspace = true }
-prost = "0.12.1"
-prost-types = "0.12.1"
+prost = { workspace = true }
+prost-types = { workspace = true }
 rand = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
 
@@ -24,4 +24,4 @@ serde_json = { workspace = true, features = ["raw_value"] }
 pretty_assertions_sorted = { workspace = true }
 
 [build-dependencies]
-prost-build = "0.12.1"
+prost-build = { workspace = true }

--- a/crates/p2p_proto_derive/Cargo.toml
+++ b/crates/p2p_proto_derive/Cargo.toml
@@ -10,6 +10,6 @@ rust-version = { workspace = true }
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.66"
-quote = "1.0"
-syn = "1.0"
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }

--- a/crates/p2p_stream/Cargo.toml
+++ b/crates/p2p_stream/Cargo.toml
@@ -13,29 +13,18 @@ rust-version = { workspace = true }
 [dependencies]
 async-trait = { workspace = true }
 futures = { workspace = true }
-futures-bounded = "0.2.1"
-libp2p = { version = "0.53.0", default-features = false, features = [
-    "identify",
-    "noise",
-    "tcp",
-    "tokio",
-] }
+futures-bounded = { workspace = true }
+libp2p = { workspace = true, features = ["identify", "noise", "tcp", "tokio"] }
 smallvec = { workspace = true }
 tracing = { workspace = true }
-void = "1.0.2"
+void = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
 fake = { workspace = true }
-libp2p = { version = "0.53.0", default-features = false, features = [
-    "identify",
-    "noise",
-    "tcp",
-    "tokio",
-    "yamux",
-] }
-libp2p-plaintext = "0.41.0"
-libp2p-swarm-test = "0.3.0"
+libp2p = { workspace = true, features = ["identify", "noise", "tcp", "tokio", "yamux"] }
+libp2p-plaintext = { workspace = true }
+libp2p-swarm-test = { workspace = true }
 rstest = { workspace = true }
 tokio = { workspace = true, features = ["macros", "time"] }
 tracing-subscriber = { workspace = true }

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -23,14 +23,14 @@ base64 = { workspace = true, optional = true }
 bitvec = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
-console-subscriber = { version = "0.1.10", optional = true }
+console-subscriber = { workspace = true, optional = true }
 fake = { workspace = true }
 futures = { workspace = true }
 ipnet = { workspace = true }
-jemallocator = "0.5.4"
+jemallocator = { workspace = true }
 lazy_static = { workspace = true }
 metrics = { workspace = true }
-metrics-exporter-prometheus = "0.11.0"
+metrics-exporter-prometheus = { workspace = true }
 p2p = { path = "../p2p", optional = true }
 p2p_proto = { path = "../p2p_proto", optional = true }
 pathfinder-common = { path = "../common" }
@@ -55,36 +55,32 @@ serde_json = { workspace = true, features = [
 smallvec = { workspace = true }
 starknet-gateway-client = { path = "../gateway-client" }
 starknet-gateway-types = { path = "../gateway-types" }
-tempfile = "3.8"
-thiserror = "1.0.48"
-time = { version = "0.3.28", features = ["macros"] }
+tempfile = { workspace = true }
+thiserror = { workspace = true }
+time = { workspace = true, features = ["macros"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal"] }
-tokio-stream = "0.1.14"
+tokio-stream = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3.17", features = [
-    "env-filter",
-    "time",
-    "ansi",
-] }
-url = "2.4.1"
-warp = "0.3.5"
-zeroize = { version = "1.6.0", optional = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "time", "ansi"] }
+url = { workspace = true }
+warp = { workspace = true }
+zeroize = { workspace = true, optional = true }
 zstd = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-const-decoder = "0.3.0"
+const-decoder = { workspace = true }
 flate2 = { workspace = true }
 http = { workspace = true }
-mockall = "0.11.4"
+mockall = { workspace = true }
 pathfinder-common = { path = "../common", features = ["full-serde"] }
 pathfinder-compiler = { path = "../compiler" }
 pathfinder-executor = { path = "../executor" }
 pathfinder-rpc = { path = "../rpc" }
 pathfinder-storage = { path = "../storage" }
 pretty_assertions_sorted = { workspace = true }
-proptest = "1.2.0"
-rand_chacha = "0.3.1"
+proptest = { workspace = true }
+rand_chacha = { workspace = true }
 rstest = { workspace = true }
 serde_with = { workspace = true }
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }

--- a/crates/retry/Cargo.toml
+++ b/crates/retry/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 tokio = { workspace = true }
-tokio-retry = "0.3.0"
+tokio-retry = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "test-util"] }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -14,9 +14,9 @@ base64 = { workspace = true }
 flate2 = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
-hyper = "0.14.27"
+hyper = { workspace = true }
 metrics = { workspace = true }
-mime = "0.3"
+mime = { workspace = true }
 pathfinder-common = { path = "../common" }
 pathfinder-compiler = { path = "../compiler" }
 pathfinder-crypto = { path = "../crypto" }
@@ -40,19 +40,8 @@ starknet-gateway-types = { path = "../gateway-types" }
 starknet_api = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["test-util", "process"] }
-tower = { version = "0.4.13", default-features = false, features = [
-    "filter",
-    "util",
-    "limit",
-    "timeout",
-] }
-tower-http = { version = "0.4.0", default-features = false, features = [
-    "cors",
-    "limit",
-    "request-id",
-    "trace",
-    "util",
-] }
+tower = { workspace = true, features = ["filter", "util", "limit", "timeout"] }
+tower-http = { workspace = true, features = ["cors", "limit", "request-id", "trace", "util"] }
 tracing = { workspace = true }
 zstd = { workspace = true }
 
@@ -65,7 +54,7 @@ lazy_static = { workspace = true }
 pathfinder-crypto = { path = "../crypto" }
 pretty_assertions_sorted = { workspace = true }
 rstest = { workspace = true }
-tempfile = "3.6"
+tempfile = { workspace = true }
 test-log = { workspace = true }
-tokio-tungstenite = "0.20"
+tokio-tungstenite = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-axum = { workspace = true, features = ["ws", "headers"] }
+axum = { workspace = true, features = ["ws", "headers", "macros"] }
 base64 = { workspace = true }
 flate2 = { workspace = true }
 futures = { workspace = true }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -10,12 +10,12 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 base64 = { workspace = true }
-bincode = "2.0.0-rc.3"
+bincode = { workspace = true }
 bitvec = { workspace = true }
-bloomfilter = "1.0.12"
+bloomfilter = { workspace = true }
 cached = { workspace = true }
 const_format = { workspace = true }
-data-encoding = "2.4.0"
+data-encoding = { workspace = true }
 fake = { workspace = true }
 hex = { workspace = true }
 lazy_static = { workspace = true }
@@ -24,10 +24,10 @@ pathfinder-crypto = { path = "../crypto" }
 pathfinder-ethereum = { path = "../ethereum" }
 pathfinder-serde = { path = "../serde" }
 primitive-types = { workspace = true }
-r2d2 = "0.8.10"
-r2d2_sqlite = "0.21.0"
+r2d2 = { workspace = true }
+r2d2_sqlite = { workspace = true }
 rand = { workspace = true }
-rusqlite = { version = "0.28.0", features = ["bundled", "functions"] }
+rusqlite = { workspace = true, features = ["bundled", "functions"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = [
     "arbitrary_precision",
@@ -46,6 +46,6 @@ zstd = { workspace = true }
 assert_matches = { workspace = true }
 pretty_assertions_sorted = { workspace = true }
 rstest = { workspace = true }
-tempfile = "3.6"
+tempfile = { workspace = true }
 test-log = { workspace = true }
 tracing-subscriber = { workspace = true }


### PR DESCRIPTION
This PR moves all dependencies into the workspace toml.

This was performed using the [cargo autoinherit](https://github.com/mainmatter/cargo-autoinherit) tool which lists some motivations for the _why_ - mostly the

> - When you need to add a new dependency, you first have to check if it's already used in another package of your workspace to keep versions in sync.

which can be easy to miss.

This process has an additional quirk: features are kept in the package tomls. I've manually re-added the missing ones (ones that were in workspace toml, but not the packages) and things compile and tests work. There are a couple I leftout since it compiled without them?

I like the idea; though there are some sore points like the sierra compilers being in workspace even though we know they will be restricted to a single crate.