### PR TITLE
feat(sync): initial p2p tracking implementation

### DIFF
--- a/crates/p2p/src/client/conv.rs
+++ b/crates/p2p/src/client/conv.rs
@@ -76,6 +76,10 @@ pub trait TryFromDto<T> {
         Self: Sized;
 }
 
+pub trait FromDto<T> {
+    fn from_dto(dto: T) -> Self;
+}
+
 impl TryFromDto<p2p_proto::header::SignedBlockHeader> for SignedBlockHeader {
     /// ## Important
     ///
@@ -415,6 +419,16 @@ impl TryFromDto<String> for DataAvailabilityMode {
             "L1" => Ok(Self::L1),
             "L2" => Ok(Self::L2),
             _ => anyhow::bail!("Invalid data availability mode"),
+        }
+    }
+}
+
+impl FromDto<p2p_proto::event::Event> for pathfinder_common::event::Event {
+    fn from_dto(value: p2p_proto::event::Event) -> Self {
+        Self {
+            from_address: ContractAddress(value.from_address),
+            keys: value.keys.into_iter().map(EventKey).collect(),
+            data: value.data.into_iter().map(EventData).collect(),
         }
     }
 }

--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -34,7 +34,7 @@ use crate::client::peer_aware;
 use crate::sync::protocol;
 
 /// Data received from a specific peer.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PeerData<T> {
     pub peer: PeerId,
     pub data: T,

--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -45,6 +45,12 @@ impl<T> PeerData<T> {
         Self { peer, data }
     }
 
+    pub fn from_result<E>(peer: PeerId, result: Result<T, E>) -> Result<PeerData<T>, PeerData<E>> {
+        result
+            .map(|x| Self::new(peer, x))
+            .map_err(|e| PeerData::<E>::new(peer, e))
+    }
+
     pub fn for_tests(data: T) -> Self {
         Self {
             peer: PeerId::random(),

--- a/crates/pathfinder/src/sync.rs
+++ b/crates/pathfinder/src/sync.rs
@@ -12,6 +12,7 @@ mod events;
 mod headers;
 mod receipts;
 mod state_updates;
+mod stream;
 mod transactions;
 
 const CHECKPOINT_MARGIN: u64 = 10;

--- a/crates/pathfinder/src/sync.rs
+++ b/crates/pathfinder/src/sync.rs
@@ -13,6 +13,7 @@ mod headers;
 mod receipts;
 mod state_updates;
 mod stream;
+mod track;
 mod transactions;
 
 const CHECKPOINT_MARGIN: u64 = 10;

--- a/crates/pathfinder/src/sync/error.rs
+++ b/crates/pathfinder/src/sync/error.rs
@@ -56,6 +56,10 @@ pub(super) enum SyncError2 {
     BadClassHash,
     #[error("Event commitment mismatch")]
     EventCommitmentMismatch,
+    #[error("Too many events")]
+    TooManyEvents,
+    #[error("Too few events")]
+    TooFewEvents,
 }
 
 impl PartialEq for SyncError2 {

--- a/crates/pathfinder/src/sync/error.rs
+++ b/crates/pathfinder/src/sync/error.rs
@@ -77,3 +77,9 @@ impl PartialEq for SyncError2 {
         }
     }
 }
+
+impl From<anyhow::Error> for SyncError2 {
+    fn from(value: anyhow::Error) -> Self {
+        Self::Other(Arc::new(value))
+    }
+}

--- a/crates/pathfinder/src/sync/error.rs
+++ b/crates/pathfinder/src/sync/error.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use p2p::libp2p::PeerId;
 use p2p::PeerData;
 use pathfinder_common::{BlockNumber, ClassHash, SignedBlockHeader};
@@ -24,4 +26,54 @@ pub(super) enum SyncError {
     BadClassHash(PeerId),
     #[error("Event commitment mismatch")]
     EventCommitmentMismatch(PeerId),
+}
+
+impl PartialEq for SyncError {
+    fn eq(&self, other: &Self) -> bool {
+        todo!();
+    }
+}
+
+#[derive(Debug, thiserror::Error, Clone)]
+pub(super) enum SyncError2 {
+    #[error(transparent)]
+    Other(#[from] Arc<anyhow::Error>),
+    #[error("Header signature verification failed")]
+    BadHeaderSignature,
+    #[error("Block hash verification failed")]
+    BadBlockHash,
+    #[error("Discontinuity in header chain")]
+    Discontinuity,
+    #[error("State diff signature verification failed")]
+    BadStateDiffSignature,
+    #[error("State diff commitment mismatch")]
+    StateDiffCommitmentMismatch,
+    #[error("Invalid class definition layout")]
+    BadClassLayout,
+    #[error("Unexpected class definition")]
+    UnexpectedClass,
+    #[error("Class hash verification failed")]
+    BadClassHash,
+    #[error("Event commitment mismatch")]
+    EventCommitmentMismatch,
+}
+
+impl PartialEq for SyncError2 {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Other(x), Self::Other(y)) => x.to_string() == y.to_string(),
+            (SyncError2::BadHeaderSignature, SyncError2::BadHeaderSignature) => true,
+            (SyncError2::BadBlockHash, SyncError2::BadBlockHash) => true,
+            (SyncError2::Discontinuity, SyncError2::Discontinuity) => true,
+            (SyncError2::BadStateDiffSignature, SyncError2::BadStateDiffSignature) => true,
+            (SyncError2::StateDiffCommitmentMismatch, SyncError2::StateDiffCommitmentMismatch) => {
+                true
+            }
+            (SyncError2::BadClassLayout, SyncError2::BadClassLayout) => true,
+            (SyncError2::UnexpectedClass, SyncError2::UnexpectedClass) => true,
+            (SyncError2::BadClassHash, SyncError2::BadClassHash) => true,
+            (SyncError2::EventCommitmentMismatch, SyncError2::EventCommitmentMismatch) => true,
+            _ => false,
+        }
+    }
 }

