### PR TITLE
feat(gateway-client): improve logging upon timeout

### DIFF
--- a/crates/gateway-client/Cargo.toml
+++ b/crates/gateway-client/Cargo.toml
@@ -36,6 +36,7 @@ gateway-test-utils = { path = "../gateway-test-utils" }
 httpmock = { workspace = true }
 pathfinder-crypto = { path = "../crypto" }
 pretty_assertions_sorted = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 test-log = { workspace = true, features = ["trace"] }
 tracing-subscriber = { workspace = true }

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -174,7 +174,12 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
     });
     let execution_storage = storage_manager
         .create_read_only_pool(execution_storage_pool_size)
-        .context(r"")?;
+        .context(
+            r"Creating database connection pool for execution
+
+Hint: This is usually caused by exceeding the file descriptor limit of your system.
+      Try increasing the file limit to using `ulimit` or similar tooling.",
+        )?;
 
     let p2p_storage = storage_manager
         .create_pool(NonZeroU32::new(1).unwrap())


### PR DESCRIPTION
TL;DR: timeouts are not logged clearly enough, which can be misleading

--------

1. When fetching a really large block [(sepolia/99902, ~2000txns)](https://alpha-sepolia.starknet.io/feeder_gateway/get_state_update?blockNumber=99902&includeBlock=true) my local pathfinder instance just hanged. It turned out that I was getting a [decode error](https://docs.rs/reqwest/latest/src/reqwest/error.rs.html#191):
"Request failed, retrying _reason_=error decoding response body"

2. But The core reason for this error was that the reply was timing out mid-way, so there was no way decode could succeed. However the problem in the log was that we logged the `Display` impl of  `reqwest::Error` which does not take the real __source__ into account (`TimedOut`), but only the outer kind of the error (reason=decode error).

This PR fixes this behavior by enhancing the log if `error.is_timeout() == true`, so the log now looks like this:

```
Request failed, retrying. Fetching the response or parts of it timed out. Try increasing request timeout by using the `--gateway.request-timeout` CLI option. reason=error decoding response body
```

3. The real problem lies in a discrepancy in `reqwest::Error` between its [`Display` implementation](https://docs.rs/reqwest/latest/src/reqwest/error.rs.html#185) and the semantics of [`is_timeout`](https://docs.rs/reqwest/latest/src/reqwest/error.rs.html#101) as compared to `is_<other_error>`.