### PR TITLE
feat(merkle-tree): track removed nodes

### DIFF
--- a/crates/merkle-tree/src/class.rs
+++ b/crates/merkle-tree/src/class.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::Context;
 use pathfinder_common::{
@@ -62,11 +62,11 @@ impl<'tx> ClassCommitmentTree<'tx> {
 
     /// Commits the changes and calculates the new node hashes. Returns the new commitment and
     /// any potentially newly created nodes.
-    pub fn commit(self) -> anyhow::Result<(ClassCommitment, HashMap<Felt, Node>)> {
+    pub fn commit(self) -> anyhow::Result<(ClassCommitment, HashMap<Felt, Node>, HashSet<u64>)> {
         let update = self.tree.commit(&self.storage)?;
 
         let commitment = ClassCommitment(update.root);
-        Ok((commitment, update.nodes_added))
+        Ok((commitment, update.nodes_added, update.nodes_removed))
     }
 }
 

--- a/crates/merkle-tree/src/class.rs
+++ b/crates/merkle-tree/src/class.rs
@@ -66,7 +66,7 @@ impl<'tx> ClassCommitmentTree<'tx> {
         let update = self.tree.commit(&self.storage)?;
 
         let commitment = ClassCommitment(update.root);
-        Ok((commitment, update.nodes))
+        Ok((commitment, update.nodes_added))
     }
 }
 

--- a/crates/merkle-tree/src/class.rs
+++ b/crates/merkle-tree/src/class.rs
@@ -1,11 +1,9 @@
-use std::collections::{HashMap, HashSet};
-
 use anyhow::Context;
 use pathfinder_common::{
     BlockNumber, ClassCommitment, ClassCommitmentLeafHash, ClassHash, SierraHash,
 };
 use pathfinder_crypto::Felt;
-use pathfinder_storage::{Node, Transaction};
+use pathfinder_storage::{Transaction, TrieUpdate};
 
 use crate::tree::MerkleTree;
 use pathfinder_common::hash::PoseidonHash;
@@ -62,11 +60,11 @@ impl<'tx> ClassCommitmentTree<'tx> {
 
     /// Commits the changes and calculates the new node hashes. Returns the new commitment and
     /// any potentially newly created nodes.
-    pub fn commit(self) -> anyhow::Result<(ClassCommitment, HashMap<Felt, Node>, HashSet<u64>)> {
+    pub fn commit(self) -> anyhow::Result<(ClassCommitment, TrieUpdate)> {
         let update = self.tree.commit(&self.storage)?;
 
-        let commitment = ClassCommitment(update.root);
-        Ok((commitment, update.nodes_added, update.nodes_removed))
+        let commitment = ClassCommitment(update.root_hash());
+        Ok((commitment, update))
     }
 }
 

--- a/crates/merkle-tree/src/contract.rs
+++ b/crates/merkle-tree/src/contract.rs
@@ -17,7 +17,7 @@ use pathfinder_common::{
 };
 use pathfinder_crypto::Felt;
 use pathfinder_storage::{Node, Transaction};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::ControlFlow;
 
 /// A [Patricia Merkle tree](MerkleTree) used to calculate commitments to a Starknet contract's storage.
@@ -100,10 +100,10 @@ impl<'tx> ContractsStorageTree<'tx> {
 
     /// Commits the changes and calculates the new node hashes. Returns the new commitment and
     /// any potentially newly created nodes.
-    pub fn commit(self) -> anyhow::Result<(ContractRoot, HashMap<Felt, Node>)> {
+    pub fn commit(self) -> anyhow::Result<(ContractRoot, HashMap<Felt, Node>, HashSet<u64>)> {
         let update = self.tree.commit(&self.storage)?;
         let commitment = ContractRoot(update.root);
-        Ok((commitment, update.nodes_added))
+        Ok((commitment, update.nodes_added, update.nodes_removed))
     }
 
     /// See [`MerkleTree::dfs`]
@@ -173,10 +173,10 @@ impl<'tx> StorageCommitmentTree<'tx> {
 
     /// Commits the changes and calculates the new node hashes. Returns the new commitment and
     /// any potentially newly created nodes.
-    pub fn commit(self) -> anyhow::Result<(StorageCommitment, HashMap<Felt, Node>)> {
+    pub fn commit(self) -> anyhow::Result<(StorageCommitment, HashMap<Felt, Node>, HashSet<u64>)> {
         let update = self.tree.commit(&self.storage)?;
         let commitment = StorageCommitment(update.root);
-        Ok((commitment, update.nodes_added))
+        Ok((commitment, update.nodes_added, update.nodes_removed))
     }
 
     /// Generates a proof for the given `key`. See [`MerkleTree::get_proof`].

--- a/crates/merkle-tree/src/contract.rs
+++ b/crates/merkle-tree/src/contract.rs
@@ -103,7 +103,7 @@ impl<'tx> ContractsStorageTree<'tx> {
     pub fn commit(self) -> anyhow::Result<(ContractRoot, HashMap<Felt, Node>)> {
         let update = self.tree.commit(&self.storage)?;
         let commitment = ContractRoot(update.root);
-        Ok((commitment, update.nodes))
+        Ok((commitment, update.nodes_added))
     }
 
     /// See [`MerkleTree::dfs`]
@@ -176,7 +176,7 @@ impl<'tx> StorageCommitmentTree<'tx> {
     pub fn commit(self) -> anyhow::Result<(StorageCommitment, HashMap<Felt, Node>)> {
         let update = self.tree.commit(&self.storage)?;
         let commitment = StorageCommitment(update.root);
-        Ok((commitment, update.nodes))
+        Ok((commitment, update.nodes_added))
     }
 
     /// Generates a proof for the given `key`. See [`MerkleTree::get_proof`].

--- a/crates/merkle-tree/src/contract.rs
+++ b/crates/merkle-tree/src/contract.rs
@@ -16,8 +16,7 @@ use pathfinder_common::{
     StorageCommitment, StorageValue,
 };
 use pathfinder_crypto::Felt;
-use pathfinder_storage::{Node, Transaction};
-use std::collections::{HashMap, HashSet};
+use pathfinder_storage::{Transaction, TrieUpdate};
 use std::ops::ControlFlow;
 
 /// A [Patricia Merkle tree](MerkleTree) used to calculate commitments to a Starknet contract's storage.
@@ -100,10 +99,10 @@ impl<'tx> ContractsStorageTree<'tx> {
 
     /// Commits the changes and calculates the new node hashes. Returns the new commitment and
     /// any potentially newly created nodes.
-    pub fn commit(self) -> anyhow::Result<(ContractRoot, HashMap<Felt, Node>, HashSet<u64>)> {
+    pub fn commit(self) -> anyhow::Result<(ContractRoot, TrieUpdate)> {
         let update = self.tree.commit(&self.storage)?;
-        let commitment = ContractRoot(update.root);
-        Ok((commitment, update.nodes_added, update.nodes_removed))
+        let commitment = ContractRoot(update.root_hash());
+        Ok((commitment, update))
     }
 
     /// See [`MerkleTree::dfs`]
@@ -173,10 +172,10 @@ impl<'tx> StorageCommitmentTree<'tx> {
 
     /// Commits the changes and calculates the new node hashes. Returns the new commitment and
     /// any potentially newly created nodes.
-    pub fn commit(self) -> anyhow::Result<(StorageCommitment, HashMap<Felt, Node>, HashSet<u64>)> {
+    pub fn commit(self) -> anyhow::Result<(StorageCommitment, TrieUpdate)> {
         let update = self.tree.commit(&self.storage)?;
-        let commitment = StorageCommitment(update.root);
-        Ok((commitment, update.nodes_added, update.nodes_removed))
+        let commitment = StorageCommitment(update.root_hash());
+        Ok((commitment, update))
     }
 
     /// Generates a proof for the given `key`. See [`MerkleTree::get_proof`].

--- a/crates/merkle-tree/src/contract_state.rs
+++ b/crates/merkle-tree/src/contract_state.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use crate::ContractsStorageTree;
 use anyhow::Context;
@@ -7,7 +7,7 @@ use pathfinder_common::{
     ContractRoot, ContractStateHash, StorageAddress, StorageValue,
 };
 use pathfinder_crypto::{hash::pedersen_hash, Felt};
-use pathfinder_storage::{Node, Transaction};
+use pathfinder_storage::{Transaction, TrieUpdate};
 
 #[derive(Debug)]
 pub struct ContractStateUpdateResult {
@@ -15,10 +15,7 @@ pub struct ContractStateUpdateResult {
     pub contract_address: ContractAddress,
     root: ContractRoot,
     did_storage_updates: bool,
-    // trie nodes to be inserted into the database
-    nodes_added: HashMap<Felt, Node>,
-    // trie nodes to be removed from the database
-    nodes_removed: HashSet<u64>,
+    trie_update: TrieUpdate,
 }
 
 impl ContractStateUpdateResult {
@@ -29,9 +26,9 @@ impl ContractStateUpdateResult {
     pub fn insert(self, block: BlockNumber, transaction: &Transaction<'_>) -> anyhow::Result<()> {
         // Insert nodes only if we made storage updates.
         if self.did_storage_updates {
-            let root_index = if !self.root.0.is_zero() && !self.nodes_added.is_empty() {
+            let root_index = if !self.root.0.is_zero() && !self.trie_update.nodes_added.is_empty() {
                 let root_index = transaction
-                    .insert_contract_trie(self.root, &self.nodes_added)
+                    .insert_contract_trie(&self.trie_update)
                     .context("Persisting contract trie")?;
                 Some(root_index)
             } else {
@@ -60,7 +57,7 @@ pub fn update_contract_state(
     block: BlockNumber,
 ) -> anyhow::Result<ContractStateUpdateResult> {
     // Load the contract tree and insert the updates.
-    let (new_root, nodes_added, nodes_removed) = if !updates.is_empty() {
+    let (new_root, trie_update) = if !updates.is_empty() {
         let mut contract_tree = match block.parent() {
             Some(parent) => ContractsStorageTree::load(transaction, contract_address, parent)
                 .context("Loading contract storage tree")?
@@ -74,18 +71,18 @@ pub fn update_contract_state(
                 .set(*key, *value)
                 .context("Update contract storage tree")?;
         }
-        let (contract_root, nodes_added, nodes_removed) = contract_tree
+        let (contract_root, trie_update) = contract_tree
             .commit()
             .context("Apply contract storage tree changes")?;
 
-        (contract_root, nodes_added, nodes_removed)
+        (contract_root, trie_update)
     } else {
         let current_root = transaction
             .contract_root(block, contract_address)
             .context("Querying current contract root")?
             .unwrap_or_default();
 
-        (current_root, Default::default(), Default::default())
+        (current_root, Default::default())
     };
 
     let class_hash = if contract_address.is_system_contract() {
@@ -117,8 +114,7 @@ pub fn update_contract_state(
         state_hash,
         root: new_root,
         did_storage_updates: !updates.is_empty(),
-        nodes_added,
-        nodes_removed,
+        trie_update,
     })
 }
 
@@ -190,11 +186,11 @@ pub fn revert_contract_state(
                         .context("Updating contract state")?;
                 }
 
-                let (root, nodes_added) = tree.commit().context("Committing contract state")?;
+                let (root, trie_update) = tree.commit().context("Committing contract state")?;
 
-                let root_index = if !root.0.is_zero() && !nodes_added.is_empty() {
+                let root_index = if !root.0.is_zero() && !trie_update.nodes_added.is_empty() {
                     let root_index = transaction
-                        .insert_contract_trie(root, &nodes_added)
+                        .insert_contract_trie(&trie_update)
                         .context("Persisting contract trie")?;
                     Some(root_index)
                 } else {

--- a/crates/merkle-tree/src/contract_state.rs
+++ b/crates/merkle-tree/src/contract_state.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::ContractsStorageTree;
 use anyhow::Context;
@@ -16,7 +16,9 @@ pub struct ContractStateUpdateResult {
     root: ContractRoot,
     did_storage_updates: bool,
     // trie nodes to be inserted into the database
-    nodes: HashMap<Felt, Node>,
+    nodes_added: HashMap<Felt, Node>,
+    // trie nodes to be removed from the database
+    nodes_removed: HashSet<u64>,
 }
 
 impl ContractStateUpdateResult {
@@ -27,9 +29,9 @@ impl ContractStateUpdateResult {
     pub fn insert(self, block: BlockNumber, transaction: &Transaction<'_>) -> anyhow::Result<()> {
         // Insert nodes only if we made storage updates.
         if self.did_storage_updates {
-            let root_index = if !self.root.0.is_zero() && !self.nodes.is_empty() {
+            let root_index = if !self.root.0.is_zero() && !self.nodes_added.is_empty() {
                 let root_index = transaction
-                    .insert_contract_trie(self.root, &self.nodes)
+                    .insert_contract_trie(self.root, &self.nodes_added)
                     .context("Persisting contract trie")?;
                 Some(root_index)
             } else {
@@ -58,7 +60,7 @@ pub fn update_contract_state(
     block: BlockNumber,
 ) -> anyhow::Result<ContractStateUpdateResult> {
     // Load the contract tree and insert the updates.
-    let (new_root, nodes) = if !updates.is_empty() {
+    let (new_root, nodes_added, nodes_removed) = if !updates.is_empty() {
         let mut contract_tree = match block.parent() {
             Some(parent) => ContractsStorageTree::load(transaction, contract_address, parent)
                 .context("Loading contract storage tree")?
@@ -72,18 +74,18 @@ pub fn update_contract_state(
                 .set(*key, *value)
                 .context("Update contract storage tree")?;
         }
-        let (contract_root, nodes) = contract_tree
+        let (contract_root, nodes_added, nodes_removed) = contract_tree
             .commit()
             .context("Apply contract storage tree changes")?;
 
-        (contract_root, nodes)
+        (contract_root, nodes_added, nodes_removed)
     } else {
         let current_root = transaction
             .contract_root(block, contract_address)
             .context("Querying current contract root")?
             .unwrap_or_default();
 
-        (current_root, Default::default())
+        (current_root, Default::default(), Default::default())
     };
 
     let class_hash = if contract_address.is_system_contract() {
@@ -115,7 +117,8 @@ pub fn update_contract_state(
         state_hash,
         root: new_root,
         did_storage_updates: !updates.is_empty(),
-        nodes,
+        nodes_added,
+        nodes_removed,
     })
 }
 

--- a/crates/merkle-tree/src/merkle_node.rs
+++ b/crates/merkle-tree/src/merkle_node.rs
@@ -16,7 +16,7 @@ use pathfinder_common::hash::FeltHash;
 pub enum InternalNode {
     /// A node that has not been fetched from storage yet.
     ///
-    /// As such, all we know is its hash.
+    /// As such, all we know is its index.
     Unresolved(u64),
     /// A branch node with exactly two children.
     Binary(BinaryNode),
@@ -29,6 +29,8 @@ pub enum InternalNode {
 /// Describes the [InternalNode::Binary] variant.
 #[derive(Clone, Debug, PartialEq)]
 pub struct BinaryNode {
+    /// The storage index of this node (if it was loaded from storage).
+    pub storage_index: Option<u64>,
     /// The height of this node in the tree.
     pub height: usize,
     /// [Left](Direction::Left) child.
@@ -39,6 +41,8 @@ pub struct BinaryNode {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct EdgeNode {
+    /// The storage index of this node (if it was loaded from storage).
+    pub storage_index: Option<u64>,
     /// The starting height of this node in the tree.
     pub height: usize,
     /// The path this edge takes.
@@ -209,6 +213,7 @@ mod tests {
         #[test]
         fn direction() {
             let uut = BinaryNode {
+                storage_index: None,
                 height: 1,
                 left: Rc::new(RefCell::new(InternalNode::Unresolved(1))),
                 right: Rc::new(RefCell::new(InternalNode::Unresolved(2))),
@@ -233,6 +238,7 @@ mod tests {
             let right = Rc::new(RefCell::new(InternalNode::Unresolved(2)));
 
             let uut = BinaryNode {
+                storage_index: None,
                 height: 1,
                 left: left.clone(),
                 right: right.clone(),
@@ -296,6 +302,7 @@ mod tests {
                 let child = Rc::new(RefCell::new(InternalNode::Unresolved(1)));
 
                 let uut = EdgeNode {
+                    storage_index: None,
                     height: 0,
                     path: key.view_bits().to_bitvec(),
                     child,
@@ -312,6 +319,7 @@ mod tests {
                 let path = key.view_bits()[..45].to_bitvec();
 
                 let uut = EdgeNode {
+                    storage_index: None,
                     height: 0,
                     path,
                     child,
@@ -328,6 +336,7 @@ mod tests {
                 let path = key.view_bits()[50..].to_bitvec();
 
                 let uut = EdgeNode {
+                    storage_index: None,
                     height: 50,
                     path,
                     child,
@@ -344,6 +353,7 @@ mod tests {
                 let path = key.view_bits()[230..235].to_bitvec();
 
                 let uut = EdgeNode {
+                    storage_index: None,
                     height: 230,
                     path,
                     child,

--- a/crates/merkle-tree/src/merkle_node.rs
+++ b/crates/merkle-tree/src/merkle_node.rs
@@ -141,6 +141,15 @@ impl InternalNode {
     pub fn is_leaf(&self) -> bool {
         matches!(self, InternalNode::Leaf)
     }
+
+    pub fn storage_index(&self) -> Option<u64> {
+        match self {
+            InternalNode::Unresolved(storage_index) => Some(*storage_index),
+            InternalNode::Binary(binary) => binary.storage_index,
+            InternalNode::Edge(edge) => edge.storage_index,
+            InternalNode::Leaf => None,
+        }
+    }
 }
 
 impl EdgeNode {

--- a/crates/merkle-tree/src/transaction.rs
+++ b/crates/merkle-tree/src/transaction.rs
@@ -51,7 +51,9 @@ impl TransactionOrEventTree {
     }
 
     pub fn commit(self) -> anyhow::Result<Felt> {
-        self.tree.commit(&NullStorage {}).map(|update| update.root)
+        self.tree
+            .commit(&NullStorage {})
+            .map(|update| update.root_hash())
     }
 }
 

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -1115,13 +1115,13 @@ fn update_starknet_state(
     }
 
     // Apply storage commitment tree changes.
-    let (storage_commitment, nodes_added, nodes_removed) = storage_commitment_tree
+    let (storage_commitment, trie_update) = storage_commitment_tree
         .commit()
         .context("Apply storage commitment tree updates")?;
 
     let root_idx = if !storage_commitment.0.is_zero() {
         let root_idx = transaction
-            .insert_storage_trie(storage_commitment, &nodes_added)
+            .insert_storage_trie(&trie_update)
             .context("Persisting storage trie")?;
 
         Some(root_idx)
@@ -1154,13 +1154,13 @@ fn update_starknet_state(
     }
 
     // Apply all class commitment tree changes.
-    let (class_commitment, nodes_added, nodes_removed) = class_commitment_tree
+    let (class_commitment, trie_update) = class_commitment_tree
         .commit()
         .context("Apply class commitment tree updates")?;
 
     let class_root_idx = if !class_commitment.0.is_zero() {
         let class_root_idx = transaction
-            .insert_class_trie(class_commitment, &nodes_added)
+            .insert_class_trie(&trie_update)
             .context("Persisting class trie")?;
 
         Some(class_root_idx)

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -1115,13 +1115,13 @@ fn update_starknet_state(
     }
 
     // Apply storage commitment tree changes.
-    let (storage_commitment, nodes) = storage_commitment_tree
+    let (storage_commitment, nodes_added, nodes_removed) = storage_commitment_tree
         .commit()
         .context("Apply storage commitment tree updates")?;
 
     let root_idx = if !storage_commitment.0.is_zero() {
         let root_idx = transaction
-            .insert_storage_trie(storage_commitment, &nodes)
+            .insert_storage_trie(storage_commitment, &nodes_added)
             .context("Persisting storage trie")?;
 
         Some(root_idx)
@@ -1154,13 +1154,13 @@ fn update_starknet_state(
     }
 
     // Apply all class commitment tree changes.
-    let (class_commitment, nodes) = class_commitment_tree
+    let (class_commitment, nodes_added, nodes_removed) = class_commitment_tree
         .commit()
         .context("Apply class commitment tree updates")?;
 
     let class_root_idx = if !class_commitment.0.is_zero() {
         let class_root_idx = transaction
-            .insert_class_trie(class_commitment, &nodes)
+            .insert_class_trie(class_commitment, &nodes_added)
             .context("Persisting class trie")?;
 
         Some(class_root_idx)

--- a/crates/pathfinder/src/state/sync/revert.rs
+++ b/crates/pathfinder/src/state/sync/revert.rs
@@ -87,7 +87,7 @@ fn revert_contract_updates(
 
         tracing::debug!("Applied reverse updates, committing global state tree");
 
-        let (storage_commitment, nodes_added) = global_tree
+        let (storage_commitment, trie_update) = global_tree
             .commit()
             .context("Committing global state tree")?;
 
@@ -101,7 +101,7 @@ fn revert_contract_updates(
 
         let root_idx = if !storage_commitment.0.is_zero() {
             let root_idx = transaction
-                .insert_storage_trie(storage_commitment, &nodes_added)
+                .insert_storage_trie(&trie_update)
                 .context("Persisting storage trie")?;
 
             Some(root_idx)
@@ -155,7 +155,7 @@ fn revert_class_updates(
                 .context("Updating class commitment trie")?;
         }
 
-        let (class_commitment, nodes_added) =
+        let (class_commitment, trie_update) =
             class_tree.commit().context("Committing class trie")?;
 
         if expected_class_commitment != class_commitment {
@@ -168,7 +168,7 @@ fn revert_class_updates(
 
         let root_idx = if !class_commitment.0.is_zero() {
             let root_idx = transaction
-                .insert_class_trie(class_commitment, &nodes_added)
+                .insert_class_trie(&trie_update)
                 .context("Persisting class trie")?;
 
             Some(root_idx)

--- a/crates/pathfinder/src/sync/p2p/state_updates.rs
+++ b/crates/pathfinder/src/sync/p2p/state_updates.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::num::NonZeroUsize;
 
 use anyhow::Context;
@@ -7,12 +6,11 @@ use pathfinder_common::{
     state_update::{ContractUpdates, StateUpdateCounts},
     BlockHash, BlockHeader, BlockNumber, StateUpdate, StorageCommitment,
 };
-use pathfinder_crypto::Felt;
 use pathfinder_merkle_tree::{
     contract_state::{update_contract_state, ContractStateUpdateResult},
     StorageCommitmentTree,
 };
-use pathfinder_storage::{Node, Storage};
+use pathfinder_storage::{Storage, TrieUpdate};
 use tokio::task::spawn_blocking;
 
 #[derive(Debug, thiserror::Error)]
@@ -154,7 +152,7 @@ pub(super) struct VerificationOk {
     block_hash: BlockHash,
     storage_commitment: StorageCommitment,
     contract_update_results: Vec<ContractStateUpdateResult>,
-    trie_nodes: HashMap<Felt, Node>,
+    trie_update: TrieUpdate,
     contract_updates: ContractUpdates,
 }
 
@@ -301,7 +299,7 @@ fn verify_one(
     }
 
     // Apply storage commitment tree changes.
-    let (computed_storage_commitment, nodes) = storage_commitment_tree
+    let (computed_storage_commitment, trie_update) = storage_commitment_tree
         .commit()
         .context("Apply storage commitment tree updates")?;
 
@@ -320,7 +318,7 @@ fn verify_one(
             block_hash,
             storage_commitment,
             contract_update_results,
-            trie_nodes: nodes,
+            trie_update,
             contract_updates,
         },
     ))

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -347,9 +347,10 @@ pub mod test_utils {
             .set(contract0_addr, contract_state_hash)
             .unwrap();
 
-        let (storage_commitment0, nodes) = storage_commitment_tree.commit().unwrap();
+        let (storage_commitment0, nodes_added, _nodes_removed) =
+            storage_commitment_tree.commit().unwrap();
         let storage_root_idx = db_txn
-            .insert_storage_trie(storage_commitment0, &nodes)
+            .insert_storage_trie(storage_commitment0, &nodes_added)
             .unwrap();
         db_txn
             .insert_storage_root(BlockNumber::GENESIS, Some(storage_root_idx))
@@ -388,9 +389,10 @@ pub mod test_utils {
         storage_commitment_tree
             .set(contract1_addr, contract_state_hash)
             .unwrap();
-        let (storage_commitment1, nodes) = storage_commitment_tree.commit().unwrap();
+        let (storage_commitment1, nodes_added, _nodes_removed) =
+            storage_commitment_tree.commit().unwrap();
         let storage_root_idx = db_txn
-            .insert_storage_trie(storage_commitment1, &nodes)
+            .insert_storage_trie(storage_commitment1, &nodes_added)
             .unwrap();
         db_txn
             .insert_storage_root(BlockNumber::GENESIS + 1, Some(storage_root_idx))
@@ -447,9 +449,10 @@ pub mod test_utils {
         storage_commitment_tree
             .set(contract2_addr, contract_state_hash)
             .unwrap();
-        let (storage_commitment2, nodes) = storage_commitment_tree.commit().unwrap();
+        let (storage_commitment2, nodes_added, _nodes_removed) =
+            storage_commitment_tree.commit().unwrap();
         let storage_root_idx = db_txn
-            .insert_storage_trie(storage_commitment2, &nodes)
+            .insert_storage_trie(storage_commitment2, &nodes_added)
             .unwrap();
         db_txn
             .insert_storage_root(BlockNumber::GENESIS + 2, Some(storage_root_idx))

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -347,11 +347,8 @@ pub mod test_utils {
             .set(contract0_addr, contract_state_hash)
             .unwrap();
 
-        let (storage_commitment0, nodes_added, _nodes_removed) =
-            storage_commitment_tree.commit().unwrap();
-        let storage_root_idx = db_txn
-            .insert_storage_trie(storage_commitment0, &nodes_added)
-            .unwrap();
+        let (storage_commitment0, trie_update) = storage_commitment_tree.commit().unwrap();
+        let storage_root_idx = db_txn.insert_storage_trie(&trie_update).unwrap();
         db_txn
             .insert_storage_root(BlockNumber::GENESIS, Some(storage_root_idx))
             .unwrap();
@@ -389,11 +386,8 @@ pub mod test_utils {
         storage_commitment_tree
             .set(contract1_addr, contract_state_hash)
             .unwrap();
-        let (storage_commitment1, nodes_added, _nodes_removed) =
-            storage_commitment_tree.commit().unwrap();
-        let storage_root_idx = db_txn
-            .insert_storage_trie(storage_commitment1, &nodes_added)
-            .unwrap();
+        let (storage_commitment1, trie_update) = storage_commitment_tree.commit().unwrap();
+        let storage_root_idx = db_txn.insert_storage_trie(&trie_update).unwrap();
         db_txn
             .insert_storage_root(BlockNumber::GENESIS + 1, Some(storage_root_idx))
             .unwrap();
@@ -449,11 +443,8 @@ pub mod test_utils {
         storage_commitment_tree
             .set(contract2_addr, contract_state_hash)
             .unwrap();
-        let (storage_commitment2, nodes_added, _nodes_removed) =
-            storage_commitment_tree.commit().unwrap();
-        let storage_root_idx = db_txn
-            .insert_storage_trie(storage_commitment2, &nodes_added)
-            .unwrap();
+        let (storage_commitment2, trie_update) = storage_commitment_tree.commit().unwrap();
+        let storage_root_idx = db_txn.insert_storage_trie(&trie_update).unwrap();
         db_txn
             .insert_storage_root(BlockNumber::GENESIS + 2, Some(storage_root_idx))
             .unwrap();

--- a/crates/storage/src/connection.rs
+++ b/crates/storage/src/connection.rs
@@ -27,9 +27,13 @@ pub(crate) use reorg_counter::ReorgCounter;
 use smallvec::SmallVec;
 pub use transaction::TransactionStatus;
 
-pub use trie::{Child, Node, StoredNode};
+pub use trie::{Node, NodeRef, StoredNode, TrieUpdate};
 
-use pathfinder_common::*;
+use pathfinder_common::{
+    BlockCommitmentSignature, BlockHash, BlockHeader, BlockNumber, CasmHash,
+    ClassCommitmentLeafHash, ClassHash, ContractAddress, ContractNonce, ContractRoot,
+    ContractStateHash, SierraHash, StateUpdate, StorageAddress, StorageValue, TransactionHash,
+};
 use pathfinder_crypto::Felt;
 use pathfinder_ethereum::EthereumStateUpdate;
 
@@ -433,30 +437,18 @@ impl<'inner> Transaction<'inner> {
     }
 
     /// Stores the class trie information.
-    pub fn insert_class_trie(
-        &self,
-        root: ClassCommitment,
-        nodes: &HashMap<Felt, Node>,
-    ) -> anyhow::Result<u64> {
-        trie::trie_class::insert(self, root.0, nodes)
+    pub fn insert_class_trie(&self, update: &TrieUpdate) -> anyhow::Result<u64> {
+        trie::trie_class::insert(self, update)
     }
 
     /// Stores a single contract's storage trie information.
-    pub fn insert_contract_trie(
-        &self,
-        root: ContractRoot,
-        nodes: &HashMap<Felt, Node>,
-    ) -> anyhow::Result<u64> {
-        trie::trie_contracts::insert(self, root.0, nodes)
+    pub fn insert_contract_trie(&self, update: &TrieUpdate) -> anyhow::Result<u64> {
+        trie::trie_contracts::insert(self, update)
     }
 
     /// Stores the global starknet storage trie information.
-    pub fn insert_storage_trie(
-        &self,
-        root: StorageCommitment,
-        nodes: &HashMap<Felt, Node>,
-    ) -> anyhow::Result<u64> {
-        trie::trie_storage::insert(self, root.0, nodes)
+    pub fn insert_storage_trie(&self, update: &TrieUpdate) -> anyhow::Result<u64> {
+        trie::trie_storage::insert(self, update)
     }
 
     pub fn class_trie_node(&self, index: u64) -> anyhow::Result<Option<StoredNode>> {

--- a/justfile
+++ b/justfile
@@ -26,6 +26,9 @@ clippy:
 dep-sort:
     cargo sort --check --workspace
 
+doc:
+    cargo doc --no-deps --document-private-items
+
 alias b := build 
 alias t := test 
 alias c := check 


### PR DESCRIPTION
As a requirement for Merkle trie pruning, this PR adds code for tracking the storage indices for trie nodes that have been removed during trie updates and fixes a node-reuse issue that prevents actually removing nodes from Merkle tries constructed by our previous implementation.

This PR does _not_ add the actual removal of these nodes from storage -- that will be left for a follow-up PR.

Rough list of changes:

- Merkle tree `InternalNode` now stores the storage index of the node if it was loaded from storage.
- `MerkleTree::commit()` now returns a `TrieUpdate` structure instead of the commitment and the new nodes. `TrieUpdate` contains the commitment, the nodes added and the storage ids for the nodes that have been removed during the update.
- Previously we were using a HashMap to return new nodes when committing the Merkle trie and hash values as unique ids for child nodes. Unfortunately this might have lead to reusing the same storage index multiple times if the Merkle tree had subtrees inserted which were exactly the same.
Normally this is not a problem -- but if we ever want to remove nodes this breaks the assumption that we can safely delete a node from the storage if it's not referenced by its parent anymore.
`TrieUpdate` uses a vector to return new nodes. Child nodes are referenced by their index in the vector.