### PR TITLE
chore(load-test): update `starknet_getEvent` scenario

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,10 @@ jobs:
           cargo clean
           rm -rf ~/.cargo/registry
           rm -rf ~/.cargo/git
-      - run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings -D rust_2018_idioms
+      - run: |
+          cargo clippy --workspace --all-targets --all-features --locked -- -D warnings -D rust_2018_idioms
+          cargo clippy --workspace --all-targets --all-features --locked --manifest-path crates/load-test/Cargo.toml -- -D warnings -D rust_2018_idioms
+
 
   rustfmt:
     runs-on: ubuntu-latest
@@ -86,7 +89,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-      - run: cargo +nightly fmt --all -- --check
+      - run: |
+          cargo +nightly fmt --all -- --check
+          cargo +nightly fmt --all --manifest-path crates/load-test/Cargo.toml -- --check
 
   doc:
     runs-on: ubuntu-latest

--- a/crates/load-test/Cargo.lock
+++ b/crates/load-test/Cargo.lock
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-crypto"
-version = "0.11.6"
+version = "0.12.0"
 dependencies = [
  "bitvec",
  "fake",

--- a/crates/load-test/src/main.rs
+++ b/crates/load-test/src/main.rs
@@ -3,7 +3,8 @@
 //! Load test for pathfinder JSON-RPC endpoints.
 //!
 //! This program expects a mainnet pathfinder node synced until block 1800,
-//! since it contains references to transactions and contract addresses on mainnet.
+//! since it contains references to transactions and contract addresses on
+//! mainnet.
 //!
 //! Running the load test:
 //! ```
@@ -16,10 +17,7 @@ mod tasks;
 mod types;
 
 fn register_v05(attack: GooseAttack) -> GooseAttack {
-    use tasks::scripted::{
-        mainnet_scripted,
-        mainnet_scripted_without_huge_calls,
-    };
+    use tasks::scripted::{mainnet_scripted, mainnet_scripted_without_huge_calls};
     use tasks::v05::*;
 
     attack

--- a/crates/load-test/src/requests/v05.rs
+++ b/crates/load-test/src/requests/v05.rs
@@ -1,11 +1,16 @@
 use goose::prelude::*;
-use serde::{de::DeserializeOwned, Deserialize};
+use pathfinder_crypto::Felt;
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
 use serde_json::json;
 
-use pathfinder_crypto::Felt;
-
 use crate::types::{
-    Block, ContractClass, FeeEstimate, StateUpdate, Transaction, TransactionReceipt,
+    Block,
+    ContractClass,
+    FeeEstimate,
+    StateUpdate,
+    Transaction,
+    TransactionReceipt,
 };
 
 pub type MethodResult<T> = Result<T, Box<goose::goose::TransactionError>>;

--- a/crates/load-test/src/requests/v05.rs
+++ b/crates/load-test/src/requests/v05.rs
@@ -181,7 +181,7 @@ pub async fn get_events(
             "to_block": to_block,
             "address": filter.address,
             "keys": filter.keys,
-            "chunk_size": 1000,
+            "chunk_size": filter.chunk_size,
         }}),
     )
     .await
@@ -192,8 +192,7 @@ pub struct EventFilter {
     pub to_block: Option<u64>,
     pub address: Option<Felt>,
     pub keys: Vec<Vec<Felt>>,
-    pub page_size: u64,
-    pub page_number: u64,
+    pub chunk_size: u64,
 }
 
 #[derive(Clone, Debug, serde::Deserialize, PartialEq, Eq)]

--- a/crates/load-test/src/tasks/scripted.rs
+++ b/crates/load-test/src/tasks/scripted.rs
@@ -1,13 +1,16 @@
 use std::collections::HashMap;
 
 use goose::prelude::*;
-use serde::{de::DeserializeOwned, Deserialize};
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
 
 use crate::requests::v05::*;
 
-/// Script from Starkware that contain some heavy-weight calls mixed with wallet-like calls.
+/// Script from Starkware that contain some heavy-weight calls mixed with
+/// wallet-like calls.
 const MAINNET_SCRIPT: &str = include_str!("mainnet_script.txt");
