### PR TITLE
feat: use random peers instead of querying for capabilities

### DIFF
--- a/crates/p2p/src/behaviour.rs
+++ b/crates/p2p/src/behaviour.rs
@@ -523,6 +523,10 @@ impl Behaviour {
         self.inner.kademlia.get_providers(key)
     }
 
+    pub fn get_closest_peers(&mut self, peer: PeerId) -> kad::QueryId {
+        self.inner.kademlia.get_closest_peers(peer)
+    }
+
     pub fn subscribe_topic(&mut self, topic: &IdentTopic) -> anyhow::Result<()> {
         self.inner.gossipsub.subscribe(topic)?;
         Ok(())

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -135,6 +135,10 @@ enum Command {
         capability: String,
         sender: mpsc::Sender<anyhow::Result<HashSet<PeerId>>>,
     },
+    GetClosestPeers {
+        peer: PeerId,
+        sender: mpsc::Sender<anyhow::Result<Vec<PeerId>>>,
+    },
     SubscribeTopic {
         topic: IdentTopic,
         sender: EmptyResultSender,


### PR DESCRIPTION
Fixes: #2119 

Random peers are obtained by querying for closest peer to a random peerId (essentially a random key).