### PR TITLE
fix(github): fix triggers for our CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+  pull_request:
   # Daily cron job used to clear and rebuild cache (https://github.com/Swatinem/rust-cache/issues/181).
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
We want to have it run for all pushes to `main` _and_ all PRs in general.
