### PR TITLE
feat(storage): prune trie roots and contract  state hashes

### DIFF
--- a/crates/merkle-tree/src/contract_state.rs
+++ b/crates/merkle-tree/src/contract_state.rs
@@ -198,7 +198,7 @@ pub fn revert_contract_state(
                 };
 
                 transaction
-                    .insert_or_update_contract_root(target_block, contract_address, root_index)
+                    .insert_contract_root(target_block, contract_address, root_index)
                     .context("Inserting contract's root index")?;
 
                 root

--- a/crates/pathfinder/examples/test_state_rollback.rs
+++ b/crates/pathfinder/examples/test_state_rollback.rs
@@ -44,7 +44,7 @@ fn main() -> anyhow::Result<()> {
 
     let to_header = tx.block_header(to.into()).unwrap().unwrap();
 
-    pathfinder_lib::state::revert::revert_starknet_state(&tx, from, to, to_header, true)?;
+    pathfinder_lib::state::revert::revert_starknet_state(&tx, from, to, to_header)?;
 
     tracing::info!(
         from=%from,

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -990,7 +990,7 @@ async fn l2_reorg(connection: &mut Connection, reorg_tail: BlockNumber) -> anyho
                 .block_header(target_block.into())
                 .context("Fetching target block header")?
                 .context("Expected target header to exist")?;
-            revert::revert_starknet_state(&transaction, head, target_block, target_header, false)?;
+            revert::revert_starknet_state(&transaction, head, target_block, target_header)?;
         }
 
         // Purge each block one at a time.

--- a/crates/pathfinder/src/state/sync/revert.rs
+++ b/crates/pathfinder/src/state/sync/revert.rs
@@ -15,21 +15,18 @@ pub fn revert_starknet_state(
     head: BlockNumber,
     target_block: BlockNumber,
     target_header: BlockHeader,
-    force: bool,
 ) -> Result<(), anyhow::Error> {
     revert_contract_updates(
         transaction,
         head,
         target_block,
         target_header.storage_commitment,
-        force,
     )?;
     revert_class_updates(
         transaction,
         head,
         target_block,
         target_header.class_commitment,
-        force,
     )?;
     Ok(())
 }
@@ -43,9 +40,8 @@ fn revert_contract_updates(
     head: BlockNumber,
     target_block: BlockNumber,
     expected_storage_commitment: StorageCommitment,
-    force: bool,
 ) -> anyhow::Result<()> {
-    if force || !transaction.storage_root_exists(target_block)? {
+    if !transaction.storage_root_exists(target_block)? {
         let updates = transaction.reverse_contract_updates(head, target_block)?;
 
         let mut global_tree = StorageCommitmentTree::load(transaction, head)
@@ -109,9 +105,8 @@ fn revert_class_updates(
     head: BlockNumber,
     target_block: BlockNumber,
     expected_class_commitment: ClassCommitment,
-    force: bool,
 ) -> anyhow::Result<()> {
-    if force || !transaction.class_root_exists(target_block)? {
+    if !transaction.class_root_exists(target_block)? {
         let updates = transaction.reverse_sierra_class_updates(head, target_block)?;
 
         let mut class_tree = ClassCommitmentTree::load(transaction, head)


### PR DESCRIPTION
When state trie pruning is enabled historical root indices are no longer available, so there's no point in storing those in the database.

Likewise, contract state hashes (leaves of the storage trie) are also only used for the _last_ state of the contract as that's the only value referenced by the storage trie.

This PR makes sure that old root indices and contract state hashes are removed before inserting new values if state trie pruning is enabled.