### PR TITLE
fix(rpc): fix continuation token checking for pending events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Pathfinder sometimes returns an INVALID_CONTINUATION_TOKEN error when requesting events from the pending block and providing a continuation token.
+
 ### Added
 
 - Pathfinder JSON-RPC extension methods are now also exposed on the `/rpc/pathfinder/v0_1` endpoint.


### PR DESCRIPTION
We do check the continuation token before appending pending events to the result set. However, the check was too strict: in case of an extract block number match we used the offset from the token and we returned an error in all other cases.

Unfortunately this breaks in the completely valid case where a continuation token was in the request pointing to the non-pending block but the page was not full with results from the database yet so we go on appending events from the pending block.

This change fixes the check: if the block number in the token is _before_ the pending block we simply start from offset 0 instead of returning an error.

Closes: #2191
