### PR TITLE
feat(pathfinder): create database directory if it does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Pathfinder now creates a new directory if the database path specified does not exist.
+
 ### Fixed
 
 - Pathfinder exits with an error when detecting a one-block reorg if `--storage.state-tries` is set to `0`.

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -58,6 +58,12 @@ async fn async_main() -> anyhow::Result<()> {
         "🏁 Starting node."
     );
 
+    if !config.data_directory.exists() {
+        std::fs::DirBuilder::new()
+            .create(&config.data_directory)
+            .context("Creating database directory")?;
+    }
+
     permission_check(&config.data_directory)?;
 
     let available_parallelism = std::thread::available_parallelism()?;


### PR DESCRIPTION
To make it easier to start up pathfinder with a new database we now create a new directory if the database path specified does not exist.

Closes: #2126 