### PR TITLE
feat: sync stages

### DIFF
--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -34,7 +34,7 @@ use crate::client::peer_aware;
 use crate::sync::protocol;
 
 /// Data received from a specific peer.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PeerData<T> {
     pub peer: PeerId,
     pub data: T,

--- a/crates/pathfinder/src/sync.rs
+++ b/crates/pathfinder/src/sync.rs
@@ -12,6 +12,7 @@ mod events;
 mod headers;
 mod receipts;
 mod state_updates;
+mod stream;
 mod transactions;
 
 const CHECKPOINT_MARGIN: u64 = 10;

--- a/crates/pathfinder/src/sync/error.rs
+++ b/crates/pathfinder/src/sync/error.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use p2p::libp2p::PeerId;
 use p2p::PeerData;
 use pathfinder_common::{BlockNumber, ClassHash, SignedBlockHeader};
@@ -24,4 +26,54 @@ pub(super) enum SyncError {
     BadClassHash(PeerId),
     #[error("Event commitment mismatch")]
     EventCommitmentMismatch(PeerId),
+}
+
+impl PartialEq for SyncError {
+    fn eq(&self, other: &Self) -> bool {
+        todo!();
+    }
+}
+
+#[derive(Debug, thiserror::Error, Clone)]
+pub(super) enum SyncError2 {
+    #[error(transparent)]
+    Other(#[from] Arc<anyhow::Error>),
+    #[error("Header signature verification failed")]
+    BadHeaderSignature,
+    #[error("Block hash verification failed")]
+    BadBlockHash,
+    #[error("Discontinuity in header chain")]
+    Discontinuity,
+    #[error("State diff signature verification failed")]
+    BadStateDiffSignature,
+    #[error("State diff commitment mismatch")]
+    StateDiffCommitmentMismatch,
+    #[error("Invalid class definition layout")]
+    BadClassLayout,
+    #[error("Unexpected class definition")]
+    UnexpectedClass,
+    #[error("Class hash verification failed")]
+    BadClassHash,
+    #[error("Event commitment mismatch")]
+    EventCommitmentMismatch,
+}
+
+impl PartialEq for SyncError2 {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Other(x), Self::Other(y)) => x.to_string() == y.to_string(),
+            (SyncError2::BadHeaderSignature, SyncError2::BadHeaderSignature) => true,
+            (SyncError2::BadBlockHash, SyncError2::BadBlockHash) => true,
+            (SyncError2::Discontinuity, SyncError2::Discontinuity) => true,
+            (SyncError2::BadStateDiffSignature, SyncError2::BadStateDiffSignature) => true,
+            (SyncError2::StateDiffCommitmentMismatch, SyncError2::StateDiffCommitmentMismatch) => {
+                true
+            }
+            (SyncError2::BadClassLayout, SyncError2::BadClassLayout) => true,
+            (SyncError2::UnexpectedClass, SyncError2::UnexpectedClass) => true,
+            (SyncError2::BadClassHash, SyncError2::BadClassHash) => true,
+            (SyncError2::EventCommitmentMismatch, SyncError2::EventCommitmentMismatch) => true,
+            _ => false,
+        }
+    }
 }

