### PR TITLE
fix(merke-tree): don't re-create tree root node when committing

### DIFF
--- a/crates/merkle-tree/src/class.rs
+++ b/crates/merkle-tree/src/class.rs
@@ -63,7 +63,7 @@ impl<'tx> ClassCommitmentTree<'tx> {
     pub fn commit(self) -> anyhow::Result<(ClassCommitment, TrieUpdate)> {
         let update = self.tree.commit(&self.storage)?;
 
-        let commitment = ClassCommitment(update.root_hash());
+        let commitment = ClassCommitment(update.root_commitment);
         Ok((commitment, update))
     }
 }

--- a/crates/merkle-tree/src/contract.rs
+++ b/crates/merkle-tree/src/contract.rs
@@ -101,7 +101,7 @@ impl<'tx> ContractsStorageTree<'tx> {
     /// any potentially newly created nodes.
     pub fn commit(self) -> anyhow::Result<(ContractRoot, TrieUpdate)> {
         let update = self.tree.commit(&self.storage)?;
-        let commitment = ContractRoot(update.root_hash());
+        let commitment = ContractRoot(update.root_commitment);
         Ok((commitment, update))
     }
 
@@ -174,7 +174,7 @@ impl<'tx> StorageCommitmentTree<'tx> {
     /// any potentially newly created nodes.
     pub fn commit(self) -> anyhow::Result<(StorageCommitment, TrieUpdate)> {
         let update = self.tree.commit(&self.storage)?;
-        let commitment = StorageCommitment(update.root_hash());
+        let commitment = StorageCommitment(update.root_commitment);
         Ok((commitment, update))
     }
 

--- a/crates/merkle-tree/src/transaction.rs
+++ b/crates/merkle-tree/src/transaction.rs
@@ -53,7 +53,7 @@ impl TransactionOrEventTree {
     pub fn commit(self) -> anyhow::Result<Felt> {
         self.tree
             .commit(&NullStorage {})
-            .map(|update| update.root_hash())
+            .map(|update| update.root_commitment)
     }
 }
 

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -1120,15 +1120,9 @@ fn update_starknet_state(
         .commit()
         .context("Apply storage commitment tree updates")?;
 
-    let root_idx = if !storage_commitment.0.is_zero() {
-        let root_idx = transaction
-            .insert_storage_trie(&trie_update, block)
-            .context("Persisting storage trie")?;
-
-        Some(root_idx)
-    } else {
-        None
-    };
+    let root_idx = transaction
+        .insert_storage_trie(&trie_update, block)
+        .context("Persisting storage trie")?;
 
     transaction
         .insert_storage_root(block, root_idx)
@@ -1159,15 +1153,9 @@ fn update_starknet_state(
         .commit()
         .context("Apply class commitment tree updates")?;
 
-    let class_root_idx = if !class_commitment.0.is_zero() {
-        let class_root_idx = transaction
-            .insert_class_trie(&trie_update, block)
-            .context("Persisting class trie")?;
-
-        Some(class_root_idx)
-    } else {
-        None
-    };
+    let class_root_idx = transaction
+        .insert_class_trie(&trie_update, block)
+        .context("Persisting class trie")?;
 
     transaction
         .insert_class_root(block, class_root_idx)

--- a/crates/pathfinder/src/state/sync/revert.rs
+++ b/crates/pathfinder/src/state/sync/revert.rs
@@ -79,15 +79,9 @@ fn revert_contract_updates(
             );
         }
 
-        let root_idx = if !storage_commitment.0.is_zero() {
-            let root_idx = transaction
-                .insert_storage_trie(&trie_update, target_block)
-                .context("Persisting storage trie")?;
-
-            Some(root_idx)
-        } else {
-            None
-        };
+        let root_idx = transaction
+            .insert_storage_trie(&trie_update, target_block)
+            .context("Persisting storage trie")?;
 
         transaction
             .insert_storage_root(target_block, root_idx)
@@ -140,15 +134,9 @@ fn revert_class_updates(
             );
         }
 
-        let root_idx = if !class_commitment.0.is_zero() {
-            let root_idx = transaction
-                .insert_class_trie(&trie_update, target_block)
-                .context("Persisting class trie")?;
-
-            Some(root_idx)
-        } else {
-            None
-        };
+        let root_idx = transaction
+            .insert_class_trie(&trie_update, target_block)
+            .context("Persisting class trie")?;
 
         transaction
             .insert_class_root(target_block, root_idx)

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -353,7 +353,7 @@ pub mod test_utils {
             .insert_storage_trie(&trie_update, BlockNumber::GENESIS)
             .unwrap();
         db_txn
-            .insert_storage_root(BlockNumber::GENESIS, Some(storage_root_idx))
+            .insert_storage_root(BlockNumber::GENESIS, storage_root_idx)
             .unwrap();
         let header0 = BlockHeader::builder()
             .with_number(BlockNumber::GENESIS)
@@ -394,7 +394,7 @@ pub mod test_utils {
             .insert_storage_trie(&trie_update, BlockNumber::GENESIS + 1)
             .unwrap();
         db_txn
-            .insert_storage_root(BlockNumber::GENESIS + 1, Some(storage_root_idx))
+            .insert_storage_root(BlockNumber::GENESIS + 1, storage_root_idx)
             .unwrap();
         let header1 = header0
             .child_builder()
@@ -453,7 +453,7 @@ pub mod test_utils {
             .insert_storage_trie(&trie_update, BlockNumber::GENESIS + 2)
             .unwrap();
         db_txn
-            .insert_storage_root(BlockNumber::GENESIS + 2, Some(storage_root_idx))
+            .insert_storage_root(BlockNumber::GENESIS + 2, storage_root_idx)
             .unwrap();
         let header2 = header1
             .child_builder()

--- a/crates/rpc/src/pathfinder/methods/get_proof.rs
+++ b/crates/rpc/src/pathfinder/methods/get_proof.rs
@@ -301,6 +301,7 @@ mod tests {
             &pathfinder_storage::TrieUpdate {
                 nodes_added: vec![(Felt::from_u64(0), pathfinder_storage::Node::LeafBinary)],
                 nodes_removed: (0..100).collect(),
+                root_commitment: Felt::ZERO,
             },
             BlockNumber::GENESIS + 3,
         )
@@ -311,6 +312,7 @@ mod tests {
             &pathfinder_storage::TrieUpdate {
                 nodes_added: vec![(Felt::from_u64(1), pathfinder_storage::Node::LeafBinary)],
                 nodes_removed: vec![],
+                root_commitment: Felt::ZERO,
             },
             BlockNumber::GENESIS + 4,
         )

--- a/crates/storage/src/connection.rs
+++ b/crates/storage/src/connection.rs
@@ -25,7 +25,7 @@ pub(crate) use reorg_counter::ReorgCounter;
 pub use transaction::TransactionData;
 pub use transaction::TransactionStatus;
 
-pub use trie::{Node, NodeRef, StoredNode, TrieUpdate};
+pub use trie::{Node, NodeRef, RootIndexUpdate, StoredNode, TrieUpdate};
 
 use pathfinder_common::{BlockNumber, TransactionHash};
 

--- a/crates/storage/src/connection/trie.rs
+++ b/crates/storage/src/connection/trie.rs
@@ -481,14 +481,10 @@ pub struct TrieUpdate {
     ///
     /// The last node is the root of the trie.
     pub nodes_added: Vec<(Felt, Node)>,
-    // Nodes committed to storage that have been removed.
+    /// Nodes committed to storage that have been removed.
     pub nodes_removed: Vec<u64>,
-}
-
-impl TrieUpdate {
-    pub fn root_hash(&self) -> Felt {
-        self.nodes_added.last().map(|x| x.0).unwrap_or_default()
-    }
+    /// New root commitment of the trie.
+    pub root_hash: Felt,
 }
 
 #[derive(Clone, Debug)]
@@ -957,6 +953,7 @@ mod tests {
                     (felt!("2"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
+                root_hash: Felt::ZERO,
             },
             BlockNumber::GENESIS,
         )
@@ -975,6 +972,7 @@ mod tests {
                     (felt!("5"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![1],
+                root_hash: Felt::ZERO,
             },
             BlockNumber::GENESIS + 1,
         )
@@ -993,6 +991,7 @@ mod tests {
                     (felt!("8"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
+                root_hash: Felt::ZERO,
             },
             BlockNumber::GENESIS + 2,
         )
@@ -1011,6 +1010,7 @@ mod tests {
                     (felt!("11"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
+                root_hash: Felt::ZERO,
             },
             BlockNumber::GENESIS + 3,
         )
@@ -1033,6 +1033,7 @@ mod tests {
                     (felt!("14"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
+                root_hash: Felt::ZERO,
             },
             BlockNumber::GENESIS + 4,
         )
@@ -1066,6 +1067,7 @@ mod tests {
                     (felt!("2"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
+                root_hash: Felt::ZERO,
             },
             BlockNumber::GENESIS,
         )
@@ -1084,6 +1086,7 @@ mod tests {
                     (felt!("5"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![1],
+                root_hash: Felt::ZERO,
             },
             BlockNumber::GENESIS + 1,
         )
@@ -1102,6 +1105,7 @@ mod tests {
                     (felt!("8"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
+                root_hash: Felt::ZERO,
             },
             BlockNumber::GENESIS + 2,
         )
@@ -1120,6 +1124,7 @@ mod tests {
                     (felt!("11"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
+                root_hash: Felt::ZERO,
             },
             BlockNumber::GENESIS + 3,
         )
@@ -1139,6 +1144,7 @@ mod tests {
                     (felt!("14"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
+                root_hash: Felt::ZERO,
             },
             BlockNumber::GENESIS + 4,
         )
@@ -1184,6 +1190,7 @@ mod tests {
                     (felt!("2"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
+                root_hash: Felt::ZERO,
             },
             BlockNumber::GENESIS,
         )
@@ -1202,6 +1209,7 @@ mod tests {
                     (felt!("5"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
+                root_hash: Felt::ZERO,
             },
             BlockNumber::GENESIS,
         )
@@ -1220,6 +1228,7 @@ mod tests {
                     (felt!("8"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
+                root_hash: Felt::ZERO,
             },
             BlockNumber::GENESIS,
         )
@@ -1244,6 +1253,7 @@ mod tests {
                     (felt!("5"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![1, 2, 3],
+                root_hash: Felt::ZERO,
             },
             BlockNumber::GENESIS + 1,
         )
@@ -1262,6 +1272,7 @@ mod tests {
                     (felt!("8"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
+                root_hash: Felt::ZERO,
             },
             BlockNumber::GENESIS + 2,
         )

--- a/crates/storage/src/connection/trie.rs
+++ b/crates/storage/src/connection/trie.rs
@@ -89,8 +89,14 @@ impl Transaction<'_> {
     pub fn insert_class_root(
         &self,
         block_number: BlockNumber,
-        root: Option<u64>,
+        update: RootIndexUpdate,
     ) -> anyhow::Result<()> {
+        let new_root_index = match update {
+            RootIndexUpdate::Unchanged => return Ok(()),
+            RootIndexUpdate::Updated(idx) => Some(idx),
+            RootIndexUpdate::TrieEmpty => None,
+        };
+
         if let TriePruneMode::Prune { num_blocks_kept } = self.trie_prune_mode {
             if let Some(block_number) = block_number.checked_sub(num_blocks_kept) {
                 self.delete_class_roots(block_number)?;
@@ -99,7 +105,7 @@ impl Transaction<'_> {
 
         self.inner().execute(
             "INSERT INTO class_roots (block_number, root_index) VALUES(?, ?)",
-            params![&block_number, &root],
+            params![&block_number, &new_root_index],
         )?;
         Ok(())
     }
@@ -160,18 +166,24 @@ impl Transaction<'_> {
     pub fn insert_storage_root(
         &self,
         block_number: BlockNumber,
-        root: Option<u64>,
+        update: RootIndexUpdate,
     ) -> anyhow::Result<()> {
+        let new_root_index = match update {
+            RootIndexUpdate::Unchanged => return Ok(()),
+            RootIndexUpdate::Updated(idx) => Some(idx),
+            RootIndexUpdate::TrieEmpty => None,
+        };
+
         if let TriePruneMode::Prune { num_blocks_kept } = self.trie_prune_mode {
             if let Some(block_number) = block_number.checked_sub(num_blocks_kept) {
                 self.delete_storage_roots(block_number)?;
             }
         }
-
         self.inner().execute(
             "INSERT INTO storage_roots (block_number, root_index) VALUES(?, ?)",
-            params![&block_number, &root],
+            params![&block_number, &new_root_index],
         )?;
+
         Ok(())
     }
 
@@ -187,8 +199,14 @@ impl Transaction<'_> {
         &self,
         block_number: BlockNumber,
         contract: ContractAddress,
-        root: Option<u64>,
+        update: RootIndexUpdate,
     ) -> anyhow::Result<()> {
+        let new_root_index = match update {
+            RootIndexUpdate::Unchanged => return Ok(()),
+            RootIndexUpdate::Updated(idx) => Some(idx),
+            RootIndexUpdate::TrieEmpty => None,
+        };
+
         if let TriePruneMode::Prune { num_blocks_kept } = self.trie_prune_mode {
             if let Some(block_number) = block_number.checked_sub(num_blocks_kept) {
                 self.delete_contract_roots(contract, block_number)?;
@@ -197,8 +215,9 @@ impl Transaction<'_> {
 
         self.inner().execute(
             "INSERT INTO contract_roots (block_number, contract_address, root_index) VALUES(?, ?, ?)",
-            params![&block_number, &contract, &root],
+            params![&block_number, &contract, &new_root_index],
         )?;
+
         Ok(())
     }
 
@@ -206,7 +225,7 @@ impl Transaction<'_> {
         &self,
         update: &TrieUpdate,
         block_number: BlockNumber,
-    ) -> anyhow::Result<u64> {
+    ) -> anyhow::Result<RootIndexUpdate> {
         self.insert_trie(update, block_number, "trie_contracts")
     }
 
@@ -222,7 +241,7 @@ impl Transaction<'_> {
         &self,
         update: &TrieUpdate,
         block_number: BlockNumber,
-    ) -> anyhow::Result<u64> {
+    ) -> anyhow::Result<RootIndexUpdate> {
         self.insert_trie(update, block_number, "trie_class")
     }
 
@@ -238,7 +257,7 @@ impl Transaction<'_> {
         &self,
         update: &TrieUpdate,
         block_number: BlockNumber,
-    ) -> anyhow::Result<u64> {
+    ) -> anyhow::Result<RootIndexUpdate> {
         self.insert_trie(update, block_number, "trie_storage")
     }
 
@@ -351,22 +370,25 @@ impl Transaction<'_> {
         Ok(())
     }
 
-    /// Stores the node data for a trie and returns the index of the root.
+    /// Stores the node data for a trie and returns the root index change.
     fn insert_trie(
         &self,
         update: &TrieUpdate,
         block_number: BlockNumber,
         table: &'static str,
-    ) -> anyhow::Result<u64> {
+    ) -> anyhow::Result<RootIndexUpdate> {
         if let TriePruneMode::Prune { num_blocks_kept } = self.trie_prune_mode {
             self.prune_trie(block_number, num_blocks_kept, table)?;
             self.remove_trie(&update.nodes_removed, block_number, table)?;
         }
 
-        assert!(
-            !update.nodes_added.is_empty(),
-            "Must have at least one node"
-        );
+        if update.nodes_added.is_empty() {
+            if !update.nodes_removed.is_empty() && update.root_commitment.is_zero() {
+                return Ok(RootIndexUpdate::TrieEmpty);
+            } else {
+                return Ok(RootIndexUpdate::Unchanged);
+            }
+        }
 
         let mut stmt = self
             .inner()
@@ -429,9 +451,11 @@ impl Transaction<'_> {
             metrics::increment_counter!(METRIC_TRIE_NODES_ADDED, "table" => table);
         }
 
-        Ok(*indices
-            .get(&(update.nodes_added.len() - 1))
-            .expect("Root index must exist as we just inserted it"))
+        Ok(RootIndexUpdate::Updated(
+            *indices
+                .get(&(update.nodes_added.len() - 1))
+                .expect("Root index must exist as we just inserted it"),
+        ))
     }
 
     /// Returns the node with the given index.
@@ -484,7 +508,15 @@ pub struct TrieUpdate {
     /// Nodes committed to storage that have been removed.
     pub nodes_removed: Vec<u64>,
     /// New root commitment of the trie.
-    pub root_hash: Felt,
+    pub root_commitment: Felt,
+}
+
+/// The result of inserting a `TrieUpdate`.
+#[derive(Debug, PartialEq)]
+pub enum RootIndexUpdate {
+    Unchanged,
+    Updated(u64),
+    TrieEmpty,
 }
 
 #[derive(Clone, Debug)]
@@ -653,12 +685,12 @@ mod tests {
         let result = tx.class_root_index(BlockNumber::GENESIS).unwrap();
         assert_eq!(result, None);
 
-        tx.insert_class_root(BlockNumber::GENESIS, Some(123))
+        tx.insert_class_root(BlockNumber::GENESIS, RootIndexUpdate::Updated(123))
             .unwrap();
         let result = tx.class_root_index(BlockNumber::GENESIS).unwrap();
         assert_eq!(result, Some(123));
 
-        tx.insert_class_root(BlockNumber::GENESIS + 1, Some(456))
+        tx.insert_class_root(BlockNumber::GENESIS + 1, RootIndexUpdate::Updated(456))
             .unwrap();
         let result = tx.class_root_index(BlockNumber::GENESIS).unwrap();
         assert_eq!(result, Some(123));
@@ -667,7 +699,7 @@ mod tests {
         let result = tx.class_root_index(BlockNumber::GENESIS + 2).unwrap();
         assert_eq!(result, Some(456));
 
-        tx.insert_class_root(BlockNumber::GENESIS + 10, Some(789))
+        tx.insert_class_root(BlockNumber::GENESIS + 10, RootIndexUpdate::Updated(789))
             .unwrap();
         let result = tx.class_root_index(BlockNumber::GENESIS + 9).unwrap();
         assert_eq!(result, Some(456));
@@ -676,7 +708,7 @@ mod tests {
         let result = tx.class_root_index(BlockNumber::GENESIS + 11).unwrap();
         assert_eq!(result, Some(789));
 
-        tx.insert_class_root(BlockNumber::GENESIS + 12, None)
+        tx.insert_class_root(BlockNumber::GENESIS + 12, RootIndexUpdate::TrieEmpty)
             .unwrap();
         let result = tx.class_root_index(BlockNumber::GENESIS + 12).unwrap();
         assert_eq!(result, None);
@@ -695,12 +727,12 @@ mod tests {
         let result = tx.storage_root_index(BlockNumber::GENESIS).unwrap();
         assert_eq!(result, None);
 
-        tx.insert_storage_root(BlockNumber::GENESIS, Some(123))
+        tx.insert_storage_root(BlockNumber::GENESIS, RootIndexUpdate::Updated(123))
             .unwrap();
         let result = tx.storage_root_index(BlockNumber::GENESIS).unwrap();
         assert_eq!(result, Some(123));
 
-        tx.insert_storage_root(BlockNumber::GENESIS + 1, Some(456))
+        tx.insert_storage_root(BlockNumber::GENESIS + 1, RootIndexUpdate::Updated(456))
             .unwrap();
         let result = tx.storage_root_index(BlockNumber::GENESIS).unwrap();
         assert_eq!(result, Some(123));
@@ -709,7 +741,7 @@ mod tests {
         let result = tx.storage_root_index(BlockNumber::GENESIS + 2).unwrap();
         assert_eq!(result, Some(456));
 
-        tx.insert_storage_root(BlockNumber::GENESIS + 10, Some(789))
+        tx.insert_storage_root(BlockNumber::GENESIS + 10, RootIndexUpdate::Updated(789))
             .unwrap();
         let result = tx.storage_root_index(BlockNumber::GENESIS + 9).unwrap();
         assert_eq!(result, Some(456));
@@ -718,7 +750,7 @@ mod tests {
         let result = tx.storage_root_index(BlockNumber::GENESIS + 11).unwrap();
         assert_eq!(result, Some(789));
 
-        tx.insert_storage_root(BlockNumber::GENESIS + 12, None)
+        tx.insert_storage_root(BlockNumber::GENESIS + 12, RootIndexUpdate::TrieEmpty)
             .unwrap();
         let result = tx.storage_root_index(BlockNumber::GENESIS + 12).unwrap();
         assert_eq!(result, None);
@@ -746,14 +778,17 @@ mod tests {
             ..Default::default()
         };
 
-        let idx0 = tx
+        let idx0_update = tx
             .insert_contract_trie(&update, BlockNumber::GENESIS)
             .unwrap();
+        let RootIndexUpdate::Updated(idx0) = idx0_update else {
+            panic!("Expected the root index to be updated");
+        };
 
         let result1 = tx.contract_root_index(BlockNumber::GENESIS, c1).unwrap();
         assert_eq!(result1, None);
 
-        tx.insert_contract_root(BlockNumber::GENESIS, c1, Some(idx0))
+        tx.insert_contract_root(BlockNumber::GENESIS, c1, idx0_update)
             .unwrap();
         let result1 = tx.contract_root_index(BlockNumber::GENESIS, c1).unwrap();
         let result2 = tx.contract_root_index(BlockNumber::GENESIS, c2).unwrap();
@@ -771,13 +806,16 @@ mod tests {
             ..Default::default()
         };
 
-        let idx1 = tx
+        let idx1_update = tx
             .insert_contract_trie(&update, BlockNumber::GENESIS + 1)
             .unwrap();
+        let RootIndexUpdate::Updated(idx1) = idx1_update else {
+            panic!("Expected the root index to be updated");
+        };
 
-        tx.insert_contract_root(BlockNumber::GENESIS + 1, c1, Some(idx1))
+        tx.insert_contract_root(BlockNumber::GENESIS + 1, c1, idx1_update)
             .unwrap();
-        tx.insert_contract_root(BlockNumber::GENESIS + 1, c2, Some(888))
+        tx.insert_contract_root(BlockNumber::GENESIS + 1, c2, RootIndexUpdate::Updated(888))
             .unwrap();
         let result1 = tx.contract_root_index(BlockNumber::GENESIS, c1).unwrap();
         let result2 = tx.contract_root_index(BlockNumber::GENESIS, c2).unwrap();
@@ -812,13 +850,16 @@ mod tests {
             nodes_added: nodes,
             ..Default::default()
         };
-        let idx2 = tx
+        let idx2_update = tx
             .insert_contract_trie(&update, BlockNumber::GENESIS + 10)
             .unwrap();
+        let RootIndexUpdate::Updated(idx2) = idx2_update else {
+            panic!("Expected the root index to be updated");
+        };
 
-        tx.insert_contract_root(BlockNumber::GENESIS + 10, c1, Some(idx2))
+        tx.insert_contract_root(BlockNumber::GENESIS + 10, c1, idx2_update)
             .unwrap();
-        tx.insert_contract_root(BlockNumber::GENESIS + 11, c2, Some(999))
+        tx.insert_contract_root(BlockNumber::GENESIS + 11, c2, RootIndexUpdate::Updated(999))
             .unwrap();
         let result1 = tx
             .contract_root_index(BlockNumber::GENESIS + 9, c1)
@@ -847,7 +888,7 @@ mod tests {
         assert_eq!(result2, Some(999));
         assert_eq!(hash1, Some(root2));
 
-        tx.insert_contract_root(BlockNumber::GENESIS + 12, c1, None)
+        tx.insert_contract_root(BlockNumber::GENESIS + 12, c1, RootIndexUpdate::TrieEmpty)
             .unwrap();
         let result1 = tx
             .contract_root_index(BlockNumber::GENESIS + 10, c1)
@@ -953,7 +994,7 @@ mod tests {
                     (felt!("2"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
-                root_hash: Felt::ZERO,
+                root_commitment: Felt::ZERO,
             },
             BlockNumber::GENESIS,
         )
@@ -972,7 +1013,7 @@ mod tests {
                     (felt!("5"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![1],
-                root_hash: Felt::ZERO,
+                root_commitment: Felt::ZERO,
             },
             BlockNumber::GENESIS + 1,
         )
@@ -991,7 +1032,7 @@ mod tests {
                     (felt!("8"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
-                root_hash: Felt::ZERO,
+                root_commitment: Felt::ZERO,
             },
             BlockNumber::GENESIS + 2,
         )
@@ -1010,7 +1051,7 @@ mod tests {
                     (felt!("11"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
-                root_hash: Felt::ZERO,
+                root_commitment: Felt::ZERO,
             },
             BlockNumber::GENESIS + 3,
         )
@@ -1033,7 +1074,7 @@ mod tests {
                     (felt!("14"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
-                root_hash: Felt::ZERO,
+                root_commitment: Felt::ZERO,
             },
             BlockNumber::GENESIS + 4,
         )
@@ -1067,7 +1108,7 @@ mod tests {
                     (felt!("2"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
-                root_hash: Felt::ZERO,
+                root_commitment: Felt::ZERO,
             },
             BlockNumber::GENESIS,
         )
@@ -1086,7 +1127,7 @@ mod tests {
                     (felt!("5"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![1],
-                root_hash: Felt::ZERO,
+                root_commitment: Felt::ZERO,
             },
             BlockNumber::GENESIS + 1,
         )
@@ -1105,7 +1146,7 @@ mod tests {
                     (felt!("8"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
-                root_hash: Felt::ZERO,
+                root_commitment: Felt::ZERO,
             },
             BlockNumber::GENESIS + 2,
         )
@@ -1124,7 +1165,7 @@ mod tests {
                     (felt!("11"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
-                root_hash: Felt::ZERO,
+                root_commitment: Felt::ZERO,
             },
             BlockNumber::GENESIS + 3,
         )
@@ -1144,7 +1185,7 @@ mod tests {
                     (felt!("14"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
-                root_hash: Felt::ZERO,
+                root_commitment: Felt::ZERO,
             },
             BlockNumber::GENESIS + 4,
         )
@@ -1190,7 +1231,7 @@ mod tests {
                     (felt!("2"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
-                root_hash: Felt::ZERO,
+                root_commitment: Felt::ZERO,
             },
             BlockNumber::GENESIS,
         )
@@ -1209,7 +1250,7 @@ mod tests {
                     (felt!("5"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
-                root_hash: Felt::ZERO,
+                root_commitment: Felt::ZERO,
             },
             BlockNumber::GENESIS,
         )
@@ -1228,7 +1269,7 @@ mod tests {
                     (felt!("8"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
-                root_hash: Felt::ZERO,
+                root_commitment: Felt::ZERO,
             },
             BlockNumber::GENESIS,
         )
@@ -1253,7 +1294,7 @@ mod tests {
                     (felt!("5"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![1, 2, 3],
-                root_hash: Felt::ZERO,
+                root_commitment: Felt::ZERO,
             },
             BlockNumber::GENESIS + 1,
         )
@@ -1272,7 +1313,7 @@ mod tests {
                     (felt!("8"), Node::LeafBinary),
                 ],
                 nodes_removed: vec![],
-                root_hash: Felt::ZERO,
+                root_commitment: Felt::ZERO,
             },
             BlockNumber::GENESIS + 2,
         )
@@ -1282,5 +1323,38 @@ mod tests {
         assert!(tx.class_trie_node(1).unwrap().is_none());
         assert!(tx.class_trie_node(2).unwrap().is_none());
         assert!(tx.class_trie_node(3).unwrap().is_none());
+    }
+
+    #[test]
+    fn trie_root_updates() {
+        let mut db = crate::StorageBuilder::in_memory_with_trie_pruning(TriePruneMode::Prune {
+            num_blocks_kept: 0,
+        })
+        .unwrap()
+        .connection()
+        .unwrap();
+        let tx = db.transaction().unwrap();
+
+        let root_update = tx
+            .insert_class_trie(
+                &TrieUpdate {
+                    nodes_added: vec![
+                        (
+                            felt!("0"),
+                            Node::Binary {
+                                left: NodeRef::Index(1),
+                                right: NodeRef::Index(2),
+                            },
+                        ),
+                        (felt!("1"), Node::LeafBinary),
+                        (felt!("2"), Node::LeafBinary),
+                    ],
+                    nodes_removed: vec![],
+                    root_commitment: Felt::ZERO,
+                },
+                BlockNumber::GENESIS,
+            )
+            .unwrap();
+        assert_eq!(root_update, RootIndexUpdate::Updated(1));
     }
 }

--- a/crates/storage/src/connection/trie.rs
+++ b/crates/storage/src/connection/trie.rs
@@ -430,7 +430,7 @@ impl Transaction<'_> {
         }
 
         Ok(*indices
-            .get(&update.root_index().unwrap())
+            .get(&(update.nodes_added.len() - 1))
             .expect("Root index must exist as we just inserted it"))
     }
 
@@ -486,14 +486,6 @@ pub struct TrieUpdate {
 }
 
 impl TrieUpdate {
-    pub fn root_index(&self) -> Option<usize> {
-        if self.nodes_added.is_empty() {
-            None
-        } else {
-            Some(self.nodes_added.len() - 1)
-        }
-    }
-
     pub fn root_hash(&self) -> Felt {
         self.nodes_added.last().map(|x| x.0).unwrap_or_default()
     }


### PR DESCRIPTION
If the root node is unresolved then the Merkle tree has been created but no update operations have been made.

In this case the previous code caused `commit()` to always re-create the root node so that opening a tree, then committing without changes added a new root node. This change makes sure we return the current root commitment  in that case instead.

Tree root updates also have to be done correctly. An unchanged root index should _not_ be inserted into storage, while in case the tree has became empty as a result of an update a NULL shall be recorded as a root index.

This change simplifies handling of these cases: `insert_XXX_trie()` now returns a `RootIndexUpdate` type that explicitly represents the three different cases. `insert_XXX_root()` takes that update value directly as its input and handles all cases correctly, skipping inserting a new value entirely in case there was no change.

This PR also includes a fix for an oversight I've found while adding tests: `MerkleTree::delete_leaf()` did not properly return all removed nodes in case the tree became empty after the deletion.