### PR TITLE
feat(rpc/websocket): expose "normal" JSON-RPC methods over Websockets

### DIFF
--- a/crates/rpc/src/jsonrpc.rs
+++ b/crates/rpc/src/jsonrpc.rs
@@ -10,14 +10,14 @@ pub use response::RpcResponse;
 pub use router::{rpc_handler, RpcRouter, RpcRouterBuilder};
 
 #[derive(Debug, PartialEq, Clone)]
-pub enum RequestId<'a> {
+pub enum RequestId {
     Number(i64),
-    String(std::borrow::Cow<'a, str>),
+    String(String),
     Null,
     Notification,
 }
 
-impl RequestId<'_> {
+impl RequestId {
     pub fn is_notification(&self) -> bool {
         self == &RequestId::Notification
     }

--- a/crates/rpc/src/jsonrpc/response.rs
+++ b/crates/rpc/src/jsonrpc/response.rs
@@ -7,34 +7,34 @@ use crate::jsonrpc::error::RpcError;
 use crate::jsonrpc::RequestId;
 
 #[derive(Debug, PartialEq)]
-pub struct RpcResponse<'a> {
+pub struct RpcResponse {
     pub output: RpcResult,
-    pub id: RequestId<'a>,
+    pub id: RequestId,
 }
 
-impl<'a> RpcResponse<'a> {
-    pub const fn parse_error(error: String) -> RpcResponse<'a> {
+impl RpcResponse {
+    pub const fn parse_error(error: String) -> RpcResponse {
         Self {
             output: Err(RpcError::ParseError(error)),
             id: RequestId::Null,
         }
     }
 
-    pub const fn invalid_request(error: String) -> RpcResponse<'a> {
+    pub const fn invalid_request(error: String) -> RpcResponse {
         Self {
             output: Err(RpcError::InvalidRequest(error)),
             id: RequestId::Null,
         }
     }
 
-    pub const fn method_not_found(id: RequestId<'a>) -> RpcResponse<'a> {
+    pub const fn method_not_found(id: RequestId) -> RpcResponse {
         Self {
             output: Err(RpcError::MethodNotFound),
             id,
         }
     }
 
-    pub const fn invalid_params(id: RequestId<'a>, error: String) -> RpcResponse<'a> {
+    pub const fn invalid_params(id: RequestId, error: String) -> RpcResponse {
         Self {
             output: Err(RpcError::InvalidParams(error)),
             id,
@@ -44,7 +44,7 @@ impl<'a> RpcResponse<'a> {
 
 pub type RpcResult = Result<Value, RpcError>;
 
-impl Serialize for RpcResponse<'_> {
+impl Serialize for RpcResponse {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -70,7 +70,7 @@ impl Serialize for RpcResponse<'_> {
     }
 }
 
-impl IntoResponse for RpcResponse<'_> {
+impl IntoResponse for RpcResponse {
     fn into_response(self) -> axum::response::Response {
         // Log internal errors.
         match &self.output {

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -195,19 +195,6 @@ pub(super) enum RpcResponses<'a> {
     Multiple(Vec<RpcResponse<'a>>),
 }
 
-impl serde::ser::Serialize for RpcResponses<'_> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        match self {
-            RpcResponses::Empty => ().serialize(serializer),
-            RpcResponses::Single(response) => response.serialize(serializer),
-            RpcResponses::Multiple(responses) => responses.serialize(serializer),
-        }
-    }
-}
-
 /// Helper to scope the responses so we can set the content-type afterwards
 /// instead of dealing with branches / early exits.
 pub(super) async fn handle_json_rpc_body<'a>(

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -19,7 +19,7 @@ use crate::RpcVersion;
 
 #[derive(Clone)]
 pub struct RpcRouter {
-    context: RpcContext,
+    pub context: RpcContext,
     methods: &'static HashMap<&'static str, Box<dyn RpcMethod>>,
     version: RpcVersion,
 }

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -12,7 +12,6 @@ use serde_json::value::RawValue;
 use tracing::Instrument;
 
 use crate::context::RpcContext;
-use crate::dto::serialize::SerializeForVersion;
 use crate::jsonrpc::error::RpcError;
 use crate::jsonrpc::request::{RawParams, RpcRequest};
 use crate::jsonrpc::response::{RpcResponse, RpcResult};
@@ -165,68 +164,17 @@ pub async fn rpc_handler(
         return StatusCode::UNSUPPORTED_MEDIA_TYPE.into_response();
     }
 
-    #[inline]
-    /// Helper to scope the responses so we can set the content-type afterwards
-    /// instead of dealing with branches / early exits.
-    async fn handle(
-        state: RpcRouter,
-        body: axum::body::Bytes,
-    ) -> impl axum::response::IntoResponse {
-        // Unfortunately due to this https://github.com/serde-rs/json/issues/497
-        // we cannot use an enum with borrowed raw values inside to do a single
-        // deserialization for us. Instead we have to distinguish manually
-        // between a single request and a batch request which we do by checking
-        // the first byte.
-        if body.as_ref().first() != Some(&b'[') {
-            let request = match serde_json::from_slice::<&RawValue>(&body) {
-                Ok(request) => request,
-                Err(e) => {
-                    return RpcResponse::parse_error(e.to_string()).into_response();
-                }
-            };
-
-            match state.run_request(request.get()).await {
-                Some(response) => response.into_response(),
-                None => ().into_response(),
+    let mut response = match handle_json_rpc_body(&state, body.as_ref()).await {
+        Ok(responses) => match responses {
+            RpcResponses::Empty => ().into_response(),
+            RpcResponses::Single(response) => response.into_response(),
+            RpcResponses::Multiple(responses) => {
+                serde_json::to_string(&responses).unwrap().into_response()
             }
-        } else {
-            let requests = match serde_json::from_slice::<Vec<&RawValue>>(&body) {
-                Ok(requests) => requests,
-                Err(e) => {
-                    return RpcResponse::parse_error(e.to_string()).into_response();
-                }
-            };
-
-            if requests.is_empty() {
-                return RpcResponse::invalid_request(
-                    "A batch request must contain at least one request".to_owned(),
-                )
-                .into_response();
-            }
-
-            let responses = run_concurrently(
-                state.context.config.batch_concurrency_limit,
-                requests.into_iter().enumerate(),
-                |(idx, request)| {
-                    state
-                        .run_request(request.get())
-                        .instrument(tracing::debug_span!("batch", idx))
-                },
-            )
-            .await
-            .flatten()
-            .collect::<Vec<RpcResponse<'_>>>();
-
-            // All requests were notifications.
-            if responses.is_empty() {
-                return ().into_response();
-            }
-
-            serde_json::to_string(&responses).unwrap().into_response()
-        }
-    }
-
-    let mut response = handle(state, body).await.into_response();
+        },
+        Err(RpcRequestError::ParseError(e)) => RpcResponse::parse_error(e).into_response(),
+        Err(RpcRequestError::InvalidRequest(e)) => RpcResponse::invalid_request(e).into_response(),
+    };
 
     use http::header::CONTENT_TYPE;
     static APPLICATION_JSON: HeaderValue = HeaderValue::from_static("application/json");
@@ -234,6 +182,89 @@ pub async fn rpc_handler(
         .headers_mut()
         .insert(CONTENT_TYPE, APPLICATION_JSON.clone());
     response
+}
+
+pub(super) enum RpcRequestError {
+    ParseError(String),
+    InvalidRequest(String),
+}
+
+pub(super) enum RpcResponses<'a> {
+    Empty,
+    Single(RpcResponse<'a>),
+    Multiple(Vec<RpcResponse<'a>>),
+}
+
+impl serde::ser::Serialize for RpcResponses<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            RpcResponses::Empty => ().serialize(serializer),
+            RpcResponses::Single(response) => response.serialize(serializer),
+            RpcResponses::Multiple(responses) => responses.serialize(serializer),
+        }
+    }
+}
+
+/// Helper to scope the responses so we can set the content-type afterwards
+/// instead of dealing with branches / early exits.
+pub(super) async fn handle_json_rpc_body<'a>(
+    state: &RpcRouter,
+    body: &'a [u8],
+) -> Result<RpcResponses<'a>, RpcRequestError> {
+    // Unfortunately due to this https://github.com/serde-rs/json/issues/497
+    // we cannot use an enum with borrowed raw values inside to do a single
+    // deserialization for us. Instead we have to distinguish manually
+    // between a single request and a batch request which we do by checking
+    // the first byte.
+    if body.first() != Some(&b'[') {
+        let request = match serde_json::from_slice::<&RawValue>(body) {
+            Ok(request) => request,
+            Err(e) => {
+                return Err(RpcRequestError::ParseError(e.to_string()));
+            }
+        };
+
+        match state.run_request(request.get()).await {
+            Some(response) => Ok(RpcResponses::Single(response)),
+            None => Ok(RpcResponses::Empty),
+        }
+    } else {
+        let requests = match serde_json::from_slice::<Vec<&RawValue>>(body) {
+            Ok(requests) => requests,
+            Err(e) => {
+                return Err(RpcRequestError::ParseError(e.to_string()));
+            }
+        };
+
+        if requests.is_empty() {
+            return Err(RpcRequestError::InvalidRequest(
+                "A batch request must contain at least one request".to_owned(),
+            ));
+        }
+
+        let responses = run_concurrently(
+            state.context.config.batch_concurrency_limit,
+            requests.into_iter().enumerate(),
+            |(idx, request)| {
+                state
+                    .run_request(request.get())
+                    .instrument(tracing::debug_span!("batch", idx))
+            },
+        )
+        .await
+        .flatten()
+        .collect::<Vec<RpcResponse<'_>>>();
+
+        // All requests were notifications.
+        if responses.is_empty() {
+            return Ok(RpcResponses::Empty);
+        }
+
+        Ok(RpcResponses::Multiple(responses))
+    }
 }
 
 #[axum::async_trait]
@@ -282,7 +313,7 @@ mod sealed {
     use std::marker::PhantomData;
 
     use super::*;
-    use crate::dto::serialize::Serializer;
+    use crate::dto::serialize::{SerializeForVersion, Serializer};
     use crate::jsonrpc::error::RpcError;
     use crate::RpcVersion;
 

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -79,7 +79,7 @@ impl RpcRouter {
     async fn run_request(&self, request: &str) -> Option<RpcResponse> {
         tracing::trace!(%request, "Running request");
 
-        let request = match serde_json::from_str::<RpcRequest>(request) {
+        let request = match serde_json::from_str::<RpcRequest<'_>>(request) {
             Ok(request) => request,
             Err(e) => {
                 return Some(RpcResponse::invalid_request(e.to_string()));

--- a/crates/rpc/src/jsonrpc/websocket/data.rs
+++ b/crates/rpc/src/jsonrpc/websocket/data.rs
@@ -7,6 +7,7 @@ use serde::ser::Error;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::jsonrpc::router::RpcResponses;
 use crate::jsonrpc::{RequestId, RpcError, RpcResponse};
 
 #[derive(serde::Deserialize, Serialize)]
@@ -80,6 +81,77 @@ impl<'a> From<&'a OwnedRequestId> for RequestId<'a> {
     }
 }
 
+pub(super) struct OwnedRpcResponse {
+    output: crate::jsonrpc::response::RpcResult,
+    id: OwnedRequestId,
+}
+
+impl From<RpcResponse<'_>> for OwnedRpcResponse {
+    fn from(value: RpcResponse<'_>) -> Self {
+        Self {
+            output: value.output,
+            id: value.id.into(),
+        }
+    }
+}
+
+impl serde::ser::Serialize for OwnedRpcResponse {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+
+        let mut obj = serializer.serialize_map(Some(3))?;
+        obj.serialize_entry("jsonrpc", "2.0")?;
+
+        match &self.output {
+            Ok(x) => obj.serialize_entry("result", &x)?,
+            Err(e) => obj.serialize_entry("error", &e)?,
+        };
+
+        match &self.id {
+            OwnedRequestId::Number(x) => obj.serialize_entry("id", &x)?,
+            OwnedRequestId::String(x) => obj.serialize_entry("id", &x)?,
+            OwnedRequestId::Null => obj.serialize_entry("id", &Value::Null)?,
+            OwnedRequestId::Notification => {}
+        };
+
+        obj.end()
+    }
+}
+
+pub(super) enum OwnedRpcResponses {
+    Empty,
+    Single(OwnedRpcResponse),
+    Multiple(Vec<OwnedRpcResponse>),
+}
+
+impl From<RpcResponses<'_>> for OwnedRpcResponses {
+    fn from(value: RpcResponses<'_>) -> Self {
+        match value {
+            RpcResponses::Empty => Self::Empty,
+            RpcResponses::Single(response) => Self::Single(response.into()),
+            RpcResponses::Multiple(responses) => {
+                Self::Multiple(responses.into_iter().map(Into::into).collect())
+            }
+        }
+    }
+}
+
+impl serde::ser::Serialize for OwnedRpcResponses {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Empty => ().serialize(serializer),
+            Self::Single(response) => response.serialize(serializer),
+            Self::Multiple(responses) => responses.serialize(serializer),
+        }
+    }
+}
+
 pub(super) enum ResponseEvent {
     Subscribed {
         subscription_id: u32,
@@ -94,21 +166,21 @@ pub(super) enum ResponseEvent {
         reason: String,
     },
     InvalidRequest(String),
-    InvalidMethod(OwnedRequestId),
     InvalidParams(OwnedRequestId, String),
     Header(SubscriptionItem<Arc<Value>>),
+    Responses(OwnedRpcResponses),
 }
 
 impl ResponseEvent {
     pub(super) fn kind(&self) -> &'static str {
         match self {
             ResponseEvent::InvalidRequest(_) => "InvalidRequest",
-            ResponseEvent::InvalidMethod(_) => "InvalidMethod",
             ResponseEvent::Header(_) => "BlockHeader",
             ResponseEvent::Subscribed { .. } => "Subscribed",
             ResponseEvent::Unsubscribed { .. } => "Unsubscribed",
             ResponseEvent::SubscriptionClosed { .. } => "SubscriptionClosed",
             ResponseEvent::InvalidParams(..) => "InvalidParams",
+            ResponseEvent::Responses(_) => "Responses",
         }
     }
 }
@@ -121,9 +193,6 @@ impl Serialize for ResponseEvent {
         match self {
             ResponseEvent::InvalidRequest(e) => {
                 RpcResponse::invalid_request(e.clone()).serialize(serializer)
-            }
-            ResponseEvent::InvalidMethod(id) => {
-                RpcResponse::method_not_found(id.into()).serialize(serializer)
             }
             ResponseEvent::InvalidParams(id, e) => {
                 RpcResponse::invalid_params(id.into(), e.clone()).serialize(serializer)
@@ -152,6 +221,7 @@ impl Serialize for ResponseEvent {
                 id: RequestId::Null,
             }
             .serialize(serializer),
+            ResponseEvent::Responses(responses) => responses.serialize(serializer),
         }
     }
 }

--- a/crates/rpc/src/jsonrpc/websocket/logic.rs
+++ b/crates/rpc/src/jsonrpc/websocket/logic.rs
@@ -58,7 +58,10 @@ pub async fn websocket_handler(
     ws: WebSocketUpgrade,
     State(router): State<RpcRouter>,
 ) -> impl IntoResponse {
-    let mut upgrade_response = ws.on_upgrade(|socket| handle_socket(socket, router));
+    let mut upgrade_response = ws
+        .max_message_size(crate::REQUEST_MAX_SIZE)
+        .on_failed_upgrade(|error| tracing::debug!(%error, "Websocket upgrade failed"))
+        .on_upgrade(|socket| handle_socket(socket, router));
 
     static APPLICATION_JSON: http::HeaderValue = http::HeaderValue::from_static("application/json");
     upgrade_response

--- a/crates/rpc/src/jsonrpc/websocket/logic.rs
+++ b/crates/rpc/src/jsonrpc/websocket/logic.rs
@@ -215,7 +215,7 @@ struct SubscriptionManager {
 impl SubscriptionManager {
     async fn unsubscribe(
         &mut self,
-        request_id: RequestId<'_>,
+        request_id: RequestId,
         request_params: RawParams<'_>,
     ) -> ResponseEvent {
         let subscription_id = match request_params.deserialize::<SubscriptionId>() {
@@ -250,7 +250,7 @@ impl SubscriptionManager {
 
     fn subscribe(
         &mut self,
-        request_id: RequestId<'_>,
+        request_id: RequestId,
         request_params: RawParams<'_>,
         response_sender: mpsc::Sender<ResponseEvent>,
         websocket_source: TopicBroadcasters,

--- a/crates/rpc/src/jsonrpc/websocket/logic.rs
+++ b/crates/rpc/src/jsonrpc/websocket/logic.rs
@@ -187,7 +187,7 @@ async fn read(
                     .await
             }
             _ => match super::super::router::handle_json_rpc_body(&router, &request).await {
-                Ok(responses) => ResponseEvent::Responses(responses.into()),
+                Ok(responses) => ResponseEvent::Responses(responses),
                 Err(RpcRequestError::ParseError(e)) => ResponseEvent::InvalidRequest(e),
                 Err(RpcRequestError::InvalidRequest(e)) => ResponseEvent::InvalidRequest(e),
             },
@@ -221,11 +221,11 @@ impl SubscriptionManager {
         let subscription_id = match request_params.deserialize::<SubscriptionId>() {
             Ok(x) => x,
             Err(crate::jsonrpc::RpcError::InvalidParams(e)) => {
-                return ResponseEvent::InvalidParams(request_id.into(), e)
+                return ResponseEvent::InvalidParams(request_id, e)
             }
             Err(_) => {
                 return ResponseEvent::InvalidParams(
-                    request_id.into(),
+                    request_id,
                     "Unexpected parsing error".to_owned(),
                 )
             }
@@ -244,7 +244,7 @@ impl SubscriptionManager {
 
         ResponseEvent::Unsubscribed {
             success,
-            request_id: request_id.into(),
+            request_id,
         }
     }
 
@@ -258,11 +258,11 @@ impl SubscriptionManager {
         let kind = match request_params.deserialize::<Kind<'_>>() {
             Ok(x) => x,
             Err(crate::jsonrpc::RpcError::InvalidParams(e)) => {
-                return ResponseEvent::InvalidParams(request_id.into(), e)
+                return ResponseEvent::InvalidParams(request_id, e)
             }
             Err(_) => {
                 return ResponseEvent::InvalidParams(
-                    request_id.into(),
+                    request_id,
                     "Unexpected parsing error".to_owned(),
                 )
             }
@@ -279,7 +279,7 @@ impl SubscriptionManager {
             )),
             _ => {
                 return ResponseEvent::InvalidParams(
-                    request_id.into(),
+                    request_id,
                     "Unknown subscription type".to_owned(),
                 )
             }
@@ -289,7 +289,7 @@ impl SubscriptionManager {
 
         ResponseEvent::Subscribed {
             subscription_id,
-            request_id: request_id.into(),
+            request_id,
         }
     }
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -187,7 +187,7 @@ impl RpcServer {
             // Also return success for get's with an empty body. These are often
             // used by monitoring bots to check service health.
             .route("/", get(empty_body).post(rpc_handler))
-            .with_state(default_router)
+            .with_state(default_router.clone())
             .route("/rpc/v0.4", post(rpc_handler))
             .route("/rpc/v0_4", post(rpc_handler))
             .with_state(v04_routes)
@@ -195,21 +195,25 @@ impl RpcServer {
             .route("/rpc/v0_5", post(rpc_handler))
             .with_state(v05_routes)
             .route("/rpc/v0_6", post(rpc_handler))
-            .with_state(v06_routes)
+            .with_state(v06_routes.clone())
             .route("/rpc/v0_7", post(rpc_handler))
-            .with_state(v07_routes)
+            .with_state(v07_routes.clone())
             .route("/rpc/pathfinder/v0.1", post(rpc_handler))
             .with_state(pathfinder_routes);
 
         let router = if self.context.websocket.is_some() {
-            router.route("/ws", get(websocket_handler))
-        } else {
             router
+                .route("/ws", get(websocket_handler))
+                .with_state(default_router)
+                .route("/ws/rpc/v0_6", get(websocket_handler))
+                .with_state(v06_routes)
+                .route("/ws/rpc/v0_7", get(websocket_handler))
+                .with_state(v07_routes)
+        } else {
+            router.with_state(default_router)
         };
 
-        let router = router
-            .with_state(self.context.websocket.clone().unwrap_or_default())
-            .layer(middleware);
+        let router = router.layer(middleware);
 
         let server_handle = tokio::spawn(async move {
             server

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -65,6 +65,11 @@ impl RpcVersion {
     }
 }
 
+// TODO: make this configurable
+const REQUEST_MAX_SIZE: usize = 10 * 1024 * 1024;
+// TODO: make this configurable
+const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
 pub struct RpcServer {
     addr: SocketAddr,
     context: RpcContext,
@@ -99,11 +104,6 @@ impl RpcServer {
     /// Starts the HTTP-RPC server.
     pub fn spawn(self) -> Result<(JoinHandle<anyhow::Result<()>>, SocketAddr), anyhow::Error> {
         use axum::routing::{get, post};
-
-        // TODO: make this configurable
-        const REQUEST_MAX_SIZE: usize = 10 * 1024 * 1024;
-        // TODO: make this configurable
-        const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
         let listener = match std::net::TcpListener::bind(self.addr) {
             Ok(listener) => listener,


### PR DESCRIPTION
This PR exposes the "normal" JSON-RPC methods over a set of versioned WebSocket endpoints. In addition to the `/ws` endpoint (exposing the default JSON-RPC version) this change adds `/ws/rpc/v0_6` and `/ws/rpc/v0_7` for the 0.6 and 0.7 JSON-RPC API.

The implementation is sub-optimal: because the `pathfinder_subscribe` and `pathfinder_unsubscribe` require per-connection context (for the subscription management) these two are not handled as all other methods but are left as special cases in the Websocket code.

Closes #2001.