### PR TITLE
chore: backport some fixes to 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- `--sync.l1-poll-interval` CLI option has been added to set the poll interval for L1 state. Defaults to 30s.
+
 ## [0.14.1] - 2024-07-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Pathfinder sometimes returns an INVALID_CONTINUATION_TOKEN error when requesting events from the pending block and providing a continuation token.
+- `starknet_getEvents` incorrectly returns pending events if `from_block` is greater than latest_block_number + 1.
+- `starknet_getEvents` incorrectly does not return pending events if `from_block` is `pending` and `to_block` is missing.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Pathfinder sometimes returns an INVALID_CONTINUATION_TOKEN error when requesting events from the pending block and providing a continuation token.
+
 ### Added
 
 - `--sync.l1-poll-interval` CLI option has been added to set the poll interval for L1 state. Defaults to 30s.

--- a/crates/gateway-client/Cargo.toml
+++ b/crates/gateway-client/Cargo.toml
@@ -38,6 +38,7 @@ httpmock = { workspace = true }
 lazy_static = { workspace = true }
 pathfinder-crypto = { path = "../crypto" }
 pretty_assertions_sorted = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 test-log = { workspace = true, features = ["trace"] }
 tracing-subscriber = { workspace = true }

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -133,6 +133,14 @@ Examples:
     poll_interval: std::num::NonZeroU64,
 
     #[arg(
+        long = "sync.l1-poll-interval",
+        long_help = "L1 state poll interval in seconds",
+        default_value = "30",
+        env = "PATHFINDER_L1_POLL_INTERVAL_SECONDS"
+    )]
+    l1_poll_interval: std::num::NonZeroU64,
+
+    #[arg(
         long = "color",
         long_help = "This flag controls when to use colors in the output logs.",
         default_value = "auto",
@@ -669,6 +677,7 @@ pub struct Config {
     pub sqlite_wal: JournalMode,
     pub max_rpc_connections: std::num::NonZeroUsize,
     pub poll_interval: std::time::Duration,
+    pub l1_poll_interval: std::time::Duration,
     pub color: Color,
     pub p2p: P2PConfig,
     pub debug: DebugConfig,
@@ -953,6 +962,7 @@ impl Config {
             },
             max_rpc_connections: cli.max_rpc_connections,
             poll_interval: Duration::from_secs(cli.poll_interval.get()),
+            l1_poll_interval: Duration::from_secs(cli.l1_poll_interval.get()),
             color: cli.color,
             p2p: P2PConfig::parse_or_exit(cli.p2p),
             debug: DebugConfig::parse(cli.debug),

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -174,7 +174,12 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
     });
     let execution_storage = storage_manager
         .create_read_only_pool(execution_storage_pool_size)
