### PR TITLE
followup for PR #2136

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6331,6 +6331,7 @@ dependencies = [
  "tagged-debug-derive",
  "test-log",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-subscriber",
  "unsigned-varint 0.8.0",

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -51,6 +51,7 @@ sha3 = { workspace = true }
 tagged = { path = "../tagged" }
 tagged-debug-derive = { path = "../tagged-debug-derive" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
+tokio-stream = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 unsigned-varint = { workspace = true, features = ["futures"] }

--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -764,8 +764,8 @@ mod transaction_stream {
                         {
                             Action::NextPeer => continue 'next_peer,
                             Action::TerminateStream => break 'outer,
-                            Action::TryYield(t, r) => {
-                                transactions.push((t, r));
+                            Action::TryYield(txn) => {
+                                transactions.push(*txn);
                                 if try_yield(
                                     peer,
                                     &mut progress,
@@ -823,7 +823,7 @@ mod transaction_stream {
                 match progress.count_mut().checked_sub(1) {
                     Some(x) => {
                         *progress.count_mut() = x;
-                        Action::TryYield(t, r)
+                        Action::TryYield(Box::new((t, r)))
                     }
                     None => {
                         // TODO punish the peer
@@ -917,7 +917,7 @@ mod transaction_stream {
     enum Action {
         NextPeer,
         TerminateStream,
-        TryYield(TransactionVariant, Receipt),
+        TryYield(Box<(TransactionVariant, Receipt)>),
     }
 
     #[derive(Clone, Copy, Debug)]

--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -784,12 +784,12 @@ mod transaction_stream {
                         }
                     }
 
-                    // FIXME
-
-                    // We got all the data we need but the last peer has not sent a Fin.
+                    // The current peer is not giving us a Fin
                     // TODO punish the peer
                     tracing::debug!(%peer, "Fin missing");
+
                     if progress.count() == 0 && start == stop {
+                        // The last block we were looking for was not followed by a Fin
                         break 'outer;
                     }
                 }
@@ -1033,12 +1033,12 @@ mod state_diff_stream {
                         }
                     }
 
-                    // FIXME
-
-                    // We got all the data we need but the last peer has not sent a Fin.
+                    // The current peer is not giving us a Fin
                     // TODO punish the peer
                     tracing::debug!(%peer, "Fin missing");
+
                     if progress.count() == 0 && start == stop {
+                        // The last block we were looking for was not followed by a Fin
                         break 'outer;
                     }
                 }

--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use futures::channel::mpsc as fmpsc;
-use futures::{pin_mut, Stream, StreamExt};
+use futures::{Stream, StreamExt};
 use libp2p::PeerId;
 use p2p_proto::class::{ClassesRequest, ClassesResponse};
 use p2p_proto::common::{Direction, Iteration};
@@ -259,12 +259,11 @@ impl EventStream for Client {
         self,
         start: BlockNumber,
         stop: BlockNumber,
-        event_counts_stream: impl Stream<Item = anyhow::Result<usize>>,
-    ) -> impl Stream<Item = Result<PeerData<EventsForBlockByTransaction>, PeerData<anyhow::Error>>>
-    {
+        event_counts_stream: impl Stream<Item = anyhow::Result<usize>> + Send + 'static,
+    ) -> impl Stream<Item = PeerData<EventsForBlockByTransaction>> {
         let inner = self.inner.clone();
         let outer = self;
-        make_event_stream(
+        event_stream::make(
             start,
             stop,
             event_counts_stream,
@@ -1492,133 +1491,137 @@ mod class_definition_stream {
     }
 }
 
-pub fn make_event_stream<PF, RF>(
-    mut start: BlockNumber,
-    stop: BlockNumber,
-    event_counts_stream: impl Stream<Item = anyhow::Result<usize>>,
-    get_peers: impl Fn() -> PF,
-    send_request: impl Fn(PeerId, EventsRequest) -> RF,
-) -> impl Stream<Item = Result<PeerData<EventsForBlockByTransaction>, PeerData<anyhow::Error>>>
-where
-    PF: Future<Output = Vec<PeerId>>,
-    RF: Future<Output = anyhow::Result<fmpsc::Receiver<EventsResponse>>>,
-{
-    tracing::trace!(?start, ?stop, "Streaming events");
+mod event_stream {
+    use super::*;
 
-    async_stream::try_stream! {
-        pin_mut!(event_counts_stream);
+    pub fn make<PF, RF>(
+        mut start: BlockNumber,
+        stop: BlockNumber,
+        counts_stream: impl Stream<Item = anyhow::Result<usize>> + Send + 'static,
+        get_peers: impl Fn() -> PF + Send + 'static,
+        send_request: impl Fn(PeerId, EventsRequest) -> RF + Send + 'static,
+    ) -> impl Stream<Item = PeerData<EventsForBlockByTransaction>>
+    where
+        PF: Future<Output = Vec<PeerId>> + Send,
+        RF: Future<Output = anyhow::Result<fmpsc::Receiver<EventsResponse>>> + Send,
+    {
+        tracing::trace!(?start, ?stop, "Streaming events");
 
-        let mut current_count_outer = None;
+        let (tx, rx) = mpsc::channel(1);
+        tokio::spawn(async move {
+            let mut counts_stream = Box::pin(counts_stream);
 
-        if start <= stop {
-            // Loop which refreshes peer set once we exhaust it.
-            'outer: loop {
-                let peers = get_peers().await;
+            let Some(Ok(mut current_count_outer)) = counts_stream.next().await else {
+                tracing::debug!("Event counts stream terminated prematurely");
+                return;
+            };
 
-                // Attempt each peer.
-                'next_peer: for peer in peers {
-                    let peer_err = |e: anyhow::Error| PeerData::new(peer, e);
-                    let limit = stop.get() - start.get() + 1;
+            if start <= stop {
+                // Loop which refreshes peer set once we exhaust it.
+                'outer: loop {
+                    'next_peer: for peer in get_peers().await {
+                        let mut responses =
+                            match send_request(peer, make_request(start, stop)).await {
+                                Ok(x) => x,
+                                Err(error) => {
+                                    // TODO punish the peer
+                                    tracing::debug!(%peer, reason=%error, "Events request failed");
+                                    continue 'next_peer;
+                                }
+                            };
 
-                    let request = EventsRequest {
-                        iteration: Iteration {
-                            start: start.get().into(),
-                            direction: Direction::Forward,
-                            limit,
-                            step: 1.into(),
-                        },
-                    };
+                        // Maintain the current transaction hash to group events by transaction
+                        // This grouping is TRUSTED for pre 0.13.2 Starknet blocks.
+                        let mut current_txn_hash = None;
+                        let mut current_count = current_count_outer;
 
-                    let mut responses =
-                        match send_request(peer, request).await {
-                            Ok(x) => x,
-                            Err(error) => {
-                                // Failed to establish connection, try next peer.
-                                tracing::debug!(%peer, reason=%error, "Events request failed");
-                                continue 'next_peer;
-                            }
-                        };
+                        while start <= stop {
+                            tracing::trace!(block_number=%start, expected_responses=%current_count, "Expecting event responses");
 
-                    // Maintain the current transaction hash to group events by transaction
-                    // This grouping is TRUSTED for pre 0.13.2 Starknet blocks.
-                    let mut current_txn_hash = None;
-                    let mut current_count = match current_count_outer {
-                        // Still the same block
-                        Some(backup) => backup,
-                        // Move to the next block
-                        None => {
-                            let x = event_counts_stream.next().await
-                                .ok_or_else(|| anyhow::anyhow!("Event counts stream terminated prematurely at block {start}"))
-                                .map_err(peer_err)?
-                                .map_err(peer_err)?;
-                            current_count_outer = Some(x);
-                            x
-                        }
-                    };
+                            let mut events: Vec<(TransactionHash, Vec<Event>)> = Vec::new();
 
-                    while start <= stop {
-                        tracing::trace!(block_number=%start, expected_responses=%current_count, "Expecting event responses");
+                            while current_count > 0 {
+                                if let Some(response) = responses.next().await {
+                                    match response {
+                                        EventsResponse::Event(event) => {
+                                            let txn_hash =
+                                                TransactionHash(event.transaction_hash.0);
+                                            let Ok(event) = Event::try_from_dto(event) else {
+                                                // TODO punish the peer
+                                                tracing::debug!(%peer, "Event failed to parse");
+                                                continue 'next_peer;
+                                            };
 
-                        let mut events: Vec<(TransactionHash, Vec<Event>)> = Vec::new();
-
-                        while current_count > 0 {
-                            if let Some(response) = responses.next().await {
-                                match response {
-                                    EventsResponse::Event(event) => {
-                                        let txn_hash = TransactionHash(event.transaction_hash.0);
-                                        let event = Event::try_from_dto(event).map_err(peer_err)?;
-
-                                        match current_txn_hash {
-                                            Some(x) if x == txn_hash => {
-                                                // Same transaction
-                                                events.last_mut().expect("not empty").1.push(event);
-                                            }
-                                            None | Some(_) => {
-                                                // New transaction
-                                                events.push((txn_hash, vec![event]));
-                                                current_txn_hash = Some(txn_hash);
+                                            match current_txn_hash {
+                                                Some(x) if x == txn_hash => {
+                                                    // Same transaction
+                                                    events
+                                                        .last_mut()
+                                                        .expect("not empty")
+                                                        .1
+                                                        .push(event);
+                                                }
+                                                None | Some(_) => {
+                                                    // New transaction
+                                                    events.push((txn_hash, vec![event]));
+                                                    current_txn_hash = Some(txn_hash);
+                                                }
                                             }
                                         }
-                                    }
-                                    EventsResponse::Fin => {
-                                        tracing::debug!(%peer, "Received FIN, continuing with next peer");
-                                        continue 'next_peer;
-                                    }
-                                };
+                                        EventsResponse::Fin => {
+                                            tracing::debug!(%peer, "Received FIN, continuing with next peer");
+                                            continue 'next_peer;
+                                        }
+                                    };
 
-                                current_count -= 1;
-                            } else {
-                                // Stream closed before receiving all expected events for this block
-                                tracing::debug!(%peer, block_number=%start, "Premature event stream termination");
-                                // TODO punish the peer
-                                continue 'next_peer;
+                                    current_count -= 1;
+                                } else {
+                                    // Stream closed before receiving all expected events for this
+                                    // block
+                                    tracing::debug!(%peer, block_number=%start, "Premature event stream termination");
+                                    // TODO punish the peer
+                                    continue 'next_peer;
+                                }
                             }
+
+                            tracing::trace!(block_number=%start, "All events received for block");
+
+                            _ = tx.send(PeerData::new(peer, (start, events))).await;
+
+                            if start == stop {
+                                break 'outer;
+                            }
+
+                            start += 1;
+
+                            let Some(Ok(cnt)) = counts_stream.next().await else {
+                                tracing::debug!("Event counts stream terminated prematurely");
+                                break 'outer;
+                            };
+
+                            current_count_outer = cnt;
+                            current_count = cnt;
+
+                            tracing::trace!(next_block=%start, expected_responses=%cnt, "Moving to next block");
                         }
 
-                        tracing::trace!(block_number=%start, "All events received for block");
-
-                        yield PeerData::new(
-                            peer,
-                            (start, std::mem::take(&mut events)),
-                        );
-
-                        if start == stop {
-                            break 'outer;
-                        }
-
-                        start += 1;
-                        current_count = event_counts_stream.next().await
-                            .ok_or_else(|| anyhow::anyhow!("Event counts stream terminated prematurely at block {start}"))
-                            .map_err(peer_err)?
-                            .map_err(peer_err)?;
-                        current_count_outer = Some(current_count);
-
-                        tracing::trace!(next_block=%start, expected_responses=%current_count, "Moving to next block");
+                        break 'outer;
                     }
-
-                    break 'outer;
                 }
             }
+        });
+
+        ReceiverStream::new(rx)
+    }
+
+    fn make_request(start: BlockNumber, stop: BlockNumber) -> EventsRequest {
+        EventsRequest {
+            iteration: Iteration {
+                start: start.get().into(),
+                direction: Direction::Forward,
+                limit: stop.get() - start.get() + 1,
+                step: 1.into(),
+            },
         }
     }
 }

--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -784,6 +784,8 @@ mod transaction_stream {
                         }
                     }
 
+                    // FIXME
+
                     // We got all the data we need but the last peer has not sent a Fin.
                     // TODO punish the peer
                     tracing::debug!(%peer, "Fin missing");
@@ -797,7 +799,6 @@ mod transaction_stream {
         ReceiverStream::new(rx)
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn handle_response(
         peer: PeerId,
         response: TransactionsResponse,
@@ -842,7 +843,6 @@ mod transaction_stream {
                 }
 
                 if is_last_block {
-                    // We're done, terminate the stream
                     return Action::TerminateStream;
                 }
 
@@ -964,7 +964,7 @@ mod state_diff_stream {
     pub fn make<PF, RF>(
         mut start: BlockNumber,
         stop: BlockNumber,
-        state_diff_length_and_commitment_stream: impl Stream<Item = anyhow::Result<(usize, StateDiffCommitment)>>
+        len_and_commitment_stream: impl Stream<Item = anyhow::Result<(usize, StateDiffCommitment)>>
             + Send
             + 'static,
         get_peers: impl Fn() -> PF + Send + 'static,
@@ -978,228 +978,208 @@ mod state_diff_stream {
 
         let (tx, rx) = mpsc::channel(1);
         tokio::spawn(async move {
-            pin_mut!(state_diff_length_and_commitment_stream);
+            let mut len_and_commitment_stream = Box::pin(len_and_commitment_stream);
 
-            let Some(Ok(cnt)) = state_diff_length_and_commitment_stream.next().await else {
+            let Some(Ok(cnt)) = len_and_commitment_stream.next().await else {
                 tracing::debug!("Transaction counts and commitments stream terminated prematurely");
                 return;
             };
 
             let mut progress = StateDiffStreamProgress::new(cnt);
 
-            if start <= stop {
-                // Loop which refreshes peer set once we exhaust it.
-                'outer: loop {
-                    'next_peer: for peer in get_peers().await {
-                        let mut responses = match send_request(peer, make_request(start, stop))
-                            .await
-                        {
-                            Ok(x) => x,
-                            Err(error) => {
-                                // Failed to establish connection, try next peer.
-                                tracing::debug!(%peer, reason=%error, "State diffs request failed");
-                                continue 'next_peer;
-                            }
-                        };
+            // Loop which refreshes peer set once we exhaust it.
+            'outer: loop {
+                'next_peer: for peer in get_peers().await {
+                    let mut responses = match send_request(peer, make_request(start, stop)).await {
+                        Ok(x) => x,
+                        Err(error) => {
+                            tracing::debug!(%peer, reason=%error, "State diff request failed");
+                            continue 'next_peer;
+                        }
+                    };
 
-                        // If the previous peer failed to provide the entire block we need to start
-                        // over
-                        progress.rollback();
-                        tracing::trace!(block_number=%start, num_responses=%progress.count(), "Expecting");
+                    // If the previous peer failed to provide the entire block we need to start over
+                    progress.rollback();
+                    tracing::trace!(block_number=%start, num_responses=%progress.count(), "Expecting");
 
-                        let mut state_diff = StateUpdateData::default();
+                    let mut state_diff = StateUpdateData::default();
 
-                        while let Some(state_diff_response) = responses.next().await {
-                            match state_diff_response {
-                                StateDiffsResponse::ContractDiff(ContractDiff {
-                                    address,
-                                    nonce,
-                                    class_hash,
-                                    values,
-                                    domain: _,
-                                }) => {
-                                    let address = ContractAddress(address.0);
-
-                                    match progress.count_mut().checked_sub(values.len()) {
-                                        Some(x) => *progress.count_mut() = x,
-                                        None => {
-                                            tracing::debug!(%peer, %start, "Too many storage diffs: {} > {}", values.len(), progress.count());
-                                            // TODO punish the peer
-
-                                            // We can only get here in case of the last block, which
-                                            // means that the stream should be terminated
-                                            debug_assert!(start == stop);
-                                            break 'outer;
-                                        }
-                                    }
-
-                                    if address == ContractAddress::ONE {
-                                        let storage = &mut state_diff
-                                            .system_contract_updates
-                                            .entry(address)
-                                            .or_default()
-                                            .storage;
-                                        values.into_iter().for_each(
-                                            |ContractStoredValue { key, value }| {
-                                                storage.insert(
-                                                    StorageAddress(key),
-                                                    StorageValue(value),
-                                                );
-                                            },
-                                        );
-                                    } else {
-                                        let update = &mut state_diff
-                                            .contract_updates
-                                            .entry(address)
-                                            .or_default();
-                                        values.into_iter().for_each(
-                                            |ContractStoredValue { key, value }| {
-                                                update.storage.insert(
-                                                    StorageAddress(key),
-                                                    StorageValue(value),
-                                                );
-                                            },
-                                        );
-
-                                        if let Some(nonce) = nonce {
-                                            match progress.count_mut().checked_sub(1) {
-                                                Some(x) => *progress.count_mut() = x,
-                                                None => {
-                                                    tracing::debug!(%peer, %start, "Too many nonce updates");
-                                                    // TODO punish the peer
-
-                                                    // We can only get here in case of the last
-                                                    // block, which means that the stream should be
-                                                    // terminated
-                                                    debug_assert!(start == stop);
-                                                    break 'outer;
-                                                }
-                                            }
-
-                                            update.nonce = Some(ContractNonce(nonce));
-                                        }
-
-                                        if let Some(class_hash) = class_hash.map(|x| ClassHash(x.0))
-                                        {
-                                            match progress.count_mut().checked_sub(1) {
-                                                Some(x) => *progress.count_mut() = x,
-                                                None => {
-                                                    tracing::debug!(%peer, %start, "Too many deployed contracts");
-                                                    // TODO punish the peer
-
-                                                    // We can only get here in case of the last
-                                                    // block, which means that the stream should be
-                                                    // terminated
-                                                    debug_assert!(start == stop);
-                                                    break 'outer;
-                                                }
-                                            }
-
-                                            update.class =
-                                                Some(ContractClassUpdate::Deploy(class_hash));
-                                        }
-                                    }
+                    while let Some(state_diff_response) = responses.next().await {
+                        match handle_response(
+                            peer,
+                            state_diff_response,
+                            &mut state_diff,
+                            &mut progress,
+                            start == stop,
+                        ) {
+                            Action::NextPeer => continue 'next_peer,
+                            Action::TerminateStream => break 'outer,
+                            Action::TryYield => {
+                                if try_yield(
+                                    peer,
+                                    &mut progress,
+                                    &mut len_and_commitment_stream,
+                                    &mut state_diff,
+                                    &mut start,
+                                    stop,
+                                    tx.clone(),
+                                )
+                                .await
+                                {
+                                    break 'outer;
                                 }
-                                StateDiffsResponse::DeclaredClass(DeclaredClass {
-                                    class_hash,
-                                    compiled_class_hash,
-                                }) => {
-                                    if let Some(compiled_class_hash) = compiled_class_hash {
-                                        state_diff.declared_sierra_classes.insert(
-                                            SierraHash(class_hash.0),
-                                            CasmHash(compiled_class_hash.0),
-                                        );
-                                    } else {
-                                        state_diff
-                                            .declared_cairo_classes
-                                            .insert(ClassHash(class_hash.0));
-                                    }
-
-                                    match progress.count_mut().checked_sub(1) {
-                                        Some(x) => *progress.count_mut() = x,
-                                        None => {
-                                            tracing::debug!(%peer, %start, "Too many declared classes");
-                                            // TODO punish the peer
-
-                                            // We can only get here in case of the last block, which
-                                            // means that the stream should be terminated
-                                            debug_assert!(start == stop);
-                                            break 'outer;
-                                        }
-                                    }
-                                }
-                                StateDiffsResponse::Fin => {
-                                    if progress.count() == 0 {
-                                        if start == stop {
-                                            // We're done, terminate the stream
-                                            break 'outer;
-                                        }
-                                    } else {
-                                        tracing::debug!(%peer, "Premature state diff stream Fin");
-                                        // TODO punish the peer
-                                        continue 'next_peer;
-                                    }
-                                }
-                            };
-
-                            if progress.count() == 0 {
-                                // All the counters for this block have been exhausted which means
-                                // that the state update for this block is complete.
-                                tracing::trace!(block_number=%start, "State diff received for block");
-
-                                _ = tx
-                                    .send(PeerData::new(
-                                        peer,
-                                        (
-                                            UnverifiedStateUpdateData {
-                                                expected_commitment: progress.commitment(),
-                                                state_diff: std::mem::take(&mut state_diff),
-                                            },
-                                            start,
-                                        ),
-                                    ))
-                                    .await;
-
-                                if start < stop {
-                                    // Move to the next block
-                                    start += 1;
-                                    tracing::trace!(next_block=%start, "Moving to next block");
-
-                                    let Some(Ok(cnt)) =
-                                        state_diff_length_and_commitment_stream.next().await
-                                    else {
-                                        tracing::debug!(
-                                            "Transaction counts and commitments stream terminated \
-                                             prematurely"
-                                        );
-                                        break 'outer;
-                                    };
-
-                                    progress = StateDiffStreamProgress::new(cnt);
-
-                                    tracing::trace!(block_number=%start, num_responses=%progress.count(), "Expecting");
-                                }
+                                // Move to the next response
                             }
                         }
+                    }
 
-                        // TODO punish the peer
-                        // If we reach here, the peer did not send a Fin, so the counter for the
-                        // current block should be reset and we should start
-                        // from the current block again but from the next peer.
-                        tracing::debug!(%peer, "Fin missing");
+                    // FIXME
 
-                        // The above situation can also happen when we've received all the data we
-                        // need but the last peer has not sent a Fin.
-                        if progress.count() == 0 && start == stop {
-                            // We're done, terminate the stream
-                            break 'outer;
-                        }
+                    // We got all the data we need but the last peer has not sent a Fin.
+                    // TODO punish the peer
+                    tracing::debug!(%peer, "Fin missing");
+                    if progress.count() == 0 && start == stop {
+                        break 'outer;
                     }
                 }
             }
         });
 
         ReceiverStream::new(rx)
+    }
+
+    fn handle_response(
+        peer: PeerId,
+        response: StateDiffsResponse,
+        state_diff: &mut StateUpdateData,
+        progress: &mut StateDiffStreamProgress,
+        is_last_block: bool,
+    ) -> Action {
+        match response {
+            StateDiffsResponse::ContractDiff(ContractDiff {
+                address,
+                nonce,
+                class_hash,
+                values,
+                domain: _,
+            }) => {
+                let address = ContractAddress(address.0);
+
+                match progress.count_mut().checked_sub(values.len()) {
+                    Some(x) => *progress.count_mut() = x,
+                    None => {
+                        // TODO punish the peer
+                        tracing::debug!(%peer, "Too many storage diffs: {} > {}", values.len(), progress.count());
+                        // We can only get here in case of the last block, which means that the
+                        // stream should be terminated
+                        debug_assert!(is_last_block);
+                        return Action::TerminateStream;
+                    }
+                }
+
+                if address == ContractAddress::ONE {
+                    let storage = &mut state_diff
+                        .system_contract_updates
+                        .entry(address)
+                        .or_default()
+                        .storage;
+                    values
+                        .into_iter()
+                        .for_each(|ContractStoredValue { key, value }| {
+                            storage.insert(StorageAddress(key), StorageValue(value));
+                        });
+
+                    Action::TryYield
+                } else {
+                    let update = &mut state_diff.contract_updates.entry(address).or_default();
+                    values
+                        .into_iter()
+                        .for_each(|ContractStoredValue { key, value }| {
+                            update
+                                .storage
+                                .insert(StorageAddress(key), StorageValue(value));
+                        });
+
+                    if let Some(nonce) = nonce {
+                        match progress.count_mut().checked_sub(1) {
+                            Some(x) => *progress.count_mut() = x,
+                            None => {
+                                // TODO punish the peer
+                                tracing::debug!(%peer, "Too many nonce updates");
+                                // We can only get here in case of the last block, which means that
+                                // the stream should be terminated
+                                debug_assert!(is_last_block);
+                                return Action::TerminateStream;
+                            }
+                        }
+
+                        update.nonce = Some(ContractNonce(nonce));
+                    }
+
+                    if let Some(class_hash) = class_hash.map(|x| ClassHash(x.0)) {
+                        match progress.count_mut().checked_sub(1) {
+                            Some(x) => *progress.count_mut() = x,
+                            None => {
+                                // TODO punish the peer
+                                tracing::debug!(%peer, "Too many deployed contracts");
+                                // We can only get here in case of the last block, which means that
+                                // the stream should be terminated
+                                debug_assert!(is_last_block);
+                                return Action::TerminateStream;
+                            }
+                        }
+
+                        update.class = Some(ContractClassUpdate::Deploy(class_hash));
+                    }
+
+                    Action::TryYield
+                }
+            }
+            StateDiffsResponse::DeclaredClass(DeclaredClass {
+                class_hash,
+                compiled_class_hash,
+            }) => {
+                if let Some(compiled_class_hash) = compiled_class_hash {
+                    state_diff
+                        .declared_sierra_classes
+                        .insert(SierraHash(class_hash.0), CasmHash(compiled_class_hash.0));
+                } else {
+                    state_diff
+                        .declared_cairo_classes
+                        .insert(ClassHash(class_hash.0));
+                }
+
+                match progress.count_mut().checked_sub(1) {
+                    Some(x) => {
+                        *progress.count_mut() = x;
+                        Action::TryYield
+                    }
+                    None => {
+                        // TODO punish the peer
+                        tracing::debug!(%peer, "Too many declared classes");
+
+                        // We can only get here in case of the last block, which
+                        // means that the stream should be terminated
+                        debug_assert!(is_last_block);
+                        Action::TerminateStream
+                    }
+                }
+            }
+            StateDiffsResponse::Fin => {
+                if progress.count() > 0 {
+                    // TODO punish the peer
+                    tracing::debug!(%peer, "Premature state diff stream Fin");
+                    return Action::NextPeer;
+                }
+
+                if is_last_block {
+                    return Action::TerminateStream;
+                }
+
+                // This peer will not give us more blocks
+                Action::TryYield
+            }
+        }
     }
 
     fn make_request(start: BlockNumber, stop: BlockNumber) -> StateDiffsRequest {
@@ -1211,6 +1191,67 @@ mod state_diff_stream {
                 step: 1.into(),
             },
         }
+    }
+
+    enum Action {
+        NextPeer,
+        TerminateStream,
+        TryYield,
+    }
+
+    /// ### Important
+    ///
+    /// Returns true if the stream should be terminated
+    async fn try_yield(
+        peer: PeerId,
+        progress: &mut StateDiffStreamProgress,
+        state_diff_length_and_commitment_stream: &mut (impl Stream<Item = anyhow::Result<(usize, StateDiffCommitment)>>
+                  + Unpin
+                  + Send
+                  + 'static),
+        state_diff: &mut StateUpdateData,
+        start: &mut BlockNumber,
+        stop: BlockNumber,
+        tx: mpsc::Sender<PeerData<(UnverifiedStateUpdateData, BlockNumber)>>,
+    ) -> bool {
+        if progress.count() == 0 {
+            // All the counters for this block have been exhausted which means
+            // that the state update for this block is complete.
+            tracing::trace!(block_number=%start, "State diff received for block");
+
+            _ = tx
+                .send(PeerData::new(
+                    peer,
+                    (
+                        UnverifiedStateUpdateData {
+                            expected_commitment: progress.commitment(),
+                            state_diff: std::mem::take(state_diff),
+                        },
+                        *start,
+                    ),
+                ))
+                .await;
+
+            if *start < stop {
+                // Move to the next block
+                *start += 1;
+                tracing::trace!(next_block=%start, "Moving to next block");
+
+                let Some(Ok(cnt)) = state_diff_length_and_commitment_stream.next().await else {
+                    tracing::debug!(
+                        "Transaction counts and commitments stream terminated prematurely"
+                    );
+
+                    return true;
+                };
+
+                *progress = StateDiffStreamProgress::new(cnt);
+
+                tracing::trace!(block_number=%start, num_responses=%progress.count(), "Expecting");
+            }
+        }
+
+        false
     }
 
     #[derive(Clone, Copy, Debug)]

--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -967,9 +967,10 @@ mod state_diff_stream {
                         while progress.count() > 0 {
                             match responses.next().await {
                                 Some(r) => {
-                                    match handle_response(peer, r, &mut state_diff, &mut progress) {
-                                        None => continue 'next_peer,
-                                        _ => {}
+                                    if handle_response(peer, r, &mut state_diff, &mut progress)
+                                        .is_none()
+                                    {
+                                        continue 'next_peer;
                                     }
                                 }
                                 None => continue 'next_peer,

--- a/crates/p2p/src/client/peer_agnostic/tests.rs
+++ b/crates/p2p/src/client/peer_agnostic/tests.rs
@@ -1,4 +1,4 @@
-use futures::{stream, TryStreamExt};
+use futures::stream;
 use rstest::rstest;
 use BlockHeadersResponse::Fin as HdrFin;
 use ClassesResponse::Fin as ClassFin;
@@ -749,17 +749,17 @@ async fn make_class_definition_stream(
     vec![Ok((peer(0), vec![event_resp(0, 0), event_resp(1, 0), event_resp(2, 2), EventFin]))],
     vec![3],
     //                                      transaction
-    //                                events   |                block
-    //                                   / \   |                  |
-    vec![Ok((peer(0), events(vec![(vec![0, 1], 0), (vec![2], 2)], 0)))]
+    //                             events   |                block
+    //                                / \   |                  |
+    vec![(peer(0), events(vec![(vec![0, 1], 0), (vec![2], 2)], 0))]
 )]
 #[case::one_peer_2_blocks(
     2,
     vec![Ok((peer(0), vec![event_resp(3, 3), event_resp(4, 3), event_resp(5, 5), event_resp(6, 6), EventFin]))],
     vec![2, 2],
     vec![
-        Ok((peer(0), events(vec![(vec![3, 4], 3)], 0))),
-        Ok((peer(0), events(vec![(vec![5], 5), (vec![6], 6)], 1)))
+        (peer(0), events(vec![(vec![3, 4], 3)], 0)),
+        (peer(0), events(vec![(vec![5], 5), (vec![6], 6)], 1))
     ]
 )]
 #[case::one_peer_2_blocks_in_2_attempts(
@@ -771,8 +771,8 @@ async fn make_class_definition_stream(
     ],
     vec![2, 2],
     vec![
-        Ok((peer(0), events(vec![(vec![7], 7), (vec![8], 8)], 0))),
-        Ok((peer(0), events(vec![(vec![9, 10], 9)], 1))),
+        (peer(0), events(vec![(vec![7], 7), (vec![8], 8)], 0)),
+        (peer(0), events(vec![(vec![9, 10], 9)], 1)),
     ]
 )]
 #[case::two_peers_1_block_per_peer(
@@ -786,8 +786,8 @@ async fn make_class_definition_stream(
     ],
     vec![2, 1],
     vec![
-        Ok((peer(0), events(vec![(vec![11, 12], 11)], 0))),
-        Ok((peer(1), events(vec![(vec![13], 13)], 1))),
+        (peer(0), events(vec![(vec![11, 12], 11)], 0)),
+        (peer(1), events(vec![(vec![13], 13)], 1)),
     ]
 )]
 #[case::first_peer_premature_eos_with_fin(
@@ -799,8 +799,8 @@ async fn make_class_definition_stream(
     ],
     vec![2, 2],
     vec![
-        Ok((peer(0), events(vec![(vec![14, 15], 14)], 0))),
-        Ok((peer(1), events(vec![(vec![16, 17], 16)], 1))),
+        (peer(0), events(vec![(vec![14, 15], 14)], 0)),
+        (peer(1), events(vec![(vec![16, 17], 16)], 1)),
     ]
 )]
 #[case::first_peer_full_block_no_fin(
@@ -812,8 +812,8 @@ async fn make_class_definition_stream(
     ],
     vec![1, 1],
     vec![
-        Ok((peer(0), events(vec![(vec![18], 18)], 0))),
-        Ok((peer(1), events(vec![(vec![19], 19)], 1))),
+        (peer(0), events(vec![(vec![18], 18)], 0)),
+        (peer(1), events(vec![(vec![19], 19)], 1)),
     ]
 )]
 #[case::last_peer_full_block_no_fin(
@@ -824,8 +824,8 @@ async fn make_class_definition_stream(
     ],
     vec![1, 1],
     vec![
-        Ok((peer(0), events(vec![(vec![18], 18)], 0))),
-        Ok((peer(1), events(vec![(vec![19], 19)], 1))),
+        (peer(0), events(vec![(vec![18], 18)], 0)),
+        (peer(1), events(vec![(vec![19], 19)], 1)),
     ]
 )]
 // The same as above but the first peer gives half of the second block before closing the
@@ -839,8 +839,8 @@ async fn make_class_definition_stream(
     ],
     vec![2, 3],
     vec![
-        Ok((peer(0), events(vec![(vec![20], 20), (vec![21], 21)], 0))),
-        Ok((peer(1), events(vec![(vec![22, 23, 24], 22)], 1))),
+        (peer(0), events(vec![(vec![20], 20), (vec![21], 21)], 0)),
+        (peer(1), events(vec![(vec![22, 23, 24], 22)], 1)),
     ]
 )]
 #[case::count_steam_is_too_short(
@@ -852,8 +852,8 @@ async fn make_class_definition_stream(
     ],
     vec![1], // but only 1 block provided in the count stream
     vec![
-        Ok((peer(0), events(vec![(vec![25], 25)], 0))),
-        Err(peer(0)) // the second block is not processed
+        (peer(0), events(vec![(vec![25], 25)], 0)),
+        // the second block is not processed
     ]
 )]
 #[case::too_many_responses_with_fin(
@@ -861,7 +861,7 @@ async fn make_class_definition_stream(
     vec![Ok((peer(0), vec![event_resp(27, 27), event_resp(28, 27), event_resp(29, 27), EventFin]))],
     vec![1],
     vec![
-        Ok((peer(0), events(vec![(vec![27], 27)], 0))),
+        (peer(0), events(vec![(vec![27], 27)], 0)),
     ]
 )]
 #[case::too_many_responses_no_fin(
@@ -869,7 +869,7 @@ async fn make_class_definition_stream(
     vec![Ok((peer(0), vec![event_resp(27, 27), event_resp(28, 27), event_resp(29, 27)]))],
     vec![1],
     vec![
-        Ok((peer(0), events(vec![(vec![27], 27)], 0))),
+        (peer(0), events(vec![(vec![27], 27)], 0)),
     ]
 )]
 #[case::empty_response_streams_are_ignored(
@@ -881,7 +881,7 @@ async fn make_class_definition_stream(
     ],
     vec![1],
     vec![
-        Ok((peer(0), events(vec![(vec![30], 30)], 0)))
+        (peer(0), events(vec![(vec![30], 30)], 0))
     ]
 )]
 #[case::empty_responses_are_ignored(
@@ -893,7 +893,7 @@ async fn make_class_definition_stream(
     ],
     vec![1],
     vec![
-        Ok((peer(0), events(vec![(vec![30], 30)], 0)))
+        (peer(0), events(vec![(vec![30], 30)], 0))
     ]
 )]
 #[test_log::test(tokio::test)]
@@ -901,25 +901,30 @@ async fn make_event_stream(
     #[case] num_blocks: usize,
     #[case] responses: Vec<Result<(TestPeer, Vec<EventsResponse>), TestPeer>>,
     #[case] events_per_block: Vec<usize>,
-    #[case] expected_stream: Vec<Result<(TestPeer, TaggedEventsForBlockByTransaction), TestPeer>>,
+    #[case] expected_stream: Vec<(TestPeer, TaggedEventsForBlockByTransaction)>,
 ) {
     let _ = env_logger::builder().is_test(true).try_init();
     let (peers, responses) = unzip_fixtures(responses);
-    let get_peers = || async { peers.clone() };
-    let send_request =
-        |_: PeerId, _: EventsRequest| async { send_request(responses.clone()).await };
+    let get_peers = move || {
+        let peers = peers.clone();
+        async move { peers }
+    };
+    let send_request = move |_: PeerId, _: EventsRequest| {
+        let responses = responses.clone();
+        async move { send_request(responses).await }
+    };
 
     let start = BlockNumber::GENESIS;
     let stop = start + (num_blocks - 1) as u64;
 
-    let actual = super::make_event_stream(
+    let actual = super::event_stream::make(
         start,
         stop,
         stream::iter(events_per_block.into_iter().map(Ok)),
         get_peers,
         send_request,
     )
-    .map_ok(|x| {
+    .map(|x| {
         (
             TestPeer(x.peer),
             (
@@ -932,7 +937,6 @@ async fn make_event_stream(
             ),
         )
     })
-    .map_err(|x| TestPeer(x.peer))
     .collect::<Vec<_>>()
     .await;
 

--- a/crates/p2p/src/client/peer_agnostic/tests.rs
+++ b/crates/p2p/src/client/peer_agnostic/tests.rs
@@ -146,9 +146,9 @@ async fn make_header_stream(
     // Expected number of transactions per block
     vec![2],
     // Expected stream
-    //               transaction  transaction index
-    //                         |  |
-    vec![Ok((peer(0), vec![txn(0, 0), txn(1, 1)]))]
+    //            transaction  transaction index
+    //                      |  |
+    vec![(peer(0), vec![txn(0, 0), txn(1, 1)])]
 )]
 #[case::one_peer_2_blocks(
     // Peer gives responses for all blocks in one go
@@ -156,8 +156,8 @@ async fn make_header_stream(
     vec![Ok((peer(0), vec![txn_resp(2, 0), txn_resp(3, 0), TxnFin]))],
     vec![1, 1],
     vec![
-        Ok((peer(0), vec![txn(2, 0)])), // block 0
-        Ok((peer(0), vec![txn(3, 0)]))  // block 1
+        (peer(0), vec![txn(2, 0)]), // block 0
+        (peer(0), vec![txn(3, 0)])  // block 1
     ]
 )]
 #[case::one_peer_2_blocks_in_2_attempts(
@@ -169,8 +169,8 @@ async fn make_header_stream(
     ],
     vec![1, 1],
     vec![
-        Ok((peer(0), vec![txn(4, 0)])),
-        Ok((peer(0), vec![txn(5, 0)]))
+        (peer(0), vec![txn(4, 0)]),
+        (peer(0), vec![txn(5, 0)])
     ]
 )]
 #[case::two_peers_1_block_per_peer(
@@ -184,8 +184,8 @@ async fn make_header_stream(
     ],
     vec![1, 1],
     vec![
-        Ok((peer(0), vec![txn(6, 0)])),
-        Ok((peer(1), vec![txn(7, 0)]))
+        (peer(0), vec![txn(6, 0)]),
+        (peer(1), vec![txn(7, 0)])
     ]
 )]
 #[case::first_peer_premature_eos_with_fin(
@@ -197,8 +197,8 @@ async fn make_header_stream(
     ],
     vec![1, 2],
     vec![
-        Ok((peer(0), vec![txn(8, 0)])),
-        Ok((peer(1), vec![txn(9, 0), txn(10, 1)]))
+        (peer(0), vec![txn(8, 0)]),
+        (peer(1), vec![txn(9, 0), txn(10, 1)])
     ]
 )]
 #[case::first_peer_full_block_no_fin(
