### PR TITLE
fix: fix multiple issues in P2P checkpoint sync

### DIFF
--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -782,6 +782,10 @@ impl Client {
                                 );
                             }
 
+                            if start == stop_inclusive {
+                                break 'outer;
+                            }
+
                             start += 1;
                             current_count = declared_class_counts_stream.next().await
                                 .ok_or_else(|| anyhow::anyhow!("Declared class counts stream terminated prematurely at block {start}"))??;

--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -218,8 +218,17 @@ impl Client {
                 // Attempt each peer.
                 'next_peer: for peer in peers {
 
-                    if start == stop {
-                        break 'outer;
+                    match direction {
+                        Direction::Forward => {
+                            if start >= stop {
+                                break 'outer;
+                            }
+                        }
+                        Direction::Backward => {
+                            if start <= stop {
+                                break 'outer;
+                            }
+                        }
                     }
 
                     let limit = start.get().max(stop.get()) - start.get().min(stop.get()) + 1;

--- a/crates/pathfinder/src/sync/class_definitions.rs
+++ b/crates/pathfinder/src/sync/class_definitions.rs
@@ -80,10 +80,12 @@ pub(super) async fn next_missing(
 
         let next_missing = db
             .first_block_with_missing_class_definitions()
-            .context("Querying first block number with missing class definitions")?
-            .unwrap_or_default();
+            .context("Querying first block number with missing class definitions")?;
 
-        Ok((next_missing <= head).then_some(next_missing))
+        match next_missing {
+            Some(next_missing) if next_missing <= head => Ok(Some(next_missing)),
+            Some(_) | None => Ok(None),
+        }
     })
     .await
     .context("Joining blocking task")?

--- a/crates/storage/src/connection/block.rs
+++ b/crates/storage/src/connection/block.rs
@@ -382,8 +382,7 @@ impl Transaction<'_> {
             FROM class_definitions
             WHERE definition IS NULL",
         )?;
-        stmt.query_row([], |row| row.get_block_number(0))
-            .optional()
+        stmt.query_row([], |row| row.get_optional_block_number(0))
             .context("Querying first block with missing class definitions")
     }
 


### PR DESCRIPTION
This PR fixes the following issues in our checkpoint sync implementation:

- Finding the next missing class definition now correctly handles the case where there are no missing classes.
- Class definition stream should not pull the next count if it has already reached the end of the gap.
- Header stream should properly terminate both for forward and backward streaming.