--- a/crates/pathfinder/src/sync/events.rs
+++ b/crates/pathfinder/src/sync/events.rs
@@ -1,14 +1,17 @@
+use std::collections::HashMap;
 use std::num::NonZeroUsize;
 
 use anyhow::Context;
 use p2p::client::peer_agnostic::EventsForBlockByTransaction;
 use p2p::PeerData;
-use pathfinder_common::BlockNumber;
+use pathfinder_common::event::Event;
+use pathfinder_common::{BlockHeader, BlockNumber, TransactionHash};
 use pathfinder_storage::Storage;
 use tokio::task::spawn_blocking;
 
 use super::error::SyncError;
 use crate::state::block_hash::calculate_event_commitment;
+use crate::sync::stream::MapStage;
 
 /// Returns the first block number whose events are missing in storage, counting
 /// from genesis
@@ -145,4 +148,21 @@ pub(super) async fn persist(
     })
     .await
     .context("Joining blocking task")?
+}
+
+pub struct BlockEvents {
+    pub header: BlockHeader,
+    pub events: HashMap<TransactionHash, Vec<Event>>,
+}
+pub struct VerifyCommitment;
+
+impl MapStage for VerifyCommitment {
+    type Input = BlockEvents;
+    type Output = BlockEvents;
+
+    async fn map(&mut self, input: Self::Input) -> Result<Self::Output, super::error::SyncError2> {
+        tokio::task::spawn_blocking(move || todo!("Calculate and verify event commitment"))
+            .await
+            .context("Joining blocking task")?
+    }
 }

