### PR TITLE
feat(p2p): do not add dialed peer to the DHT explicitly

### DIFF
--- a/crates/p2p/src/main_loop.rs
+++ b/crates/p2p/src/main_loop.rs
@@ -752,10 +752,6 @@ impl MainLoop {
                 if let std::collections::hash_map::Entry::Vacant(e) =
                     self.pending_dials.entry(peer_id)
                 {
-                    self.swarm
-                        .behaviour_mut()
-                        .kademlia_mut()
-                        .add_address(&peer_id, addr.clone());
                     match self.swarm.dial(
                         // Dial a known peer with a given address only if it's not connected yet
                         // and we haven't started dialing yet.


### PR DESCRIPTION
We were calling [`kad::Behaviour::add_address`](https://docs.rs/libp2p/latest/libp2p/kad/struct.Behaviour.html#method.add_address) just before dialing a peer.

- This is not necessary as the peer will be added when [the connection is established](https://github.com/libp2p/rust-libp2p/blob/8ceadaac5aec4b462463ef4082d6af577a3158b1/protocols/kad/src/behaviour.rs#L135).
- `add_address` is still called in reaction to Identify messages, which is it's intended use.