### PR TITLE
feat(sync): add `BufferStage`

### DIFF
--- a/crates/pathfinder/src/sync/stream.rs
+++ b/crates/pathfinder/src/sync/stream.rs
@@ -28,12 +28,11 @@ pub trait ProcessStage {
 }
 
 pub trait BufferStage {
-    type T;
-    type Meta;
+    type AdditionalData;
 
     const TOO_FEW_ERROR: SyncError2;
 
-    fn next_amount(&mut self) -> Option<(usize, Self::Meta)>;
+    fn next_amount(&mut self) -> Option<(usize, Self::AdditionalData)>;
 }
 
 impl<T: Send + 'static> ChunkSyncReceiver<T> {
@@ -126,11 +125,10 @@ impl<T: Send + 'static> SyncReceiver<T> {
         SyncReceiver::from_receiver(rx)
     }
 
-    fn buffer<S>(mut self, mut stage: S, buffer: usize) -> SyncReceiver<(Vec<T>, S::Meta)>
+    fn buffer<S>(mut self, mut stage: S, buffer: usize) -> SyncReceiver<(Vec<T>, S::AdditionalData)>
     where
-        S: BufferStage<T = T> + Send + 'static,
-        S::T: Send,
-        S::Meta: Send,
+        S: BufferStage + Send + 'static,
+        S::AdditionalData: Send,
     {
         let (tx, rx) = tokio::sync::mpsc::channel(buffer);
 

--- a/crates/pathfinder/src/sync/transactions.rs
+++ b/crates/pathfinder/src/sync/transactions.rs
@@ -230,7 +230,7 @@ impl BufferStage for DatabaseBlockBuffer {
                 tracing::warn!(%error, block=%self.block, "Failed to read transaction count and commitment");
             })
             .ok()?
-            .pop();
+            .pop_front();
 
         if amount.is_none() {
             tracing::warn!(block=%self.block, "No transaction count and commitment found in database.");

--- a/crates/pathfinder/src/sync/transactions.rs
+++ b/crates/pathfinder/src/sync/transactions.rs
@@ -210,11 +210,10 @@ pub struct DatabaseBlockBuffer {
 }
 
 impl BufferStage for DatabaseBlockBuffer {
-    type T = TransactionData;
-    type Meta = TransactionCommitment;
+    type AdditionalData = TransactionCommitment;
     const TOO_FEW_ERROR: SyncError2 = SyncError2::TooFewTransactions;
 
-    fn next_amount(&mut self) -> Option<(usize, Self::Meta)> {
+    fn next_amount(&mut self) -> Option<(usize, Self::AdditionalData)> {
         if self.block > self.end {
             return None;
         }


### PR DESCRIPTION
This PR adds the `BufferStage` trait to the sync stages framework.

This trait and its associated `SyncReceiver::buffer` method abstracts over the common pattern of taking a p2p element stream and transforming it into a stream of block data.

The abstraction is not entirely perfect; but I think this will help simplify things.

As a demonstration I've implemented this (somewhat hackily) for the transaction checkpoint sync (without connecting it to anything yet). For tracking sync, we would implement something similar that simply receives these counts from the header fanout.

Transaction source from p2p then becomes a normal transaction stream, which is then connected to one the above stages.