### PR TITLE
Fix reorg with state pruning enabled

### DIFF
--- a/crates/pathfinder/examples/test_state_rollback.rs
+++ b/crates/pathfinder/examples/test_state_rollback.rs
@@ -12,6 +12,9 @@ fn main() -> anyhow::Result<()> {
 
     let database_path = std::env::args().nth(1).unwrap();
     let storage = StorageBuilder::file(database_path.into())
+        .trie_prune_mode(pathfinder_storage::TriePruneMode::Prune {
+            num_blocks_kept: 10,
+        })
         .migrate()?
         .create_pool(NonZeroU32::new(10).unwrap())?;
     let mut db = storage

--- a/crates/storage/src/connection/block.rs
+++ b/crates/storage/src/connection/block.rs
@@ -158,6 +158,27 @@ impl Transaction<'_> {
             )
             .context("Deleting block from storage_roots table")?;
 
+        self.inner()
+            .execute(
+                "DELETE FROM trie_contracts_removals WHERE block_number = ?",
+                params![&block],
+            )
+            .context("Deleting block from trie_contracts_removals table")?;
+
+        self.inner()
+            .execute(
+                "DELETE FROM trie_storage_removals WHERE block_number = ?",
+                params![&block],
+            )
+            .context("Deleting block from trie_storage_removals table")?;
+
+        self.inner()
+            .execute(
+                "DELETE FROM trie_class_removals WHERE block_number = ?",
+                params![&block],
+            )
+            .context("Deleting block from trie_class_removals table")?;
+
         Ok(())
     }
 

--- a/crates/storage/src/connection/trie.rs
+++ b/crates/storage/src/connection/trie.rs
@@ -104,7 +104,7 @@ impl Transaction<'_> {
         }
 
         self.inner().execute(
-            "INSERT INTO class_roots (block_number, root_index) VALUES(?, ?)",
+            "INSERT OR REPLACE INTO class_roots (block_number, root_index) VALUES(?, ?)",
             params![&block_number, &new_root_index],
         )?;
         Ok(())
@@ -145,7 +145,7 @@ impl Transaction<'_> {
             }
         }
 
-        self.inner().execute("INSERT INTO contract_state_hashes(block_number, contract_address, state_hash) VALUES(?,?,?)", 
+        self.inner().execute("INSERT OR REPLACE INTO contract_state_hashes(block_number, contract_address, state_hash) VALUES(?,?,?)", 
         params![&block_number, &contract, &state_hash])?;
 
         Ok(())
@@ -210,7 +210,7 @@ impl Transaction<'_> {
             }
         }
         self.inner().execute(
-            "INSERT INTO storage_roots (block_number, root_index) VALUES(?, ?)",
+            "INSERT OR REPLACE INTO storage_roots (block_number, root_index) VALUES(?, ?)",
             params![&block_number, &new_root_index],
         )?;
 
@@ -258,7 +258,7 @@ impl Transaction<'_> {
         }
 
         self.inner().execute(
-            "INSERT INTO contract_roots (block_number, contract_address, root_index) VALUES(?, ?, ?)",
+            "INSERT OR REPLACE INTO contract_roots (block_number, contract_address, root_index) VALUES(?, ?, ?)",
             params![&block_number, &contract, &new_root_index],
         )?;
 

--- a/crates/storage/src/connection/trie.rs
+++ b/crates/storage/src/connection/trie.rs
@@ -123,7 +123,7 @@ impl Transaction<'_> {
             .optional()?;
 
         if let Some(last_block_with_root_index) = last_block_with_root_index {
-            tracing::info!(%last_block_with_root_index, "Removing class roots");
+            tracing::trace!(%last_block_with_root_index, "Removing class roots");
             let mut stmt = self
                 .inner()
                 .prepare_cached("DELETE FROM class_roots WHERE block_number < ?")?;

--- a/crates/storage/src/schema/revision_0055.rs
+++ b/crates/storage/src/schema/revision_0055.rs
@@ -4,18 +4,20 @@ pub(crate) fn migrate(tx: &rusqlite::Transaction<'_>) -> anyhow::Result<()> {
     tx.execute_batch(
         r"
         CREATE TABLE trie_class_removals (
-            block_number INTEGER PRIMARY KEY,
+            block_number INTEGER NOT NULL,
             indices BLOB
         );
+        CREATE INDEX trie_class_removals_block_number ON trie_class_removals(block_number);
         CREATE TABLE trie_contracts_removals (
             block_number INTEGER NOT NULL,
             indices BLOB
         );
         CREATE INDEX trie_contracts_removals_block_number ON trie_contracts_removals(block_number);
         CREATE TABLE trie_storage_removals (
-            block_number INTEGER PRIMARY KEY,
+            block_number INTEGER NOT NULL,
             indices BLOB
         );
+        CREATE INDEX trie_storage_removals_block_number ON trie_storage_removals(block_number);
         ",
     )
     .context("Creating removals tables")?;


### PR DESCRIPTION
During a reorg we check if the target block still has a state trie available. If it's out of the region we're keeping state trie data for we re-compute the state by applying a reverse-diff to the latest state.

Handling of delayed removal of trie data is more complicated: we have to account for removed trie nodes separately.

In general, removing the trie nodes deleted at block N is only safe if we don't ever need to access trie state at block < N. This is not necessarily the case during a reorg: if our reorg/revert target is still in the range of blocks we're keeping trie history for then removing deleted nodes for the reorged-away blocks would break the trie for the blocks _before_ the reorg target. Instead, we move all the removed nodes in the reorged-away range to be "owned" by the revert target block.

This algorithm works even for the case where the target block is outside the last-N-blocks-of-state range: simply dropping those rows from the "removals" tables would leak the trie nodes. Moving ownership of that data to the reorg target makes sure that the unreachable nodes will be eventually removed.

This PR implements that "moving" of removed node data by:
- changing the schema so that _all_ trie removals tables allow for duplicate block numbers
- when "moving" data we just update the `block_number` in the respective rows in the removals table.