### PR TITLE
feat(pathfinder): add CLI option for setting L1 poll interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Pathfinder JSON-RPC extension methods are now also exposed on the `/rpc/pathfinder/v0_1` endpoint.
+- `--sync.l1-poll-interval` CLI option has been added to set the poll interval for L1 state. Defaults to 30s.
 
 ## [0.14.1] - 2024-07-29
 

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -133,6 +133,14 @@ Examples:
     poll_interval: std::num::NonZeroU64,
 
     #[arg(
+        long = "sync.l1-poll-interval",
+        long_help = "L1 state poll interval in seconds",
+        default_value = "30",
+        env = "PATHFINDER_L1_POLL_INTERVAL_SECONDS"
+    )]
+    l1_poll_interval: std::num::NonZeroU64,
+
+    #[arg(
         long = "color",
         long_help = "This flag controls when to use colors in the output logs.",
         default_value = "auto",
@@ -669,6 +677,7 @@ pub struct Config {
     pub sqlite_wal: JournalMode,
     pub max_rpc_connections: std::num::NonZeroUsize,
     pub poll_interval: std::time::Duration,
+    pub l1_poll_interval: std::time::Duration,
     pub color: Color,
     pub p2p: P2PConfig,
     pub debug: DebugConfig,
@@ -953,6 +962,7 @@ impl Config {
             },
             max_rpc_connections: cli.max_rpc_connections,
             poll_interval: Duration::from_secs(cli.poll_interval.get()),
+            l1_poll_interval: Duration::from_secs(cli.l1_poll_interval.get()),
             color: cli.color,
             p2p: P2PConfig::parse_or_exit(cli.p2p),
             debug: DebugConfig::parse(cli.debug),

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -538,6 +538,7 @@ fn start_sync(
     gossiper: state::Gossiper,
     gateway_public_key: pathfinder_common::PublicKey,
     _p2p_client: Option<p2p::client::peer_agnostic::Client>,
+    _verify_tree_hashes: bool,
 ) -> tokio::task::JoinHandle<anyhow::Result<()>> {
     start_feeder_gateway_sync(
         storage,

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -573,6 +573,7 @@ fn start_feeder_gateway_sync(
         sequencer: pathfinder_context.gateway,
         state: sync_state.clone(),
         head_poll_interval: config.poll_interval,
+        l1_poll_interval: config.l1_poll_interval,
         pending_data: tx_pending,
         block_validation_mode: state::l2::BlockValidationMode::Strict,
         websocket_txs,

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -78,6 +78,7 @@ pub struct SyncContext<G, E> {
     pub sequencer: G,
     pub state: Arc<SyncState>,
     pub head_poll_interval: Duration,
+    pub l1_poll_interval: Duration,
     pub pending_data: WatchSender<PendingData>,
     pub block_validation_mode: l2::BlockValidationMode,
     pub websocket_txs: Option<TopicBroadcasters>,
@@ -97,7 +98,7 @@ where
             ethereum: value.ethereum.clone(),
             chain: value.chain,
             core_address: value.core_address,
-            poll_interval: value.head_poll_interval,
+            poll_interval: value.l1_poll_interval,
         }
     }
 }
@@ -183,6 +184,7 @@ where
         sequencer,
         state,
         head_poll_interval,
+        l1_poll_interval: _,
         pending_data,
         block_validation_mode: _,
         websocket_txs,


### PR DESCRIPTION
This defaulted to the L2 poll interval, which is 2s right now. This is completely unjustified and just results in us polling L1 with a much higher rate than expected.

This change adds the `--sync.l1-poll-interval` CLI option that defaults to 30s.
