### PR TITLE
(fix) montfelt cios revert

### DIFF
--- a/crates/crypto/src/algebra/field/montfelt/multiplicative.rs
+++ b/crates/crypto/src/algebra/field/montfelt/multiplicative.rs
@@ -83,81 +83,44 @@ impl MontFelt {
         MontFelt::const_mont_reduce(r0, r1, r2, r3, r4, r5, r6, r7)
     }
 
-    /// CIOS multiplication algorithm
+    /// SOS multiplication algorithm
     #[inline(always)]
     #[allow(unused)]
     pub fn mul(&self, x: &MontFelt) -> MontFelt {
-        let a = &self.0;
-        let b = &x.0;
-        let n = &Self::P.0;
+        // Compute a[0] * b
+        let mut carry = 0;
+        let r0 = mac(self.0[0], x.0[0], 0, &mut carry);
+        let r1 = mac(self.0[0], x.0[1], 0, &mut carry);
+        let r2 = mac(self.0[0], x.0[2], 0, &mut carry);
+        let r3 = mac(self.0[0], x.0[3], 0, &mut carry);
+        let r4 = carry;
 
-        // Compute a * b[0]
-        let mut carry1 = 0u64;
-        let r0 = mac(a[0], b[0], 0, &mut carry1);
-        let r1 = mac(a[1], b[0], 0, &mut carry1);
-        let r2 = mac(a[2], b[0], 0, &mut carry1);
-        let r3 = mac(a[3], b[0], 0, &mut carry1);
+        // Compute a[1] * b
+        let mut carry = 0;
+        let r1 = mac(self.0[1], x.0[0], r1, &mut carry);
+        let r2 = mac(self.0[1], x.0[1], r2, &mut carry);
+        let r3 = mac(self.0[1], x.0[2], r3, &mut carry);
+        let r4 = mac(self.0[1], x.0[3], r4, &mut carry);
+        let r5 = carry;
 
-        // Reduce it
-        let k = r0.wrapping_mul(Self::M0);
-        let mut carry2 = 0u64;
-        mac(k, n[0], r0, &mut carry2);
-        let r0 = mac(k, n[1], r1, &mut carry2);
-        let r1 = mac(k, n[2], r2, &mut carry2);
-        let r2 = mac(k, n[3], r3, &mut carry2);
-        let r3 = carry1 + carry2;
+        // Compute a[2] * b
+        let mut carry = 0;
+        let r2 = mac(self.0[2], x.0[0], r2, &mut carry);
+        let r3 = mac(self.0[2], x.0[1], r3, &mut carry);
+        let r4 = mac(self.0[2], x.0[2], r4, &mut carry);
+        let r5 = mac(self.0[2], x.0[3], r5, &mut carry);
+        let r6 = carry;
 
-        // Compute a * b[1]
-        let mut carry1 = 0u64;
-        let r0 = mac(a[0], b[1], r0, &mut carry1);
-        let r1 = mac(a[1], b[1], r1, &mut carry1);
-        let r2 = mac(a[2], b[1], r2, &mut carry1);
-        let r3 = mac(a[3], b[1], r3, &mut carry1);
+        // Compute a[3] * b
+        let mut carry = 0;
+        let r3 = mac(self.0[3], x.0[0], r3, &mut carry);
+        let r4 = mac(self.0[3], x.0[1], r4, &mut carry);
+        let r5 = mac(self.0[3], x.0[2], r5, &mut carry);
+        let r6 = mac(self.0[3], x.0[3], r6, &mut carry);
+        let r7 = carry;
 
-        // Reduce it
-        let k = r0.wrapping_mul(Self::M0);
-        let mut carry2 = 0u64;
-        mac(k, n[0], r0, &mut carry2);
-        let r0 = mac(k, n[1], r1, &mut carry2);
-        let r1 = mac(k, n[2], r2, &mut carry2);
-        let r2 = mac(k, n[3], r3, &mut carry2);
-        let r3 = carry1 + carry2;
-
-        // Compute a * b[2]
-        let mut carry1 = 0u64;
-        let r0 = mac(a[0], b[2], r0, &mut carry1);
-        let r1 = mac(a[1], b[2], r1, &mut carry1);
-        let r2 = mac(a[2], b[2], r2, &mut carry1);
-        let r3 = mac(a[3], b[2], r3, &mut carry1);
-
-        // Reduce it
-        let k = r0.wrapping_mul(Self::M0);
-        let mut carry2 = 0u64;
-        mac(k, n[0], r0, &mut carry2);
-        let r0 = mac(k, n[1], r1, &mut carry2);
-        let r1 = mac(k, n[2], r2, &mut carry2);
-        let r2 = mac(k, n[3], r3, &mut carry2);
-        let r3 = carry1 + carry2;
-
-        // Compute a * b[3]
-        let mut carry1 = 0u64;
-        let r0 = mac(a[0], b[3], r0, &mut carry1);
-        let r1 = mac(a[1], b[3], r1, &mut carry1);
-        let r2 = mac(a[2], b[3], r2, &mut carry1);
-        let r3 = mac(a[3], b[3], r3, &mut carry1);
-
-        // Reduce it
-        let k = r0.wrapping_mul(Self::M0);
-        let mut carry2 = 0u64;
-        mac(k, n[0], r0, &mut carry2);
-        let r0 = mac(k, n[1], r1, &mut carry2);
-        let r1 = mac(k, n[2], r2, &mut carry2);
-        let r2 = mac(k, n[3], r3, &mut carry2);
-        let r3 = carry1 + carry2;
-
-        // Subtract modulus if needed
-        let r = MontFelt([r0, r1, r2, r3]);
-        r.reduce_partial()
+        // Montgomery reduction
+        MontFelt::mont_reduce(r0, r1, r2, r3, r4, r5, r6, r7)
     }
 
     /// SOS squaring algorithm
@@ -246,5 +209,34 @@ impl std::ops::MulAssign<&mut Self> for MontFelt {
     #[inline(always)]
     fn mul_assign(&mut self, rhs: &mut Self) {
         *self = Self::mul(self, rhs);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use num_bigint::BigUint;
+
+    use super::*;
+
+    #[test]
+    fn test_mul_random() {
+        let mut rng = rand::thread_rng();
+        let bn_p = BigUint::from_str(
+            "3618502788666131213697322783095070105623107215331596699973092056135872020481",
+        )
+        .unwrap();
+        for _ in 0..1_000 {
+            let a = MontFelt::random(&mut rng);
+            let b = MontFelt::random(&mut rng);
+            let c = a.mul(&b);
+
+            let bn_a = BigUint::from_bytes_be(&a.to_be_bytes());
+            let bn_b = BigUint::from_bytes_be(&b.to_be_bytes());
+            let bn_c = &bn_a * &bn_b % &bn_p;
+
+            assert_eq!(BigUint::from_bytes_be(&c.to_be_bytes()), bn_c);
+        }
     }
 }


### PR DESCRIPTION
In very unique scenario's the carry handling of the current CIOS multiplication overflows.
This PR reverts it back to SOS algorithm until proper analysis/handling.