### PR TITLE
unordered block fetching in fgw sync

### DIFF
--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -743,7 +743,7 @@ where
                     .await
                     .expect("Panic on rayon thread while verifying block")
                     .context("Verifying block contents")
-                    .map_err(|e| (block_number, e.into()))?;
+                    .map_err(|e| (block_number, e))?;
 
                 let t_declare = std::time::Instant::now();
                 let downloaded_classes = download_new_classes(&state_update, &sequencer, storage)
@@ -751,7 +751,7 @@ where
                     .with_context(|| {
                         format!("Handling newly declared classes for block {block_number:?}")
                     })
-                    .map_err(|e| (block_number, e.into()))?;
+                    .map_err(|e| (block_number, e))?;
                 let t_declare = t_declare.elapsed();
 
                 let timings = Timings {
@@ -3066,50 +3066,77 @@ mod tests {
                 assert_matches!(result, Ok(Some((BLOCK1_NUMBER, BLOCK1_HASH, _))));
             }
 
-            #[tokio::test]
-            async fn no_such_block() {
-                let (tx_event, mut rx_event) = tokio::sync::mpsc::channel(1);
-                let mut mock = MockGatewayApi::new();
+            mod no_such_block {
+                use pretty_assertions_sorted::{assert_eq, assert_eq_sorted};
 
-                // Download the genesis block with respective state update and contracts
-                expect_state_update_with_block_no_sequence(
-                    &mut mock,
-                    BLOCK0_NUMBER,
-                    Ok((BLOCK0.clone(), STATE_UPDATE0.clone())),
-                );
-                expect_class_by_hash_no_sequence(
-                    &mut mock,
-                    CONTRACT0_HASH,
-                    Ok(CONTRACT0_DEF.clone()),
-                );
-                expect_signature_no_sequence(
-                    &mut mock,
-                    BLOCK0_NUMBER.into(),
-                    Ok(BLOCK0_SIGNATURE.clone()),
-                );
-                // Downloading block 1 fails with block not found
-                expect_state_update_with_block_no_sequence(
-                    &mut mock,
-                    BLOCK1_NUMBER,
-                    Err(block_not_found()),
-                );
+                use super::*;
 
-                // Let's run the UUT
-                let jh = spawn_bulk_sync(tx_event, mock);
+                #[tokio::test]
+                async fn first_in_batch() {
+                    let (tx_event, mut rx_event) = tokio::sync::mpsc::channel(1);
+                    let mut mock = MockGatewayApi::new();
 
-                assert_matches!(rx_event.recv().await.unwrap(),
-                    SyncEvent::CairoClass { hash, .. } => {
-                        assert_eq!(hash, CONTRACT0_HASH);
-                });
-                assert_matches!(rx_event.recv().await.unwrap(), SyncEvent::Block((block, _), state_update, signature, _, _) => {
-                    assert_eq!(*block, *BLOCK0);
-                    assert_eq_sorted!(*state_update, *STATE_UPDATE0);
-                    assert_eq!(*signature, BLOCK0_SIGNATURE.signature());
-                });
+                    // Downloading the genesis block fails with block not found
+                    expect_state_update_with_block_no_sequence(
+                        &mut mock,
+                        BLOCK0_NUMBER,
+                        Err(block_not_found()),
+                    );
 
-                // Bulk sync should _not_ fail if the block is not found
-                let result = jh.await.unwrap();
-                assert_matches!(result, Ok(Some((BLOCK0_NUMBER, BLOCK0_HASH, _))));
+                    // Let's run the UUT
+                    let jh = spawn_bulk_sync(tx_event, mock);
+
+                    assert!(rx_event.recv().await.is_none());
+
+                    let result = jh.await.unwrap();
+                    assert_matches!(result, Ok(None));
+                }
+
+                #[tokio::test]
+                async fn further_in_batch() {
+                    let (tx_event, mut rx_event) = tokio::sync::mpsc::channel(1);
+                    let mut mock = MockGatewayApi::new();
+
+                    // Download the genesis block with respective state update and contracts
+                    expect_state_update_with_block_no_sequence(
+                        &mut mock,
+                        BLOCK0_NUMBER,
+                        Ok((BLOCK0.clone(), STATE_UPDATE0.clone())),
+                    );
+                    expect_class_by_hash_no_sequence(
+                        &mut mock,
+                        CONTRACT0_HASH,
+                        Ok(CONTRACT0_DEF.clone()),
+                    );
+                    expect_signature_no_sequence(
+                        &mut mock,
+                        BLOCK0_NUMBER.into(),
+                        Ok(BLOCK0_SIGNATURE.clone()),
+                    );
+                    // Downloading block 1 fails with block not found
+                    expect_state_update_with_block_no_sequence(
+                        &mut mock,
+                        BLOCK1_NUMBER,
+                        Err(block_not_found()),
+                    );
+
+                    // Let's run the UUT
+                    let jh = spawn_bulk_sync(tx_event, mock);
+
+                    assert_matches!(rx_event.recv().await.unwrap(),
+                        SyncEvent::CairoClass { hash, .. } => {
+                            assert_eq!(hash, CONTRACT0_HASH);
+                    });
+                    assert_matches!(rx_event.recv().await.unwrap(), SyncEvent::Block((block, _), state_update, signature, _, _) => {
+                        assert_eq!(*block, *BLOCK0);
+                        assert_eq_sorted!(*state_update, *STATE_UPDATE0);
+                        assert_eq!(*signature, BLOCK0_SIGNATURE.signature());
+                    });
+
+                    // Bulk sync should _not_ fail if the block is not found
+                    let result = jh.await.unwrap();
+                    assert_matches!(result, Ok(Some((BLOCK0_NUMBER, BLOCK0_HASH, _))));
+                }
             }
         }
     }

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -1555,6 +1555,19 @@ mod tests {
                 .return_once(move |_| returned_result);
         }
 
