### PR TITLE
chore(p2p): change/add some logs

### DIFF
--- a/crates/p2p/src/main_loop.rs
+++ b/crates/p2p/src/main_loop.rs
@@ -203,6 +203,8 @@ impl MainLoop {
     }
 
     async fn handle_event(&mut self, event: SwarmEvent<behaviour::Event>) {
+        tracing::trace!(?event, "Handling swarm event");
+
         match event {
             // ===========================
             // Connection management

--- a/crates/pathfinder/src/sync/checkpoint.rs
+++ b/crates/pathfinder/src/sync/checkpoint.rs
@@ -327,10 +327,7 @@ async fn handle_transaction_stream(
         .pipe(transactions::VerifyCommitment, 10)
         .pipe(transactions::Store::new(storage.connection()?, start), 10)
         .into_stream()
-        .inspect_ok(|x| {
-            tracing::info!(tail=%x.data, "Transactions chunk
-    synced")
-        })
+        .inspect_ok(|x| tracing::info!(tail=%x.data, "Transactions chunk synced"))
         .try_fold((), |_, _| std::future::ready(Ok(())))
         .await
         .map_err(SyncError::from_v2)?;

--- a/crates/pathfinder/src/sync/stream.rs
+++ b/crates/pathfinder/src/sync/stream.rs
@@ -161,10 +161,8 @@ impl<T: Send + 'static> SyncReceiver<T> {
                         let elements_per_sec = count as f32 / t.elapsed().as_secs_f32();
                         let queue_fullness = queue_capacity - self.inner.capacity();
                         let input_queue = Fullness(queue_fullness, queue_capacity);
-                        tracing::debug!(
-                            "Stage: {}, queue: {}, {elements_per_sec:.0} items/s",
-                            S::NAME,
-                            input_queue
+                        tracing::trace!(stage=%S::NAME, %input_queue, %elements_per_sec,
+                            "Stage metrics"
                         );
 
                         output


### PR DESCRIPTION
This PR

- Moves queue stats logging to trace level.
- Fixes a log message in transaction sync.
- Makes sure we log _every_ swarm event in full detail on trace level.