### PR TITLE
chore: upgrade blockifier to 0.6.0-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "blockifier"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e32cf74759dc6be99389096fd3fa0a8cc9e8cd44dd2c5f0f076f418df69397d"
+checksum = "c7ed27d8734e64869d24bed5cdcfefd3e069cb1e0d3d07c6e07135cdf226fd94"
 dependencies = [
  "anyhow",
  "ark-ec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ async-trait = "0.1.73"
 axum = { version = "0.6.19", features = ["macros"] }
 base64 = "0.13.1"
 bitvec = "1.0.1"
-blockifier = "=0.6.0-rc.1"
+blockifier = "=0.6.0-rc.2"
 bytes = "1.4.0"
 cached = "0.44.0"
 # This one needs to match the version used by blockifier


### PR DESCRIPTION
This version includes the rounding error fix for the recent reorg.
