### PR TITLE
fix: broken storage from changes to to_address

### DIFF
--- a/crates/storage/src/connection/transaction.rs
+++ b/crates/storage/src/connection/transaction.rs
@@ -940,12 +940,24 @@ pub(crate) mod dto {
     }
 
     /// Represents deserialized L2 to L1 message.
-    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Dummy)]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
     #[serde(deny_unknown_fields)]
     pub struct L2ToL1MessageV1 {
         pub from_address: MinimalFelt,
         pub payload: Vec<MinimalFelt>,
         pub to_address: MinimalFelt,
+    }
+
+    impl<T> Dummy<T> for L2ToL1MessageV1 {
+        fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &T, rng: &mut R) -> Self {
+            Self {
+                from_address: Faker.fake_with_rng(rng),
+                payload: fake::vec![MinimalFelt; 1..10],
+                // Create a Felt using only 160 bits. This is required because p2p specification
+                // uses the wrong type to represent this field.
+                to_address: MinimalFelt(Felt::from_be_slice(&fake::vec![u8; 20]).unwrap()),
+            }
+        }
     }
 
     impl From<L2ToL1MessageV0> for L2ToL1MessageV1 {

--- a/crates/storage/src/connection/transaction.rs
+++ b/crates/storage/src/connection/transaction.rs
@@ -931,24 +931,12 @@ pub(crate) mod dto {
     }
 
     /// Represents deserialized L2 to L1 message.
-    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Dummy)]
     #[serde(deny_unknown_fields)]
     pub struct L2ToL1Message {
         pub from_address: MinimalFelt,
         pub payload: Vec<MinimalFelt>,
-        pub to_address: MinimalFelt,
-    }
-
-    impl<T> Dummy<T> for L2ToL1Message {
-        fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &T, rng: &mut R) -> Self {
-            Self {
-                from_address: Faker.fake_with_rng(rng),
-                payload: fake::vec![MinimalFelt; 1..10],
-                // Create a Felt using only 160 bits. This is required because p2p specification
-                // uses the wrong type to represent this field.
-                to_address: MinimalFelt(Felt::from_be_slice(&fake::vec![u8; 20]).unwrap()),
-            }
-        }
+        pub to_address: EthereumAddress,
     }
 
     impl From<L2ToL1Message> for pathfinder_common::receipt::L2ToL1Message {
@@ -964,7 +952,7 @@ pub(crate) mod dto {
                     .into_iter()
                     .map(|x| L2ToL1MessagePayloadElem(x.into()))
                     .collect(),
-                to_address: ContractAddress::new_or_panic(to_address.into()),
+                to_address,
             }
         }
     }
@@ -982,7 +970,7 @@ pub(crate) mod dto {
                     .into_iter()
                     .map(|x| x.as_inner().to_owned().into())
                     .collect(),
-                to_address: to_address.as_inner().to_owned().into(),
+                to_address,
             }
         }
     }

