### PR TITLE
fix(rpc): fix serialization of `replaced_classes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pathfinder does not properly limit the number of concurrent executors when using the `--rpc.execution-concurrency` CLI option.
 - Pathfinder returns non-conforming `STRUCT_ABI_ENTRY` objects in response to `starknet_getClass` requests.
+- Pathfinder returns `starknet_getStateUpdate` responses that are non-conformant with the specification if there are replaced classes in the response.
 
 ## [0.14.0] - 2024-07-22
 

--- a/crates/rpc/src/dto/state_update.rs
+++ b/crates/rpc/src/dto/state_update.rs
@@ -150,10 +150,7 @@ impl SerializeForVersion for StateDiff<'_> {
                 .filter_map(|(address, update)| {
                     update
                         .replaced_class()
-                        .map(|class_hash| DeployedContractItem {
-                            address,
-                            class_hash,
-                        })
+                        .map(|hash| ReplacedClass { address, hash })
                 });
 
         let mut nonces = self


### PR DESCRIPTION
The contract address was being incorrectly serialized as `address` instead of `contract_address`

Closes #2139
