### PR TITLE
feat(common/transaction): split TransactionVariant::Deploy into V0 and V1

### DIFF
--- a/crates/crypto/src/algebra/field/felt.rs
+++ b/crates/crypto/src/algebra/field/felt.rs
@@ -75,6 +75,7 @@ impl std::fmt::Display for OverflowError {
 
 impl Felt {
     pub const ZERO: Felt = Felt([0u8; 32]);
+    pub const ONE: Felt = Self::from_u64(1);
 
     /// Return true if the element is zero.
     pub fn is_zero(&self) -> bool {

--- a/crates/pathfinder/src/p2p_network/sync_handlers/conv.rs
+++ b/crates/pathfinder/src/p2p_network/sync_handlers/conv.rs
@@ -83,13 +83,17 @@ impl ToDto<p2p_proto::transaction::Transaction> for Transaction {
                 nonce_data_availability_mode: x.nonce_data_availability_mode.to_dto(),
                 fee_data_availability_mode: x.fee_data_availability_mode.to_dto(),
             }),
-            Deploy(x) => proto::Transaction::Deploy(proto::Deploy {
+            DeployV0(x) => proto::Transaction::Deploy(proto::Deploy {
                 class_hash: Hash(x.class_hash.0),
                 address_salt: x.contract_address_salt.0,
                 calldata: x.constructor_calldata.into_iter().map(|c| c.0).collect(),
-                // address: Address(x.contract_address.0), FIXME
-                // Only these two values are allowed in storage
-                version: if x.version.is_zero() { 0 } else { 1 },
+                version: 0,
+            }),
+            DeployV1(x) => proto::Transaction::Deploy(proto::Deploy {
+                class_hash: Hash(x.class_hash.0),
+                address_salt: x.contract_address_salt.0,
+                calldata: x.constructor_calldata.into_iter().map(|c| c.0).collect(),
+                version: 1,
             }),
             DeployAccountV1(x) => proto::Transaction::DeployAccountV1(proto::DeployAccountV1 {
                 max_fee: x.max_fee.0,
@@ -218,7 +222,11 @@ impl ToDto<p2p_proto::receipt::Receipt> for (&Transaction, Receipt) {
             | TransactionVariant::DeclareV1(_)
             | TransactionVariant::DeclareV2(_)
             | TransactionVariant::DeclareV3(_) => Declare(DeclareTransactionReceipt { common }),
-            TransactionVariant::Deploy(x) => Deploy(DeployTransactionReceipt {
+            TransactionVariant::DeployV0(x) => Deploy(DeployTransactionReceipt {
+                common,
+                contract_address: x.contract_address.0,
+            }),
+            TransactionVariant::DeployV1(x) => Deploy(DeployTransactionReceipt {
                 common,
                 contract_address: x.contract_address.0,
             }),

--- a/crates/pathfinder/src/p2p_network/sync_handlers/tests.rs
+++ b/crates/pathfinder/src/p2p_network/sync_handlers/tests.rs
@@ -428,7 +428,8 @@ mod prop {
                             let mut tv = workaround::for_legacy_l1_handlers(t.variant);
                             // P2P transactions don't carry contract address, so zero them just like `try_from_dto` does
                             match &mut tv {
-                                TransactionVariant::Deploy(x) => x.contract_address = ContractAddress::ZERO,
+                                TransactionVariant::DeployV0(x) => x.contract_address = ContractAddress::ZERO,
+                                TransactionVariant::DeployV1(x) => x.contract_address = ContractAddress::ZERO,
                                 TransactionVariant::DeployAccountV1(x) => x.contract_address = ContractAddress::ZERO,
                                 TransactionVariant::DeployAccountV3(x) => x.contract_address = ContractAddress::ZERO,
                                 _ => {}

--- a/crates/pathfinder/src/state/block_hash.rs
+++ b/crates/pathfinder/src/state/block_hash.rs
@@ -373,7 +373,8 @@ fn calculate_transaction_hash_with_signature_pre_0_11_1(tx: &Transaction) -> Fel
         | TransactionVariant::DeclareV1(_)
         | TransactionVariant::DeclareV2(_)
         | TransactionVariant::DeclareV3(_)
-        | TransactionVariant::Deploy(_)
+        | TransactionVariant::DeployV0(_)
+        | TransactionVariant::DeployV1(_)
         | TransactionVariant::DeployAccountV1(_)
         | TransactionVariant::DeployAccountV3(_)
         | TransactionVariant::L1Handler(_) => *HASH_OF_EMPTY_LIST,
@@ -406,7 +407,9 @@ fn calculate_transaction_hash_with_signature(tx: &Transaction) -> Felt {
         TransactionVariant::DeployAccountV3(tx) => calculate_signature_hash(&tx.signature),
         TransactionVariant::InvokeV1(tx) => calculate_signature_hash(&tx.signature),
         TransactionVariant::InvokeV3(tx) => calculate_signature_hash(&tx.signature),
-        TransactionVariant::Deploy(_) | TransactionVariant::L1Handler(_) => *HASH_OF_EMPTY_LIST,
+        TransactionVariant::DeployV0(_)
+        | TransactionVariant::DeployV1(_)
+        | TransactionVariant::L1Handler(_) => *HASH_OF_EMPTY_LIST,
     };
 
     pedersen_hash(tx.hash.0, signature_hash)

--- a/crates/pathfinder/src/sync/checkpoint.rs
+++ b/crates/pathfinder/src/sync/checkpoint.rs
@@ -728,7 +728,7 @@ mod tests {
         use futures::stream;
         use p2p::libp2p::PeerId;
         use pathfinder_common::state_update::{ContractClassUpdate, StateUpdateData};
-        use pathfinder_common::transaction::DeployTransaction;
+        use pathfinder_common::transaction::DeployTransactionV0;
         use pathfinder_common::TransactionHash;
         use pathfinder_crypto::Felt;
         use pathfinder_storage::fake::{self as fake_storage, Block};

--- a/crates/rpc/src/dto/receipt.rs
+++ b/crates/rpc/src/dto/receipt.rs
@@ -166,7 +166,8 @@ impl SerializeForVersion for DeployTxnReceipt<'_> {
         let contract_address = match &self.0.transaction.variant {
             // Partial match here is safe since this variant is deprecated.
             // i.e. no risk of forgetting to handle a new variant.
-            TransactionVariant::Deploy(tx) => &tx.contract_address,
+            TransactionVariant::DeployV0(tx) => &tx.contract_address,
+            TransactionVariant::DeployV1(tx) => &tx.contract_address,
             _ => {
                 return Err(serde_json::error::Error::custom(
                     "expected Deploy transaction",
@@ -192,13 +193,14 @@ impl SerializeForVersion for DeployAccountTxnReceipt<'_> {
             | TransactionVariant::DeclareV1(_)
             | TransactionVariant::DeclareV2(_)
             | TransactionVariant::DeclareV3(_)
-            | TransactionVariant::Deploy(_)
+            | TransactionVariant::DeployV0(_)
+            | TransactionVariant::DeployV1(_)
             | TransactionVariant::InvokeV0(_)
             | TransactionVariant::InvokeV1(_)
             | TransactionVariant::InvokeV3(_)
             | TransactionVariant::L1Handler(_) => {
                 return Err(serde_json::error::Error::custom(
-                    "expected Deploy transaction",
+                    "expected deploy account transaction",
                 ))
             }
         };
@@ -236,7 +238,8 @@ impl SerializeForVersion for L1HandlerTxnReceipt<'_> {
             | TransactionVariant::DeclareV1(_)
             | TransactionVariant::DeclareV2(_)
             | TransactionVariant::DeclareV3(_)
-            | TransactionVariant::Deploy(_)
+            | TransactionVariant::DeployV0(_)
+            | TransactionVariant::DeployV1(_)
             | TransactionVariant::DeployAccountV1(_)
             | TransactionVariant::DeployAccountV3(_)
             | TransactionVariant::InvokeV0(_)

--- a/crates/rpc/src/executor.rs
+++ b/crates/rpc/src/executor.rs
@@ -262,7 +262,7 @@ fn map_transaction_variant(
                 starknet_api::transaction::DeclareTransaction::V3(tx),
             ))
         }
-        TransactionVariant::Deploy(_) => {
+        TransactionVariant::DeployV0(_) | TransactionVariant::DeployV1(_) => {
             anyhow::bail!("Deploy transactions are not yet supported in blockifier")
         }
         TransactionVariant::DeployAccountV1(tx) => {
@@ -506,7 +506,8 @@ pub fn compose_executor_transaction(
                 class_definition.abi.len(),
             )?)
         }
-        TransactionVariant::Deploy(_)
+        TransactionVariant::DeployV0(_)
+        | TransactionVariant::DeployV1(_)
         | TransactionVariant::DeployAccountV1(_)
         | TransactionVariant::DeployAccountV3(_)
         | TransactionVariant::InvokeV0(_)
@@ -536,7 +537,8 @@ pub fn compose_executor_transaction(
         | TransactionVariant::DeclareV1(_)
         | TransactionVariant::DeclareV2(_)
         | TransactionVariant::DeclareV3(_)
-        | TransactionVariant::Deploy(_)
+        | TransactionVariant::DeployV0(_)
+        | TransactionVariant::DeployV1(_)
         | TransactionVariant::InvokeV0(_)
         | TransactionVariant::InvokeV1(_)
         | TransactionVariant::InvokeV3(_)

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -633,7 +633,7 @@ pub mod test_utils {
             },
             Transaction {
                 hash: transaction_hash_bytes!(b"pending tx hash 1"),
-                variant: TransactionVariant::Deploy(DeployTransaction {
+                variant: TransactionVariant::DeployV0(DeployTransactionV0 {
                     contract_address: contract_address!("0x1122355"),
                     contract_address_salt: contract_address_salt_bytes!(b"salty"),
                     class_hash: class_hash_bytes!(b"pending class hash 1"),

--- a/crates/rpc/src/v04/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v04/method/get_transaction_receipt.rs
@@ -242,7 +242,11 @@ pub mod types {
                 | TransactionVariant::DeclareV3(_) => {
                     Self::Declare(DeclareTransactionReceipt { common })
                 }
-                TransactionVariant::Deploy(tx) => Self::Deploy(DeployTransactionReceipt {
+                TransactionVariant::DeployV0(tx) => Self::Deploy(DeployTransactionReceipt {
+                    common,
+                    contract_address: tx.contract_address,
+                }),
+                TransactionVariant::DeployV1(tx) => Self::Deploy(DeployTransactionReceipt {
                     common,
                     contract_address: tx.contract_address,
                 }),
@@ -372,7 +376,11 @@ pub mod types {
                 | TransactionVariant::DeclareV3(_) => {
                     Self::Declare(PendingDeclareTransactionReceipt { common })
                 }
-                TransactionVariant::Deploy(tx) => Self::Deploy(PendingDeployTransactionReceipt {
+                TransactionVariant::DeployV0(tx) => Self::Deploy(PendingDeployTransactionReceipt {
+                    common,
+                    contract_address: tx.contract_address,
+                }),
+                TransactionVariant::DeployV1(tx) => Self::Deploy(PendingDeployTransactionReceipt {
                     common,
                     contract_address: tx.contract_address,
                 }),

--- a/crates/rpc/src/v04/method/pending_transactions.rs
+++ b/crates/rpc/src/v04/method/pending_transactions.rs
@@ -43,7 +43,7 @@ mod tests {
     use pathfinder_common::macro_prelude::*;
     use pathfinder_common::transaction::EntryPointType::External;
     use pathfinder_common::transaction::{
-        DeployTransaction,
+        DeployTransactionV0,
         InvokeTransactionV0,
         TransactionVariant,
     };
@@ -67,7 +67,7 @@ mod tests {
 
         let tx1 = TransactionWithHash {
             transaction_hash: transaction_hash_bytes!(b"pending tx hash 1"),
-            txn: Transaction(TransactionVariant::Deploy(DeployTransaction {
+            txn: Transaction(TransactionVariant::DeployV0(DeployTransactionV0 {
                 contract_address: contract_address!("0x1122355"),
                 class_hash: class_hash_bytes!(b"pending class hash 1"),
                 contract_address_salt: contract_address_salt_bytes!(b"salty"),

--- a/crates/rpc/src/v05/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v05/method/trace_block_transactions.rs
@@ -104,7 +104,13 @@ pub(crate) fn map_gateway_trace(
             validate_invocation: trace.validate_invocation.map(Into::into),
             state_diff: None,
         }),
-        TransactionVariant::Deploy(_) => TransactionTrace::DeployAccount(DeployAccountTxnTrace {
+        TransactionVariant::DeployV0(_) => TransactionTrace::DeployAccount(DeployAccountTxnTrace {
+            constructor_invocation: trace.function_invocation.map(Into::into),
+            fee_transfer_invocation: trace.fee_transfer_invocation.map(Into::into),
+            validate_invocation: trace.validate_invocation.map(Into::into),
+            state_diff: None,
+        }),
+        TransactionVariant::DeployV1(_) => TransactionTrace::DeployAccount(DeployAccountTxnTrace {
             constructor_invocation: trace.function_invocation.map(Into::into),
             fee_transfer_invocation: trace.fee_transfer_invocation.map(Into::into),
             validate_invocation: trace.validate_invocation.map(Into::into),

--- a/crates/rpc/src/v06/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v06/method/get_transaction_receipt.rs
@@ -513,7 +513,11 @@ pub mod types {
                 TransactionVariant::DeclareV3(_) => {
                     Self::Declare(DeclareTransactionReceipt { common })
                 }
-                TransactionVariant::Deploy(tx) => Self::Deploy(DeployTransactionReceipt {
+                TransactionVariant::DeployV0(tx) => Self::Deploy(DeployTransactionReceipt {
+                    common,
+                    contract_address: tx.contract_address,
+                }),
+                TransactionVariant::DeployV1(tx) => Self::Deploy(DeployTransactionReceipt {
                     common,
                     contract_address: tx.contract_address,
                 }),
@@ -654,7 +658,11 @@ pub mod types {
                 TransactionVariant::DeclareV3(_) => {
                     Self::Declare(PendingDeclareTransactionReceipt { common })
                 }
-                TransactionVariant::Deploy(tx) => Self::Deploy(PendingDeployTransactionReceipt {
+                TransactionVariant::DeployV0(tx) => Self::Deploy(PendingDeployTransactionReceipt {
+                    common,
+                    contract_address: tx.contract_address,
+                }),
+                TransactionVariant::DeployV1(tx) => Self::Deploy(PendingDeployTransactionReceipt {
                     common,
                     contract_address: tx.contract_address,
                 }),

--- a/crates/rpc/src/v06/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v06/method/trace_block_transactions.rs
@@ -137,15 +137,18 @@ pub(crate) fn map_gateway_trace(
         }),
         TransactionVariant::DeployAccountV1(_)
         | TransactionVariant::DeployAccountV3(_)
-        | TransactionVariant::Deploy(_) => TransactionTrace::DeployAccount(DeployAccountTxnTrace {
-            constructor_invocation: function_invocation.ok_or(TraceConversionError(
-                "constructor_invocation is missing from trace response",
-            ))?,
-            fee_transfer_invocation,
-            validate_invocation,
-            state_diff,
-            execution_resources,
-        }),
+        | TransactionVariant::DeployV0(_)
+        | TransactionVariant::DeployV1(_) => {
+            TransactionTrace::DeployAccount(DeployAccountTxnTrace {
+                constructor_invocation: function_invocation.ok_or(TraceConversionError(
+                    "constructor_invocation is missing from trace response",
+                ))?,
+                fee_transfer_invocation,
+                validate_invocation,
+                state_diff,
+                execution_resources,
+            })
+        }
         TransactionVariant::InvokeV0(_)
         | TransactionVariant::InvokeV1(_)
         | TransactionVariant::InvokeV3(_) => TransactionTrace::Invoke(InvokeTxnTrace {

--- a/crates/rpc/src/v06/types/transaction.rs
+++ b/crates/rpc/src/v06/types/transaction.rs
@@ -5,7 +5,8 @@ use pathfinder_common::transaction::{
     DeclareTransactionV3,
     DeployAccountTransactionV1,
     DeployAccountTransactionV3,
-    DeployTransaction,
+    DeployTransactionV0,
+    DeployTransactionV1,
     InvokeTransactionV0,
     InvokeTransactionV1,
     InvokeTransactionV3,
@@ -55,7 +56,8 @@ impl Serialize for Transaction {
             TransactionVariant::DeclareV1(x) => DeclareV1Helper(x).serialize(serializer),
             TransactionVariant::DeclareV2(x) => DeclareV2Helper(x).serialize(serializer),
             TransactionVariant::DeclareV3(x) => DeclareV3Helper(x).serialize(serializer),
-            TransactionVariant::Deploy(x) => DeployHelper(x).serialize(serializer),
+            TransactionVariant::DeployV0(x) => DeployV0Helper(x).serialize(serializer),
+            TransactionVariant::DeployV1(x) => DeployV1Helper(x).serialize(serializer),
             TransactionVariant::DeployAccountV1(x) => {
                 DeployAccountV1Helper(x).serialize(serializer)
             }
@@ -74,7 +76,9 @@ struct DeclareV0Helper<'a>(&'a DeclareTransactionV0V1);
 struct DeclareV1Helper<'a>(&'a DeclareTransactionV0V1);
 struct DeclareV2Helper<'a>(&'a DeclareTransactionV2);
 struct DeclareV3Helper<'a>(&'a DeclareTransactionV3);
-struct DeployHelper<'a>(&'a DeployTransaction);
+struct DeployV0Helper<'a>(&'a DeployTransactionV0);
+struct DeployV1Helper<'a>(&'a DeployTransactionV1);
+
 struct DeployAccountV1Helper<'a>(&'a DeployAccountTransactionV1);
 struct DeployAccountV3Helper<'a>(&'a DeployAccountTransactionV3);
 struct InvokeV0Helper<'a>(&'a InvokeTransactionV0);
@@ -172,13 +176,34 @@ impl Serialize for DeclareV3Helper<'_> {
     }
 }
 
-impl Serialize for DeployHelper<'_> {
+impl Serialize for DeployV0Helper<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
         let mut s = serializer.serialize_struct("Deploy", 5)?;
-        s.serialize_field("version", &TransactionVersionHelper(&self.0.version))?;
+        s.serialize_field(
+            "version",
+            &TransactionVersionHelper(&TransactionVersion::ZERO),
+        )?;
+        s.serialize_field("type", "DEPLOY")?;
+        s.serialize_field("contract_address_salt", &self.0.contract_address_salt)?;
+        s.serialize_field("constructor_calldata", &self.0.constructor_calldata)?;
+        s.serialize_field("class_hash", &self.0.class_hash)?;
+        s.end()
+    }
+}
+
+impl Serialize for DeployV1Helper<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut s = serializer.serialize_struct("Deploy", 5)?;
+        s.serialize_field(
+            "version",
+            &TransactionVersionHelper(&TransactionVersion::ONE),
+        )?;
         s.serialize_field("type", "DEPLOY")?;
         s.serialize_field("contract_address_salt", &self.0.contract_address_salt)?;
         s.serialize_field("constructor_calldata", &self.0.constructor_calldata)?;
@@ -407,7 +432,7 @@ mod tests {
 
     mod serialization {
         use pathfinder_common::transaction::*;
-        use pathfinder_common::{ResourceAmount, ResourcePricePerUnit, Tip, TransactionVersion};
+        use pathfinder_common::{ResourceAmount, ResourcePricePerUnit, Tip};
         use pretty_assertions_sorted::assert_eq;
         use serde_json::json;
 
@@ -557,7 +582,7 @@ mod tests {
 
         #[test]
         fn deploy() {
-            let original: TransactionVariant = DeployTransaction {
+            let original: TransactionVariant = DeployTransactionV0 {
                 contract_address: contract_address!("0xabc"),
                 contract_address_salt: contract_address_salt!("0xeeee"),
                 class_hash: class_hash!("0x123"),
@@ -565,7 +590,6 @@ mod tests {
                     constructor_param!("0xbbb0"),
                     constructor_param!("0xbbb1"),
                 ],
-                version: TransactionVersion::TWO,
             }
             .into();
 
@@ -574,7 +598,7 @@ mod tests {
                 "contract_address_salt": "0xeeee",
                 "class_hash": "0x123",
                 "constructor_calldata": ["0xbbb0","0xbbb1"],
-                "version": "0x2",
+                "version": "0x0",
             });
             let uut = Transaction(original);
             let result = serde_json::to_value(uut).unwrap();

--- a/crates/rpc/src/v07/dto/receipt.rs
+++ b/crates/rpc/src/v07/dto/receipt.rs
@@ -200,7 +200,11 @@ impl PendingTxnReceipt {
             TransactionVariant::DeclareV1(_) => Self::Declare { common },
             TransactionVariant::DeclareV2(_) => Self::Declare { common },
             TransactionVariant::DeclareV3(_) => Self::Declare { common },
-            TransactionVariant::Deploy(tx) => Self::Deploy {
+            TransactionVariant::DeployV0(tx) => Self::Deploy {
+                contract_address: tx.contract_address,
+                common,
+            },
+            TransactionVariant::DeployV1(tx) => Self::Deploy {
                 contract_address: tx.contract_address,
                 common,
             },

--- a/crates/storage/src/fake.rs
+++ b/crates/storage/src/fake.rs
@@ -175,7 +175,7 @@ pub mod init {
             // There must be at least 1 transaction per block
             let transaction_data = fake_non_empty_with_rng::<
                 Vec<_>,
-                crate::connection::transaction::dto::Transaction,
+                crate::connection::transaction::dto::TransactionV1,
             >(rng)
             .into_iter()
             .enumerate()

--- a/crates/storage/src/test_utils.rs
+++ b/crates/storage/src/test_utils.rs
@@ -3,7 +3,7 @@ use pathfinder_common::macro_prelude::*;
 use pathfinder_common::receipt::{ExecutionDataAvailability, ExecutionResources, Receipt};
 use pathfinder_common::transaction::{
     DeclareTransactionV0V1,
-    DeployTransaction,
+    DeployTransactionV0,
     EntryPointType,
     InvokeTransactionV0,
     Transaction,
@@ -80,7 +80,7 @@ pub(crate) fn create_transactions_and_receipts(
         {
             Transaction {
                 hash: TransactionHash(Felt::from_hex_str(&"9".repeat(i + 3)).unwrap()),
-                variant: TransactionVariant::Deploy(DeployTransaction {
+                variant: TransactionVariant::DeployV0(DeployTransactionV0 {
                     contract_address: ContractAddress::new_or_panic(
                         Felt::from_hex_str(&"5".repeat(i + 3)).unwrap(),
                     ),
@@ -91,7 +91,6 @@ pub(crate) fn create_transactions_and_receipts(
                     constructor_calldata: vec![ConstructorParam(
                         Felt::from_hex_str(&"8".repeat(i + 3)).unwrap(),
                     )],
-                    version: TransactionVersion::ZERO,
                 }),
             }
         }


### PR DESCRIPTION
The only possible versions for deploy transactions are 0 and 1, so we can split `TransactionVariant::Deploy` into a V0 and a V1 variant and remove the `version` field.

Closes #1723