### PR TITLE
fix: message to L1's to_address should be Felt

### DIFF
--- a/crates/common/src/receipt.rs
+++ b/crates/common/src/receipt.rs
@@ -27,7 +27,11 @@ impl Receipt {
 pub struct L2ToL1Message {
     pub from_address: ContractAddress,
     pub payload: Vec<L2ToL1MessagePayloadElem>,
-    pub to_address: EthereumAddress,
+    // This is purposefully not EthereumAddress even though this
+    // represents an Ethereum address normally. Starknet allows this value
+    // to be Felt sized; so technically callers can send a message to a garbage
+    // address.
+    pub to_address: ContractAddress,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -484,8 +484,7 @@ pub(crate) mod transaction {
         pub from_address: ContractAddress,
         #[serde_as(as = "Vec<L2ToL1MessagePayloadElemAsDecimalStr>")]
         pub payload: Vec<L2ToL1MessagePayloadElem>,
-        #[serde_as(as = "EthereumAddressAsHexStr")]
-        pub to_address: EthereumAddress,
+        pub to_address: ContractAddress,
     }
 
     impl From<L2ToL1Message> for pathfinder_common::receipt::L2ToL1Message {

--- a/crates/p2p/src/client/conv.rs
+++ b/crates/p2p/src/client/conv.rs
@@ -42,7 +42,6 @@ use pathfinder_common::{
     ContractAddress,
     ContractAddressSalt,
     EntryPoint,
-    EthereumAddress,
     EventCommitment,
     EventData,
     EventKey,
@@ -387,7 +386,10 @@ impl TryFromDto<(p2p_proto::receipt::Receipt, TransactionIndex)> for Receipt {
                             .into_iter()
                             .map(L2ToL1MessagePayloadElem)
                             .collect(),
-                        to_address: EthereumAddress(x.to_address.0),
+                        to_address: ContractAddress::new_or_panic(
+                            Felt::from_be_slice(x.to_address.0.as_bytes())
+                                .expect("H160 should always fix in Felt"),
+                        ),
                     })
                     .collect(),
                 execution_status: match common.revert_reason {

--- a/crates/pathfinder/src/p2p_network/sync_handlers/conv.rs
+++ b/crates/pathfinder/src/p2p_network/sync_handlers/conv.rs
@@ -181,7 +181,11 @@ impl ToDto<p2p_proto::receipt::Receipt> for (&Transaction, Receipt) {
                 .map(|m| MessageToL1 {
                     from_address: m.from_address.0,
                     payload: m.payload.into_iter().map(|p| p.0).collect(),
-                    to_address: EthereumAddress(m.to_address.0),
+                    // FIXME: to_address is incorrect in the p2p specification and should actually
+                    // be a Felt type. Once the spec is fixed, we can remove this temporary hack.
+                    to_address: EthereumAddress(primitive_types::H160::from_slice(
+                        &m.to_address.0.to_be_bytes()[12..],
+                    )),
                 })
                 .collect(),
             execution_resources: {

--- a/crates/rpc/src/dto/receipt.rs
+++ b/crates/rpc/src/dto/receipt.rs
@@ -308,14 +308,8 @@ impl SerializeForVersion for MsgToL1<'_> {
     fn serialize(&self, serializer: Serializer) -> Result<serialize::Ok, serialize::Error> {
         let mut serializer = serializer.serialize_struct()?;
 
-        // FIXME: This clone could be elided if either the specification is fixed to
-        // represent this as an ETH_ADDRESS. Alternatively, we can amend dto::Felt to an
-        // enum over [Felt, EthAddress] but that seems worse than the clone imo.
-        let to_address = pathfinder_crypto::Felt::from_be_slice(self.0.to_address.0.as_bytes())
-            .expect("Ethereum address should fit in a felt");
-
         serializer.serialize_field("from_address", &dto::Felt(&self.0.from_address.0))?;
-        serializer.serialize_field("to_address", &dto::Felt(&to_address))?;
+        serializer.serialize_field("to_address", &dto::Felt(&self.0.to_address.0))?;
         serializer.serialize_field("from_address", &dto::Felt(&self.0.from_address.0))?;
 
         serializer.end()

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -258,7 +258,6 @@ pub mod test_utils {
     use pathfinder_common::transaction::*;
     use pathfinder_merkle_tree::StorageCommitmentTree;
     use pathfinder_storage::{BlockId, Storage, StorageBuilder};
-    use primitive_types::H160;
     use starknet_gateway_types::reply::GasPrices;
 
     use crate::pending::PendingData;
@@ -550,7 +549,7 @@ pub mod test_utils {
                     l2_to_l1_message_payload_elem!("0x2"),
                     l2_to_l1_message_payload_elem!("0x3"),
                 ],
-                to_address: EthereumAddress(H160::zero()),
+                to_address: ContractAddress::ZERO,
             }],
             ..receipt0.clone()
         };

--- a/crates/rpc/src/v04/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v04/method/get_transaction_receipt.rs
@@ -83,14 +83,12 @@ pub mod types {
         BlockHash,
         BlockNumber,
         ContractAddress,
-        EthereumAddress,
         EventData,
         EventKey,
         Fee,
         L2ToL1MessagePayloadElem,
         TransactionHash,
     };
-    use pathfinder_serde::EthereumAddressAsHexStr;
     use serde::Serialize;
     use serde_with::serde_as;
 
@@ -409,8 +407,7 @@ pub mod types {
     #[serde(deny_unknown_fields)]
     pub struct MessageToL1 {
         pub from_address: ContractAddress,
-        #[serde_as(as = "EthereumAddressAsHexStr")]
-        pub to_address: EthereumAddress,
+        pub to_address: ContractAddress,
         #[serde_as(as = "Vec<RpcFelt>")]
         pub payload: Vec<L2ToL1MessagePayloadElem>,
     }
@@ -479,8 +476,7 @@ mod tests {
     // TODO: add serialization tests for each receipt variant..
 
     use pathfinder_common::macro_prelude::*;
-    use pathfinder_common::{BlockNumber, EthereumAddress, Fee};
-    use primitive_types::H160;
+    use pathfinder_common::{BlockNumber, Fee};
 
     use super::*;
 
@@ -590,7 +586,7 @@ mod tests {
                         block_number: BlockNumber::new_or_panic(2),
                         messages_sent: vec![MessageToL1 {
                             from_address: contract_address!("0xcafebabe"),
-                            to_address: EthereumAddress(H160::zero()),
+                            to_address: pathfinder_common::ContractAddress::ZERO,
                             payload: vec![
                                 l2_to_l1_message_payload_elem!("0x1"),
                                 l2_to_l1_message_payload_elem!("0x2"),

--- a/crates/rpc/src/v06/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v06/method/get_transaction_receipt.rs
@@ -92,7 +92,6 @@ pub mod types {
         BlockHash,
         BlockNumber,
         ContractAddress,
-        EthereumAddress,
         EventData,
         EventKey,
         Fee,
@@ -100,7 +99,7 @@ pub mod types {
         TransactionHash,
         TransactionVersion,
     };
-    use pathfinder_serde::{u64_as_hex_str, EthereumAddressAsHexStr, H256AsNoLeadingZerosHexStr};
+    use pathfinder_serde::{u64_as_hex_str, H256AsNoLeadingZerosHexStr};
     use primitive_types::H256;
     use serde::Serialize;
     use serde_with::serde_as;
@@ -697,8 +696,7 @@ pub mod types {
     #[serde(deny_unknown_fields)]
     pub struct MessageToL1 {
         pub from_address: ContractAddress,
-        #[serde_as(as = "EthereumAddressAsHexStr")]
-        pub to_address: EthereumAddress,
+        pub to_address: ContractAddress,
         #[serde_as(as = "Vec<RpcFelt>")]
         pub payload: Vec<L2ToL1MessagePayloadElem>,
     }
@@ -769,8 +767,7 @@ mod tests {
 
     use pathfinder_common::macro_prelude::*;
     use pathfinder_common::receipt::{BuiltinCounters, ExecutionResources};
-    use pathfinder_common::{BlockNumber, EthereumAddress};
-    use primitive_types::H160;
+    use pathfinder_common::BlockNumber;
 
     use super::types::ExecutionResourcesProperties;
     use super::*;
@@ -899,7 +896,7 @@ mod tests {
                         block_number: BlockNumber::new_or_panic(2),
                         messages_sent: vec![MessageToL1 {
                             from_address: contract_address!("0xcafebabe"),
-                            to_address: EthereumAddress(H160::zero()),
+                            to_address: pathfinder_common::ContractAddress::ZERO,
                             payload: vec![
                                 l2_to_l1_message_payload_elem!("0x1"),
                                 l2_to_l1_message_payload_elem!("0x2"),

--- a/crates/storage/src/connection/transaction.rs
+++ b/crates/storage/src/connection/transaction.rs
@@ -918,12 +918,24 @@ pub(crate) mod dto {
     }
 
     /// Represents deserialized L2 to L1 message.
-    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Dummy)]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
     #[serde(deny_unknown_fields)]
     pub struct L2ToL1Message {
         pub from_address: MinimalFelt,
         pub payload: Vec<MinimalFelt>,
-        pub to_address: EthereumAddress,
+        pub to_address: MinimalFelt,
+    }
+
+    impl<T> Dummy<T> for L2ToL1Message {
+        fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &T, rng: &mut R) -> Self {
+            Self {
+                from_address: Faker.fake_with_rng(rng),
+                payload: fake::vec![MinimalFelt; 1..10],
+                // Create a Felt using only 160 bits. This is required because p2p specification
+                // uses the wrong type to represent this field.
+                to_address: MinimalFelt(Felt::from_be_slice(&fake::vec![u8; 20]).unwrap()),
+            }
+        }
     }
 
     impl From<L2ToL1Message> for pathfinder_common::receipt::L2ToL1Message {
@@ -939,7 +951,7 @@ pub(crate) mod dto {
                     .into_iter()
                     .map(|x| L2ToL1MessagePayloadElem(x.into()))
                     .collect(),
-                to_address,
+                to_address: ContractAddress::new_or_panic(to_address.into()),
             }
         }
     }
@@ -957,7 +969,7 @@ pub(crate) mod dto {
                     .into_iter()
                     .map(|x| x.as_inner().to_owned().into())
                     .collect(),
-                to_address,
+                to_address: to_address.as_inner().to_owned().into(),
             }
         }
     }

--- a/crates/storage/src/schema/revision_0052.rs
+++ b/crates/storage/src/schema/revision_0052.rs
@@ -512,7 +512,7 @@ mod dto {
     pub struct L2ToL1Message {
         pub from_address: MinimalFelt,
         pub payload: Vec<MinimalFelt>,
-        pub to_address: EthereumAddress,
+        pub to_address: MinimalFelt,
     }
 
     impl From<L2ToL1Message> for pathfinder_common::receipt::L2ToL1Message {
@@ -528,7 +528,7 @@ mod dto {
                     .into_iter()
                     .map(|x| L2ToL1MessagePayloadElem(x.into()))
                     .collect(),
-                to_address,
+                to_address: ContractAddress::new_or_panic(to_address.into()),
             }
         }
     }
@@ -546,7 +546,7 @@ mod dto {
                     .into_iter()
                     .map(|x| x.as_inner().to_owned().into())
                     .collect(),
-                to_address,
+                to_address: to_address.as_inner().to_owned().into(),
             }
         }
     }
@@ -1634,7 +1634,6 @@ pub(crate) mod old_dto {
     use pathfinder_serde::{
         CallParamAsDecimalStr,
         ConstructorParamAsDecimalStr,
-        EthereumAddressAsHexStr,
         L2ToL1MessagePayloadElemAsDecimalStr,
         ResourceAmountAsHexStr,
         ResourcePricePerUnitAsHexStr,
@@ -1831,8 +1830,7 @@ pub(crate) mod old_dto {
         pub from_address: ContractAddress,
         #[serde_as(as = "Vec<L2ToL1MessagePayloadElemAsDecimalStr>")]
         pub payload: Vec<L2ToL1MessagePayloadElem>,
-        #[serde_as(as = "EthereumAddressAsHexStr")]
-        pub to_address: EthereumAddress,
+        pub to_address: ContractAddress,
     }
 
     impl From<L2ToL1Message> for pathfinder_common::receipt::L2ToL1Message {

--- a/crates/storage/src/schema/revision_0057.rs
+++ b/crates/storage/src/schema/revision_0057.rs
@@ -560,7 +560,7 @@ pub(crate) mod dto {
     pub struct L2ToL1Message {
         pub from_address: MinimalFelt,
         pub payload: Vec<MinimalFelt>,
-        pub to_address: EthereumAddress,
+        pub to_address: MinimalFelt,
     }
 
     impl From<L2ToL1Message> for pathfinder_common::receipt::L2ToL1Message {
@@ -576,7 +576,7 @@ pub(crate) mod dto {
                     .into_iter()
                     .map(|x| L2ToL1MessagePayloadElem(x.into()))
                     .collect(),
-                to_address,
+                to_address: ContractAddress::new_or_panic(to_address.into()),
             }
         }
     }
@@ -594,7 +594,7 @@ pub(crate) mod dto {
                     .into_iter()
                     .map(|x| x.as_inner().to_owned().into())
                     .collect(),
-                to_address,
+                to_address: to_address.as_inner().to_owned().into(),
             }
         }
     }


### PR DESCRIPTION
Our internal representation of an L1 message's `to_address` field is incorrect.

Though this is meant to represent an Ethereum address, starknet accepts any Felt. This fixes our representation of this type to match this expectation.

Unfortunately, the p2p specification also has this typed (incorrectly) as an Ethereum address. Until then we have a "lossy" conversion there still.

Another concern is that this touches migrations - but I *think* this doesn't actually change anything there.