### PR TITLE
chore: merge 0.14.2 release into `main`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Pathfinder now fetches data concurrently from the feeder gateway when catching up. The `--gateway.fetch-concurrency` CLI option can be used to limit how many blocks are fetched concurrently (the default is 8).
+
+## [0.14.2] - 2024-09-03
+
 ### Fixed
 
 - Pathfinder sometimes returns an INVALID_CONTINUATION_TOKEN error when requesting events from the pending block and providing a continuation token.
+- `starknet_getEvents` incorrectly returns pending events if `from_block` is greater than latest_block_number + 1.
+- `starknet_getEvents` incorrectly does not return pending events if `from_block` is `pending` and `to_block` is missing.
 
 ### Added
 
-- Pathfinder JSON-RPC extension methods are now also exposed on the `/rpc/pathfinder/v0_1` endpoint.
 - `--sync.l1-poll-interval` CLI option has been added to set the poll interval for L1 state. Defaults to 30s.
-- Pathfinder now fetches data concurrently from the feeder gateway when catching up. The `--gateway.fetch-concurrency` CLI option can be used to limit how many blocks are fetched concurrently (the default is 8).
+- Support for Starknet 0.13.2.1.
 
 ## [0.14.1] - 2024-07-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,9 +929,9 @@ dependencies = [
 
 [[package]]
 name = "blockifier"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb87d3c5d71fe593c120cd73036d3982986596942e3c1a5dc81e2661f397cf4"
