### PR TITLE
fix(pathfinder/sync/headers): fix header sync

### DIFF
--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -215,7 +215,7 @@ impl Client {
 
                 // Attempt each peer.
                 'next_peer: for peer in peers {
-                    let limit = start.get().max(stop.get()) - start.get().min(stop.get());
+                    let limit = start.get().max(stop.get()) - start.get().min(stop.get()) + 1;
 
                     let request = BlockHeadersRequest {
                         iteration: Iteration {

--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -206,15 +206,22 @@ impl Client {
             false => (start, stop, Direction::Forward),
         };
 
+        tracing::trace!(?start, ?stop, ?direction, "Streaming headers");
+
         async_stream::stream! {
             // Loop which refreshes peer set once we exhaust it.
-            loop {
+            'outer: loop {
                 let peers = self
                     .get_update_peers_with_sync_capability(protocol::Headers::NAME)
                     .await;
 
                 // Attempt each peer.
                 'next_peer: for peer in peers {
+
+                    if start == stop {
+                        break 'outer;
+                    }
+
                     let limit = start.get().max(stop.get()) - start.get().min(stop.get()) + 1;
 
                     let request = BlockHeadersRequest {

--- a/crates/pathfinder/src/sync/checkpoint.rs
+++ b/crates/pathfinder/src/sync/checkpoint.rs
@@ -135,7 +135,7 @@ impl Sync {
                 .await
                 .context("Finding next gap in header chain")?
         {
-            // TODO: create a tracing scope for this gap start, stop.
+            tracing::info!(?gap, "Syncing headers");
 
             handle_header_stream(
                 self.p2p.clone().header_stream(gap.tail, gap.head, true),

--- a/crates/pathfinder/src/sync/checkpoint.rs
+++ b/crates/pathfinder/src/sync/checkpoint.rs
@@ -795,28 +795,29 @@ mod tests {
             );
         }
 
-        #[tokio::test]
-        async fn bad_signature() {
-            let Setup {
-                streamed_headers,
-                storage,
-                head,
-                ..
-            } = setup().await;
+        // TODO readd once the signature verification is enabled
+        // #[tokio::test]
+        // async fn bad_signature() {
+        //     let Setup {
+        //         streamed_headers,
+        //         storage,
+        //         head,
+        //         ..
+        //     } = setup().await;
 
-            assert_matches!(
-                handle_header_stream(
-                    stream::iter(streamed_headers),
-                    head,
-                    Chain::SepoliaTestnet,
-                    ChainId::SEPOLIA_TESTNET,
-                    PublicKey::ZERO, // Invalid public key
-                    storage.clone(),
-                )
-                .await,
-                Err(SyncError::BadHeaderSignature(_))
-            );
-        }
+        //     assert_matches!(
+        //         handle_header_stream(
+        //             stream::iter(streamed_headers),
+        //             head,
+        //             Chain::SepoliaTestnet,
+        //             ChainId::SEPOLIA_TESTNET,
+        //             PublicKey::ZERO, // Invalid public key
+        //             storage.clone(),
+        //         )
+        //         .await,
+        //         Err(SyncError::BadHeaderSignature(_))
+        //     );
+        // }
 
         #[tokio::test]
         async fn db_failure() {

--- a/crates/pathfinder/src/sync/checkpoint.rs
+++ b/crates/pathfinder/src/sync/checkpoint.rs
@@ -138,7 +138,7 @@ impl Sync {
             // TODO: create a tracing scope for this gap start, stop.
 
             handle_header_stream(
-                self.p2p.clone().header_stream(gap.head, gap.tail, true),
+                self.p2p.clone().header_stream(gap.tail, gap.head, true),
                 gap.head(),
                 self.chain,
                 self.chain_id,

--- a/crates/pathfinder/src/sync/headers.rs
+++ b/crates/pathfinder/src/sync/headers.rs
@@ -227,7 +227,9 @@ impl ProcessStage for VerifyHashAndSignature {
         }
 
         if !self.verify_signature(&input) {
-            return Err(SyncError2::BadHeaderSignature);
+            // TODO: make this an error once state diff commitments and signatures are fixed
+            // on the feeder gateway return Err(SyncError2::BadHeaderSignature);
+            tracing::debug!(header=?input.header, "Header signature verification failed");
         }
 
         Ok(input)

--- a/crates/pathfinder/src/sync/stream.rs
+++ b/crates/pathfinder/src/sync/stream.rs
@@ -91,7 +91,10 @@ impl<T: Send + 'static> SyncReceiver<T> {
                         let output = stage
                             .map(data)
                             .map(|x| PeerData::new(peer, x))
-                            .map_err(|e| PeerData::new(peer, e));
+                            .map_err(|e| {
+                                tracing::debug!(error=%e, "Processing item failed");
+                                PeerData::new(peer, e)
+                            });
 
                         // Log trace and metrics.
                         let elements_per_sec = count as f32 / t.elapsed().as_secs_f32();


### PR DESCRIPTION
This PR fixes a few unrelated issues in header sync:

- finding the next gap to be synced
- stop condition for the sync
- start/stop point of the actual sync

It also temporarily disables signature verification as the signatures produced by the feeder gateway are invalid for some state diffs we produce due to feeder gateway bugs.

This is probably the easiest to review commit-by-commit.