### PR TITLE
Disable version update check flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Pathfinder now fetches data concurrently from the feeder gateway when catching up. The `--gateway.fetch-concurrency` CLI option can be used to limit how many blocks are fetched concurrently (the default is 8).
+- `--disable-version-update-check` CLI option has been added to disable the periodic checking for a new version.
 
 ### Changed
 

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -149,6 +149,15 @@ Examples:
     )]
     color: Color,
 
+    #[arg(
+        long = "disable-version-update-check",
+        long_help = "Disable the periodic version update check.",
+        default_value = "false",
+        env = "PATHFINDER_DISABLE_VERSION_UPDATE_CHECK",
+        value_name = "BOOL"
+    )]
+    disable_version_update_check: bool,
+
     #[cfg(feature = "p2p")]
     #[clap(flatten)]
     p2p: P2PCli,
@@ -684,6 +693,7 @@ pub struct Config {
     pub poll_interval: std::time::Duration,
     pub l1_poll_interval: std::time::Duration,
     pub color: Color,
+    pub disable_version_update_check: bool,
     pub p2p: P2PConfig,
     pub debug: DebugConfig,
     pub verify_tree_hashes: bool,
@@ -970,6 +980,7 @@ impl Config {
             poll_interval: Duration::from_secs(cli.poll_interval.get()),
             l1_poll_interval: Duration::from_secs(cli.l1_poll_interval.get()),
             color: cli.color,
+            disable_version_update_check: cli.disable_version_update_check,
             p2p: P2PConfig::parse_or_exit(cli.p2p),
             debug: DebugConfig::parse(cli.debug),
             verify_tree_hashes: cli.verify_tree_node_data,

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -289,7 +289,9 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
         tokio::spawn(std::future::pending())
     };
 
-    tokio::spawn(update::poll_github_for_releases());
+    if !config.disable_version_update_check {
+        tokio::spawn(update::poll_github_for_releases());
+    }
 
     let mut term_signal = signal(SignalKind::terminate())?;
     let mut int_signal = signal(SignalKind::interrupt())?;


### PR DESCRIPTION
Add flag to disable the version update check.

---------------------------

The version update check is not useful in some environments, and adds unnecessary noise to the logs in these situations.  This allows for the check to be disabled if required.

---------------------------
