### PR TITLE
feat(executor): upgrade blockifier to 0.6.0-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Support for Starknet v0.13.1.1 (lowered declare transaction fees).
+
 ### Fixed
 
 - `starknet_estimateFee` and `starknet_simulateTransactions` can return fee estimates below the minimum fee expected by the sequencer for trivial transactions.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "blockifier"
-version = "0.5.0"
+version = "0.6.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a41962da92cb8daab297c29fb54289a0291d84cd87d82ad8b616948b0f64b1"
+checksum = "6457e011283e86eca26a28c7a7d7c2653c1c65a6baff29c5a6474946c37771dc"
 dependencies = [
  "anyhow",
  "ark-ec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "blockifier"
-version = "0.5.0-rc.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7619ae814dc5224dff007fe33693982e6684c11d9cabba23cfe5a5b21c340dac"
+checksum = "93a41962da92cb8daab297c29fb54289a0291d84cd87d82ad8b616948b0f64b1"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -890,10 +890,10 @@ dependencies = [
  "ark-secp256r1",
  "cached",
  "cairo-felt 0.9.1",
- "cairo-lang-casm 2.6.0-rc.1",
+ "cairo-lang-casm 2.6.0",
  "cairo-lang-runner",
  "cairo-lang-starknet-classes",
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0",
  "cairo-vm",
  "derive_more",
  "indexmap 2.2.1",
@@ -1095,11 +1095,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0946e77ad3088c0e3b46f685ed0cf59810138abc285b112bd2386d9dba51cd"
+checksum = "ed99c41d458d27dd6d42eed29c57c09e8e6d7c70e546b61cb4bfdb9842d0a279"
 dependencies = [
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0",
  "indoc 2.0.4",
  "num-bigint",
  "num-traits 0.2.17",
@@ -1184,22 +1184,22 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e6b8cf598402a9fb70a84ec599e16c66ba6f28930ac34edfdf00251b4f54db"
+checksum = "064f1515038f0496a52a3def9c11879491f76b72cb064d28b9fb6d5e4557ba8a"
 dependencies = [
  "anyhow",
- "cairo-lang-defs 2.6.0-rc.1",
- "cairo-lang-diagnostics 2.6.0-rc.1",
- "cairo-lang-filesystem 2.6.0-rc.1",
- "cairo-lang-lowering 2.6.0-rc.1",
- "cairo-lang-parser 2.6.0-rc.1",
- "cairo-lang-project 2.6.0-rc.1",
- "cairo-lang-semantic 2.6.0-rc.1",
- "cairo-lang-sierra 2.6.0-rc.1",
- "cairo-lang-sierra-generator 2.6.0-rc.1",
- "cairo-lang-syntax 2.6.0-rc.1",
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-defs 2.6.0",
+ "cairo-lang-diagnostics 2.6.0",
+ "cairo-lang-filesystem 2.6.0",
+ "cairo-lang-lowering 2.6.0",
+ "cairo-lang-parser 2.6.0",
+ "cairo-lang-project 2.6.0",
+ "cairo-lang-semantic 2.6.0",
+ "cairo-lang-sierra 2.6.0",
+ "cairo-lang-sierra-generator 2.6.0",
+ "cairo-lang-syntax 2.6.0",
+ "cairo-lang-utils 2.6.0",
  "salsa",
  "smol_str 0.2.1",
  "thiserror",
@@ -1223,11 +1223,11 @@ checksum = "c99d41a14f98521c617c0673a0faa41fd00029d32106a4643e1291a1813340a7"
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2f336e086ea0c55a2d8db410b358a881e2910bd6cadd79059ee66666334a61"
+checksum = "9d3179c07c03cb5d9a36f3ed7e7402bdfe16b9d0de5a960a9fd598a356032be0"
 dependencies = [
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0",
 ]
 
 [[package]]
@@ -1284,16 +1284,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47344ed1dd561da66d415b0d9c20f83c900d9956b86e36dc52abfed7f1ea2dc2"
+checksum = "a52a7e66818a41ad4332f07fbd7aba09522c2f05e0436dc7ceb2c989067a5e41"
 dependencies = [
- "cairo-lang-debug 2.6.0-rc.1",
- "cairo-lang-diagnostics 2.6.0-rc.1",
- "cairo-lang-filesystem 2.6.0-rc.1",
- "cairo-lang-parser 2.6.0-rc.1",
- "cairo-lang-syntax 2.6.0-rc.1",
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-debug 2.6.0",
+ "cairo-lang-diagnostics 2.6.0",
+ "cairo-lang-filesystem 2.6.0",
+ "cairo-lang-parser 2.6.0",
+ "cairo-lang-syntax 2.6.0",
+ "cairo-lang-utils 2.6.0",
  "itertools 0.11.0",
  "salsa",
  "smol_str 0.2.1",
@@ -1335,13 +1335,13 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a43cb751b873725f7b9b4eee0161673b082f698d2436ee5ecda93b271219690"
+checksum = "2dfe5fc09df15dd815f09257ac7fe2cbfce775ea992b699f4d76f475538d402d"
 dependencies = [
- "cairo-lang-debug 2.6.0-rc.1",
- "cairo-lang-filesystem 2.6.0-rc.1",
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-debug 2.6.0",
+ "cairo-lang-filesystem 2.6.0",
+ "cairo-lang-utils 2.6.0",
  "itertools 0.11.0",
 ]
 
@@ -1381,11 +1381,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c5a172ef9a6c193dc03142148c3c2047a7f44175b9faaa75a0945261b1d7c"
+checksum = "ae770ae2d5ae2f4b6202137dc3a4053f89ad635ae0328a8f4807a3c5856f2ae9"
 dependencies = [
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0",
  "good_lp",
 ]
 
@@ -1430,12 +1430,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feaf3b3beedb8ce3cabdb8a7777431d04b507bc264add66e18dd4ecc66e1d67b"
+checksum = "fee331de8d8dfddcdb015e86be282819d9c93ee2925f3f188d9af41455dda30d"
 dependencies = [
- "cairo-lang-debug 2.6.0-rc.1",
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-debug 2.6.0",
+ "cairo-lang-utils 2.6.0",
  "path-clean 1.0.1",
  "salsa",
  "serde",
@@ -1517,19 +1517,19 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb288727186146a68871d70d8c1f8de34db21195ff432fb5d90c9363adb038c"
+checksum = "c81afe28160958fb6ca0dd0c7fc40972d3664f390a29b63190b2441ef67d59df"
 dependencies = [
- "cairo-lang-debug 2.6.0-rc.1",
- "cairo-lang-defs 2.6.0-rc.1",
- "cairo-lang-diagnostics 2.6.0-rc.1",
- "cairo-lang-filesystem 2.6.0-rc.1",
- "cairo-lang-parser 2.6.0-rc.1",
- "cairo-lang-proc-macros 2.6.0-rc.1",
- "cairo-lang-semantic 2.6.0-rc.1",
- "cairo-lang-syntax 2.6.0-rc.1",
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-debug 2.6.0",
+ "cairo-lang-defs 2.6.0",
+ "cairo-lang-diagnostics 2.6.0",
+ "cairo-lang-filesystem 2.6.0",
+ "cairo-lang-parser 2.6.0",
+ "cairo-lang-proc-macros 2.6.0",
+ "cairo-lang-semantic 2.6.0",
+ "cairo-lang-syntax 2.6.0",
+ "cairo-lang-utils 2.6.0",
  "id-arena",
  "itertools 0.11.0",
  "log",
@@ -1600,15 +1600,15 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9613127cee21b8c45f0e42016b22a5bca08721ed3750d342d25662cfa9acd16a"
+checksum = "d1ce7492bbd227138fad2687094af0d1fe0e7ce33f561ab11d6fb0c53bccf01d"
 dependencies = [
- "cairo-lang-diagnostics 2.6.0-rc.1",
- "cairo-lang-filesystem 2.6.0-rc.1",
- "cairo-lang-syntax 2.6.0-rc.1",
- "cairo-lang-syntax-codegen 2.6.0-rc.1",
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-diagnostics 2.6.0",
+ "cairo-lang-filesystem 2.6.0",
+ "cairo-lang-syntax 2.6.0",
+ "cairo-lang-syntax-codegen 2.6.0",
+ "cairo-lang-utils 2.6.0",
  "colored",
  "itertools 0.11.0",
  "num-bigint",
@@ -1676,16 +1676,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e231acf33b6c8c2ec0e491f42d9fa60f5b8d68f69ad87ed783970eeb59b16818"
+checksum = "41dbe519ef698fe0f295b49031cb35ccb919610338a6a5136e8968e13791864d"
 dependencies = [
- "cairo-lang-defs 2.6.0-rc.1",
- "cairo-lang-diagnostics 2.6.0-rc.1",
- "cairo-lang-filesystem 2.6.0-rc.1",
- "cairo-lang-parser 2.6.0-rc.1",
- "cairo-lang-syntax 2.6.0-rc.1",
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-defs 2.6.0",
+ "cairo-lang-diagnostics 2.6.0",
+ "cairo-lang-filesystem 2.6.0",
+ "cairo-lang-parser 2.6.0",
+ "cairo-lang-syntax 2.6.0",
+ "cairo-lang-utils 2.6.0",
  "indent",
  "indoc 2.0.4",
  "itertools 0.11.0",
@@ -1726,11 +1726,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d11dd056948249102687d1152ef1fec418c562128a74e0ee77c627446424bc"
+checksum = "cd65bf4d71ebc1efb0181b6c4d27c93e7e01fe5d521a15f2a5695cd7b5d79f36"
 dependencies = [
- "cairo-lang-debug 2.6.0-rc.1",
+ "cairo-lang-debug 2.6.0",
  "quote",
  "syn 2.0.48",
 ]
@@ -1774,12 +1774,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27d557c942c12cc372c46319a83c253bc2fbe14282f122e4577b77022c8faf97"
+checksum = "81ecab619e54abf610eefa4918d03831e50e54738b1973e37419734cefd73a77"
 dependencies = [
- "cairo-lang-filesystem 2.6.0-rc.1",
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-filesystem 2.6.0",
+ "cairo-lang-utils 2.6.0",
  "serde",
  "smol_str 0.2.1",
  "thiserror",
@@ -1788,24 +1788,24 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runner"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18585650b961dada1311844d1a279f3fa9fce14445057210d99000672b09edb6"
+checksum = "be60564ec98572096428145342047dddc1bec5c84992f20d38353bd7fbb6c2c4"
 dependencies = [
  "ark-ff",
  "ark-secp256k1",
  "ark-secp256r1",
  "ark-std",
  "cairo-felt 0.9.1",
- "cairo-lang-casm 2.6.0-rc.1",
- "cairo-lang-lowering 2.6.0-rc.1",
- "cairo-lang-sierra 2.6.0-rc.1",
- "cairo-lang-sierra-ap-change 2.6.0-rc.1",
- "cairo-lang-sierra-generator 2.6.0-rc.1",
- "cairo-lang-sierra-to-casm 2.6.0-rc.1",
+ "cairo-lang-casm 2.6.0",
+ "cairo-lang-lowering 2.6.0",
+ "cairo-lang-sierra 2.6.0",
+ "cairo-lang-sierra-ap-change 2.6.0",
+ "cairo-lang-sierra-generator 2.6.0",
+ "cairo-lang-sierra-to-casm 2.6.0",
  "cairo-lang-sierra-type-size",
- "cairo-lang-starknet 2.6.0-rc.1",
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-starknet 2.6.0",
+ "cairo-lang-utils 2.6.0",
  "cairo-vm",
  "itertools 0.11.0",
  "keccak",
@@ -1888,19 +1888,19 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4805057e20661751822c30ec57f2082e9a6a4b8f4c743d3142ae7e557e34fbdd"
+checksum = "9d2a528f1c547e67631dcea299b6864f96792052e3a7ce27e5cbc23d6fce0fcf"
 dependencies = [
- "cairo-lang-debug 2.6.0-rc.1",
- "cairo-lang-defs 2.6.0-rc.1",
- "cairo-lang-diagnostics 2.6.0-rc.1",
- "cairo-lang-filesystem 2.6.0-rc.1",
- "cairo-lang-parser 2.6.0-rc.1",
- "cairo-lang-plugins 2.6.0-rc.1",
- "cairo-lang-proc-macros 2.6.0-rc.1",
- "cairo-lang-syntax 2.6.0-rc.1",
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-debug 2.6.0",
+ "cairo-lang-defs 2.6.0",
+ "cairo-lang-diagnostics 2.6.0",
+ "cairo-lang-filesystem 2.6.0",
+ "cairo-lang-parser 2.6.0",
+ "cairo-lang-plugins 2.6.0",
+ "cairo-lang-proc-macros 2.6.0",
+ "cairo-lang-syntax 2.6.0",
+ "cairo-lang-utils 2.6.0",
  "id-arena",
  "indoc 2.0.4",
  "itertools 0.11.0",
@@ -1980,13 +1980,13 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ef37c891ea0ab18d818fd74ceea6a865685c93a1c7a4ace1301909ba87bb82"
+checksum = "5774a2d5725d9cd96cfead69ea070ddfc87f912c36ab91086df66efe90e89e7c"
 dependencies = [
  "anyhow",
  "cairo-felt 0.9.1",
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0",
  "const-fnv1a-hash",
  "convert_case 0.6.0",
  "derivative",
@@ -2043,14 +2043,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c830940809184a4cf74b70b8ca3e479272fbc91c9b7fbd0e1ab00c49a6f4f809"
+checksum = "237de08219efe89406ce1cd6db8c2c1b8b062b090156ea82fb4f6eb8899d47f0"
 dependencies = [
- "cairo-lang-eq-solver 2.6.0-rc.1",
- "cairo-lang-sierra 2.6.0-rc.1",
+ "cairo-lang-eq-solver 2.6.0",
+ "cairo-lang-sierra 2.6.0",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0",
  "itertools 0.11.0",
  "num-traits 0.2.17",
  "thiserror",
@@ -2095,14 +2095,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b99b1095e496a5060607c2aac7c0487843a38166b4882efb98244d588e9fbb1"
+checksum = "f7b6fcdb1894da323e17c0f8388aab0622d25ace481c8d71eccafb764a2651fe"
 dependencies = [
- "cairo-lang-eq-solver 2.6.0-rc.1",
- "cairo-lang-sierra 2.6.0-rc.1",
+ "cairo-lang-eq-solver 2.6.0",
+ "cairo-lang-sierra 2.6.0",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0",
  "itertools 0.11.0",
  "num-traits 0.2.17",
  "thiserror",
@@ -2186,22 +2186,22 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab0d0990afbdad473e45a55979e8ca959f6e20a98455c52e57a2817b587c084"
+checksum = "9507e0de57e9e3bd973c6b1e341910283d9283649f9c003fe1ed62c94270a447"
 dependencies = [
- "cairo-lang-debug 2.6.0-rc.1",
- "cairo-lang-defs 2.6.0-rc.1",
- "cairo-lang-diagnostics 2.6.0-rc.1",
- "cairo-lang-filesystem 2.6.0-rc.1",
- "cairo-lang-lowering 2.6.0-rc.1",
- "cairo-lang-parser 2.6.0-rc.1",
- "cairo-lang-semantic 2.6.0-rc.1",
- "cairo-lang-sierra 2.6.0-rc.1",
- "cairo-lang-syntax 2.6.0-rc.1",
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-debug 2.6.0",
+ "cairo-lang-defs 2.6.0",
+ "cairo-lang-diagnostics 2.6.0",
+ "cairo-lang-filesystem 2.6.0",
+ "cairo-lang-lowering 2.6.0",
+ "cairo-lang-parser 2.6.0",
+ "cairo-lang-semantic 2.6.0",
+ "cairo-lang-sierra 2.6.0",
+ "cairo-lang-syntax 2.6.0",
+ "cairo-lang-utils 2.6.0",
  "itertools 0.11.0",
- "num-bigint",
+ "num-traits 0.2.17",
  "once_cell",
  "salsa",
  "smol_str 0.2.1",
@@ -2276,18 +2276,18 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95cef15ac7c317f2d3d494a594f2d35465e182400656e5a9cbb7d0cffc0fd227"
+checksum = "042ca9969b62580fbd9f257e60c9e441715335a2fe7c79826aa9664ef4e21187"
 dependencies = [
  "assert_matches",
  "cairo-felt 0.9.1",
- "cairo-lang-casm 2.6.0-rc.1",
- "cairo-lang-sierra 2.6.0-rc.1",
- "cairo-lang-sierra-ap-change 2.6.0-rc.1",
- "cairo-lang-sierra-gas 2.6.0-rc.1",
+ "cairo-lang-casm 2.6.0",
+ "cairo-lang-sierra 2.6.0",
+ "cairo-lang-sierra-ap-change 2.6.0",
+ "cairo-lang-sierra-gas 2.6.0",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-utils 2.6.0",
  "indoc 2.0.4",
  "itertools 0.11.0",
  "num-bigint",
@@ -2297,12 +2297,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3407dee40282408638acb476f4f8a4821fbd8c68eb6d1194a213a7de28e375a"
+checksum = "859e83d8ceeec98b72119c89281468ad08b6a60c9f2d99ddce407df0c6b8377c"
 dependencies = [
- "cairo-lang-sierra 2.6.0-rc.1",
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-sierra 2.6.0",
+ "cairo-lang-utils 2.6.0",
 ]
 
 [[package]]
@@ -2427,24 +2427,24 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04b3700cb2bc4d44f9e6b0e81de38501cd601db95ffe97469a06a80ea91b798"
+checksum = "76a22e15a9c91f26fe9b8638bddcb8b08282b7a27d1435c8390f5fa6abdef768"
 dependencies = [
  "anyhow",
  "cairo-felt 0.9.1",
- "cairo-lang-compiler 2.6.0-rc.1",
- "cairo-lang-defs 2.6.0-rc.1",
- "cairo-lang-diagnostics 2.6.0-rc.1",
- "cairo-lang-filesystem 2.6.0-rc.1",
- "cairo-lang-lowering 2.6.0-rc.1",
- "cairo-lang-plugins 2.6.0-rc.1",
- "cairo-lang-semantic 2.6.0-rc.1",
- "cairo-lang-sierra 2.6.0-rc.1",
- "cairo-lang-sierra-generator 2.6.0-rc.1",
+ "cairo-lang-compiler 2.6.0",
+ "cairo-lang-defs 2.6.0",
+ "cairo-lang-diagnostics 2.6.0",
+ "cairo-lang-filesystem 2.6.0",
+ "cairo-lang-lowering 2.6.0",
+ "cairo-lang-plugins 2.6.0",
+ "cairo-lang-semantic 2.6.0",
+ "cairo-lang-sierra 2.6.0",
+ "cairo-lang-sierra-generator 2.6.0",
  "cairo-lang-starknet-classes",
- "cairo-lang-syntax 2.6.0-rc.1",
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-syntax 2.6.0",
+ "cairo-lang-utils 2.6.0",
  "const_format",
  "indent",
  "indoc 2.0.4",
@@ -2458,15 +2458,15 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet-classes"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19152cb8a07c399d72e11bde4bc0c6b10db5c716e621b498b89573a00c517d0c"
+checksum = "39d9d31715b12f46963373bf0c4eeaa66c1839ee44fb176e39fe49d364aea0cf"
 dependencies = [
  "cairo-felt 0.9.1",
- "cairo-lang-casm 2.6.0-rc.1",
- "cairo-lang-sierra 2.6.0-rc.1",
- "cairo-lang-sierra-to-casm 2.6.0-rc.1",
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-casm 2.6.0",
+ "cairo-lang-sierra 2.6.0",
+ "cairo-lang-sierra-to-casm 2.6.0",
+ "cairo-lang-utils 2.6.0",
  "convert_case 0.6.0",
  "itertools 0.11.0",
  "num-bigint",
@@ -2528,13 +2528,13 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1293b76a4f6711178dafd5a65b35de5289ef7737f1d4fb9c2cd5f25a36da2d1f"
+checksum = "03bca67a21f85098d3185a2c016ef335ffc0b815a8305aad4a117876379c2cb3"
 dependencies = [
- "cairo-lang-debug 2.6.0-rc.1",
- "cairo-lang-filesystem 2.6.0-rc.1",
- "cairo-lang-utils 2.6.0-rc.1",
+ "cairo-lang-debug 2.6.0",
+ "cairo-lang-filesystem 2.6.0",
+ "cairo-lang-utils 2.6.0",
  "num-bigint",
  "num-traits 0.2.17",
  "salsa",
@@ -2578,9 +2578,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6211d20dc94543416f96b55c785273ab92180a58602121194ab5cb8282d1744"
+checksum = "06841b9eb87842cad1679f3c8534d25bbb5710923fd9e1903ca62e0663d91698"
 dependencies = [
  "genco",
  "xshell",
@@ -2637,9 +2637,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.6.0-rc.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4ce2f99f15869184146f8223b2d09b0d93679cb2bea5465c96b981cecb40b6"
+checksum = "15222608b6afc529e86554f5f8722cb37de9d73f28384ad33d86e6749ab6d13f"
 dependencies = [
  "hashbrown 0.14.3",
  "indexmap 2.2.1",
@@ -6198,7 +6198,7 @@ dependencies = [
  "cairo-lang-starknet 1.0.0-alpha.6",
  "cairo-lang-starknet 1.0.0-rc0",
  "cairo-lang-starknet 1.1.1",
- "cairo-lang-starknet 2.6.0-rc.1",
+ "cairo-lang-starknet 2.6.0",
  "cairo-lang-starknet-classes",
  "pathfinder-common",
  "serde",
@@ -8054,9 +8054,9 @@ dependencies = [
 
 [[package]]
 name = "starknet_api"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8bfc63e01213a3a39af29aa061435b80a24919ac02d1dce758d9e1ac8be2a44"
+checksum = "9e6aeb260177f5ca6dde788e844825d8d83782905dbac1b24c0c620743284475"
 dependencies = [
  "cairo-lang-starknet-classes",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ async-trait = "0.1.73"
 axum = { version = "0.6.19", features = ["macros"] }
 base64 = "0.13.1"
 bitvec = "1.0.1"
-blockifier = "=0.5.0"
+blockifier = "=0.6.0-rc.0"
 bytes = "1.4.0"
 cached = "0.44.0"
 # This one needs to match the version used by blockifier

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ async-trait = "0.1.73"
 axum = { version = "0.6.19", features = ["macros"] }
 base64 = "0.13.1"
 bitvec = "1.0.1"
-blockifier = "=0.5.0-rc.3"
+blockifier = "=0.5.0"
 bytes = "1.4.0"
 cached = "0.44.0"
 # This one needs to match the version used by blockifier
@@ -78,7 +78,7 @@ serde_json = "1.0.105"
 serde_with = "3.0.0"
 sha3 = "0.10"
 # This one needs to match the version used by blockifier
-starknet_api = "=0.8.0"
+starknet_api = "=0.10.0"
 test-log = { version = "0.2.12", default-features = false, features = [
     "trace",
 ] }

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -9,11 +9,11 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-cairo-lang-starknet-classes = "=2.6.0-rc.1"
+cairo-lang-starknet-classes = "=2.6.0"
 casm-compiler-v1_0_0-alpha6 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-alpha.6" }
 casm-compiler-v1_0_0-rc0 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-rc0" }
 casm-compiler-v1_1_1 = { package = "cairo-lang-starknet", version = "=1.1.1" }
-casm-compiler-v2 = { package = "cairo-lang-starknet", version = "=2.6.0-rc.1" }
+casm-compiler-v2 = { package = "cairo-lang-starknet", version = "=2.6.0" }
 pathfinder-common = { path = "../common" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = [

--- a/crates/executor/resources/versioned_constants_13_1.json
+++ b/crates/executor/resources/versioned_constants_13_1.json
@@ -1,0 +1,462 @@
+{
+    "tx_event_limits": {
+        "max_data_length": 300,
+        "max_keys_length": 50,
+        "max_n_emitted_events": 1000
+    },
+    "gateway": {
+        "max_calldata_length": 4000,
+        "max_contract_bytecode_size": 81920
+    },
+    "invoke_tx_max_n_steps": 4000000,
+    "l2_resource_gas_costs": {
+        "milligas_per_data_felt": 128,
+        "event_key_factor": 2,
+        "milligas_per_code_byte": 875
+    },
+    "max_recursion_depth": 50,
+    "os_constants": {
+        "nop_entry_point_offset": -1,
+        "entry_point_type_external": 0,
+        "entry_point_type_l1_handler": 1,
+        "entry_point_type_constructor": 2,
+        "l1_handler_version": 0,
+        "sierra_array_len_bound": 4294967296,
+        "constructor_entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+        "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+        "validate_entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+        "validate_declare_entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
+        "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
+        "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+        "default_entry_point_selector": 0,
+        "block_hash_contract_address": 1,
+        "stored_block_hash_buffer": 10,
+        "step_gas_cost": 100,
+        "range_check_gas_cost": 70,
+        "memory_hole_gas_cost": 10,
+        "initial_gas_cost": {
+            "step_gas_cost": 100000000
+        },
+        "entry_point_initial_budget": {
+            "step_gas_cost": 100
+        },
+        "syscall_base_gas_cost": {
+            "step_gas_cost": 100
+        },
+        "entry_point_gas_cost": {
+            "entry_point_initial_budget": 1,
+            "step_gas_cost": 500
+        },
+        "fee_transfer_gas_cost": {
+            "entry_point_gas_cost": 1,
+            "step_gas_cost": 100
+        },
+        "transaction_gas_cost": {
+            "entry_point_gas_cost": 2,
+            "fee_transfer_gas_cost": 1,
+            "step_gas_cost": 100
+        },
+        "call_contract_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 10,
+            "entry_point_gas_cost": 1
+        },
+        "deploy_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 200,
+            "entry_point_gas_cost": 1
+        },
+        "get_block_hash_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 50
+        },
+        "get_execution_info_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 10
+        },
+        "library_call_gas_cost": {
+            "call_contract_gas_cost": 1
+        },
+        "replace_class_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 50
+        },
+        "storage_read_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 50
+        },
+        "storage_write_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 50
+        },
+        "emit_event_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 10
+        },
+        "send_message_to_l1_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 50
+        },
+        "secp256k1_add_gas_cost": {
+            "step_gas_cost": 406,
+            "range_check_gas_cost": 29
+        },
+        "secp256k1_get_point_from_x_gas_cost": {
+            "step_gas_cost": 391,
+            "range_check_gas_cost": 30,
+            "memory_hole_gas_cost": 20
+        },
+        "secp256k1_get_xy_gas_cost": {
+            "step_gas_cost": 239,
+            "range_check_gas_cost": 11,
+            "memory_hole_gas_cost": 40
+        },
+        "secp256k1_mul_gas_cost": {
+            "step_gas_cost": 76501,
+            "range_check_gas_cost": 7045,
+            "memory_hole_gas_cost": 2
+        },
+        "secp256k1_new_gas_cost": {
+            "step_gas_cost": 475,
+            "range_check_gas_cost": 35,
+            "memory_hole_gas_cost": 40
+        },
+        "secp256r1_add_gas_cost": {
+            "step_gas_cost": 589,
+            "range_check_gas_cost": 57
+        },
+        "secp256r1_get_point_from_x_gas_cost": {
+            "step_gas_cost": 510,
+            "range_check_gas_cost": 44,
+            "memory_hole_gas_cost": 20
+        },
+        "secp256r1_get_xy_gas_cost": {
+            "step_gas_cost": 241,
+            "range_check_gas_cost": 11,
+            "memory_hole_gas_cost": 40
+        },
+        "secp256r1_mul_gas_cost": {
+            "step_gas_cost": 125340,
+            "range_check_gas_cost": 13961,
+            "memory_hole_gas_cost": 2
+        },
+        "secp256r1_new_gas_cost": {
+            "step_gas_cost": 594,
+            "range_check_gas_cost": 49,
+            "memory_hole_gas_cost": 40
+        },
+        "keccak_gas_cost": {
+            "syscall_base_gas_cost": 1
+        },
+        "keccak_round_cost_gas_cost": 180000,
+        "error_block_number_out_of_range": "Block number out of range",
+        "error_out_of_gas": "Out of gas",
+        "error_invalid_input_len": "Invalid input length",
+        "error_invalid_argument": "Invalid argument",
+        "validated": "VALID",
+        "l1_gas": "L1_GAS",
+        "l2_gas": "L2_GAS",
+        "l1_gas_index": 0,
+        "l2_gas_index": 1,
+        "validate_rounding_consts": {
+            "validate_block_number_rounding": 100,
+            "validate_timestamp_rounding": 3600
+        }
+    },
+    "os_resources": {
+        "execute_syscalls": {
+            "CallContract": {
+                "n_steps": 760,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 20
+                },
+                "n_memory_holes": 0
+            },
+            "DelegateCall": {
+                "n_steps": 713,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 19
+                },
+                "n_memory_holes": 0
+            },
+            "DelegateL1Handler": {
+                "n_steps": 692,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 15
+                },
+                "n_memory_holes": 0
+            },
+            "Deploy": {
+                "n_steps": 1012,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 7,
+                    "range_check_builtin": 19
+                },
+                "n_memory_holes": 0
+            },
+            "EmitEvent": {
+                "n_steps": 61,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "GetBlockHash": {
+                "n_steps": 104,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 2
+                },
+                "n_memory_holes": 0
+            },
+            "GetBlockNumber": {
+                "n_steps": 40,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            },
+            "GetBlockTimestamp": {
+                "n_steps": 38,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            },
+            "GetCallerAddress": {
+                "n_steps": 64,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "GetContractAddress": {
+                "n_steps": 64,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "GetExecutionInfo": {
+                "n_steps": 64,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "GetSequencerAddress": {
+                "n_steps": 34,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            },
+            "GetTxInfo": {
+                "n_steps": 64,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "GetTxSignature": {
+                "n_steps": 44,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            },
+            "Keccak": {
+                "n_steps": 381,
+                "builtin_instance_counter": {
+                    "bitwise_builtin": 6,
+                    "keccak_builtin": 1,
+                    "range_check_builtin": 56
+                },
+                "n_memory_holes": 0
+            },
+            "LibraryCall": {
+                "n_steps": 751,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 20
+                },
+                "n_memory_holes": 0
+            },
+            "LibraryCallL1Handler": {
+                "n_steps": 659,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 15
+                },
+                "n_memory_holes": 0
+            },
+            "ReplaceClass": {
+                "n_steps": 98,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256k1Add": {
+                "n_steps": 408,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 29
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256k1GetPointFromX": {
+                "n_steps": 393,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 30
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256k1GetXy": {
+                "n_steps": 205,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 11
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256k1Mul": {
+                "n_steps": 76503,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 7045
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256k1New": {
+                "n_steps": 459,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 35
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256r1Add": {
+                "n_steps": 591,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 57
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256r1GetPointFromX": {
+                "n_steps": 512,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 44
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256r1GetXy": {
+                "n_steps": 207,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 11
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256r1Mul": {
+                "n_steps": 125342,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 13961
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256r1New": {
+                "n_steps": 578,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 49
+                },
+                "n_memory_holes": 0
+            },
+            "SendMessageToL1": {
+                "n_steps": 139,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "StorageRead": {
+                "n_steps": 87,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "StorageWrite": {
+                "n_steps": 89,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            }
+        },
+        "execute_txs_inner": {
+            "Declare": {
+                "constant": {
+                    "n_steps": 2839,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 16,
+                        "range_check_builtin": 63
+                    },
+                    "n_memory_holes": 0
+                },
+                "calldata_factor": {
+                    "n_steps": 0,
+                    "builtin_instance_counter": {},
+                    "n_memory_holes": 0
+                }
+            },
+            "DeployAccount": {
+                "constant": {
+                    "n_steps": 3792,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 23,
+                        "range_check_builtin": 83
+                    },
+                    "n_memory_holes": 0
+                },
+                "calldata_factor": {
+                    "n_steps": 21,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 2
+                    },
+                    "n_memory_holes": 0
+                }
+            },
+            "InvokeFunction": {
+                "constant": {
+                    "n_steps": 3546,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 14,
+                        "range_check_builtin": 80
+                    },
+                    "n_memory_holes": 0
+                },
+                "calldata_factor": {
+                    "n_steps": 8,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 1
+                    },
+                    "n_memory_holes": 0
+                }
+            },
+            "L1Handler": {
+                "constant": {
+                    "n_steps": 1146,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 11,
+                        "range_check_builtin": 17
+                    },
+                    "n_memory_holes": 0
+                },
+                "calldata_factor": {
+                    "n_steps": 13,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 1
+                    },
+                    "n_memory_holes": 0
+                }
+            }
+        }
+    },
+    "validate_max_n_steps": 1000000,
+    "vm_resource_fee_cost": {
+        "bitwise_builtin": 0.16,
+        "ec_op_builtin": 2.56,
+        "ecdsa_builtin": 5.12,
+        "keccak_builtin": 5.12,
+        "n_steps": 0.0025,
+        "output_builtin": 0,
+        "pedersen_builtin": 0.08,
+        "poseidon_builtin": 0.08,
+        "range_check_builtin": 0.04
+    }
+}

--- a/crates/executor/src/execution_state.rs
+++ b/crates/executor/src/execution_state.rs
@@ -29,19 +29,27 @@ mod versioned_constants {
     const BLOCKIFIER_VERSIONED_CONSTANTS_JSON_0_13_0: &[u8] =
         include_bytes!("../resources/versioned_constants_13_0.json");
 
-    const STARKNET_VERSION_MATCHING_LATEST_BLOCKIFIER: StarknetVersion =
-        StarknetVersion::new(0, 13, 1, 0);
+    const BLOCKIFIER_VERSIONED_CONSTANTS_JSON_0_13_1: &[u8] =
+        include_bytes!("../resources/versioned_constants_13_1.json");
+
+    const STARKNET_VERSION_0_13_1: StarknetVersion = StarknetVersion::new(0, 13, 1, 0);
+
+    const STARKNET_VERSION_0_13_1_1: StarknetVersion = StarknetVersion::new(0, 13, 1, 1);
 
     lazy_static::lazy_static! {
         pub static ref BLOCKIFIER_VERSIONED_CONSTANTS_0_13_0: VersionedConstants =
             serde_json::from_slice(BLOCKIFIER_VERSIONED_CONSTANTS_JSON_0_13_0).unwrap();
+
+        pub static ref BLOCKIFIER_VERSIONED_CONSTANTS_0_13_1: VersionedConstants =
+            serde_json::from_slice(BLOCKIFIER_VERSIONED_CONSTANTS_JSON_0_13_1).unwrap();
     }
 
     pub(super) fn for_version(version: &StarknetVersion) -> &'static VersionedConstants {
-        // Right now we only properly support two versions: 0.13.0 and 0.13.1.
         // We use 0.13.0 for all blocks _before_ 0.13.1.
-        if version < &STARKNET_VERSION_MATCHING_LATEST_BLOCKIFIER {
+        if version < &STARKNET_VERSION_0_13_1 {
             &BLOCKIFIER_VERSIONED_CONSTANTS_0_13_0
+        } else if version < &STARKNET_VERSION_0_13_1_1 {
+            &BLOCKIFIER_VERSIONED_CONSTANTS_0_13_1
         } else {
             VersionedConstants::latest_constants()
         }

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -28,7 +28,7 @@ async-trait = { workspace = true }
 base64 = { workspace = true, optional = true }
 bitvec = { workspace = true }
 bytes = { workspace = true }
-cairo-lang-starknet-classes = { version = "=2.6.0-rc.1", optional = true }
+cairo-lang-starknet-classes = { version = "=2.6.0", optional = true }
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
 console-subscriber = { version = "0.1.10", optional = true }
 fake = { workspace = true }

--- a/crates/rpc/src/v07/method/estimate_fee.rs
+++ b/crates/rpc/src/v07/method/estimate_fee.rs
@@ -36,14 +36,7 @@ mod tests {
         ContractClass, DataAvailabilityMode, ResourceBounds, SierraContractClass,
     };
 
-    #[tokio::test]
-    async fn declare_deploy_and_invoke_sierra_class() {
-        let (context, last_block_header, account_contract_address, universal_deployer_address) =
-            crate::test_setup::test_context_with_starknet_version(StarknetVersion::new(
-                0, 13, 1, 0,
-            ))
-            .await;
-
+    fn declare_transaction(account_contract_address: ContractAddress) -> BroadcastedTransaction {
         let sierra_definition = include_bytes!("../../../fixtures/contracts/storage_access.json");
         let sierra_hash =
             class_hash!("0544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90");
@@ -60,9 +53,8 @@ mod tests {
 
         let max_fee = Fee::default();
 
-        // declare test class
-        let declare_transaction = BroadcastedTransaction::Declare(
-            BroadcastedDeclareTransaction::V2(BroadcastedDeclareTransactionV2 {
+        BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V2(
+            BroadcastedDeclareTransactionV2 {
                 version: TransactionVersion::TWO,
                 max_fee,
                 signature: vec![],
@@ -70,10 +62,19 @@ mod tests {
                 contract_class,
                 sender_address: account_contract_address,
                 compiled_class_hash: casm_hash,
-            }),
-        );
-        // deploy with unversal deployer contract
-        let deploy_transaction = BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(
+            },
+        ))
+    }
+
+    fn deploy_transaction(
+        account_contract_address: ContractAddress,
+        universal_deployer_address: ContractAddress,
+    ) -> BroadcastedTransaction {
+        let max_fee = Fee::default();
+        let sierra_hash =
+            class_hash!("0544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90");
+
+        BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(
             BroadcastedInvokeTransactionV1 {
                 nonce: transaction_nonce!("0x1"),
                 version: TransactionVersion::ONE,
@@ -96,9 +97,13 @@ mod tests {
                     call_param!("0x0"),
                 ],
             },
-        ));
-        // invoke deployed contract
-        let invoke_transaction = BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(
+        ))
+    }
+
+    fn invoke_transaction(account_contract_address: ContractAddress) -> BroadcastedTransaction {
+        let max_fee = Fee::default();
+
+        BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(
             BroadcastedInvokeTransactionV1 {
                 nonce: transaction_nonce!("0x2"),
                 version: TransactionVersion::ONE,
@@ -116,11 +121,14 @@ mod tests {
                     call_param!("0"),
                 ],
             },
-        ));
+        ))
+    }
 
-        // do the same invoke with a v0 transaction
-        let invoke_v0_transaction = BroadcastedTransaction::Invoke(
-            BroadcastedInvokeTransaction::V0(BroadcastedInvokeTransactionV0 {
+    fn invoke_v0_transaction() -> BroadcastedTransaction {
+        let max_fee = Fee::default();
+
+        BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V0(
+            BroadcastedInvokeTransactionV0 {
                 version: TransactionVersion::ONE,
                 max_fee,
                 signature: vec![],
@@ -129,12 +137,13 @@ mod tests {
                 ),
                 entry_point_selector: EntryPoint::hashed(b"get_data"),
                 calldata: vec![],
-            }),
-        );
+            },
+        ))
+    }
 
-        // do the same invoke with a v3 transaction
-        let invoke_v3_transaction = BroadcastedTransaction::Invoke(
-            BroadcastedInvokeTransaction::V3(BroadcastedInvokeTransactionV3 {
+    fn invoke_v3_transaction(account_contract_address: ContractAddress) -> BroadcastedTransaction {
+        BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V3(
+            BroadcastedInvokeTransactionV3 {
                 version: TransactionVersion::THREE,
                 signature: vec![],
                 sender_address: account_contract_address,
@@ -155,8 +164,29 @@ mod tests {
                 account_deployment_data: vec![],
                 nonce_data_availability_mode: DataAvailabilityMode::L1,
                 fee_data_availability_mode: DataAvailabilityMode::L1,
-            }),
-        );
+            },
+        ))
+    }
+
+    #[tokio::test]
+    async fn declare_deploy_and_invoke_sierra_class_starknet_0_13_1() {
+        let (context, last_block_header, account_contract_address, universal_deployer_address) =
+            crate::test_setup::test_context_with_starknet_version(StarknetVersion::new(
+                0, 13, 1, 0,
+            ))
+            .await;
+
+        // declare test class
+        let declare_transaction = declare_transaction(account_contract_address);
+        // deploy with unversal deployer contract
+        let deploy_transaction =
+            deploy_transaction(account_contract_address, universal_deployer_address);
+        // invoke deployed contract
+        let invoke_transaction = invoke_transaction(account_contract_address);
+        // do the same invoke with a v0 transaction
+        let invoke_v0_transaction = invoke_v0_transaction();
+        // do the same invoke with a v3 transaction
+        let invoke_v3_transaction = invoke_v3_transaction(account_contract_address);
 
         let input = EstimateFeeInput {
             request: vec![
@@ -174,6 +204,91 @@ mod tests {
             gas_consumed: 23817.into(),
             gas_price: 1.into(),
             overall_fee: 24201.into(),
+            unit: PriceUnit::Wei,
+            data_gas_consumed: Some(192.into()),
+            data_gas_price: Some(2.into()),
+        };
+        let deploy_expected = FeeEstimate {
+            gas_consumed: 15.into(),
+            gas_price: 1.into(),
+            overall_fee: 463.into(),
+            unit: PriceUnit::Wei,
+            data_gas_consumed: Some(224.into()),
+            data_gas_price: Some(2.into()),
+        };
+        let invoke_expected = FeeEstimate {
+            gas_consumed: 12.into(),
+            gas_price: 1.into(),
+            overall_fee: 268.into(),
+            unit: PriceUnit::Wei,
+            data_gas_consumed: Some(128.into()),
+            data_gas_price: Some(2.into()),
+        };
+        let invoke_v0_expected = FeeEstimate {
+            gas_consumed: 10.into(),
+            gas_price: 1.into(),
+            overall_fee: 266.into(),
+            unit: PriceUnit::Wei,
+            data_gas_consumed: Some(128.into()),
+            data_gas_price: Some(2.into()),
+        };
+        let invoke_v3_expected = FeeEstimate {
+            gas_consumed: 12.into(),
+            // STRK gas price is 2
+            gas_price: 2.into(),
+            overall_fee: 280.into(),
+            unit: PriceUnit::Fri,
+            data_gas_consumed: Some(128.into()),
+            data_gas_price: Some(2.into()),
+        };
+        assert_eq!(
+            result,
+            vec![
+                declare_expected,
+                deploy_expected,
+                invoke_expected,
+                invoke_v0_expected,
+                invoke_v3_expected,
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn declare_deploy_and_invoke_sierra_class_starknet_0_13_1_1() {
+        let (context, last_block_header, account_contract_address, universal_deployer_address) =
+            crate::test_setup::test_context_with_starknet_version(StarknetVersion::new(
+                0, 13, 1, 1,
+            ))
+            .await;
+
+        // declare test class
+        let declare_transaction = declare_transaction(account_contract_address);
+        // deploy with unversal deployer contract
+        let deploy_transaction =
+            deploy_transaction(account_contract_address, universal_deployer_address);
+        // invoke deployed contract
+        let invoke_transaction = invoke_transaction(account_contract_address);
+        // do the same invoke with a v0 transaction
+        let invoke_v0_transaction = invoke_v0_transaction();
+        // do the same invoke with a v3 transaction
+        let invoke_v3_transaction = invoke_v3_transaction(account_contract_address);
+
+        let input = EstimateFeeInput {
+            request: vec![
+                declare_transaction,
+                deploy_transaction,
+                invoke_transaction,
+                invoke_v0_transaction,
+                invoke_v3_transaction,
+            ],
+            simulation_flags: SimulationFlags(vec![]),
+            block_id: BlockId::Number(last_block_header.number),
+        };
+        let result = super::estimate_fee(context, input).await.unwrap();
+        let declare_expected = FeeEstimate {
+            gas_consumed: 878.into(),
+            gas_price: 1.into(),
+            overall_fee: 1262.into(),
             unit: PriceUnit::Wei,
             data_gas_consumed: Some(192.into()),
             data_gas_price: Some(2.into()),


### PR DESCRIPTION
This PR upgrades blockifier to 0.6.0-rc.0 so that we support new declare transaction estimations in Starknet 0.13.1.1 and adds versioned constants for Starknet 0.13.1 so that we keep compatibility.

Closes #1888