### PR TITLE
refactor(rpc): refactor `v07` RPC to use `DeserializeForVersion`

### DIFF
--- a/crates/rpc/src/dto.rs
+++ b/crates/rpc/src/dto.rs
@@ -33,13 +33,25 @@ pub trait DeserializeForVersion: Sized {
 #[derive(Debug)]
 pub struct Value {
     data: serde_json::Value,
-    version: RpcVersion,
+    pub version: RpcVersion,
     /// The name of the field that this value was deserialized from. None if
     /// this is a root value.
     name: Option<&'static str>,
 }
 
 impl Value {
+    pub fn new(data: serde_json::Value, version: RpcVersion) -> Self {
+        Self {
+            data,
+            version,
+            name: None,
+        }
+    }
+
+    pub fn is_string(&self) -> bool {
+        self.data.is_string()
+    }
+
     pub fn deserialize<T: DeserializeForVersion>(self) -> Result<T, serde_json::Error> {
         T::deserialize(self)
     }
@@ -55,32 +67,49 @@ impl Value {
         self,
         cb: impl FnOnce(&mut Map) -> Result<T, serde_json::Error>,
     ) -> Result<T, serde_json::Error> {
-        let serde_json::Value::Object(map) = self.data else {
-            return Err(serde_json::Error::custom(match self.name {
-                Some(name) => format!("expected object for \"{name}\""),
-                None => "expected object".to_string(),
-            }));
+        let data = match self.data {
+            serde_json::Value::Object(map) => MapOrArray::Map(map),
+            serde_json::Value::Array(values) => MapOrArray::Array { values, offset: 0 },
+            _ => {
+                return Err(serde_json::Error::custom(match self.name {
+                    Some(name) => format!("expected object or array for \"{name}\""),
+                    None => "expected object or array".to_string(),
+                }))
+            }
         };
         let mut map = Map {
-            data: map,
+            data,
             version: self.version,
         };
         let result = cb(&mut map)?;
-        if !map.data.is_empty() {
-            let fields = map
-                .data
-                .keys()
-                .map(|key| format!("\"{key}\""))
-                .collect::<Vec<_>>()
-                .join(", ");
-            return Err(serde_json::Error::custom(format!(
-                "unexpected field{}: {fields}{}",
-                if map.data.len() == 1 { "" } else { "s" },
-                match self.name {
-                    Some(name) => format!(" for \"{name}\""),
-                    None => Default::default(),
-                },
-            )));
+        match map.data {
+            MapOrArray::Map(map) => {
+                if !map.is_empty() {
+                    let fields = map
+                        .keys()
+                        .map(|key| format!("\"{key}\""))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    return Err(serde_json::Error::custom(format!(
+                        "unexpected field{}: {fields}{}",
+                        if map.len() == 1 { "" } else { "s" },
+                        match self.name {
+                            Some(name) => format!(" for \"{name}\""),
+                            None => Default::default(),
+                        },
+                    )));
+                }
+            }
+            MapOrArray::Array { values, offset } => {
+                if offset < values.len() {
+                    return Err(serde_json::Error::custom(format!(
+                        "expected {} field{}, got {}",
+                        values.len(),
+                        if values.len() == 1 { "" } else { "s" },
+                        offset,
+                    )));
+                }
+            }
         }
         Ok(result)
     }
@@ -109,25 +138,93 @@ impl Value {
 }
 
 pub struct Map {
-    data: serde_json::value::Map<String, serde_json::Value>,
+    data: MapOrArray,
     version: RpcVersion,
 }
 
+enum MapOrArray {
+    Map(serde_json::value::Map<String, serde_json::Value>),
+    Array {
+        values: Vec<serde_json::Value>,
+        offset: usize,
+    },
+}
+
 impl Map {
+    pub fn contains_key(&self, key: &'static str) -> bool {
+        match &self.data {
+            MapOrArray::Map(data) => data.contains_key(key),
+            MapOrArray::Array { values, offset } => false,
+        }
+    }
+
     pub fn deserialize<T: DeserializeForVersion>(
         &mut self,
         key: &'static str,
     ) -> Result<T, serde_json::Error> {
-        let value = self
-            .data
-            .remove(key)
-            .ok_or_else(|| serde_json::Error::custom(format!("missing field: \"{key}\"")))?;
-        Value {
-            data: value,
-            name: Some(key),
-            version: self.version,
+        match &mut self.data {
+            MapOrArray::Map(data) => {
+                let value = data.remove(key).ok_or_else(|| {
+                    serde_json::Error::custom(format!("missing field: \"{key}\""))
+                })?;
+                Value {
+                    data: value,
+                    name: Some(key),
+                    version: self.version,
+                }
+                .deserialize()
+            }
+            MapOrArray::Array { values, offset } => {
+                let value = values
+                    .get_mut(*offset)
+                    .ok_or_else(|| serde_json::Error::custom(format!("missing field: \"{key}\"")))?
+                    .take();
+                *offset += 1;
+                Value {
+                    data: value,
+                    name: Some(key),
+                    version: self.version,
+                }
+                .deserialize()
+            }
         }
-        .deserialize()
+    }
+
+    pub fn deserialize_optional<T: DeserializeForVersion>(
+        &mut self,
+        key: &'static str,
+    ) -> Result<Option<T>, serde_json::Error> {
+        match &mut self.data {
+            MapOrArray::Map(data) => {
+                let value = data.remove(key);
+                match value {
+                    Some(value) => {
+                        let value = Value {
+                            data: value,
+                            name: Some(key),
+                            version: self.version,
+                        };
+                        Ok(Some(value.deserialize()?))
+                    }
+                    None => Ok(None),
+                }
+            }
+            MapOrArray::Array { values, offset } => {
+                let value = values.get_mut(*offset).map(|value| value.take());
+                match value {
+                    Some(value) => {
+                        let value = Value {
+                            data: value,
+                            name: Some(key),
+                            version: self.version,
+                        };
+                        *offset += 1;
+                        Ok(Some(value.deserialize()?))
+                    }
+                    None => Ok(None),
+                }
+            }
+        }
     }
 
     // TODO This should be removed once all existing DTOs have been migrated.
@@ -135,16 +232,70 @@ impl Map {
         &mut self,
         key: &'static str,
     ) -> Result<T, serde_json::Error> {
-        let value = self
-            .data
-            .remove(key)
-            .ok_or_else(|| serde_json::Error::custom(format!("missing field: \"{key}\"")))?;
-        Value {
-            data: value,
-            name: Some(key),
-            version: self.version,
+        match &mut self.data {
+            MapOrArray::Map(data) => {
+                let value = data.remove(key).ok_or_else(|| {
+                    serde_json::Error::custom(format!("missing field: \"{key}\""))
+                })?;
+                Value {
+                    data: value,
+                    name: Some(key),
+                    version: self.version,
+                }
+                .deserialize_serde()
+            }
+            MapOrArray::Array { values, offset } => {
+                let value = values
+                    .get_mut(*offset)
+                    .ok_or_else(|| serde_json::Error::custom(format!("missing field: \"{key}\"")))?
+                    .take();
+                *offset += 1;
+                Value {
+                    data: value,
+                    name: Some(key),
+                    version: self.version,
+                }
+                .deserialize_serde()
+            }
         }
-        .deserialize_serde()
+    }
+
+    // TODO This should be removed once all existing DTOs have been migrated.
+    pub fn deserialize_optional_serde<T: for<'a> serde::Deserialize<'a>>(
+        &mut self,
+        key: &'static str,
+    ) -> Result<Option<T>, serde_json::Error> {
+        match &mut self.data {
+            MapOrArray::Map(data) => {
+                let value = data.remove(key);
+                match value {
+                    Some(value) => {
+                        let value = Value {
+                            data: value,
+                            name: Some(key),
+                            version: self.version,
+                        };
+                        Ok(Some(value.deserialize_serde()?))
+                    }
+                    None => Ok(None),
+                }
+            }
+            MapOrArray::Array { values, offset } => {
+                let value = values.get_mut(*offset).map(|value| value.take());
+                match value {
+                    Some(value) => {
+                        let value = Value {
+                            data: value,
+                            name: Some(key),
+                            version: self.version,
+                        };
+                        *offset += 1;
+                        Ok(Some(value.deserialize_serde()?))
+                    }
+                    None => Ok(None),
+                }
+            }
+        }
     }
 
     pub fn deserialize_map<T>(
@@ -152,16 +303,70 @@ impl Map {
         key: &'static str,
         cb: impl Fn(&mut Map) -> Result<T, serde_json::Error>,
     ) -> Result<T, serde_json::Error> {
-        let value = self
-            .data
-            .remove(key)
-            .ok_or_else(|| serde_json::Error::custom(format!("missing field: \"{key}\"")))?;
-        Value {
-            data: value,
-            name: Some(key),
-            version: self.version,
+        match &mut self.data {
+            MapOrArray::Map(data) => {
+                let value = data.remove(key).ok_or_else(|| {
+                    serde_json::Error::custom(format!("missing field: \"{key}\""))
+                })?;
+                Value {
+                    data: value,
+                    name: Some(key),
+                    version: self.version,
+                }
+                .deserialize_map(cb)
+            }
+            MapOrArray::Array { values, offset } => {
+                let value = values
+                    .get_mut(*offset)
+                    .ok_or_else(|| serde_json::Error::custom(format!("missing field: \"{key}\"")))?
+                    .take();
+                *offset += 1;
+                Value {
+                    data: value,
+                    name: Some(key),
+                    version: self.version,
+                }
+                .deserialize_map(cb)
+            }
         }
-        .deserialize_map(cb)
+    }
+
+    pub fn deserialize_optional_map<T>(
+        &mut self,
+        key: &'static str,
+        cb: impl Fn(&mut Map) -> Result<T, serde_json::Error>,
+    ) -> Result<Option<T>, serde_json::Error> {
+        match &mut self.data {
+            MapOrArray::Map(data) => {
+                let value = data.remove(key);
+                match value {
+                    Some(value) => {
+                        let value = Value {
+                            data: value,
+                            name: Some(key),
+                            version: self.version,
+                        };
+                        Ok(Some(value.deserialize_map(cb)?))
+                    }
+                    None => Ok(None),
+                }
+            }
+            MapOrArray::Array { values, offset } => {
+                let value = values.get_mut(*offset).map(|value| value.take());
+                match value {
+                    Some(value) => {
+                        let value = Value {
+                            data: value,
+                            name: Some(key),
+                            version: self.version,
+                        };
+                        *offset += 1;
+                        Ok(Some(value.deserialize_map(cb)?))
+                    }
+                    None => Ok(None),
+                }
+            }
+        }
     }
 
     pub fn deserialize_array<T>(
@@ -169,15 +374,69 @@ impl Map {
         key: &'static str,
         cb: impl Fn(Value) -> Result<T, serde_json::Error>,
     ) -> Result<Vec<T>, serde_json::Error> {
-        let value = self
-            .data
-            .remove(key)
-            .ok_or_else(|| serde_json::Error::custom(format!("missing field: \"{key}\"")))?;
-        Value {
-            data: value,
-            name: Some(key),
-            version: self.version,
+        match &mut self.data {
+            MapOrArray::Map(data) => {
+                let value = data.remove(key).ok_or_else(|| {
+                    serde_json::Error::custom(format!("missing field: \"{key}\""))
+                })?;
+                Value {
+                    data: value,
+                    name: Some(key),
+                    version: self.version,
+                }
+                .deserialize_array(cb)
+            }
+            MapOrArray::Array { values, offset } => {
+                let value = values
+                    .get_mut(*offset)
+                    .ok_or_else(|| serde_json::Error::custom(format!("missing field: \"{key}\"")))?
+                    .take();
+                *offset += 1;
+                Value {
+                    data: value,
+                    name: Some(key),
+                    version: self.version,
+                }
+                .deserialize_array(cb)
+            }
         }
-        .deserialize_array(cb)
+    }
+
+    pub fn deserialize_optional_array<T>(
+        &mut self,
+        key: &'static str,
+        cb: impl Fn(Value) -> Result<T, serde_json::Error>,
+    ) -> Result<Option<Vec<T>>, serde_json::Error> {
+        match &mut self.data {
+            MapOrArray::Map(data) => {
+                let value = data.remove(key);
+                match value {
+                    Some(value) => {
+                        let value = Value {
+                            data: value,
+                            name: Some(key),
+                            version: self.version,
+                        };
+                        Ok(Some(value.deserialize_array(cb)?))
+                    }
+                    None => Ok(None),
+                }
+            }
+            MapOrArray::Array { values, offset } => {
+                let value = values.get_mut(*offset).map(|value| value.take());
+                match value {
+                    Some(value) => {
+                        let value = Value {
+                            data: value,
+                            name: Some(key),
+                            version: self.version,
+                        };
+                        *offset += 1;
+                        Ok(Some(value.deserialize_array(cb)?))
+                    }
+                    None => Ok(None),
+                }
+            }
+        }
     }
 }

--- a/crates/rpc/src/dto/block.rs
+++ b/crates/rpc/src/dto/block.rs
@@ -1,4 +1,5 @@
 use pathfinder_common::{GasPrice, L1DataAvailabilityMode};
+use serde::de::Error;
 
 use super::serialize::SerializeStruct;
 
@@ -7,6 +8,36 @@ pub struct BlockHeader<'a>(pub &'a pathfinder_common::BlockHeader);
 
 #[derive(Debug)]
 pub struct PendingBlockHeader<'a>(pub &'a starknet_gateway_types::reply::PendingBlock);
+
+impl crate::dto::DeserializeForVersion for pathfinder_common::BlockId {
+    fn deserialize(value: super::Value) -> Result<Self, serde_json::Error> {
+        if value.is_string() {
+            let value: String = value.deserialize_serde()?;
+            match value.as_str() {
+                "latest" => Ok(Self::Latest),
+                "pending" => Ok(Self::Pending),
+                _ => Err(serde_json::Error::custom("Invalid block id")),
+            }
+        } else {
+            value.deserialize_map(|value| {
+                if value.contains_key("block_number") {
+                    Ok(Self::Number(
+                        pathfinder_common::BlockNumber::new(
+                            value.deserialize_serde("block_number")?,
+                        )
+                        .ok_or_else(|| serde_json::Error::custom("Invalid block number"))?,
+                    ))
+                } else if value.contains_key("block_hash") {
+                    Ok(Self::Hash(pathfinder_common::BlockHash(
+                        value.deserialize("block_hash")?,
+                    )))
+                } else {
+                    Err(serde_json::Error::custom("Invalid block id"))
+                }
+            })
+        }
+    }
+}
 
 impl crate::dto::serialize::SerializeForVersion for BlockHeader<'_> {
     fn serialize(
@@ -99,14 +130,8 @@ impl crate::dto::serialize::SerializeForVersion for ResourcePrice {
         serializer: super::serialize::Serializer,
     ) -> Result<super::serialize::Ok, super::serialize::Error> {
         let mut serializer = serializer.serialize_struct()?;
-        serializer.serialize_field(
-            "price_in_wei",
-            &crate::dto::NumAsHex::U128(self.price_in_wei.0),
-        )?;
-        serializer.serialize_field(
-            "price_in_fri",
-            &crate::dto::NumAsHex::U128(self.price_in_fri.0),
-        )?;
+        serializer.serialize_field("price_in_wei", &crate::dto::U128Hex(self.price_in_wei.0))?;
+        serializer.serialize_field("price_in_fri", &crate::dto::U128Hex(self.price_in_fri.0))?;
         serializer.end()
     }
 }

--- a/crates/rpc/src/dto/class.rs
+++ b/crates/rpc/src/dto/class.rs
@@ -1,7 +1,8 @@
 use serde_with::ser::SerializeAsWrap;
 
+use super::U64Hex;
 use crate::dto::serialize::SerializeForVersion;
-use crate::dto::{serialize, Felt, NumAsHex};
+use crate::dto::{serialize, Felt};
 use crate::v02::types;
 
 pub struct DeprecatedContractClass<'a>(pub &'a types::CairoContractClass);
@@ -138,7 +139,7 @@ impl SerializeForVersion for DeprecatedCairoEntryPoint<'_> {
     ) -> Result<serialize::Ok, serialize::Error> {
         let mut serializer = serializer.serialize_struct()?;
 
-        serializer.serialize_field("offset", &NumAsHex::U64(self.0.offset))?;
+        serializer.serialize_field("offset", &self.0.offset)?;
         serializer.serialize_field("selector", &Felt(&self.0.selector))?;
 
         serializer.end()

--- a/crates/rpc/src/dto/fee.rs
+++ b/crates/rpc/src/dto/fee.rs
@@ -1,4 +1,4 @@
-use super::NumAsHex;
+use super::U256Hex;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct FeeEstimate<'a>(pub &'a pathfinder_executor::types::FeeEstimate);
@@ -9,14 +9,11 @@ impl crate::dto::serialize::SerializeForVersion for FeeEstimate<'_> {
         serializer: crate::dto::serialize::Serializer,
     ) -> Result<crate::dto::serialize::Ok, crate::dto::serialize::Error> {
         let mut serializer = serializer.serialize_struct()?;
-        serializer.serialize_field("gas_consumed", &NumAsHex::U256(&self.0.gas_consumed))?;
-        serializer.serialize_field("gas_price", &NumAsHex::U256(&self.0.gas_price))?;
-        serializer.serialize_field(
-            "data_gas_consumed",
-            &NumAsHex::U256(&self.0.data_gas_consumed),
-        )?;
-        serializer.serialize_field("data_gas_price", &NumAsHex::U256(&self.0.data_gas_price))?;
-        serializer.serialize_field("overall_fee", &NumAsHex::U256(&self.0.overall_fee))?;
+        serializer.serialize_field("gas_consumed", &U256Hex(self.0.gas_consumed))?;
+        serializer.serialize_field("gas_price", &U256Hex(self.0.gas_price))?;
+        serializer.serialize_field("data_gas_consumed", &U256Hex(self.0.data_gas_consumed))?;
+        serializer.serialize_field("data_gas_price", &U256Hex(self.0.data_gas_price))?;
+        serializer.serialize_field("overall_fee", &U256Hex(self.0.overall_fee))?;
         serializer.serialize_field("unit", &PriceUnit(&self.0.unit))?;
         serializer.end()
     }

--- a/crates/rpc/src/dto/primitives.rs
+++ b/crates/rpc/src/dto/primitives.rs
@@ -1,6 +1,8 @@
 use pathfinder_common::ContractAddress;
+use serde::de::Error;
 
 use super::serialize::SerializeForVersion;
+use super::{DeserializeForVersion, Value};
 use crate::dto::serialize::{self, Serializer};
 
 pub struct SyncStatus<'a>(pub &'a crate::v02::types::syncing::Status);
@@ -9,17 +11,26 @@ pub struct Felt<'a>(pub &'a pathfinder_crypto::Felt);
 pub struct BlockHash<'a>(pub &'a pathfinder_common::BlockHash);
 pub struct ChainId<'a>(pub &'a pathfinder_common::ChainId);
 pub struct BlockNumber(pub pathfinder_common::BlockNumber);
-pub enum NumAsHex<'a> {
-    U64(u64),
-    U128(u128),
-    H256(&'a primitive_types::H256),
-    U256(&'a primitive_types::U256),
-}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct U64Hex(pub u64);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct U128Hex(pub u128);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct H256Hex(pub primitive_types::H256);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct U256Hex(pub primitive_types::U256);
+
 pub struct Address<'a>(pub &'a ContractAddress);
 pub struct EthAddress<'a>(pub &'a pathfinder_common::EthereumAddress);
 
