### PR TITLE
feat: manually fetch initial Ethereum state on sync start

### DIFF
--- a/crates/pathfinder/src/state/sync/l1.rs
+++ b/crates/pathfinder/src/state/sync/l1.rs
@@ -35,7 +35,11 @@ where
         poll_interval,
     } = context;
 
-    // Listen for state updates and send them to the event channel
+    // Fetch the current Starknet state from Ethereum
+    let state_update = ethereum.get_starknet_state(&core_address).await?;
+    let _ = tx_event.send(SyncEvent::L1Update(state_update)).await;
+
+    // Subscribe to subsequent state updates and message logs
     let tx_event = std::sync::Arc::new(tx_event);
     ethereum
         .listen(&core_address, poll_interval, move |event| {


### PR DESCRIPTION
Manually sync latest Ethereum state on startup, thus preventing initial periods of unknown state due to lack of activity on the network.

Closes #2232