### PR TITLE
fix(rpc/method/syncing): `starknet_syncing` should return false when caught up

### DIFF
--- a/crates/rpc/src/method/syncing.rs
+++ b/crates/rpc/src/method/syncing.rs
@@ -7,7 +7,17 @@ pub struct Output(Syncing);
 
 pub async fn syncing(context: RpcContext) -> Result<Output, Error> {
     // Scoped so I don't have to think too hard about mutex guard drop semantics.
-    let value = { context.sync_status.status.read().await.clone() };
+    let value = match *context.sync_status.status.read().await {
+        Syncing::False(_) => Syncing::False(false),
+        Syncing::Status(status) => {
+            if status.highest.number.get() - status.current.number.get() < 6 {
+                // In case we're (almost) caught up we just return false.
+                Syncing::False(false)
+            } else {
+                Syncing::Status(status)
+            }
+        }
+    };
 
     Ok(Output(value))
 }
@@ -21,5 +31,68 @@ impl crate::dto::serialize::SerializeForVersion for Output {
             Syncing::False(_) => serializer.serialize_bool(false),
             Syncing::Status(status) => serializer.serialize(&crate::dto::SyncStatus(&status)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pathfinder_common::{block_hash, BlockNumber};
+
+    use super::*;
+    use crate::v02::types::syncing::{NumberedBlock, Status};
+
+    #[tokio::test]
+    async fn not_started_yet() {
+        let context = RpcContext::for_tests();
+
+        *context.sync_status.status.write().await = Syncing::False(false);
+
+        assert_eq!(syncing(context).await.unwrap().0, Syncing::False(false));
+    }
+
+    #[tokio::test]
+    async fn caught_up() {
+        let context = RpcContext::for_tests();
+
+        *context.sync_status.status.write().await = Syncing::Status(Status {
+            starting: NumberedBlock {
+                hash: block_hash!("0xaaaa"),
+                number: BlockNumber::new_or_panic(0),
+            },
+            current: NumberedBlock {
+                hash: block_hash!("0xaaaa"),
+                number: BlockNumber::new_or_panic(0),
+            },
+            highest: NumberedBlock {
+                hash: block_hash!("0xaaaa"),
+                number: BlockNumber::new_or_panic(0),
+            },
+        });
+
+        assert_eq!(syncing(context).await.unwrap().0, Syncing::False(false));
+    }
+
+    #[tokio::test]
+    async fn syncing_in_progress() {
+        let context = RpcContext::for_tests();
+
+        let status = Status {
+            starting: NumberedBlock {
+                hash: block_hash!("0xaaaa"),
+                number: BlockNumber::new_or_panic(0),
+            },
+            current: NumberedBlock {
+                hash: block_hash!("0xbbbb"),
+                number: BlockNumber::new_or_panic(2),
+            },
+            highest: NumberedBlock {
+                hash: block_hash!("0xcccc"),
+                number: BlockNumber::new_or_panic(10),
+            },
+        };
+
+        *context.sync_status.status.write().await = Syncing::Status(status);
+
+        assert_eq!(syncing(context).await.unwrap().0, Syncing::Status(status));
     }
 }


### PR DESCRIPTION
This change modifies the `starknet_syncing` method to just return false when we're caught up. "Caught up" means within 5 blocks of the tip of the chain for now.

This PR does change behavior only for the JSON-RPC 0.7.1 API though -- we plan to remove the 0.6 API soon anyway so we should not be making semantic changes there.

Closes: #2253
