### PR TITLE
fix(rpc/v07): remove `status` property from pending block responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- `starknet_getBlockWithTxHashes` and `starknet_getBlockWithTxs` returns the pending block with a `status` property that's not in the JSON-RPC specification. This has been fixed for the JSON-RPC 0.7 API endpoint.
+
 ### Added
 
 - `/ready/synced` endpoint to check if the JSON RPC API is ready _and_ also check if the node is synced. Useful for Docker nodes which only want to be available after syncing.

--- a/crates/rpc/src/v07/method/get_block_with_tx_hashes.rs
+++ b/crates/rpc/src/v07/method/get_block_with_tx_hashes.rs
@@ -30,7 +30,6 @@ pub struct BlockWithTxHashes {
 pub struct PendingBlockWithTxHashes {
     #[serde(flatten)]
     header: dto::header::PendingHeader,
-    status: BlockStatus,
     transactions: Vec<TransactionHash>,
 }
 
@@ -62,7 +61,6 @@ pub async fn get_block_with_tx_hashes(context: RpcContext, input: Input) -> Resu
 
                 return Ok(Output::Pending(PendingBlockWithTxHashes {
                     header: pending.header().into(),
-                    status: BlockStatus::Pending,
                     transactions,
                 }));
             }

--- a/crates/rpc/src/v07/method/get_block_with_txs.rs
+++ b/crates/rpc/src/v07/method/get_block_with_txs.rs
@@ -32,7 +32,6 @@ pub struct BlockWithTxs {
 pub struct PendingBlockWithTxs {
     #[serde(flatten)]
     header: dto::header::PendingHeader,
-    status: BlockStatus,
     transactions: Vec<TransactionWithHash>,
 }
 
@@ -70,7 +69,6 @@ pub async fn get_block_with_txs(context: RpcContext, input: Input) -> Result<Out
 
                 return Ok(Output::Pending(PendingBlockWithTxs {
                     header: pending.header().into(),
-                    status: BlockStatus::Pending,
                     transactions,
                 }));
             }


### PR DESCRIPTION
According to the JSON-RPC specification the pending block has no `status` property. This has been the case for all supported JSON-RPC versions.

Since we've pretty much forever have served this extra property we only fix this for the latest JSON-RPC 0.7 API endpoint.

Closes #1974 