### PR TITLE
chore: add RPC-over-Websocket info to README and changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,12 +280,11 @@ The `path` of the URL used to access the JSON-RPC server determines which versio
 
 - the `v0.4.0` API is exposed on the `/rpc/v0.4` and `/rpc/v0_4` path
 - the `v0.5.1` API is exposed on the `/`, `/rpc/v0.5` and `/rpc/v0_5` path
-- the `v0.6.0` API is exposed on the `/rpc/v0_6` path
-- the `v0.7.0` API is exposed on the `/rpc/v0_7` path
-- the pathfinder extension API is exposed on `/rpc/pathfinder/v0.1`
-- websocket API is exposed on the `/ws` path
+- the `v0.6.0` API is exposed on the `/rpc/v0_6` path via HTTP and on `/ws/rpc/v0_6` via Websocket
+- the `v0.7.0` API is exposed on the `/rpc/v0_7` path via HTTP and on `/ws/rpc/v0_7` via Websocket
+- the pathfinder extension API is exposed on `/rpc/pathfinder/v0.1` via HTTP and `/ws/rpc/pathfinder/v0_1` via Websocket.
 
-Version of the API, which is served on the root (`/`) path, can be configured via the pathfinder parameter `--rpc.root-version` (or the `RPC_ROOT_VERSION` environment variable).
+Version of the API, which is served on the root (`/`) path via HTTP and on `/ws` via Websocket, can be configured via the pathfinder parameter `--rpc.root-version` (or the `RPC_ROOT_VERSION` environment variable).
 
 Note that the pathfinder extension is versioned separately from the Starknet specification itself.
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -199,7 +199,7 @@ impl RpcServer {
             .route("/rpc/v0_7", post(rpc_handler))
             .with_state(v07_routes.clone())
             .route("/rpc/pathfinder/v0.1", post(rpc_handler))
-            .with_state(pathfinder_routes);
+            .with_state(pathfinder_routes.clone());
 
         let router = if self.context.websocket.is_some() {
             router
@@ -209,6 +209,8 @@ impl RpcServer {
                 .with_state(v06_routes)
                 .route("/ws/rpc/v0_7", get(websocket_handler))
                 .with_state(v07_routes)
+                .route("/ws/rpc/pathfinder/v0_1", get(websocket_handler))
+                .with_state(pathfinder_routes)
         } else {
             router.with_state(default_router)
         };


### PR DESCRIPTION
This PR exposes the Pathfinder extension methods on Websocket via `/ws/rpc/pathfinder/v0_1` and adds Websocket paths to the documentation.