### PR TITLE
fix(storage/trie): fix reorg failure for no-history pruning mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Pathfinder exits with an error when detecting a one-block reorg if `--storage.state-tries` is set to `0`.
+
 ## [0.13.2] - 2024-06-24
 
 ### Fixed

--- a/crates/pathfinder/examples/feeder_gateway.rs
+++ b/crates/pathfinder/examples/feeder_gateway.rs
@@ -294,6 +294,12 @@ async fn serve(cli: Cli) -> anyhow::Result<()> {
             }
         });
 
+    let get_public_key = warp::path("get_public_key").then(|| async {
+        warp::reply::json(&serde_json::json!(
+            "0x1252b6bce1351844c677869c6327e80eae1535755b611c66b8f46e595b40eea"
+        ))
+    });
+
     #[derive(Debug, Deserialize)]
     struct ClassHashParam {
         #[serde(rename = "classHash")]
@@ -336,7 +342,8 @@ async fn serve(cli: Cli) -> anyhow::Result<()> {
                 .or(get_state_update)
                 .or(get_contract_addresses)
                 .or(get_class_by_hash)
-                .or(get_signature),
+                .or(get_signature)
+                .or(get_public_key),
         )
         .with(warp::filters::trace::request());
 

--- a/crates/storage/src/connection/trie.rs
+++ b/crates/storage/src/connection/trie.rs
@@ -1435,7 +1435,7 @@ mod tests {
     }
 
     #[test]
-    fn trie_root_updates() {
+    fn class_trie_root_updates() {
         let mut db = crate::StorageBuilder::in_memory_with_trie_pruning(TriePruneMode::Prune {
             num_blocks_kept: 0,
         })
@@ -1465,5 +1465,249 @@ mod tests {
             )
             .unwrap();
         assert_eq!(root_update, RootIndexUpdate::Updated(1));
+    }
+
+    #[test]
+    fn class_root_insert_should_prune_old_roots() {
+        let mut db = crate::StorageBuilder::in_memory_with_trie_pruning(TriePruneMode::Prune {
+            num_blocks_kept: 1,
+        })
+        .unwrap()
+        .connection()
+        .unwrap();
+        let tx = db.transaction().unwrap();
+
+        tx.insert_class_root(BlockNumber::GENESIS, RootIndexUpdate::Updated(1))
+            .unwrap();
+        tx.insert_class_root(BlockNumber::new_or_panic(1), RootIndexUpdate::Updated(2))
+            .unwrap();
+        // no root inserted for block 2
+        tx.insert_class_root(BlockNumber::new_or_panic(3), RootIndexUpdate::Updated(3))
+            .unwrap();
+
+        assert!(!tx.class_root_exists(BlockNumber::GENESIS).unwrap());
+        // root at block 1 cannot be deleted because it is still required for
+        // reconstructing state at block 2
+        assert!(tx.class_root_exists(BlockNumber::new_or_panic(1)).unwrap());
+        assert!(tx.class_root_exists(BlockNumber::new_or_panic(3)).unwrap());
+    }
+
+    #[test]
+    fn class_root_insert_should_prune_old_roots_in_no_history_mode() {
+        let mut db = crate::StorageBuilder::in_memory_with_trie_pruning(TriePruneMode::Prune {
+            num_blocks_kept: 0,
+        })
+        .unwrap()
+        .connection()
+        .unwrap();
+        let tx = db.transaction().unwrap();
+
+        tx.insert_class_root(BlockNumber::GENESIS, RootIndexUpdate::Updated(1))
+            .unwrap();
+        tx.insert_class_root(BlockNumber::new_or_panic(1), RootIndexUpdate::Updated(2))
+            .unwrap();
+
+        assert!(!tx.class_root_exists(BlockNumber::GENESIS).unwrap());
+        assert!(tx.class_root_exists(BlockNumber::new_or_panic(1)).unwrap());
+    }
+
+    #[test]
+    fn contract_state_hash_insert_should_prune_old_state_hashes() {
+        let mut db = crate::StorageBuilder::in_memory_with_trie_pruning(TriePruneMode::Prune {
+            num_blocks_kept: 1,
+        })
+        .unwrap()
+        .connection()
+        .unwrap();
+        let tx = db.transaction().unwrap();
+
+        let contract = contract_address!("0xdeadbeef");
+        tx.insert_contract_state_hash(BlockNumber::GENESIS, contract, contract_state_hash!("0x01"))
+            .unwrap();
+        tx.insert_contract_state_hash(
+            BlockNumber::new_or_panic(1),
+            contract,
+            contract_state_hash!("0x02"),
+        )
+        .unwrap();
+        // no new state hash for block 2
+        tx.insert_contract_state_hash(
+            BlockNumber::new_or_panic(3),
+            contract,
+            contract_state_hash!("0x03"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            tx.contract_state_hash(BlockNumber::GENESIS, contract)
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            tx.contract_state_hash(BlockNumber::new_or_panic(2), contract)
+                .unwrap(),
+            Some(contract_state_hash!("0x02"))
+        );
+        assert_eq!(
+            tx.contract_state_hash(BlockNumber::new_or_panic(3), contract)
+                .unwrap(),
+            Some(contract_state_hash!("0x03"))
+        );
+    }
+
+    #[test]
+    fn contract_state_hash_insert_should_prune_all_old_state_in_no_history_mode() {
+        let mut db = crate::StorageBuilder::in_memory_with_trie_pruning(TriePruneMode::Prune {
+            num_blocks_kept: 0,
+        })
+        .unwrap()
+        .connection()
+        .unwrap();
+        let tx = db.transaction().unwrap();
+
+        let contract = contract_address!("0xdeadbeef");
+        tx.insert_contract_state_hash(BlockNumber::GENESIS, contract, contract_state_hash!("0x01"))
+            .unwrap();
+        tx.insert_contract_state_hash(
+            BlockNumber::new_or_panic(1),
+            contract,
+            contract_state_hash!("0x02"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            tx.contract_state_hash(BlockNumber::GENESIS, contract)
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            tx.contract_state_hash(BlockNumber::new_or_panic(1), contract)
+                .unwrap(),
+            Some(contract_state_hash!("0x02"))
+        );
+    }
+
+    #[test]
+    fn storage_root_insert_should_prune_old_roots() {
+        let mut db = crate::StorageBuilder::in_memory_with_trie_pruning(TriePruneMode::Prune {
+            num_blocks_kept: 1,
+        })
+        .unwrap()
+        .connection()
+        .unwrap();
+        let tx = db.transaction().unwrap();
+
+        tx.insert_storage_root(BlockNumber::GENESIS, RootIndexUpdate::Updated(1))
+            .unwrap();
+        tx.insert_storage_root(BlockNumber::new_or_panic(1), RootIndexUpdate::Updated(2))
+            .unwrap();
+        // no new root index for block 2
+        tx.insert_storage_root(BlockNumber::new_or_panic(3), RootIndexUpdate::Updated(3))
+            .unwrap();
+
+        assert!(!tx.storage_root_exists(BlockNumber::GENESIS).unwrap());
+        assert!(tx
+            .storage_root_exists(BlockNumber::new_or_panic(1))
+            .unwrap());
+        assert!(tx
+            .storage_root_exists(BlockNumber::new_or_panic(3))
+            .unwrap());
+    }
+
+    #[test]
+    fn storage_root_insert_should_prune_all_old_roots_in_no_history_mode() {
+        let mut db = crate::StorageBuilder::in_memory_with_trie_pruning(TriePruneMode::Prune {
+            num_blocks_kept: 0,
+        })
+        .unwrap()
+        .connection()
+        .unwrap();
+        let tx = db.transaction().unwrap();
+
+        tx.insert_storage_root(BlockNumber::GENESIS, RootIndexUpdate::Updated(1))
+            .unwrap();
+        tx.insert_storage_root(BlockNumber::new_or_panic(1), RootIndexUpdate::Updated(2))
+            .unwrap();
+
+        assert!(!tx.storage_root_exists(BlockNumber::GENESIS).unwrap());
+        assert!(tx
+            .storage_root_exists(BlockNumber::new_or_panic(1))
+            .unwrap());
+    }
+
+    #[test]
+    fn contract_root_insert_should_prune_old_state_hashes() {
+        let mut db = crate::StorageBuilder::in_memory_with_trie_pruning(TriePruneMode::Prune {
+            num_blocks_kept: 1,
+        })
+        .unwrap()
+        .connection()
+        .unwrap();
+        let tx = db.transaction().unwrap();
+
+        let contract = contract_address!("0xdeadbeef");
+        tx.insert_contract_root(BlockNumber::GENESIS, contract, RootIndexUpdate::Updated(1))
+            .unwrap();
+        tx.insert_contract_root(
+            BlockNumber::new_or_panic(1),
+            contract,
+            RootIndexUpdate::Updated(2),
+        )
+        .unwrap();
+        // no new root for block 2
+        tx.insert_contract_root(
+            BlockNumber::new_or_panic(3),
+            contract,
+            RootIndexUpdate::Updated(3),
+        )
+        .unwrap();
+
+        assert_eq!(
+            tx.contract_root_index(BlockNumber::GENESIS, contract)
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            tx.contract_root_index(BlockNumber::new_or_panic(2), contract)
+                .unwrap(),
+            Some(2)
+        );
+        assert_eq!(
+            tx.contract_root_index(BlockNumber::new_or_panic(3), contract)
+                .unwrap(),
+            Some(3)
+        );
+    }
+
+    #[test]
+    fn contract_root_insert_should_prune_all_old_roots_in_no_history_mode() {
+        let mut db = crate::StorageBuilder::in_memory_with_trie_pruning(TriePruneMode::Prune {
+            num_blocks_kept: 0,
+        })
+        .unwrap()
+        .connection()
+        .unwrap();
+        let tx = db.transaction().unwrap();
+
+        let contract = contract_address!("0xdeadbeef");
+        tx.insert_contract_root(BlockNumber::GENESIS, contract, RootIndexUpdate::Updated(1))
+            .unwrap();
+        tx.insert_contract_root(
+            BlockNumber::new_or_panic(1),
+            contract,
+            RootIndexUpdate::Updated(2),
+        )
+        .unwrap();
+
+        assert_eq!(
+            tx.contract_root_index(BlockNumber::GENESIS, contract)
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            tx.contract_root_index(BlockNumber::new_or_panic(1), contract)
+                .unwrap(),
+            Some(2)
+        );
     }
 }


### PR DESCRIPTION
When inserting a new trie root (or contract state hash) we were first pruning the old values (so that data that is out of the number-of-blocks-kept window is removed). The pruning functions make sure that there's at least one value kept at or before the first block of the availability window.

This was working correctly for non-zero number-of-blocks-kept values, but was causing missed removals for the no-history case. When number-of-block-kept is zero we were keeping the _previous_ value (root / state hash) in addition to the new value we were being inserting. This lead to missing a required revert operation upon a one-block reorg because the global storage root index was still in place for the target block.

This change fixes this by reordering insertion of the new node and pruning. This way we correctly remove old values in the no-history case.

Closes: #2110 
