### PR TITLE
feat(pathfinder/sync/l2): add a bulk fetch mode to feeder gateway sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pathfinder JSON-RPC extension methods are now also exposed on the `/rpc/pathfinder/v0_1` endpoint.
 - `--sync.l1-poll-interval` CLI option has been added to set the poll interval for L1 state. Defaults to 30s.
+- Pathfinder now fetches data concurrently from the feeder gateway when catching up. The `--gateway.fetch-concurrency` CLI option can be used to limit how many blocks are fetched concurrently (the default is 8).
 
 ## [0.14.1] - 2024-07-29
 

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -229,6 +229,15 @@ This should only be enabled for debugging purposes as it adds substantial proces
     gateway_timeout: std::num::NonZeroU64,
 
     #[arg(
+        long = "gateway.fetch-concurrency",
+        long_help = "How many concurrent requests to send to the feeder gateway when fetching \
+                     block data",
+        env = "PATHFINDER_GATEWAY_FETCH_CONCURRENCY",
+        default_value = "8"
+    )]
+    feeder_gateway_fetch_concurrency: std::num::NonZeroUsize,
+
+    #[arg(
         long = "storage.event-bloom-filter-cache-size",
         long_help = "The number of blocks whose event bloom filters are cached in memory. This \
                      cache speeds up event related RPC queries at the cost of using extra memory. \
@@ -689,6 +698,7 @@ pub struct Config {
     pub get_events_max_uncached_bloom_filters_to_load: NonZeroUsize,
     pub state_tries: Option<StateTries>,
     pub custom_versioned_constants: Option<VersionedConstants>,
+    pub feeder_gateway_fetch_concurrency: NonZeroUsize,
 }
 
 pub struct Ethereum {
@@ -973,6 +983,7 @@ impl Config {
             get_events_max_uncached_bloom_filters_to_load: cli
                 .get_events_max_uncached_bloom_filters_to_load,
             gateway_timeout: Duration::from_secs(cli.gateway_timeout.get()),
+            feeder_gateway_fetch_concurrency: cli.feeder_gateway_fetch_concurrency,
             state_tries: cli.state_tries,
             custom_versioned_constants: cli
                 .custom_versioned_constants_path

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -586,6 +586,7 @@ fn start_feeder_gateway_sync(
         verify_tree_hashes: config.verify_tree_hashes,
         gossiper,
         sequencer_public_key: gateway_public_key,
+        fetch_concurrency: config.feeder_gateway_fetch_concurrency,
     };
 
     tokio::spawn(state::sync(sync_context, state::l1::sync, state::l2::sync))

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -199,8 +199,7 @@ where
         .connection()
         .context("Creating database connection")?;
 
-    // TODO: consider increasing the capacity.
-    let (event_sender, event_receiver) = mpsc::channel(2);
+    let (event_sender, event_receiver) = mpsc::channel(8);
 
     let l2_head = tokio::task::block_in_place(|| -> anyhow::Result<_> {
         let tx = db_conn.transaction()?;

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -87,6 +87,7 @@ pub struct SyncContext<G, E> {
     pub verify_tree_hashes: bool,
     pub gossiper: Gossiper,
     pub sequencer_public_key: PublicKey,
+    pub fetch_concurrency: std::num::NonZeroUsize,
 }
 
 impl<G, E> From<&SyncContext<G, E>> for L1SyncContext<E>
@@ -115,6 +116,7 @@ where
             block_validation_mode: value.block_validation_mode,
             storage: value.storage.clone(),
             sequencer_public_key: value.sequencer_public_key,
+            fetch_concurrency: value.fetch_concurrency,
         }
     }
 }
@@ -193,6 +195,7 @@ where
         verify_tree_hashes: _,
         gossiper,
         sequencer_public_key: _,
+        fetch_concurrency: _,
     } = context;
 
     let mut db_conn = storage