--- a/crates/storage/src/fake.rs
+++ b/crates/storage/src/fake.rs
@@ -185,7 +185,7 @@ pub mod init {
                 let transaction_hash = t.variant.calculate_hash(ChainId::SEPOLIA_TESTNET, false);
                 t.hash = transaction_hash;
 
-                let r: Receipt = crate::connection::transaction::dto::Receipt {
+                let r: Receipt = crate::connection::transaction::dto::ReceiptV0 {
                     transaction_hash: transaction_hash.as_inner().to_owned().into(),
                     transaction_index: TransactionIndex::new_or_panic(
                         i.try_into().expect("u64 is at least as wide as usize"),

--- a/crates/storage/src/fake.rs
+++ b/crates/storage/src/fake.rs
@@ -185,7 +185,7 @@ pub mod init {
                 let transaction_hash = t.variant.calculate_hash(ChainId::SEPOLIA_TESTNET, false);
                 t.hash = transaction_hash;
 
-                let r: Receipt = crate::connection::transaction::dto::ReceiptV0 {
+                let r: Receipt = crate::connection::transaction::dto::ReceiptV1 {
                     transaction_hash: transaction_hash.as_inner().to_owned().into(),
                     transaction_index: TransactionIndex::new_or_panic(
                         i.try_into().expect("u64 is at least as wide as usize"),

--- a/crates/storage/src/schema/revision_0052.rs
+++ b/crates/storage/src/schema/revision_0052.rs
@@ -512,7 +512,7 @@ mod dto {
     pub struct L2ToL1Message {
         pub from_address: MinimalFelt,
         pub payload: Vec<MinimalFelt>,
-        pub to_address: MinimalFelt,
+        pub to_address: EthereumAddress,
     }
 
     impl From<L2ToL1Message> for pathfinder_common::receipt::L2ToL1Message {
@@ -528,7 +528,7 @@ mod dto {
                     .into_iter()
                     .map(|x| L2ToL1MessagePayloadElem(x.into()))
                     .collect(),
-                to_address: ContractAddress::new_or_panic(to_address.into()),
+                to_address,
             }
         }
     }
@@ -546,7 +546,7 @@ mod dto {
                     .into_iter()
                     .map(|x| x.as_inner().to_owned().into())
                     .collect(),
-                to_address: to_address.as_inner().to_owned().into(),
+                to_address,
             }
         }
     }
@@ -1634,6 +1634,7 @@ pub(crate) mod old_dto {
     use pathfinder_serde::{
         CallParamAsDecimalStr,
         ConstructorParamAsDecimalStr,
+        EthereumAddressAsHexStr,
         L2ToL1MessagePayloadElemAsDecimalStr,
         ResourceAmountAsHexStr,
         ResourcePricePerUnitAsHexStr,
@@ -1830,7 +1831,8 @@ pub(crate) mod old_dto {
         pub from_address: ContractAddress,
         #[serde_as(as = "Vec<L2ToL1MessagePayloadElemAsDecimalStr>")]
         pub payload: Vec<L2ToL1MessagePayloadElem>,
-        pub to_address: ContractAddress,
+        #[serde_as(as = "EthereumAddressAsHexStr")]
+        pub to_address: EthereumAddress,
     }
 
     impl From<L2ToL1Message> for pathfinder_common::receipt::L2ToL1Message {

--- a/crates/storage/src/schema/revision_0052.rs
+++ b/crates/storage/src/schema/revision_0052.rs
@@ -528,7 +528,9 @@ mod dto {
                     .into_iter()
                     .map(|x| L2ToL1MessagePayloadElem(x.into()))
                     .collect(),
-                to_address,
+                to_address: ContractAddress::new_or_panic(
+                    Felt::from_be_slice(to_address.0.as_bytes()).expect("H160 always fits in Felt"),
+                ),
             }
         }
     }
@@ -546,7 +548,11 @@ mod dto {
                     .into_iter()
                     .map(|x| x.as_inner().to_owned().into())
                     .collect(),
-                to_address,
+                // This is lossless and safe only because at the time of migration only values of
+                // H160 were stored.
+                to_address: EthereumAddress(primitive_types::H160::from_slice(
+                    &to_address.as_inner().as_be_bytes()[12..],
+                )),
             }
         }
     }
@@ -1845,7 +1851,9 @@ pub(crate) mod old_dto {
             pathfinder_common::receipt::L2ToL1Message {
                 from_address,
                 payload,
-                to_address,
+                to_address: ContractAddress::new_or_panic(
+                    Felt::from_be_slice(to_address.0.as_bytes()).expect("H160 always fits in Felt"),
+                ),
             }
         }
     }
@@ -1860,7 +1868,11 @@ pub(crate) mod old_dto {
             Self {
                 from_address,
                 payload,
-                to_address,
+                // This is lossless and safe only because at the time of migration only values of
+                // H160 were stored.
+                to_address: EthereumAddress(primitive_types::H160::from_slice(
+                    &to_address.as_inner().as_be_bytes()[12..],
+                )),
             }
         }
     }

--- a/crates/storage/src/schema/revision_0057.rs
+++ b/crates/storage/src/schema/revision_0057.rs
@@ -560,7 +560,7 @@ pub(crate) mod dto {
     pub struct L2ToL1Message {
         pub from_address: MinimalFelt,
         pub payload: Vec<MinimalFelt>,
-        pub to_address: MinimalFelt,
+        pub to_address: EthereumAddress,
     }
 
     impl From<L2ToL1Message> for pathfinder_common::receipt::L2ToL1Message {
@@ -576,7 +576,7 @@ pub(crate) mod dto {
                     .into_iter()
                     .map(|x| L2ToL1MessagePayloadElem(x.into()))
                     .collect(),
-                to_address: ContractAddress::new_or_panic(to_address.into()),
+                to_address,
             }
         }
     }
@@ -594,7 +594,7 @@ pub(crate) mod dto {
                     .into_iter()
                     .map(|x| x.as_inner().to_owned().into())
                     .collect(),
-                to_address: to_address.as_inner().to_owned().into(),
+                to_address,
             }
         }
     }

--- a/crates/storage/src/schema/revision_0057.rs
+++ b/crates/storage/src/schema/revision_0057.rs
@@ -576,7 +576,9 @@ pub(crate) mod dto {
                     .into_iter()
                     .map(|x| L2ToL1MessagePayloadElem(x.into()))
                     .collect(),
-                to_address,
+                to_address: ContractAddress::new_or_panic(
+                    Felt::from_be_slice(to_address.0.as_bytes()).expect("H160 always fits in Felt"),
+                ),
             }
         }
     }
@@ -594,7 +596,11 @@ pub(crate) mod dto {
                     .into_iter()
                     .map(|x| x.as_inner().to_owned().into())
                     .collect(),
-                to_address,
+                // This is lossless and safe only because at the time of migration only values of
+                // H160 were stored.
+                to_address: EthereumAddress(primitive_types::H160::from_slice(
+                    &to_address.as_inner().as_be_bytes()[12..],
+                )),
             }
         }
     }


### PR DESCRIPTION
This PR fixes storage which was broken by me in #2011.

#2011 forced a change of `H160` to `MinimalFelt` which are incompatible ito schema (`[u8; 20]` vs `Vec<u8>`). This PR reverts the damage and then introduces a new schema variant which correctly allows for this.

i.e. we now have `v0 = [u8; 20]` and `v1 = Vec<u8>`.

The reversion was done by reverting the storage file changes from #2011 entirely and then fixing up from there.

No migration required as the "schema" change is entirely encapsulated as a blob.