### PR TITLE
feat(rpc): Add `DeserializeForVersion`

### DIFF
--- a/crates/rpc/src/dto.rs
+++ b/crates/rpc/src/dto.rs
@@ -1,5 +1,7 @@
 #![allow(unused)]
 
+use serde::de::{Error, IntoDeserializer};
+
 mod block;
 mod class;
 mod event;
@@ -21,3 +23,161 @@ pub use receipt::*;
 pub use simulation::*;
 pub use state_update::*;
 pub use transaction::*;
+
+use crate::RpcVersion;
+
+pub trait DeserializeForVersion: Sized {
+    fn deserialize(value: Value) -> Result<Self, serde_json::Error>;
+}
+
+#[derive(Debug)]
+pub struct Value {
+    data: serde_json::Value,
+    version: RpcVersion,
+    /// The name of the field that this value was deserialized from. None if
+    /// this is a root value.
+    name: Option<&'static str>,
+}
+
+impl Value {
+    pub fn deserialize<T: DeserializeForVersion>(self) -> Result<T, serde_json::Error> {
+        T::deserialize(self)
+    }
+
+    // TODO This should be removed once all existing DTOs have been migrated.
+    pub fn deserialize_serde<T: for<'a> serde::Deserialize<'a>>(
+        self,
+    ) -> Result<T, serde_json::Error> {
+        serde::Deserialize::deserialize(self.data.into_deserializer())
+    }
+
+    pub fn deserialize_map<T>(
+        self,
+        cb: impl FnOnce(&mut Map) -> Result<T, serde_json::Error>,
+    ) -> Result<T, serde_json::Error> {
+        let serde_json::Value::Object(map) = self.data else {
+            return Err(serde_json::Error::custom(match self.name {
+                Some(name) => format!("expected object for \"{name}\""),
+                None => "expected object".to_string(),
+            }));
+        };
+        let mut map = Map {
+            data: map,
+            version: self.version,
+        };
+        let result = cb(&mut map)?;
+        if !map.data.is_empty() {
+            let fields = map
+                .data
+                .keys()
+                .map(|key| format!("\"{key}\""))
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(serde_json::Error::custom(format!(
+                "unexpected field{}: {fields}{}",
+                if map.data.len() == 1 { "" } else { "s" },
+                match self.name {
+                    Some(name) => format!(" for \"{name}\""),
+                    None => Default::default(),
+                },
+            )));
+        }
+        Ok(result)
+    }
+
+    pub fn deserialize_array<T>(
+        self,
+        cb: impl Fn(Value) -> Result<T, serde_json::Error>,
+    ) -> Result<Vec<T>, serde_json::Error> {
+        let serde_json::Value::Array(array) = self.data else {
+            return Err(serde_json::Error::custom(match self.name {
+                Some(name) => format!("expected array for \"{name}\""),
+                None => "expected array".to_string(),
+            }));
+        };
+        array
+            .into_iter()
+            .map(|value| {
+                cb(Value {
+                    data: value,
+                    name: None,
+                    version: self.version,
+                })
+            })
+            .collect()
+    }
+}
+
+pub struct Map {
+    data: serde_json::value::Map<String, serde_json::Value>,
+    version: RpcVersion,
+}
+
+impl Map {
+    pub fn deserialize<T: DeserializeForVersion>(
+        &mut self,
+        key: &'static str,
+    ) -> Result<T, serde_json::Error> {
+        let value = self
+            .data
+            .remove(key)
+            .ok_or_else(|| serde_json::Error::custom(format!("missing field: \"{key}\"")))?;
+        Value {
+            data: value,
+            name: Some(key),
+            version: self.version,
+        }
+        .deserialize()
+    }
+
+    // TODO This should be removed once all existing DTOs have been migrated.
+    pub fn deserialize_serde<T: for<'a> serde::Deserialize<'a>>(
+        &mut self,
+        key: &'static str,
+    ) -> Result<T, serde_json::Error> {
+        let value = self
+            .data
+            .remove(key)
+            .ok_or_else(|| serde_json::Error::custom(format!("missing field: \"{key}\"")))?;
+        Value {
+            data: value,
+            name: Some(key),
+            version: self.version,
+        }
+        .deserialize_serde()
+    }
+
+    pub fn deserialize_map<T>(
+        &mut self,
+        key: &'static str,
+        cb: impl Fn(&mut Map) -> Result<T, serde_json::Error>,
+    ) -> Result<T, serde_json::Error> {
+        let value = self
+            .data
+            .remove(key)
+            .ok_or_else(|| serde_json::Error::custom(format!("missing field: \"{key}\"")))?;
+        Value {
+            data: value,
+            name: Some(key),
+            version: self.version,
+        }
+        .deserialize_map(cb)
+    }
+
+    pub fn deserialize_array<T>(
+        &mut self,
+        key: &'static str,
+        cb: impl Fn(Value) -> Result<T, serde_json::Error>,
+    ) -> Result<Vec<T>, serde_json::Error> {
+        let value = self
+            .data
+            .remove(key)
+            .ok_or_else(|| serde_json::Error::custom(format!("missing field: \"{key}\"")))?;
+        Value {
+            data: value,
+            name: Some(key),
+            version: self.version,
+        }
+        .deserialize_array(cb)
+    }
+}

--- a/crates/rpc/src/method/call.rs
+++ b/crates/rpc/src/method/call.rs
@@ -74,6 +74,25 @@ pub struct FunctionCall {
     pub calldata: Vec<CallParam>,
 }
 
+// TODO: Not used yet, just an example for now.
+impl crate::dto::DeserializeForVersion for Input {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_map(|value| {
+            Ok(Self {
+                request: value.deserialize_map("request", |value| {
+                    Ok(FunctionCall {
+                        contract_address: value.deserialize_serde("contract_address")?,
+                        entry_point_selector: value.deserialize_serde("entry_point_selector")?,
+                        calldata: value
+                            .deserialize_array("calldata", crate::dto::Value::deserialize_serde)?,
+                    })
+                })?,
+                block_id: value.deserialize_serde("block_id")?,
+            })
+        })
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct Output(pub Vec<CallResultValue>);
 


### PR DESCRIPTION
Closes https://github.com/eqlabs/pathfinder/issues/1990.

Adds a version-aware deserializer and provides an example usage.