### PR TITLE
fix(rpc): fix serialization of `STRUCT_ABI_ENTRY`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Pathfinder does not properly limit the number of concurrent executors when using the `--rpc.execution-concurrency` CLI option.
+- Pathfinder returns non-conforming `STRUCT_ABI_ENTRY` objects in response to `starknet_getClass` requests.
 
 ## [0.14.0] - 2024-07-22
 

--- a/crates/rpc/src/dto/class.rs
+++ b/crates/rpc/src/dto/class.rs
@@ -244,7 +244,7 @@ impl SerializeForVersion for StructAbiEntry<'_> {
     ) -> Result<serialize::Ok, serialize::Error> {
         let mut serializer = serializer.serialize_struct()?;
 
-        serializer.serialize_field("type", &EventAbiType)?;
+        serializer.serialize_field("type", &StructAbiType)?;
         serializer.serialize_field("name", &self.0.name)?;
         // FIXME: this should be a NonZero according to the RPC spec.
         serializer.serialize_field("size", &self.0.size)?;


### PR DESCRIPTION
The `type` property of this object was `event` instead of `struct`.

Closes #2137