-mod hex_str {
+pub mod hex_str {
     use std::borrow::Cow;
+
+    use anyhow::anyhow;
 
     const LUT: [u8; 16] = *b"0123456789abcdef";
 
@@ -72,6 +83,83 @@ mod hex_str {
         // SAFETY: we only insert hex digits.
         unsafe { String::from_utf8_unchecked(buf) }
     }
+
+    pub fn bytes_from_hex_str_stripped<const N: usize>(hex_str: &str) -> anyhow::Result<[u8; N]> {
+        from_hex_str(hex_str, true)
+    }
+
+    #[inline]
+    fn from_hex_str<const N: usize>(hex_str: &str, stripped: bool) -> anyhow::Result<[u8; N]> {
+        fn parse_hex_digit(digit: u8) -> anyhow::Result<u8> {
+            match digit {
+                b'0'..=b'9' => Ok(digit - b'0'),
+                b'A'..=b'F' => Ok(digit - b'A' + 10),
+                b'a'..=b'f' => Ok(digit - b'a' + 10),
+                other => Err(anyhow!("invalid hex digit: {}", other)),
+            }
+        }
+
+        let bytes = hex_str.as_bytes();
+        let start = if bytes.len() >= 2 && bytes[0] == b'0' && bytes[1] == b'x' {
+            2
+        } else {
+            0
+        };
+        let len = bytes.len() - start;
+
+        if len > 2 * N {
+            return Err(anyhow!(
+                "hex string too long: expected at most 64 characters, got {}",
+                len
+            ));
+        }
+
+        let mut buf = [0u8; N];
+
+        if stripped {
+            // Handle a possible odd nibble remaining nibble.
+            if len % 2 == 1 {
+                let idx = len / 2;
+                buf[N - 1 - idx] = match parse_hex_digit(bytes[start]) {
+                    Ok(b) => b,
+                    Err(e) => return Err(e),
+                };
+            }
+        } else if len != 2 * N {
+            return Err(anyhow!(
+                "hex string too short: expected 64 characters, got {}",
+                len
+            ));
+        }
+
+        let chunks = len / 2;
+        let mut chunk = 0;
+
+        while chunk < chunks {
+            let lower = match parse_hex_digit(bytes[bytes.len() - chunk * 2 - 1]) {
+                Ok(b) => b,
+                Err(e) => return Err(e),
+            };
+            let upper = match parse_hex_digit(bytes[bytes.len() - chunk * 2 - 2]) {
+                Ok(b) => b,
+                Err(e) => return Err(e),
+            };
+            buf[N - 1 - chunk] = upper << 4 | lower;
+            chunk += 1;
+        }
+
+        Ok(buf)
+    }
+}
+
+impl DeserializeForVersion for U64Hex {
+    fn deserialize(value: Value) -> Result<Self, serde_json::Error> {
+        let hex_str: String = value.deserialize_serde()?;
+        let bytes = hex_str::bytes_from_hex_str_stripped::<8>(&hex_str).map_err(|e| {
+            serde_json::Error::custom(format!("failed to parse hex string as u64: {}", e))
+        })?;
+        Ok(Self(u64::from_be_bytes(bytes)))
+    }
 }
 
 impl SerializeForVersion for SyncStatus<'_> {
@@ -94,6 +182,15 @@ impl SerializeForVersion for Felt<'_> {
     }
 }
 
