### PR TITLE
refactor(storage): macros considered harmful

### DIFF
--- a/crates/storage/src/connection.rs
+++ b/crates/storage/src/connection.rs
@@ -95,15 +95,6 @@ impl<'inner> Transaction<'inner> {
     // The implementations here are intentionally kept as simple wrappers. This lets the real implementations
     // be kept in separate files with more reasonable LOC counts and easier test oversight.
 
-    #[cfg(test)]
-    pub(crate) fn new(tx: rusqlite::Transaction<'inner>) -> Self {
-        Self {
-            transaction: tx,
-            bloom_filter_cache: Arc::new(crate::bloom::Cache::with_size(1)),
-            prune_merkle_tries: false,
-        }
-    }
-
     fn inner(&self) -> &rusqlite::Transaction<'_> {
         &self.transaction
     }


### PR DESCRIPTION
Macros are worse than `unsafe`. Some clippy lints don't work inside macros, autocomplete doesn't work inside macros, IDE linting often does not work inside macros, automatic formatting doesn't work inside macros, IDE features (such as go-to references) don't work inside macros. This is unacceptable and below all standards we hold ourselves up to.

This PR removes 3x more code than it adds (including tests for the macro).