### PR TITLE
fix(p2p_proto/receipt): L1->L2 message hashes are 256 bit hashes

### DIFF
--- a/crates/p2p/src/client/conv.rs
+++ b/crates/p2p/src/client/conv.rs
@@ -7,7 +7,7 @@ use std::io::Read;
 
 use anyhow::Context;
 use p2p_proto::class::{Cairo0Class, Cairo1Class, Cairo1EntryPoints, SierraEntryPoint};
-use p2p_proto::common::{Address, Hash};
+use p2p_proto::common::{Address, Hash, Hash256};
 use p2p_proto::receipt::execution_resources::BuiltinCounter;
 use p2p_proto::receipt::{
     DeclareTransactionReceipt,
@@ -364,9 +364,9 @@ impl ToDto<p2p_proto::receipt::Receipt> for (&TransactionVariant, Receipt) {
             TransactionVariant::InvokeV0(_)
             | TransactionVariant::InvokeV1(_)
             | TransactionVariant::InvokeV3(_) => Invoke(InvokeTransactionReceipt { common }),
-            TransactionVariant::L1Handler(_) => L1Handler(L1HandlerTransactionReceipt {
+            TransactionVariant::L1Handler(tx) => L1Handler(L1HandlerTransactionReceipt {
                 common,
-                msg_hash: Hash(Felt::ZERO), // TODO what is this
+                msg_hash: Hash256(tx.calculate_message_hash()),
             }),
         }
     }

--- a/crates/p2p_proto/proto/common.proto
+++ b/crates/p2p_proto/proto/common.proto
@@ -6,7 +6,13 @@ message Felt252 {
     bytes elements = 1;
 }
 
+// A hash value represented as a Felt252
 message Hash {
+    bytes elements = 1;
+}
+
+// A 256 bit hash value (like Keccak256)
+message Hash256 {
     bytes elements = 1;
 }
 

--- a/crates/p2p_proto/proto/receipt.proto
+++ b/crates/p2p_proto/proto/receipt.proto
@@ -58,7 +58,7 @@ message Receipt {
 
   message L1Handler {
     Common               common   = 1;
-    starknet.common.Hash msg_hash = 2;
+    starknet.common.Hash256 msg_hash = 2;
   }
 
   message Declare {

--- a/crates/p2p_proto/src/receipt.rs
+++ b/crates/p2p_proto/src/receipt.rs
@@ -2,7 +2,7 @@ use fake::Dummy;
 use pathfinder_crypto::Felt;
 use primitive_types::H160;
 
-use crate::common::Hash;
+use crate::common::Hash256;
 use crate::{proto, proto_field, ToProtobuf, TryFromProtobuf};
 
 #[derive(Debug, Clone, PartialEq, Eq, ToProtobuf, TryFromProtobuf, Dummy)]
@@ -76,7 +76,7 @@ pub struct InvokeTransactionReceipt {
 #[protobuf(name = "crate::proto::receipt::receipt::L1Handler")]
 pub struct L1HandlerTransactionReceipt {
     pub common: ReceiptCommon,
-    pub msg_hash: Hash,
+    pub msg_hash: Hash256,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ToProtobuf, TryFromProtobuf, Dummy)]


### PR DESCRIPTION
L1 message hashes are Keccak256 output, but since we parse the `Hash` message contents as felts there are some hash values that cause a parse error (felt out of range). 

This change introduces a `Hash256` type to describe fields which represent 256 bit hash values (like the output of Keccak256) and changes the L1 transaction receipt to use that for the message hash.

P2P protocol specification change: https://github.com/starknet-io/starknet-p2p-specs/pull/46