### PR TITLE
fix(pathfinder/sync/class_definitions): fix class definitions sync

### DIFF
--- a/crates/pathfinder/src/sync/class_definitions.rs
+++ b/crates/pathfinder/src/sync/class_definitions.rs
@@ -291,6 +291,10 @@ pub(super) fn verify_declared_at(
                     tracing::info!(hash=%class.data.hash, block_number=%class.data.block_number, "Class was not expected in this block");
                     Err(SyncError::UnexpectedClass(class.peer))?;
                 }
+
+                if declared.is_empty() {
+                    break;
+                }
             }
 
         }

--- a/crates/pathfinder/src/sync/class_definitions.rs
+++ b/crates/pathfinder/src/sync/class_definitions.rs
@@ -78,12 +78,12 @@ pub(super) async fn next_missing(
             .context("Creating database connection")?;
         let db = db.transaction().context("Creating database transaction")?;
 
-        let highest = db
-            .highest_block_with_all_class_definitions_downloaded()
-            .context("Querying highest block with any class definitions")?
+        let next_missing = db
+            .first_block_with_missing_class_definitions()
+            .context("Querying first block number with missing class definitions")?
             .unwrap_or_default();
 
-        Ok((highest < head).then_some(highest + 1))
+        Ok((next_missing <= head).then_some(next_missing))
     })
     .await
     .context("Joining blocking task")?

--- a/crates/storage/src/connection/block.rs
+++ b/crates/storage/src/connection/block.rs
@@ -373,25 +373,18 @@ impl Transaction<'_> {
         }
     }
 
-    pub fn highest_block_with_all_class_definitions_downloaded(
+    pub fn first_block_with_missing_class_definitions(
         &self,
     ) -> anyhow::Result<Option<BlockNumber>> {
         let mut stmt = self.inner().prepare_cached(
-            r"SELECT block_headers.number
-        FROM block_headers
-        JOIN (
-            SELECT COUNT(1) as count, block_number
+            r"
+            SELECT min(block_number)
             FROM class_definitions
-            GROUP BY block_number
-            ORDER BY block_number DESC
-        )
-        ON block_headers.number = block_number
-        WHERE block_headers.declared_classes_count = count
-        ORDER BY block_headers.number DESC LIMIT 1",
+            WHERE definition IS NULL",
         )?;
         stmt.query_row([], |row| row.get_block_number(0))
             .optional()
-            .context("Querying highest block with all class definitions downloaded")
+            .context("Querying first block with missing class definitions")
     }
 
     pub fn highest_block_with_all_events_downloaded(&self) -> anyhow::Result<Option<BlockNumber>> {


### PR DESCRIPTION
This PR fixes a few unrelated issues in class definition sync:

- finding class definition gap: there was an error in the SQL query and an off-by-one in `next_missing()`
- `verify_declared_at()` did not properly go on to the next block after processing all declared classes
- `peer_agnostic::Client::class_definitions_stream()` now handles FIN as the terminator of the response stream
- `peer_agnostic::Client::class_definitions_stream()` did not handle class definition counts of zero (that is, blocks that did not declare classes)