### PR TITLE
feat(crypto): add xyzz coordinates

### DIFF
--- a/crates/crypto/examples/consts_pedersen.rs
+++ b/crates/crypto/examples/consts_pedersen.rs
@@ -33,13 +33,13 @@ fn generate_consts(bits: u32) -> Result<String, std::fmt::Error> {
     write!(buf, "use crate::algebra::curve::AffinePoint;\n\n")?;
     write!(buf, "pub const CURVE_CONSTS_BITS: usize = {bits};\n\n")?;
 
-    push_points(&mut buf, "P1", &PEDERSEN_P1, 248, bits)?;
+    push_points(&mut buf, "P1", PEDERSEN_P1, 248, bits)?;
     buf.push_str("\n\n\n");
-    push_points(&mut buf, "P2", &PEDERSEN_P2, 4, bits)?;
+    push_points(&mut buf, "P2", PEDERSEN_P2, 4, bits)?;
     buf.push_str("\n\n\n");
-    push_points(&mut buf, "P3", &PEDERSEN_P3, 248, bits)?;
+    push_points(&mut buf, "P3", PEDERSEN_P3, 248, bits)?;
     buf.push_str("\n\n\n");
-    push_points(&mut buf, "P4", &PEDERSEN_P4, 4, bits)?;
+    push_points(&mut buf, "P4", PEDERSEN_P4, 4, bits)?;
 
     Ok(buf)
 }