--- a/crates/pathfinder/src/sync/stream.rs
+++ b/crates/pathfinder/src/sync/stream.rs
@@ -1,0 +1,298 @@
+use futures::{Future, Stream, StreamExt, TryFutureExt, TryStream, TryStreamExt};
+use p2p::libp2p::PeerId;
+use p2p::PeerData;
+
+use super::error::SyncError2;
+
+pub trait SyncStream<T>: Stream<Item = PeerData<SyncResult<T>>> {}
+pub type SyncResult<T> = Result<T, SyncError2>;
+
+impl<T, U> SyncStream<T> for U where U: Stream<Item = PeerData<SyncResult<T>>> {}
+
+pub trait MapStage {
+    type Input;
+    type Output;
+
+    fn map(
+        &mut self,
+        input: Self::Input,
+    ) -> impl Future<Output = Result<Self::Output, SyncError2>> + Send;
+}
+
+/// A stage which collects items into buffers before outputting the collection.
+///
+/// This provides an [N] -> [M] style mapping where N >= M. This can therefore
+/// be used to represent operations such as transforming a stream of
+/// transactions to a stream of block's of transactions.
+pub trait BatchStage {
+    type Input;
+    /// This will usually be some form of collection over [Self::Input].
+    type Output;
+
+    /// Aggregate the incoming item and optional provide an output.
+    fn buffer(
+        &mut self,
+        input: Self::Input,
+    ) -> impl Future<Output = Result<Option<Self::Output>, SyncError2>> + Send;
+
+    /// Process and output any remaining items as the pipeline is being shut
+    /// down.
+    ///
+    /// This may also be used to output an error if more items were expected.
+    /// Note that this will only be called in the event of a successful end of
+    /// stream, so this is not guaranteed to be called.
+    fn flush(self) -> impl Future<Output = Result<Option<Self::Output>, SyncError2>> + Send;
+}
+
+impl<T, U> SyncStreamExt<T> for U
+where
+    U: SyncStream<T> + Send + 'static,
+    T: Send,
+{
+}
+
+pub trait SyncStreamExt<T>: SyncStream<T> + Sized + Send + 'static {
+    /// Adds a [MapStage] to the stream pipeline spawned as a separate task.
+    ///
+    /// `buffer` specifies the amount of buffering applied to the output stream.
+    fn map_stage<S>(mut self, mut stage: S, buffer: usize) -> impl SyncStream<S::Output>
+    where
+        S: MapStage<Input = T> + Send + 'static,
+        S::Output: Send,
+        T: Send + 'static,
+    {
+        let (tx, rx) = tokio::sync::mpsc::channel(buffer);
+
+        tokio::spawn(async move {
+            let mut stream = Box::pin(self);
+            while let Some(input) = stream.next().await {
+                let PeerData { peer, data } = input;
+                let result = std::future::ready(data).and_then(|x| stage.map(x)).await;
+                let result = PeerData::new(peer, result);
+
+                let is_err = result.data.is_err();
+                if tx.send(result).await.is_err() || is_err {
+                    return;
+                }
+            }
+        });
+
+        tokio_stream::wrappers::ReceiverStream::new(rx)
+    }
+
+    // / Adds a [BatchStage] to the stream pipeline spawned as a separate task.
+    // /
+    // / `buffer` specifies the amount of buffering applied to the output stream.
+    fn stage_batch<S>(mut self, mut stage: S, buffer: usize) -> impl SyncStream<S::Output>
+    where
+        S: BatchStage<Input = T> + Send + 'static,
+        S::Output: Send,
+        T: Send,
+    {
+        let (tx, rx) = tokio::sync::mpsc::channel(buffer);
+
+        tokio::spawn(async move {
+            let mut stream = Box::pin(self);
+            let mut latest_peer = None;
+            while let Some(input) = stream.next().await {
+                let PeerData { peer, data } = input;
+                latest_peer = Some(peer);
+
+                let result = std::future::ready(data)
+                    .and_then(|x| stage.buffer(x))
+                    .await
+                    .transpose();
+
+                let Some(result) = result else {
+                    continue;
+                };
+
+                let result = PeerData::new(peer, result);
+                let is_err = result.data.is_err();
+
+                if tx.send(result).await.is_err() || is_err {
+                    return;
+                }
+            }
+
+            if let Some(output) = stage.flush().await.transpose() {
+                let Some(latest_peer) = latest_peer else {
+                    tracing::warn!("Flush data without an attached peer");
+                    return;
+                };
+
+                let output = PeerData::new(latest_peer, output);
+                let _ = tx.send(output).await;
+            }
+        });
+
+        tokio_stream::wrappers::ReceiverStream::new(rx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SyncStreamExt, *};
+
+    mod map {
+        use super::*;
+
+        #[rstest::rstest]
+        #[case::all_ok(
+            vec![Ok(0), Ok(1), Ok(2)],
+            vec![Ok(0), Ok(1), Ok(2)]
+        )]
+        #[case::short_circuit_on_error(
+            vec![Ok(0), Ok(1), Err(SyncError2::BadBlockHash), Ok(2)],
+            vec![Ok(0), Ok(1), Err(SyncError2::BadBlockHash)],
+        )]
+        #[tokio::test]
+        async fn input_stream(
+            #[case] input: Vec<SyncResult<u8>>,
+            #[case] expected: Vec<SyncResult<u8>>,
+        ) {
+            struct NoOp;
+            impl MapStage for NoOp {
+                type Input = u8;
+                type Output = u8;
+
+                async fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError2> {
+                    Ok(input)
+                }
+            }
+
+            let peer = PeerId::random();
+
+            let input = input
+                .into_iter()
+                .map(|x| PeerData::new(peer, x))
+                .collect::<Vec<_>>();
+            let expected = expected
+                .into_iter()
+                .map(|x| PeerData::new(peer, x))
+                .collect::<Vec<_>>();
+
+            let stage = NoOp {};
+
+            let output = tokio_stream::iter(input)
+                .map_stage(stage, 5)
+                .collect::<Vec<_>>()
+                .await;
+
+            assert_eq!(output, expected);
+        }
+
+        #[tokio::test]
+        async fn short_circuit_on_map_error() {
+            struct OnlyOnce(u8);
+
+            impl MapStage for OnlyOnce {
+                type Input = u8;
+                type Output = u8;
+
+                async fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError2> {
+                    if self.0 == 0 {
+                        self.0 = 1;
+                        Ok(input)
+                    } else {
+                        Err(SyncError2::BadBlockHash)
+                    }
+                }
+            }
+
+            let peer = PeerId::random();
+            let input = (0..10)
+                .map(|x| PeerData { peer, data: Ok(x) })
+                .collect::<Vec<_>>();
+            let expected = vec![
+                PeerData { peer, data: Ok(0) },
+                PeerData {
+                    peer,
+                    data: Err(SyncError2::BadBlockHash),
+                },
+            ];
+
+            let stage = OnlyOnce(0);
+            let result = tokio_stream::iter(input)
+                .map_stage(stage, 5)
+                .collect::<Vec<_>>()
+                .await;
+
+            assert_eq!(result, expected);
+        }
+    }
+
+    #[rstest::rstest]
+    #[case::ok_and_flush(
+        vec![Ok(1), Ok(2), Ok(3), Ok(4)],
+        vec![Ok(6), Ok(4)]
+    )]
+    #[case::error_short_circuits(
+        vec![Ok(255), Ok(1), Ok(2)],
+        vec![Err(SyncError2::BadBlockHash)]
+    )]
+    #[case::stream_error_short_circuits(
+        vec![Ok(1), Err(SyncError2::BadBlockHash), Ok(2), Ok(3)],
+        vec![Err(SyncError2::BadBlockHash)]
+    )]
+    #[tokio::test]
+    async fn batch(#[case] input: Vec<SyncResult<u8>>, #[case] expected: Vec<SyncResult<u8>>) {
+        /// Sums every 3 elements together. Flushes the sum of any remaining
+        /// elements.
+        ///
+        /// Throws an error on overflow.
+        struct Sum3 {
+            count: usize,
+            total: u8,
+        };
+
+        impl BatchStage for Sum3 {
+            type Input = u8;
+            type Output = u8;
+
+            async fn buffer(
+                &mut self,
+                input: Self::Input,
+            ) -> Result<Option<Self::Output>, SyncError2> {
+                self.total = self
+                    .total
+                    .checked_add(input)
+                    .ok_or(SyncError2::BadBlockHash)?;
+                self.count += 1;
+
+                if self.count == 3 {
+                    self.count = 0;
+                    Ok(Some(std::mem::take(&mut self.total)))
+                } else {
+                    Ok(None)
+                }
+            }
+
+            async fn flush(self) -> Result<Option<Self::Output>, SyncError2> {
+                if self.count > 0 {
+                    Ok(Some(self.total))
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+
+        let stage = Sum3 { count: 0, total: 0 };
+        let peer = PeerId::random();
+
+        let input = input
+            .into_iter()
+            .map(|x| PeerData::new(peer, x))
+            .collect::<Vec<_>>();
+        let expected = expected
+            .into_iter()
+            .map(|x| PeerData::new(peer, x))
+            .collect::<Vec<_>>();
+
+        let result = tokio_stream::iter(input)
+            .stage_batch(stage, 3)
+            .collect::<Vec<_>>()
+            .await;
+        assert_eq!(result, expected);
+    }
+}


### PR DESCRIPTION
This PR introduces a new concurrency primitive for streams called stages.

A stage represents a processing step in a stream which is spawned as a separate tokio task loop. This PR adds two types of stages:

1. `MapStage` which as the name implies simply maps from `X -> Y`
2. `BatchStage` which can aggregate items

These stages align (mostly) with the stream api, which means you can write things like

```rust
header_stream
     .map_stage(VerifyHeaderStage)
     .map_stage(VerifyContinuityStage)
     ....
```

while still having concurrency and buffering at each level.

I'm not completely happy with the API or naming - although I am happy with the map and batch traits themselves.

Some questionable choices

- `PeerData<Result<_,_>>`. This let's us attach peer IDs to the entire result instead of manually propagating the peer ID. However now we no longer have a top level result.
  - `Result<PeerData<_>, PeerData<_>>` could also work but also seems weird.
  - We currently use `Result<PeerData<_>, E>` where `E` manually assigns peer IDs to some errors.
- The trait bounds are a bit weird? Maybe not..
- The stream extension now does the peer ID management; this does simplify implementing the stage traits but maybe they actually want this at some point 🤷
- `BatchStage` is technically a super-set of `MapStage` but I like having the simpler API of map