### PR TITLE
refactor transaction checkpoint sync to use the stages framework

### DIFF
--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -358,7 +358,6 @@ impl Client {
                                         yield PeerData::new(
                                             peer,
                                             TransactionData {
-                                                block_number: start,
                                                 expected_commitment: std::mem::take(&mut current_commitment),
                                                 transactions: std::mem::take(&mut transactions),
                                             },
@@ -995,7 +994,6 @@ impl From<pathfinder_common::receipt::Receipt> for Receipt {
 /// For a single block
 #[derive(Clone, Debug)]
 pub struct TransactionData {
-    pub block_number: BlockNumber,
     pub expected_commitment: TransactionCommitment,
     pub transactions: Vec<(TransactionVariant, Receipt)>,
 }

--- a/crates/pathfinder/src/p2p_network/sync_handlers/tests.rs
+++ b/crates/pathfinder/src/p2p_network/sync_handlers/tests.rs
@@ -104,11 +104,7 @@ mod prop {
     use futures::channel::mpsc;
     use futures::StreamExt;
     use p2p::client::conv::{CairoDefinition, SierraDefinition, TryFromDto};
-    use p2p::client::peer_agnostic::{
-        Receipt,
-        SignedBlockHeader as P2PSignedBlockHeader,
-        TransactionBlockData,
-    };
+    use p2p::client::peer_agnostic::{Receipt, SignedBlockHeader as P2PSignedBlockHeader};
     use p2p_proto::class::{Class, ClassesRequest, ClassesResponse};
     use p2p_proto::common::{BlockNumberOrHash, Iteration};
     use p2p_proto::event::{EventsRequest, EventsResponse};
@@ -129,6 +125,7 @@ mod prop {
     use pathfinder_common::state_update::SystemContractUpdate;
     use pathfinder_common::transaction::TransactionVariant;
     use pathfinder_common::{
+        BlockNumber,
         CasmHash,
         ClassHash,
         ContractAddress,
@@ -427,7 +424,7 @@ mod prop {
                             (tv, r.into())
                         }).collect::<Vec<_>>()
                     )
-            ).collect::<Vec<TransactionBlockData>>();
+            ).collect::<Vec<(BlockNumber, Vec<(TransactionVariant, Receipt)>)>>();
             // Run the handler
             let request = TransactionsRequest { iteration: Iteration { start: BlockNumberOrHash::Number(start_block), limit, step, direction, } };
             let mut responses = Runtime::new().unwrap().block_on(async {

--- a/crates/pathfinder/src/sync/checkpoint.rs
+++ b/crates/pathfinder/src/sync/checkpoint.rs
@@ -289,10 +289,7 @@ async fn handle_transaction_stream(
         .spawn()
         .pipe(transactions::CalculateHashes(chain_id), 10)
         .pipe(transactions::VerifyCommitment, 10)
-        .pipe(
-            transactions::StoreTransactions::new(storage.connection()?, start),
-            10,
-        )
+        .pipe(transactions::Store::new(storage.connection()?, start), 10)
         .into_stream()
         .inspect_ok(|x| tracing::info!(tail=%x.data, "Transactions chunk synced"))
         .try_fold((), |_, _| std::future::ready(Ok(())))

--- a/crates/pathfinder/src/sync/checkpoint.rs
+++ b/crates/pathfinder/src/sync/checkpoint.rs
@@ -289,12 +289,8 @@ async fn handle_transaction_stream(
         .spawn()
         .pipe(transactions::CalculateHashes(chain_id), 10)
         .pipe(transactions::VerifyCommitment, 10)
-        .try_chunks(10, 10)
         .pipe(
-            transactions::StoreTransactions {
-                db: storage.connection()?,
-                start,
-            },
+            transactions::StoreTransactions::new(storage.connection()?, start),
             10,
         )
         .into_stream()

--- a/crates/pathfinder/src/sync/headers.rs
+++ b/crates/pathfinder/src/sync/headers.rs
@@ -260,24 +260,6 @@ impl VerifyHashAndSignature {
     }
 }
 
-pub fn spawn_header_source(
-    header_stream: impl futures::Stream<Item = PeerData<SignedBlockHeader>> + Send + 'static,
-) -> SyncReceiver<SignedBlockHeader> {
-    let (tx, rx) = tokio::sync::mpsc::channel(1);
-
-    tokio::spawn(async move {
-        let mut headers = Box::pin(header_stream);
-
-        while let Some(header) = headers.next().await {
-            if tx.send(Ok(header)).await.is_err() {
-                return;
-            }
-        }
-    });
-
-    SyncReceiver::from_receiver(rx)
-}
-
 pub struct Persist {
     pub connection: pathfinder_storage::Connection,
 }

--- a/crates/pathfinder/src/sync/stream.rs
+++ b/crates/pathfinder/src/sync/stream.rs
@@ -350,4 +350,19 @@ mod tests {
 
         assert_eq!(result, expected);
     }
+
+    #[tokio::test]
+    async fn short_circuit_on_source_error() {
+        let ok = Ok(PeerData::for_tests(0));
+        let err = Err(PeerData::for_tests(SyncError2::BadBlockHash));
+        let ok_unprocessed = Ok(PeerData::for_tests(1));
+
+        let input = vec![ok.clone(), err.clone(), ok_unprocessed];
+        let expected = vec![ok, err];
+
+        let source = Source::from_stream(futures::stream::iter(input));
+        let actual = source.spawn().into_stream().collect::<Vec<_>>().await;
+
+        assert_eq!(actual, expected);
+    }
 }

--- a/crates/pathfinder/src/sync/stream.rs
+++ b/crates/pathfinder/src/sync/stream.rs
@@ -248,7 +248,7 @@ where
         Self(stream)
     }
 
-    /// Short circuits on the first error.    
+    /// Short circuits on the first error.
     pub fn spawn(self) -> SyncReceiver<I> {
         let (tx, rx) = tokio::sync::mpsc::channel(1);
 

--- a/crates/pathfinder/src/sync/track.rs
+++ b/crates/pathfinder/src/sync/track.rs
@@ -87,7 +87,6 @@ where
         let transactions = TransactionSource {
             p2p: self.p2p.clone(),
             headers: transactions,
-            chain_id,
         }
         .spawn()
         .pipe(transactions::CalculateHashes(chain_id), 10)
@@ -307,7 +306,6 @@ impl HeaderFanout {
 struct TransactionSource {
     p2p: P2PClient,
     headers: BoxStream<'static, P2PBlockHeader>,
-    chain_id: ChainId,
 }
 
 impl TransactionSource {
@@ -319,11 +317,7 @@ impl TransactionSource {
     )> {
         let (tx, rx) = tokio::sync::mpsc::channel(1);
         tokio::spawn(async move {
-            let Self {
-                p2p,
-                mut headers,
-                chain_id,
-            } = self;
+            let Self { p2p, mut headers } = self;
 
             while let Some(header) = headers.next().await {
                 let (peer, mut transactions) = loop {

--- a/crates/pathfinder/src/sync/transactions.rs
+++ b/crates/pathfinder/src/sync/transactions.rs
@@ -161,12 +161,12 @@ impl ProcessStage for VerifyCommitment {
     }
 }
 
-pub struct StoreTransactions {
+pub struct Store {
     db: pathfinder_storage::Connection,
     current_block: BlockNumber,
 }
 
-impl StoreTransactions {
+impl Store {
     pub fn new(db: pathfinder_storage::Connection, start: BlockNumber) -> Self {
         Self {
             db,
@@ -175,7 +175,7 @@ impl StoreTransactions {
     }
 }
 
-impl ProcessStage for StoreTransactions {
+impl ProcessStage for Store {
     const NAME: &'static str = "Transactions::Persist";
     type Input = Vec<(Transaction, Receipt)>;
     type Output = BlockNumber;

--- a/crates/pathfinder/src/sync/transactions.rs
+++ b/crates/pathfinder/src/sync/transactions.rs
@@ -100,7 +100,6 @@ pub(super) fn counts_and_commitments_stream(
     }
 }
 
-
 pub struct CalculateHashes(pub ChainId);
 
 impl ProcessStage for CalculateHashes {

--- a/crates/pathfinder/src/sync/transactions.rs
+++ b/crates/pathfinder/src/sync/transactions.rs
@@ -100,34 +100,6 @@ pub(super) fn counts_and_commitments_stream(
     }
 }
 
-// pub(super) async fn persist(
-//     storage: Storage,
-//     transactions: Vec<PeerData<VerifiedTransactions>>,
-// ) -> Result<BlockNumber, SyncError> {
-//     tokio::task::spawn_blocking(move || {
-//         let mut db = storage
-//             .connection()
-//             .context("Creating database connection")?;
-//         let db = db.transaction().context("Creating database transaction")?;
-//         let tail = transactions
-//             .last()
-//             .map(|x| x.data.block_number)
-//             .context("Verification results are empty, no block to persist")?;
-
-//         for VerifiedTransactions {
-//             block_number,
-//             transactions,
-//         } in transactions.into_iter().map(|x| x.data)
-//         {
-//             db.insert_transaction_data(block_number, &transactions, None)
-//                 .context("Inserting transactions")?;
-//         }
-//         db.commit().context("Committing db transaction")?;
-//         Ok(tail)
-//     })
-//     .await
-//     .context("Joining blocking task")?
-// }
 
 pub struct CalculateHashes(pub ChainId);
 

--- a/crates/pathfinder/src/sync/transactions.rs
+++ b/crates/pathfinder/src/sync/transactions.rs
@@ -167,7 +167,7 @@ pub struct StoreTransactions {
 }
 
 impl ProcessStage for StoreTransactions {
-    const NAME: &'static str = "Transactions::Store";
+    const NAME: &'static str = "Transactions::Persist";
     type Input = Vec<Vec<(Transaction, Receipt)>>;
     type Output = BlockNumber;
 


### PR DESCRIPTION
Title :arrow_up: 

One major flow change:
- commitment verification does not require db reads because the expected commitment is streamed along expected transaction count