@@ -211,8 +211,8 @@ async fn make_header_stream(
     vec![1, 1],
     vec![
         // We assume this block 0 could be correct
-        Ok((peer(0), vec![txn(11, 0)])), // block 0
-        Ok((peer(1), vec![txn(12, 0)]))  // block 1
+        (peer(0), vec![txn(11, 0)]), // block 0
+        (peer(1), vec![txn(12, 0)])  // block 1
     ]
 )]
 #[case::last_peer_full_block_no_fin(
@@ -223,8 +223,8 @@ async fn make_header_stream(
     ],
     vec![1, 1],
     vec![
-        Ok((peer(0), vec![txn(11, 0)])), // block 0
-        Ok((peer(1), vec![txn(12, 0)]))  // block 1
+        (peer(0), vec![txn(11, 0)]), // block 0
+        (peer(1), vec![txn(12, 0)])  // block 1
     ]
 )]
 // The same as above but the first peer gives half of the second block before closing the
@@ -239,8 +239,8 @@ async fn make_header_stream(
     vec![1, 2],
     vec![
         // We assume this block could be correct so we move to the next one
-        Ok((peer(0), vec![txn(13, 0)])),            // block 0
-        Ok((peer(1), vec![txn(14, 0), txn(15, 1)])) // block 1
+        (peer(0), vec![txn(13, 0)]),            // block 0
+        (peer(1), vec![txn(14, 0), txn(15, 1)]) // block 1
     ]
 )]
 #[case::count_steam_is_too_short(
