### PR TITLE
feat(pathfinder): enable P2P sync client

### DIFF
--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/lib.rs"
 
 [features]
 tokio-console = ["console-subscriber", "tokio/tracing"]
-p2p = ["dep:base64", "dep:p2p", "dep:p2p_proto", "dep:zeroize"]
+p2p = []
 rpc-full-serde = []
 
 [dependencies]
@@ -21,7 +21,7 @@ anyhow = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
-base64 = { workspace = true, optional = true }
+base64 = { workspace = true }
 bitvec = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
@@ -35,8 +35,8 @@ jemallocator = { workspace = true }
 lazy_static = { workspace = true }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
-p2p = { path = "../p2p", optional = true }
-p2p_proto = { path = "../p2p_proto", optional = true }
+p2p = { path = "../p2p" }
+p2p_proto = { path = "../p2p_proto" }
 pathfinder-common = { path = "../common" }
 pathfinder-compiler = { path = "../compiler" }
 pathfinder-crypto = { path = "../crypto" }
@@ -70,7 +70,7 @@ tracing-subscriber = { workspace = true, features = [
     "ansi",
 ] }
 url = { workspace = true }
-zeroize = { workspace = true, optional = true }
+zeroize = { workspace = true }
 zstd = { workspace = true }
 
 [dev-dependencies]

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -590,6 +590,7 @@ pub struct Ethereum {
     pub password: Option<String>,
 }
 
+#[derive(Clone)]
 pub enum NetworkConfig {
     Mainnet,
     SepoliaTestnet,
@@ -602,6 +603,7 @@ pub enum NetworkConfig {
 }
 
 #[cfg(feature = "p2p")]
+#[derive(Clone)]
 pub struct P2PConfig {
     pub proxy: bool,
     pub identity_config_file: Option<std::path::PathBuf>,
@@ -616,6 +618,7 @@ pub struct P2PConfig {
 }
 
 #[cfg(not(feature = "p2p"))]
+#[derive(Clone)]
 pub struct P2PConfig;
 
 pub struct DebugConfig {

--- a/crates/pathfinder/src/lib.rs
+++ b/crates/pathfinder/src/lib.rs
@@ -2,7 +2,6 @@
 
 pub mod monitoring;
 pub mod state;
-mod sync;
+pub mod sync;
 
-#[cfg(feature = "p2p")]
 pub mod p2p_network;

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -494,6 +494,7 @@ async fn download_block(
             // Check if block hash is correct.
             let verify_hash = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
                 let block_number = block.block_number;
+
                 // In p2p the state commitment which is required to calculate the block hash can
                 // be missing, and in such case it is marked as 0s.
                 #[cfg(feature = "p2p")]

--- a/crates/pathfinder/src/sync.rs
+++ b/crates/pathfinder/src/sync.rs
@@ -1,7 +1,6 @@
-#![cfg(feature = "p2p")]
 #![allow(dead_code, unused)]
 
-use anyhow::{Chain, Context};
+use anyhow::Context;
 use p2p::client::peer_agnostic::Client as P2PClient;
 use pathfinder_common::ChainId;
 use primitive_types::H160;

--- a/crates/pathfinder/src/sync/class_definitions.rs
+++ b/crates/pathfinder/src/sync/class_definitions.rs
@@ -361,7 +361,7 @@ pub(super) async fn persist(
             .context("No class definitions to persist")?;
 
         for CompiledClass {
-            block_number,
+            block_number: _,
             definition,
             hash,
         } in classes.into_iter().map(|x| x.data)

--- a/crates/pathfinder/src/sync/transactions.rs
+++ b/crates/pathfinder/src/sync/transactions.rs
@@ -96,7 +96,7 @@ pub(super) fn counts_stream(
 }
 
 pub(super) async fn compute_hashes(
-    mut transactions: PeerData<TransactionBlockData>,
+    transactions: PeerData<TransactionBlockData>,
     chain_id: ChainId,
 ) -> Result<PeerData<TransactionsWithHashesForBlock>, SyncError> {
     Ok(tokio::task::spawn_blocking(move || {


### PR DESCRIPTION
This change makes _most_ of our code implementing P2P compile even without the "p2p" feature enabled and starts the P2P sync client instead of gateway sync if "p2p" is enabled unless the `p2p.proxy` CLI argument is enabled.

The actual enablement of P2P and related config options are still gated by the "p2p" feature so our release builds will still not contain any P2P functionality -- but conditional compilation is done only in the "pathfinder" crate.

(Note that the P2P sync client is not really functional yet without further fixes.)