### PR TITLE
demo: p2p source abstraction

### DIFF
--- a/crates/pathfinder/src/sync.rs
+++ b/crates/pathfinder/src/sync.rs
@@ -11,6 +11,7 @@ mod class_definitions;
 mod error;
 mod events;
 mod headers;
+mod source;
 mod state_updates;
 mod stream;
 mod track;

--- a/crates/pathfinder/src/sync/source.rs
+++ b/crates/pathfinder/src/sync/source.rs
@@ -1,0 +1,133 @@
+use futures::stream::{BoxStream, FusedStream};
+use futures::{Stream, StreamExt};
+use p2p::client::peer_agnostic::PartialReceipt;
+use p2p::libp2p::PeerId;
+use p2p::PeerData;
+use pathfinder_common::prelude::*;
+use pathfinder_common::transaction::TransactionVariant;
+
+use crate::sync::error::SyncError2;
+use crate::sync::stream::SyncReceiver;
+
+type P2PClient = p2p::client::peer_agnostic::Client;
+
+pub struct TransactionSource {
+    p2p: P2PClient,
+    target: BoxStream<'static, BlockNumber>,
+    start: BlockNumber,
+    counts: BoxStream<'static, (usize, TransactionCommitment)>,
+}
+
+impl TransactionSource {
+    pub fn checkpoint(
+        p2p: P2PClient,
+        start: BlockNumber,
+        stop: BlockNumber,
+        counts: impl Stream<Item = (usize, TransactionCommitment)> + Send + 'static,
+    ) -> Self {
+        Self::track(
+            p2p,
+            start,
+            counts,
+            futures::stream::once(async move { stop }),
+        )
+    }
+
+    pub fn track(
+        p2p: P2PClient,
+        start: BlockNumber,
+        counts: impl Stream<Item = (usize, TransactionCommitment)> + Send + 'static,
+        target: impl Stream<Item = BlockNumber> + Send + 'static,
+    ) -> Self {
+        Self {
+            p2p,
+            start,
+            target: target.boxed(),
+            counts: counts.boxed(),
+        }
+    }
+
+    pub fn spawn(
+        mut self,
+        buffer: usize,
+    ) -> SyncReceiver<Vec<(TransactionVariant, PartialReceipt)>> {
+        let (tx, rx) = tokio::sync::mpsc::channel(buffer);
+
+        tokio::spawn(async move {
+            let mut stream = None;
+
+            while let Some(target) = self.target.next().await {
+                for block in self.start.get()..=target.get() {
+                    let Some((count, commitment)) = self.counts.next().await else {
+                        tracing::warn!(%block, %target, "Counts stream ended prematurely");
+                        return;
+                    };
+
+                    // Keep retrying stream until we succeed.
+                    //
+                    // If we don't isolate this process we might accidentily skip a count/commitment
+                    // in the case where the block doesn't actually complete
+                    // succesfully.
+                    'block: loop {
+                        // Refresh the stream if required. This would occur if the previous stream
+                        // ended, either naturally (e.g. peer ran out of relevant data), or because
+                        // we encountered an error in the stream.
+                        let (peer, ref mut stream) = match &mut stream {
+                            None => {
+                                let (peer, data) = self
+                                    .p2p
+                                    .clone()
+                                    .transactions_stream2(self.start, target)
+                                    .await;
+
+                                tracing::debug!(%peer, "Opened stream");
+                                stream = Some((peer, data));
+                                continue;
+                            }
+                            Some(ref mut x) => x,
+                        };
+
+                        let mut data = Vec::with_capacity(count);
+                        for i in 0..count {
+                            let Some(item) = stream.next().await else {
+                                // It is legal for a peer to end on a block boundary.
+                                if i == 0 {
+                                    continue 'block;
+                                } else {
+                                    // The peer short-changed us.
+                                    _ = tx
+                                        .send(Err(PeerData::new(
+                                            peer.clone(),
+                                            SyncError2::TooFewTransactions,
+                                        )))
+                                        .await;
+                                    return;
+                                }
+                            };
+
+                            match item {
+                                Ok(x) => data.push(x),
+                                Err(err) => {
+                                    _ = tx.send(Err(PeerData::new(peer.clone(), err.into()))).await;
+                                    return;
+                                }
+                            };
+                        }
+
+                        if tx
+                            .send(Ok(PeerData::new(peer.clone(), data)))
+                            .await
+                            .is_err()
+                        {
+                            return;
+                        }
+
+                        self.start += 1;
+                    }
+                }
+            }
+        });
+
+        SyncReceiver::from_receiver(rx)
+    }
+}


### PR DESCRIPTION
This is intended as a possible blueprint for abstracting over p2p sources. The current issue is that there are many corner cases in how raw p2p streams are transformed into a stream of block's of items.

Ideally we would have a single source of truth which does this robustly. This PR is an attempt at implementing this for transactions -- however it should be possible to extrapolate this to all streams (maybe excluding headers - but since those are already "blockified" they matter less).

This PR introduces three things, the first two being fairly minor but still nice to consider

1. `PartialReceipt` as a wrapper around `Receipt`. p2p receipts aren't complete ito information as we require the transaction index - which is only available after blockification. However, constantly adding new types is cumbersome, so this is a neat way of "hiding" the data until it is completed.
2. limit the stream from p2p client. I think ideally this would __only__ perform a single stream attempt from one random peer. This moves the retry logic etc out to sync which simplifies things.
3. A single `TransactionSource` which can be spawned as either tracking or checkpoint mode, utilising the same underlying code.

### Elaborating on (3) as that's the actual core idea

It should be possible to abstract out all transaction specific parts into one or more traits. Similarly, (1) should also be abstractable in the same way - the only real difference is which protocol is used - just create a `StreamKind` enum and abstract over that. 

I would suggest excluding headers, though it should also be possible to shoehorn them in here.. but probably not needed.

Something to also consider is that something like the state diffs probably want a different output format than `Vec<T>` -- that could be built into the abstraction, or just handled by the following stage. Similarly, the counting will need to be specialised, I don't think state diff counts are a 1-1 mapping. But this is easily solved via `fn count(&T) -> usize` method.

Example of the abstraction trait

```rust
trait Source {
   type Input;
   
   // Defines the stream string to pass to p2p.
   const KIND: StreamKind;

   fn count(&Self::Input) -> usize;
}
```