@@ -251,22 +251,19 @@ async fn make_header_stream(
         Ok((peer(0), vec![txn_resp(17, 0), TxnFin]))
     ],
     vec![1], // but only 1 block provided in the count stream
-    vec![
-        Ok((peer(0), vec![txn(16, 0)])),
-        Err(peer(0)) // the second block is not processed
-    ]
+    vec![(peer(0), vec![txn(16, 0)])]
 )]
 #[case::too_many_responses_with_fin(
     1,
     vec![Ok((peer(0), vec![txn_resp(18, 0), txn_resp(19, 0), TxnFin]))],
     vec![1],
-    vec![Ok((peer(0), vec![txn(18, 0)]))]
+    vec![(peer(0), vec![txn(18, 0)])]
 )]
 #[case::too_many_responses_no_fin(
     1,
     vec![Ok((peer(0), vec![txn_resp(18, 0), txn_resp(19, 0)]))],
     vec![1],
-    vec![Ok((peer(0), vec![txn(18, 0)]))]
+    vec![(peer(0), vec![txn(18, 0)])]
 )]
 #[case::empty_response_streams_are_ignored(
     1,
@@ -276,7 +273,7 @@ async fn make_header_stream(
         Ok((peer(2), vec![]))
     ],
     vec![1],
-    vec![Ok((peer(1), vec![txn(20, 0)]))]
+    vec![(peer(1), vec![txn(20, 0)])]
 )]
 #[case::empty_responses_are_ignored(
     1,