+impl DeserializeForVersion for pathfinder_crypto::Felt {
+    fn deserialize(value: Value) -> Result<Self, serde_json::Error> {
+        let hex_str: String = value.deserialize_serde()?;
+        let bytes = hex_str::bytes_from_hex_str_stripped::<32>(&hex_str)
+            .map_err(|e| serde_json::Error::custom(format!("failed to parse hex string: {}", e)))?;
+        Self::from_be_bytes(bytes).map_err(|e| serde_json::Error::custom("felt overflow"))
+    }
+}
+
 impl SerializeForVersion for BlockHash<'_> {
     fn serialize(&self, serializer: Serializer) -> Result<serialize::Ok, serialize::Error> {
         serializer.serialize(&Felt(&self.0 .0))
@@ -113,15 +210,39 @@ impl SerializeForVersion for BlockNumber {
     }
 }
 
-impl SerializeForVersion for NumAsHex<'_> {
+impl SerializeForVersion for U64Hex {
     fn serialize(&self, serializer: Serializer) -> Result<serialize::Ok, serialize::Error> {
-        let hex_str = match self {
-            NumAsHex::U64(x) => hex_str::bytes_to_hex_str_stripped(&x.to_be_bytes()),
-            NumAsHex::U128(x) => hex_str::bytes_to_hex_str_stripped(&x.to_be_bytes()),
-            NumAsHex::H256(x) => hex_str::bytes_to_hex_str_stripped(x.as_bytes()),
-            NumAsHex::U256(&x) => hex_str::bytes_to_hex_str_stripped(&<[u8; 32]>::from(x)),
-        };
-        serializer.serialize_str(&hex_str)
+        serializer.serialize_str(&hex_str::bytes_to_hex_str_stripped(&self.0.to_be_bytes()))
+    }
+}
+
+impl SerializeForVersion for U128Hex {
+    fn serialize(&self, serializer: Serializer) -> Result<serialize::Ok, serialize::Error> {
+        serializer.serialize_str(&hex_str::bytes_to_hex_str_stripped(&self.0.to_be_bytes()))
+    }
+}
+
+impl DeserializeForVersion for U128Hex {
+    fn deserialize(value: Value) -> Result<Self, serde_json::Error> {
+        let hex_str: String = value.deserialize_serde()?;
+        let bytes = hex_str::bytes_from_hex_str_stripped::<16>(&hex_str).map_err(|e| {
+            serde_json::Error::custom(format!("failed to parse hex string as u128: {}", e))
+        })?;
+        Ok(Self(u128::from_be_bytes(bytes)))
+    }
+}
+
+impl SerializeForVersion for H256Hex {
+    fn serialize(&self, serializer: Serializer) -> Result<serialize::Ok, serialize::Error> {
+        serializer.serialize_str(&hex_str::bytes_to_hex_str_stripped(self.0.as_bytes()))
+    }
+}
+
+impl SerializeForVersion for U256Hex {
+    fn serialize(&self, serializer: Serializer) -> Result<serialize::Ok, serialize::Error> {
+        serializer.serialize_str(&hex_str::bytes_to_hex_str_stripped(&<[u8; 32]>::from(
+            self.0,
+        )))
     }
 }
 
