### PR TITLE
chore: make MerkleTree::storage mod public

### DIFF
--- a/crates/merkle-tree/src/lib.rs
+++ b/crates/merkle-tree/src/lib.rs
@@ -1,10 +1,10 @@
 pub mod contract_state;
 pub mod merkle_node;
+pub mod storage;
 pub mod tree;
 
 mod class;
 mod contract;
-mod storage;
 mod transaction;
 
 pub use class::ClassCommitmentTree;


### PR DESCRIPTION
Make storage mod public in the MerkleTree trait

I want to use the MerkleTree crate in an external project. Currently, this is not possible, as the Storage trait is not accessible.