@@ -286,14 +283,14 @@ async fn make_header_stream(
         Ok((peer(2), vec![TxnFin]))
     ],
     vec![1],
-    vec![Ok((peer(1), vec![txn(20, 0)]))]
+    vec![(peer(1), vec![txn(20, 0)])]
 )]
 #[test_log::test(tokio::test)]
 async fn make_transaction_stream(
     #[case] num_blocks: usize,
     #[case] responses: Vec<Result<(TestPeer, Vec<TransactionsResponse>), TestPeer>>,
     #[case] num_txns_per_block: Vec<usize>,
-    #[case] expected_stream: Vec<Result<(TestPeer, Vec<TestTxn>), TestPeer>>,
+    #[case] expected_stream: Vec<(TestPeer, Vec<TestTxn>)>,
 ) {
     let _ = env_logger::builder().is_test(true).try_init();
     let (peers, responses) = unzip_fixtures(responses);
@@ -319,7 +316,7 @@ async fn make_transaction_stream(
         get_peers,
         send_request,
     )
-    .map_ok(|x| {
+    .map(|x| {
         (
             TestPeer(x.peer),
             x.data
@@ -330,7 +327,6 @@ async fn make_transaction_stream(
                 .collect(),
         )
     })
-    .map_err(|x| TestPeer(x.peer))
     .collect::<Vec<_>>()
     .await;
 

--- a/crates/p2p/src/client/peer_agnostic/tests.rs
+++ b/crates/p2p/src/client/peer_agnostic/tests.rs
@@ -338,15 +338,15 @@ async fn make_transaction_stream(
     1,
     vec![Ok((peer(0), vec![contract_diff(0), declared_class(0), SDFin]))],
     vec![len(0)],
-    vec![Ok((peer(0), state_diff(0)))]
+    vec![(peer(0), state_diff(0))]
 )]
 #[case::one_peer_2_blocks(
     2,
     vec![Ok((peer(0), vec![contract_diff(1), declared_class(1), contract_diff(2), declared_class(2), SDFin]))],
     vec![len(1), len(2)],
     vec![
-        Ok((peer(0), state_diff(1))),
-        Ok((peer(0), state_diff(2)))
+        (peer(0), state_diff(1)),
+        (peer(0), state_diff(2))
     ]
 )]
 #[case::one_peer_2_blocks_in_2_attempts(
@@ -358,8 +358,8 @@ async fn make_transaction_stream(
     ],
     vec![len(3), len(4)],
     vec![
-        Ok((peer(0), state_diff(3))),
-        Ok((peer(0), state_diff(4)))
+        (peer(0), state_diff(3)),
+        (peer(0), state_diff(4))
     ]
 )]
 #[case::two_peers_1_block_per_peer(