@@ -224,7 +345,7 @@ mod tests {
         bytes[30] = 0x12;
         bytes[31] = 0x34;
         let uut = primitive_types::H256(bytes);
-        let uut = NumAsHex::H256(&uut);
+        let uut = H256Hex(uut);
         let expected = json!("0x1234");
         let encoded = uut.serialize(Default::default()).unwrap();
 
@@ -233,7 +354,7 @@ mod tests {
 
     #[test]
     fn num_as_hex_u64() {
-        let uut = NumAsHex::U64(0x1234);
+        let uut = U64Hex(0x1234);
         let expected = json!("0x1234");
         let encoded = uut.serialize(Default::default()).unwrap();
 
@@ -254,7 +375,7 @@ mod tests {
         assert_eq!(encoded, expected);
     }
 
-    mod hex_str {
+    mod to_hex {
         use super::super::hex_str::*;
 
         #[test]
@@ -290,6 +411,45 @@ mod tests {
             let data = 0x123456u32.to_be_bytes();
             assert_eq!(&bytes_to_hex_str_full(&data), "0x00123456");
             assert_eq!(&bytes_to_hex_str_stripped(&data), "0x123456");
+        }
+    }
+
+    mod from_hex {
+        use super::super::hex_str::*;
+
+        #[test]
+        fn zero() {
+            let bytes = bytes_from_hex_str_stripped::<2>("0x0").unwrap();
+            assert_eq!(bytes, [0; 2]);
+
+            let bytes = bytes_from_hex_str_stripped::<2>("0x").unwrap();
+            assert_eq!(bytes, [0; 2]);
+        }
+
+        #[test]
+        fn leading_zeros_even() {
+            let bytes = bytes_from_hex_str_stripped::<2>("0x12").unwrap();
+            assert_eq!(bytes, [0, 0x12]);
+            let bytes = bytes_from_hex_str_stripped::<2>("0x0012").unwrap();
+            assert_eq!(bytes, [0, 0x12]);
+        }
+
+        #[test]
+        fn leading_zeros_odd() {
+            let bytes = bytes_from_hex_str_stripped::<2>("0x1").unwrap();
+            assert_eq!(bytes, [0, 0x1]);
+        }
+
+        #[test]
+        fn multibyte_odd() {
+            let bytes = bytes_from_hex_str_stripped::<4>("0x12345").unwrap();
+            assert_eq!(bytes, [0, 0x01, 0x23, 0x45]);
+        }
+
+        #[test]
+        fn multibyte_even() {
+            let bytes = bytes_from_hex_str_stripped::<4>("0x123456").unwrap();
+            assert_eq!(bytes, [0, 0x12, 0x34, 0x56]);
         }
     }
 }

--- a/crates/rpc/src/dto/receipt.rs
+++ b/crates/rpc/src/dto/receipt.rs
@@ -4,7 +4,7 @@ use pathfinder_common::transaction::{Transaction, TransactionKind, TransactionVa
 use pathfinder_common::{BlockHash, BlockNumber, TransactionHash, TransactionVersion};
 use serde::ser::Error;
 
-use super::serialize;
+use super::{serialize, H256Hex};
 use crate::dto::serialize::{SerializeForVersion, Serializer};
 use crate::{dto, RpcVersion};
 
@@ -277,7 +277,7 @@ impl SerializeForVersion for L1HandlerTxnReceipt<'_> {
 
         serializer.flatten(&CommonReceiptProperties(self.0))?;
         serializer.serialize_field("type", &"L1_HANDLER")?;
-        serializer.serialize_field("message_hash", &dto::NumAsHex::H256(&message_hash))?;
+        serializer.serialize_field("message_hash", &H256Hex(message_hash))?;
 
         serializer.end()
     }

--- a/crates/rpc/src/method/get_block_transaction_count.rs
+++ b/crates/rpc/src/method/get_block_transaction_count.rs
@@ -3,10 +3,19 @@ use pathfinder_common::BlockId;
 
 use crate::context::RpcContext;
 
-#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Input {
     block_id: BlockId,
+}
+
+impl crate::dto::DeserializeForVersion for Input {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_map(|value| {
+            Ok(Self {
+                block_id: value.deserialize("block_id")?,
+            })
+        })
+    }
 }
 
 crate::error::generate_rpc_error_subset!(Error: BlockNotFound);

--- a/crates/rpc/src/method/get_block_with_receipts.rs
+++ b/crates/rpc/src/method/get_block_with_receipts.rs
@@ -25,6 +25,16 @@ pub struct Input {
     pub block_id: BlockId,
 }
 
+impl crate::dto::DeserializeForVersion for Input {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_map(|value| {
+            Ok(Self {
+                block_id: value.deserialize_serde("block_id")?,
+            })
+        })
+    }
+}
+
 crate::error::generate_rpc_error_subset!(Error: BlockNotFound);
 
 pub async fn get_block_with_receipts(context: RpcContext, input: Input) -> Result<Output, Error> {

--- a/crates/rpc/src/method/get_block_with_tx_hashes.rs
+++ b/crates/rpc/src/method/get_block_with_tx_hashes.rs
@@ -13,6 +13,16 @@ pub struct Input {
     pub block_id: BlockId,
 }
 
+impl crate::dto::DeserializeForVersion for Input {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_map(|value| {
+            Ok(Self {
+                block_id: value.deserialize("block_id")?,
+            })
+        })
+    }
+}
+
 #[derive(Debug)]
 pub enum Output {
     Pending {

--- a/crates/rpc/src/method/get_block_with_txs.rs
+++ b/crates/rpc/src/method/get_block_with_txs.rs
@@ -14,6 +14,16 @@ pub struct Input {
     pub block_id: BlockId,
 }
 
+impl crate::dto::DeserializeForVersion for Input {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_map(|value| {
+            Ok(Self {
+                block_id: value.deserialize("block_id")?,
+            })
+        })
+    }
+}
+
 #[derive(Debug)]
 pub enum Output {
     Pending {

--- a/crates/rpc/src/method/get_class.rs
+++ b/crates/rpc/src/method/get_class.rs
@@ -8,11 +8,21 @@ use crate::v02::types::{CairoContractClass, ContractClass, SierraContractClass};
 
 crate::error::generate_rpc_error_subset!(Error: BlockNotFound, ClassHashNotFound);
 
-#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Input {
     block_id: BlockId,
     class_hash: ClassHash,
+}
+
+impl crate::dto::DeserializeForVersion for Input {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_map(|value| {
+            Ok(Self {
+                block_id: value.deserialize("block_id")?,
+                class_hash: ClassHash(value.deserialize("class_hash")?),
+            })
+        })
+    }
 }
 
 #[derive(Debug)]
@@ -108,9 +118,11 @@ mod tests {
     use super::*;
 
     mod parsing {
+        use dto::DeserializeForVersion;
         use serde_json::json;
 
         use super::*;
+        use crate::RpcVersion;
 
         #[test]
         fn positional_args() {
@@ -119,7 +131,8 @@ mod tests {
                 "0x12345"
             ]);
 
-            let input = serde_json::from_value::<Input>(positional).unwrap();
+            let input =
+                Input::deserialize(crate::dto::Value::new(positional, RpcVersion::V07)).unwrap();
             let expected = Input {
                 block_id: block_hash!("0xabcde").into(),
                 class_hash: class_hash!("0x12345"),
@@ -134,7 +147,7 @@ mod tests {
                 "class_hash": "0x12345"
             });
 
-            let input = serde_json::from_value::<Input>(named).unwrap();
+            let input = Input::deserialize(crate::dto::Value::new(named, RpcVersion::V07)).unwrap();
             let expected = Input {
                 block_id: block_hash!("0xabcde").into(),
                 class_hash: class_hash!("0x12345"),

--- a/crates/rpc/src/method/get_class_at.rs
+++ b/crates/rpc/src/method/get_class_at.rs
@@ -8,11 +8,21 @@ use crate::v02::types::{CairoContractClass, ContractClass, SierraContractClass};
 
 crate::error::generate_rpc_error_subset!(Error: BlockNotFound, ContractNotFound);
 
-#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Input {
     block_id: BlockId,
     contract_address: ContractAddress,
+}
+
+impl crate::dto::DeserializeForVersion for Input {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_map(|value| {
+            Ok(Self {
+                block_id: value.deserialize("block_id")?,
+                contract_address: ContractAddress(value.deserialize("contract_address")?),
+            })
+        })
+    }
 }
 
 #[derive(Debug)]
@@ -107,9 +117,11 @@ mod tests {
     use super::*;
 
     mod parsing {
+        use dto::DeserializeForVersion;
         use serde_json::json;
 
         use super::*;
+        use crate::RpcVersion;
 
         #[test]
         fn positional_args() {
@@ -118,7 +130,8 @@ mod tests {
                 "0x12345"
             ]);
 
-            let input = serde_json::from_value::<Input>(positional).unwrap();
+            let input =
+                Input::deserialize(crate::dto::Value::new(positional, RpcVersion::V07)).unwrap();
             let expected = Input {
                 block_id: block_hash!("0xabcde").into(),
                 contract_address: contract_address!("0x12345"),
@@ -133,7 +146,7 @@ mod tests {
                 "contract_address": "0x12345"
             });
 
-            let input = serde_json::from_value::<Input>(named).unwrap();
+            let input = Input::deserialize(crate::dto::Value::new(named, RpcVersion::V07)).unwrap();
             let expected = Input {
                 block_id: block_hash!("0xabcde").into(),
                 contract_address: contract_address!("0x12345"),

--- a/crates/rpc/src/method/get_nonce.rs
+++ b/crates/rpc/src/method/get_nonce.rs
@@ -3,11 +3,21 @@ use pathfinder_common::{BlockId, ContractAddress, ContractNonce};
 
 use crate::context::RpcContext;
 
-#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Input {
     block_id: BlockId,
     contract_address: ContractAddress,
+}
+
+impl crate::dto::DeserializeForVersion for Input {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_map(|value| {
+            Ok(Self {
+                block_id: value.deserialize("block_id")?,
+                contract_address: value.deserialize("contract_address").map(ContractAddress)?,
+            })
+        })
+    }
 }
 
 #[derive(Debug)]

--- a/crates/rpc/src/method/get_transaction_by_block_id_and_index.rs
+++ b/crates/rpc/src/method/get_transaction_by_block_id_and_index.rs
@@ -11,6 +11,17 @@ pub struct Input {
     index: TransactionIndex,
 }
 
+impl crate::dto::DeserializeForVersion for Input {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_map(|value| {
+            Ok(Self {
+                block_id: value.deserialize("block_id")?,
+                index: value.deserialize("index")?,
+            })
+        })
+    }
+}
+
 crate::error::generate_rpc_error_subset!(
     GetTransactionByBlockIdAndIndexError: BlockNotFound,
     InvalidTxnIndex

--- a/crates/rpc/src/method/get_transaction_by_hash.rs
+++ b/crates/rpc/src/method/get_transaction_by_hash.rs
@@ -12,6 +12,16 @@ pub struct Input {
     transaction_hash: TransactionHash,
 }
 
+impl crate::dto::DeserializeForVersion for Input {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_map(|value| {
+            Ok(Self {
+                transaction_hash: value.deserialize("transaction_hash").map(TransactionHash)?,
+            })
+        })
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct Output(Transaction);
 

--- a/crates/rpc/src/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/method/get_transaction_receipt.rs
@@ -7,10 +7,18 @@ use pathfinder_common::{BlockHash, BlockNumber, TransactionHash};
 use crate::context::RpcContext;
 use crate::dto::{self, serialize};
 
-#[derive(serde::Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct Input {
     pub transaction_hash: TransactionHash,
+}
+
+impl crate::dto::DeserializeForVersion for Input {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_map(|value| {
+            Ok(Self {
+                transaction_hash: value.deserialize("transaction_hash").map(TransactionHash)?,
+            })
+        })
+    }
 }
 
 pub enum Output {

--- a/crates/rpc/src/method/get_transaction_status.rs
+++ b/crates/rpc/src/method/get_transaction_status.rs
@@ -4,9 +4,19 @@ use pathfinder_common::TransactionHash;
 use crate::context::RpcContext;
 use crate::dto::TxnExecutionStatus;
 
-#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Input {
     transaction_hash: TransactionHash,
+}
+
+impl crate::dto::DeserializeForVersion for Input {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_map(|value| {
+            Ok(Self {
+                transaction_hash: value.deserialize("transaction_hash").map(TransactionHash)?,
+            })
+        })
+    }
 }
 
 #[derive(Debug, PartialEq)]

--- a/crates/rpc/src/pathfinder/methods/get_transaction_status.rs
+++ b/crates/rpc/src/pathfinder/methods/get_transaction_status.rs
@@ -11,6 +11,16 @@ pub struct GetGatewayTransactionInput {
 
 crate::error::generate_rpc_error_subset!(GetGatewayTransactionError:);
 
+impl crate::dto::DeserializeForVersion for GetGatewayTransactionInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_map(|value| {
+            Ok(Self {
+                transaction_hash: TransactionHash(value.deserialize("transaction_hash")?),
+            })
+        })
+    }
+}
+
 pub async fn get_transaction_status(
     context: RpcContext,
     input: GetGatewayTransactionInput,

--- a/crates/rpc/src/v02/method/get_block_transaction_count.rs
+++ b/crates/rpc/src/v02/method/get_block_transaction_count.rs
@@ -9,6 +9,12 @@ pub struct GetBlockTransactionCountInput {
     block_id: BlockId,
 }
 
+impl crate::dto::DeserializeForVersion for GetBlockTransactionCountInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 type BlockTransactionCount = u64;
 
 crate::error::generate_rpc_error_subset!(GetBlockTransactionCountError: BlockNotFound);

--- a/crates/rpc/src/v02/method/get_class.rs
+++ b/crates/rpc/src/v02/method/get_class.rs
@@ -13,6 +13,12 @@ pub struct GetClassInput {
     class_hash: ClassHash,
 }
 
+impl crate::dto::DeserializeForVersion for GetClassInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 pub async fn get_class(
     context: RpcContext,
     input: GetClassInput,

--- a/crates/rpc/src/v02/method/get_class_at.rs
+++ b/crates/rpc/src/v02/method/get_class_at.rs
@@ -13,6 +13,12 @@ pub struct GetClassAtInput {
     contract_address: ContractAddress,
 }
 
+impl crate::dto::DeserializeForVersion for GetClassAtInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 pub async fn get_class_at(
     context: RpcContext,
     input: GetClassAtInput,

--- a/crates/rpc/src/v02/method/get_class_hash_at.rs
+++ b/crates/rpc/src/v02/method/get_class_hash_at.rs
@@ -13,6 +13,12 @@ pub struct GetClassHashAtInput {
     contract_address: ContractAddress,
 }
 
+impl crate::dto::DeserializeForVersion for GetClassHashAtInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 #[serde_with::serde_as]
 #[derive(serde::Serialize, Debug)]
 pub struct GetClassHashOutput(#[serde_as(as = "RpcFelt")] ClassHash);

--- a/crates/rpc/src/v02/method/get_nonce.rs
+++ b/crates/rpc/src/v02/method/get_nonce.rs
@@ -11,6 +11,12 @@ pub struct GetNonceInput {
     contract_address: ContractAddress,
 }
 
+impl crate::dto::DeserializeForVersion for GetNonceInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 #[serde_with::serde_as]
 #[derive(serde::Serialize, Debug, PartialEq)]
 pub struct GetNonceOutput(#[serde_as(as = "RpcFelt")] ContractNonce);

--- a/crates/rpc/src/v02/method/get_storage_at.rs
+++ b/crates/rpc/src/v02/method/get_storage_at.rs
@@ -13,6 +13,12 @@ pub struct GetStorageAtInput {
     pub block_id: BlockId,
 }
 
+impl crate::dto::DeserializeForVersion for GetStorageAtInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 #[serde_with::serde_as]
 #[derive(serde::Serialize, Debug)]
 pub struct GetStorageOutput(#[serde_as(as = "RpcFelt")] StorageValue);

--- a/crates/rpc/src/v02/method/get_transaction_by_block_id_and_index.rs
+++ b/crates/rpc/src/v02/method/get_transaction_by_block_id_and_index.rs
@@ -11,6 +11,12 @@ pub struct GetTransactionByBlockIdAndIndexInput {
     index: TransactionIndex,
 }
 
+impl crate::dto::DeserializeForVersion for GetTransactionByBlockIdAndIndexInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 crate::error::generate_rpc_error_subset!(
     GetTransactionByBlockIdAndIndexError: BlockNotFound,
     InvalidTxnIndex

--- a/crates/rpc/src/v02/method/get_transaction_by_hash.rs
+++ b/crates/rpc/src/v02/method/get_transaction_by_hash.rs
@@ -10,6 +10,12 @@ pub struct GetTransactionByHashInput {
     transaction_hash: TransactionHash,
 }
 
+impl crate::dto::DeserializeForVersion for GetTransactionByHashInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 pub async fn get_transaction_by_hash_impl(
     context: RpcContext,
     input: GetTransactionByHashInput,

--- a/crates/rpc/src/v02/types.rs
+++ b/crates/rpc/src/v02/types.rs
@@ -3,13 +3,27 @@
 pub(crate) mod class;
 pub use class::*;
 use pathfinder_common::{ResourceAmount, ResourcePricePerUnit};
+use serde::de::Error;
 use serde_with::serde_as;
+
+use crate::dto::{U128Hex, U64Hex};
 pub mod syncing;
 
 #[derive(Copy, Clone, Debug, Default, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
 pub struct ResourceBounds {
     pub l1_gas: ResourceBound,
     pub l2_gas: ResourceBound,
+}
+
+impl crate::dto::DeserializeForVersion for ResourceBounds {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_map(|value| {
+            Ok(Self {
+                l1_gas: value.deserialize("l1_gas")?,
+                l2_gas: value.deserialize("l2_gas")?,
+            })
+        })
+    }
 }
 
 impl From<ResourceBounds> for pathfinder_common::transaction::ResourceBounds {
@@ -30,6 +44,19 @@ pub struct ResourceBound {
     pub max_price_per_unit: ResourcePricePerUnit,
 }
 
+impl crate::dto::DeserializeForVersion for ResourceBound {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_map(|value| {
+            Ok(Self {
+                max_amount: ResourceAmount(value.deserialize::<U64Hex>("max_amount")?.0),
+                max_price_per_unit: ResourcePricePerUnit(
+                    value.deserialize::<U128Hex>("max_price_per_unit")?.0,
+                ),
+            })
+        })
+    }
+}
+
 impl From<ResourceBound> for pathfinder_common::transaction::ResourceBound {
     fn from(resource_bound: ResourceBound) -> Self {
         Self {
@@ -44,6 +71,17 @@ pub enum DataAvailabilityMode {
     #[default]
     L1,
     L2,
+}
+
+impl crate::dto::DeserializeForVersion for DataAvailabilityMode {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        let value: String = value.deserialize_serde()?;
+        match value.as_str() {
+            "L1" => Ok(Self::L1),
+            "L2" => Ok(Self::L2),
+            _ => Err(serde_json::Error::custom("invalid data availability mode")),
+        }
+    }
 }
 
 impl From<DataAvailabilityMode> for pathfinder_common::transaction::DataAvailabilityMode {
@@ -82,8 +120,11 @@ pub mod request {
         TransactionSignatureElem,
         TransactionVersion,
     };
+    use serde::de::Error;
     use serde::Deserialize;
     use serde_with::serde_as;
+
+    use crate::dto::U64Hex;
 
     /// "Broadcasted" L2 transaction in requests the RPC API.
     ///
@@ -100,6 +141,26 @@ pub mod request {
         Invoke(BroadcastedInvokeTransaction),
         #[serde(rename = "DEPLOY_ACCOUNT")]
         DeployAccount(BroadcastedDeployAccountTransaction),
+    }
+
+    impl crate::dto::DeserializeForVersion for BroadcastedTransaction {
+        fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+            value.deserialize_map(|value| {
+                let tag: String = value.deserialize_serde("type")?;
+                match tag.as_str() {
+                    "DECLARE" => Ok(Self::Declare(BroadcastedDeclareTransaction::deserialize(
+                        value,
+                    )?)),
+                    "INVOKE" => Ok(Self::Invoke(BroadcastedInvokeTransaction::deserialize(
+                        value,
+                    )?)),
+                    "DEPLOY_ACCOUNT" => Ok(Self::DeployAccount(
+                        BroadcastedDeployAccountTransaction::deserialize(value)?,
+                    )),
+                    _ => Err(serde_json::Error::custom("unknown transaction type")),
+                }
+            })
+        }
     }
 
     impl BroadcastedTransaction {
@@ -152,6 +213,63 @@ pub mod request {
         V1(BroadcastedDeclareTransactionV1),
         V2(BroadcastedDeclareTransactionV2),
         V3(BroadcastedDeclareTransactionV3),
+    }
+
+    impl BroadcastedDeclareTransaction {
+        pub fn deserialize(value: &mut crate::dto::Map) -> Result<Self, serde_json::Error> {
+            let version = value.deserialize("version").map(TransactionVersion)?;
+            let signature = value.deserialize_array("signature", |value| {
+                value.deserialize().map(TransactionSignatureElem)
+            })?;
+            let sender_address = value.deserialize("sender_address").map(ContractAddress)?;
+            match version.without_query_version() {
+                0 => Ok(Self::V0(BroadcastedDeclareTransactionV0 {
+                    max_fee: value.deserialize("max_fee").map(Fee)?,
+                    version,
+                    signature,
+                    contract_class: value.deserialize("contract_class")?,
+                    sender_address,
+                })),
+                1 => Ok(Self::V1(BroadcastedDeclareTransactionV1 {
+                    max_fee: value.deserialize("max_fee").map(Fee)?,
+                    version,
+                    signature,
+                    nonce: value.deserialize("nonce").map(TransactionNonce)?,
+                    contract_class: value.deserialize("contract_class")?,
+                    sender_address,
+                })),
+                2 => Ok(Self::V2(BroadcastedDeclareTransactionV2 {
+                    max_fee: value.deserialize("max_fee").map(Fee)?,
+                    version,
+                    signature,
+                    nonce: value.deserialize("nonce").map(TransactionNonce)?,
+                    compiled_class_hash: value.deserialize("compiled_class_hash").map(CasmHash)?,
+                    contract_class: value.deserialize("contract_class")?,
+                    sender_address,
+                })),
+                3 => Ok(Self::V3(BroadcastedDeclareTransactionV3 {
+                    version,
+                    signature,
+                    nonce: value.deserialize("nonce").map(TransactionNonce)?,
+                    resource_bounds: value.deserialize("resource_bounds")?,
+                    tip: value.deserialize::<U64Hex>("tip").map(|tip| Tip(tip.0))?,
+                    paymaster_data: value.deserialize_array("paymaster_data", |value| {
+                        value.deserialize().map(PaymasterDataElem)
+                    })?,
+                    account_deployment_data: value
+                        .deserialize_array("account_deployment_data", |value| {
+                            value.deserialize().map(AccountDeploymentDataElem)
+                        })?,
+                    nonce_data_availability_mode: value
+                        .deserialize("nonce_data_availability_mode")?,
+                    fee_data_availability_mode: value.deserialize("fee_data_availability_mode")?,
+                    compiled_class_hash: value.deserialize("compiled_class_hash").map(CasmHash)?,
+                    contract_class: value.deserialize("contract_class")?,
+                    sender_address,
+                })),
+                _ => Err(serde_json::Error::custom("unknown transaction version")),
+            }
+        }
     }
 
     impl<'de> serde::Deserialize<'de> for BroadcastedDeclareTransaction {
@@ -266,15 +384,6 @@ pub mod request {
         V3(BroadcastedDeployAccountTransactionV3),
     }
 
-    impl BroadcastedDeployAccountTransaction {
-        pub fn deployed_contract_address(&self) -> ContractAddress {
-            match self {
-                Self::V1(tx) => tx.deployed_contract_address(),
-                Self::V3(tx) => tx.deployed_contract_address(),
-            }
-        }
-    }
-
     impl<'de> serde::Deserialize<'de> for BroadcastedDeployAccountTransaction {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where
@@ -300,6 +409,59 @@ pub mod request {
                         .map_err(de::Error::custom)?,
                 )),
                 v => Err(de::Error::custom(format!("invalid version {v}"))),
+            }
+        }
+    }
+
+    impl BroadcastedDeployAccountTransaction {
+        pub fn deserialize(value: &mut crate::dto::Map) -> Result<Self, serde_json::Error> {
+            let version = value.deserialize("version").map(TransactionVersion)?;
+            let signature = value.deserialize_array("signature", |value| {
+                value.deserialize().map(TransactionSignatureElem)
+            })?;
+            let nonce = value.deserialize("nonce").map(TransactionNonce)?;
+            let contract_address_salt = value
+                .deserialize("contract_address_salt")
+                .map(ContractAddressSalt)?;
+            let constructor_calldata = value
+                .deserialize_array("constructor_calldata", |value| {
+                    value.deserialize().map(CallParam)
+                })?;
+            let class_hash = value.deserialize("class_hash").map(ClassHash)?;
+            match version.without_query_version() {
+                1 => Ok(Self::V1(BroadcastedDeployAccountTransactionV1 {
+                    version,
+                    max_fee: value.deserialize("max_fee").map(Fee)?,
+                    signature,
+                    nonce,
+                    contract_address_salt,
+                    constructor_calldata,
+                    class_hash,
+                })),
+                3 => Ok(Self::V3(BroadcastedDeployAccountTransactionV3 {
+                    version,
+                    signature,
+                    nonce,
+                    resource_bounds: value.deserialize("resource_bounds")?,
+                    tip: value.deserialize::<U64Hex>("tip").map(|tip| Tip(tip.0))?,
+                    paymaster_data: value.deserialize_array("paymaster_data", |value| {
+                        value.deserialize().map(PaymasterDataElem)
+                    })?,
+                    nonce_data_availability_mode: value
+                        .deserialize("nonce_data_availability_mode")?,
+                    fee_data_availability_mode: value.deserialize("fee_data_availability_mode")?,
+                    contract_address_salt,
+                    constructor_calldata,
+                    class_hash,
+                })),
+                _ => Err(serde_json::Error::custom("unknown transaction version")),
+            }
+        }
+
+        pub fn deployed_contract_address(&self) -> ContractAddress {
+            match self {
+                Self::V1(tx) => tx.deployed_contract_address(),
+                Self::V3(tx) => tx.deployed_contract_address(),
             }
         }
     }
@@ -369,22 +531,6 @@ pub mod request {
         V3(BroadcastedInvokeTransactionV3),
     }
 
-    impl BroadcastedInvokeTransaction {
-        pub fn into_v1(self) -> Option<BroadcastedInvokeTransactionV1> {
-            match self {
-                Self::V1(x) => Some(x),
-                _ => None,
-            }
-        }
-
-        pub fn into_v0(self) -> Option<BroadcastedInvokeTransactionV0> {
-            match self {
-                Self::V0(x) => Some(x),
-                _ => None,
-            }
-        }
-    }
-
     impl<'de> Deserialize<'de> for BroadcastedInvokeTransaction {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where
@@ -411,6 +557,71 @@ pub mod request {
                     BroadcastedInvokeTransactionV3::deserialize(&v).map_err(de::Error::custom)?,
                 )),
                 _ => Err(de::Error::custom("version must be 0, 1 or 3")),
+            }
+        }
+    }
+
+    impl BroadcastedInvokeTransaction {
+        pub fn deserialize(value: &mut crate::dto::Map) -> Result<Self, serde_json::Error> {
+            let version = value.deserialize("version").map(TransactionVersion)?;
+            let signature = value.deserialize_array("signature", |value| {
+                value.deserialize().map(TransactionSignatureElem)
+            })?;
+            let calldata =
+                value.deserialize_array("calldata", |value| value.deserialize().map(CallParam))?;
+            match version.without_query_version() {
+                0 => Ok(Self::V0(BroadcastedInvokeTransactionV0 {
+                    version,
+                    max_fee: value.deserialize("max_fee").map(Fee)?,
+                    signature,
+                    contract_address: value.deserialize("contract_address").map(ContractAddress)?,
+                    entry_point_selector: value
+                        .deserialize("entry_point_selector")
+                        .map(EntryPoint)?,
+                    calldata,
+                })),
+                1 => Ok(Self::V1(BroadcastedInvokeTransactionV1 {
+                    version,
+                    max_fee: value.deserialize("max_fee").map(Fee)?,
+                    signature,
+                    nonce: value.deserialize("nonce").map(TransactionNonce)?,
+                    sender_address: value.deserialize("sender_address").map(ContractAddress)?,
+                    calldata,
+                })),
+                3 => Ok(Self::V3(BroadcastedInvokeTransactionV3 {
+                    version,
+                    signature,
+                    nonce: value.deserialize("nonce").map(TransactionNonce)?,
+                    resource_bounds: value.deserialize("resource_bounds")?,
+                    tip: value.deserialize::<U64Hex>("tip").map(|tip| Tip(tip.0))?,
+                    paymaster_data: value.deserialize_array("paymaster_data", |value| {
+                        value.deserialize().map(PaymasterDataElem)
+                    })?,
+                    account_deployment_data: value
+                        .deserialize_array("account_deployment_data", |value| {
+                            value.deserialize().map(AccountDeploymentDataElem)
+                        })?,
+                    nonce_data_availability_mode: value
+                        .deserialize("nonce_data_availability_mode")?,
+                    fee_data_availability_mode: value.deserialize("fee_data_availability_mode")?,
+                    sender_address: value.deserialize("sender_address").map(ContractAddress)?,
+                    calldata,
+                })),
+                _ => Err(serde_json::Error::custom("unknown transaction version")),
+            }
+        }
+
+        pub fn into_v1(self) -> Option<BroadcastedInvokeTransactionV1> {
+            match self {
+                Self::V1(x) => Some(x),
+                _ => None,
+            }
+        }
+
+        pub fn into_v0(self) -> Option<BroadcastedInvokeTransactionV0> {
+            match self {
+                Self::V0(x) => Some(x),
+                _ => None,
             }
         }
     }
@@ -619,6 +830,7 @@ pub mod request {
             use pretty_assertions_sorted::assert_eq;
 
             use super::super::*;
+            use crate::dto::DeserializeForVersion;
             use crate::v02::types::{
                 CairoContractClass,
                 ContractEntryPoints,
@@ -809,11 +1021,16 @@ pub mod request {
                     )),
                 ];
 
-                let json_fixture = fixture!("broadcasted_transactions.json");
+                let json_fixture: serde_json::Value =
+                    serde_json::from_str(&fixture!("broadcasted_transactions.json")).unwrap();
 
-                assert_eq!(serde_json::to_string(&txs).unwrap(), json_fixture);
+                assert_eq!(serde_json::to_value(&txs).unwrap(), json_fixture);
                 assert_eq!(
-                    serde_json::from_str::<Vec<BroadcastedTransaction>>(&json_fixture).unwrap(),
+                    crate::dto::Value::new(dbg!(json_fixture), crate::RpcVersion::V07)
+                        .deserialize_array(
+                            <BroadcastedTransaction as DeserializeForVersion>::deserialize
+                        )
+                        .unwrap(),
                     txs
                 );
             }

--- a/crates/rpc/src/v03/method/get_events.rs
+++ b/crates/rpc/src/v03/method/get_events.rs
@@ -48,6 +48,12 @@ pub struct GetEventsInput {
     filter: EventFilter,
 }
 
+impl crate::dto::DeserializeForVersion for GetEventsInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 /// Contains event filter parameters passed to `starknet_getEvents`.
 #[serde_with::skip_serializing_none]
 #[derive(Default, Clone, Debug, Deserialize, PartialEq, Eq)]

--- a/crates/rpc/src/v03/method/get_state_update.rs
+++ b/crates/rpc/src/v03/method/get_state_update.rs
@@ -9,6 +9,12 @@ pub struct GetStateUpdateInput {
     block_id: BlockId,
 }
 
+impl crate::dto::DeserializeForVersion for GetStateUpdateInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 crate::error::generate_rpc_error_subset!(GetStateUpdateError: BlockNotFound);
 
 pub async fn get_state_update(

--- a/crates/rpc/src/v06/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v06/method/add_declare_transaction.rs
@@ -143,6 +143,12 @@ pub struct AddDeclareTransactionInput {
     token: Option<String>,
 }
 
+impl crate::dto::DeserializeForVersion for AddDeclareTransactionInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 #[serde_with::serde_as]
 #[derive(serde::Serialize, Debug, PartialEq, Eq)]
 pub struct AddDeclareTransactionOutput {

--- a/crates/rpc/src/v06/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/v06/method/add_deploy_account_transaction.rs
@@ -22,6 +22,12 @@ pub struct AddDeployAccountTransactionInput {
     deploy_account_transaction: Transaction,
 }
 
+impl crate::dto::DeserializeForVersion for AddDeployAccountTransactionInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 #[serde_with::serde_as]
 #[derive(serde::Serialize, Debug, PartialEq, Eq)]
 pub struct AddDeployAccountTransactionOutput {

--- a/crates/rpc/src/v06/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/v06/method/add_invoke_transaction.rs
@@ -19,6 +19,12 @@ pub struct AddInvokeTransactionInput {
     invoke_transaction: Transaction,
 }
 
+impl crate::dto::DeserializeForVersion for AddInvokeTransactionInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 #[serde_with::serde_as]
 #[derive(serde::Serialize, Debug, PartialEq, Eq)]
 pub struct AddInvokeTransactionOutput {

--- a/crates/rpc/src/v06/method/call.rs
+++ b/crates/rpc/src/v06/method/call.rs
@@ -67,6 +67,12 @@ pub struct CallInput {
     pub block_id: BlockId,
 }
 
+impl crate::dto::DeserializeForVersion for CallInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 #[derive(Clone, serde::Deserialize, serde::Serialize, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct FunctionCall {
@@ -144,6 +150,8 @@ mod tests {
         use serde_json::json;
 
         use super::*;
+        use crate::dto::DeserializeForVersion;
+        use crate::RpcVersion;
 
         #[test]
         fn positional_args() {
@@ -152,7 +160,8 @@ mod tests {
                 { "block_hash": "0xbbbbbbbb" }
             ]);
 
-            let input = serde_json::from_value::<CallInput>(positional).unwrap();
+            let input = CallInput::deserialize(crate::dto::Value::new(positional, RpcVersion::V07))
+                .unwrap();
             let expected = CallInput {
                 request: FunctionCall {
                     contract_address: contract_address!("0xabcde"),
@@ -171,7 +180,8 @@ mod tests {
                 "block_id": { "block_hash": "0xbbbbbbbb" }
             });
 
-            let input = serde_json::from_value::<CallInput>(named).unwrap();
+            let input =
+                CallInput::deserialize(crate::dto::Value::new(named, RpcVersion::V07)).unwrap();
             let expected = CallInput {
                 request: FunctionCall {
                     contract_address: contract_address!("0xabcde"),

--- a/crates/rpc/src/v06/method/estimate_fee.rs
+++ b/crates/rpc/src/v06/method/estimate_fee.rs
@@ -16,6 +16,12 @@ pub struct EstimateFeeInput {
     pub block_id: BlockId,
 }
 
+impl crate::dto::DeserializeForVersion for EstimateFeeInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 #[derive(Debug, serde::Deserialize, Eq, PartialEq)]
 pub struct SimulationFlags(pub Vec<SimulationFlag>);
 

--- a/crates/rpc/src/v06/method/estimate_message_fee.rs
+++ b/crates/rpc/src/v06/method/estimate_message_fee.rs
@@ -79,6 +79,12 @@ pub struct EstimateMessageFeeInput {
     pub block_id: BlockId,
 }
 
+impl crate::dto::DeserializeForVersion for EstimateMessageFeeInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
 pub struct MsgFromL1 {
     pub from_address: EthereumAddress,

--- a/crates/rpc/src/v06/method/get_block_with_tx_hashes.rs
+++ b/crates/rpc/src/v06/method/get_block_with_tx_hashes.rs
@@ -12,6 +12,12 @@ pub struct GetBlockInput {
     block_id: BlockId,
 }
 
+impl crate::dto::DeserializeForVersion for GetBlockInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 crate::error::generate_rpc_error_subset!(GetBlockError: BlockNotFound);
 
 /// Get block information with transaction hashes given the block id

--- a/crates/rpc/src/v06/method/get_block_with_txs.rs
+++ b/crates/rpc/src/v06/method/get_block_with_txs.rs
@@ -13,6 +13,12 @@ pub struct GetBlockInput {
     block_id: BlockId,
 }
 
+impl crate::dto::DeserializeForVersion for GetBlockInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 crate::error::generate_rpc_error_subset!(GetBlockError: BlockNotFound);
 
 /// Get block information with full transactions given the block id

--- a/crates/rpc/src/v06/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v06/method/get_transaction_receipt.rs
@@ -9,6 +9,12 @@ pub struct GetTransactionReceiptInput {
     pub transaction_hash: TransactionHash,
 }
 
+impl crate::dto::DeserializeForVersion for GetTransactionReceiptInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 crate::error::generate_rpc_error_subset!(GetTransactionReceiptError: TxnHashNotFound);
 
 pub async fn get_transaction_receipt(

--- a/crates/rpc/src/v06/method/get_transaction_status.rs
+++ b/crates/rpc/src/v06/method/get_transaction_status.rs
@@ -9,6 +9,12 @@ pub struct GetTransactionStatusInput {
     transaction_hash: TransactionHash,
 }
 
+impl crate::dto::DeserializeForVersion for GetTransactionStatusInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 #[skip_serializing_none]
 pub enum GetTransactionStatusOutput {

--- a/crates/rpc/src/v06/method/simulate_transactions.rs
+++ b/crates/rpc/src/v06/method/simulate_transactions.rs
@@ -18,6 +18,12 @@ pub struct SimulateTransactionInput {
     pub simulation_flags: dto::SimulationFlags,
 }
 
+impl crate::dto::DeserializeForVersion for SimulateTransactionInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 #[derive(Debug, Serialize, Eq, PartialEq)]
 pub struct SimulateTransactionOutput(pub Vec<dto::SimulatedTransaction>);
 

--- a/crates/rpc/src/v06/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v06/method/trace_block_transactions.rs
@@ -29,6 +29,12 @@ pub struct TraceBlockTransactionsInput {
     pub block_id: BlockId,
 }
 
+impl crate::dto::DeserializeForVersion for TraceBlockTransactionsInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 #[derive(Debug, Serialize, Eq, PartialEq, Clone)]
 pub struct Trace {
     pub transaction_hash: TransactionHash,

--- a/crates/rpc/src/v06/method/trace_transaction.rs
+++ b/crates/rpc/src/v06/method/trace_transaction.rs
@@ -21,6 +21,12 @@ pub struct TraceTransactionInput {
     pub transaction_hash: TransactionHash,
 }
 
+impl crate::dto::DeserializeForVersion for TraceTransactionInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_serde()
+    }
+}
+
 #[derive(Debug, Serialize, Eq, PartialEq)]
 pub struct TraceTransactionOutput(pub TransactionTrace);
 

--- a/crates/serde/src/lib.rs
+++ b/crates/serde/src/lib.rs
@@ -256,6 +256,7 @@ serde_with::serde_conv!(
     |s: &str| bytes_from_hex_str::<8>(s).map(|b| Tip(u64::from_be_bytes(b)))
 );
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct U64AsHexStr(pub u64);
 
 impl serde::Serialize for U64AsHexStr {


### PR DESCRIPTION
Some stuff still falls back to `serde::Deserialize` usually because it's used by `v06` which will be removed. Also I use `serde::Deserialize` for primitive types, this will be very easy to change though.