--- a/crates/pathfinder/src/sync/events.rs
+++ b/crates/pathfinder/src/sync/events.rs
@@ -160,9 +160,7 @@ impl ProcessStage for VerifyCommitment {
     type Input = BlockEvents;
     type Output = BlockEvents;
 
-    async fn map(&mut self, input: Self::Input) -> Result<Self::Output, super::error::SyncError2> {
-        tokio::task::spawn_blocking(move || todo!("Calculate and verify event commitment"))
-            .await
-            .context("Joining blocking task")?
+    fn map(&mut self, _input: Self::Input) -> Result<Self::Output, super::error::SyncError2> {
+        todo!()
     }
 }

--- a/crates/pathfinder/src/sync/events.rs
+++ b/crates/pathfinder/src/sync/events.rs
@@ -11,7 +11,7 @@ use tokio::task::spawn_blocking;
 
 use super::error::SyncError;
 use crate::state::block_hash::calculate_event_commitment;
-use crate::sync::stream::MapStage;
+use crate::sync::stream::ProcessStage;
 
 /// Returns the first block number whose events are missing in storage, counting
 /// from genesis
@@ -156,7 +156,7 @@ pub struct BlockEvents {
 }
 pub struct VerifyCommitment;
 
-impl MapStage for VerifyCommitment {
+impl ProcessStage for VerifyCommitment {
     type Input = BlockEvents;
     type Output = BlockEvents;
 

--- a/crates/pathfinder/src/sync/headers.rs
+++ b/crates/pathfinder/src/sync/headers.rs
@@ -224,7 +224,7 @@ impl ProcessStage for ForwardContinuity {
     type Input = SignedBlockHeader;
     type Output = SignedBlockHeader;
 
-    async fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError2> {
+    fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError2> {
         let header = &input.header;
 
         if header.number != self.next || header.parent_hash != self.parent_hash {
@@ -242,19 +242,15 @@ impl ProcessStage for VerifyHash {
     type Input = SignedBlockHeader;
     type Output = SignedBlockHeader;
 
-    async fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError2> {
-        tokio::task::spawn_blocking(move || {
-            if !input.header.verify_hash() {
-                return Err(SyncError2::BadBlockHash);
-            }
+    fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError2> {
+        if !input.header.verify_hash() {
+            return Err(SyncError2::BadBlockHash);
+        }
 
-            if !input.verify_signature() {
-                return Err(SyncError2::BadHeaderSignature);
-            }
+        if !input.verify_signature() {
+            return Err(SyncError2::BadHeaderSignature);
+        }
 
-            Ok(input)
-        })
-        .await
-        .context("Joining blocking task")?
+        Ok(input)
     }
 }

--- a/crates/pathfinder/src/sync/headers.rs
+++ b/crates/pathfinder/src/sync/headers.rs
@@ -12,7 +12,8 @@ use pathfinder_common::{
 use pathfinder_storage::Storage;
 use tokio::task::spawn_blocking;
 
-use crate::sync::error::SyncError;
+use crate::sync::error::{SyncError, SyncError2};
+use crate::sync::stream::MapStage;
 
 type SignedHeaderResult = Result<PeerData<SignedBlockHeader>, SyncError>;
 

--- a/crates/pathfinder/src/sync/stream.rs
+++ b/crates/pathfinder/src/sync/stream.rs
@@ -1,15 +1,17 @@
 use futures::{Future, Stream, StreamExt, TryFutureExt, TryStream, TryStreamExt};
 use p2p::libp2p::PeerId;
 use p2p::PeerData;
+use tokio::sync::mpsc::Receiver;
+use tokio_stream::wrappers::ReceiverStream;
 
 use crate::sync::error::SyncError2;
 
-pub trait SyncStream<T>: Stream<Item = PeerData<SyncResult<T>>> {}
-pub type SyncResult<T> = Result<T, SyncError2>;
+pub struct SyncReceiver<T> {
+    inner: Receiver<SyncResult<T>>,
+}
+pub type SyncResult<T> = Result<PeerData<T>, PeerData<SyncError2>>;
 
-impl<T, U> SyncStream<T> for U where U: Stream<Item = PeerData<SyncResult<T>>> {}
-
-pub trait MapStage {
+pub trait ProcessStage {
     type Input;
     type Output;
 
@@ -19,136 +21,150 @@ pub trait MapStage {
     ) -> impl Future<Output = Result<Self::Output, SyncError2>> + Send;
 }
 
-impl<T, U> SyncStreamExt<T> for U
-where
-    U: SyncStream<T> + Send + 'static,
-    T: Send,
-{
-}
-
-pub trait SyncStreamExt<T>: SyncStream<T> + Sized + Send + 'static {
-    /// Adds a [MapStage] to the stream pipeline spawned as a separate task.
+impl<T: Send + 'static> SyncReceiver<T> {
+    /// Adds a [ProcessStage] to the stream pipeline spawned as a separate task.
     ///
     /// `buffer` specifies the amount of buffering applied to the output stream.
-    fn map_stage<S>(
-        mut self,
-        mut stage: S,
-        buffer: usize,
-    ) -> impl SyncStream<S::Output> + Sized + Send + 'static
+    pub fn pipe<S>(mut self, mut stage: S, buffer: usize) -> SyncReceiver<S::Output>
     where
-        S: MapStage<Input = T> + Send + 'static,
+        S: ProcessStage<Input = T> + Send + 'static,
         S::Output: Send,
-        T: Send,
     {
         let (tx, rx) = tokio::sync::mpsc::channel(buffer);
 
         tokio::spawn(async move {
-            let mut stream = Box::pin(self);
-            while let Some(input) = stream.next().await {
-                let PeerData { peer, data } = input;
-                let result = std::future::ready(data).and_then(|x| stage.map(x)).await;
-                let result = PeerData::new(peer, result);
+            while let Some(input) = self.inner.recv().await {
+                let result = match input {
+                    Ok(PeerData { peer, data }) => stage
+                        .map(data)
+                        .await
+                        .map(|x| PeerData::new(peer, x))
+                        .map_err(|e| PeerData::new(peer, e)),
+                    Err(e) => Err(e),
+                };
 
-                let is_err = result.data.is_err();
+                let is_err = result.is_err();
                 if tx.send(result).await.is_err() || is_err {
                     return;
                 }
             }
         });
 
-        tokio_stream::wrappers::ReceiverStream::new(rx)
+        SyncReceiver::from_receiver(rx)
+    }
+
+    pub fn from_receiver(receiver: Receiver<SyncResult<T>>) -> Self
+    where
+        T: Send,
+    {
+        Self { inner: receiver }
+    }
+
+    #[cfg(test)]
+    pub fn iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = SyncResult<T>> + Send + 'static,
+        I::IntoIter: Send,
+    {
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        tokio::spawn(async move {
+            for value in iter.into_iter() {
+                if tx.send(value).await.is_err() {
+                    return;
+                }
+            }
+        });
+        Self::from_receiver(rx)
+    }
+
+    pub fn into_stream(self) -> ReceiverStream<SyncResult<T>> {
+        ReceiverStream::new(self.inner)
+    }
+
+    pub async fn recv(&mut self) -> Option<SyncResult<T>> {
+        self.inner.recv().await
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{SyncStreamExt, *};
+    use super::*;
 
-    mod map {
-        use super::*;
-
-        #[rstest::rstest]
-        #[case::all_ok(
+    #[rstest::rstest]
+    #[case::all_ok(
             vec![Ok(0), Ok(1), Ok(2)],
             vec![Ok(0), Ok(1), Ok(2)]
         )]
-        #[case::short_circuit_on_error(
+    #[case::short_circuit_on_error(
             vec![Ok(0), Ok(1), Err(SyncError2::BadBlockHash), Ok(2)],
             vec![Ok(0), Ok(1), Err(SyncError2::BadBlockHash)],
         )]
-        #[tokio::test]
-        async fn input_stream(
-            #[case] input: Vec<SyncResult<u8>>,
-            #[case] expected: Vec<SyncResult<u8>>,
-        ) {
-            struct NoOp;
-            impl MapStage for NoOp {
-                type Input = u8;
-                type Output = u8;
+    #[tokio::test]
+    async fn input_stream(
+        #[case] input: Vec<Result<u8, SyncError2>>,
+        #[case] expected: Vec<Result<u8, SyncError2>>,
+    ) {
+        struct NoOp;
+        impl ProcessStage for NoOp {
+            type Input = u8;
+            type Output = u8;
 
-                async fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError2> {
+            async fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError2> {
+                Ok(input)
+            }
+        }
+
+        let peer = PeerId::random();
+
+        let input = SyncReceiver::iter(
+            input
+                .into_iter()
+                .map(move |x| PeerData::from_result(peer, x)),
+        );
+        let expected = expected
+            .into_iter()
+            .map(|x| PeerData::from_result(peer, x))
+            .collect::<Vec<_>>();
+
+        let stage = NoOp {};
+
+        let output = input.pipe(stage, 5).into_stream().collect::<Vec<_>>().await;
+
+        assert_eq!(output, expected);
+    }
+
+    #[tokio::test]
+    async fn short_circuit_on_map_error() {
+        struct OnlyOnce(u8);
+
+        impl ProcessStage for OnlyOnce {
+            type Input = u8;
+            type Output = u8;
+
+            async fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError2> {
+                if self.0 == 0 {
+                    self.0 = 1;
                     Ok(input)
+                } else {
+                    Err(SyncError2::BadBlockHash)
                 }
             }
-
-            let peer = PeerId::random();
-
-            let input = input
-                .into_iter()
-                .map(|x| PeerData::new(peer, x))
-                .collect::<Vec<_>>();
-            let expected = expected
-                .into_iter()
-                .map(|x| PeerData::new(peer, x))
-                .collect::<Vec<_>>();
-
-            let stage = NoOp {};
-
-            let output = tokio_stream::iter(input)
-                .map_stage(stage, 5)
-                .collect::<Vec<_>>()
-                .await;
-
-            assert_eq!(output, expected);
         }
 
-        #[tokio::test]
-        async fn short_circuit_on_map_error() {
-            struct OnlyOnce(u8);
+        let peer = PeerId::random();
+        let input = (0..10).map(move |x| PeerData::from_result(peer, Ok(x)));
+        let expected = vec![
+            Ok(PeerData::new(peer, 0)),
+            Err(PeerData::new(peer, SyncError2::BadBlockHash)),
+        ];
 
-            impl MapStage for OnlyOnce {
-                type Input = u8;
-                type Output = u8;
+        let stage = OnlyOnce(0);
+        let result = SyncReceiver::iter(input)
+            .pipe(stage, 5)
+            .into_stream()
+            .collect::<Vec<_>>()
+            .await;
 
-                async fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError2> {
-                    if self.0 == 0 {
-                        self.0 = 1;
-                        Ok(input)
-                    } else {
-                        Err(SyncError2::BadBlockHash)
-                    }
-                }
-            }
-
-            let peer = PeerId::random();
-            let input = (0..10)
-                .map(|x| PeerData { peer, data: Ok(x) })
-                .collect::<Vec<_>>();
-            let expected = vec![
-                PeerData { peer, data: Ok(0) },
-                PeerData {
-                    peer,
-                    data: Err(SyncError2::BadBlockHash),
-                },
-            ];
-
-            let stage = OnlyOnce(0);
-            let result = tokio_stream::iter(input)
-                .map_stage(stage, 5)
-                .collect::<Vec<_>>()
-                .await;
-
-            assert_eq!(result, expected);
-        }
+        assert_eq!(result, expected);
     }
 }

--- a/crates/pathfinder/src/sync/stream.rs
+++ b/crates/pathfinder/src/sync/stream.rs
@@ -2,7 +2,7 @@ use futures::{Future, Stream, StreamExt, TryFutureExt, TryStream, TryStreamExt};
 use p2p::libp2p::PeerId;
 use p2p::PeerData;
 
-use super::error::SyncError2;
+use crate::sync::error::SyncError2;
 
 pub trait SyncStream<T>: Stream<Item = PeerData<SyncResult<T>>> {}
 pub type SyncResult<T> = Result<T, SyncError2>;

--- a/crates/pathfinder/src/sync/stream.rs
+++ b/crates/pathfinder/src/sync/stream.rs
@@ -55,11 +55,15 @@ pub trait SyncStreamExt<T>: SyncStream<T> + Sized + Send + 'static {
     /// Adds a [MapStage] to the stream pipeline spawned as a separate task.
     ///
     /// `buffer` specifies the amount of buffering applied to the output stream.
-    fn map_stage<S>(mut self, mut stage: S, buffer: usize) -> impl SyncStream<S::Output>
+    fn map_stage<S>(
+        mut self,
+        mut stage: S,
+        buffer: usize,
+    ) -> impl SyncStream<S::Output> + Sized + Send + 'static
     where
         S: MapStage<Input = T> + Send + 'static,
         S::Output: Send,
-        T: Send + 'static,
+        T: Send,
     {
         let (tx, rx) = tokio::sync::mpsc::channel(buffer);
 

--- a/crates/pathfinder/src/sync/stream.rs
+++ b/crates/pathfinder/src/sync/stream.rs
@@ -19,31 +19,6 @@ pub trait MapStage {
     ) -> impl Future<Output = Result<Self::Output, SyncError2>> + Send;
 }
 
-/// A stage which collects items into buffers before outputting the collection.
-///
-/// This provides an [N] -> [M] style mapping where N >= M. This can therefore
-/// be used to represent operations such as transforming a stream of
-/// transactions to a stream of block's of transactions.
-pub trait BatchStage {
-    type Input;
-    /// This will usually be some form of collection over [Self::Input].
-    type Output;
-
-    /// Aggregate the incoming item and optional provide an output.
-    fn buffer(
-        &mut self,
-        input: Self::Input,
-    ) -> impl Future<Output = Result<Option<Self::Output>, SyncError2>> + Send;
-
-    /// Process and output any remaining items as the pipeline is being shut
-    /// down.
-    ///
-    /// This may also be used to output an error if more items were expected.
-    /// Note that this will only be called in the event of a successful end of
-    /// stream, so this is not guaranteed to be called.
-    fn flush(self) -> impl Future<Output = Result<Option<Self::Output>, SyncError2>> + Send;
-}
-
 impl<T, U> SyncStreamExt<T> for U
 where
     U: SyncStream<T> + Send + 'static,
@@ -78,55 +53,6 @@ pub trait SyncStreamExt<T>: SyncStream<T> + Sized + Send + 'static {
                 if tx.send(result).await.is_err() || is_err {
                     return;
                 }
-            }
-        });
-
-        tokio_stream::wrappers::ReceiverStream::new(rx)
-    }
-
-    // / Adds a [BatchStage] to the stream pipeline spawned as a separate task.
-    // /
-    // / `buffer` specifies the amount of buffering applied to the output stream.
-    fn stage_batch<S>(mut self, mut stage: S, buffer: usize) -> impl SyncStream<S::Output>
-    where
-        S: BatchStage<Input = T> + Send + 'static,
-        S::Output: Send,
-        T: Send,
-    {
-        let (tx, rx) = tokio::sync::mpsc::channel(buffer);
-
-        tokio::spawn(async move {
-            let mut stream = Box::pin(self);
-            let mut latest_peer = None;
-            while let Some(input) = stream.next().await {
-                let PeerData { peer, data } = input;
-                latest_peer = Some(peer);
-
-                let result = std::future::ready(data)
-                    .and_then(|x| stage.buffer(x))
-                    .await
-                    .transpose();
-
-                let Some(result) = result else {
-                    continue;
-                };
-
-                let result = PeerData::new(peer, result);
-                let is_err = result.data.is_err();
-
-                if tx.send(result).await.is_err() || is_err {
-                    return;
-                }
-            }
-
-            if let Some(output) = stage.flush().await.transpose() {
-                let Some(latest_peer) = latest_peer else {
-                    tracing::warn!("Flush data without an attached peer");
-                    return;
-                };
-
-                let output = PeerData::new(latest_peer, output);
-                let _ = tx.send(output).await;
             }
         });
 
@@ -224,79 +150,5 @@ mod tests {
 
             assert_eq!(result, expected);
         }
-    }
-
-    #[rstest::rstest]
-    #[case::ok_and_flush(
-        vec![Ok(1), Ok(2), Ok(3), Ok(4)],
-        vec![Ok(6), Ok(4)]
-    )]
-    #[case::error_short_circuits(
-        vec![Ok(255), Ok(1), Ok(2)],
-        vec![Err(SyncError2::BadBlockHash)]
-    )]
-    #[case::stream_error_short_circuits(
-        vec![Ok(1), Err(SyncError2::BadBlockHash), Ok(2), Ok(3)],
-        vec![Err(SyncError2::BadBlockHash)]
-    )]
-    #[tokio::test]
-    async fn batch(#[case] input: Vec<SyncResult<u8>>, #[case] expected: Vec<SyncResult<u8>>) {
-        /// Sums every 3 elements together. Flushes the sum of any remaining
-        /// elements.
-        ///
-        /// Throws an error on overflow.
-        struct Sum3 {
-            count: usize,
-            total: u8,
-        };
-
-        impl BatchStage for Sum3 {
-            type Input = u8;
-            type Output = u8;
-
-            async fn buffer(
-                &mut self,
-                input: Self::Input,
-            ) -> Result<Option<Self::Output>, SyncError2> {
-                self.total = self
-                    .total
-                    .checked_add(input)
-                    .ok_or(SyncError2::BadBlockHash)?;
-                self.count += 1;
-
-                if self.count == 3 {
-                    self.count = 0;
-                    Ok(Some(std::mem::take(&mut self.total)))
-                } else {
-                    Ok(None)
-                }
-            }
-
-            async fn flush(self) -> Result<Option<Self::Output>, SyncError2> {
-                if self.count > 0 {
-                    Ok(Some(self.total))
-                } else {
-                    Ok(None)
-                }
-            }
-        }
-
-        let stage = Sum3 { count: 0, total: 0 };
-        let peer = PeerId::random();
-
-        let input = input
-            .into_iter()
-            .map(|x| PeerData::new(peer, x))
-            .collect::<Vec<_>>();
-        let expected = expected
-            .into_iter()
-            .map(|x| PeerData::new(peer, x))
-            .collect::<Vec<_>>();
-
-        let result = tokio_stream::iter(input)
-            .stage_batch(stage, 3)
-            .collect::<Vec<_>>()
-            .await;
-        assert_eq!(result, expected);
     }
 }