@@ -373,8 +373,8 @@ async fn make_transaction_stream(
     ],
     vec![len(5), len(6)],
     vec![
-        Ok((peer(0), state_diff(5))),
-        Ok((peer(1), state_diff(6)))
+        (peer(0), state_diff(5)),
+        (peer(1), state_diff(6))
     ]
 )]
 #[case::first_peer_premature_eos_with_fin(
@@ -386,8 +386,8 @@ async fn make_transaction_stream(
     ],
     vec![len(7), len(8)],
     vec![
-        Ok((peer(0), state_diff(7))),
-        Ok((peer(1), state_diff(8)))
+        (peer(0), state_diff(7)),
+        (peer(1), state_diff(8))
     ]
 )]
 #[case::first_peer_full_block_no_fin(
@@ -399,8 +399,8 @@ async fn make_transaction_stream(
     ],
     vec![len(9), len(10)],
     vec![
-        Ok((peer(0), state_diff(9))),
-        Ok((peer(1), state_diff(10)))
+        (peer(0), state_diff(9)),
+        (peer(1), state_diff(10))
     ]
 )]
 #[case::last_peer_full_block_no_fin(
@@ -411,8 +411,8 @@ async fn make_transaction_stream(
     ],
     vec![len(9), len(10)],
     vec![
-        Ok((peer(0), state_diff(9))),
-        Ok((peer(1), state_diff(10)))
+        (peer(0), state_diff(9)),
+        (peer(1), state_diff(10))
     ]
 )]
 // The same as above but the first peer gives half of the second block before closing the
@@ -426,8 +426,8 @@ async fn make_transaction_stream(
     ],
     vec![len(11), len(12)],
     vec![
-        Ok((peer(0), state_diff(11))),
-        Ok((peer(1), state_diff(12)))
+        (peer(0), state_diff(11)),
+        (peer(1), state_diff(12))
     ]
 )]
 #[case::count_steam_is_too_short(
@@ -438,58 +438,55 @@ async fn make_transaction_stream(
         Ok((peer(0), vec![contract_diff(14), declared_class(14), SDFin]))
     ],
     vec![len(13)], // but only 1 block provided in the count stream
-    vec![
-        Ok((peer(0), state_diff(13))),
-        Err(peer(0)) // the second block is not processed
-    ]
+    vec![(peer(0), state_diff(13))]
 )]
 #[case::too_many_responses_storage_with_fin(
     1,
     vec![Ok((peer(0), vec![contract_diff(15), declared_class(15), surplus_storage(), SDFin]))],
     vec![len(15)],
