### PR TITLE
fix(executor): don't duplicate messages from internal calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- `starknet_traceTransaction` and `starknet_traceBlockTransactions` returns L2 to L1 messages from inner calls duplicated.
+
 ## [0.13.1] - 2024-06-19
 
 ### Fixed

--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -373,19 +373,17 @@ fn ordered_l2_to_l1_messages(
 ) -> Vec<MsgToL1> {
     let mut messages = BTreeMap::new();
 
-    for call in call_info.into_iter() {
-        for OrderedL2ToL1Message { order, message } in &call.execution.l2_to_l1_messages {
-            messages.insert(
-                order,
-                MsgToL1 {
-                    order: *order,
-                    payload: message.payload.0.iter().map(IntoFelt::into_felt).collect(),
-                    to_address: Felt::from_be_slice(message.to_address.0.as_bytes())
-                        .expect("Ethereum address should fit into felt"),
-                    from_address: call.call.storage_address.0.key().into_felt(),
-                },
-            );
-        }
+    for OrderedL2ToL1Message { order, message } in &call_info.execution.l2_to_l1_messages {
+        messages.insert(
+            order,
+            MsgToL1 {
+                order: *order,
+                payload: message.payload.0.iter().map(IntoFelt::into_felt).collect(),
+                to_address: Felt::from_be_slice(message.to_address.0.as_bytes())
+                    .expect("Ethereum address should fit into felt"),
+                from_address: call_info.call.storage_address.0.key().into_felt(),
+            },
+        );
     }
 
     messages.into_values().collect()


### PR DESCRIPTION
When converting a blockifier `CallInfo` to a FUNCTION_INVOCATION we must _not_ process all messages from inner calls recursively. Doing so results in duplicating all messages from inner calls on the outer level, leading to an inconsistency with the output from the feeder gateway.

Easy to reproduce with Sepolia testnet transaction 0x04faf2a913828ab965de32bf3004ce183e035e92ddbf9517772c5beaa4edb216 where the message is emitted by an inner call and not the top-level contract.

Closes #2094