### PR TITLE
fix(pathfinder/sync/transactions): fix transaction sync

### DIFF
--- a/crates/pathfinder/src/sync/class_definitions.rs
+++ b/crates/pathfinder/src/sync/class_definitions.rs
@@ -135,6 +135,10 @@ pub(super) fn declared_class_counts_stream(
 
             start += batch.len().try_into().expect("ptr size is 64bits");
         }
+
+        while let Some(counts) = batch.pop() {
+            yield counts;
+        }
     }
 }
 

--- a/crates/pathfinder/src/sync/state_updates.rs
+++ b/crates/pathfinder/src/sync/state_updates.rs
@@ -81,6 +81,10 @@ pub(super) fn state_diff_lengths_stream(
 
             start += batch.len().try_into().expect("ptr size is 64bits");
         }
+
+        while let Some(counts) = batch.pop_front() {
+            yield counts;
+        }
     }
 }
 

--- a/crates/pathfinder/src/sync/state_updates.rs
+++ b/crates/pathfinder/src/sync/state_updates.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::num::NonZeroUsize;
 
 use anyhow::Context;
@@ -42,10 +43,10 @@ pub(super) fn state_diff_lengths_stream(
     const BATCH_SIZE: usize = 1000;
 
     async_stream::try_stream! {
-        let mut batch = Vec::new();
+        let mut batch = VecDeque::new();
 
         while start <= stop_inclusive {
-            if let Some(counts) = batch.pop() {
+            if let Some(counts) = batch.pop_front() {
                 yield counts;
                 continue;
             }

--- a/crates/pathfinder/src/sync/transactions.rs
+++ b/crates/pathfinder/src/sync/transactions.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::num::NonZeroUsize;
 
 use anyhow::{anyhow, Context};
@@ -59,10 +59,10 @@ pub(super) fn counts_and_commitments_stream(
     const BATCH_SIZE: usize = 1000;
 
     async_stream::try_stream! {
-        let mut batch = Vec::new();
+        let mut batch = VecDeque::new();
 
         while start <= stop_inclusive {
-            if let Some(counts) = batch.pop() {
+            if let Some(counts) = batch.pop_front() {
                 yield counts;
                 continue;
             }

--- a/crates/pathfinder/src/sync/transactions.rs
+++ b/crates/pathfinder/src/sync/transactions.rs
@@ -97,6 +97,10 @@ pub(super) fn counts_and_commitments_stream(
 
             start += batch.len().try_into().expect("ptr size is 64bits");
         }
+
+        while let Some(counts) = batch.pop_front() {
+            yield counts;
+        }
     }
 }
 

--- a/crates/storage/src/connection/block.rs
+++ b/crates/storage/src/connection/block.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::num::NonZeroUsize;
 
 use anyhow::Context;
@@ -444,7 +445,7 @@ impl Transaction<'_> {
         &self,
         block: BlockId,
         max_len: NonZeroUsize,
-    ) -> anyhow::Result<Vec<(usize, TransactionCommitment)>> {
+    ) -> anyhow::Result<VecDeque<(usize, TransactionCommitment)>> {
         let Some((block_number, _)) = self.block_id(block).context("Querying block header")? else {
             return Ok(Default::default());
         };
@@ -466,15 +467,17 @@ impl Transaction<'_> {
             })
             .context("Querying event counts")?;
 
-        let mut ret = Vec::new();
+        let mut ret = VecDeque::new();
 
         while let Some(cc) = rows
             .next()
             .transpose()
             .context("Iterating over rows of transaction counts & commitments")?
         {
-            ret.push(cc);
+            ret.push_back(cc);
         }
+
+        tracing::trace!(?ret, "Transaction counts");
 
         Ok(ret)
     }

--- a/crates/storage/src/connection/block.rs
+++ b/crates/storage/src/connection/block.rs
@@ -453,8 +453,8 @@ impl Transaction<'_> {
         let mut stmt = self
             .inner()
             .prepare_cached(
-                "SELECT (transaction_count, transaction_commitment) FROM block_headers WHERE \
-                 number >= ? ORDER BY number ASC LIMIT ?",
+                "SELECT transaction_count, transaction_commitment FROM block_headers WHERE number \
+                 >= ? ORDER BY number ASC LIMIT ?",
             )
             .context("Preparing get transaction counts statement")?;
 

--- a/crates/storage/src/connection/state_update.rs
+++ b/crates/storage/src/connection/state_update.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::num::NonZeroUsize;
 
 use anyhow::Context;
@@ -463,12 +463,11 @@ impl Transaction<'_> {
             .context("Querying highest storage update")
     }
 
-    /// Items are sorted in descending order.
     pub fn state_diff_lengths(
         &self,
         start: BlockNumber,
         max_num_blocks: NonZeroUsize,
-    ) -> anyhow::Result<Vec<usize>> {
+    ) -> anyhow::Result<VecDeque<usize>> {
         let mut stmt = self
             .inner()
             .prepare_cached(
@@ -481,13 +480,11 @@ impl Transaction<'_> {
             .query_map(params![&start, &max_len], |row| row.get(0))
             .context("Querying state diff lengths")?;
 
-        let mut ret = Vec::new();
+        let mut ret = VecDeque::new();
 
         while let Some(stat) = counts.next().transpose().context("Iterating over rows")? {
-            ret.push(stat);
+            ret.push_back(stat);
         }
-
-        ret.reverse();
 
         Ok(ret)
     }


### PR DESCRIPTION
This PR fixes a few unrelated issues in transaction sync:

- queries returning counts from the block header now return data in-order in a VecDeque
- "counts" streams now pop the next element off of the front of the queue
- "counts" streams now properly yield all elements from the last chunk
- SQL query for transaction counts / commitments contained a syntax error
- `peer_agnostic::Client::transaction_stream()` should handle FIN as the stream termination, not as a block separator