-    vec![Ok((peer(0), state_diff(15)))]
+    vec![(peer(0), state_diff(15))]
 )]
 #[case::too_many_responses_storage_no_fin(
     1,
     vec![Ok((peer(0), vec![contract_diff(15), declared_class(15), surplus_storage()]))],
     vec![len(15)],
-    vec![Ok((peer(0), state_diff(15)))]
+    vec![(peer(0), state_diff(15))]
 )]
 #[case::too_many_responses_nonce_with_fin(
     1,
     vec![Ok((peer(0), vec![contract_diff(16), declared_class(16), surplus_nonce(), SDFin]))],
     vec![len(16)],
-    vec![Ok((peer(0), state_diff(16)))]
+    vec![(peer(0), state_diff(16))]
 )]
 #[case::too_many_responses_nonce_no_fin(
     1,
     vec![Ok((peer(0), vec![contract_diff(16), declared_class(16), surplus_nonce()]))],
     vec![len(16)],
-    vec![Ok((peer(0), state_diff(16)))]
+    vec![(peer(0), state_diff(16))]
 )]
 #[case::too_many_responses_class_with_fin(
     1,
     vec![Ok((peer(0), vec![contract_diff(17), declared_class(17), surplus_class(), SDFin]))],
     vec![len(17)],
-    vec![Ok((peer(0), state_diff(17)))]
+    vec![(peer(0), state_diff(17))]
 )]
 #[case::too_many_responses_class_no_fin(
     1,
     vec![Ok((peer(0), vec![contract_diff(17), declared_class(17), surplus_class()]))],
     vec![len(17)],
-    vec![Ok((peer(0), state_diff(17)))]
+    vec![(peer(0), state_diff(17))]
 )]
 #[case::too_many_responses_declaration_with_fin(
     1,
     vec![Ok((peer(0), vec![contract_diff(18), declared_class(18), declared_class(19), SDFin]))],
     vec![len(18)],
-    vec![Ok((peer(0), state_diff(18)))]
+    vec![(peer(0), state_diff(18))]
 )]
 #[case::too_many_responses_declaration_no_fin(
     1,
     vec![Ok((peer(0), vec![contract_diff(18), declared_class(18), declared_class(19)]))],
     vec![len(18)],
-    vec![Ok((peer(0), state_diff(18)))]
+    vec![(peer(0), state_diff(18))]
 )]
 #[case::empty_response_streams_are_ignored(
     1,
@@ -499,7 +496,7 @@ async fn make_transaction_stream(
         Ok((peer(2), vec![]))
     ],
     vec![len(20)],
-    vec![Ok((peer(1), state_diff(20)))]
+    vec![(peer(1), state_diff(20))]
 )]
 #[case::empty_responses_are_ignored(
     1,
@@ -509,25 +506,30 @@ async fn make_transaction_stream(
         Ok((peer(2), vec![SDFin]))
     ],
     vec![len(20)],
-    vec![Ok((peer(1), state_diff(20)))]
+    vec![(peer(1), state_diff(20))]
 )]
 #[test_log::test(tokio::test)]
 async fn make_state_diff_stream(
     #[case] num_blocks: usize,
     #[case] responses: Vec<Result<(TestPeer, Vec<StateDiffsResponse>), TestPeer>>,
     #[case] state_diff_len_per_block: Vec<usize>,
-    #[case] expected_stream: Vec<Result<(TestPeer, UnverifiedStateUpdateData), TestPeer>>,
+    #[case] expected_stream: Vec<(TestPeer, UnverifiedStateUpdateData)>,
 ) {
     let _ = env_logger::builder().is_test(true).try_init();
     let (peers, responses) = unzip_fixtures(responses);
-    let get_peers = || async { peers.clone() };
-    let send_request =
-        |_: PeerId, _: StateDiffsRequest| async { send_request(responses.clone()).await };
+    let get_peers = move || {
+        let peers = peers.clone();
+        async move { peers }
+    };
+    let send_request = move |_: PeerId, _: StateDiffsRequest| {
+        let responses = responses.clone();
+        async move { send_request(responses).await }
+    };
 
     let start = BlockNumber::GENESIS;
     let stop = start + (num_blocks - 1) as u64;
 
-    let actual = super::make_state_diff_stream(
+    let actual = super::state_diff_stream::make(
         start,
         stop,
         stream::iter(
@@ -538,15 +540,14 @@ async fn make_state_diff_stream(
         get_peers,
         send_request,
     )
-    .map_ok(|x| (TestPeer(x.peer), x.data))
-    .map_err(|x| TestPeer(x.peer))
+    .map(|x| (TestPeer(x.peer), x.data))
     .collect::<Vec<_>>()
     .await;
 
     let expected = expected_stream
         .into_iter()
         .enumerate()
-        .map(|(i, x)| x.map(|(p, su)| (p, (su, BlockNumber::new_or_panic(i as u64)))))
+        .map(|(i, (p, su))| (p, (su, BlockNumber::new_or_panic(i as u64))))
         .collect::<Vec<_>>();
 
     pretty_assertions_sorted::assert_eq!(actual, expected);

--- a/crates/p2p/src/client/peer_agnostic/tests.rs
+++ b/crates/p2p/src/client/peer_agnostic/tests.rs
@@ -674,13 +674,13 @@ async fn make_state_diff_stream(
         // the second block is not processed
     ]
 )]
-#[case::too_many_responses_declaration_with_fin(
+#[case::too_many_responses_with_fin(
     1,
     vec![Ok((peer(0), vec![class_resp(21), class_resp(22), ClassFin]))],
     vec![1],
     vec![(peer(0), class(21, 0))]
 )]
-#[case::too_many_responses_declaration_no_fin(
+#[case::too_many_responses_no_fin(
     1,
     vec![Ok((peer(0), vec![class_resp(21), class_resp(22)]))],
     vec![1],

--- a/crates/p2p/src/client/peer_agnostic/tests.rs
+++ b/crates/p2p/src/client/peer_agnostic/tests.rs
@@ -724,9 +724,14 @@ async fn make_class_definition_stream(
 ) {
     let _ = env_logger::builder().is_test(true).try_init();
     let (peers, responses) = unzip_fixtures(responses);
-    let get_peers = || async { peers.clone() };
-    let send_request =
-        |_: PeerId, _: ClassesRequest| async { send_request(responses.clone()).await };
+    let get_peers = move || {
+        let peers = peers.clone();
+        async move { peers }
+    };
+    let send_request = move |_: PeerId, _: ClassesRequest| {
+        let responses = responses.clone();
+        async move { send_request(responses).await }
+    };
 
     let start = BlockNumber::GENESIS;
     let stop = start + (num_blocks - 1) as u64;
@@ -910,9 +915,14 @@ async fn make_event_stream(
 ) {
     let _ = env_logger::builder().is_test(true).try_init();
     let (peers, responses) = unzip_fixtures(responses);
-    let get_peers = || async { peers.clone() };
-    let send_request =
-        |_: PeerId, _: EventsRequest| async { send_request(responses.clone()).await };
+    let get_peers = move || {
+        let peers = peers.clone();
+        async move { peers }
+    };
+    let send_request = move |_: PeerId, _: EventsRequest| {
+        let responses = responses.clone();
+        async move { send_request(responses).await }
+    };
 
     let start = BlockNumber::GENESIS;
     let stop = start + (num_blocks - 1) as u64;

--- a/crates/p2p/src/client/peer_agnostic/tests.rs
+++ b/crates/p2p/src/client/peer_agnostic/tests.rs
@@ -253,7 +253,7 @@ async fn make_header_stream(
     vec![1], // but only 1 block provided in the count stream
     vec![
         Ok((peer(0), vec![txn(16, 0)])),
-        Err(peer(0)) // the second block is not processed
+        Err(()) // the second block is not processed
     ]
 )]
 #[case::too_many_responses_with_fin(
@@ -293,7 +293,7 @@ async fn make_transaction_stream(
     #[case] num_blocks: usize,
     #[case] responses: Vec<Result<(TestPeer, Vec<TransactionsResponse>), TestPeer>>,
     #[case] num_txns_per_block: Vec<usize>,
-    #[case] expected_stream: Vec<Result<(TestPeer, Vec<TestTxn>), TestPeer>>,
+    #[case] expected_stream: Vec<Result<(TestPeer, Vec<TestTxn>), ()>>,
 ) {
     let _ = env_logger::builder().is_test(true).try_init();
     let (peers, responses) = unzip_fixtures(responses);
@@ -331,7 +331,7 @@ async fn make_transaction_stream(
                 .collect(),
         )
     })
-    .map_err(|x| TestPeer(x.peer))
+    .map_err(|_| ())
     .collect::<Vec<_>>()
     .await;
 
@@ -445,7 +445,7 @@ async fn make_transaction_stream(
     vec![len(13)], // but only 1 block provided in the count stream
     vec![
         Ok((peer(0), state_diff(13))),
-        Err(peer(0)) // the second block is not processed
+        Err(()) // the second block is not processed
     ]
 )]
 #[case::too_many_responses_storage_with_fin(
