### PR TITLE
chore(github): add workflow for building P2P-enabled Docker images

### DIFF
--- a/.github/workflows/docker-p2p.yml
+++ b/.github/workflows/docker-p2p.yml
@@ -1,0 +1,69 @@
+# Builds and uploads a P2P-enabled Docker image whenever triggered manually
+
+name: Docker - P2P
+
+on:
+  workflow_dispatch:
+
+env:
+  # Workaround for https://github.com/rust-lang/cargo/issues/8719#issuecomment-1516492970
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
+jobs:
+  # Build a docker image unless this was triggered by a release.
+  build-image-p2p:
+    runs-on: pathfinder-large-ubuntu
+    steps:
+      - name: Determine Docker image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: eqlabs/pathfinder
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Generate version
+        id: generate_version
+        run: |
+          echo -n "pathfinder_version=" >> $GITHUB_OUTPUT
+          git describe --tags --dirty >> $GITHUB_OUTPUT
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config-inline: |
+            [worker.oci]
+              max-parallelism = 4
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      # Required for git security reasons. See https://github.com/rustyhorde/vergen/pull/126#issuecomment-1201088162
+      - name: Vergen git safe directory
+        run: git config --global --add safe.directory /workspace
+      - name: Build
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: |
+            linux/amd64
+          file: ./Dockerfile
+          build-args: |
+            PATHFINDER_FORCE_VERSION=${{ steps.generate_version.outputs.pathfinder_version }}
+            CARGO_EXTRA_ARGS="--features p2p"
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            eqlabs/pathfinder:snapshot-p2p-${{ github.sha }}
+            eqlabs/pathfinder:latest-p2p
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM --platform=$BUILDPLATFORM cargo-chef AS rust-builder
+ARG CARGO_EXTRA_ARGS
 ARG TARGETARCH
 COPY ./build/prepare.sh prepare.sh
 RUN TARGETARCH=${TARGETARCH} ./prepare.sh
@@ -26,7 +27,7 @@ RUN TARGETARCH=${TARGETARCH} ./prepare.sh
 # input required for cargo chef cook, the command that will build out our dependencies.
 COPY --from=rust-planner /usr/src/pathfinder/recipe.json recipe.json
 COPY ./build/cargo-chef-cook.sh ./cargo-chef-cook.sh
-RUN TARGETARCH=${TARGETARCH} ./cargo-chef-cook.sh --profile release-lto --recipe-path recipe.json --package pathfinder --bin pathfinder
+RUN TARGETARCH=${TARGETARCH} ./cargo-chef-cook.sh --profile release-lto --recipe-path recipe.json --package pathfinder --bin pathfinder ${CARGO_EXTRA_ARGS}
 
 # Compile the actual libraries and binary now
 COPY . .
@@ -34,7 +35,7 @@ ARG PATHFINDER_FORCE_VERSION
 COPY ./build/cargo-build.sh ./cargo-build.sh
 RUN TARGETARCH=${TARGETARCH} \
     PATHFINDER_FORCE_VERSION=${PATHFINDER_FORCE_VERSION} \
-    ./cargo-build.sh --locked --profile release-lto --package pathfinder --bin pathfinder \
+    ./cargo-build.sh --locked --profile release-lto --package pathfinder --bin pathfinder ${CARGO_EXTRA_ARGS} \
     && cp target/*-unknown-linux-gnu/release-lto/pathfinder pathfinder-${TARGETARCH}
 
 #######################


### PR DESCRIPTION
This PR makes it possible to pass custom cargo arguments into our Docker build and adds a manually triggered GitHub actions workflow that builds and published an image to Docker Hub.

The image is tagged as `snapshot-p2p-${{ github.sha }}` and `latest-p2p` as well so that we have a stable tag that can be used to refer to the latest published version.

Closes #2245
