### PR TITLE
feat: use rustls instead of native-tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3765,21 +3765,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4488,6 +4473,7 @@ dependencies = [
  "hyper 1.4.1",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -4504,22 +4490,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.4.1",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -5913,23 +5883,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndarray"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6220,48 +6173,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.72",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "ordered-float"
@@ -7590,24 +7505,25 @@ dependencies = [
  "http-body-util",
  "hyper 1.4.1",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
- "system-configuration",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -7810,6 +7726,19 @@ dependencies = [
  "rustls-webpki 0.102.6",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -8902,16 +8831,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.72",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,11 @@ r2d2_sqlite = "0.25.0"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rayon = "1.8.0"
-reqwest = "0.12.5"
+reqwest = { version = "0.12.5", default-features = false, features = [
+    "http2",
+    "rustls-tls-native-roots",
+    "charset",
+] }
 rstest = "0.18.2"
 rusqlite = "0.32.1"
 semver = "1.0.18"

--- a/build/cargo-build.sh
+++ b/build/cargo-build.sh
@@ -5,8 +5,6 @@ elif [[ "${TARGETARCH}" == "arm64" ]]; then
     PKG_CONFIG_ALLOW_CROSS=1 \
     RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -L/usr/aarch64-linux-gnu/lib -L/build/sysroot/usr/lib/aarch64-linux-gnu" \
     C_INCLUDE_PATH=/build/sysroot/usr/include \
-    OPENSSL_LIB_DIR=/build/sysroot/usr/lib/aarch64-linux-gnu \
-    OPENSSL_INCLUDE_DIR=/build/sysroot/usr/include/aarch64-linux-gnu \
     JEMALLOC_SYS_WITH_LG_PAGE=16 \
     cargo build --target aarch64-unknown-linux-gnu $*
 fi

--- a/build/cargo-chef-cook.sh
+++ b/build/cargo-chef-cook.sh
@@ -5,8 +5,6 @@ elif [[ "${TARGETARCH}" == "arm64" ]]; then
     PKG_CONFIG_ALLOW_CROSS=1 \
     RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -L/usr/aarch64-linux-gnu/lib -L/build/sysroot/usr/lib/aarch64-linux-gnu" \
     C_INCLUDE_PATH=/build/sysroot/usr/include \
-    OPENSSL_LIB_DIR=/build/sysroot/usr/lib/aarch64-linux-gnu \
-    OPENSSL_INCLUDE_DIR=/build/sysroot/usr/include/aarch64-linux-gnu \
     JEMALLOC_SYS_WITH_LG_PAGE=16 \
     cargo chef cook --target aarch64-unknown-linux-gnu $*
 fi

--- a/build/prepare.sh
+++ b/build/prepare.sh
@@ -1,15 +1,13 @@
 #!/bin/bash -e
 if [[ "${TARGETARCH}" == "amd64" ]]; then
     apt-get update
-    DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config libssl-dev libzstd-dev protobuf-compiler make
+    DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config libzstd-dev protobuf-compiler make
 elif [[ "${TARGETARCH}" == "arm64" ]]; then
     echo "deb [arch=arm64] http://deb.debian.org/debian bookworm main" >>/etc/apt/sources.list
     apt-get update
-    DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config libssl-dev libzstd-dev protobuf-compiler gcc-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross make
-    apt-get download libssl-dev:arm64 libssl3:arm64 libzstd-dev:arm64
+    DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config libzstd-dev protobuf-compiler gcc-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross make
+    apt-get download libzstd-dev:arm64
     mkdir -p /build/sysroot
-    dpkg -x libssl-dev_*.deb /build/sysroot/
-    dpkg -x libssl3_*.deb /build/sysroot/
     dpkg -x libzstd-dev_*.deb /build/sysroot/
     rustup target add aarch64-unknown-linux-gnu
 fi


### PR DESCRIPTION
Currently we're using `native-tls` which is a bit problematic on Linux. Build time we're linking to the version of OpenSSL that is available on the build host.

For example, Ubuntu 20.04 uses OpenSSL 1.1 so that the release binaries we're building now are linked to that version of the library. That binary won't work on Ubuntu 22.04 (and up) since those versions use OpenSSL 3.0.

This change switches `reqwest` to use `rustls` instead (with native certs, meaning we're still using the same certificate store as OpenSSL). This way we're no longer linking to OpenSSL and so our release binaries will be more portable.