### PR TITLE
fix(p2p_stream): change default request timeout

### DIFF
--- a/crates/p2p_stream/src/lib.rs
+++ b/crates/p2p_stream/src/lib.rs
@@ -244,7 +244,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            request_timeout: Duration::from_secs(10),
+            request_timeout: Duration::from_secs(60),
             max_concurrent_streams: 100,
         }
     }


### PR DESCRIPTION
10 seconds is not enough for streaming/processing all responses of a request for all transactions or classes of a 100 block range.

Currently there's a single timeout for the whole duration of the subchannel: that is the whole request/response stream has to be completed before timing out. Ideally we'd be implementing a different kind of timeout for the request-response protocol: one that only times out if no request is received or responses are received for some time.