### PR TITLE
feat: add `--rpc.custom-versioned-constants-json-path` CLI option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Pathfinder now creates a new directory if the database path specified does not exist.
+- Pathfinder now has a CLI option (`--rpc.custom-versioned-constants-json-path`) to allow loading a custom versioned constants JSON file. When specified the contents of the file is then used instead of the _latest_ constants built into the blockifier crate during execution of Cairo code.
 
 ### Fixed
 

--- a/crates/executor/src/call.rs
+++ b/crates/executor/src/call.rs
@@ -13,7 +13,7 @@ use super::execution_state::ExecutionState;
 use super::felt::{IntoFelt, IntoStarkFelt};
 
 pub fn call(
-    mut execution_state: ExecutionState<'_>,
+    execution_state: ExecutionState<'_>,
     contract_address: ContractAddress,
     entry_point_selector: EntryPoint,
     calldata: Vec<CallParam>,

--- a/crates/executor/src/estimate.rs
+++ b/crates/executor/src/estimate.rs
@@ -6,7 +6,7 @@ use super::execution_state::ExecutionState;
 use super::types::FeeEstimate;
 
 pub fn estimate(
-    mut execution_state: ExecutionState<'_>,
+    execution_state: ExecutionState<'_>,
     transactions: Vec<Transaction>,
     skip_validate: bool,
 ) -> Result<Vec<FeeEstimate>, TransactionExecutionError> {

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -15,6 +15,7 @@ pub mod types;
 pub use blockifier::execution::contract_class::ClassInfo;
 pub use blockifier::transaction::account_transaction::AccountTransaction;
 pub use blockifier::transaction::transaction_execution::Transaction;
+pub use blockifier::versioned_constants::VersionedConstants;
 pub use call::call;
 pub use class::{parse_casm_definition, parse_deprecated_class_definition};
 pub use error::{CallError, TransactionExecutionError};

--- a/crates/executor/src/simulate.rs
+++ b/crates/executor/src/simulate.rs
@@ -74,7 +74,7 @@ impl Default for TraceCache {
 }
 
 pub fn simulate(
-    mut execution_state: ExecutionState<'_>,
+    execution_state: ExecutionState<'_>,
     transactions: Vec<Transaction>,
     skip_validate: bool,
     skip_fee_charge: bool,
@@ -140,7 +140,7 @@ pub fn simulate(
 }
 
 pub fn trace(
-    mut execution_state: ExecutionState<'_>,
+    execution_state: ExecutionState<'_>,
     cache: TraceCache,
     block_hash: BlockHash,
     transactions: Vec<Transaction>,

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -41,6 +41,7 @@ pathfinder-common = { path = "../common" }
 pathfinder-compiler = { path = "../compiler" }
 pathfinder-crypto = { path = "../crypto" }
 pathfinder-ethereum = { path = "../ethereum" }
+pathfinder-executor = { path = "../executor" }
 pathfinder-merkle-tree = { path = "../merkle-tree" }
 pathfinder-retry = { path = "../retry" }
 pathfinder-rpc = { path = "../rpc" }

--- a/crates/pathfinder/examples/re_execute.rs
+++ b/crates/pathfinder/examples/re_execute.rs
@@ -132,7 +132,7 @@ fn execute(storage: &mut Storage, chain_id: ChainId, work: Work) {
 
     let db_tx = connection.transaction().expect("Create transaction");
 
-    let execution_state = ExecutionState::trace(&db_tx, chain_id, work.header.clone(), None);
+    let execution_state = ExecutionState::trace(&db_tx, chain_id, work.header.clone(), None, None);
 
     let transactions = work
         .transactions

--- a/crates/pathfinder/resources/invalid_versioned_constants.json
+++ b/crates/pathfinder/resources/invalid_versioned_constants.json
@@ -1,0 +1,3 @@
+{
+    "invalid": "contents"
+}

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -48,7 +48,7 @@ async fn async_main() -> anyhow::Result<()> {
         std::env::set_var("RUST_LOG", "pathfinder=info");
     }
 
-    let config = config::Config::parse();
+    let mut config = config::Config::parse();
 
     setup_tracing(config.color, config.debug.pretty_log);
 
@@ -209,7 +209,7 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
         get_events_max_blocks_to_scan: config.get_events_max_blocks_to_scan,
         get_events_max_uncached_bloom_filters_to_load: config
             .get_events_max_uncached_bloom_filters_to_load,
-        custom_versioned_constants: None,
+        custom_versioned_constants: config.custom_versioned_constants.take(),
     };
 
     let context = pathfinder_rpc::context::RpcContext::new(

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -209,6 +209,7 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
         get_events_max_blocks_to_scan: config.get_events_max_blocks_to_scan,
         get_events_max_uncached_bloom_filters_to_load: config
             .get_events_max_uncached_bloom_filters_to_load,
+        custom_versioned_constants: None,
     };
 
     let context = pathfinder_rpc::context::RpcContext::new(

--- a/crates/rpc/src/context.rs
+++ b/crates/rpc/src/context.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use pathfinder_common::ChainId;
-use pathfinder_executor::TraceCache;
+use pathfinder_executor::{TraceCache, VersionedConstants};
 use pathfinder_storage::Storage;
 
 pub use crate::jsonrpc::websocket::WebsocketContext;
@@ -17,6 +17,7 @@ pub struct RpcConfig {
     pub batch_concurrency_limit: NonZeroUsize,
     pub get_events_max_blocks_to_scan: NonZeroUsize,
     pub get_events_max_uncached_bloom_filters_to_load: NonZeroUsize,
+    pub custom_versioned_constants: Option<VersionedConstants>,
 }
 
 #[derive(Clone)]
@@ -100,6 +101,7 @@ impl RpcContext {
             batch_concurrency_limit: NonZeroUsize::new(8).unwrap(),
             get_events_max_blocks_to_scan: NonZeroUsize::new(1000).unwrap(),
             get_events_max_uncached_bloom_filters_to_load: NonZeroUsize::new(1000).unwrap(),
+            custom_versioned_constants: None,
         };
 
         Self::new(

--- a/crates/rpc/src/v04/method/simulate_transactions.rs
+++ b/crates/rpc/src/v04/method/simulate_transactions.rs
@@ -107,6 +107,7 @@ pub async fn simulate_transactions(
             header,
             pending,
             pathfinder_executor::L1BlobDataAvailability::Disabled,
+            context.config.custom_versioned_constants,
         );
 
         let transactions = input

--- a/crates/rpc/src/v05/method/call.rs
+++ b/crates/rpc/src/v05/method/call.rs
@@ -116,6 +116,7 @@ pub async fn call(context: RpcContext, input: CallInput) -> Result<CallOutput, C
             header,
             pending,
             L1BlobDataAvailability::Disabled,
+            context.config.custom_versioned_constants,
         );
 
         let result = pathfinder_executor::call(

--- a/crates/rpc/src/v05/method/estimate_fee.rs
+++ b/crates/rpc/src/v05/method/estimate_fee.rs
@@ -133,6 +133,7 @@ pub async fn estimate_fee(
             header,
             pending,
             L1BlobDataAvailability::Disabled,
+            context.config.custom_versioned_constants,
         );
 
         let transactions = input

--- a/crates/rpc/src/v05/method/simulate_transactions.rs
+++ b/crates/rpc/src/v05/method/simulate_transactions.rs
@@ -130,6 +130,7 @@ pub async fn simulate_transactions(
             header,
             pending,
             L1BlobDataAvailability::Disabled,
+            context.config.custom_versioned_constants,
         );
 
         let transactions = input

--- a/crates/rpc/src/v05/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v05/method/trace_block_transactions.rs
@@ -221,7 +221,13 @@ pub async fn trace_block_transactions(
             .collect::<Result<Vec<_>, _>>()?;
 
         let hash = header.hash;
-        let state = ExecutionState::trace(&db, context.chain_id, header, None);
+        let state = ExecutionState::trace(
+            &db,
+            context.chain_id,
+            header,
+            None,
+            context.config.custom_versioned_constants,
+        );
         let traces =
             match pathfinder_executor::trace(state, cache, hash, executor_transactions, true, true)
             {

--- a/crates/rpc/src/v05/method/trace_transaction.rs
+++ b/crates/rpc/src/v05/method/trace_transaction.rs
@@ -174,7 +174,13 @@ pub async fn trace_transaction(
             };
 
             let hash = header.hash;
-            let state = ExecutionState::trace(&db, context.chain_id, header, None);
+            let state = ExecutionState::trace(
+                &db,
+                context.chain_id,
+                header,
+                None,
+                context.config.custom_versioned_constants,
+            );
 
             let executor_transactions = transactions
                 .iter()

--- a/crates/rpc/src/v06/method/estimate_fee.rs
+++ b/crates/rpc/src/v06/method/estimate_fee.rs
@@ -177,6 +177,7 @@ pub async fn estimate_fee_impl(
             header,
             pending,
             l1_blob_data_availability,
+            context.config.custom_versioned_constants,
         );
 
         let skip_validate = input

--- a/crates/rpc/src/v06/method/estimate_message_fee.rs
+++ b/crates/rpc/src/v06/method/estimate_message_fee.rs
@@ -147,6 +147,7 @@ pub(crate) async fn estimate_message_fee_impl(
             header,
             pending,
             l1_blob_data_availability,
+            context.config.custom_versioned_constants,
         );
 
         let transaction = create_executor_transaction(input, context.chain_id)?;

--- a/crates/rpc/src/v06/method/simulate_transactions.rs
+++ b/crates/rpc/src/v06/method/simulate_transactions.rs
@@ -147,6 +147,7 @@ pub async fn simulate_transactions_impl(
             header,
             pending,
             l1_blob_data_availability,
+            context.config.custom_versioned_constants,
         );
 
         let transactions = input

--- a/crates/rpc/src/v06/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v06/method/trace_block_transactions.rs
@@ -261,7 +261,13 @@ pub async fn trace_block_transactions_impl(
             .collect::<Result<Vec<_>, _>>()?;
 
         let hash = header.hash;
-        let state = ExecutionState::trace(&db, context.chain_id, header, None);
+        let state = ExecutionState::trace(
+            &db,
+            context.chain_id,
+            header,
+            None,
+            context.config.custom_versioned_constants,
+        );
         let traces =
             match pathfinder_executor::trace(state, cache, hash, executor_transactions, true, true)
             {

--- a/crates/rpc/src/v06/method/trace_transaction.rs
+++ b/crates/rpc/src/v06/method/trace_transaction.rs
@@ -189,7 +189,13 @@ pub async fn trace_transaction_impl(
             };
 
             let hash = header.hash;
-            let state = ExecutionState::trace(&db, context.chain_id, header, None);
+            let state = ExecutionState::trace(
+                &db,
+                context.chain_id,
+                header,
+                None,
+                context.config.custom_versioned_constants,
+            );
 
             let executor_transactions = transactions
                 .iter()


### PR DESCRIPTION
This allows loading a custom versioned constants JSON to use instead of the latest version (0.13.2 currently) of constants built into blockifier.

Closes: #2127
