### PR TITLE
feat(rpc/executor): fall back to feeder gateway for traces for Starknet <0.13.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `starknet_getBlockWithTxHashes` and `starknet_getBlockWithTxs` returns the pending block with a `status` property that's not in the JSON-RPC specification. This has been fixed for the JSON-RPC 0.7 API endpoint.
+- `starknet_traceBlockTransactions` and `starknet_traceTransaction` now falls back to fetching the trace from the feeder gateway for all blocks before Starknet 0.13.1.1.
 
 ### Added
 

--- a/crates/rpc/src/executor.rs
+++ b/crates/rpc/src/executor.rs
@@ -23,7 +23,7 @@ impl From<anyhow::Error> for ExecutionStateError {
 }
 
 pub const VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEWAY:
-    StarknetVersion = StarknetVersion::new(0, 13, 0, 0);
+    StarknetVersion = StarknetVersion::new(0, 13, 1, 1);
 
 pub(crate) fn map_broadcasted_transaction(
     transaction: &BroadcastedTransaction,

--- a/crates/rpc/src/v04/method/simulate_transactions.rs
+++ b/crates/rpc/src/v04/method/simulate_transactions.rs
@@ -852,7 +852,7 @@ pub(crate) mod tests {
             use super::dto::*;
             use super::*;
 
-            const DECLARE_GAS_CONSUMED: u64 = 2768;
+            const DECLARE_GAS_CONSUMED: u64 = 3632;
 
             pub fn declare(
                 account_contract_address: ContractAddress,
@@ -963,7 +963,7 @@ pub(crate) mod tests {
                 }
             }
 
-            const UNIVERSAL_DEPLOYER_GAS_CONSUMED: u64 = 3020;
+            const UNIVERSAL_DEPLOYER_GAS_CONSUMED: u64 = 3009;
 
             pub fn universal_deployer(
                 account_contract_address: ContractAddress,
@@ -1210,7 +1210,7 @@ pub(crate) mod tests {
                 }
             }
 
-            const INVOKE_GAS_CONSUMED: u64 = 1674;
+            const INVOKE_GAS_CONSUMED: u64 = 1664;
 
             pub fn invoke(
                 account_contract_address: ContractAddress,
@@ -1415,16 +1415,6 @@ pub(crate) mod tests {
         )
     }
 
-    pub(crate) async fn setup_storage() -> (
-        Storage,
-        BlockHeader,
-        ContractAddress,
-        ContractAddress,
-        StorageValue,
-    ) {
-        setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 0, 0)).await
-    }
-
     #[test_log::test(tokio::test)]
     async fn declare_deploy_and_invoke_sierra_class() {
         let (
@@ -1433,7 +1423,7 @@ pub(crate) mod tests {
             account_contract_address,
             universal_deployer_address,
             test_storage_value,
-        ) = setup_storage().await;
+        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 1)).await;
         let context = RpcContext::for_tests().with_storage(storage);
 
         let input = SimulateTransactionInput {
@@ -1476,7 +1466,7 @@ pub(crate) mod tests {
             account_contract_address,
             universal_deployer_address,
             test_storage_value,
-        ) = setup_storage().await;
+        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 1)).await;
         let context = RpcContext::for_tests().with_storage(storage);
 
         let input = SimulateTransactionInput {
@@ -1517,7 +1507,7 @@ pub(crate) mod tests {
             account_contract_address,
             universal_deployer_address,
             test_storage_value,
-        ) = setup_storage().await;
+        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 1)).await;
         let context = RpcContext::for_tests().with_storage(storage);
 
         let input = SimulateTransactionInput {

--- a/crates/rpc/src/v05/method/simulate_transactions.rs
+++ b/crates/rpc/src/v05/method/simulate_transactions.rs
@@ -549,7 +549,7 @@ pub mod dto {
 #[cfg(test)]
 pub(crate) mod tests {
     use pathfinder_common::macro_prelude::*;
-    use pathfinder_common::{felt, ClassHash, StorageValue, TransactionVersion};
+    use pathfinder_common::{felt, ClassHash, StarknetVersion, StorageValue, TransactionVersion};
     use starknet_gateway_test_fixtures::class_definitions::{
         DUMMY_ACCOUNT_CLASS_HASH,
         ERC20_CONTRACT_DEFINITION_CLASS_HASH,
@@ -562,7 +562,7 @@ pub(crate) mod tests {
     };
     use crate::v02::types::ContractClass;
     use crate::v03::method::get_state_update::types::{DeployedContract, Nonce, StateDiff};
-    pub(crate) use crate::v04::method::simulate_transactions::tests::setup_storage;
+    pub(crate) use crate::v04::method::simulate_transactions::tests::setup_storage_with_starknet_version;
     use crate::v05::method::call::FunctionCall;
 
     #[tokio::test]
@@ -681,7 +681,8 @@ pub(crate) mod tests {
 
         assert_eq!(contract_class.class_hash().unwrap().hash(), CAIRO0_HASH);
 
-        let (storage, last_block_header, account_contract_address, _, _) = setup_storage().await;
+        let (storage, last_block_header, account_contract_address, _, _) =
+            setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 1)).await;
         let context = RpcContext::for_tests().with_storage(storage);
 
         let declare = BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V1(
@@ -703,7 +704,7 @@ pub(crate) mod tests {
 
         let result = simulate_transactions(context, input).await.unwrap();
 
-        const DECLARE_GAS_CONSUMED: u64 = 1666;
+        const DECLARE_GAS_CONSUMED: u64 = 2225;
         use super::dto::*;
         use crate::v03::method::get_state_update::types::{StorageDiff, StorageEntry};
 
@@ -771,7 +772,7 @@ pub(crate) mod tests {
                             storage_entries: vec![
                                 StorageEntry {
                                     key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                                    value: storage_value!("0x000000000000000000000000000000000000fffffffffffffffffffffffff97e")
+                                    value: storage_value!("0x000000000000000000000000000000000000fffffffffffffffffffffffff74f")
                                 },
                                 StorageEntry {
                                     key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
@@ -824,7 +825,7 @@ pub(crate) mod tests {
                 StorageEntry,
             };
 
-            const DECLARE_GAS_CONSUMED: u64 = 2768;
+            const DECLARE_GAS_CONSUMED: u64 = 3632;
 
             pub fn declare(
                 account_contract_address: ContractAddress,
@@ -917,7 +918,7 @@ pub(crate) mod tests {
                     storage_entries: vec![
                         StorageEntry {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: storage_value!("0x000000000000000000000000000000000000fffffffffffffffffffffffff530")
+                            value: storage_value!("0x000000000000000000000000000000000000fffffffffffffffffffffffff1d0")
                         },
                         StorageEntry {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
@@ -981,7 +982,7 @@ pub(crate) mod tests {
                 }
             }
 
-            const UNIVERSAL_DEPLOYER_GAS_CONSUMED: u64 = 3020;
+            const UNIVERSAL_DEPLOYER_GAS_CONSUMED: u64 = 3009;
 
             pub fn universal_deployer(
                 account_contract_address: ContractAddress,
@@ -1104,7 +1105,7 @@ pub(crate) mod tests {
                     storage_entries: vec![
                         StorageEntry {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffffe964")
+                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffffe60f")
                         },
                         StorageEntry {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
@@ -1278,7 +1279,7 @@ pub(crate) mod tests {
                 }
             }
 
-            const INVOKE_GAS_CONSUMED: u64 = 1674;
+            const INVOKE_GAS_CONSUMED: u64 = 1664;
 
             pub fn invoke(
                 account_contract_address: ContractAddress,
@@ -1383,7 +1384,7 @@ pub(crate) mod tests {
                     storage_entries: vec![
                         StorageEntry {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffffe2da")
+                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffffdf8f")
                         },
                         StorageEntry {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
@@ -1502,7 +1503,7 @@ pub(crate) mod tests {
             account_contract_address,
             universal_deployer_address,
             test_storage_value,
-        ) = setup_storage().await;
+        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 1)).await;
         let context = RpcContext::for_tests().with_storage(storage);
 
         let input = SimulateTransactionInput {
@@ -1545,7 +1546,7 @@ pub(crate) mod tests {
             account_contract_address,
             universal_deployer_address,
             test_storage_value,
-        ) = setup_storage().await;
+        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 1)).await;
         let context = RpcContext::for_tests().with_storage(storage);
 
         let input = SimulateTransactionInput {
@@ -1586,7 +1587,7 @@ pub(crate) mod tests {
             account_contract_address,
             universal_deployer_address,
             test_storage_value,
-        ) = setup_storage().await;
+        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 1)).await;
         let context = RpcContext::for_tests().with_storage(storage);
 
         let input = SimulateTransactionInput {

--- a/crates/rpc/src/v05/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v05/method/trace_block_transactions.rs
@@ -288,6 +288,7 @@ pub(crate) mod tests {
         GasPrice,
         SequencerAddress,
         SierraHash,
+        StarknetVersion,
         TransactionIndex,
     };
     use pathfinder_crypto::Felt;
@@ -297,7 +298,10 @@ pub(crate) mod tests {
 
     pub(crate) async fn setup_multi_tx_trace_test(
     ) -> anyhow::Result<(RpcContext, BlockHeader, Vec<Trace>)> {
-        use super::super::simulate_transactions::tests::{fixtures, setup_storage};
+        use super::super::simulate_transactions::tests::{
+            fixtures,
+            setup_storage_with_starknet_version,
+        };
 
         let (
             storage,
@@ -305,7 +309,7 @@ pub(crate) mod tests {
             account_contract_address,
             universal_deployer_address,
             test_storage_value,
-        ) = setup_storage().await;
+        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 1)).await;
         let context = RpcContext::for_tests().with_storage(storage.clone());
 
         let transactions = vec![
@@ -405,7 +409,10 @@ pub(crate) mod tests {
 
     pub(crate) async fn setup_multi_tx_trace_pending_test(
     ) -> anyhow::Result<(RpcContext, Vec<Trace>)> {
-        use super::super::simulate_transactions::tests::{fixtures, setup_storage};
+        use super::super::simulate_transactions::tests::{
+            fixtures,
+            setup_storage_with_starknet_version,
+        };
 
         let (
             storage,
@@ -413,7 +420,7 @@ pub(crate) mod tests {
             account_contract_address,
             universal_deployer_address,
             test_storage_value,
-        ) = setup_storage().await;
+        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 1)).await;
         let context = RpcContext::for_tests().with_storage(storage.clone());
 
         let transactions: Vec<Transaction> = vec![

--- a/crates/rpc/src/v06/method/simulate_transactions.rs
+++ b/crates/rpc/src/v06/method/simulate_transactions.rs
@@ -790,8 +790,7 @@ pub(crate) mod tests {
     };
     use crate::v02::types::ContractClass;
     use crate::v03::method::get_state_update::types::{DeployedContract, Nonce, StateDiff};
-    pub(crate) use crate::v04::method::simulate_transactions::tests::setup_storage;
-    use crate::v04::method::simulate_transactions::tests::setup_storage_with_starknet_version;
+    pub(crate) use crate::v04::method::simulate_transactions::tests::setup_storage_with_starknet_version;
     use crate::v05::method::call::FunctionCall;
     use crate::v06::types::PriceUnit;
 
@@ -918,7 +917,8 @@ pub(crate) mod tests {
 
         assert_eq!(contract_class.class_hash().unwrap().hash(), CAIRO0_HASH);
 
-        let (storage, last_block_header, account_contract_address, _, _) = setup_storage().await;
+        let (storage, last_block_header, account_contract_address, _, _) =
+            setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 1)).await;
         let context = RpcContext::for_tests().with_storage(storage);
 
         let declare = BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V1(
@@ -940,7 +940,7 @@ pub(crate) mod tests {
 
         let result = simulate_transactions(context, input).await.unwrap();
 
-        const DECLARE_GAS_CONSUMED: u64 = 1666;
+        const DECLARE_GAS_CONSUMED: u64 = 2225;
         use super::dto::*;
         use crate::v03::method::get_state_update::types::{StorageDiff, StorageEntry};
 
@@ -987,9 +987,9 @@ pub(crate) mod tests {
                             messages: vec![],
                             result: vec![felt!("0x1")],
                             execution_resources: ComputationResources {
-                                steps: 936,
+                                steps: 1354,
                                 memory_holes: 59,
-                                range_check_builtin_applications: 21,
+                                range_check_builtin_applications: 31,
                                 pedersen_builtin_applications: 4,
                                 ..Default::default()
                             },
@@ -1022,7 +1022,7 @@ pub(crate) mod tests {
                             storage_entries: vec![
                                 StorageEntry {
                                     key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                                    value: storage_value!("0x000000000000000000000000000000000000fffffffffffffffffffffffff97e")
+                                    value: storage_value!("0x000000000000000000000000000000000000fffffffffffffffffffffffff74f")
                                 },
                                 StorageEntry {
                                     key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
@@ -1063,7 +1063,7 @@ pub(crate) mod tests {
             pub use crate::v04::method::simulate_transactions::tests::fixtures::input::*;
         }
 
-        pub mod expected_output_0_13_0 {
+        pub mod expected_output_0_13_1_1 {
             use pathfinder_common::{BlockHeader, ContractAddress, SierraHash, StorageValue};
 
             use super::dto::*;
@@ -1074,783 +1074,7 @@ pub(crate) mod tests {
                 StorageEntry,
             };
 
-            const DECLARE_GAS_CONSUMED: u64 = 2768;
-
-            pub fn declare(
-                account_contract_address: ContractAddress,
-                last_block_header: &BlockHeader,
-            ) -> SimulatedTransaction {
-                SimulatedTransaction {
-                    fee_estimation: FeeEstimate {
-                        gas_consumed: DECLARE_GAS_CONSUMED.into(),
-                        gas_price: 1.into(),
-                        data_gas_consumed: None,
-                        data_gas_price: None,
-                        overall_fee: DECLARE_GAS_CONSUMED.into(),
-                        unit: PriceUnit::Wei,
-                    },
-                    transaction_trace: TransactionTrace::Declare(DeclareTxnTrace {
-                        fee_transfer_invocation: Some(declare_fee_transfer(
-                            account_contract_address,
-                            last_block_header,
-                        )),
-                        validate_invocation: Some(declare_validate(account_contract_address)),
-                        state_diff: Some(declare_state_diff(
-                            account_contract_address,
-                            declare_fee_transfer_storage_diffs(),
-                        )),
-                        execution_resources: None,
-                    }),
-                }
-            }
-
-            pub fn declare_without_fee_transfer(
-                account_contract_address: ContractAddress,
-            ) -> SimulatedTransaction {
-                SimulatedTransaction {
-                    fee_estimation: FeeEstimate {
-                        gas_consumed: DECLARE_GAS_CONSUMED.into(),
-                        gas_price: 1.into(),
-                        data_gas_consumed: None,
-                        data_gas_price: None,
-                        overall_fee: DECLARE_GAS_CONSUMED.into(),
-                        unit: PriceUnit::Wei,
-                    },
-                    transaction_trace: TransactionTrace::Declare(DeclareTxnTrace {
-                        fee_transfer_invocation: None,
-                        validate_invocation: Some(declare_validate(account_contract_address)),
-                        state_diff: Some(declare_state_diff(account_contract_address, vec![])),
-                        execution_resources: None,
-                    }),
-                }
-            }
-
-            pub fn declare_without_validate(
-                account_contract_address: ContractAddress,
-                last_block_header: &BlockHeader,
-            ) -> SimulatedTransaction {
-                SimulatedTransaction {
-                    fee_estimation: FeeEstimate {
-                        gas_consumed: DECLARE_GAS_CONSUMED.into(),
-                        gas_price: 1.into(),
-                        data_gas_consumed: None,
-                        data_gas_price: None,
-                        overall_fee: DECLARE_GAS_CONSUMED.into(),
-                        unit: PriceUnit::Wei,
-                    },
-                    transaction_trace: TransactionTrace::Declare(DeclareTxnTrace {
-                        fee_transfer_invocation: Some(declare_fee_transfer(
-                            account_contract_address,
-                            last_block_header,
-                        )),
-                        validate_invocation: None,
-                        state_diff: Some(declare_state_diff(
-                            account_contract_address,
-                            declare_fee_transfer_storage_diffs(),
-                        )),
-                        execution_resources: None,
-                    }),
-                }
-            }
-
-            fn declare_state_diff(
-                account_contract_address: ContractAddress,
-                storage_diffs: Vec<StorageDiff>,
-            ) -> StateDiff {
-                StateDiff {
-                    storage_diffs,
-                    deprecated_declared_classes: vec![],
-                    declared_classes: vec![DeclaredSierraClass {
-                        class_hash: SierraHash(SIERRA_HASH.0),
-                        compiled_class_hash: CASM_HASH,
-                    }],
-                    deployed_contracts: vec![],
-                    replaced_classes: vec![],
-                    nonces: vec![Nonce {
-                        contract_address: account_contract_address,
-                        nonce: contract_nonce!("0x1"),
-                    }],
-                }
-            }
-
-            fn declare_fee_transfer_storage_diffs() -> Vec<StorageDiff> {
-                vec![StorageDiff {
-                    address: pathfinder_executor::ETH_FEE_TOKEN_ADDRESS,
-                    storage_entries: vec![
-                        StorageEntry {
-                            key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: storage_value!("0x000000000000000000000000000000000000fffffffffffffffffffffffff530")
-                        },
-                        StorageEntry {
-                            key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
-                            value: StorageValue(DECLARE_GAS_CONSUMED.into()),
-                        },
-                    ],
-                }]
-            }
-
-            fn declare_fee_transfer(
-                account_contract_address: ContractAddress,
-                last_block_header: &BlockHeader,
-            ) -> FunctionInvocation {
-                FunctionInvocation {
-                    call_type: CallType::Call,
-                    caller_address: *account_contract_address.get(),
-                    calls: vec![],
-                    class_hash: Some(ERC20_CONTRACT_DEFINITION_CLASS_HASH.0),
-                    entry_point_type: EntryPointType::External,
-                    events: vec![OrderedEvent {
-                        order: 0,
-                        data: vec![
-                            *account_contract_address.get(),
-                            last_block_header.sequencer_address.0,
-                            Felt::from_u64(DECLARE_GAS_CONSUMED),
-                            felt!("0x0"),
-                        ],
-                        keys: vec![felt!(
-                            "0x0099CD8BDE557814842A3121E8DDFD433A539B8C9F14BF31EBF108D12E6196E9"
-                        )],
-                    }],
-                    function_call: FunctionCall {
-                        calldata: vec![
-                            CallParam(last_block_header.sequencer_address.0),
-                            CallParam(Felt::from_u64(DECLARE_GAS_CONSUMED)),
-                            call_param!("0x0"),
-                        ],
-                        contract_address: pathfinder_executor::ETH_FEE_TOKEN_ADDRESS,
-                        entry_point_selector: EntryPoint::hashed(b"transfer"),
-                    },
-                    messages: vec![],
-                    result: vec![felt!("0x1")],
-                    execution_resources: ComputationResources {
-                        steps: 936,
-                        memory_holes: 59,
-                        range_check_builtin_applications: 21,
-                        pedersen_builtin_applications: 4,
-                        ..Default::default()
-                    },
-                }
-            }
-
-            fn declare_validate(account_contract_address: ContractAddress) -> FunctionInvocation {
-                FunctionInvocation {
-                    call_type: CallType::Call,
-                    caller_address: felt!("0x0"),
-                    calls: vec![],
-                    class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
-                    entry_point_type: EntryPointType::External,
-                    events: vec![],
-                    function_call: FunctionCall {
-                        contract_address: account_contract_address,
-                        entry_point_selector: EntryPoint::hashed(b"__validate_declare__"),
-                        calldata: vec![CallParam(SIERRA_HASH.0)],
-                    },
-                    messages: vec![],
-                    result: vec![],
-                    execution_resources: ComputationResources {
-                        steps: 12,
-                        ..Default::default()
-                    },
-                }
-            }
-
-            const UNIVERSAL_DEPLOYER_GAS_CONSUMED: u64 = 3020;
-
-            pub fn universal_deployer(
-                account_contract_address: ContractAddress,
-                last_block_header: &BlockHeader,
-                universal_deployer_address: ContractAddress,
-            ) -> SimulatedTransaction {
-                SimulatedTransaction {
-                    fee_estimation: FeeEstimate {
-                        gas_consumed: UNIVERSAL_DEPLOYER_GAS_CONSUMED.into(),
-                        gas_price: 1.into(),
-                        data_gas_consumed: None,
-                        data_gas_price: None,
-                        overall_fee: UNIVERSAL_DEPLOYER_GAS_CONSUMED.into(),
-                        unit: PriceUnit::Wei,
-                    },
-                    transaction_trace: TransactionTrace::Invoke(InvokeTxnTrace {
-                        validate_invocation: Some(universal_deployer_validate(
-                            account_contract_address,
-                            universal_deployer_address,
-                        )),
-                        execute_invocation: ExecuteInvocation::FunctionInvocation(
-                            universal_deployer_execute(
-                                account_contract_address,
-                                universal_deployer_address,
-                            ),
-                        ),
-                        fee_transfer_invocation: Some(universal_deployer_fee_transfer(
-                            account_contract_address,
-                            last_block_header,
-                        )),
-                        state_diff: Some(universal_deployer_state_diff(
-                            account_contract_address,
-                            universal_deployer_fee_transfer_storage_diffs(),
-                        )),
-                        execution_resources: None,
-                    }),
-                }
-            }
-
-            pub fn universal_deployer_without_fee_transfer(
-                account_contract_address: ContractAddress,
-                universal_deployer_address: ContractAddress,
-            ) -> SimulatedTransaction {
-                SimulatedTransaction {
-                    fee_estimation: FeeEstimate {
-                        gas_consumed: UNIVERSAL_DEPLOYER_GAS_CONSUMED.into(),
-                        gas_price: 1.into(),
-                        data_gas_consumed: None,
-                        data_gas_price: None,
-                        overall_fee: UNIVERSAL_DEPLOYER_GAS_CONSUMED.into(),
-                        unit: PriceUnit::Wei,
-                    },
-                    transaction_trace: TransactionTrace::Invoke(InvokeTxnTrace {
-                        validate_invocation: Some(universal_deployer_validate(
-                            account_contract_address,
-                            universal_deployer_address,
-                        )),
-                        execute_invocation: ExecuteInvocation::FunctionInvocation(
-                            universal_deployer_execute(
-                                account_contract_address,
-                                universal_deployer_address,
-                            ),
-                        ),
-                        fee_transfer_invocation: None,
-                        state_diff: Some(universal_deployer_state_diff(
-                            account_contract_address,
-                            vec![],
-                        )),
-                        execution_resources: None,
-                    }),
-                }
-            }
-
-            pub fn universal_deployer_without_validate(
-                account_contract_address: ContractAddress,
-                last_block_header: &BlockHeader,
-                universal_deployer_address: ContractAddress,
-            ) -> SimulatedTransaction {
-                SimulatedTransaction {
-                    fee_estimation: FeeEstimate {
-                        gas_consumed: UNIVERSAL_DEPLOYER_GAS_CONSUMED.into(),
-                        gas_price: 1.into(),
-                        data_gas_consumed: None,
-                        data_gas_price: None,
-                        overall_fee: UNIVERSAL_DEPLOYER_GAS_CONSUMED.into(),
-                        unit: PriceUnit::Wei,
-                    },
-                    transaction_trace: TransactionTrace::Invoke(InvokeTxnTrace {
-                        validate_invocation: None,
-                        execute_invocation: ExecuteInvocation::FunctionInvocation(
-                            universal_deployer_execute(
-                                account_contract_address,
-                                universal_deployer_address,
-                            ),
-                        ),
-                        fee_transfer_invocation: Some(universal_deployer_fee_transfer(
-                            account_contract_address,
-                            last_block_header,
-                        )),
-                        state_diff: Some(universal_deployer_state_diff(
-                            account_contract_address,
-                            universal_deployer_fee_transfer_storage_diffs(),
-                        )),
-                        execution_resources: None,
-                    }),
-                }
-            }
-
-            fn universal_deployer_state_diff(
-                account_contract_address: ContractAddress,
-                storage_diffs: Vec<StorageDiff>,
-            ) -> StateDiff {
-                StateDiff {
-                    storage_diffs,
-                    deprecated_declared_classes: vec![],
-                    declared_classes: vec![],
-                    deployed_contracts: vec![DeployedContract {
-                        address: DEPLOYED_CONTRACT_ADDRESS,
-                        class_hash: SIERRA_HASH,
-                    }],
-                    replaced_classes: vec![],
-                    nonces: vec![Nonce {
-                        contract_address: account_contract_address,
-                        nonce: contract_nonce!("0x2"),
-                    }],
-                }
-            }
-
-            fn universal_deployer_fee_transfer_storage_diffs() -> Vec<StorageDiff> {
-                vec![StorageDiff {
-                    address: pathfinder_executor::ETH_FEE_TOKEN_ADDRESS,
-                    storage_entries: vec![
-                        StorageEntry {
-                            key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffffe964")
-                        },
-                        StorageEntry {
-                            key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
-                            value: StorageValue((DECLARE_GAS_CONSUMED + UNIVERSAL_DEPLOYER_GAS_CONSUMED).into()),
-                        },
-                    ],
-                }]
-            }
-
-            fn universal_deployer_validate(
-                account_contract_address: ContractAddress,
-                universal_deployer_address: ContractAddress,
-            ) -> FunctionInvocation {
-                FunctionInvocation {
-                    call_type: CallType::Call,
-                    caller_address: felt!("0x0"),
-                    calls: vec![],
-                    class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
-                    entry_point_type: EntryPointType::External,
-                    events: vec![],
-                    function_call: FunctionCall {
-                        contract_address: account_contract_address,
-                        entry_point_selector: EntryPoint::hashed(b"__validate__"),
-                        calldata: vec![
-                            CallParam(universal_deployer_address.0),
-                            CallParam(EntryPoint::hashed(b"deployContract").0),
-                            // calldata_len
-                            call_param!("0x4"),
-                            // classHash
-                            CallParam(SIERRA_HASH.0),
-                            // salt
-                            call_param!("0x0"),
-                            // unique
-                            call_param!("0x0"),
-                            // calldata_len
-                            call_param!("0x0"),
-                        ],
-                    },
-                    messages: vec![],
-                    result: vec![],
-                    execution_resources: ComputationResources {
-                        steps: 21,
-                        range_check_builtin_applications: 1,
-                        ..Default::default()
-                    },
-                }
-            }
-
-            fn universal_deployer_execute(
-                account_contract_address: ContractAddress,
-                universal_deployer_address: ContractAddress,
-            ) -> FunctionInvocation {
-                FunctionInvocation {
-                    call_type: CallType::Call,
-                    caller_address: felt!("0x0"),
-                    calls: vec![
-                        FunctionInvocation {
-                            call_type: CallType::Call,
-                            caller_address: *account_contract_address.get(),
-                            calls: vec![
-                                FunctionInvocation {
-                                    call_type: CallType::Call,
-                                    caller_address: *universal_deployer_address.get(),
-                                    calls: vec![],
-                                    class_hash: Some(SIERRA_HASH.0),
-                                    entry_point_type: EntryPointType::Constructor,
-                                    events: vec![],
-                                    function_call: FunctionCall {
-                                        contract_address: DEPLOYED_CONTRACT_ADDRESS,
-                                        entry_point_selector: EntryPoint::hashed(b"constructor"),
-                                        calldata: vec![],
-                                    },
-                                    messages: vec![],
-                                    result: vec![],
-                                    execution_resources: ComputationResources::default(),
-                                },
-                            ],
-                            class_hash: Some(UNIVERSAL_DEPLOYER_CLASS_HASH.0),
-                            entry_point_type: EntryPointType::External,
-                            events: vec![
-                                OrderedEvent {
-                                    order: 0,
-                                    data: vec![
-                                        *DEPLOYED_CONTRACT_ADDRESS.get(),
-                                        *account_contract_address.get(),
-                                        felt!("0x0"),
-                                        SIERRA_HASH.0,
-                                        felt!("0x0"),
-                                        felt!("0x0"),
-                                    ],
-                                    keys: vec![
-                                        felt!("0x026B160F10156DEA0639BEC90696772C640B9706A47F5B8C52EA1ABE5858B34D"),
-                                    ]
-                                },
-                            ],
-                            function_call: FunctionCall {
-                                contract_address: universal_deployer_address,
-                                entry_point_selector: EntryPoint::hashed(b"deployContract"),
-                                calldata: vec![
-                                    // classHash
-                                    CallParam(SIERRA_HASH.0),
-                                    // salt
-                                    call_param!("0x0"),
-                                    // unique
-                                    call_param!("0x0"),
-                                    //  calldata_len
-                                    call_param!("0x0"),
-                                ],
-                            },
-                            messages: vec![],
-                            result: vec![
-                                *DEPLOYED_CONTRACT_ADDRESS.get(),
-                            ],
-                            execution_resources: ComputationResources {
-                                steps: 1120,
-                                memory_holes: 2,
-                                range_check_builtin_applications: 20,
-                                pedersen_builtin_applications: 7,
-                                ..Default::default()
-                            },
-                        }
-                    ],
-                    class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
-                    entry_point_type: EntryPointType::External,
-                    events: vec![],
-                    function_call: FunctionCall {
-                        contract_address: account_contract_address,
-                        entry_point_selector: EntryPoint::hashed(b"__execute__"),
-                        calldata: vec![
-                            CallParam(universal_deployer_address.0),
-                            CallParam(EntryPoint::hashed(b"deployContract").0),
-                            call_param!("0x4"),
-                            // classHash
-                            CallParam(SIERRA_HASH.0),
-                            // salt
-                            call_param!("0x0"),
-                            // unique
-                            call_param!("0x0"),
-                            // calldata_len
-                            call_param!("0x0"),
-                        ],
-                    },
-                    messages: vec![],
-                    result: vec![
-                        *DEPLOYED_CONTRACT_ADDRESS.get(),
-                    ],
-                    execution_resources: ComputationResources {
-                        steps: 1850,
-                        memory_holes: 2,
-                        range_check_builtin_applications: 40,
-                        pedersen_builtin_applications: 7,
-                        ..Default::default()
-                    },
-                }
-            }
-
-            fn universal_deployer_fee_transfer(
-                account_contract_address: ContractAddress,
-                last_block_header: &BlockHeader,
-            ) -> FunctionInvocation {
-                FunctionInvocation {
-                    call_type: CallType::Call,
-                    caller_address: *account_contract_address.get(),
-                    calls: vec![],
-                    class_hash: Some(ERC20_CONTRACT_DEFINITION_CLASS_HASH.0),
-                    entry_point_type: EntryPointType::External,
-                    events: vec![OrderedEvent {
-                        order: 0,
-                        data: vec![
-                            *account_contract_address.get(),
-                            last_block_header.sequencer_address.0,
-                            Felt::from_u64(UNIVERSAL_DEPLOYER_GAS_CONSUMED),
-                            felt!("0x0"),
-                        ],
-                        keys: vec![felt!(
-                            "0x0099CD8BDE557814842A3121E8DDFD433A539B8C9F14BF31EBF108D12E6196E9"
-                        )],
-                    }],
-                    function_call: FunctionCall {
-                        calldata: vec![
-                            CallParam(last_block_header.sequencer_address.0),
-                            CallParam(Felt::from_u64(UNIVERSAL_DEPLOYER_GAS_CONSUMED)),
-                            // calldata_len
-                            call_param!("0x0"),
-                        ],
-                        contract_address: pathfinder_executor::ETH_FEE_TOKEN_ADDRESS,
-                        entry_point_selector: EntryPoint::hashed(b"transfer"),
-                    },
-                    messages: vec![],
-                    result: vec![felt!("0x1")],
-                    execution_resources: ComputationResources {
-                        steps: 936,
-                        memory_holes: 59,
-                        range_check_builtin_applications: 21,
-                        pedersen_builtin_applications: 4,
-                        ..Default::default()
-                    },
-                }
-            }
-
-            const INVOKE_GAS_CONSUMED: u64 = 1674;
-
-            pub fn invoke(
-                account_contract_address: ContractAddress,
-                last_block_header: &BlockHeader,
-                test_storage_value: StorageValue,
-            ) -> SimulatedTransaction {
-                SimulatedTransaction {
-                    fee_estimation: FeeEstimate {
-                        gas_consumed: INVOKE_GAS_CONSUMED.into(),
-                        gas_price: 1.into(),
-                        data_gas_consumed: None,
-                        data_gas_price: None,
-                        overall_fee: INVOKE_GAS_CONSUMED.into(),
-                        unit: PriceUnit::Wei,
-                    },
-                    transaction_trace: TransactionTrace::Invoke(InvokeTxnTrace {
-                        validate_invocation: Some(invoke_validate(account_contract_address)),
-                        execute_invocation: ExecuteInvocation::FunctionInvocation(invoke_execute(
-                            account_contract_address,
-                            test_storage_value,
-                        )),
-                        fee_transfer_invocation: Some(invoke_fee_transfer(
-                            account_contract_address,
-                            last_block_header,
-                        )),
-                        state_diff: Some(invoke_state_diff(
-                            account_contract_address,
-                            invoke_fee_transfer_storage_diffs(),
-                        )),
-                        execution_resources: None,
-                    }),
-                }
-            }
-
-            pub fn invoke_without_fee_transfer(
-                account_contract_address: ContractAddress,
-                test_storage_value: StorageValue,
-            ) -> SimulatedTransaction {
-                SimulatedTransaction {
-                    fee_estimation: FeeEstimate {
-                        gas_consumed: INVOKE_GAS_CONSUMED.into(),
-                        gas_price: 1.into(),
-                        data_gas_consumed: None,
-                        data_gas_price: None,
-                        overall_fee: INVOKE_GAS_CONSUMED.into(),
-                        unit: PriceUnit::Wei,
-                    },
-                    transaction_trace: TransactionTrace::Invoke(InvokeTxnTrace {
-                        validate_invocation: Some(invoke_validate(account_contract_address)),
-                        execute_invocation: ExecuteInvocation::FunctionInvocation(invoke_execute(
-                            account_contract_address,
-                            test_storage_value,
-                        )),
-                        fee_transfer_invocation: None,
-                        state_diff: Some(invoke_state_diff(account_contract_address, vec![])),
-                        execution_resources: None,
-                    }),
-                }
-            }
-
-            pub fn invoke_without_validate(
-                account_contract_address: ContractAddress,
-                last_block_header: &BlockHeader,
-                test_storage_value: StorageValue,
-            ) -> SimulatedTransaction {
-                SimulatedTransaction {
-                    fee_estimation: FeeEstimate {
-                        gas_consumed: INVOKE_GAS_CONSUMED.into(),
-                        gas_price: 1.into(),
-                        data_gas_consumed: None,
-                        data_gas_price: None,
-                        overall_fee: INVOKE_GAS_CONSUMED.into(),
-                        unit: PriceUnit::Wei,
-                    },
-                    transaction_trace: TransactionTrace::Invoke(InvokeTxnTrace {
-                        validate_invocation: None,
-                        execute_invocation: ExecuteInvocation::FunctionInvocation(invoke_execute(
-                            account_contract_address,
-                            test_storage_value,
-                        )),
-                        fee_transfer_invocation: Some(invoke_fee_transfer(
-                            account_contract_address,
-                            last_block_header,
-                        )),
-                        state_diff: Some(invoke_state_diff(
-                            account_contract_address,
-                            invoke_fee_transfer_storage_diffs(),
-                        )),
-                        execution_resources: None,
-                    }),
-                }
-            }
-
-            fn invoke_state_diff(
-                account_contract_address: ContractAddress,
-                storage_diffs: Vec<StorageDiff>,
-            ) -> StateDiff {
-                StateDiff {
-                    storage_diffs,
-                    deprecated_declared_classes: vec![],
-                    declared_classes: vec![],
-                    deployed_contracts: vec![],
-                    replaced_classes: vec![],
-                    nonces: vec![Nonce {
-                        contract_address: account_contract_address,
-                        nonce: contract_nonce!("0x3"),
-                    }],
-                }
-            }
-
-            fn invoke_fee_transfer_storage_diffs() -> Vec<StorageDiff> {
-                vec![StorageDiff {
-                    address: pathfinder_executor::ETH_FEE_TOKEN_ADDRESS,
-                    storage_entries: vec![
-                        StorageEntry {
-                            key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffffe2da")
-                        },
-                        StorageEntry {
-                            key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
-                            value: StorageValue((DECLARE_GAS_CONSUMED + UNIVERSAL_DEPLOYER_GAS_CONSUMED + INVOKE_GAS_CONSUMED).into()),
-                        },
-                    ],
-                }]
-            }
-
-            fn invoke_validate(account_contract_address: ContractAddress) -> FunctionInvocation {
-                FunctionInvocation {
-                    call_type: CallType::Call,
-                    caller_address: felt!("0x0"),
-                    calls: vec![],
-                    class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
-                    entry_point_type: EntryPointType::External,
-                    events: vec![],
-                    function_call: FunctionCall {
-                        contract_address: account_contract_address,
-                        entry_point_selector: EntryPoint::hashed(b"__validate__"),
-                        calldata: vec![
-                            CallParam(DEPLOYED_CONTRACT_ADDRESS.0),
-                            CallParam(EntryPoint::hashed(b"get_data").0),
-                            // calldata_len
-                            call_param!("0x0"),
-                        ],
-                    },
-                    messages: vec![],
-                    result: vec![],
-                    execution_resources: ComputationResources {
-                        steps: 21,
-                        range_check_builtin_applications: 1,
-                        ..Default::default()
-                    },
-                }
-            }
-
-            fn invoke_execute(
-                account_contract_address: ContractAddress,
-                test_storage_value: StorageValue,
-            ) -> FunctionInvocation {
-                FunctionInvocation {
-                    call_type: CallType::Call,
-                    caller_address: felt!("0x0"),
-                    calls: vec![FunctionInvocation {
-                        call_type: CallType::Call,
-                        caller_address: *account_contract_address.get(),
-                        calls: vec![],
-                        class_hash: Some(SIERRA_HASH.0),
-                        entry_point_type: EntryPointType::External,
-                        events: vec![],
-                        function_call: FunctionCall {
-                            contract_address: DEPLOYED_CONTRACT_ADDRESS,
-                            entry_point_selector: EntryPoint::hashed(b"get_data"),
-                            calldata: vec![],
-                        },
-                        messages: vec![],
-                        result: vec![test_storage_value.0],
-                        execution_resources: ComputationResources {
-                            steps: 122,
-                            range_check_builtin_applications: 2,
-                            ..Default::default()
-                        },
-                    }],
-                    class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
-                    entry_point_type: EntryPointType::External,
-                    events: vec![],
-                    function_call: FunctionCall {
-                        contract_address: account_contract_address,
-                        entry_point_selector: EntryPoint::hashed(b"__execute__"),
-                        calldata: vec![
-                            CallParam(DEPLOYED_CONTRACT_ADDRESS.0),
-                            CallParam(EntryPoint::hashed(b"get_data").0),
-                            // calldata_len
-                            call_param!("0x0"),
-                        ],
-                    },
-                    messages: vec![],
-                    result: vec![test_storage_value.0],
-                    execution_resources: ComputationResources {
-                        steps: 852,
-                        range_check_builtin_applications: 22,
-                        ..Default::default()
-                    },
-                }
-            }
-
-            fn invoke_fee_transfer(
-                account_contract_address: ContractAddress,
-                last_block_header: &BlockHeader,
-            ) -> FunctionInvocation {
-                FunctionInvocation {
-                    call_type: CallType::Call,
-                    caller_address: *account_contract_address.get(),
-                    calls: vec![],
-                    class_hash: Some(ERC20_CONTRACT_DEFINITION_CLASS_HASH.0),
-                    entry_point_type: EntryPointType::External,
-                    events: vec![OrderedEvent {
-                        order: 0,
-                        data: vec![
-                            *account_contract_address.get(),
-                            last_block_header.sequencer_address.0,
-                            Felt::from_u64(INVOKE_GAS_CONSUMED),
-                            felt!("0x0"),
-                        ],
-                        keys: vec![felt!(
-                            "0x0099CD8BDE557814842A3121E8DDFD433A539B8C9F14BF31EBF108D12E6196E9"
-                        )],
-                    }],
-                    function_call: FunctionCall {
-                        calldata: vec![
-                            CallParam(last_block_header.sequencer_address.0),
-                            CallParam(Felt::from_u64(INVOKE_GAS_CONSUMED)),
-                            call_param!("0x0"),
-                        ],
-                        contract_address: pathfinder_executor::ETH_FEE_TOKEN_ADDRESS,
-                        entry_point_selector: EntryPoint::hashed(b"transfer"),
-                    },
-                    messages: vec![],
-                    result: vec![felt!("0x1")],
-                    execution_resources: ComputationResources {
-                        steps: 936,
-                        memory_holes: 59,
-                        range_check_builtin_applications: 21,
-                        pedersen_builtin_applications: 4,
-                        ..Default::default()
-                    },
-                }
-            }
-        }
-
-        pub mod expected_output_0_13_1 {
-            use pathfinder_common::{BlockHeader, ContractAddress, SierraHash, StorageValue};
-
-            use super::dto::*;
-            use super::*;
-            use crate::v03::method::get_state_update::types::{
-                DeclaredSierraClass,
-                StorageDiff,
-                StorageEntry,
-            };
-
-            const DECLARE_GAS_CONSUMED: u64 = 26571;
+            const DECLARE_GAS_CONSUMED: u64 = 3632;
 
             pub fn declare(
                 account_contract_address: ContractAddress,
@@ -1906,7 +1130,7 @@ pub(crate) mod tests {
                     storage_entries: vec![
                         StorageEntry {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffff9835")
+                            value: storage_value!("0x000000000000000000000000000000000000fffffffffffffffffffffffff1d0")
                         },
                         StorageEntry {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
@@ -2047,7 +1271,7 @@ pub(crate) mod tests {
                     storage_entries: vec![
                         StorageEntry {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffff8c74")
+                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffffe60f")
                         },
                         StorageEntry {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
@@ -2306,7 +1530,7 @@ pub(crate) mod tests {
                     storage_entries: vec![
                         StorageEntry {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffff85f4")
+                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffffdf8f")
                         },
                         StorageEntry {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
@@ -2440,14 +1664,14 @@ pub(crate) mod tests {
     }
 
     #[test_log::test(tokio::test)]
-    async fn declare_deploy_and_invoke_sierra_class() {
+    async fn declare_deploy_and_invoke_sierra_class_for_starknet_0_13_1_1() {
         let (
             storage,
             last_block_header,
             account_contract_address,
             universal_deployer_address,
             test_storage_value,
-        ) = setup_storage().await;
+        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 1)).await;
         let context = RpcContext::for_tests().with_storage(storage);
 
         let input = SimulateTransactionInput {
@@ -2467,151 +1691,16 @@ pub(crate) mod tests {
         pretty_assertions_sorted::assert_eq!(
             result,
             SimulateTransactionOutput(vec![
-                fixtures::expected_output_0_13_0::declare(
+                fixtures::expected_output_0_13_1_1::declare(
                     account_contract_address,
                     &last_block_header
                 ),
-                fixtures::expected_output_0_13_0::universal_deployer(
+                fixtures::expected_output_0_13_1_1::universal_deployer(
                     account_contract_address,
                     &last_block_header,
                     universal_deployer_address,
                 ),
-                fixtures::expected_output_0_13_0::invoke(
-                    account_contract_address,
-                    &last_block_header,
-                    test_storage_value,
-                ),
-            ])
-        );
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn declare_deploy_and_invoke_sierra_class_with_skip_fee_charge() {
-        let (
-            storage,
-            last_block_header,
-            account_contract_address,
-            universal_deployer_address,
-            test_storage_value,
-        ) = setup_storage().await;
-        let context = RpcContext::for_tests().with_storage(storage);
-
-        let input = SimulateTransactionInput {
-            transactions: vec![
-                fixtures::input::declare(account_contract_address),
-                fixtures::input::universal_deployer(
-                    account_contract_address,
-                    universal_deployer_address,
-                ),
-                fixtures::input::invoke(account_contract_address),
-            ],
-            block_id: BlockId::Number(last_block_header.number),
-            simulation_flags: dto::SimulationFlags(vec![dto::SimulationFlag::SkipFeeCharge]),
-        };
-        let result = simulate_transactions(context, input).await.unwrap();
-
-        pretty_assertions_sorted::assert_eq!(
-            result,
-            SimulateTransactionOutput(vec![
-                fixtures::expected_output_0_13_0::declare_without_fee_transfer(
-                    account_contract_address
-                ),
-                fixtures::expected_output_0_13_0::universal_deployer_without_fee_transfer(
-                    account_contract_address,
-                    universal_deployer_address,
-                ),
-                fixtures::expected_output_0_13_0::invoke_without_fee_transfer(
-                    account_contract_address,
-                    test_storage_value,
-                ),
-            ])
-        );
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn declare_deploy_and_invoke_sierra_class_with_skip_validate() {
-        let (
-            storage,
-            last_block_header,
-            account_contract_address,
-            universal_deployer_address,
-            test_storage_value,
-        ) = setup_storage().await;
-        let context = RpcContext::for_tests().with_storage(storage);
-
-        let input = SimulateTransactionInput {
-            transactions: vec![
-                fixtures::input::declare(account_contract_address),
-                fixtures::input::universal_deployer(
-                    account_contract_address,
-                    universal_deployer_address,
-                ),
-                fixtures::input::invoke(account_contract_address),
-            ],
-            block_id: BlockId::Number(last_block_header.number),
-            simulation_flags: dto::SimulationFlags(vec![dto::SimulationFlag::SkipValidate]),
-        };
-        let result = simulate_transactions(context, input).await.unwrap();
-
-        pretty_assertions_sorted::assert_eq!(
-            result,
-            SimulateTransactionOutput(vec![
-                fixtures::expected_output_0_13_0::declare_without_validate(
-                    account_contract_address,
-                    &last_block_header,
-                ),
-                fixtures::expected_output_0_13_0::universal_deployer_without_validate(
-                    account_contract_address,
-                    &last_block_header,
-                    universal_deployer_address,
-                ),
-                fixtures::expected_output_0_13_0::invoke_without_validate(
-                    account_contract_address,
-                    &last_block_header,
-                    test_storage_value,
-                ),
-            ])
-        );
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn declare_deploy_and_invoke_sierra_class_for_starknet_0_13_1() {
-        let (
-            storage,
-            last_block_header,
-            account_contract_address,
-            universal_deployer_address,
-            test_storage_value,
-        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 0)).await;
-        let context = RpcContext::for_tests().with_storage(storage);
-
-        let input = SimulateTransactionInput {
-            transactions: vec![
-                fixtures::input::declare(account_contract_address),
-                fixtures::input::universal_deployer(
-                    account_contract_address,
-                    universal_deployer_address,
-                ),
-                fixtures::input::invoke(account_contract_address),
-            ],
-            block_id: BlockId::Number(last_block_header.number),
-            simulation_flags: dto::SimulationFlags(vec![]),
-        };
-        let result = simulate_transactions(context, input).await.unwrap();
-
-        pretty_assertions_sorted::assert_eq!(
-            result,
-            SimulateTransactionOutput(vec![
-                fixtures::expected_output_0_13_1::declare(
-                    account_contract_address,
-                    &last_block_header
-                ),
-                fixtures::expected_output_0_13_1::universal_deployer(
-                    account_contract_address,
-                    &last_block_header,
-                    universal_deployer_address,
-                ),
-                fixtures::expected_output_0_13_1::invoke(
+                fixtures::expected_output_0_13_1_1::invoke(
                     account_contract_address,
                     &last_block_header,
                     test_storage_value,

--- a/crates/rpc/src/v06/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v06/method/trace_block_transactions.rs
@@ -329,6 +329,7 @@ pub(crate) mod tests {
         GasPrice,
         SequencerAddress,
         SierraHash,
+        StarknetVersion,
         TransactionIndex,
     };
     use pathfinder_crypto::Felt;
@@ -339,7 +340,10 @@ pub(crate) mod tests {
 
     pub(crate) async fn setup_multi_tx_trace_test(
     ) -> anyhow::Result<(RpcContext, BlockHeader, Vec<Trace>)> {
-        use super::super::simulate_transactions::tests::{fixtures, setup_storage};
+        use super::super::simulate_transactions::tests::{
+            fixtures,
+            setup_storage_with_starknet_version,
+        };
 
         let (
             storage,
@@ -347,7 +351,7 @@ pub(crate) mod tests {
             account_contract_address,
             universal_deployer_address,
             test_storage_value,
-        ) = setup_storage().await;
+        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 1)).await;
         let context = RpcContext::for_tests().with_storage(storage.clone());
 
         let transactions = vec![
@@ -361,15 +365,18 @@ pub(crate) mod tests {
         ];
 
         let traces = vec![
-            fixtures::expected_output_0_13_0::declare(account_contract_address, &last_block_header)
-                .transaction_trace,
-            fixtures::expected_output_0_13_0::universal_deployer(
+            fixtures::expected_output_0_13_1_1::declare(
+                account_contract_address,
+                &last_block_header,
+            )
+            .transaction_trace,
+            fixtures::expected_output_0_13_1_1::universal_deployer(
                 account_contract_address,
                 &last_block_header,
                 universal_deployer_address,
             )
             .transaction_trace,
-            fixtures::expected_output_0_13_0::invoke(
+            fixtures::expected_output_0_13_1_1::invoke(
                 account_contract_address,
                 &last_block_header,
                 test_storage_value,
@@ -480,7 +487,10 @@ pub(crate) mod tests {
 
     pub(crate) async fn setup_multi_tx_trace_pending_test(
     ) -> anyhow::Result<(RpcContext, Vec<Trace>)> {
-        use super::super::simulate_transactions::tests::{fixtures, setup_storage};
+        use super::super::simulate_transactions::tests::{
+            fixtures,
+            setup_storage_with_starknet_version,
+        };
 
         let (
             storage,
@@ -488,7 +498,7 @@ pub(crate) mod tests {
             account_contract_address,
             universal_deployer_address,
             test_storage_value,
-        ) = setup_storage().await;
+        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 1)).await;
         let context = RpcContext::for_tests().with_storage(storage.clone());
 
         let transactions = vec![
@@ -502,15 +512,18 @@ pub(crate) mod tests {
         ];
 
         let traces = vec![
-            fixtures::expected_output_0_13_0::declare(account_contract_address, &last_block_header)
-                .transaction_trace,
-            fixtures::expected_output_0_13_0::universal_deployer(
+            fixtures::expected_output_0_13_1_1::declare(
+                account_contract_address,
+                &last_block_header,
+            )
+            .transaction_trace,
+            fixtures::expected_output_0_13_1_1::universal_deployer(
                 account_contract_address,
                 &last_block_header,
                 universal_deployer_address,
             )
             .transaction_trace,
-            fixtures::expected_output_0_13_0::invoke(
+            fixtures::expected_output_0_13_1_1::invoke(
                 account_contract_address,
                 &last_block_header,
                 test_storage_value,

--- a/crates/rpc/src/v07/method/simulate_transactions.rs
+++ b/crates/rpc/src/v07/method/simulate_transactions.rs
@@ -340,7 +340,7 @@ pub(crate) mod tests {
             pub use crate::v04::method::simulate_transactions::tests::fixtures::input::*;
         }
 
-        pub mod expected_output_0_13_1 {
+        pub mod expected_output_0_13_1_1 {
             use pathfinder_common::{BlockHeader, ContractAddress, SierraHash, StorageValue};
 
             use super::dto::*;
@@ -351,8 +351,8 @@ pub(crate) mod tests {
                 StorageEntry,
             };
 
-            const DECLARE_OVERALL_FEE: u64 = 24201;
-            const DECLARE_GAS_CONSUMED: u64 = 23817;
+            const DECLARE_OVERALL_FEE: u64 = 1262;
+            const DECLARE_GAS_CONSUMED: u64 = 878;
             const DECLARE_DATA_GAS_CONSUMED: u64 = 192;
 
             pub fn declare(
@@ -494,7 +494,7 @@ pub(crate) mod tests {
                     storage_entries: vec![
                         StorageEntry {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffffa177")
+                            value: storage_value!("0x000000000000000000000000000000000000fffffffffffffffffffffffffb12")
                         },
                         StorageEntry {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
@@ -750,7 +750,7 @@ pub(crate) mod tests {
                     storage_entries: vec![
                         StorageEntry {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffff9fa7")
+                            value: storage_value!("0x000000000000000000000000000000000000fffffffffffffffffffffffff942")
                         },
                         StorageEntry {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
@@ -1102,7 +1102,7 @@ pub(crate) mod tests {
                     storage_entries: vec![
                         StorageEntry {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffff9e9b")
+                            value: storage_value!("0x000000000000000000000000000000000000fffffffffffffffffffffffff836")
                         },
                         StorageEntry {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
@@ -1417,7 +1417,7 @@ pub(crate) mod tests {
             account_contract_address,
             universal_deployer_address,
             test_storage_value,
-        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 0)).await;
+        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 1)).await;
         let context = RpcContext::for_tests().with_storage(storage);
 
         let input = SimulateTransactionInput {
@@ -1438,21 +1438,21 @@ pub(crate) mod tests {
         pretty_assertions_sorted::assert_eq!(
             result,
             SimulateTransactionOutput(vec![
-                fixtures::expected_output_0_13_1::declare(
+                fixtures::expected_output_0_13_1_1::declare(
                     account_contract_address,
                     &last_block_header
                 ),
-                fixtures::expected_output_0_13_1::universal_deployer(
+                fixtures::expected_output_0_13_1_1::universal_deployer(
                     account_contract_address,
                     &last_block_header,
                     universal_deployer_address,
                 ),
-                fixtures::expected_output_0_13_1::invoke(
+                fixtures::expected_output_0_13_1_1::invoke(
                     account_contract_address,
                     &last_block_header,
                     test_storage_value,
                 ),
-                fixtures::expected_output_0_13_1::invoke_v3(
+                fixtures::expected_output_0_13_1_1::invoke_v3(
                     account_contract_address,
                     &last_block_header,
                     test_storage_value,
@@ -1469,7 +1469,7 @@ pub(crate) mod tests {
             account_contract_address,
             universal_deployer_address,
             test_storage_value,
-        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 0)).await;
+        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 1)).await;
         let context = RpcContext::for_tests().with_storage(storage);
 
         let input = SimulateTransactionInput {
@@ -1490,18 +1490,18 @@ pub(crate) mod tests {
         pretty_assertions_sorted::assert_eq!(
             result,
             SimulateTransactionOutput(vec![
-                fixtures::expected_output_0_13_1::declare_without_fee_transfer(
+                fixtures::expected_output_0_13_1_1::declare_without_fee_transfer(
                     account_contract_address
                 ),
-                fixtures::expected_output_0_13_1::universal_deployer_without_fee_transfer(
+                fixtures::expected_output_0_13_1_1::universal_deployer_without_fee_transfer(
                     account_contract_address,
                     universal_deployer_address,
                 ),
-                fixtures::expected_output_0_13_1::invoke_without_fee_transfer(
+                fixtures::expected_output_0_13_1_1::invoke_without_fee_transfer(
                     account_contract_address,
                     test_storage_value,
                 ),
-                fixtures::expected_output_0_13_1::invoke_v3_without_fee_transfer(
+                fixtures::expected_output_0_13_1_1::invoke_v3_without_fee_transfer(
                     account_contract_address,
                     test_storage_value,
                 ),
@@ -1517,7 +1517,7 @@ pub(crate) mod tests {
             account_contract_address,
             universal_deployer_address,
             test_storage_value,
-        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 0)).await;
+        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 1)).await;
         let context = RpcContext::for_tests().with_storage(storage);
 
         let input = SimulateTransactionInput {
@@ -1538,21 +1538,21 @@ pub(crate) mod tests {
         pretty_assertions_sorted::assert_eq!(
             result,
             SimulateTransactionOutput(vec![
-                fixtures::expected_output_0_13_1::declare_without_validate(
+                fixtures::expected_output_0_13_1_1::declare_without_validate(
                     account_contract_address,
                     &last_block_header,
                 ),
-                fixtures::expected_output_0_13_1::universal_deployer_without_validate(
+                fixtures::expected_output_0_13_1_1::universal_deployer_without_validate(
                     account_contract_address,
                     &last_block_header,
                     universal_deployer_address,
                 ),
-                fixtures::expected_output_0_13_1::invoke_without_validate(
+                fixtures::expected_output_0_13_1_1::invoke_without_validate(
                     account_contract_address,
                     &last_block_header,
                     test_storage_value,
                 ),
-                fixtures::expected_output_0_13_1::invoke_v3_without_validate(
+                fixtures::expected_output_0_13_1_1::invoke_v3_without_validate(
                     account_contract_address,
                     &last_block_header,
                     test_storage_value,

--- a/crates/rpc/src/v07/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v07/method/trace_block_transactions.rs
@@ -39,7 +39,7 @@ pub(crate) mod tests {
             account_contract_address,
             universal_deployer_address,
             test_storage_value,
-        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 0)).await;
+        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 1)).await;
         let context = RpcContext::for_tests().with_storage(storage.clone());
 
         let transactions = vec![
@@ -53,15 +53,18 @@ pub(crate) mod tests {
         ];
 
         let traces = vec![
-            fixtures::expected_output_0_13_1::declare(account_contract_address, &last_block_header)
-                .transaction_trace,
-            fixtures::expected_output_0_13_1::universal_deployer(
+            fixtures::expected_output_0_13_1_1::declare(
+                account_contract_address,
+                &last_block_header,
+            )
+            .transaction_trace,
+            fixtures::expected_output_0_13_1_1::universal_deployer(
                 account_contract_address,
                 &last_block_header,
                 universal_deployer_address,
             )
             .transaction_trace,
-            fixtures::expected_output_0_13_1::invoke(
+            fixtures::expected_output_0_13_1_1::invoke(
                 account_contract_address,
                 &last_block_header,
                 test_storage_value,
@@ -88,7 +91,7 @@ pub(crate) mod tests {
                 .with_starknet_version(last_block_header.starknet_version)
                 .with_sequencer_address(last_block_header.sequencer_address)
                 .with_timestamp(last_block_header.timestamp)
-                .with_starknet_version(StarknetVersion::new(0, 13, 1, 0))
+                .with_starknet_version(StarknetVersion::new(0, 13, 1, 1))
                 .with_l1_da_mode(L1DataAvailabilityMode::Blob)
                 .finalize_with_hash(block_hash!("0x1"));
             tx.insert_block_header(&next_block_header)?;
@@ -182,7 +185,7 @@ pub(crate) mod tests {
             account_contract_address,
             universal_deployer_address,
             test_storage_value,
-        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 0)).await;
+        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 1)).await;
         let context = RpcContext::for_tests().with_storage(storage.clone());
 
         let transactions = vec![
@@ -196,15 +199,18 @@ pub(crate) mod tests {
         ];
 
         let traces = vec![
-            fixtures::expected_output_0_13_1::declare(account_contract_address, &last_block_header)
-                .transaction_trace,
-            fixtures::expected_output_0_13_1::universal_deployer(
+            fixtures::expected_output_0_13_1_1::declare(
+                account_contract_address,
+                &last_block_header,
+            )
+            .transaction_trace,
+            fixtures::expected_output_0_13_1_1::universal_deployer(
                 account_contract_address,
                 &last_block_header,
                 universal_deployer_address,
             )
             .transaction_trace,
-            fixtures::expected_output_0_13_1::invoke(
+            fixtures::expected_output_0_13_1_1::invoke(
                 account_contract_address,
                 &last_block_header,
                 test_storage_value,


### PR DESCRIPTION
Our current blockifier version cannot reliably reproduce transaction traces for some blocks due to an incompatible change between Starknet 0.13.1.1 and previous versions.

This change bumps the version where we even try to do execution ourselves to Starknet 0.13.1.1 (and thus we now fall back to fetching traces from the gateway for Starknet <= 0.13.1).