@@ -521,7 +521,7 @@ async fn make_state_diff_stream(
     #[case] num_blocks: usize,
     #[case] responses: Vec<Result<(TestPeer, Vec<StateDiffsResponse>), TestPeer>>,
     #[case] state_diff_len_per_block: Vec<usize>,
-    #[case] expected_stream: Vec<Result<(TestPeer, UnverifiedStateUpdateData), TestPeer>>,
+    #[case] expected_stream: Vec<Result<(TestPeer, UnverifiedStateUpdateData), ()>>,
 ) {
     let _ = env_logger::builder().is_test(true).try_init();
     let (peers, responses) = unzip_fixtures(responses);
@@ -549,7 +549,7 @@ async fn make_state_diff_stream(
         send_request,
     )
     .map_ok(|x| (TestPeer(x.peer), x.data))
-    .map_err(|x| TestPeer(x.peer))
+    .map_err(|_| ())
     .collect::<Vec<_>>()
     .await;
 
@@ -680,7 +680,7 @@ async fn make_state_diff_stream(
     vec![1], // but only 1 block provided in the count stream
     vec![
         Ok((peer(0), class(19, 0))),
-        Err(peer(0)) // the second block is not processed
+        Err(()) // the second block is not processed
     ]
 )]
 #[case::too_many_responses_declaration_with_fin(
@@ -720,7 +720,7 @@ async fn make_class_definition_stream(
     #[case] num_blocks: usize,
     #[case] responses: Vec<Result<(TestPeer, Vec<ClassesResponse>), TestPeer>>,
     #[case] declared_classes_per_block: Vec<usize>,
-    #[case] expected_stream: Vec<Result<(TestPeer, ClassDefinition), TestPeer>>,
+    #[case] expected_stream: Vec<Result<(TestPeer, ClassDefinition), ()>>,
 ) {
     let _ = env_logger::builder().is_test(true).try_init();
     let (peers, responses) = unzip_fixtures(responses);
@@ -744,7 +744,7 @@ async fn make_class_definition_stream(
         send_request,
     )
     .map_ok(|x| (TestPeer(x.peer), x.data))
-    .map_err(|x| TestPeer(x.peer))
+    .map_err(|_| ())
     .collect::<Vec<_>>()
     .await;
 
@@ -863,7 +863,7 @@ async fn make_class_definition_stream(
     vec![1], // but only 1 block provided in the count stream
     vec![
         Ok((peer(0), events(vec![(vec![25], 25)], 0))),
-        Err(peer(0)) // the second block is not processed
+        Err(()) // the second block is not processed
     ]
 )]
 #[case::too_many_responses_with_fin(
@@ -911,7 +911,7 @@ async fn make_event_stream(
     #[case] num_blocks: usize,
     #[case] responses: Vec<Result<(TestPeer, Vec<EventsResponse>), TestPeer>>,
     #[case] events_per_block: Vec<usize>,
-    #[case] expected_stream: Vec<Result<(TestPeer, TaggedEventsForBlockByTransaction), TestPeer>>,
+    #[case] expected_stream: Vec<Result<(TestPeer, TaggedEventsForBlockByTransaction), ()>>,
 ) {
     let _ = env_logger::builder().is_test(true).try_init();
     let (peers, responses) = unzip_fixtures(responses);
@@ -947,7 +947,7 @@ async fn make_event_stream(
             ),
         )
     })
-    .map_err(|x| TestPeer(x.peer))
+    .map_err(|_| ())
     .collect::<Vec<_>>()
     .await;
 

--- a/crates/p2p/src/client/peer_agnostic/tests.rs
+++ b/crates/p2p/src/client/peer_agnostic/tests.rs
@@ -560,17 +560,17 @@ async fn make_state_diff_stream(
     //                                |
     vec![Ok((peer(0), vec![class_resp(0), ClassFin]))],
     vec![1],
-    //                  class  block
-    //                      |  |
-    vec![Ok((peer(0), class(0, 0)))]
+    //               class  block
+    //                   |  |
+    vec![(peer(0), class(0, 0))]
 )]
 #[case::one_peer_2_blocks(
     2,
     vec![Ok((peer(0), vec![class_resp(1), class_resp(2), ClassFin]))],
     vec![1, 1],
     vec![
-        Ok((peer(0), class(1, 0))),
-        Ok((peer(0), class(2, 1)))
+        (peer(0), class(1, 0)),
+        (peer(0), class(2, 1))
     ]
 )]
 #[case::one_peer_2_blocks_in_2_attempts(
@@ -582,10 +582,10 @@ async fn make_state_diff_stream(
     ],
     vec![2, 2],
     vec![
-        Ok((peer(0), class(3, 0))),
-        Ok((peer(0), class(4, 0))),
-        Ok((peer(0), class(5, 1))),
-        Ok((peer(0), class(6, 1)))
+        (peer(0), class(3, 0)),
+        (peer(0), class(4, 0)),
+        (peer(0), class(5, 1)),
+        (peer(0), class(6, 1))
     ]
 )]
 #[case::two_peers_1_block_per_peer(
@@ -599,8 +599,8 @@ async fn make_state_diff_stream(
     ],
     vec![1, 1],
     vec![
-        Ok((peer(0), class(7, 0))),
-        Ok((peer(1), class(8, 1)))
+        (peer(0), class(7, 0)),
+        (peer(1), class(8, 1))
     ]
 )]
 #[case::first_peer_premature_eos_with_fin(
@@ -612,9 +612,9 @@ async fn make_state_diff_stream(
     ],
     vec![1, 2],
     vec![
-        Ok((peer(0), class(9, 0))),
-        Ok((peer(1), class(10, 1))),
-        Ok((peer(1), class(11, 1)))
+        (peer(0), class(9, 0)),
+        (peer(1), class(10, 1)),
+        (peer(1), class(11, 1))
     ]
 )]
 #[case::first_peer_full_block_no_fin(
@@ -626,9 +626,9 @@ async fn make_state_diff_stream(
     ],
     vec![2, 1],
     vec![
-        Ok((peer(0), class(12, 0))),
-        Ok((peer(0), class(13, 0))),
-        Ok((peer(1), class(14, 1))),
+        (peer(0), class(12, 0)),
+        (peer(0), class(13, 0)),
+        (peer(1), class(14, 1)),
     ]
 )]
 #[case::last_peer_full_block_no_fin(
@@ -639,9 +639,9 @@ async fn make_state_diff_stream(
     ],
     vec![2, 1],
     vec![
-        Ok((peer(0), class(12, 0))),
-        Ok((peer(0), class(13, 0))),
-        Ok((peer(1), class(14, 1))),
+        (peer(0), class(12, 0)),
+        (peer(0), class(13, 0)),
+        (peer(1), class(14, 1)),
     ]
 )]
 // The same as above but the first peer gives half of the second block before closing the
@@ -655,10 +655,10 @@ async fn make_state_diff_stream(
     ],
     vec![1, 3],
     vec![
-        Ok((peer(0), class(15, 0))),
-        Ok((peer(1), class(16, 1))),
-        Ok((peer(1), class(17, 1))),
-        Ok((peer(1), class(18, 1))),
+        (peer(0), class(15, 0)),
+        (peer(1), class(16, 1)),
+        (peer(1), class(17, 1)),
+        (peer(1), class(18, 1)),
     ]
 )]
 #[case::count_steam_is_too_short(
@@ -670,21 +670,21 @@ async fn make_state_diff_stream(
     ],
     vec![1], // but only 1 block provided in the count stream
     vec![
-        Ok((peer(0), class(19, 0))),
-        Err(peer(0)) // the second block is not processed
+        (peer(0), class(19, 0)),
+        // the second block is not processed
     ]
 )]
 #[case::too_many_responses_declaration_with_fin(
     1,
     vec![Ok((peer(0), vec![class_resp(21), class_resp(22), ClassFin]))],
     vec![1],
-    vec![Ok((peer(0), class(21, 0)))]
+    vec![(peer(0), class(21, 0))]
 )]
 #[case::too_many_responses_declaration_no_fin(
     1,
     vec![Ok((peer(0), vec![class_resp(21), class_resp(22)]))],
     vec![1],
-    vec![Ok((peer(0), class(21, 0)))]
+    vec![(peer(0), class(21, 0))]
 )]
 #[case::empty_response_streams_are_ignored(
     1,
@@ -694,7 +694,7 @@ async fn make_state_diff_stream(
         Ok((peer(2), vec![]))
     ],
     vec![1],
-    vec![Ok((peer(1), class(22, 0)))]
+    vec![(peer(1), class(22, 0))]
 )]
 #[case::empty_responses_are_ignored(
     1,
@@ -704,14 +704,14 @@ async fn make_state_diff_stream(
         Ok((peer(2), vec![ClassFin]))
     ],
     vec![1],
-    vec![Ok((peer(1), class(22, 0)))]
+    vec![(peer(1), class(22, 0))]
 )]
 #[test_log::test(tokio::test)]
 async fn make_class_definition_stream(
     #[case] num_blocks: usize,
     #[case] responses: Vec<Result<(TestPeer, Vec<ClassesResponse>), TestPeer>>,
     #[case] declared_classes_per_block: Vec<usize>,
-    #[case] expected_stream: Vec<Result<(TestPeer, ClassDefinition), TestPeer>>,
+    #[case] expected_stream: Vec<(TestPeer, ClassDefinition)>,
 ) {
     let _ = env_logger::builder().is_test(true).try_init();
     let (peers, responses) = unzip_fixtures(responses);
@@ -729,8 +729,7 @@ async fn make_class_definition_stream(
         get_peers,
         send_request,
     )
-    .map_ok(|x| (TestPeer(x.peer), x.data))
-    .map_err(|x| TestPeer(x.peer))
+    .map(|x| (TestPeer(x.peer), x.data))
     .collect::<Vec<_>>()
     .await;
 

--- a/crates/p2p/src/client/peer_agnostic/tests.rs
+++ b/crates/p2p/src/client/peer_agnostic/tests.rs
@@ -107,7 +107,7 @@ use crate::client::peer_agnostic::fixtures::*;
     vec![(peer(1), hdr(11))]
 )]
 #[test_log::test(tokio::test)]
