### PR TITLE
fix(executor): never return fee estimates lower than the minimal values expected by blockifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- `starknet_estimateFee` and `starknet_simulateTransactions` can return fee estimates below the minimum fee expected by the sequencer for trivial transactions.
+
 ## [0.11.3] - 2024-03-13
 
 ### Fixed

--- a/crates/executor/src/estimate.rs
+++ b/crates/executor/src/estimate.rs
@@ -39,7 +39,21 @@ pub fn estimate(
             blockifier::transaction::objects::FeeType::Eth => PriceUnit::Wei,
         };
 
-        let tx_info = transaction
+        let minimal_l1_gas_amount_vector = match &transaction {
+            Transaction::AccountTransaction(account_transaction) => Some(
+                blockifier::fee::gas_usage::estimate_minimal_gas_vector(
+                    &block_context,
+                    account_transaction,
+                )
+                .map_err(|e| TransactionExecutionError::new(transaction_idx, e.into()))?,
+            ),
+            Transaction::L1HandlerTransaction(_) => None,
+        };
+
+        let tx_info: Result<
+            blockifier::transaction::objects::TransactionExecutionInfo,
+            blockifier::transaction::errors::TransactionExecutionError,
+        > = transaction
             .execute(&mut state, &block_context, false, !skip_validate)
             .and_then(|mut tx_info| {
                 if tx_info.actual_fee.0 == 0 {
@@ -71,6 +85,7 @@ pub fn estimate(
                     gas_price,
                     data_gas_price,
                     unit,
+                    minimal_l1_gas_amount_vector,
                 ));
             }
             Err(error) => {

--- a/crates/rpc/src/v05/method/estimate_fee.rs
+++ b/crates/rpc/src/v05/method/estimate_fee.rs
@@ -369,9 +369,9 @@ pub(crate) mod tests {
                 overall_fee: 1674.into(),
             };
             let invoke_v0_expected = FeeEstimate {
-                gas_consumed: 880.into(),
+                gas_consumed: 1669.into(),
                 gas_price: 1.into(),
-                overall_fee: 880.into(),
+                overall_fee: 1669.into(),
             };
             assert_eq!(
                 result,

--- a/crates/rpc/src/v06/method/estimate_fee.rs
+++ b/crates/rpc/src/v06/method/estimate_fee.rs
@@ -467,9 +467,9 @@ pub(crate) mod tests {
                 data_gas_price: None,
             };
             let invoke_v0_expected = FeeEstimate {
-                gas_consumed: 880.into(),
+                gas_consumed: 1669.into(),
                 gas_price: 1.into(),
-                overall_fee: 880.into(),
+                overall_fee: 1669.into(),
                 unit: PriceUnit::Wei,
                 data_gas_consumed: None,
                 data_gas_price: None,

--- a/crates/rpc/src/v07/method/estimate_fee.rs
+++ b/crates/rpc/src/v07/method/estimate_fee.rs
@@ -195,9 +195,9 @@ mod tests {
         let invoke_v0_expected = FeeEstimate {
             gas_consumed: 10.into(),
             gas_price: 1.into(),
-            overall_fee: 138.into(),
+            overall_fee: 266.into(),
             unit: PriceUnit::Wei,
-            data_gas_consumed: Some(64.into()),
+            data_gas_consumed: Some(128.into()),
             data_gas_price: Some(2.into()),
         };
         let invoke_v3_expected = FeeEstimate {


### PR DESCRIPTION
Blockifier has some minimum gas usage estimates and all transactions submitted for inclusion on the chain are expected to pay _at least_ the cost of those estimates.

When Pathfinder is doing fee estimations we're skipping the actual fee transfer costs -- while the minimum expected gas usage estimates do contain the storage updates resulting from the fee transfer.

This PR updates our code so that we don't return gas usage values that are _lower_ than the minimum values expected.

In particular, trivial version 0 invoke transactions were found to have an estimate that is too low.

Closes: #1901 