### PR TITLE
fix: correctly handle contract without storage items

### DIFF
--- a/crates/merkle-tree/src/contract.rs
+++ b/crates/merkle-tree/src/contract.rs
@@ -12,13 +12,8 @@ use bitvec::slice::BitSlice;
 use pathfinder_common::hash::PedersenHash;
 use pathfinder_common::trie::TrieNode;
 use pathfinder_common::{
-    BlockNumber,
-    ContractAddress,
-    ContractRoot,
-    ContractStateHash,
-    StorageAddress,
-    StorageCommitment,
-    StorageValue,
+    BlockNumber, ContractAddress, ContractRoot, ContractStateHash, StorageAddress,
+    StorageCommitment, StorageValue,
 };
 use pathfinder_crypto::Felt;
 use pathfinder_storage::{Transaction, TrieUpdate};
@@ -83,15 +78,8 @@ impl<'tx> ContractsStorageTree<'tx> {
         contract: ContractAddress,
         block: BlockNumber,
         key: &BitSlice<u8, Msb0>,
+        root: u64,
     ) -> anyhow::Result<Option<Vec<TrieNode>>> {
-        let root = tx
-            .contract_root_index(block, contract)
-            .context("Querying contract root index")?;
-
-        let Some(root) = root else {
-            return Ok(None);
-        };
-
         let storage = ContractStorage {
             tx,
             block: Some(block),

--- a/crates/rpc/src/pathfinder/methods/get_proof.rs
+++ b/crates/rpc/src/pathfinder/methods/get_proof.rs
@@ -214,7 +214,11 @@ pub async fn get_proof(
             .contract_state_hash(header.number, input.contract_address)
             .context("Fetching contract's state hash")?;
 
-        if contract_state_hash.is_none() {
+        let root = tx
+            .contract_root_index(header.number, input.contract_address)
+            .context("Querying contract root index")?;
+
+        if contract_state_hash.is_none() || root.is_none() {
             return Ok(GetProofOutput {
                 state_commitment,
                 class_commitment,
@@ -245,6 +249,7 @@ pub async fn get_proof(
                 input.contract_address,
                 header.number,
                 k.view_bits(),
+                root.unwrap()
             )
             .context("Get proof from contract state tree")?
             .ok_or_else(|| {


### PR DESCRIPTION
Problem: pathfinder returns an internal error when one tries to fetch a proof for contract without storage items.

Solution: Early return when the root is none.

