### PR TITLE
feat(pathfinder): verify block commitment signatures

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -513,6 +513,7 @@ macros::felt_newtypes!(
         L1ToL2MessagePayloadElem,
         L2ToL1MessagePayloadElem,
         PaymasterDataElem,
+        PublicKey,
         SequencerAddress,
         StateCommitment,
         StateDiffCommitment,

--- a/crates/common/src/signature.rs
+++ b/crates/common/src/signature.rs
@@ -1,9 +1,58 @@
 use fake::Dummy;
+use pathfinder_crypto::hash::poseidon_hash_many;
+use pathfinder_crypto::signature::{ecdsa_verify_partial, SignatureError};
+use pathfinder_crypto::Felt;
 
-use crate::BlockCommitmentSignatureElem;
+use crate::{BlockCommitmentSignatureElem, BlockHash, PublicKey, StateDiffCommitment};
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Dummy)]
 pub struct BlockCommitmentSignature {
     pub r: BlockCommitmentSignatureElem,
     pub s: BlockCommitmentSignatureElem,
+}
+
+impl BlockCommitmentSignature {
+    pub fn verify(
+        &self,
+        public_key: PublicKey,
+        block_hash: BlockHash,
+        state_diff_commitment: StateDiffCommitment,
+    ) -> Result<(), SignatureError> {
+        let msg = Felt::from(poseidon_hash_many(&[
+            block_hash.0.into(),
+            state_diff_commitment.0.into(),
+        ]));
+        ecdsa_verify_partial(public_key.0, msg, self.r.0, self.s.0)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::macro_prelude::*;
+    use crate::BlockCommitmentSignature;
+
+    #[test]
+    fn test_verify() {
+        // From https://alpha-mainnet.starknet.io/feeder_gateway/get_public_key
+        let public_key =
+            public_key!("0x48253ff2c3bed7af18bde0b611b083b39445959102d4947c51c4db6aa4f4e58");
+        // From https://alpha-mainnet.starknet.io/feeder_gateway/get_signature?blockNumber=635000
+        let block_hash =
+            block_hash!("0x164685e53f274ecb60a3941303a6ee913aeb9016fbca5ba65c1cb8bdaee17a0");
+        let state_diff_commitment = state_diff_commitment!(
+            "0x620efa2bd1149abe485486efa35c29571b4883f9f54a7f4938389276b0579ff"
+        );
+        let signature = BlockCommitmentSignature {
+            r: block_commitment_signature_elem!(
+                "0x222679bdc9007386f5c2de62e89839b442799f356b24657af77e2a8aa87e74d"
+            ),
+            s: block_commitment_signature_elem!(
+                "0x16c9d0bab74fe4f268705559e16ebb36a5326e75c6a580e6ad3194fb9a0b1ed"
+            ),
+        };
+
+        assert!(signature
+            .verify(public_key, block_hash, state_diff_commitment)
+            .is_ok());
+    }
 }

--- a/crates/crypto/src/signature/mod.rs
+++ b/crates/crypto/src/signature/mod.rs
@@ -1,3 +1,10 @@
 mod ecdsa;
 
-pub use ecdsa::{ecdsa_sign, ecdsa_sign_k, ecdsa_verify, ecdsa_verify_partial, get_pk};
+pub use ecdsa::{
+    ecdsa_sign,
+    ecdsa_sign_k,
+    ecdsa_verify,
+    ecdsa_verify_partial,
+    get_pk,
+    SignatureError,
+};

--- a/crates/gateway-client/src/builder.rs
+++ b/crates/gateway-client/src/builder.rs
@@ -146,6 +146,7 @@ impl<'a> Request<'a, stage::Method> {
         get_block_traces,
         get_transaction_trace,
         get_signature,
+        get_public_key,
     );
 
     /// Appends the given method to the request url.

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -114,6 +114,12 @@ async fn async_main() -> anyhow::Result<()> {
 
     verify_networks(pathfinder_context.network, ethereum.chain)?;
 
+    let gateway_public_key = pathfinder_context
+        .gateway
+        .public_key()
+        .await
+        .context("Fetching Starknet gateway public key")?;
+
     // Setup and verify database
 
     let storage_manager =
@@ -252,6 +258,7 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
         restart_delay: config.debug.restart_delay,
         verify_tree_hashes: config.verify_tree_hashes,
         gossiper,
+        sequencer_public_key: gateway_public_key,
     };
 
     let sync_handle = if config.is_sync_enabled {

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::Context;
 use pathfinder_common::prelude::*;
-use pathfinder_common::{BlockCommitmentSignature, Chain};
+use pathfinder_common::{BlockCommitmentSignature, Chain, PublicKey};
 use pathfinder_crypto::Felt;
 use pathfinder_ethereum::{EthereumApi, EthereumStateUpdate};
 use pathfinder_merkle_tree::contract_state::update_contract_state;
@@ -73,6 +73,7 @@ pub struct SyncContext<G, E> {
     pub restart_delay: Duration,
     pub verify_tree_hashes: bool,
     pub gossiper: Gossiper,
+    pub sequencer_public_key: PublicKey,
 }
 
 impl<G, E> From<&SyncContext<G, E>> for L1SyncContext<E>
@@ -100,6 +101,7 @@ where
             chain_id: value.chain_id,
             block_validation_mode: value.block_validation_mode,
             storage: value.storage.clone(),
+            sequencer_public_key: value.sequencer_public_key,
         }
     }
 }
@@ -176,6 +178,7 @@ where
         restart_delay,
         verify_tree_hashes: _,
         gossiper,
+        sequencer_public_key: _,
     } = context;
 
     let mut db_conn = storage


### PR DESCRIPTION
This change adds a verification step to L2 sync for block commitment signatures downloaded from the feeder gateway.

Upon startup pathfinder fetches the public key from the gateway. During sync downloaded block commitment signatures are verified to make sure that the data we add to our database is consistent.

Closes: #1374 