### PR TITLE
feat(p2p): tracing for sync stages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4283,7 +4283,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -8491,9 +8491,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -8521,9 +8521,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/pathfinder/src/sync/class_definitions.rs
+++ b/crates/pathfinder/src/sync/class_definitions.rs
@@ -399,6 +399,8 @@ pub(super) async fn persist(
 pub struct VerifyClassHashes;
 
 impl ProcessStage for VerifyClassHashes {
+    const NAME: &'static str = "Classes::Verify";
+
     type Input = (DeclaredClasses, Vec<ClassWithLayout>);
     type Output = Vec<GwClassDefinition<'static>>;
 

--- a/crates/pathfinder/src/sync/events.rs
+++ b/crates/pathfinder/src/sync/events.rs
@@ -155,6 +155,8 @@ pub(super) async fn persist(
 pub struct VerifyCommitment;
 
 impl ProcessStage for VerifyCommitment {
+    const NAME: &'static str = "Events::Verify";
+
     type Input = (
         EventCommitment,
         Vec<TransactionHash>,

--- a/crates/pathfinder/src/sync/headers.rs
+++ b/crates/pathfinder/src/sync/headers.rs
@@ -147,6 +147,8 @@ impl ForwardContinuity {
 }
 
 impl ProcessStage for ForwardContinuity {
+    const NAME: &'static str = "Headers::Continuity";
+
     type Input = SignedBlockHeader;
     type Output = SignedBlockHeader;
 
@@ -176,6 +178,8 @@ impl BackwardContinuity {
 }
 
 impl ProcessStage for BackwardContinuity {
+    const NAME: &'static str = "Headers::Continuity";
+
     type Input = SignedBlockHeader;
     type Output = SignedBlockHeader;
 
@@ -194,6 +198,7 @@ impl ProcessStage for BackwardContinuity {
 }
 
 impl ProcessStage for VerifyHashAndSignature {
+    const NAME: &'static str = "Headers::Verify";
     type Input = SignedBlockHeader;
     type Output = SignedBlockHeader;
 
@@ -277,6 +282,7 @@ pub struct Persist {
 }
 
 impl ProcessStage for Persist {
+    const NAME: &'static str = "Headers::Persist";
     type Input = Vec<SignedBlockHeader>;
     type Output = ();
 

--- a/crates/pathfinder/src/sync/state_updates.rs
+++ b/crates/pathfinder/src/sync/state_updates.rs
@@ -141,6 +141,7 @@ pub(super) async fn persist(
 pub struct VerifyDiff;
 
 impl crate::sync::stream::ProcessStage for VerifyDiff {
+    const NAME: &'static str = "StateDiff::Continuity";
     type Input = StateUpdate;
     type Output = StateUpdate;
 

--- a/crates/pathfinder/src/sync/stream.rs
+++ b/crates/pathfinder/src/sync/stream.rs
@@ -94,10 +94,10 @@ impl<T: Send + 'static> SyncReceiver<T> {
                             .map_err(|e| PeerData::new(peer, e));
 
                         // Log trace and metrics.
-                        let throughput = count as f32 / t.elapsed().as_secs_f32();
+                        let elements_per_sec = count as f32 / t.elapsed().as_secs_f32();
                         let queue_fullness = queue_capacity - self.inner.capacity();
                         let input_queue = Fullness(queue_fullness, queue_capacity);
-                        tracing::debug!(stage=S::NAME, %input_queue, %throughput, "Item processed");
+                        tracing::debug!(stage=S::NAME, %input_queue, %elements_per_sec, "Item processed");
 
                         output
                     }

--- a/crates/pathfinder/src/sync/track.rs
+++ b/crates/pathfinder/src/sync/track.rs
@@ -105,7 +105,6 @@ where
         }
         .spawn()
         .pipe(events::VerifyCommitment, 10);
-
         let state_diff = StateDiffSource {
             p2p: self.p2p.clone(),
             headers: state_diff,
@@ -562,6 +561,7 @@ impl StoreBlock {
 }
 
 impl ProcessStage for StoreBlock {
+    const NAME: &'static str = "Blocks::Persist";
     type Input = BlockData;
     type Output = ();
 

--- a/crates/pathfinder/src/sync/transactions.rs
+++ b/crates/pathfinder/src/sync/transactions.rs
@@ -202,6 +202,7 @@ pub(super) async fn persist(
 pub struct CalculateHashes(pub ChainId);
 
 impl ProcessStage for CalculateHashes {
+    const NAME: &'static str = "Transactions::Hashes";
     type Input = (
         TransactionCommitment,
         Vec<(TransactionVariant, peer_agnostic::Receipt)>,
@@ -236,6 +237,7 @@ impl ProcessStage for CalculateHashes {
 pub struct VerifyCommitment;
 
 impl ProcessStage for VerifyCommitment {
+    const NAME: &'static str = "Transactions::Verify";
     type Input = (TransactionCommitment, Vec<(Transaction, Receipt)>);
     type Output = Vec<(Transaction, Receipt)>;
 


### PR DESCRIPTION
This PR adds tracing to the P2P sync stages.

Example trace looks something like this
```
DEBUG stage=Headers::Verify, input_queue=50%, (50/100), throughput=1234, Item processed
```

It displays the assigned stage name, the input queue fullness (both in percentage and actual amount) and the instantaneous throughput this iteration was processed at.

Things I'm on the fence about

- `throughput` is a misleading term here, but dunno what else to use
- the stage name could instead be `spans` which might be more appropriate?
- `Item processed` is quite generic and pointless

Its also unclear to me which metrics would be useful here. Probably both queue fullness and throughput would be something we want to measure. However, for metrics the consumer can also compute the averages if they want.

Also note that this throughput isn't measuring over the wait time for sending and receiving as blocking here could lead to misleading values.