### PR TITLE
fix: class block number is overwritten

### DIFF
--- a/crates/storage/src/connection/state_update.rs
+++ b/crates/storage/src/connection/state_update.rs
@@ -120,8 +120,9 @@ impl Transaction<'_> {
             .inner()
             .prepare_cached(
                 r"INSERT INTO class_definitions (block_number, hash) VALUES (?1, ?2)
-                ON CONFLICT(hash) WHERE block_number IS NULL
-                DO UPDATE SET block_number=excluded.block_number",
+                ON CONFLICT(hash)
+                    DO UPDATE SET block_number=excluded.block_number
+                    WHERE block_number IS NULL",
             )
             .context("Preparing class hash and block number upsert statement")?;
         // OR IGNORE is required to handle legacy syncing logic, where the casm


### PR DESCRIPTION
Starknet allows duplicate class declarations for V1 declares. We only store the latest declaration's block number whereas we should be storing the first.

This occurs due to an incorrect `WHERE` guard clause.

This PR adds a regression test (was red), and a fix (test now green).