--- a/crates/pathfinder/src/state/sync/class.rs
+++ b/crates/pathfinder/src/state/sync/class.rs
@@ -60,16 +60,15 @@ pub async fn download_class<SequencerClient: GatewayApi>(
             // The work-around ignores compilation errors on integration, and instead
             // replaces the casm definition with empty bytes.
             let span = tracing::Span::current();
-            let (casm_definition, sierra_definition) =
-                tokio::task::spawn_blocking(move || -> (anyhow::Result<_>, _) {
-                    let _span = span.entered();
-                    (
-                        pathfinder_compiler::compile_to_casm(&definition)
-                            .context("Compiling Sierra class"),
-                        definition,
-                    )
-                })
-                .await?;
+            let (send, recv) = tokio::sync::oneshot::channel();
+            rayon::spawn(move || {
+                let _span = span.entered();
+                let compile_result = pathfinder_compiler::compile_to_casm(&definition)
+                    .context("Compiling Sierra class");
+
+                let _ = send.send((compile_result, definition));
+            });
+            let (casm_definition, sierra_definition) = recv.await.expect("Panic on rayon thread");
 
             let casm_definition = match casm_definition {
                 Ok(casm_definition) => casm_definition,

--- a/crates/pathfinder/src/state/sync/class.rs
+++ b/crates/pathfinder/src/state/sync/class.rs
@@ -59,8 +59,10 @@ pub async fn download_class<SequencerClient: GatewayApi>(
             //
             // The work-around ignores compilation errors on integration, and instead
             // replaces the casm definition with empty bytes.
+            let span = tracing::Span::current();
             let (casm_definition, sierra_definition) =
                 tokio::task::spawn_blocking(move || -> (anyhow::Result<_>, _) {
+                    let _span = span.entered();
                     (
                         pathfinder_compiler::compile_to_casm(&definition)
                             .context("Compiling Sierra class"),

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -474,7 +474,7 @@ pub async fn download_new_classes(
         .in_current_span()
     });
 
-    let stream = futures::stream::iter(futures).buffer_unordered(8);
+    let stream = futures::stream::iter(futures).buffer_unordered(4);
 
     let downloaded_classes = stream.try_collect().await?;
 

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use anyhow::{anyhow, Context};
+use futures::StreamExt;
 use pathfinder_common::state_update::{ContractClassUpdate, StateUpdateData};
 use pathfinder_common::{
     BlockCommitmentSignature,
@@ -441,12 +442,24 @@ pub async fn download_new_classes(
     .context("Joining database task")?
     .context("Querying database for missing classes")?;
 
-    for class_hash in require_downloading {
-        let class = download_class(sequencer, class_hash)
-            .await
-            .with_context(|| format!("Downloading class {}", class_hash.0))?;
+    let futures = require_downloading
+        .into_iter()
+        .map(|class_hash| async move {
+            (
+                class_hash,
+                download_class(sequencer, class_hash)
+                    .await
+                    .with_context(|| format!("Downloading class {}", class_hash.0)),
+            )
+        });
 
-        match class {
+    let mut stream = futures::stream::iter(futures).buffer_unordered(8);
+
+    while let Some(result) = stream.next().await {
+        let (class_hash, downloaded_class_result) = result;
+        let downloaded_class = downloaded_class_result?;
+
+        match downloaded_class {
             DownloadedClass::Cairo { definition, hash } => tx_event
                 .send(SyncEvent::CairoClass { definition, hash })
                 .await

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -456,16 +456,17 @@ pub async fn download_new_classes(
     .context("Joining database task")?
     .context("Querying database for missing classes")?;
 
-    let futures = require_downloading
-        .into_iter()
-        .map(|class_hash| async move {
+    let futures = require_downloading.into_iter().map(|class_hash| {
+        async move {
             (
                 class_hash,
                 download_class(sequencer, class_hash)
                     .await
                     .with_context(|| format!("Downloading class {}", class_hash.0)),
             )
-        });
+        }
+        .in_current_span()
+    });
 
     let mut stream = futures::stream::iter(futures).buffer_unordered(8);
 


### PR DESCRIPTION
Just like we do checkpoint sync as a first step of a P2P sync this change implements a special "bulk" sync mode for feeder gateway sync.

In bulk mode we do _not_ expect reorgs to happen so the fetch logic is way simpler. We also concurrently fetch and verify data for multiple blocks at once, improving fetching throughput even if latency is high.

Block fetching _and verification_ now happens in individual futures of a buffered stream. The level of buffering determines the level of concurrency we're doing with fetching. To avoid deadlocks all events are emitted in the consumer of the stream.

Initial measurements are very promising: together with the Pedersen hash improvements we can now sync the first 80k blocks of the Sepolia testnet in ~1h 30s.