+        fn expect_state_update_with_block_no_sequence_at_most_once(
+            mock: &mut MockGatewayApi,
+            block: BlockNumber,
+            returned_result: Result<(reply::Block, StateUpdate), SequencerError>,
+        ) {
+            use mockall::predicate::eq;
+
+            mock.expect_state_update_with_block()
+                .with(eq(block))
+                .times(..=1)
+                .return_once(move |_| returned_result);
+        }
+
         /// Convenience wrapper
         fn expect_block_header(
             mock: &mut MockGatewayApi,
@@ -1601,6 +1614,19 @@ mod tests {
                 .return_once(|_| returned_result);
         }
 
+        fn expect_signature_no_sequence_at_most_once(
+            mock: &mut MockGatewayApi,
+            block: BlockId,
+            returned_result: Result<reply::BlockSignature, SequencerError>,
+        ) {
+            use mockall::predicate::eq;
+
+            mock.expect_signature()
+                .with(eq(block))
+                .times(..=1)
+                .return_once(|_| returned_result);
+        }
+
         /// Convenience wrapper
         fn expect_class_by_hash(
             mock: &mut MockGatewayApi,
@@ -1624,6 +1650,17 @@ mod tests {
             mock.expect_pending_class_by_hash()
                 .withf(move |x| x == &class_hash)
                 .times(1)
+                .return_once(|_| returned_result);
+        }
+
+        fn expect_class_by_hash_no_sequence_at_most_once(
+            mock: &mut MockGatewayApi,
+            class_hash: ClassHash,
+            returned_result: Result<bytes::Bytes, SequencerError>,
+        ) {
+            mock.expect_pending_class_by_hash()
+                .withf(move |x| x == &class_hash)
+                .times(..=1)
                 .return_once(|_| returned_result);
         }
 
@@ -3047,18 +3084,19 @@ mod tests {
                 let (tx_event, mut rx_event) = tokio::sync::mpsc::channel(1);
                 let mut mock = MockGatewayApi::new();
 
-                // Download the genesis block with respective state update and contracts
-                expect_state_update_with_block_no_sequence(
+                // Downloading the genesis block data is racing against the failure of block 1,
+                // hence "at most once"
+                expect_state_update_with_block_no_sequence_at_most_once(
                     &mut mock,
                     BLOCK0_NUMBER,
                     Ok((BLOCK0.clone(), STATE_UPDATE0.clone())),
                 );
-                expect_class_by_hash_no_sequence(
+                expect_class_by_hash_no_sequence_at_most_once(
                     &mut mock,
                     CONTRACT0_HASH,
                     Ok(CONTRACT0_DEF.clone()),
                 );
-                expect_signature_no_sequence(
+                expect_signature_no_sequence_at_most_once(
                     &mut mock,
                     BLOCK0_NUMBER.into(),
                     Ok(BLOCK0_SIGNATURE.clone()),
@@ -3073,19 +3111,12 @@ mod tests {
                 // Let's run the UUT
                 let jh = spawn_bulk_sync(tx_event, mock);
 
-                assert_matches!(rx_event.recv().await.unwrap(),
-                    SyncEvent::CairoClass { hash, .. } => {
-                        assert_eq!(hash, CONTRACT0_HASH);
-                });
-                assert_matches!(rx_event.recv().await.unwrap(), SyncEvent::Block((block, _), state_update, signature, _, _) => {
-                    assert_eq!(*block, *BLOCK0);
-                    assert_eq_sorted!(*state_update, *STATE_UPDATE0);
-                    assert_eq!(*signature, BLOCK0_SIGNATURE.signature());
-                });
+                // The entire unemitted, yet cached batch is rejected
+                assert!(rx_event.recv().await.is_none());
 
                 // Bulk sync should _not_ fail if the block is not found
                 let result = jh.await.unwrap();
-                assert_matches!(result, Ok(Some((BLOCK0_NUMBER, BLOCK0_HASH, _))));
+                assert_matches!(result, Ok(None));
             }
         }
     }

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -1579,19 +1579,6 @@ mod tests {
                 .return_once(move |_| returned_result);
         }
 
-        fn expect_state_update_with_block_no_sequence_at_most_once(
-            mock: &mut MockGatewayApi,
-            block: BlockNumber,
-            returned_result: Result<(reply::Block, StateUpdate), SequencerError>,
-        ) {
-            use mockall::predicate::eq;
-
-            mock.expect_state_update_with_block()
-                .with(eq(block))
-                .times(..=1)
-                .return_once(move |_| returned_result);
-        }
-
         /// Convenience wrapper
         fn expect_block_header(
             mock: &mut MockGatewayApi,
@@ -1638,19 +1625,6 @@ mod tests {
                 .return_once(|_| returned_result);
         }
 
-        fn expect_signature_no_sequence_at_most_once(
-            mock: &mut MockGatewayApi,
-            block: BlockId,
-            returned_result: Result<reply::BlockSignature, SequencerError>,
-        ) {
-            use mockall::predicate::eq;
-
-            mock.expect_signature()
-                .with(eq(block))
-                .times(..=1)
-                .return_once(|_| returned_result);
-        }
-
         /// Convenience wrapper
         fn expect_class_by_hash(
             mock: &mut MockGatewayApi,
@@ -1674,17 +1648,6 @@ mod tests {
             mock.expect_pending_class_by_hash()
                 .withf(move |x| x == &class_hash)
                 .times(1)
-                .return_once(|_| returned_result);
-        }
-
-        fn expect_class_by_hash_no_sequence_at_most_once(
-            mock: &mut MockGatewayApi,
-            class_hash: ClassHash,
-            returned_result: Result<bytes::Bytes, SequencerError>,
-        ) {
-            mock.expect_pending_class_by_hash()
-                .withf(move |x| x == &class_hash)
-                .times(..=1)
                 .return_once(|_| returned_result);
         }
 
@@ -3108,19 +3071,18 @@ mod tests {
                 let (tx_event, mut rx_event) = tokio::sync::mpsc::channel(1);
                 let mut mock = MockGatewayApi::new();
 
-                // Downloading the genesis block data is racing against the failure of block 1,
-                // hence "at most once"
-                expect_state_update_with_block_no_sequence_at_most_once(
+                // Download the genesis block with respective state update and contracts
+                expect_state_update_with_block_no_sequence(
                     &mut mock,
                     BLOCK0_NUMBER,
                     Ok((BLOCK0.clone(), STATE_UPDATE0.clone())),
                 );
-                expect_class_by_hash_no_sequence_at_most_once(
+                expect_class_by_hash_no_sequence(
                     &mut mock,
                     CONTRACT0_HASH,
                     Ok(CONTRACT0_DEF.clone()),
                 );
-                expect_signature_no_sequence_at_most_once(
+                expect_signature_no_sequence(
                     &mut mock,
                     BLOCK0_NUMBER.into(),
                     Ok(BLOCK0_SIGNATURE.clone()),
@@ -3135,12 +3097,19 @@ mod tests {
                 // Let's run the UUT
                 let jh = spawn_bulk_sync(tx_event, mock);
 
-                // The entire unemitted, yet cached batch is rejected
-                assert!(rx_event.recv().await.is_none());
+                assert_matches!(rx_event.recv().await.unwrap(),
+                    SyncEvent::CairoClass { hash, .. } => {
+                        assert_eq!(hash, CONTRACT0_HASH);
+                });
+                assert_matches!(rx_event.recv().await.unwrap(), SyncEvent::Block((block, _), state_update, signature, _, _) => {
+                    assert_eq!(*block, *BLOCK0);
+                    assert_eq_sorted!(*state_update, *STATE_UPDATE0);
+                    assert_eq!(*signature, BLOCK0_SIGNATURE.signature());
+                });
 
                 // Bulk sync should _not_ fail if the block is not found
                 let result = jh.await.unwrap();
-                assert_matches!(result, Ok(None));
+                assert_matches!(result, Ok(Some((BLOCK0_NUMBER, BLOCK0_HASH, _))));
             }
         }
     }

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -667,11 +667,17 @@ where
 
             async move {
                 let t_block = std::time::Instant::now();
-                let (block, state_update) = sequencer.state_update_with_block(block_number).await?;
+                let (block, state_update) = sequencer
+                    .state_update_with_block(block_number)
+                    .await
+                    .map_err(|e| (block_number, e.into()))?;
                 let t_block = t_block.elapsed();
 
                 let t_signature = std::time::Instant::now();
-                let signature = sequencer.signature(block_number.into()).await?;
+                let signature = sequencer
+                    .signature(block_number.into())
+                    .await
+                    .map_err(|e| (block_number, e.into()))?;
                 let t_signature = t_signature.elapsed();
 
                 let span = tracing::Span::current();
@@ -736,14 +742,16 @@ where
                 ) = rx
                     .await
                     .expect("Panic on rayon thread while verifying block")
-                    .context("Verifying block contents")?;
+                    .context("Verifying block contents")
+                    .map_err(|e| (block_number, e.into()))?;
 
                 let t_declare = std::time::Instant::now();
                 let downloaded_classes = download_new_classes(&state_update, &sequencer, storage)
                     .await
                     .with_context(|| {
                         format!("Handling newly declared classes for block {block_number:?}")
-                    })?;
+                    })
+                    .map_err(|e| (block_number, e.into()))?;
                 let t_declare = t_declare.elapsed();
 
                 let timings = Timings {
@@ -752,7 +760,7 @@ where
                     signature_download: t_signature,
                 };
 
-                Ok::<_, anyhow::Error>((
+                Ok::<_, (BlockNumber, anyhow::Error)>((
                     block,
                     state_update,
                     signature,
@@ -787,17 +795,28 @@ where
             futures::stream::iter(futures_chunk).buffer_unordered(fetch_concurrency.get());
 
         let mut ordered_blocks = BTreeMap::new();
+        let mut failed_block = None;
 
         while let Some(result) = stream.next().await {
-            let Ok(ok) = result else {
-                // We've hit an error, so we stop the loop and return. `head` has been updated
-                // to the last synced block so our "tracking" sync will just
-                // continue from there.
-                tracing::info!(
-                    "Error during bulk syncing blocks, falling back to normal sync: {}",
-                    result.err().unwrap()
-                );
-                return Ok(());
+            let ok = match result {
+                Ok(x) => x,
+                Err((block, error)) => {
+                    // We've hit an error, so we stop the loop and return. `head` has been updated
+                    // to the last synced block so our "tracking" sync will just
+                    // continue from there.
+                    tracing::info!(
+                        %block, %error,
+                        "Error during bulk syncing blocks, falling back to normal sync",
+                    );
+
+                    if block == start {
+                        return Ok(());
+                    } else {
+                        // We can still emit up to the failed block
+                        failed_block = Some(block);
+                        continue;
+                    }
+                }
             };
 
             ordered_blocks.insert(ok.0.block_number.get(), ok);
@@ -866,6 +885,11 @@ where
                     ))
                     .await
                     .context("Event channel closed")?;
+            }
+
+            match failed_block {
+                Some(x) if start == x.get() => return Ok(()),
+                _ => {}
             }
         }
     }


### PR DESCRIPTION
Depends on: #2175 

This PR swaps `buffered` for `buffer_unordered` in the bulk sync logic increasing sync speed a bit more. A coarse test on mainnet in the range `65351..68251` shows a roughly 18% speed up (4625s vs 3810s). The test was done by running the previous ("ordered") and the new ("unordered") impls in parallel with the assumptions that:
- the OS is pretty fair wrt resource allocation,
- the qos of my internet connection should be the same for both processes during the test and this is hard to do otherwise (my internet connection is 4G and the qos can vary over time).

Downloaded blocks are cached in an ordered map which acts as a queue that allows for easy detection of a contiguous range of blocks at its head. This range at the head of the queue is then emitted to the rest of the sync logic.