### PR TITLE
chore(ci): speed up `test` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: rui314/setup-mold@v1
       - uses: Swatinem/rust-cache@v2
         with:
-          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          save-if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule' }}
       - uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,8 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          remove-dotnet: "true"
-          remove-android: "true"
-          remove-haskell: "true"
-          remove-codeql: "true"
-          remove-docker-images: "true"
-          root-reserve-mb: "2048"
-          temp-reserve-mb: "2048"
+          root-reserve-mb: "3072"
+          temp-reserve-mb: "3072"
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,7 @@ jobs:
           rm -rf ~/.cargo/registry
           rm -rf ~/.cargo/git
       - name: Compile unit tests
-        # --build-jobs 1 as we are constantly OOMing during compilation.
-        run: cargo nextest run --all-targets --all-features --workspace --locked --no-run --timings --build-jobs 1
+        run: cargo nextest run --all-targets --all-features --workspace --locked --no-run --timings
       - name: Run unit tests
         run: timeout 10m cargo nextest run --no-fail-fast --all-targets --all-features --workspace --locked
       - name: Store timings


### PR DESCRIPTION
This PR makes three modifications that result in slight improvements in the `test` job:

- Removes `--build-jobs 1` from the compilation command: the runner we're running this on has 2 CPUs. We did limit this because occasionally we were running out of memory. According to my tests this is not a problem with the deps / compiler we are using now.
- Changes configuration of the `maximize-build-space` action: removing Docker container images seems to take really long (~2 minutes) and it seems that we do not actually need the ~20GB extra space removing unnecessary software and Docker images brings us.
- We have nightly scheduled jobs that test a full compilation (cleans build artifacts before the build). We now store the resulting build artifacts in the Rust build cache for scheduled jobs.