### PR TITLE
Fix flaky tests

### DIFF
--- a/crates/p2p/src/behaviour.rs
+++ b/crates/p2p/src/behaviour.rs
@@ -678,7 +678,7 @@ impl Behaviour {
         let timeout = if cfg!(test) {
             // Needs to be large enough to mitigate the possibility of failing explicit
             // dials in tests, due to implicit dials triggered by automatic bootstrapping.
-            Duration::from_secs(15)
+            Duration::from_secs(5)
         } else {
             Duration::from_secs(30)
         };

--- a/crates/p2p/src/behaviour/builder.rs
+++ b/crates/p2p/src/behaviour/builder.rs
@@ -80,7 +80,7 @@ impl Builder {
         self
     }
 
-    pub fn build(self, client: crate::Client) -> BehaviourWithRelayTransport {
+    pub fn build(self) -> BehaviourWithRelayTransport {
         let Self {
             identity,
             chain_id,
@@ -150,7 +150,6 @@ impl Builder {
             Behaviour {
                 peers: PeerSet::new(cfg.eviction_timeout),
                 cfg,
-                swarm: client,
                 secret,
                 inner: Inner {
                     relay,
@@ -172,6 +171,7 @@ impl Builder {
                     transaction_sync,
                     event_sync,
                 },
+                pending_events: Default::default(),
             },
             relay_transport,
         )

--- a/crates/p2p/src/builder.rs
+++ b/crates/p2p/src/builder.rs
@@ -50,7 +50,7 @@ impl Builder {
 
         let (behaviour, relay_transport) = behaviour_builder
             .unwrap_or_else(|| Behaviour::builder(keypair.clone(), chain_id, cfg))
-            .build(client.clone());
+            .build();
 
         let swarm = Swarm::new(
             transport::create(&keypair, relay_transport),

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -25,6 +25,7 @@ mod main_loop;
 mod peer_data;
 mod peers;
 mod secret;
+mod short_id;
 mod sync;
 #[cfg(test)]
 mod test_utils;

--- a/crates/p2p/src/short_id.rs
+++ b/crates/p2p/src/short_id.rs
@@ -1,0 +1,115 @@
+#![allow(dead_code)]
+
+use std::fmt::{Debug, Display};
+use std::str;
+
+use libp2p::PeerId;
+
+/// A debug-friendly representation of a `PeerId` that only keeps the last two
+/// characters of the base58 representation.
+///
+/// ### Important
+///
+/// Do not use it in production, given a large number of peers collisions
+/// __will__ occur.
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ShortId([u8; 2]);
+
+impl Debug for ShortId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(str::from_utf8(&self.0).expect("Base58 characters are ASCII"))
+    }
+}
+
+impl Display for ShortId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(self, f)
+    }
+}
+
+impl From<&PeerId> for ShortId {
+    fn from(peer_id: &PeerId) -> Self {
+        let s = peer_id.to_base58();
+        let s = s.as_bytes();
+        let mut short = [0; 2];
+        short.copy_from_slice(&s[s.len() - 2..]);
+        ShortId(short)
+    }
+}
+
+impl From<PeerId> for ShortId {
+    fn from(peer_id: PeerId) -> Self {
+        ShortId::from(&peer_id)
+    }
+}
+
+pub mod prelude {
+    use std::collections::{BTreeSet, HashMap, HashSet};
+
+    use libp2p::PeerId;
+
+    use super::ShortId;
+
+    pub trait Short {
+        fn short(&self) -> ShortId;
+    }
+
+    impl Short for PeerId {
+        fn short(&self) -> ShortId {
+            ShortId::from(self)
+        }
+    }
+
+    pub trait IntoKeysShort {
+        fn into_keys_short(self) -> BTreeSet<ShortId>;
+    }
+
+    impl<T, U, V> IntoKeysShort for T
+    where
+        T: IntoIterator<Item = V, IntoIter = U>,
+        U: Iterator<Item = V>,
+        V: PeerIdField,
+    {
+        fn into_keys_short(self) -> BTreeSet<ShortId> {
+            self.into_iter().map(|x| x.peer_id().short()).collect()
+        }
+    }
+
+    pub trait KeysShort {
+        fn keys_short(&self) -> BTreeSet<ShortId>;
+    }
+
+    impl KeysShort for Vec<PeerId> {
+        fn keys_short(&self) -> BTreeSet<ShortId> {
+            self.iter().map(Short::short).collect()
+        }
+    }
+
+    impl KeysShort for HashSet<PeerId> {
+        fn keys_short(&self) -> BTreeSet<ShortId> {
+            self.iter().map(Short::short).collect()
+        }
+    }
+
+    impl<T> KeysShort for HashMap<PeerId, T> {
+        fn keys_short(&self) -> BTreeSet<ShortId> {
+            self.keys().map(Short::short).collect()
+        }
+    }
+
+    pub trait PeerIdField {
+        fn peer_id(&self) -> PeerId;
+    }
+
+    impl<T> PeerIdField for (PeerId, T) {
+        fn peer_id(&self) -> PeerId {
+            self.0
+        }
+    }
+
+    impl PeerIdField for PeerId {
+        fn peer_id(&self) -> PeerId {
+            *self
+        }
+    }
+}

--- a/crates/p2p/src/tests.rs
+++ b/crates/p2p/src/tests.rs
@@ -595,6 +595,9 @@ async fn inbound_peer_eviction() {
     .await
     .unwrap();
 
+    // Let it settle.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
     let connected = peer.connected().await;
     // 25 inbound and 1 outbound peer.
     assert_eq!(connected.len(), 26);
@@ -685,6 +688,13 @@ async fn evicted_peer_reconnection() {
         _ => None,
     })
     .await;
+
+    // Let it settle.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let connected_to_peer1 = peer1.connected().await;
+    assert!(connected_to_peer1.contains_key(&peer2.peer_id));
+    assert!(!connected_to_peer1.contains_key(&peer3.peer_id));
 }
 
 /// Test that peers can only connect if they are whitelisted.

--- a/crates/p2p/src/tests.rs
+++ b/crates/p2p/src/tests.rs
@@ -567,6 +567,10 @@ async fn inbound_peer_eviction() {
             .unwrap();
     }
 
+    // Let the automatic bootstrap "noise" fade away as in some circumstances it can
+    // cause additional dials that interrupt the flow of the test
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
     let connected = peer.connected().await;
     // 25 inbound and 1 outbound peer.
     assert_eq!(connected.len(), 26);


### PR DESCRIPTION
- Attempt to remove the sloppiness from `evicted_peer_reconnection` and `inbound_peer_eviction`.
- Switch to using `ToSwarm` for peer disconnection.
- A `Short[Peer]Id` utility for debugging.