-        .context(r"")?;
+        .context(
+            r"Creating database connection pool for execution
+
+Hint: This is usually caused by exceeding the file descriptor limit of your system.
+      Try increasing the file limit to using `ulimit` or similar tooling.",
+        )?;
 
     let p2p_storage = storage_manager
         .create_pool(NonZeroU32::new(1).unwrap())

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -534,6 +534,7 @@ fn start_sync(
     gossiper: state::Gossiper,
     gateway_public_key: pathfinder_common::PublicKey,
     _p2p_client: Option<p2p::client::peer_agnostic::Client>,
+    _verify_tree_hashes: bool,
 ) -> tokio::task::JoinHandle<anyhow::Result<()>> {
     start_feeder_gateway_sync(
         storage,

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -569,6 +569,7 @@ fn start_feeder_gateway_sync(
         sequencer: pathfinder_context.gateway,
         state: sync_state.clone(),
         head_poll_interval: config.poll_interval,
+        l1_poll_interval: config.l1_poll_interval,
         pending_data: tx_pending,
         block_validation_mode: state::l2::BlockValidationMode::Strict,
         websocket_txs,

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -76,6 +76,7 @@ pub struct SyncContext<G, E> {
     pub sequencer: G,
     pub state: Arc<SyncState>,
     pub head_poll_interval: Duration,
+    pub l1_poll_interval: Duration,
     pub pending_data: WatchSender<PendingData>,
     pub block_validation_mode: l2::BlockValidationMode,
     pub websocket_txs: Option<TopicBroadcasters>,
@@ -95,7 +96,7 @@ where
             ethereum: value.ethereum.clone(),
             chain: value.chain,
             core_address: value.core_address,
-            poll_interval: value.head_poll_interval,
+            poll_interval: value.l1_poll_interval,
         }
     }
 }
@@ -181,6 +182,7 @@ where
         sequencer,
         state,
         head_poll_interval,
+        l1_poll_interval: _,
         pending_data,
         block_validation_mode: _,
         websocket_txs,

--- a/crates/rpc/src/method/get_events.rs
+++ b/crates/rpc/src/method/get_events.rs
@@ -137,13 +137,13 @@ pub async fn get_events(
 
         // Handle the trivial (1), (2) and (4a) cases.
         match (&request.from_block, &request.to_block) {
-            (Some(Pending), non_pending) if *non_pending != Some(Pending) => {
+            (Some(Pending), id) if !matches!(id, Some(Pending) | None) => {
                 return Ok(types::GetEventsResult {
                     events: Vec::new(),
                     continuation_token: None,
                 });
             }
-            (Some(Pending), Some(Pending)) => {
+            (Some(Pending), Some(Pending) | None) => {
                 let pending = context
                     .pending_data
                     .get(&transaction)

--- a/crates/rpc/src/method/get_events.rs
+++ b/crates/rpc/src/method/get_events.rs
@@ -1081,5 +1081,21 @@ mod tests {
             let result = get_events(context, input).await.unwrap();
             assert!(result.events.is_empty());
         }
+
+        #[tokio::test]
+        async fn from_block_pending_to_block_none() {
+            let context = RpcContext::for_tests_with_pending().await;
+
+            let input = GetEventsInput {
+                filter: EventFilter {
+                    from_block: Some(BlockId::Pending),
+                    to_block: None,
+                    chunk_size: 100,
+                    ..Default::default()
+                },
+            };
+            let result = get_events(context, input).await.unwrap();
+            assert!(!result.events.is_empty());
+        }
     }
 }

--- a/crates/rpc/src/method/get_events.rs
+++ b/crates/rpc/src/method/get_events.rs
@@ -176,16 +176,6 @@ pub async fn get_events(
                     continuation_token: None,
                 });
             }
-
-            let pending = context
-                .pending_data
-                .get(&transaction)
-                .context("Querying pending data")?;
-
-            // `from_block` is the pending block's number
-            if from_block == pending_block_number {
-                return get_pending_events(&request, &pending, continuation_token);
-            }
         }
 
         let (from_block, requested_offset) = match continuation_token {

--- a/crates/rpc/src/method/get_events.rs
+++ b/crates/rpc/src/method/get_events.rs
@@ -87,11 +87,12 @@ pub async fn get_events(
     // The database query for 3 and 4 is combined into one step.
     //
     // 4 requires some additional logic to handle some edge cases:
-    //  a) Query database
-    //  b) if full page -> return page
+    //  a) if from_block_number > pending_block_number -> return empty result
+    //  b) Query database
+    //  c) if full page -> return page
     //      check if there are matching events in the pending block
     //      and return a continuation token for the pending block
-    //  c) else if empty / partially full -> append events from start of pending
+    //  d) else if empty / partially full -> append events from start of pending
     //      if there are more pending events return a continuation token
     //      with the appropriate offset within the pending block
 

--- a/crates/rpc/src/method/get_events.rs
+++ b/crates/rpc/src/method/get_events.rs
@@ -135,7 +135,7 @@ pub async fn get_events(
             .transaction()
             .context("Creating database transaction")?;
 
-        // Handle the trivial (1) and (2) cases.
+        // Handle the trivial (1), (2) and (4a) cases.
         match (&request.from_block, &request.to_block) {
             (Some(Pending), non_pending) if *non_pending != Some(Pending) => {
                 return Ok(types::GetEventsResult {
@@ -150,6 +150,20 @@ pub async fn get_events(
                     .context("Querying pending data")?;
                 return get_pending_events(&request, &pending, continuation_token);
             }
+            (Some(BlockId::Number(from_block)), Some(BlockId::Pending)) => {
+                let pending = context
+                    .pending_data
+                    .get(&transaction)
+                    .context("Querying pending data")?;
+
+                // `from_block` is larger than or equal to pending block's number
+                if from_block >= &pending.number {
+                    return Ok(types::GetEventsResult {
+                        events: Vec::new(),
+                        continuation_token: None,
+                    });
+                }
+            }
             _ => {}
         }
 
@@ -157,27 +171,6 @@ pub async fn get_events(
         let to_block = map_to_block_to_number(&transaction, request.to_block)?;
 
         // Handle cases (3) and (4) where `from_block` is non-pending.
-
-        // early return when to_block is pending and from_block is block_number
-        if let (Some(BlockId::Number(from_block)), Some(BlockId::Pending)) =
-            (request.from_block, request.to_block)
-        {
-            let latest_block_number = &transaction
-                .block_id(pathfinder_storage::BlockId::Latest)
-                .context("Querying latest block number")?
-                .ok_or(GetEventsError::BlockNotFound)?
-                .0;
-
-            let pending_block_number = *latest_block_number + 1;
-
-            // `from_block` is larger than pending block's number
-            if from_block > pending_block_number {
-                return Ok(types::GetEventsResult {
-                    events: Vec::new(),
-                    continuation_token: None,
-                });
-            }
-        }
 
         let (from_block, requested_offset) = match continuation_token {
             Some(token) => token.start_block_and_offset(from_block)?,
@@ -1071,6 +1064,22 @@ mod tests {
                 .unwrap()
                 .events;
             assert_eq!(events, &all[1..2]);
+        }
+
+        #[tokio::test]
+        async fn from_block_past_pending() {
+            let context = RpcContext::for_tests_with_pending().await;
+
+            let input = GetEventsInput {
+                filter: EventFilter {
+                    from_block: Some(BlockId::Number(BlockNumber::new_or_panic(4))),
+                    to_block: Some(BlockId::Pending),
+                    chunk_size: 100,
+                    ..Default::default()
+                },
+            };
+            let result = get_events(context, input).await.unwrap();
+            assert!(result.events.is_empty());
         }
     }
 }


### PR DESCRIPTION
This PR backports bugfixes and some improvements from `main` to 0.14.2:

- increasing the L1 poll interval from 2s to 30s and adding a CLI option for the poll interval
- JSON-RPC `starknet_getEvents` bugfixes
- improved logging if a feeder gateway request times out