@@ -48,12 +48,10 @@ fn generate_consts(bits: u32) -> Result<String, std::fmt::Error> {
 fn push_points(
     buf: &mut String,
     name: &str,
-    base: &ProjectivePoint,
+    base: AffinePoint,
     max_bits: u32,
     bits: u32,
 ) -> std::fmt::Result {
-    let base = AffinePoint::from(base);
-
     let full_chunks = max_bits / bits;
     let leftover_bits = max_bits % bits;
     let table_size_full = (1 << bits) - 1;

--- a/crates/crypto/src/algebra/curve/affine.rs
+++ b/crates/crypto/src/algebra/curve/affine.rs
@@ -25,6 +25,20 @@ impl From<&ProjectivePoint> for AffinePoint {
     }
 }
 
+impl From<&XYZZPoint> for AffinePoint {
+    fn from(p: &XYZZPoint) -> Self {
+        let a = p.zzz.inverse().unwrap();
+        let b = (p.zz * a).square();
+        let x = p.x * b;
+        let y = p.y * a;
+        AffinePoint {
+            x,
+            y,
+            infinity: false,
+        }
+    }
+}
+
 impl AffinePoint {
     /// Create a point from (x,y) as raw u64's in Montgomery representation
     pub const fn from_raw(x: [u64; 4], y: [u64; 4]) -> Self {

--- a/crates/crypto/src/algebra/curve/mod.rs
+++ b/crates/crypto/src/algebra/curve/mod.rs
@@ -4,9 +4,12 @@ mod gen_mul;
 mod params;
 mod projective;
 
+mod xyzz;
+
 pub use affine::AffinePoint;
 pub use params::{CURVE_A, CURVE_B, CURVE_G, CURVE_ORDER};
 pub use projective::ProjectivePoint;
+pub use xyzz::XYZZPoint;
 
 #[cfg(test)]
 mod tests;

--- a/crates/crypto/src/algebra/curve/xyzz.rs
+++ b/crates/crypto/src/algebra/curve/xyzz.rs
@@ -1,0 +1,69 @@
+use crate::algebra::curve::*;
+use crate::algebra::field::*;
+
+/// A XYZZ point on an elliptic curve over [MontFelt] satisfying:
+///   x = X / ZZ
+///   y = Y / ZZ
+///   ZZ^3 = ZZZ^2
+///
+/// This point representation is used for fast table-based scalar multiplication
+/// and only include add_affine and add_affine_unchecked operations.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct XYZZPoint {
+    pub x: MontFelt,
+    pub y: MontFelt,
+    pub zz: MontFelt,
+    pub zzz: MontFelt,
+}
+
+impl From<&AffinePoint> for XYZZPoint {
+    fn from(p: &AffinePoint) -> Self {
+        let x = p.x;
+        let y = p.y;
+        let zz = MontFelt::ONE;
+        let zzz = MontFelt::ONE;
+        XYZZPoint { x, y, zz, zzz }
+    }
+}
+
+impl XYZZPoint {
+    /// Check if the point is the point of infinity
+    pub fn is_infinity(&self) -> bool {
+        self.zz.is_zero()
+    }
+
+    /// Add an affine point to this point
+    pub fn add_affine(&mut self, other: &AffinePoint) {
+        if other.infinity {
+            return;
+        }
+        if self.is_infinity() {
+            self.x = other.x;
+            self.y = other.y;
+            let z = if other.infinity {
+                MontFelt::ZERO
+            } else {
+                MontFelt::ONE
+            };
+            self.zz = z;
+            self.zzz = z;
+
+            return;
+        }
+        self.add_affine_unchecked(other);
+    }
+
+    /// Add an affine point to this point, neither must be the point of infinity
+    pub fn add_affine_unchecked(&mut self, other: &AffinePoint) {
+        // See https://www.hyperelliptic.org/EFD/g1p/auto-shortw-xyzz.html#addition-madd-2008-s
+        let p = other.x * self.zz - self.x;
+        let r = other.y * self.zzz - self.y;
+        let pp = p.square();
+        let ppp = p * pp;
+        let q = self.x * pp;
+        self.x = r.square() - ppp - q.double();
+        self.y = r * (q - self.x) - self.y * ppp;
+        self.zz *= pp;
+        self.zzz *= ppp;
+    }
+}

--- a/crates/crypto/src/hash/pedersen/gens.rs
+++ b/crates/crypto/src/hash/pedersen/gens.rs
@@ -1,34 +1,34 @@
 //! Generators for the Pedersen hash function.
 //!
 //! See <https://docs.starkware.co/starkex/crypto/pedersen-hash-function.html>
-use crate::algebra::curve::ProjectivePoint;
+use crate::algebra::curve::AffinePoint;
 
 /// Montgomery representation of the Stark curve constant P0.
-pub const PEDERSEN_P0: ProjectivePoint = ProjectivePoint::from_hex(
+pub const PEDERSEN_P0: AffinePoint = AffinePoint::from_hex(
     "49EE3EBA8C1600700EE1B87EB599F16716B0B1022947733551FDE4050CA6804",
     "3CA0CFE4B3BC6DDF346D49D06EA0ED34E621062C0E056C1D0405D266E10268A",
 );
 
 /// Montgomery representation of the Stark curve constant P1.
-pub const PEDERSEN_P1: ProjectivePoint = ProjectivePoint::from_hex(
+pub const PEDERSEN_P1: AffinePoint = AffinePoint::from_hex(
     "234287DCBAFFE7F969C748655FCA9E58FA8120B6D56EB0C1080D17957EBE47B",
     "3B056F100F96FB21E889527D41F4E39940135DD7A6C94CC6ED0268EE89E5615",
 );
 
 /// Montgomery representation of the Stark curve constant P2.
-pub const PEDERSEN_P2: ProjectivePoint = ProjectivePoint::from_hex(
+pub const PEDERSEN_P2: AffinePoint = AffinePoint::from_hex(
     "4FA56F376C83DB33F9DAB2656558F3399099EC1DE5E3018B7A6932DBA8AA378",
     "3FA0984C931C9E38113E0C0E47E4401562761F92A7A23B45168F4E80FF5B54D",
 );
 
 /// Montgomery representation of the Stark curve constant P3.
-pub const PEDERSEN_P3: ProjectivePoint = ProjectivePoint::from_hex(
+pub const PEDERSEN_P3: AffinePoint = AffinePoint::from_hex(
     "4BA4CC166BE8DEC764910F75B45F74B40C690C74709E90F3AA372F0BD2D6997",
     "40301CF5C1751F4B971E46C4EDE85FCAC5C59A5CE5AE7C48151F27B24B219C",
 );
 
 /// Montgomery representation of the Stark curve constant P4.
-pub const PEDERSEN_P4: ProjectivePoint = ProjectivePoint::from_hex(
+pub const PEDERSEN_P4: AffinePoint = AffinePoint::from_hex(
     "54302DCB0E6CC1C6E44CCA8F61A63BB2CA65048D53FB325D36FF12C49A58202",
     "1B77B3E37D13504B348046268D8AE25CE98AD783C25561A879DCC77E99C2426",
 );


### PR DESCRIPTION
This PR adds XYZZ coordinates support for faster table-based scalar-multiplication:
- Positive: Decreases the main elliptic curve operation used from 13M+2S to 8M+2S, where M is the field multiplications and S the number of squares.
- Negative: Increases an elliptic curve point representation to four coordinates (x, y, zz, zzz) instead of standard two or three.

It is currently only applied to Pedersen, but should be applied to ECDSA during future revisions. From the decrease in field operation count, we should be able to get >30% off in theory. In practice, given the representation overhead, we get some ~10% off the table-based Pedersen-hash.

Additional notes:
- We now let z=0 represent infinity in projective/xyzz coordinates (not affine), which is pretty standard and saves one word, concretely measured to 5-6% faster against the old projective-based Pedersen-hash during dev.
- While this is faster, we should consider Jacobian for scalar-multiplication: More field operations than XYZZ, but less than Projective, while still only requiring three coordinates (x,y,z).