### PR TITLE
fix(rpc/dto/receipt): allow `steps` to be zero in COMPUTATION_RESOURCES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Pathfinder exits with an error when detecting a one-block reorg if `--storage.state-tries` is set to `0`.
+- Pathfinder returns an internal error for `starknet_getTransactionReceipt` requests where `steps` would be zero in COMPUTATION_RESOURCES.
 
 ## [0.13.2] - 2024-06-24
 

--- a/crates/rpc/src/dto/receipt.rs
+++ b/crates/rpc/src/dto/receipt.rs
@@ -388,10 +388,10 @@ impl SerializeForVersion for ComputationResources<'_> {
     fn serialize(&self, serializer: Serializer) -> Result<serialize::Ok, serialize::Error> {
         use std::num::NonZeroU64;
 
-        // All values are required to be non-zero. Steps MUST be non-zero as it is
-        // required, however the rest are simply skipped if zero.
-        let steps = NonZeroU64::new(self.0.n_steps)
-            .ok_or_else(|| serde_json::error::Error::custom("steps was zero which is invalid"))?;
+        // We're technically breaking the spec here if `steps` is zero but turns out
+        // there _are_ transactions on Starknet mainnet with steps being zero:
+        // https://starkscan.co/tx/0x04026b1598e5915737d439e8b8493cce9e47a5a334948e28f55c391bc2e0c2e2
+        let steps = self.0.n_steps;
         let memory_holes = NonZeroU64::new(self.0.n_memory_holes);
         let range_check = NonZeroU64::new(self.0.builtins.range_check);
         let pedersen = NonZeroU64::new(self.0.builtins.pedersen);


### PR DESCRIPTION
This is technically breaking the JSON-RPC 0.7.0 specification, but it turns out that there are mainnet transactions for which `n_steps` is zero in the receipt: 0x04026b1598e5915737d439e8b8493cce9e47a5a334948e28f55c391bc2e0c2e2. Returning 0 here risks SDKs doing proper validation rejecting the response anyway -- but even in that case the result is not worse than it is now.

Before this fix querying the receipt for the transaction above lead to an internal error but just returning zero might be more sensible until we get the specification fixed.

Closes #2117 
