### PR TITLE
fix(pathfinder/state/revert): fix potential reorg Merkle trie corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ethereum RPC API now requires Websocket endpoints (prev. HTTP). If an HTTP url is provided instead, Pathfinder will attempt to connect vía Websocket protocol at that same url.
 
+### Fixed
+
+- Pathfinder occasionally corrupts its Merkle trie storage during reorgs and then stops later with a "Node X at height Y is missing" or "Stored node's hash is missing" error.
 
 ## [0.14.2] - 2024-09-03
 

--- a/crates/merkle-tree/src/contract_state.rs
+++ b/crates/merkle-tree/src/contract_state.rs
@@ -207,7 +207,7 @@ pub fn revert_contract_state(
             } else {
                 transaction
                     .contract_root(head, contract_address)?
-                    .context("Fetching current contract root")?
+                    .unwrap_or(ContractRoot::ZERO)
             };
 
             let state_hash = if contract_address.is_system_contract() && root == ContractRoot::ZERO

--- a/crates/pathfinder/src/state/sync/revert.rs
+++ b/crates/pathfinder/src/state/sync/revert.rs
@@ -49,8 +49,7 @@ pub fn revert_starknet_state(
         target_block,
         target_header.class_commitment,
     )?;
-
-    transaction.coalesce_trie_nodes(target_block)
+    transaction.coalesce_trie_removals(target_block)
 }
 
 /// Revert all contract/global storage trie updates.
