### PR TITLE
Add process_start_time_seconds metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pathfinder now fetches data concurrently from the feeder gateway when catching up. The `--gateway.fetch-concurrency` CLI option can be used to limit how many blocks are fetched concurrently (the default is 8).
 - `--disable-version-update-check` CLI option has been added to disable the periodic checking for a new version.
+- add `process_start_time_seconds` metric showing the unix timestamp when the process started.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -317,6 +317,10 @@ This endpoint is useful for Docker nodes which only want to present themselves a
 
 `/metrics` provides a [Prometheus](https://prometheus.io/) metrics scrape endpoint. Currently the following metrics are available:
 
+#### Process metrics
+
+- `process_start_time_seconds` provides the unix timestamp at which pathfinder started
+
 #### RPC related counters
 
 - `rpc_method_calls_total`,


### PR DESCRIPTION
Add a metric tracking the start time of the process.


Most L1 clients have this kind of metric, which allows alerting in case of crash/failure and restart.  This adds the `process_start_time_seconds` metric which is set to a suitable value when pathfinder starts.