### PR TITLE
refactor: remove p2p `BlockHeader` types

### DIFF
--- a/crates/common/src/header.rs
+++ b/crates/common/src/header.rs
@@ -38,7 +38,7 @@ pub enum L1DataAvailabilityMode {
     Blob,
 }
 
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Default, Dummy)]
 pub struct SignedBlockHeader {
     pub header: BlockHeader,
     pub signature: BlockCommitmentSignature,

--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -29,6 +29,7 @@ use pathfinder_common::{
     ContractAddress,
     ContractNonce,
     SierraHash,
+    SignedBlockHeader,
     StateDiffCommitment,
     StorageAddress,
     StorageValue,
@@ -61,7 +62,6 @@ use crate::client::types::{
     EventsForBlockByTransaction,
     IncorrectStateDiffCount,
     Receipt,
-    SignedBlockHeader,
     UnverifiedStateUpdateData,
     UnverifiedTransactionData,
     UnverifiedTransactionDataWithBlockNumber,
@@ -647,7 +647,7 @@ where
 
                     match signed_header {
                         BlockHeadersResponse::Header(hdr) => {
-                            match SignedBlockHeader::try_from(*hdr) {
+                            match SignedBlockHeader::try_from_dto(*hdr) {
                                 Ok(hdr) => {
                                     yield PeerData::new(peer, hdr);
 

--- a/crates/p2p/src/client/peer_agnostic/fixtures.rs
+++ b/crates/p2p/src/client/peer_agnostic/fixtures.rs
@@ -15,13 +15,13 @@ use pathfinder_common::event::Event;
 use pathfinder_common::state_update::{ContractClassUpdate, ContractUpdate, StateUpdateData};
 use pathfinder_common::transaction::TransactionVariant;
 use pathfinder_common::{
+    BlockHeader,
     BlockNumber,
     CasmHash,
-    ClassCommitment,
     ClassHash,
     ContractAddress,
     SierraHash,
-    StorageCommitment,
+    SignedBlockHeader,
     TransactionHash,
     TransactionIndex,
 };
@@ -32,7 +32,6 @@ use tokio::sync::Mutex;
 use super::{ClassDefinition, UnverifiedStateUpdateData};
 use crate::client::conv::{CairoDefinition, SierraDefinition, ToDto, TryFromDto};
 use crate::client::peer_agnostic::Receipt;
-use crate::client::types::{BlockHeader, SignedBlockHeader};
 
 #[derive(Clone, PartialEq, TaggedDebug)]
 pub struct TestPeer(pub PeerId);
@@ -104,8 +103,6 @@ pub async fn send_request<T>(
 
 pub fn hdr_resp(tag: i32) -> BlockHeadersResponse {
     let h = hdr(tag);
-    // TODO
-    let h = h.finalize(StorageCommitment::ZERO, ClassCommitment::ZERO);
     BlockHeadersResponse::Header(Box::new(h.to_dto()))
 }
 
@@ -113,6 +110,9 @@ pub fn hdr(tag: i32) -> SignedBlockHeader {
     Tagged::get(format!("header {tag}"), || SignedBlockHeader {
         header: BlockHeader {
             number: BlockNumber::new_or_panic(tag as u64),
+            // TODO Set storage and class commitment
+            storage_commitment: Default::default(),
+            class_commitment: Default::default(),
             ..Faker.fake()
         },
         ..Faker.fake()

--- a/crates/p2p/src/client/peer_agnostic/traits.rs
+++ b/crates/p2p/src/client/peer_agnostic/traits.rs
@@ -3,7 +3,13 @@ use libp2p::PeerId;
 use pathfinder_common::event::Event;
 use pathfinder_common::state_update::StateUpdateData;
 use pathfinder_common::transaction::TransactionVariant;
-use pathfinder_common::{BlockNumber, StateDiffCommitment, TransactionCommitment, TransactionHash};
+use pathfinder_common::{
+    BlockNumber,
+    SignedBlockHeader,
+    StateDiffCommitment,
+    TransactionCommitment,
+    TransactionHash,
+};
 
 use crate::client::types::{
     ClassDefinition,
@@ -11,7 +17,6 @@ use crate::client::types::{
     EventsForBlockByTransaction,
     IncorrectStateDiffCount,
     Receipt,
-    SignedBlockHeader,
     UnverifiedStateUpdateData,
     UnverifiedTransactionData,
 };

--- a/crates/pathfinder/src/sync/events.rs
+++ b/crates/pathfinder/src/sync/events.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, VecDeque};
 use std::num::NonZeroUsize;
 
 use anyhow::Context;
-use p2p::client::types::{BlockHeader as P2PBlockHeader, EventsForBlockByTransaction};
+use p2p::client::types::EventsForBlockByTransaction;
 use p2p::PeerData;
 use pathfinder_common::event::Event;
 use pathfinder_common::receipt::Receipt;


### PR DESCRIPTION
Remove the P2P `BlockHeader` types in favor of the `common` ones. Closes https://github.com/eqlabs/pathfinder/issues/2151.