@@ -63,55 +62,52 @@ fn revert_contract_updates(
     target_block: BlockNumber,
     expected_storage_commitment: StorageCommitment,
 ) -> anyhow::Result<()> {
-    if !transaction.storage_root_exists(target_block)? {
-        let updates = transaction.reverse_contract_updates(head, target_block)?;
+    let updates = transaction.reverse_contract_updates(head, target_block)?;
 
-        let mut global_tree = StorageCommitmentTree::load(transaction, head)
-            .context("Loading global storage tree")?;
+    let mut global_tree =
+        StorageCommitmentTree::load(transaction, head).context("Loading global storage tree")?;
 
-        for (contract_address, contract_update) in updates {
-            let state_hash = pathfinder_merkle_tree::contract_state::revert_contract_state(
-                transaction,
-                contract_address,
-                head,
-                target_block,
-                contract_update,
-            )?;
-
-            transaction
-                .insert_contract_state_hash(target_block, contract_address, state_hash)
-                .context("Inserting reverted contract state hash")?;
-
-            global_tree
-                .set(contract_address, state_hash)
-                .context("Updating contract state hash in global tree")?;
-        }
-
-        tracing::debug!("Applied reverse updates, committing global state tree");
-
-        let (storage_commitment, trie_update) = global_tree
-            .commit()
-            .context("Committing global state tree")?;
-
-        if expected_storage_commitment != storage_commitment {
-            anyhow::bail!(
-                "Storage commitment mismatch: expected {}, calculated {}",
-                expected_storage_commitment,
-                storage_commitment
-            );
-        }
-
-        let root_idx = transaction
-            .insert_storage_trie(&trie_update, target_block)
-            .context("Persisting storage trie")?;
+    for (contract_address, contract_update) in updates {
+        let state_hash = pathfinder_merkle_tree::contract_state::revert_contract_state(
+            transaction,
+            contract_address,
+            head,
+            target_block,
+            contract_update,
+        )?;
 
         transaction
-            .insert_storage_root(target_block, root_idx)
-            .context("Inserting storage root index")?;
-        tracing::debug!(%target_block, %storage_commitment, "Committed global state tree");
-    } else {
-        tracing::debug!(%target_block, "State tree root node exists");
+            .insert_contract_state_hash(target_block, contract_address, state_hash)
+            .context("Inserting reverted contract state hash")?;
+
+        global_tree
+            .set(contract_address, state_hash)
+            .context("Updating contract state hash in global tree")?;
     }
+
+    tracing::debug!("Applied reverse updates, committing global state tree");
+
+    let (storage_commitment, trie_update) = global_tree
+        .commit()
+        .context("Committing global state tree")?;
+
+    if expected_storage_commitment != storage_commitment {
+        anyhow::bail!(
+            "Storage commitment mismatch: expected {}, calculated {}",
+            expected_storage_commitment,
+            storage_commitment
+        );
+    }
+
+    let root_idx = transaction
+        .insert_storage_trie(&trie_update, target_block)
+        .context("Persisting storage trie")?;
+
+    transaction
+        .insert_storage_root(target_block, root_idx)
+        .context("Inserting storage root index")?;
+    tracing::debug!(%target_block, %storage_commitment, "Committed global state tree");
+
     Ok(())
 }
 
@@ -122,51 +118,48 @@ fn revert_class_updates(
     target_block: BlockNumber,
     expected_class_commitment: ClassCommitment,
 ) -> anyhow::Result<()> {
-    if !transaction.class_root_exists(target_block)? {
-        let updates = transaction.reverse_sierra_class_updates(head, target_block)?;
+    let updates = transaction.reverse_sierra_class_updates(head, target_block)?;
 
-        let mut class_tree = ClassCommitmentTree::load(transaction, head)
-            .context("Loading class commitment trie")?;
+    let mut class_tree =
+        ClassCommitmentTree::load(transaction, head).context("Loading class commitment trie")?;
 
-        for (class_hash, casm_update) in updates {
-            let new_value = match casm_update {
-                None => {
-                    // The class must be removed
-                    ClassCommitmentLeafHash::ZERO
-                }
-                Some(casm_hash) => {
-                    // Class hash has changed. Note that the class commitment leaf must have already
-                    // been added to storage.
-                    pathfinder_common::calculate_class_commitment_leaf_hash(casm_hash)
-                }
-            };
+    for (class_hash, casm_update) in updates {
+        let new_value = match casm_update {
+            None => {
+                // The class must be removed
+                ClassCommitmentLeafHash::ZERO
+            }
+            Some(casm_hash) => {
+                // Class hash has changed. Note that the class commitment leaf must have already
+                // been added to storage.
+                pathfinder_common::calculate_class_commitment_leaf_hash(casm_hash)
+            }
+        };
 
-            class_tree
-                .set(class_hash, new_value)
-                .context("Updating class commitment trie")?;
-        }
-
-        let (class_commitment, trie_update) =
-            class_tree.commit().context("Committing class trie")?;
-
-        if expected_class_commitment != class_commitment {
-            anyhow::bail!(
-                "Storage commitment mismatch: expected {}, calculated {}",
-                expected_class_commitment,
-                class_commitment
-            );
-        }
-
-        let root_idx = transaction
-            .insert_class_trie(&trie_update, target_block)
-            .context("Persisting class trie")?;
-
-        transaction
-            .insert_class_root(target_block, root_idx)
-            .context("Inserting class root index")?;
-
-        tracing::debug!(%target_block, %class_commitment, "Committed class trie");
+        class_tree
+            .set(class_hash, new_value)
+            .context("Updating class commitment trie")?;
     }
+
+    let (class_commitment, trie_update) = class_tree.commit().context("Committing class trie")?;
+
+    if expected_class_commitment != class_commitment {
+        anyhow::bail!(
+            "Storage commitment mismatch: expected {}, calculated {}",
+            expected_class_commitment,
+            class_commitment
+        );
+    }
+
+    let root_idx = transaction
+        .insert_class_trie(&trie_update, target_block)
+        .context("Persisting class trie")?;
+
+    transaction
+        .insert_class_root(target_block, root_idx)
+        .context("Inserting class root index")?;
+
+    tracing::debug!(%target_block, %class_commitment, "Committed class trie");
 
     Ok(())
 }

--- a/crates/storage/src/connection/trie.rs
+++ b/crates/storage/src/connection/trie.rs
@@ -366,7 +366,7 @@ impl Transaction<'_> {
         Ok(())
     }
 
-    pub fn coalesce_trie_nodes(&self, target_block: BlockNumber) -> anyhow::Result<()> {
+    pub fn coalesce_trie_removals(&self, target_block: BlockNumber) -> anyhow::Result<()> {
         self.coalesce_removed_trie_nodes(target_block, "trie_contracts")?;
         self.coalesce_removed_trie_nodes(target_block, "trie_storage")?;
         self.coalesce_removed_trie_nodes(target_block, "trie_class")


### PR DESCRIPTION
When reverting Merkle tries to a previous state we have been checking if we still have the tree root for the revert target. This seems like a good idea, because if we _still_ have the trie(s) for the target block then why bother applying reverse state updates from the current state?

It turns out that's not so simple. First, trie nodes added in blocks that are being deleted (right after the revert when pruning the block range that has been reorged away) will be permanently leaked. There's no way around that because we do not keep track of per-block trie node _additions_, only _removals_.

Second -- and this is _much_ more problematic -- the way we were handling trie removals data was just plain wrong. When reverting trie state to block N we've just moved removals data for all blocks > N into our target block. That removals data was effectively nodes that have been deleted from the trie after block N. The problem with this is that when we were then removing trie nodes based on the removals data of block N later, we might be deleting nodes that were still reachable at that block!

This change fixes this by removing the special case: when doing a revert we are _always_ just applying a reverse diff to the _current_ state of the trie. This makes sure that we'll compute and insert new state roots for the target block and that the _removals_ data for that block will indeed only contain nodes that are unreachable (either by having been removed at a previous reorged-away block _or_ by the reverse update).

Another independent problem was fixed: when reverting state for a contract whose storage is completely empty the revert process stopped with an error. Such contracts have _no_ contract root in the database so in case loading the contract root fails we should default that to zero instead of failing.

This change has been tested using the `feeder_gateway` tool triggering thousands of multi-block reorgs while syncing Sepolia testnet block range 113k to 194k. Without this fix this end-to-end test was consistently reproducing the "missing node" issue.

Closes: #2170