--- a/crates/pathfinder/src/sync/stream.rs
+++ b/crates/pathfinder/src/sync/stream.rs
@@ -1,0 +1,298 @@
+use futures::{Future, Stream, StreamExt, TryFutureExt, TryStream, TryStreamExt};
+use p2p::libp2p::PeerId;
+use p2p::PeerData;
+
+use super::error::SyncError2;
+
+pub trait SyncStream<T>: Stream<Item = PeerData<SyncResult<T>>> {}
+pub type SyncResult<T> = Result<T, SyncError2>;
+
+impl<T, U> SyncStream<T> for U where U: Stream<Item = PeerData<SyncResult<T>>> {}
+
+pub trait MapStage {
+    type Input;
+    type Output;
+
+    fn map(
+        &mut self,
+        input: Self::Input,
+    ) -> impl Future<Output = Result<Self::Output, SyncError2>> + Send;
+}
+
+/// A stage which collects items into buffers before outputting the collection.
+///
+/// This provides an [N] -> [M] style mapping where N >= M. This can therefore
+/// be used to represent operations such as transforming a stream of
+/// transactions to a stream of block's of transactions.
+pub trait BatchStage {
+    type Input;
+    /// This will usually be some form of collection over [Self::Input].
+    type Output;
+
+    /// Aggregate the incoming item and optional provide an output.
+    fn buffer(
+        &mut self,
+        input: Self::Input,
+    ) -> impl Future<Output = Result<Option<Self::Output>, SyncError2>> + Send;
+
+    /// Process and output any remaining items as the pipeline is being shut
+    /// down.
+    ///
+    /// This may also be used to output an error if more items were expected.
+    /// Note that this will only be called in the event of a successful end of
+    /// stream, so this is not guaranteed to be called.
+    fn flush(self) -> impl Future<Output = Result<Option<Self::Output>, SyncError2>> + Send;
+}
+
+impl<T, U> SyncStreamExt<T> for U
+where
+    U: SyncStream<T> + Send + 'static,
+    T: Send,
+{
+}
+
+pub trait SyncStreamExt<T>: SyncStream<T> + Sized + Send + 'static {
+    /// Adds a [MapStage] to the stream pipeline spawned as a separate task.
+    ///
+    /// `buffer` specifies the amount of buffering applied to the output stream.
+    fn map_stage<S>(mut self, mut stage: S, buffer: usize) -> impl SyncStream<S::Output>
+    where
+        S: MapStage<Input = T> + Send + 'static,
+        S::Output: Send,
+        T: Send + 'static,
+    {
+        let (tx, rx) = tokio::sync::mpsc::channel(buffer);
+
+        tokio::spawn(async move {
+            let mut stream = Box::pin(self);
+            while let Some(input) = stream.next().await {
+                let PeerData { peer, data } = input;
+                let result = std::future::ready(data).and_then(|x| stage.map(x)).await;
+                let result = PeerData::new(peer, result);
+
+                let is_err = result.data.is_err();
+                if tx.send(result).await.is_err() || is_err {
+                    return;
+                }
+            }
+        });
+
+        tokio_stream::wrappers::ReceiverStream::new(rx)
+    }
+
+    // / Adds a [BatchStage] to the stream pipeline spawned as a separate task.
+    // /
+    // / `buffer` specifies the amount of buffering applied to the output stream.
+    fn stage_batch<S>(mut self, mut stage: S, buffer: usize) -> impl SyncStream<S::Output>
+    where
+        S: BatchStage<Input = T> + Send + 'static,
+        S::Output: Send,
+        T: Send,
+    {
+        let (tx, rx) = tokio::sync::mpsc::channel(buffer);
+
+        tokio::spawn(async move {
+            let mut stream = Box::pin(self);
+            let mut latest_peer = None;
+            while let Some(input) = stream.next().await {
+                let PeerData { peer, data } = input;
+                latest_peer = Some(peer);
+
+                let result = std::future::ready(data)
+                    .and_then(|x| stage.buffer(x))
+                    .await
+                    .transpose();
+
+                let Some(result) = result else {
+                    continue;
+                };
+
+                let result = PeerData::new(peer, result);
+                let is_err = result.data.is_err();
+
+                if tx.send(result).await.is_err() || is_err {
+                    return;
+                }
+            }
+
+            if let Some(output) = stage.flush().await.transpose() {
+                let Some(latest_peer) = latest_peer else {
+                    tracing::warn!("Flush data without an attached peer");
+                    return;
+                };
+
+                let output = PeerData::new(latest_peer, output);
+                let _ = tx.send(output).await;
+            }
+        });
+
+        tokio_stream::wrappers::ReceiverStream::new(rx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SyncStreamExt, *};
+
+    mod map {
+        use super::*;
+
+        #[rstest::rstest]
+        #[case::all_ok(
+            vec![Ok(0), Ok(1), Ok(2)],
+            vec![Ok(0), Ok(1), Ok(2)]
+        )]
+        #[case::short_circuit_on_error(
+            vec![Ok(0), Ok(1), Err(SyncError2::BadBlockHash), Ok(2)],
+            vec![Ok(0), Ok(1), Err(SyncError2::BadBlockHash)],
+        )]
+        #[tokio::test]
+        async fn input_stream(
+            #[case] input: Vec<SyncResult<u8>>,
+            #[case] expected: Vec<SyncResult<u8>>,
+        ) {
+            struct NoOp;
+            impl MapStage for NoOp {
+                type Input = u8;
+                type Output = u8;
+
+                async fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError2> {
+                    Ok(input)
+                }
+            }
+
+            let peer = PeerId::random();
+
+            let input = input
+                .into_iter()
+                .map(|x| PeerData::new(peer, x))
+                .collect::<Vec<_>>();
+            let expected = expected
+                .into_iter()
+                .map(|x| PeerData::new(peer, x))
+                .collect::<Vec<_>>();
+
+            let stage = NoOp {};
+
+            let output = tokio_stream::iter(input)
+                .map_stage(stage, 5)
+                .collect::<Vec<_>>()
+                .await;
+
+            assert_eq!(output, expected);
+        }
+
+        #[tokio::test]
+        async fn short_circuit_on_map_error() {
+            struct OnlyOnce(u8);
+
+            impl MapStage for OnlyOnce {
+                type Input = u8;
+                type Output = u8;
+
+                async fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError2> {
+                    if self.0 == 0 {
+                        self.0 = 1;
+                        Ok(input)
+                    } else {
+                        Err(SyncError2::BadBlockHash)
+                    }
+                }
+            }
+
+            let peer = PeerId::random();
+            let input = (0..10)
+                .map(|x| PeerData { peer, data: Ok(x) })
+                .collect::<Vec<_>>();
+            let expected = vec![
+                PeerData { peer, data: Ok(0) },
+                PeerData {
+                    peer,
+                    data: Err(SyncError2::BadBlockHash),
+                },
+            ];
+
+            let stage = OnlyOnce(0);
+            let result = tokio_stream::iter(input)
+                .map_stage(stage, 5)
+                .collect::<Vec<_>>()
+                .await;
+
+            assert_eq!(result, expected);
+        }
+    }
+
+    #[rstest::rstest]
+    #[case::ok_and_flush(
+        vec![Ok(1), Ok(2), Ok(3), Ok(4)],
+        vec![Ok(6), Ok(4)]
+    )]
+    #[case::error_short_circuits(
+        vec![Ok(255), Ok(1), Ok(2)],
+        vec![Err(SyncError2::BadBlockHash)]
+    )]
+    #[case::stream_error_short_circuits(
+        vec![Ok(1), Err(SyncError2::BadBlockHash), Ok(2), Ok(3)],
+        vec![Err(SyncError2::BadBlockHash)]
+    )]
+    #[tokio::test]
+    async fn batch(#[case] input: Vec<SyncResult<u8>>, #[case] expected: Vec<SyncResult<u8>>) {
+        /// Sums every 3 elements together. Flushes the sum of any remaining
+        /// elements.
+        ///
+        /// Throws an error on overflow.
+        struct Sum3 {
+            count: usize,
+            total: u8,
+        };
+
+        impl BatchStage for Sum3 {
+            type Input = u8;
+            type Output = u8;
+
+            async fn buffer(
+                &mut self,
+                input: Self::Input,
+            ) -> Result<Option<Self::Output>, SyncError2> {
+                self.total = self
+                    .total
+                    .checked_add(input)
+                    .ok_or(SyncError2::BadBlockHash)?;
+                self.count += 1;
+
+                if self.count == 3 {
+                    self.count = 0;
+                    Ok(Some(std::mem::take(&mut self.total)))
+                } else {
+                    Ok(None)
+                }
+            }
+
+            async fn flush(self) -> Result<Option<Self::Output>, SyncError2> {
+                if self.count > 0 {
+                    Ok(Some(self.total))
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+
+        let stage = Sum3 { count: 0, total: 0 };
+        let peer = PeerId::random();
+
+        let input = input
+            .into_iter()
+            .map(|x| PeerData::new(peer, x))
+            .collect::<Vec<_>>();
+        let expected = expected
+            .into_iter()
+            .map(|x| PeerData::new(peer, x))
+            .collect::<Vec<_>>();
+
+        let result = tokio_stream::iter(input)
+            .stage_batch(stage, 3)
+            .collect::<Vec<_>>()
+            .await;
+        assert_eq!(result, expected);
+    }
+}

--- a/crates/pathfinder/src/sync/track.rs
+++ b/crates/pathfinder/src/sync/track.rs
@@ -1,0 +1,92 @@
+use anyhow::Context;
+use futures::{Stream, StreamExt};
+use p2p::client::peer_agnostic::Client as P2PClient;
+use p2p::PeerData;
+use pathfinder_common::{BlockHash, BlockNumber, SignedBlockHeader};
+
+use crate::sync::error::SyncError2;
+use crate::sync::headers;
+use crate::sync::stream::{SyncStream, SyncStreamExt};
+
+pub struct Sync<L> {
+    latest: L,
+    p2p: P2PClient,
+    storage: pathfinder_storage::Storage,
+}
+
+impl<L> Sync<L>
+where
+    L: Stream<Item = (BlockNumber, BlockHash)> + Clone + Send + 'static,
+{
+    pub async fn run(self) -> Result<(), SyncError2> {
+        let latest_local = tokio::task::spawn_blocking({
+            let storage = self.storage.clone();
+            move || {
+                let mut db = storage
+                    .connection()
+                    .context("Creating database connection")?;
+                let db = db.transaction().context("Creating database transaction")?;
+
+                db.block_id(pathfinder_storage::BlockId::Latest)
+            }
+        })
+        .await
+        .context("Joining blocking task")?
+        .context("Querying latest local block ID")?;
+
+        let mut headers = HeaderSource {
+            p2p: self.p2p.clone(),
+            latest_onchain: self.latest.clone(),
+            start: latest_local.unwrap_or_default().0,
+        }
+        .spawn()
+        .map_stage(
+            headers::ForwardContinuityCheck::new(latest_local.clone()),
+            100,
+        )
+        .map_stage(headers::VerifyHash {}, 100);
+
+        todo!()
+    }
+}
+
+struct HeaderSource<L> {
+    p2p: P2PClient,
+    latest_onchain: L,
+    start: BlockNumber,
+}
+
+impl<L> HeaderSource<L>
+where
+    L: Stream<Item = (BlockNumber, BlockHash)> + Send + 'static,
+{
+    fn spawn(self) -> impl SyncStream<SignedBlockHeader> {
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        let Self {
+            p2p,
+            latest_onchain,
+            mut start,
+        } = self;
+
+        tokio::spawn(async move {
+            let mut latest_onchain = Box::pin(latest_onchain);
+            while let Some(latest_onchain) = latest_onchain.next().await {
+                // Ignore reorgs for now. Unsure how to handle this properly.
+
+                let mut headers =
+                    Box::pin(p2p.clone().header_stream(start, latest_onchain.0, false));
+
+                while let Some(header) = headers.next().await {
+                    start = header.data.header.number + 1;
+
+                    let header = PeerData::new(header.peer, Ok(header.data));
+                    if tx.send(header).await.is_err() {
+                        return;
+                    }
+                }
+            }
+        });
+
+        tokio_stream::wrappers::ReceiverStream::new(rx)
+    }
+}


### PR DESCRIPTION
This PR introduces `ProcessStage` abstraction and uses it to implement a basic p2p tracking skeleton. This implementation is clumsy in certain places, but should suffice for now.

### New abstractions

`SyncResult<T>` is an alias for `Result<PeerData<T>, PeerData<SyncError>>`. This is a bit clumsy, but I think its ok for now.

`SyncReceiver` is a wrapper around a tokio channel receiver. This was originally a stream extension trait but this proved unwieldy ito generics and bounds. This type acts like a pipeline, allowing you to process data concurrently in a pipeline of `ProcessStage`s. Important is that errors are fowarded and short circuit. This means that the entire pipeline will end its stages as the error progresses through until it can be handled at the end.

`ProcessStage` is a trait which simplifies creating an `X -> SyncResult<Y>` handler. It has mutable state which is nice e.g. for ensuring block numbers are consecutive.

### Tracking design

Using these abstractions, this PR includes a minimal p2p tracking sync implementation. It only includes headers and events, with the latter being an example of how to implement the rest. 

The idea is that the header stream will power the rest of the data streams. At the end these streams are merged into a stream of `BlockData` which contains all the information required for a single starknet block. This block is then stored as the final stage in the process.

I struggled to find a nice way to create an event stream source. So I settled for simply handling it one block at a time. I was searching for something which would continuously emit all events followed by a stage which would map `Stream<Event>` to `Stream<BlockEvents>` by taking in a stream of block headers. The issue comes in if the events stream ends early - which will happen if the peer doesn't have all the data yet. In this case we've also lost the block header which means the entire stream breaks. 

But this sucks because now the event source has two sources of data, headers and p2p itself. Makes for more branching within the code. A problem for another day.