+checksum = "0fb99b6d20e12f5dff17a2b53e3e6cab54766357a638f90dafcb43c0ac933d4b"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -939,10 +939,10 @@ dependencies = [
  "ark-secp256k1",
  "ark-secp256r1",
  "cached",
- "cairo-lang-casm 2.7.0-rc.3",
+ "cairo-lang-casm 2.7.1",
  "cairo-lang-runner",
  "cairo-lang-starknet-classes",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-utils 2.7.1",
  "cairo-vm",
  "derive_more",
  "indexmap 2.2.6",
@@ -954,6 +954,7 @@ dependencies = [
  "num-rational",
  "num-traits 0.2.19",
  "once_cell",
+ "paste",
  "phf",
  "serde",
  "serde_json",
@@ -961,8 +962,8 @@ dependencies = [
  "sha3",
  "starknet-types-core",
  "starknet_api",
- "strum",
- "strum_macros",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
  "thiserror",
 ]
 
@@ -1161,11 +1162,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5abf875e93f696e783412d3f2a7c6f66e94e07c30b01559380b4d0707dc0050e"
+checksum = "e4425280959f189d8a5ebf1f5363c10663bc9f843a4819253e6be87d183b583e"
 dependencies = [
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-utils 2.7.1",
  "indoc 2.0.5",
  "num-bigint 0.4.6",
  "num-traits 0.2.19",
@@ -1250,24 +1251,25 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f135e1768e199e88b04f824e34b9411ff49fc31970e77cbf5c6f448170441d18"
+checksum = "2698e2ca73db964e6d496a648fcbb2ace5559941b5179ab3310c9a0b6872b348"
 dependencies = [
  "anyhow",
- "cairo-lang-defs 2.7.0-rc.3",
- "cairo-lang-diagnostics 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-lowering 2.7.0-rc.3",
- "cairo-lang-parser 2.7.0-rc.3",
- "cairo-lang-project 2.7.0-rc.3",
- "cairo-lang-semantic 2.7.0-rc.3",
- "cairo-lang-sierra 2.7.0-rc.3",
- "cairo-lang-sierra-generator 2.7.0-rc.3",
- "cairo-lang-syntax 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-defs 2.7.1",
+ "cairo-lang-diagnostics 2.7.1",
+ "cairo-lang-filesystem 2.7.1",
+ "cairo-lang-lowering 2.7.1",
+ "cairo-lang-parser 2.7.1",
+ "cairo-lang-project 2.7.1",
+ "cairo-lang-semantic 2.7.1",
+ "cairo-lang-sierra 2.7.1",
+ "cairo-lang-sierra-generator 2.7.1",
+ "cairo-lang-syntax 2.7.1",
+ "cairo-lang-utils 2.7.1",
  "indoc 2.0.5",
  "salsa",
+ "semver",
  "smol_str 0.2.2",
  "thiserror",
 ]
@@ -1290,11 +1292,11 @@ checksum = "c99d41a14f98521c617c0673a0faa41fd00029d32106a4643e1291a1813340a7"
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e2bf0a6caf1e54938bc67ca082cbeb5385969784bfb1109c187ca9dc5e1806"
+checksum = "6ac7332f2b041ca28b24b0311a0b4a35f426bb52836a2d268a8374ea262e9e6b"
 dependencies = [
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-utils 2.7.1",
 ]
 
 [[package]]
@@ -1351,16 +1353,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65bb0e855afeb88d11585605f836bd0cd444375b234103e87342df2c91aba1b"
+checksum = "079a34b560a82b463cd12ae62022d70981e8ab56b6505f9499348ebeaf460de8"
 dependencies = [
- "cairo-lang-debug 2.7.0-rc.3",
- "cairo-lang-diagnostics 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-parser 2.7.0-rc.3",
- "cairo-lang-syntax 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-debug 2.7.1",
+ "cairo-lang-diagnostics 2.7.1",
+ "cairo-lang-filesystem 2.7.1",
+ "cairo-lang-parser 2.7.1",
+ "cairo-lang-syntax 2.7.1",
+ "cairo-lang-utils 2.7.1",
  "itertools 0.12.1",
  "salsa",
  "smol_str 0.2.2",
@@ -1402,13 +1404,13 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab96083f60a077d300d0b89bd4b9c31731c95f5db355a11c4657ee25f3acc198"
+checksum = "c29625349297ad791942377763f5b04c779ea694f436488dc6ad194720b89487"
 dependencies = [
- "cairo-lang-debug 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-debug 2.7.1",
+ "cairo-lang-filesystem 2.7.1",
+ "cairo-lang-utils 2.7.1",
  "itertools 0.12.1",
 ]
 
@@ -1448,11 +1450,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf2aaa50fa5b15070b2bf02c60a62f917f9aa1ff6dedf5a2627ecafe8e33cfa"
+checksum = "9cb26cd75126db6eaf94d5dffe0ce750d030ac879a88de5a621551969e9b59e3"
 dependencies = [
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-utils 2.7.1",
  "good_lp",
 ]
 
@@ -1497,30 +1499,31 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8094bcf7e44204c2fc2f10760e7e2e5769a6267cba5d8a303c0331dd480d5663"
+checksum = "651012f2956bea884c7a3ab9df21dc76112d7edd3f403b37ca5be62fc3f41b09"
 dependencies = [
- "cairo-lang-debug 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-debug 2.7.1",
+ "cairo-lang-utils 2.7.1",
  "path-clean 1.0.1",
  "salsa",
+ "semver",
  "serde",
  "smol_str 0.2.2",
 ]
 
 [[package]]
 name = "cairo-lang-formatter"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a1d92f1163b3b0e22e6392d22f7a275b9e64ab453f32b8b62bb1aeedbe73e04"
+checksum = "0d09ffb9498368cf4e95d0b28662596331aef1677e4f759ab5e609d27dfcb587"
 dependencies = [
  "anyhow",
- "cairo-lang-diagnostics 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-parser 2.7.0-rc.3",
- "cairo-lang-syntax 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-diagnostics 2.7.1",
+ "cairo-lang-filesystem 2.7.1",
+ "cairo-lang-parser 2.7.1",
+ "cairo-lang-syntax 2.7.1",
+ "cairo-lang-utils 2.7.1",
  "diffy",
  "ignore",
  "itertools 0.12.1",
@@ -1605,19 +1608,19 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25eb629a773c07c2863717d1711fd3ecc17807c1fc094bb90cccac56061056a4"
+checksum = "da4ffe6c197c35dec665029fcf695422f02c55b5118b4da1142e182b9fe77f87"
 dependencies = [
- "cairo-lang-debug 2.7.0-rc.3",
- "cairo-lang-defs 2.7.0-rc.3",
- "cairo-lang-diagnostics 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-parser 2.7.0-rc.3",
- "cairo-lang-proc-macros 2.7.0-rc.3",
- "cairo-lang-semantic 2.7.0-rc.3",
- "cairo-lang-syntax 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-debug 2.7.1",
+ "cairo-lang-defs 2.7.1",
+ "cairo-lang-diagnostics 2.7.1",
+ "cairo-lang-filesystem 2.7.1",
+ "cairo-lang-parser 2.7.1",
+ "cairo-lang-proc-macros 2.7.1",
+ "cairo-lang-semantic 2.7.1",
+ "cairo-lang-syntax 2.7.1",
+ "cairo-lang-utils 2.7.1",
  "id-arena",
  "itertools 0.12.1",
  "log",
@@ -1688,15 +1691,15 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7b1d7af8e1bff971b8b9bbce796650a57de93dfb092bc0c17c2f85d915de6e"
+checksum = "f262ad5f1110ff70c93deb81cce024cf160f4a4518762e7deb2047fe73846789"
 dependencies = [
- "cairo-lang-diagnostics 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-syntax 2.7.0-rc.3",
- "cairo-lang-syntax-codegen 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-diagnostics 2.7.1",
+ "cairo-lang-filesystem 2.7.1",
+ "cairo-lang-syntax 2.7.1",
+ "cairo-lang-syntax-codegen 2.7.1",
+ "cairo-lang-utils 2.7.1",
  "colored",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
@@ -1764,16 +1767,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eccf06d643d155a72057dc93c40cf34dabe11e8c629dbf3111c528a3d750a66"
+checksum = "18024b44b5edbc1f378ba85c1a4ff04e880ea465a33251053aec507f08250668"
 dependencies = [
- "cairo-lang-defs 2.7.0-rc.3",
- "cairo-lang-diagnostics 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-parser 2.7.0-rc.3",
- "cairo-lang-syntax 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-defs 2.7.1",
+ "cairo-lang-diagnostics 2.7.1",
+ "cairo-lang-filesystem 2.7.1",
+ "cairo-lang-parser 2.7.1",
+ "cairo-lang-syntax 2.7.1",
+ "cairo-lang-utils 2.7.1",
  "indent",
  "indoc 2.0.5",
  "itertools 0.12.1",
@@ -1814,11 +1817,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa10434f9ce0828e8d77f3a13ae2f878da453345b14d54a66de3e196c0e4674"
+checksum = "124402d8fad2a033bb36910dd7d0651f3100845c63dce679c58797a8cb0448c2"
 dependencies = [
- "cairo-lang-debug 2.7.0-rc.3",
+ "cairo-lang-debug 2.7.1",
  "quote",
  "syn 2.0.72",
 ]
@@ -1862,12 +1865,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4882d2263fb7c95dbab0c3b5578d8c0e2417fd680df8cc61aa50321b6a5a40d"
+checksum = "1f37dba9653eabf4dcb43a5e1436cd6bc093b5ad6f28ff42eaaef12549014213"
 dependencies = [
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-filesystem 2.7.1",
+ "cairo-lang-utils 2.7.1",
  "serde",
  "smol_str 0.2.2",
  "thiserror",
@@ -1876,22 +1879,22 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runner"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ab7b0e0640adaed21b9d9b9b94b3edf7f7ab95514b1dd40c679317a33dabea"
+checksum = "ef5bbbabd509ce88abc67436973d3377e099269dbd14578fa84fce884a74fa23"
 dependencies = [
  "ark-ff",
  "ark-secp256k1",
  "ark-secp256r1",
- "cairo-lang-casm 2.7.0-rc.3",
- "cairo-lang-lowering 2.7.0-rc.3",
- "cairo-lang-sierra 2.7.0-rc.3",
- "cairo-lang-sierra-ap-change 2.7.0-rc.3",
- "cairo-lang-sierra-generator 2.7.0-rc.3",
- "cairo-lang-sierra-to-casm 2.7.0-rc.3",
+ "cairo-lang-casm 2.7.1",
+ "cairo-lang-lowering 2.7.1",
+ "cairo-lang-sierra 2.7.1",
+ "cairo-lang-sierra-ap-change 2.7.1",
+ "cairo-lang-sierra-generator 2.7.1",
+ "cairo-lang-sierra-to-casm 2.7.1",
  "cairo-lang-sierra-type-size",
- "cairo-lang-starknet 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-starknet 2.7.0",
+ "cairo-lang-utils 2.7.1",
  "cairo-vm",
  "itertools 0.12.1",
  "keccak",
@@ -1976,20 +1979,20 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba49614f98322e1ccda33265f8193f66cbd88eff23b0deb94db981aa0666650"
+checksum = "a1612476b548e9ab8ae89ee38a73d9875339f62f2f59d9ce8a719bc1761c54c3"
 dependencies = [
- "cairo-lang-debug 2.7.0-rc.3",
- "cairo-lang-defs 2.7.0-rc.3",
- "cairo-lang-diagnostics 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-parser 2.7.0-rc.3",
- "cairo-lang-plugins 2.7.0-rc.3",
- "cairo-lang-proc-macros 2.7.0-rc.3",
- "cairo-lang-syntax 2.7.0-rc.3",
+ "cairo-lang-debug 2.7.1",
+ "cairo-lang-defs 2.7.1",
+ "cairo-lang-diagnostics 2.7.1",
+ "cairo-lang-filesystem 2.7.1",
+ "cairo-lang-parser 2.7.1",
+ "cairo-lang-plugins 2.7.1",
+ "cairo-lang-proc-macros 2.7.1",
+ "cairo-lang-syntax 2.7.1",
  "cairo-lang-test-utils",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-utils 2.7.1",
  "id-arena",
  "indoc 2.0.5",
  "itertools 0.12.1",
@@ -2070,12 +2073,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a41d56c6afebdbe2c5ffb4e216f60b07391c29c91fccf0a60790817f49ba68"
+checksum = "8209be8cf22263bf8a55df334a642b74fe563beecbbbefa55cda39fa4b131a61"
 dependencies = [
  "anyhow",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-utils 2.7.1",
  "const-fnv1a-hash",
  "convert_case 0.6.0",
  "derivative",
@@ -2135,14 +2138,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667050b93db661ebce0b33c92ce44abffebde37c5645e4761722ad3c49a1c34f"
+checksum = "1c9d1350366c23e4a9f6e18ea95939f18df52df455f06c0e3d7889f80ce18a94"
 dependencies = [
- "cairo-lang-eq-solver 2.7.0-rc.3",
- "cairo-lang-sierra 2.7.0-rc.3",
+ "cairo-lang-eq-solver 2.7.1",
+ "cairo-lang-sierra 2.7.1",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-utils 2.7.1",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
  "num-traits 0.2.19",
@@ -2188,14 +2191,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27fcbf81e8ed4efe7e9c30bbdfa8074b9af01a5e16154999dd9527baba27f1fb"
+checksum = "9fe1ff15052b173537360b7dca5f9b2ccb10392b2a1c11af99add35d42632115"
 dependencies = [
- "cairo-lang-eq-solver 2.7.0-rc.3",
- "cairo-lang-sierra 2.7.0-rc.3",
+ "cairo-lang-eq-solver 2.7.1",
+ "cairo-lang-sierra 2.7.1",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-utils 2.7.1",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
  "num-traits 0.2.19",
@@ -2280,20 +2283,20 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058c05d10913a130fb21964f0bf1a37b05eafcf2f50a73cd4aa3e11da7e4cfc7"
+checksum = "2d3802e7b6722fabc9cc0a61c86e7ad53138f6f41880aca80a60f889739fbf55"
 dependencies = [
- "cairo-lang-debug 2.7.0-rc.3",
- "cairo-lang-defs 2.7.0-rc.3",
- "cairo-lang-diagnostics 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-lowering 2.7.0-rc.3",
- "cairo-lang-parser 2.7.0-rc.3",
- "cairo-lang-semantic 2.7.0-rc.3",
- "cairo-lang-sierra 2.7.0-rc.3",
- "cairo-lang-syntax 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-debug 2.7.1",
+ "cairo-lang-defs 2.7.1",
+ "cairo-lang-diagnostics 2.7.1",
+ "cairo-lang-filesystem 2.7.1",
+ "cairo-lang-lowering 2.7.1",
+ "cairo-lang-parser 2.7.1",
+ "cairo-lang-semantic 2.7.1",
+ "cairo-lang-sierra 2.7.1",
+ "cairo-lang-syntax 2.7.1",
+ "cairo-lang-utils 2.7.1",
  "itertools 0.12.1",
  "num-traits 0.2.19",
  "once_cell",
@@ -2372,17 +2375,17 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8607cc5cf16f3a930ad4b3799e986b0ca36ada2c0da1dd6bd2ef35cbb1eb9e74"
+checksum = "355bde3b0a835bac2457af133a9042a7d039c934e678905b843bb6b420884428"
 dependencies = [
  "assert_matches",
- "cairo-lang-casm 2.7.0-rc.3",
- "cairo-lang-sierra 2.7.0-rc.3",
- "cairo-lang-sierra-ap-change 2.7.0-rc.3",
- "cairo-lang-sierra-gas 2.7.0-rc.3",
+ "cairo-lang-casm 2.7.1",
+ "cairo-lang-sierra 2.7.1",
+ "cairo-lang-sierra-ap-change 2.7.1",
+ "cairo-lang-sierra-gas 2.7.1",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-utils 2.7.1",
  "indoc 2.0.5",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
@@ -2393,12 +2396,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224624b1e279b3eea7693680f577335e66e6dd5fbfbd2576f4a7d0b5d697f61d"
+checksum = "7ddddaacc814e0ffda9f176c913fb2a9cd74fe6594dea789e8281eef10cac201"
 dependencies = [
- "cairo-lang-sierra 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-sierra 2.7.1",
+ "cairo-lang-utils 2.7.1",
 ]
 
 [[package]]
@@ -2523,23 +2526,23 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a54ebea4ea990a33a2158ecdf46ffb3cb1af8fff6a79c3dd310c6a9ed43e82"
+checksum = "f242d889180386d35935597f9d1cac07d4f3d60bd0f10558660ae4a77da701b6"
 dependencies = [
  "anyhow",
- "cairo-lang-compiler 2.7.0-rc.3",
- "cairo-lang-defs 2.7.0-rc.3",
- "cairo-lang-diagnostics 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-lowering 2.7.0-rc.3",
- "cairo-lang-plugins 2.7.0-rc.3",
- "cairo-lang-semantic 2.7.0-rc.3",
- "cairo-lang-sierra 2.7.0-rc.3",
- "cairo-lang-sierra-generator 2.7.0-rc.3",
+ "cairo-lang-compiler 2.7.1",
+ "cairo-lang-defs 2.7.1",
+ "cairo-lang-diagnostics 2.7.1",
+ "cairo-lang-filesystem 2.7.1",
+ "cairo-lang-lowering 2.7.1",
+ "cairo-lang-plugins 2.7.1",
+ "cairo-lang-semantic 2.7.1",
+ "cairo-lang-sierra 2.7.1",
+ "cairo-lang-sierra-generator 2.7.1",
  "cairo-lang-starknet-classes",
- "cairo-lang-syntax 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-syntax 2.7.1",
+ "cairo-lang-utils 2.7.1",
  "const_format",
  "indent",
  "indoc 2.0.5",
@@ -2554,14 +2557,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet-classes"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb66ae799e1963318e1bab782848f53797787c396dfd590be539f3f12d56ac4"
+checksum = "aa17b313f46fcf7ff4de32b86c250eaf584d1e2c8e37ed16db155b221721e735"
 dependencies = [
- "cairo-lang-casm 2.7.0-rc.3",
- "cairo-lang-sierra 2.7.0-rc.3",
- "cairo-lang-sierra-to-casm 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-casm 2.7.1",
+ "cairo-lang-sierra 2.7.1",
+ "cairo-lang-sierra-to-casm 2.7.1",
+ "cairo-lang-utils 2.7.1",
  "convert_case 0.6.0",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
@@ -2623,13 +2626,13 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e673dc1058a8639c094a330a701e8902cbd34defe659a3d95bcf6c3f3de249d"
+checksum = "b2a376f88d815b63505be54a6afa93d75b67cfd65835922ec648cfcbb0a5e4b4"
 dependencies = [
- "cairo-lang-debug 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-debug 2.7.1",
+ "cairo-lang-filesystem 2.7.1",
+ "cairo-lang-utils 2.7.1",
  "num-bigint 0.4.6",
  "num-traits 0.2.19",
  "salsa",
@@ -2673,9 +2676,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0dd466dbac4263573b81b83e22534285da30a4e7c15b888407fbb33d8accb9"
+checksum = "01f276bc28f6302fc63032046a12b60d18498906e65f646acb963244eed97f7c"
 dependencies = [
  "genco",
  "xshell",
@@ -2683,12 +2686,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-utils"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09431da22acc1cf081b1802b73ff484bdc75ca1cd5ad6fa9b84fba8753b2e08f"
+checksum = "21e90b6236439e19077ec913351a17a33c7be199dcafdacd8389c4c5199400d6"
 dependencies = [
  "cairo-lang-formatter",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-utils 2.7.1",
  "colored",
  "log",
  "pretty_assertions",
@@ -2745,9 +2748,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97498c08958be8d569c16982cac431d785adc3effdfa6d0775c65aec578dfd91"
+checksum = "55a394e545f1500bea093d01be40895d3234faaa24d9585d08a509c514cabd88"
 dependencies = [
  "hashbrown 0.14.5",
  "indexmap 2.2.6",
@@ -2761,9 +2764,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm"
-version = "1.0.0-rc5"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e09134ea1e0be6c1fbd330f0945df0512fa70944fd0b3ecc2f74a6008f01e9da"
+checksum = "58363ad8065ed891e3b14a8191b707677c7c7cb5b9d10030822506786d8d8108"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3955,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-test-utils"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "reqwest",
  "serde_json",
@@ -6277,7 +6280,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p2p"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6318,7 +6321,7 @@ dependencies = [
 
 [[package]]
 name = "p2p_proto"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "fake",
@@ -6339,7 +6342,7 @@ dependencies = [
 
 [[package]]
 name = "p2p_proto_derive"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6348,7 +6351,7 @@ dependencies = [
 
 [[package]]
 name = "p2p_stream"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6476,7 +6479,7 @@ checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
 name = "pathfinder"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -6541,7 +6544,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-common"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -6565,13 +6568,13 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-compiler"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "cairo-lang-starknet 1.0.0-alpha.6",
  "cairo-lang-starknet 1.0.0-rc0",
  "cairo-lang-starknet 1.1.1",
- "cairo-lang-starknet 2.7.0-rc.3",
+ "cairo-lang-starknet 2.7.0",
  "cairo-lang-starknet-classes",
  "num-bigint 0.4.6",
  "pathfinder-common",
@@ -6586,7 +6589,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-crypto"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "ark-ff",
  "assert_matches",
@@ -6603,7 +6606,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-ethereum"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6623,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-executor"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "blockifier",
@@ -6643,7 +6646,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-merkle-tree"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -6659,7 +6662,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-retry"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "tokio",
  "tokio-retry",
@@ -6667,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-rpc"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -6718,7 +6721,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-serde"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "num-bigint 0.4.6",
@@ -6733,7 +6736,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-storage"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -8002,6 +8005,9 @@ name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -8406,7 +8412,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-gateway-client"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -8439,7 +8445,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-gateway-test-fixtures"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "pathfinder-common",
  "pathfinder-crypto",
@@ -8447,7 +8453,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-gateway-types"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -8485,9 +8491,9 @@ dependencies = [
 
 [[package]]
 name = "starknet_api"
-version = "0.13.0-rc.0"
+version = "0.13.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a80f50db7439ceb65de759fcbadb1695c82aec82126b2313413632e40d4eec"
+checksum = "1b505c9c076d9fce854304bd743c93ea540ebea6b16ec96819b07343a3aa2c7c"
 dependencies = [
  "bitvec",
  "cairo-lang-starknet-classes",
@@ -8502,8 +8508,8 @@ dependencies = [
  "sha3",
  "starknet-crypto 0.5.2",
  "starknet-types-core",
- "strum",
- "strum_macros",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "thiserror",
 ]
 
@@ -8545,6 +8551,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8555,6 +8567,19 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -8631,7 +8656,7 @@ dependencies = [
 
 [[package]]
 name = "tagged"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "fake",
  "pretty_assertions_sorted",
@@ -8640,7 +8665,7 @@ dependencies = [
 
 [[package]]
 name = "tagged-debug-derive"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ lto = true
 opt-level = 3
 
 [workspace.package]
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.80"
@@ -53,17 +53,17 @@ axum = "0.7.5"
 base64 = "0.13.1"
 bincode = "2.0.0-rc.3"
 bitvec = "1.0.1"
-blockifier = "=0.8.0-rc.1"
+blockifier = "=0.8.0-rc.3"
 bloomfilter = "1.0.12"
 bytes = "1.4.0"
 cached = "0.44.0"
-cairo-lang-starknet-classes = "=2.7.0-rc.3"
+cairo-lang-starknet-classes = "=2.7.0"
 # This one needs to match the version used by blockifier
-cairo-vm = "=1.0.0-rc5"
+cairo-vm = "=1.0.1"
 casm-compiler-v1_0_0-alpha6 = { git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-alpha.6" }
 casm-compiler-v1_0_0-rc0 = { git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-rc0" }
 casm-compiler-v1_1_1 = "=1.1.1"
-casm-compiler-v2 = "=2.7.0-rc.3"
+casm-compiler-v2 = "=2.7.0"
 clap = "4.1.13"
 console-subscriber = "0.1.10"
 const-decoder = "0.3.0"
@@ -116,7 +116,7 @@ serde_with = "3.7.0"
 sha2 = "0.10.7"
 sha3 = "0.10"
 # This one needs to match the version used by blockifier
-starknet_api = "=0.13.0-rc.0"
+starknet_api = "=0.13.0-rc.1"
 # This one needs to match the version used by blockifier
 starknet-types-core = "=0.1.5"
 syn = "1.0"

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -13,7 +13,7 @@ cairo-lang-starknet-classes = { workspace = true }
 casm-compiler-v1_0_0-alpha6 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-alpha.6" }
 casm-compiler-v1_0_0-rc0 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-rc0" }
 casm-compiler-v1_1_1 = { package = "cairo-lang-starknet", version = "=1.1.1" }
-casm-compiler-v2 = { package = "cairo-lang-starknet", version = "=2.7.0-rc.3" }
+casm-compiler-v2 = { package = "cairo-lang-starknet", version = "=2.7.0" }
 num-bigint = { workspace = true }
 pathfinder-common = { path = "../common" }
 pathfinder-crypto = { path = "../crypto" }

--- a/crates/executor/resources/versioned_constants_13_2.json
+++ b/crates/executor/resources/versioned_constants_13_2.json
@@ -1,0 +1,608 @@
+{
+    "tx_event_limits": {
+        "max_data_length": 300,
+        "max_keys_length": 50,
+        "max_n_emitted_events": 1000
+    },
+    "gateway": {
+        "max_calldata_length": 5000,
+        "max_contract_bytecode_size": 81920
+    },
+    "invoke_tx_max_n_steps": 10000000,
+    "l2_resource_gas_costs": {
+        "gas_per_data_felt": [
+            128,
+            1000
+        ],
+        "event_key_factor": [
+            2,
+            1
+        ],
+        "gas_per_code_byte": [
+            875,
+            1000
+        ]
+    },
+    "disable_cairo0_redeclaration": true,
+    "max_recursion_depth": 50,
+    "segment_arena_cells": false,
+    "os_constants": {
+        "block_hash_contract_address": 1,
+        "call_contract_gas_cost": {
+            "entry_point_gas_cost": 1,
+            "step_gas_cost": 10,
+            "syscall_base_gas_cost": 1
+        },
+        "constructor_entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+        "default_entry_point_selector": 0,
+        "deploy_gas_cost": {
+            "entry_point_gas_cost": 1,
+            "step_gas_cost": 200,
+            "syscall_base_gas_cost": 1
+        },
+        "emit_event_gas_cost": {
+            "step_gas_cost": 10,
+            "syscall_base_gas_cost": 1
+        },
+        "entry_point_gas_cost": {
+            "entry_point_initial_budget": 1,
+            "step_gas_cost": 500
+        },
+        "entry_point_initial_budget": {
+            "step_gas_cost": 100
+        },
+        "entry_point_type_constructor": 2,
+        "entry_point_type_external": 0,
+        "entry_point_type_l1_handler": 1,
+        "error_block_number_out_of_range": "Block number out of range",
+        "error_invalid_input_len": "Invalid input length",
+        "error_invalid_argument": "Invalid argument",
+        "error_out_of_gas": "Out of gas",
+        "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+        "fee_transfer_gas_cost": {
+            "entry_point_gas_cost": 1,
+            "step_gas_cost": 100
+        },
+        "get_block_hash_gas_cost": {
+            "step_gas_cost": 50,
+            "syscall_base_gas_cost": 1
+        },
+        "get_execution_info_gas_cost": {
+            "step_gas_cost": 10,
+            "syscall_base_gas_cost": 1
+        },
+        "initial_gas_cost": {
+            "step_gas_cost": 100000000
+        },
+        "keccak_gas_cost": {
+            "syscall_base_gas_cost": 1
+        },
+        "keccak_round_cost_gas_cost": 180000,
+        "l1_gas": "L1_GAS",
+        "l1_gas_index": 0,
+        "l1_handler_version": 0,
+        "l2_gas": "L2_GAS",
+        "l2_gas_index": 1,
+        "library_call_gas_cost": {
+            "call_contract_gas_cost": 1
+        },
+        "sha256_process_block_gas_cost": {
+            "step_gas_cost": 1852,
+            "range_check_gas_cost": 65,
+            "bitwise_builtin_gas_cost": 1115,
+            "syscall_base_gas_cost": 1
+        },
+        "memory_hole_gas_cost": 10,
+        "nop_entry_point_offset": -1,
+        "range_check_gas_cost": 70,
+        "bitwise_builtin_gas_cost": 594,
+        "replace_class_gas_cost": {
+            "step_gas_cost": 50,
+            "syscall_base_gas_cost": 1
+        },
+        "secp256k1_add_gas_cost": {
+            "range_check_gas_cost": 29,
+            "step_gas_cost": 406
+        },
+        "secp256k1_get_point_from_x_gas_cost": {
+            "memory_hole_gas_cost": 20,
+            "range_check_gas_cost": 30,
+            "step_gas_cost": 391
+        },
+        "secp256k1_get_xy_gas_cost": {
+            "memory_hole_gas_cost": 40,
+            "range_check_gas_cost": 11,
+            "step_gas_cost": 239
+        },
+        "secp256k1_mul_gas_cost": {
+            "memory_hole_gas_cost": 2,
+            "range_check_gas_cost": 7045,
+            "step_gas_cost": 76501
+        },
+        "secp256k1_new_gas_cost": {
+            "memory_hole_gas_cost": 40,
+            "range_check_gas_cost": 35,
+            "step_gas_cost": 475
+        },
+        "secp256r1_add_gas_cost": {
+            "range_check_gas_cost": 57,
+            "step_gas_cost": 589
+        },
+        "secp256r1_get_point_from_x_gas_cost": {
+            "memory_hole_gas_cost": 20,
+            "range_check_gas_cost": 44,
+            "step_gas_cost": 510
+        },
+        "secp256r1_get_xy_gas_cost": {
+            "memory_hole_gas_cost": 40,
+            "range_check_gas_cost": 11,
+            "step_gas_cost": 241
+        },
+        "secp256r1_mul_gas_cost": {
+            "memory_hole_gas_cost": 2,
+            "range_check_gas_cost": 13961,
+            "step_gas_cost": 125340
+        },
+        "secp256r1_new_gas_cost": {
+            "memory_hole_gas_cost": 40,
+            "range_check_gas_cost": 49,
+            "step_gas_cost": 594
+        },
+        "send_message_to_l1_gas_cost": {
+            "step_gas_cost": 50,
+            "syscall_base_gas_cost": 1
+        },
+        "sierra_array_len_bound": 4294967296,
+        "step_gas_cost": 100,
+        "storage_read_gas_cost": {
+            "step_gas_cost": 50,
+            "syscall_base_gas_cost": 1
+        },
+        "storage_write_gas_cost": {
+            "step_gas_cost": 50,
+            "syscall_base_gas_cost": 1
+        },
+        "stored_block_hash_buffer": 10,
+        "syscall_base_gas_cost": {
+            "step_gas_cost": 100
+        },
+        "transaction_gas_cost": {
+            "entry_point_gas_cost": 2,
+            "fee_transfer_gas_cost": 1,
+            "step_gas_cost": 100
+        },
+        "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+        "validate_declare_entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
+        "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
+        "validate_entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+        "validate_rounding_consts": {
+            "validate_block_number_rounding": 100,
+            "validate_timestamp_rounding": 3600
+        },
+        "validated": "VALID"
+    },
+    "os_resources": {
+        "execute_syscalls": {
+            "CallContract": {
+                "n_steps": 827,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 15
+                },
+                "n_memory_holes": 0
+            },
+            "DelegateCall": {
+                "n_steps": 713,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 19
+                },
+                "n_memory_holes": 0
+            },
+            "DelegateL1Handler": {
+                "n_steps": 692,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 15
+                },
+                "n_memory_holes": 0
+            },
+            "Deploy": {
+                "n_steps": 1097,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 7,
+                    "range_check_builtin": 18
+                },
+                "n_memory_holes": 0
+            },
+            "EmitEvent": {
+                "n_steps": 61,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "GetBlockHash": {
+                "n_steps": 104,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 2
+                },
+                "n_memory_holes": 0
+            },
+            "GetBlockNumber": {
+                "n_steps": 40,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            },
+            "GetBlockTimestamp": {
+                "n_steps": 38,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            },
+            "GetCallerAddress": {
+                "n_steps": 64,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "GetContractAddress": {
+                "n_steps": 64,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "GetExecutionInfo": {
+                "n_steps": 64,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "GetSequencerAddress": {
+                "n_steps": 34,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            },
+            "GetTxInfo": {
+                "n_steps": 64,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "GetTxSignature": {
+                "n_steps": 44,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            },
+            "Keccak": {
+                "n_steps": 381,
+                "builtin_instance_counter": {
+                    "bitwise_builtin": 6,
+                    "keccak_builtin": 1,
+                    "range_check_builtin": 56
+                },
+                "n_memory_holes": 0
+            },
+            "LibraryCall": {
+                "n_steps": 818,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 15
+                },
+                "n_memory_holes": 0
+            },
+            "LibraryCallL1Handler": {
+                "n_steps": 659,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 15
+                },
+                "n_memory_holes": 0
+            },
+            "ReplaceClass": {
+                "n_steps": 98,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256k1Add": {
+                "n_steps": 410,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 29
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256k1GetPointFromX": {
+                "n_steps": 395,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 30
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256k1GetXy": {
+                "n_steps": 207,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 11
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256k1Mul": {
+                "n_steps": 76505,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 7045
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256k1New": {
+                "n_steps": 461,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 35
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256r1Add": {
+                "n_steps": 593,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 57
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256r1GetPointFromX": {
+                "n_steps": 514,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 44
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256r1GetXy": {
+                "n_steps": 209,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 11
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256r1Mul": {
+                "n_steps": 125344,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 13961
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256r1New": {
+                "n_steps": 580,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 49
+                },
+                "n_memory_holes": 0
+            },
+            "SendMessageToL1": {
+                "n_steps": 141,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "Sha256ProcessBlock": {
+                "n_steps": 1855,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 65,
+                    "bitwise_builtin": 1115
+                },
+                "n_memory_holes": 0
+            },
+            "StorageRead": {
+                "n_steps": 87,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "StorageWrite": {
+                "n_steps": 89,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            }
+        },
+        "execute_txs_inner": {
+            "Declare": {
+                "deprecated_resources": {
+                    "constant": {
+                        "n_steps": 2973,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 16,
+                            "range_check_builtin": 53
+                        },
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 0,
+                        "builtin_instance_counter": {},
+                        "n_memory_holes": 0
+                    }
+                },
+                "resources": {
+                    "constant": {
+                        "n_steps": 3079,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 4,
+                            "range_check_builtin": 58,
+                            "poseidon_builtin": 10
+                        },
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 0,
+                        "builtin_instance_counter": {},
+                        "n_memory_holes": 0
+                    }
+                }
+            },
+            "DeployAccount": {
+                "deprecated_resources": {
+                    "constant": {
+                        "n_steps": 4015,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 23,
+                            "range_check_builtin": 72
+                        },
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 21,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 2
+                        },
+                        "n_memory_holes": 0
+                    }
+                },
+                "resources": {
+                    "constant": {
+                        "n_steps": 4137,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 11,
+                            "range_check_builtin": 77,
+                            "poseidon_builtin": 10
+                        },
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 21,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 2
+                        },
+                        "n_memory_holes": 0
+                    }
+                }
+            },
+            "InvokeFunction": {
+                "deprecated_resources": {
+                    "constant": {
+                        "n_steps": 3763,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 14,
+                            "range_check_builtin": 69
+                        },
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 8,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 1
+                        },
+                        "n_memory_holes": 0
+                    }
+                },
+                "resources": {
+                    "constant": {
+                        "n_steps": 3904,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 4,
+                            "range_check_builtin": 74,
+                            "poseidon_builtin": 11
+                        },
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 8,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 1
+                        },
+                        "n_memory_holes": 0
+                    }
+                }
+            },
+            "L1Handler": {
+                "deprecated_resources": {
+                    "constant": {
+                        "n_steps": 1233,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 11,
+                            "range_check_builtin": 16
+                        },
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 13,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 1
+                        },
+                        "n_memory_holes": 0
+                    }
+                },
+                "resources": {
+                    "constant": {
+                        "n_steps": 0,
+                        "builtin_instance_counter": {},
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 13,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 1
+                        },
+                        "n_memory_holes": 0
+                    }
+                }
+            }
+        },
+        "compute_os_kzg_commitment_info": {
+            "n_steps": 113,
+            "builtin_instance_counter": {
+                "range_check_builtin": 17
+            },
+            "n_memory_holes": 0
+        }
+    },
+    "validate_max_n_steps": 1000000,
+    "vm_resource_fee_cost": {
+        "add_mod_builtin": [
+            4,
+            100
+        ],
+        "bitwise_builtin": [
+            16,
+            100
+        ],
+        "ec_op_builtin": [
+            256,
+            100
+        ],
+        "ecdsa_builtin": [
+            512,
+            100
+        ],
+        "keccak_builtin": [
+            512,
+            100
+        ],
+        "mul_mod_builtin": [
+            4,
+            100
+        ],
+        "n_steps": [
+            25,
+            10000
+        ],
+        "output_builtin": [
+            0,
+            1
+        ],
+        "pedersen_builtin": [
+            8,
+            100
+        ],
+        "poseidon_builtin": [
+            8,
+            100
+        ],
+        "range_check_builtin": [
+            4,
+            100
+        ],
+        "range_check96_builtin": [
+            4,
+            100
+        ]
+    }
+}

--- a/crates/executor/src/execution_state.rs
+++ b/crates/executor/src/execution_state.rs
@@ -43,11 +43,16 @@ mod versioned_constants {
     const BLOCKIFIER_VERSIONED_CONSTANTS_JSON_0_13_1_1: &[u8] =
         include_bytes!("../resources/versioned_constants_13_1_1.json");
 
+    const BLOCKIFIER_VERSIONED_CONSTANTS_JSON_0_13_2: &[u8] =
+        include_bytes!("../resources/versioned_constants_13_2.json");
+
     const STARKNET_VERSION_0_13_1: StarknetVersion = StarknetVersion::new(0, 13, 1, 0);
 
     const STARKNET_VERSION_0_13_1_1: StarknetVersion = StarknetVersion::new(0, 13, 1, 1);
 
     const STARKNET_VERSION_0_13_2: StarknetVersion = StarknetVersion::new(0, 13, 2, 0);
+
+    const STARKNET_VERSION_0_13_2_1: StarknetVersion = StarknetVersion::new(0, 13, 2, 1);
 
     pub static BLOCKIFIER_VERSIONED_CONSTANTS_0_13_0: LazyLock<VersionedConstants> =
         LazyLock::new(|| {
@@ -64,6 +69,11 @@ mod versioned_constants {
             serde_json::from_slice(BLOCKIFIER_VERSIONED_CONSTANTS_JSON_0_13_1_1).unwrap()
         });
 
+    pub static BLOCKIFIER_VERSIONED_CONSTANTS_0_13_2: LazyLock<VersionedConstants> =
+        LazyLock::new(|| {
+            serde_json::from_slice(BLOCKIFIER_VERSIONED_CONSTANTS_JSON_0_13_2).unwrap()
+        });
+
     pub(super) fn for_version(
         version: &StarknetVersion,
         custom_versioned_constants: Option<VersionedConstants>,
@@ -75,6 +85,8 @@ mod versioned_constants {
             Cow::Borrowed(&BLOCKIFIER_VERSIONED_CONSTANTS_0_13_1)
         } else if version < &STARKNET_VERSION_0_13_2 {
             Cow::Borrowed(&BLOCKIFIER_VERSIONED_CONSTANTS_0_13_1_1)
+        } else if version < &STARKNET_VERSION_0_13_2_1 {
+            Cow::Borrowed(&BLOCKIFIER_VERSIONED_CONSTANTS_0_13_2)
         } else {
             custom_versioned_constants
                 .map(Cow::Owned)

--- a/crates/load-test/Cargo.lock
+++ b/crates/load-test/Cargo.lock
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-crypto"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "bitvec",
  "fake",


### PR DESCRIPTION
There are two distinct changes that were made on 0.14.2 that need to be merged:

- The blockifier upgrade (containing Starknet 0.13.2.1 constants).
- Version bump and CHANGELOG.