-async fn make_header_stream(
+async fn header_stream_make(
     #[case] num_blocks: usize,
     #[case] responses: Vec<Result<(TestPeer, Vec<BlockHeadersResponse>), TestPeer>>,
     #[case] expected_stream: Vec<(TestPeer, SignedBlockHeader)>,
@@ -127,7 +127,7 @@ async fn make_header_stream(
         let start = BlockNumber::GENESIS;
         let stop = start + (num_blocks - 1) as u64;
 
-        let actual = super::make_header_stream(start, stop, reverse, get_peers, send_request)
+        let actual = super::header_stream::make(start, stop, reverse, get_peers, send_request)
             .map(|x| (TestPeer(x.peer), x.data))
             .collect::<Vec<_>>()
             .await;
@@ -305,7 +305,7 @@ async fn make_transaction_stream(
     let start = BlockNumber::GENESIS;
     let stop = start + (num_blocks - 1) as u64;
 
-    let actual = super::make_transaction_stream(
+    let actual = super::transaction_stream::make(
         start,
         stop,
         stream::iter(

--- a/crates/p2p/src/client/peer_agnostic/traits.rs
+++ b/crates/p2p/src/client/peer_agnostic/traits.rs
@@ -36,9 +36,9 @@ pub trait TransactionStream {
         self,
         start: BlockNumber,
         stop: BlockNumber,
-        transaction_counts_and_commitments_stream: impl Stream<
-            Item = anyhow::Result<(usize, TransactionCommitment)>,
-        >,
+        transaction_counts_and_commitments_stream: impl Stream<Item = anyhow::Result<(usize, TransactionCommitment)>>
+            + Send
+            + 'static,
     ) -> impl Stream<
         Item = Result<PeerData<(UnverifiedTransactionData, BlockNumber)>, PeerData<anyhow::Error>>,
     >;

--- a/crates/p2p/src/client/peer_agnostic/traits.rs
+++ b/crates/p2p/src/client/peer_agnostic/traits.rs
@@ -63,7 +63,7 @@ pub trait ClassStream {
         self,
         start: BlockNumber,
         stop: BlockNumber,
-        declared_class_counts_stream: impl Stream<Item = anyhow::Result<usize>>,
+        declared_class_counts_stream: impl Stream<Item = anyhow::Result<usize>> + Send + 'static,
     ) -> impl Stream<Item = PeerData<ClassDefinition>>;
 }
 

--- a/crates/p2p/src/client/peer_agnostic/traits.rs
+++ b/crates/p2p/src/client/peer_agnostic/traits.rs
@@ -64,7 +64,7 @@ pub trait ClassStream {
         start: BlockNumber,
         stop: BlockNumber,
         declared_class_counts_stream: impl Stream<Item = anyhow::Result<usize>>,
-    ) -> impl Stream<Item = Result<PeerData<ClassDefinition>, PeerData<anyhow::Error>>>;
+    ) -> impl Stream<Item = PeerData<ClassDefinition>>;
 }
 
 pub trait EventStream {

--- a/crates/p2p/src/client/peer_agnostic/traits.rs
+++ b/crates/p2p/src/client/peer_agnostic/traits.rs
@@ -39,9 +39,7 @@ pub trait TransactionStream {
         transaction_counts_and_commitments_stream: impl Stream<Item = anyhow::Result<(usize, TransactionCommitment)>>
             + Send
             + 'static,
-    ) -> impl Stream<
-        Item = Result<PeerData<(UnverifiedTransactionData, BlockNumber)>, PeerData<anyhow::Error>>,
-    >;
+    ) -> impl Stream<Item = PeerData<(UnverifiedTransactionData, BlockNumber)>>;
 }
 
 pub trait StateDiffStream {

--- a/crates/p2p/src/client/peer_agnostic/traits.rs
+++ b/crates/p2p/src/client/peer_agnostic/traits.rs
@@ -79,8 +79,8 @@ pub trait EventStream {
         self,
         start: BlockNumber,
         stop: BlockNumber,
-        event_counts_stream: impl Stream<Item = anyhow::Result<usize>>,
-    ) -> impl Stream<Item = Result<PeerData<EventsForBlockByTransaction>, PeerData<anyhow::Error>>>;
+        event_counts_stream: impl Stream<Item = anyhow::Result<usize>> + Send + 'static,
+    ) -> impl Stream<Item = PeerData<EventsForBlockByTransaction>>;
 }
 
 pub trait BlockClient {

--- a/crates/p2p/src/client/peer_agnostic/traits.rs
+++ b/crates/p2p/src/client/peer_agnostic/traits.rs
@@ -22,6 +22,8 @@ use crate::client::types::{
 };
 use crate::PeerData;
 
+pub type StreamItem<T> = Result<PeerData<T>, PeerData<anyhow::Error>>;
+
 pub trait HeaderStream {
     fn header_stream(
         self,
@@ -39,7 +41,7 @@ pub trait TransactionStream {
         transaction_counts_and_commitments_stream: impl Stream<Item = anyhow::Result<(usize, TransactionCommitment)>>
             + Send
             + 'static,
-    ) -> impl Stream<Item = PeerData<(UnverifiedTransactionData, BlockNumber)>>;
+    ) -> impl Stream<Item = StreamItem<(UnverifiedTransactionData, BlockNumber)>>;
 }
 
 pub trait StateDiffStream {

--- a/crates/p2p/src/client/peer_agnostic/traits.rs
+++ b/crates/p2p/src/client/peer_agnostic/traits.rs
@@ -52,12 +52,10 @@ pub trait StateDiffStream {
         self,
         start: BlockNumber,
         stop: BlockNumber,
-        state_diff_length_and_commitment_stream: impl Stream<
-            Item = anyhow::Result<(usize, StateDiffCommitment)>,
-        >,
-    ) -> impl Stream<
-        Item = Result<PeerData<(UnverifiedStateUpdateData, BlockNumber)>, PeerData<anyhow::Error>>,
-    >;
+        state_diff_length_and_commitment_stream: impl Stream<Item = anyhow::Result<(usize, StateDiffCommitment)>>
+            + Send
+            + 'static,
+    ) -> impl Stream<Item = PeerData<(UnverifiedStateUpdateData, BlockNumber)>>;
 }
 
 pub trait ClassStream {

--- a/crates/p2p/src/client/peer_agnostic/traits.rs
+++ b/crates/p2p/src/client/peer_agnostic/traits.rs
@@ -57,7 +57,7 @@ pub trait StateDiffStream {
         state_diff_length_and_commitment_stream: impl Stream<Item = anyhow::Result<(usize, StateDiffCommitment)>>
             + Send
             + 'static,
-    ) -> impl Stream<Item = PeerData<(UnverifiedStateUpdateData, BlockNumber)>>;
+    ) -> impl Stream<Item = StreamItem<(UnverifiedStateUpdateData, BlockNumber)>>;
 }
 
 pub trait ClassStream {
@@ -66,7 +66,7 @@ pub trait ClassStream {
         start: BlockNumber,
         stop: BlockNumber,
         declared_class_counts_stream: impl Stream<Item = anyhow::Result<usize>> + Send + 'static,
-    ) -> impl Stream<Item = PeerData<ClassDefinition>>;
+    ) -> impl Stream<Item = StreamItem<ClassDefinition>>;
 }
 
 pub trait EventStream {
@@ -82,7 +82,7 @@ pub trait EventStream {
         start: BlockNumber,
         stop: BlockNumber,
         event_counts_stream: impl Stream<Item = anyhow::Result<usize>> + Send + 'static,
-    ) -> impl Stream<Item = PeerData<EventsForBlockByTransaction>>;
+    ) -> impl Stream<Item = StreamItem<EventsForBlockByTransaction>>;
 }
 
 pub trait BlockClient {

--- a/crates/pathfinder/src/sync/checkpoint.rs
+++ b/crates/pathfinder/src/sync/checkpoint.rs
@@ -1088,9 +1088,7 @@ mod tests {
         use super::*;
 
         struct Setup {
-            pub streamed_state_diffs: Vec<
-                Result<PeerData<UnverifiedStateUpdateWithBlockNumber>, PeerData<anyhow::Error>>,
-            >,
+            pub streamed_state_diffs: Vec<PeerData<UnverifiedStateUpdateWithBlockNumber>>,
             pub expected_state_diffs: Vec<StateUpdateData>,
             pub storage: Storage,
         }
@@ -1193,8 +1191,6 @@ mod tests {
             } = setup(1).await;
 
             streamed_state_diffs[0]
-                .as_mut()
-                .unwrap()
                 .data
                 .0
                 .state_diff
@@ -1210,22 +1206,6 @@ mod tests {
                 )
                 .await,
                 Err(SyncError::StateDiffCommitmentMismatch(_))
-            );
-        }
-
-        #[tokio::test]
-        async fn stream_failure() {
-            assert_matches!(
-                handle_state_diff_stream(
-                    stream::once(std::future::ready(Err(PeerData::for_tests(
-                        anyhow::anyhow!("")
-                    )))),
-                    StorageBuilder::in_memory().unwrap(),
-                    BlockNumber::GENESIS,
-                    false,
-                )
-                .await,
-                Err(SyncError::Other(_))
             );
         }
 


### PR DESCRIPTION
This PR:
- fixes #2148 
- fixes #2101
- fixes p2p outbound failure handling in the main loop
- improves readability of p2p stream methods at the expense of more smaller fns
