### PR TITLE
feat(ci): add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - v[0-9]+.*
+
+jobs:
+    create-draft-release:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: taiki-e/create-gh-release-action@v1
+              with:
+                # (Optional) Path to changelog.
+                changelog: CHANGELOG.md
+                # (Optional) Create a draft release.
+                # [default value: false]
+                draft: true
+                # (Required) GitHub token for creating GitHub Releases.
+                token: ${{ secrets.GITHUB_TOKEN }}
+
+    upload-assets:
+        needs: create-draft-release
+        strategy:
+            matrix:
+              include:
+                - target: x86_64-unknown-linux-gnu
+                  os: ubuntu-20.04
+                - target: x86_64-apple-darwin
+                  os: macos-latest
+                - target: aarch64-apple-darwin
+                  os: macos-latest
+        runs-on: ${{ matrix.os }}
+        steps:
+            - uses: actions/checkout@v4
+            - uses: dtolnay/rust-toolchain@stable
+            - uses: arduino/setup-protoc@v3
+              with:
+                repo-token: ${{ secrets.GITHUB_TOKEN }}
+            - uses: taiki-e/upload-rust-binary-action@v1
+              with:
+                bin: pathfinder
+                target: ${{ matrix.target }}
+                profile: release-lto
+                token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,18 +95,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `starknet_getTransactionStatus` reports gateway errors as `TxnNotFound`. These are now reported as internal errors.
 - Sync process leaves a zombie task behind each time it restarts, wasting resources.
+- `starknet_getEvents` does not return a continuation token if not all events from the last block fit into the result page.
+- `starknet_addXXX` requests to the gateway use the configured gateway timeout, often causing these to timeout while waiting for 
+  a gateway response. These instead now use a much longer timeout.
 
 ### Changed
 
 - Default sync poll reduced from 5s to 2s. This is more appropriate given the lower block times on mainnet.
-
-## [0.11.2] - 2024-03-07
-
-### Fixed
-
-- `starknet_getEvents` does not return a continuation token if not all events from the last block fit into the result page.
-- `starknet_addXXX` requests to the gateway use the configured gateway timeout, often causing these to timeout while waiting for 
-  a gateway response. These instead now use a much longer timeout.
 
 ## [0.11.1] - 2024-03-01
 


### PR DESCRIPTION
This PR adds a workflow that automatically creates a draft release and builds and uploads a set of pathfinder binaries (for various architectures) upon pushing a release tag to the repository.

With the recent changes that enable building P2P crates some of our users are facing issues building pathfinder: our dependency on a recent version of `protoc` is causing problems for users trying to build on old Linux distributions.

Uploading "official" release binaries can help these users get pathfinder up-and-running without requiring the use of the Docker image.