### PR TITLE
fix(p2p/client/conv): fix Deploy/DeployAccount conversion

### DIFF
--- a/crates/pathfinder/src/p2p_network/sync_handlers/tests.rs
+++ b/crates/pathfinder/src/p2p_network/sync_handlers/tests.rs
@@ -425,15 +425,7 @@ mod prop {
                         header.header.number,
                         // List of tuples (TransactionVariant, Receipt)
                         transaction_data.into_iter().map(|(t, mut r, _)| {
-                            let mut tv = workaround::for_legacy_l1_handlers(t.variant);
-                            // P2P transactions don't carry contract address, so zero them just like `try_from_dto` does
-                            match &mut tv {
-                                TransactionVariant::DeployV0(x) => x.contract_address = ContractAddress::ZERO,
-                                TransactionVariant::DeployV1(x) => x.contract_address = ContractAddress::ZERO,
-                                TransactionVariant::DeployAccountV1(x) => x.contract_address = ContractAddress::ZERO,
-                                TransactionVariant::DeployAccountV3(x) => x.contract_address = ContractAddress::ZERO,
-                                _ => {}
-                            };
+                            let tv = workaround::for_legacy_l1_handlers(t.variant);
                             // P2P receipts don't carry transaction index
                             r.transaction_index = TransactionIndex::new_or_panic(0);
                             (tv, r.into())

--- a/crates/storage/src/connection/transaction.rs
+++ b/crates/storage/src/connection/transaction.rs
@@ -2063,12 +2063,25 @@ pub(crate) mod dto {
 
     impl<T> Dummy<T> for DeployTransaction {
         fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &T, rng: &mut R) -> Self {
+            let class_hash: MinimalFelt = Faker.fake_with_rng(rng);
+            let constructor_calldata: Vec<MinimalFelt> = Faker.fake_with_rng(rng);
+            let contract_address_salt: MinimalFelt = Faker.fake_with_rng(rng);
+
+            let contract_address = ContractAddress::deployed_contract_address(
+                constructor_calldata.iter().map(|f| CallParam(f.0)),
+                &ContractAddressSalt(contract_address_salt.0),
+                &ClassHash(class_hash.0),
+            )
+            .as_inner()
+            .to_owned()
+            .into();
+
             Self {
                 version: Felt::from_u64(rng.gen_range(0..=1)).into(),
-                contract_address: Faker.fake_with_rng(rng),
-                contract_address_salt: Faker.fake_with_rng(rng),
-                class_hash: Faker.fake_with_rng(rng),
-                constructor_calldata: Faker.fake_with_rng(rng),
+                contract_address,
+                contract_address_salt,
+                class_hash,
+                constructor_calldata,
             }
         }
     }
@@ -2084,11 +2097,24 @@ pub(crate) mod dto {
 
     impl<T> Dummy<T> for DeployTransactionV0 {
         fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &T, rng: &mut R) -> Self {
+            let class_hash: MinimalFelt = Faker.fake_with_rng(rng);
+            let constructor_calldata: Vec<MinimalFelt> = Faker.fake_with_rng(rng);
+            let contract_address_salt: MinimalFelt = Faker.fake_with_rng(rng);
+
+            let contract_address = ContractAddress::deployed_contract_address(
+                constructor_calldata.iter().map(|f| CallParam(f.0)),
+                &ContractAddressSalt(contract_address_salt.0),
+                &ClassHash(class_hash.0),
+            )
+            .as_inner()
+            .to_owned()
+            .into();
+
             Self {
-                contract_address: Faker.fake_with_rng(rng),
-                contract_address_salt: Faker.fake_with_rng(rng),
-                class_hash: Faker.fake_with_rng(rng),
-                constructor_calldata: Faker.fake_with_rng(rng),
+                contract_address,
+                contract_address_salt,
+                class_hash,
+                constructor_calldata,
             }
         }
     }
@@ -2104,11 +2130,24 @@ pub(crate) mod dto {
 
     impl<T> Dummy<T> for DeployTransactionV1 {
         fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &T, rng: &mut R) -> Self {
+            let class_hash: MinimalFelt = Faker.fake_with_rng(rng);
+            let constructor_calldata: Vec<MinimalFelt> = Faker.fake_with_rng(rng);
+            let contract_address_salt: MinimalFelt = Faker.fake_with_rng(rng);
+
+            let contract_address = ContractAddress::deployed_contract_address(
+                constructor_calldata.iter().map(|f| CallParam(f.0)),
+                &ContractAddressSalt(contract_address_salt.0),
+                &ClassHash(class_hash.0),
+            )
+            .as_inner()
+            .to_owned()
+            .into();
+
             Self {
-                contract_address: Faker.fake_with_rng(rng),
-                contract_address_salt: Faker.fake_with_rng(rng),
-                class_hash: Faker.fake_with_rng(rng),
-                constructor_calldata: Faker.fake_with_rng(rng),
+                contract_address,
+                contract_address_salt,
+                class_hash,
+                constructor_calldata,
             }
         }
     }


### PR DESCRIPTION
The `contract_address` field needs to be computed based on the constructor calldata, contract address salt and class hash of the transaction.