-/// A slight variation of `MAINNET_SCRIPT` that doesn't contain the heavy-weight calls.
+/// A slight variation of `MAINNET_SCRIPT` that doesn't contain the heavy-weight
+/// calls.
 const MAINNET_SCRIPT_WITHOUT_HUGE_CALLS: &str =
     include_str!("mainnet_script_without_huge_calls.txt");
 

--- a/crates/load-test/src/tasks/v05.rs
+++ b/crates/load-test/src/tasks/v05.rs
@@ -213,22 +213,24 @@ pub async fn task_get_events(user: &mut GooseUser) -> TransactionResult {
     let events = get_events(
         user,
         EventFilter {
-            from_block: Some(1000),
-            to_block: Some(1100),
+            from_block: Some(600000),
+            to_block: Some(650000),
             address: Some(
                 Felt::from_hex_str(
-                    "0x103114c4c5ac233a360d39a9217b9067be6979f3d08e1cf971fd22baf8f8713",
+                    "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
                 )
                 .unwrap(),
             ),
-            keys: vec![],
-            page_size: 1024,
-            page_number: 0,
+            keys: vec![vec![Felt::from_hex_str(
+                "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff",
+            )
+            .unwrap()]],
+            chunk_size: 500,
         },
     )
     .await?;
 
-    assert_eq!(events.events.len(), 1);
+    assert_eq!(events.events.len(), 500);
 
     Ok(())
 }

--- a/crates/load-test/src/tasks/v05.rs
+++ b/crates/load-test/src/tasks/v05.rs
@@ -4,7 +4,8 @@ use rand::{Rng, SeedableRng};
 
 use crate::requests::v05::*;
 
-/// Fetch a random block, then fetch all individual transactions and receipts in the block.
+/// Fetch a random block, then fetch all individual transactions and receipts in
+/// the block.
 pub async fn block_explorer(user: &mut GooseUser) -> TransactionResult {
     let mut rng = rand::rngs::StdRng::from_entropy();
     let block_number: u64 = rng.gen_range(1..290000);
@@ -236,11 +237,14 @@ pub async fn task_get_storage_at(user: &mut GooseUser) -> TransactionResult {
     // Taken from:
     // https://alpha-mainnet.starknet.io/feeder_gateway/get_state_update?blockNumber=1700
     //
-    // "block_hash": "0x58cfbc4ebe276882a28badaa9fe0fb545cba57314817e5f229c2c9cf1f7cc87"
+    // "block_hash":
+    // "0x58cfbc4ebe276882a28badaa9fe0fb545cba57314817e5f229c2c9cf1f7cc87"
     //
-    // "storage_diffs": {"0x27a761524e94ed6d0c882e232bb4d34f12aae1b906e29c62dc682b526349056":
+    // "storage_diffs":
+    // {"0x27a761524e94ed6d0c882e232bb4d34f12aae1b906e29c62dc682b526349056":
     // [{"key": "0x79deb98f1f7fc9a64df7073f93ce645a5f6a7588c34773ba76fdc879a2346e1",
-    // "value": "0x44054cde571399c485119e55cf0b9fc7dcc151fb3486f70020d3ee4d7b20f8d"}]
+    // "value": "0x44054cde571399c485119e55cf0b9fc7dcc151fb3486f70020d3ee4d7b20f8d"
+    // }]
     get_storage_at(
         user,
         Felt::from_hex_str("0x27a761524e94ed6d0c882e232bb4d34f12aae1b906e29c62dc682b526349056")

--- a/crates/load-test/src/types.rs
+++ b/crates/load-test/src/types.rs
@@ -1,9 +1,8 @@
 //! Contains simplified types for parsing JSON-RPC responses.
 //!
-//! In order not to depend on pathfinder_lib these types "duplicate" similar functionality
-//! already found in pathfinder. However, these types are simplified and are missing fields
-//! that are irrelevant for load tests.
-//!
+//! In order not to depend on pathfinder_lib these types "duplicate" similar
+//! functionality already found in pathfinder. However, these types are
+//! simplified and are missing fields that are irrelevant for load tests.
 use pathfinder_crypto::Felt;
 
 #[derive(Clone, Debug, serde::Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
This PR does some chores, like updating the lockfile and reformatting with the new rustfmt config, then updates the `starknet_getEvents` scenario to be more realistic (querying ETH token transfer events).