### PR TITLE
fix(pathfinder/state/revert): properly detect if trie roots are present

### DIFF
--- a/crates/pathfinder/src/state/sync/revert.rs
+++ b/crates/pathfinder/src/state/sync/revert.rs
@@ -46,12 +46,7 @@ fn revert_contract_updates(
     expected_storage_commitment: StorageCommitment,
     force: bool,
 ) -> anyhow::Result<()> {
-    let state_root_exists = match transaction.storage_root_index(target_block)? {
-        None => false,
-        Some(root_idx) => transaction.storage_trie_node(root_idx)?.is_some(),
-    };
-
-    if force || !state_root_exists {
+    if force || !transaction.storage_root_exists(target_block)? {
         let updates = transaction.reverse_contract_updates(head, target_block)?;
 
         let mut global_tree = StorageCommitmentTree::load(transaction, head)
@@ -127,12 +122,7 @@ fn revert_class_updates(
     expected_class_commitment: ClassCommitment,
     force: bool,
 ) -> anyhow::Result<()> {
-    let class_root_exists = match transaction.class_root_index(target_block)? {
-        None => false,
-        Some(root_idx) => transaction.class_trie_node(root_idx)?.is_some(),
-    };
-
-    if force || !class_root_exists {
+    if force || !transaction.class_root_exists(target_block)? {
         let updates = transaction.reverse_sierra_class_updates(head, target_block)?;
 
         let mut class_tree = ClassCommitmentTree::load(transaction, head)

--- a/crates/storage/src/connection.rs
+++ b/crates/storage/src/connection.rs
@@ -478,8 +478,16 @@ impl<'inner> Transaction<'inner> {
         trie::class_root_index(self, block)
     }
 
+    pub fn class_root_exists(&self, block: BlockNumber) -> anyhow::Result<bool> {
+        trie::class_root_exists(self, block)
+    }
+
     pub fn storage_root_index(&self, block: BlockNumber) -> anyhow::Result<Option<u64>> {
         trie::storage_root_index(self, block)
+    }
+
+    pub fn storage_root_exists(&self, block: BlockNumber) -> anyhow::Result<bool> {
+        trie::storage_root_exists(self, block)
     }
 
     pub fn contract_root_index(

--- a/crates/storage/src/connection/trie.rs
+++ b/crates/storage/src/connection/trie.rs
@@ -27,6 +27,19 @@ pub(super) fn class_root_index(
         .map_err(Into::into)
 }
 
+pub(super) fn class_root_exists(
+    tx: &Transaction<'_>,
+    block_number: BlockNumber,
+) -> anyhow::Result<bool> {
+    tx.inner()
+        .query_row(
+            "SELECT EXISTS (SELECT 1 FROM class_roots WHERE block_number=?)",
+            params![&block_number],
+            |row| row.get::<_, bool>(0),
+        )
+        .map_err(Into::into)
+}
+
 pub(super) fn storage_root_index(
     tx: &Transaction<'_>,
     block_number: BlockNumber,
@@ -39,6 +52,19 @@ pub(super) fn storage_root_index(
         )
         .optional()
         .map(|x| x.flatten())
+        .map_err(Into::into)
+}
+
+pub(super) fn storage_root_exists(
+    tx: &Transaction<'_>,
+    block_number: BlockNumber,
+) -> anyhow::Result<bool> {
+    tx.inner()
+        .query_row(
+            "SELECT EXISTS (SELECT 1 FROM storage_roots WHERE block_number=?)",
+            params![&block_number],
+            |row| row.get::<_, bool>(0),
+        )
         .map_err(Into::into)
 }
 


### PR DESCRIPTION
Trie roots can be NULL in the database (meaning an empty trie). If the trie at the revert target was empty (but present) we incorrectly tried to revert state.
