### PR TITLE
fix(pathfinder/sync/state_updates): fix state update sync

### DIFF
--- a/crates/common/src/state_update.rs
+++ b/crates/common/src/state_update.rs
@@ -302,6 +302,13 @@ impl StateUpdateData {
             &self.declared_sierra_classes,
         )
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.contract_updates.is_empty()
+            && self.system_contract_updates.is_empty()
+            && self.declared_cairo_classes.is_empty()
+            && self.declared_sierra_classes.is_empty()
+    }
 }
 
 impl From<StateUpdate> for StateUpdateData {

--- a/crates/pathfinder/src/sync/state_updates.rs
+++ b/crates/pathfinder/src/sync/state_updates.rs
@@ -26,10 +26,14 @@ pub(super) async fn next_missing(
 
         let highest = db
             .highest_block_with_state_update()
-            .context("Querying highest block with state update")?
-            .unwrap_or_default();
+            .context("Querying highest block with state update")?;
 
-        Ok((highest < head).then_some(highest + 1))
+        match highest {
+            // No state updates at all, start from genesis
+            None => Ok((head != BlockNumber::GENESIS).then_some(BlockNumber::GENESIS)),
+            // Otherwise start from the next block
+            Some(highest) => Ok((highest < head).then_some(highest + 1)),
+        }
     })
     .await
     .context("Joining blocking task")?

--- a/crates/pathfinder/src/sync/state_updates.rs
+++ b/crates/pathfinder/src/sync/state_updates.rs
@@ -111,6 +111,7 @@ pub(super) async fn verify_commitment(
         let actual = state_diff.data.1.compute_state_diff_commitment();
 
         if actual != expected {
+            tracing::trace!(%block_number, %expected, %actual, state_diff=?state_diff.data.1, "State diff commitment mismatch");
             return Err(SyncError::StateDiffCommitmentMismatch(state_diff.peer));
         }
 
@@ -135,6 +136,7 @@ pub(super) async fn persist(
             .context("Verification results are empty, no block to persist")?;
 
         for (block_number, state_diff) in state_diff.into_iter().map(|x| x.data) {
+            tracing::trace!(%block_number, "Inserting state update");
             db.insert_state_update_data(block_number, &state_diff)
                 .context("Inserting state update")?;
         }

--- a/crates/storage/src/connection/state_update.rs
+++ b/crates/storage/src/connection/state_update.rs
@@ -519,7 +519,7 @@ impl Transaction<'_> {
             .inner()
             .prepare_cached(
                 r"
-                SELECT COUNT(definition)
+                SELECT COUNT(block_number)
                 FROM canonical_blocks
                 LEFT JOIN class_definitions ON canonical_blocks.number = class_definitions.block_number
                 WHERE number >= ?

--- a/crates/storage/src/connection/state_update.rs
+++ b/crates/storage/src/connection/state_update.rs
@@ -456,10 +456,14 @@ impl Transaction<'_> {
 
     pub fn highest_block_with_state_update(&self) -> anyhow::Result<Option<BlockNumber>> {
         let mut stmt = self.inner().prepare_cached(
-            r"SELECT block_number FROM storage_updates ORDER BY block_number DESC LIMIT 1",
+            r"
+            SELECT max(storage_update.last_block, nonce_update.last_block, class_definition.last_block) 
+            FROM
+                (SELECT max(block_number) last_block FROM storage_updates) storage_update,
+                (SELECT max(block_number) last_block FROM nonce_updates) nonce_update,
+                (SELECT max(block_number) last_block FROM class_definitions) class_definition",
         )?;
-        stmt.query_row([], |row| row.get_block_number(0))
-            .optional()
+        stmt.query_row([], |row| row.get_optional_block_number(0))
             .context("Querying highest storage update")
     }
 


### PR DESCRIPTION
This PR fixes a few unrelated issues in state update sync:

- querying the highest block with a state update should check nonces and class definitions in addition to storage updates
- counting declared classes for a block cannot use `definition` for the counting because unsynced classes have their definition set to NULL
- fix finding the start of the state update gap: now handles the case where there are no updates at all
- `peer_agnostic::Client::state_diff_stream()` should handle FIN as the stream terminator, not as a block delimiter