### PR TITLE
feat(sync): tracking outline skeleton

### DIFF
--- a/crates/common/src/state_update.rs
+++ b/crates/common/src/state_update.rs
@@ -284,6 +284,13 @@ impl StateUpdate {
         len += self.declared_cairo_classes.len() + self.declared_sierra_classes.len();
         len.try_into().expect("ptr size is 64bits")
     }
+
+    pub fn declared_classes(&self) -> DeclaredClasses {
+        DeclaredClasses {
+            sierra: self.declared_sierra_classes.clone(),
+            cairo: self.declared_cairo_classes.clone(),
+        }
+    }
 }
 
 impl StateUpdateData {
@@ -531,6 +538,12 @@ impl ReverseContractUpdate {
             Self::Updated(update) => Some(update),
         }
     }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DeclaredClasses {
+    pub sierra: HashMap<SierraHash, CasmHash>,
+    pub cairo: HashSet<ClassHash>,
 }
 
 #[cfg(test)]

--- a/crates/pathfinder/src/sync/class_definitions.rs
+++ b/crates/pathfinder/src/sync/class_definitions.rs
@@ -8,7 +8,8 @@ use futures::stream::StreamExt;
 use p2p::client::peer_agnostic::ClassDefinition as P2PClassDefinition;
 use p2p::PeerData;
 use p2p_proto::transaction;
-use pathfinder_common::{BlockNumber, ClassHash, SierraHash};
+use pathfinder_common::state_update::DeclaredClasses;
+use pathfinder_common::{BlockNumber, CasmHash, ClassHash, SierraHash};
 use pathfinder_storage::Storage;
 use serde_json::de;
 use starknet_gateway_client::GatewayApi;
@@ -26,9 +27,10 @@ use tokio::sync::Mutex;
 use tokio::task::spawn_blocking;
 
 use crate::sync::error::SyncError;
+use crate::sync::stream::ProcessStage;
 
 #[derive(Debug)]
-pub(super) struct ClassWithLayout {
+pub struct ClassWithLayout {
     pub block_number: BlockNumber,
     pub definition: ClassDefinition,
     pub layout: GwClassDefinition<'static>,
@@ -396,4 +398,15 @@ pub(super) async fn persist(
     })
     .await
     .context("Joining blocking task")?
+}
+
+pub struct VerifyClassHashes;
+
+impl ProcessStage for VerifyClassHashes {
+    type Input = (DeclaredClasses, Vec<ClassWithLayout>);
+    type Output = Vec<GwClassDefinition<'static>>;
+
+    fn map(&mut self, input: Self::Input) -> Result<Self::Output, super::error::SyncError2> {
+        todo!()
+    }
 }

--- a/crates/pathfinder/src/sync/state_updates.rs
+++ b/crates/pathfinder/src/sync/state_updates.rs
@@ -137,3 +137,14 @@ pub(super) async fn persist(
     .await
     .context("Joining blocking task")?
 }
+
+pub struct VerifyDiff;
+
+impl crate::sync::stream::ProcessStage for VerifyDiff {
+    type Input = StateUpdate;
+    type Output = StateUpdate;
+
+    fn map(&mut self, _input: Self::Input) -> Result<Self::Output, super::error::SyncError2> {
+        todo!()
+    }
+}

--- a/crates/pathfinder/src/sync/transactions.rs
+++ b/crates/pathfinder/src/sync/transactions.rs
@@ -4,15 +4,16 @@ use anyhow::Context;
 use p2p::client::peer_agnostic::TransactionBlockData;
 use p2p::PeerData;
 use pathfinder_common::receipt::Receipt;
-use pathfinder_common::transaction::Transaction;
+use pathfinder_common::transaction::{Transaction, TransactionVariant};
 use pathfinder_common::{BlockHeader, BlockNumber, ChainId};
 use pathfinder_storage::Storage;
 
-use super::error::SyncError;
+use super::error::{SyncError, SyncError2};
 use crate::state::block_hash::{
     calculate_transaction_commitment,
     TransactionCommitmentFinalHashType,
 };
+use crate::sync::stream::ProcessStage;
 
 pub type TransactionsWithHashesForBlock = (BlockNumber, Vec<(Transaction, Receipt)>);
 
@@ -190,4 +191,28 @@ pub(super) async fn persist(
     })
     .await
     .context("Joining blocking task")?
+}
+
+pub struct CalculateHashes;
+pub struct VerifyCommitment;
+
+impl ProcessStage for CalculateHashes {
+    type Input = (
+        BlockHeader,
+        Vec<(TransactionVariant, p2p_proto::receipt::Receipt)>,
+    );
+    type Output = (BlockHeader, Vec<(Transaction, Receipt)>);
+
+    fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError2> {
+        todo!()
+    }
+}
+
+impl ProcessStage for VerifyCommitment {
+    type Input = (BlockHeader, Vec<(Transaction, Receipt)>);
+    type Output = Vec<(Transaction, Receipt)>;
+
+    fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError2> {
+        todo!()
+    }
 }


### PR DESCRIPTION
This PR fleshes out the tracking pipeline skeleton.

Sources and pipelines for state updates, transactions and classes are added. State trie updates are not implemented yet as it is not critical for the initial p2p mvp.

Types are not 100% correct as it might change as they are implemented. This should give a solid starting place though.