### PR TITLE
fix(p2p/client/peer_agnostic): limit sync request block ranges

### DIFF
--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -590,6 +590,9 @@ impl BlockClient for Client {
     }
 }
 
+/// Maximum number of blocks to request in a single request
+const MAX_BLOCKS_COUNT: u64 = 500;
+
 mod header_stream {
     use super::*;
 
@@ -696,13 +699,14 @@ mod header_stream {
     }
 
     fn make_request(start: i64, stop: i64, dir: Direction) -> BlockHeadersRequest {
-        let limit = start.max(stop) - start.min(stop) + 1;
+        let limit = start.abs_diff(stop) + 1;
+        let limit = limit.min(MAX_BLOCKS_COUNT);
 
         BlockHeadersRequest {
             iteration: Iteration {
                 start: u64::try_from(start).expect("start >= 0").into(),
                 direction: dir,
-                limit: limit.try_into().expect("limit >= 0"),
+                limit,
                 step: 1.into(),
             },
         }
@@ -839,11 +843,16 @@ mod transaction_stream {
     }
 
     fn make_request(start: BlockNumber, stop: BlockNumber) -> TransactionsRequest {
+        let start = start.get();
+        let stop = stop.get();
+        let limit = start.abs_diff(stop) + 1;
+        let limit = limit.min(MAX_BLOCKS_COUNT);
+
         TransactionsRequest {
             iteration: Iteration {
-                start: start.get().into(),
+                start: start.into(),
                 direction: Direction::Forward,
-                limit: stop.get() - start.get() + 1,
+                limit,
                 step: 1.into(),
             },
         }
@@ -1055,11 +1064,16 @@ mod state_diff_stream {
     }
 
     fn make_request(start: BlockNumber, stop: BlockNumber) -> StateDiffsRequest {
+        let start = start.get();
+        let stop = stop.get();
+        let limit = start.abs_diff(stop) + 1;
+        let limit = limit.min(MAX_BLOCKS_COUNT);
+
         StateDiffsRequest {
             iteration: Iteration {
-                start: start.get().into(),
+                start: start.into(),
                 direction: Direction::Forward,
-                limit: stop.get() - start.get() + 1,
+                limit,
                 step: 1.into(),
             },
         }
@@ -1189,11 +1203,16 @@ mod class_definition_stream {
     }
 
     fn make_request(start: BlockNumber, stop: BlockNumber) -> ClassesRequest {
+        let start = start.get();
+        let stop = stop.get();
+        let limit = start.abs_diff(stop) + 1;
+        let limit = limit.min(MAX_BLOCKS_COUNT);
+
         ClassesRequest {
             iteration: Iteration {
-                start: start.get().into(),
+                start: start.into(),
                 direction: Direction::Forward,
-                limit: stop.get() - start.get() + 1,
+                limit,
                 step: 1.into(),
             },
         }
@@ -1366,11 +1385,16 @@ mod event_stream {
     }
 
     fn make_request(start: BlockNumber, stop: BlockNumber) -> EventsRequest {
+        let start = start.get();
+        let stop = stop.get();
+        let limit = start.abs_diff(stop) + 1;
+        let limit = limit.min(MAX_BLOCKS_COUNT);
+
         EventsRequest {
             iteration: Iteration {
-                start: start.get().into(),
+                start: start.into(),
                 direction: Direction::Forward,
-                limit: stop.get() - start.get() + 1,
+                limit,
                 step: 1.into(),
             },
         }


### PR DESCRIPTION
Some nodes (like Juno) do not limit how many responses they return for a sync query. Since Pathfinder requests the whole gap (possibly hundreds of thousands of blocks) by default this leads to a sync request that then times out (because we currently have a "global" timeout on the sync protocol streams).

This change makes sure that we never request more than 500 blocks worth of data at once.

Closes #2121
