### PR TITLE
chore(pathfinder/sync): add logging for P2P stage failures

### DIFF
--- a/crates/pathfinder/src/sync/checkpoint.rs
+++ b/crates/pathfinder/src/sync/checkpoint.rs
@@ -141,8 +141,6 @@ impl Sync {
     /// No guarantees are made about any headers newer than the anchor.
     #[tracing::instrument(level = "debug", skip(self, anchor))]
     async fn sync_headers(&self, anchor: EthereumStateUpdate) -> Result<(), SyncError> {
-        tracing::info!(?anchor);
-
         while let Some(gap) =
             headers::next_gap(self.storage.clone(), anchor.block_number, anchor.block_hash)
                 .await
@@ -289,7 +287,6 @@ async fn handle_header_stream(
     public_key: PublicKey,
     storage: Storage,
 ) -> Result<(), SyncError> {
-    tracing::info!("Syncing headers");
     InfallibleSource::from_stream(stream)
         .spawn()
         .pipe(headers::BackwardContinuity::new(head.0, head.1), 10)
@@ -327,7 +324,7 @@ async fn handle_transaction_stream(
         .pipe(transactions::VerifyCommitment, 10)
         .pipe(transactions::Store::new(storage.connection()?, start), 10)
         .into_stream()
-        .inspect_ok(|x| tracing::info!(tail=%x.data, "Transactions chunk synced"))
+        .inspect_ok(|x| tracing::debug!(tail=%x.data, "Transactions chunk synced"))
         .try_fold((), |_, _| std::future::ready(Ok(())))
         .await
         .map_err(SyncError::from_v2)?;
@@ -357,7 +354,7 @@ async fn handle_state_diff_stream(
             10,
         )
         .into_stream()
-        .inspect_ok(|x| tracing::info!(tail=%x.data, "State diff synced"))
+        .inspect_ok(|x| tracing::debug!(tail=%x.data, "State diff synced"))
         .try_fold((), |_, _| std::future::ready(Ok(())))
         .await
         .map_err(SyncError::from_v2)?;
@@ -407,7 +404,7 @@ async fn handle_event_stream(
         .try_chunks(100)
         .map_err(|e| e.1)
         .and_then(|x| events::persist(storage.clone(), x))
-        .inspect_ok(|x| tracing::info!(tail=%x, "Events chunk synced"))
+        .inspect_ok(|x| tracing::debug!(tail=%x, "Events chunk synced"))
         // Drive stream to completion.
         .try_fold((), |_, _| std::future::ready(Ok(())))
         .await?;

--- a/crates/pathfinder/src/sync/events.rs
+++ b/crates/pathfinder/src/sync/events.rs
@@ -166,10 +166,12 @@ impl ProcessStage for VerifyCommitment {
             }
         }
         if ordered_events.len() != events.len() {
+            tracing::debug!(expected=%ordered_events.len(), actual=%events.len(), "Number of events received does not match expected number of events");
             return Err(SyncError2::EventsTransactionsMismatch);
         }
         let actual = calculate_event_commitment(&ordered_events, version)?;
         if actual != event_commitment {
+            tracing::debug!(expected=%event_commitment, actual=%actual, "Event commitment mismatch");
             return Err(SyncError2::EventCommitmentMismatch);
         }
         Ok(events)

--- a/crates/pathfinder/src/sync/headers.rs
+++ b/crates/pathfinder/src/sync/headers.rs
@@ -178,6 +178,7 @@ impl ProcessStage for ForwardContinuity {
         let header = &input.header;
 
         if header.number != self.next || header.parent_hash != self.parent_hash {
+            tracing::debug!(expected_block_number=%self.next, actual_block_number=%header.number, expected_parent_block_hash=%self.parent_hash, actual_parent_block_hash=%header.parent_hash, "Block chain discontinuity");
             return Err(SyncError2::Discontinuity);
         }
 
@@ -209,6 +210,7 @@ impl ProcessStage for BackwardContinuity {
         let number = self.number.ok_or(SyncError2::Discontinuity)?;
 
         if input.header.number != number || input.header.hash != self.hash {
+            tracing::debug!(expected_block_number=%number, actual_block_number=%input.header.number, expected_block_hash=%self.hash, actual_block_hash=%input.header.hash, "Block chain discontinuity");
             return Err(SyncError2::Discontinuity);
         }
 

--- a/crates/pathfinder/src/sync/track.rs
+++ b/crates/pathfinder/src/sync/track.rs
@@ -812,7 +812,7 @@ impl ProcessStage for StoreBlock {
             .context("Committing transaction")
             .map_err(Into::into);
 
-        tracing::info!(number=%block_number, "Block stored");
+        tracing::debug!(number=%block_number, "Block stored");
 
         result
     }

--- a/crates/pathfinder/src/sync/track.rs
+++ b/crates/pathfinder/src/sync/track.rs
@@ -343,7 +343,14 @@ struct TransactionSource<P> {
 }
 
 impl<P> TransactionSource<P> {
-    fn spawn(self) -> SyncReceiver<(TransactionData, StarknetVersion, TransactionCommitment)>
+    fn spawn(
+        self,
+    ) -> SyncReceiver<(
+        TransactionData,
+        BlockNumber,
+        StarknetVersion,
+        TransactionCommitment,
+    )>
     where
         P: Clone + BlockClient + Send + 'static,
     {
@@ -394,6 +401,7 @@ impl<P> TransactionSource<P> {
                         peer,
                         (
                             transactions_vec,
+                            header.number,
                             header.starknet_version,
                             header.transaction_commitment,
                         ),
@@ -497,7 +505,14 @@ struct StateDiffSource<P> {
 }
 
 impl<P> StateDiffSource<P> {
-    fn spawn(self) -> SyncReceiver<(StateUpdateData, StarknetVersion, StateDiffCommitment)>
+    fn spawn(
+        self,
+    ) -> SyncReceiver<(
+        StateUpdateData,
+        BlockNumber,
+        StarknetVersion,
+        StateDiffCommitment,
+    )>
     where
         P: Clone + BlockClient + Send + 'static,
     {
@@ -527,6 +542,7 @@ impl<P> StateDiffSource<P> {
                         peer,
                         (
                             state_diff,
+                            header.header.number,
                             header.header.starknet_version,
                             header.header.state_diff_commitment,
                         ),


### PR DESCRIPTION
In case one of the pipe stages fails we should print a log message with all information we have in addition to returning an error.

This PR also moves some of the logs from INFO level to DEBUG so that we don't do per-message-received log lines when running with the default log level.