### PR TITLE
fix(pathfinder/sync/events): fix events sync

### DIFF
--- a/crates/pathfinder/src/sync/events.rs
+++ b/crates/pathfinder/src/sync/events.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::num::NonZeroUsize;
 
 use anyhow::Context;
@@ -49,10 +49,10 @@ pub(super) fn counts_stream(
     const BATCH_SIZE: usize = 1000;
 
     async_stream::try_stream! {
-        let mut batch = Vec::new();
+        let mut batch = VecDeque::new();
 
         while start <= stop_inclusive {
-            if let Some(counts) = batch.pop() {
+            if let Some(counts) = batch.pop_front() {
                 yield counts;
                 continue;
             }

--- a/crates/pathfinder/src/sync/events.rs
+++ b/crates/pathfinder/src/sync/events.rs
@@ -87,6 +87,10 @@ pub(super) fn counts_stream(
 
             start += batch.len().try_into().expect("ptr size is 64bits");
         }
+
+        while let Some(counts) = batch.pop_front() {
+            yield counts;
+        }
     }
 }
 

--- a/crates/storage/src/connection/block.rs
+++ b/crates/storage/src/connection/block.rs
@@ -402,7 +402,7 @@ impl Transaction<'_> {
         &self,
         block: BlockId,
         max_len: NonZeroUsize,
-    ) -> anyhow::Result<Vec<usize>> {
+    ) -> anyhow::Result<VecDeque<usize>> {
         let Some((block_number, _)) = self.block_id(block).context("Querying block header")? else {
             return Ok(Default::default());
         };
@@ -420,14 +420,14 @@ impl Transaction<'_> {
             .query_map(params![&block_number, &max_len], |row| row.get(0))
             .context("Querying event counts")?;
 
-        let mut ret = Vec::new();
+        let mut ret = VecDeque::new();
 
         while let Some(stat) = counts
             .next()
             .transpose()
             .context("Iterating over event counts rows")?
         {
-            ret.push(stat);
+            ret.push_back(stat);
         }
 
         Ok(ret)

--- a/crates/storage/src/connection/event.rs
+++ b/crates/storage/src/connection/event.rs
@@ -68,13 +68,14 @@ pub struct PageOfEvents {
 }
 
 impl Transaction<'_> {
-    pub(super) fn insert_block_events<'a>(
+    pub(super) fn upsert_block_events<'a>(
         &self,
         block_number: BlockNumber,
         events: impl Iterator<Item = &'a Event>,
     ) -> anyhow::Result<()> {
         let mut stmt = self.inner().prepare_cached(
-            "INSERT INTO starknet_events_filters (block_number, bloom) VALUES (?, ?)",
+            "INSERT INTO starknet_events_filters (block_number, bloom) VALUES (?, ?) ON CONFLICT \
+             DO UPDATE SET bloom=excluded.bloom",
         )?;
 
         let mut bloom = BloomFilter::new();

--- a/crates/storage/src/connection/transaction.rs
+++ b/crates/storage/src/connection/transaction.rs
@@ -157,7 +157,7 @@ impl Transaction<'_> {
 
         if let Some(events) = events {
             let events = events.iter().flatten();
-            self.insert_block_events(block_number, events)
+            self.upsert_block_events(block_number, events)
                 .context("Inserting events into Bloom filter")?;
         }
 
@@ -199,7 +199,7 @@ impl Transaction<'_> {
         ])
         .context("Updating events")?;
 
-        self.insert_block_events(block_number, events.iter().flatten())
+        self.upsert_block_events(block_number, events.iter().flatten())
             .context("Inserting events into Bloom filter")?;
 
         Ok(())


### PR DESCRIPTION
This PR fixes a few issues in checkpoint events sync:

- Fix ordering of per-block event counts in the event counts stream.
- The event counts stream no longer loses the last chunk of counts.
- The per-block Bloom filters are now properly updated when inserting events, also fixing the function finding the next gap to be synced.
- peer_agnostic::Client::events_stream() now handles FIN as the terminator of the response stream
