### PR TITLE
fix(p2p): send compressed program for Cairo 0 classes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6028,6 +6028,7 @@ dependencies = [
  "clap",
  "env_logger 0.10.2",
  "fake",
+ "flate2",
  "futures",
  "hex",
  "ipnet",

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -15,9 +15,26 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
 fake = { workspace = true }
+flate2 = { workspace = true }
 futures = { workspace = true }
 ipnet = { workspace = true }
-libp2p = { workspace = true, features = ["autonat", "dcutr", "dns", "gossipsub", "identify", "kad", "macros", "noise", "ping", "relay", "request-response", "serde", "tcp", "tokio", "yamux"] }
+libp2p = { workspace = true, features = [
+    "autonat",
+    "dcutr",
+    "dns",
+    "gossipsub",
+    "identify",
+    "kad",
+    "macros",
+    "noise",
+    "ping",
+    "relay",
+    "request-response",
+    "serde",
+    "tcp",
+    "tokio",
+    "yamux",
+] }
 p2p_proto = { path = "../p2p_proto" }
 p2p_stream = { path = "../p2p_stream" }
 pathfinder-common = { path = "../common" }

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -27,6 +27,7 @@ bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
 console-subscriber = { workspace = true, optional = true }
 fake = { workspace = true }
+flate2 = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 ipnet = { workspace = true }

--- a/crates/pathfinder/src/p2p_network.rs
+++ b/crates/pathfinder/src/p2p_network.rs
@@ -109,7 +109,7 @@ pub async fn start(context: P2PContext) -> anyhow::Result<P2PNetworkHandle> {
                         Some(event) = p2p_events.recv() => {
                             match handle_p2p_event(event, storage.clone(), &mut tx).await {
                                 Ok(()) => {},
-                                Err(e) => { tracing::error!("Failed to handle P2P event: {}", e) },
+                                Err(e) => { tracing::error!("Failed to handle P2P event: {:#}", e) },
                             }
                         }
                     }

--- a/crates/pathfinder/src/p2p_network/sync_handlers.rs
+++ b/crates/pathfinder/src/p2p_network/sync_handlers.rs
@@ -143,6 +143,8 @@ fn get_header(
         if let Some(signature) = db_tx.signature(block_number.into())? {
             let state_diff_cl = db_tx.state_diff_commitment_and_length(block_number)?;
             if let Some((state_diff_commitment, state_diff_len)) = state_diff_cl {
+                tracing::trace!(?header, "Sending block header");
+
                 let txn_count = header
                     .transaction_count
                     .try_into()
@@ -230,6 +232,8 @@ fn get_classes_for_block(
 
     for class_hash in declared_classes {
         let class_definition = get_definition(block_number, class_hash)?;
+
+        tracing::trace!(?class_hash, "Sending class definition");
 
         let class: Class = match class_definition {
             ClassDefinition::Cairo(definition) => {
@@ -334,6 +338,8 @@ fn get_transactions_for_block(
     };
 
     for (txn, receipt, _) in txn_data {
+        tracing::trace!(transaction_hash=%txn.hash, "Sending transaction");
+
         let receipt = (&txn, receipt).to_dto();
         tx.blocking_send(TransactionsResponse::TransactionWithReceipt(
             TransactionWithReceipt {
@@ -415,6 +421,8 @@ fn iterate<T: Default + std::fmt::Debug>(
             }
         }
     }
+
+    tracing::trace!("Sending FIN");
 
     tx.blocking_send(T::default())
         .map_err(|_| anyhow::anyhow!("Sending Fin"))?;

--- a/crates/pathfinder/src/p2p_network/sync_handlers.rs
+++ b/crates/pathfinder/src/p2p_network/sync_handlers.rs
@@ -88,6 +88,7 @@ pub async fn get_events(
 pub(crate) mod blocking {
     use super::*;
 
+    #[tracing::instrument(skip(db_tx, tx))]
     pub(crate) fn get_headers(
         db_tx: Transaction<'_>,
         request: BlockHeadersRequest,
@@ -96,6 +97,7 @@ pub(crate) mod blocking {
         iterate(db_tx, request.iteration, get_header, tx)
     }
 
+    #[tracing::instrument(skip(db_tx, tx))]
     pub(crate) fn get_classes(
         db_tx: Transaction<'_>,
         request: ClassesRequest,
@@ -104,6 +106,7 @@ pub(crate) mod blocking {
         iterate(db_tx, request.iteration, get_classes_for_block, tx)
     }
 
+    #[tracing::instrument(skip(db_tx, tx))]
     pub(crate) fn get_state_diffs(
         db_tx: Transaction<'_>,
         request: StateDiffsRequest,
@@ -112,6 +115,7 @@ pub(crate) mod blocking {
         iterate(db_tx, request.iteration, get_state_diff, tx)
     }
 
+    #[tracing::instrument(skip(db_tx, tx))]
     pub(crate) fn get_transactions(
         db_tx: Transaction<'_>,
         request: TransactionsRequest,
@@ -120,6 +124,7 @@ pub(crate) mod blocking {
         iterate(db_tx, request.iteration, get_transactions_for_block, tx)
     }
 
+    #[tracing::instrument(skip(db_tx, tx))]
     pub(crate) fn get_events(
         db_tx: Transaction<'_>,
         request: EventsRequest,

--- a/crates/pathfinder/src/p2p_network/sync_handlers/conv.rs
+++ b/crates/pathfinder/src/p2p_network/sync_handlers/conv.rs
@@ -337,6 +337,11 @@ pub fn cairo_def_into_dto(cairo: Cairo<'_>) -> Cairo0Class {
         ),
     };
 
+    let mut gzip_encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+    serde_json::to_writer(&mut gzip_encoder, &cairo.program).unwrap();
+    let program = gzip_encoder.finish().unwrap();
+    let program = base64::encode(program);
+
     Cairo0Class {
         abi: cairo.abi.to_string(),
         externals: cairo
@@ -357,6 +362,6 @@ pub fn cairo_def_into_dto(cairo: Cairo<'_>) -> Cairo0Class {
             .into_iter()
             .map(into_dto)
             .collect(),
-        program: cairo.program.to_string(),
+        program,
     }
 }


### PR DESCRIPTION
The protocol expects the program of Cairo 0 classes to be represented as a Base64-encoded, gzip compressed JSON.

In addition to fixing that the PR also adds some tracing events/spans to sync handlers and a fix for logging errors.