### PR TITLE
fix(Dockerfile): upgrade Rust toolchain to 1.77

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@
 # Stage 1: Build the pathfinder binary #
 ########################################
 # Note that we're explicitly using the Debian bookworm image to make sure we're
-# compatible with the Python container we'll be copying the pathfinder
+# compatible with the Debian container we'll be copying the pathfinder
 # executable to.
-FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:0.1.62-rust-1.74.0-slim-bookworm AS cargo-chef
+FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:0.1.66-rust-1.77.0-slim-bookworm AS cargo-chef
 WORKDIR /usr/src/pathfinder
 
 FROM --platform=$BUILDPLATFORM cargo-chef AS rust-planner


### PR DESCRIPTION
Now that we've bumped MSRV to 1.76 the Docker container would no longer build.

