### PR TITLE
fix(pathfinder/sync/l2): make block commitment signature mismatches a warning

### DIFF
--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -278,7 +278,9 @@ where
                         );
                     (verify_result, signature, state_update)
                 }).await?;
-                verify_result.context("Verifying block commitment signature")?;
+                if let Err(error) = verify_result {
+                    tracing::warn!(%error, block_number=%block.block_number, "Block commitment signature mismatch");
+                }
                 (signature, state_update)
             }
             BlockValidationMode::AllowMismatch => (signature, state_update),


### PR DESCRIPTION
Since we've found at least one instance (mainnet block 94) where the state diff commitment we're calculating doesn't match the one returned by the feeder gateway we should demote the error to a warning for now.