### PR TITLE
fix(rpc): use execution storage for execution-related RPC methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Pathfinder does not properly limit the number of concurrent executors when using the `--rpc.execution-concurrency` CLI option.
+
 ## [0.14.0] - 2024-07-22
 
 ### Added

--- a/crates/executor/src/simulate.rs
+++ b/crates/executor/src/simulate.rs
@@ -144,8 +144,6 @@ pub fn trace(
     cache: TraceCache,
     block_hash: BlockHash,
     transactions: Vec<Transaction>,
-    charge_fee: bool,
-    validate: bool,
 ) -> Result<Vec<(TransactionHash, TransactionTrace)>, TransactionExecutionError> {
     let (mut state, block_context) = execution_state.starknet_state()?;
 
@@ -187,7 +185,7 @@ pub fn trace(
 
         let mut tx_state = CachedState::<_>::create_transactional(&mut state);
         let tx_info = tx
-            .execute(&mut tx_state, &block_context, charge_fee, validate)
+            .execute(&mut tx_state, &block_context, true, true)
             .map_err(|e| {
                 // Update the cache with the error. Lock the cache before sending to avoid
                 // race conditions between senders and receivers.

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -161,7 +161,7 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
         .expect("usize should cast to u32");
     let rpc_storage = std::cmp::max(10, max_rpc_connections / 8);
     let rpc_storage = NonZeroU32::new(rpc_storage).expect("A non-zero minimum is set");
-    let rpc_storage = storage_manager.create_pool(rpc_storage).context(
+    let rpc_storage = storage_manager.create_read_only_pool(rpc_storage).context(
         r"Creating database connection pool for RPC
 
 Hint: This is usually caused by exceeding the file descriptor limit of your system.
@@ -173,7 +173,7 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
             .expect("The number of CPU cores should be non-zero")
     });
     let execution_storage = storage_manager
-        .create_pool(execution_storage_pool_size)
+        .create_read_only_pool(execution_storage_pool_size)
         .context(r"")?;
 
     let p2p_storage = storage_manager

--- a/crates/rpc/src/v04/method/simulate_transactions.rs
+++ b/crates/rpc/src/v04/method/simulate_transactions.rs
@@ -75,7 +75,7 @@ pub async fn simulate_transactions(
             .any(|flag| flag == &dto::SimulationFlag::SkipFeeCharge);
 
         let mut db = context
-            .storage
+            .execution_storage
             .connection()
             .context("Creating database connection")?;
         let db = db.transaction().context("Creating database transaction")?;

--- a/crates/rpc/src/v05/method/estimate_fee.rs
+++ b/crates/rpc/src/v05/method/estimate_fee.rs
@@ -102,7 +102,7 @@ pub async fn estimate_fee(
     let result = tokio::task::spawn_blocking(move || {
         let _g = span.enter();
         let mut db = context
-            .storage
+            .execution_storage
             .connection()
             .context("Creating database connection")?;
         let db = db.transaction().context("Creating database transaction")?;

--- a/crates/rpc/src/v05/method/simulate_transactions.rs
+++ b/crates/rpc/src/v05/method/simulate_transactions.rs
@@ -98,7 +98,7 @@ pub async fn simulate_transactions(
             .any(|flag| flag == &dto::SimulationFlag::SkipFeeCharge);
 
         let mut db = context
-            .storage
+            .execution_storage
             .connection()
             .context("Creating database connection")?;
         let db = db.transaction().context("Creating database transaction")?;

--- a/crates/rpc/src/v05/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v05/method/trace_block_transactions.rs
@@ -228,15 +228,13 @@ pub async fn trace_block_transactions(
             None,
             context.config.custom_versioned_constants,
         );
-        let traces =
-            match pathfinder_executor::trace(state, cache, hash, executor_transactions, true, true)
-            {
-                Ok(traces) => traces,
-                Err(TransactionExecutionError::ExecutionError { .. }) => {
-                    return Ok(LocalExecution::Unsupported(transactions))
-                }
-                Err(e) => return Err(e.into()),
-            };
+        let traces = match pathfinder_executor::trace(state, cache, hash, executor_transactions) {
+            Ok(traces) => traces,
+            Err(TransactionExecutionError::ExecutionError { .. }) => {
+                return Ok(LocalExecution::Unsupported(transactions))
+            }
+            Err(e) => return Err(e.into()),
+        };
 
         let result = traces
             .into_iter()

--- a/crates/rpc/src/v05/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v05/method/trace_block_transactions.rs
@@ -157,7 +157,7 @@ pub async fn trace_block_transactions(
 
     let span = tracing::Span::current();
 
-    let storage = context.storage.clone();
+    let storage = context.execution_storage.clone();
     let traces = tokio::task::spawn_blocking(move || {
         let _g = span.enter();
 

--- a/crates/rpc/src/v05/method/trace_transaction.rs
+++ b/crates/rpc/src/v05/method/trace_transaction.rs
@@ -187,8 +187,7 @@ pub async fn trace_transaction(
                 .map(|transaction| compose_executor_transaction(transaction, &db))
                 .collect::<Result<Vec<_>, _>>()?;
 
-            match pathfinder_executor::trace(state, cache, hash, executor_transactions, true, true)
-            {
+            match pathfinder_executor::trace(state, cache, hash, executor_transactions) {
                 Ok(txs) => {
                     let trace = txs
                         .into_iter()

--- a/crates/rpc/src/v05/method/trace_transaction.rs
+++ b/crates/rpc/src/v05/method/trace_transaction.rs
@@ -109,7 +109,7 @@ pub async fn trace_transaction(
             let _g = span.enter();
 
             let mut db = context
-                .storage
+                .execution_storage
                 .connection()
                 .context("Creating database connection")?;
             let db = db.transaction().context("Creating database transaction")?;

--- a/crates/rpc/src/v06/method/estimate_fee.rs
+++ b/crates/rpc/src/v06/method/estimate_fee.rs
@@ -146,7 +146,7 @@ pub async fn estimate_fee_impl(
     let result = tokio::task::spawn_blocking(move || {
         let _g = span.enter();
         let mut db = context
-            .storage
+            .execution_storage
             .connection()
             .context("Creating database connection")?;
         let db = db.transaction().context("Creating database transaction")?;

--- a/crates/rpc/src/v06/method/simulate_transactions.rs
+++ b/crates/rpc/src/v06/method/simulate_transactions.rs
@@ -115,7 +115,7 @@ pub async fn simulate_transactions_impl(
             .any(|flag| flag == &dto::SimulationFlag::SkipFeeCharge);
 
         let mut db = context
-            .storage
+            .execution_storage
             .connection()
             .context("Creating database connection")?;
         let db = db.transaction().context("Creating database transaction")?;

--- a/crates/rpc/src/v06/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v06/method/trace_block_transactions.rs
@@ -197,7 +197,7 @@ pub async fn trace_block_transactions_impl(
 
     let span = tracing::Span::current();
 
-    let storage = context.storage.clone();
+    let storage = context.execution_storage.clone();
     let traces = tokio::task::spawn_blocking(move || {
         let _g = span.enter();
 

--- a/crates/rpc/src/v06/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v06/method/trace_block_transactions.rs
@@ -268,15 +268,13 @@ pub async fn trace_block_transactions_impl(
             None,
             context.config.custom_versioned_constants,
         );
-        let traces =
-            match pathfinder_executor::trace(state, cache, hash, executor_transactions, true, true)
-            {
-                Ok(traces) => traces,
-                Err(TransactionExecutionError::ExecutionError { .. }) => {
-                    return Ok(LocalExecution::Unsupported(transactions))
-                }
-                Err(e) => return Err(e.into()),
-            };
+        let traces = match pathfinder_executor::trace(state, cache, hash, executor_transactions) {
+            Ok(traces) => traces,
+            Err(TransactionExecutionError::ExecutionError { .. }) => {
+                return Ok(LocalExecution::Unsupported(transactions))
+            }
+            Err(e) => return Err(e.into()),
+        };
 
         let result = traces
             .into_iter()

--- a/crates/rpc/src/v06/method/trace_transaction.rs
+++ b/crates/rpc/src/v06/method/trace_transaction.rs
@@ -125,7 +125,7 @@ pub async fn trace_transaction_impl(
             let _g = span.enter();
 
             let mut db = context
-                .storage
+                .execution_storage
                 .connection()
                 .context("Creating database connection")?;
             let db = db.transaction().context("Creating database transaction")?;

--- a/crates/rpc/src/v06/method/trace_transaction.rs
+++ b/crates/rpc/src/v06/method/trace_transaction.rs
@@ -202,8 +202,7 @@ pub async fn trace_transaction_impl(
                 .map(|transaction| compose_executor_transaction(transaction, &db))
                 .collect::<Result<Vec<_>, _>>()?;
 
-            match pathfinder_executor::trace(state, cache, hash, executor_transactions, true, true)
-            {
+            match pathfinder_executor::trace(state, cache, hash, executor_transactions) {
                 Ok(txs) => {
                     let trace = txs
                         .into_iter()


### PR DESCRIPTION
Pathfinder has the `rpc.execution-concurrency` CLI option that is supposed to set the upper limit for the number of execution-related RPC methods being served in parallel. This option works by creating a new storage instance that is supposed to be used for execution and setting the connection pool size to the number configured.

Unfortunately we did not use the correct storage instance for execution-related methods, so the CLI option was not actually effective.

This PR fixes these method implementations to use the execution storage instance, plus it also forces both the RPC and execution storage to use read-only database connections.
