### PR TITLE
chore: bump version number to 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.14.2] - 2024-09-03
 
 ### Fixed
 
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `--sync.l1-poll-interval` CLI option has been added to set the poll interval for L1 state. Defaults to 30s.
+- Support for Starknet 0.13.2.1.
 
 ## [0.14.1] - 2024-07-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3922,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-test-utils"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "http 0.2.12",
  "reqwest",
@@ -6149,7 +6149,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p2p"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -6190,7 +6190,7 @@ dependencies = [
 
 [[package]]
 name = "p2p_proto"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "fake",
@@ -6211,7 +6211,7 @@ dependencies = [
 
 [[package]]
 name = "p2p_proto_derive"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6220,7 +6220,7 @@ dependencies = [
 
 [[package]]
 name = "p2p_stream"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6348,7 +6348,7 @@ checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
 name = "pathfinder"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -6415,7 +6415,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-common"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -6439,7 +6439,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-compiler"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "cairo-lang-starknet 1.0.0-alpha.6",
@@ -6460,7 +6460,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-crypto"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "ark-ff",
  "assert_matches",
@@ -6477,7 +6477,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-ethereum"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6497,7 +6497,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-executor"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "blockifier",
@@ -6518,7 +6518,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-merkle-tree"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -6534,7 +6534,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-retry"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "tokio",
  "tokio-retry",
@@ -6542,7 +6542,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-rpc"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -6593,7 +6593,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-serde"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "num-bigint 0.4.5",
@@ -6608,7 +6608,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-storage"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -8279,7 +8279,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-gateway-client"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -8314,7 +8314,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-gateway-test-fixtures"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "pathfinder-common",
  "pathfinder-crypto",
@@ -8322,7 +8322,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-gateway-types"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -8515,7 +8515,7 @@ dependencies = [
 
 [[package]]
 name = "tagged"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "fake",
  "pretty_assertions_sorted",
@@ -8524,7 +8524,7 @@ dependencies = [
 
 [[package]]
 name = "tagged-debug-derive"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ lto = true
 opt-level = 3
 
 [workspace.package]
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.76"

--- a/crates/load-test/Cargo.lock
+++ b/crates/load-test/Cargo.lock
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-crypto"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "bitvec",
  "fake",

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -539,7 +539,6 @@ fn start_sync(
     gossiper: state::Gossiper,
     gateway_public_key: pathfinder_common::PublicKey,
     _p2p_client: Option<p2p::client::peer_agnostic::Client>,
-    _verify_tree_hashes: bool,
 ) -> tokio::task::JoinHandle<anyhow::Result<()>> {
     start_feeder_gateway_sync(
         storage,


### PR DESCRIPTION
Also reverts a "fix" that we don't need.