### PR TITLE
chore: remove support for pre-0.13.2 block signatures and state diff commitments

### DIFF
--- a/crates/common/src/signature.rs
+++ b/crates/common/src/signature.rs
@@ -1,9 +1,6 @@
 use fake::Dummy;
-use pathfinder_crypto::hash::poseidon_hash_many;
-use pathfinder_crypto::signature::{ecdsa_verify_partial, SignatureError};
-use pathfinder_crypto::Felt;
 
-use crate::{BlockCommitmentSignatureElem, BlockHash, PublicKey, StateDiffCommitment};
+use crate::{BlockCommitmentSignatureElem, BlockHash, PublicKey};
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Dummy)]
 pub struct BlockCommitmentSignature {
@@ -12,69 +9,24 @@ pub struct BlockCommitmentSignature {
 }
 
 impl BlockCommitmentSignature {
-    // TODO remove fallback to pre-0.13.2 verification method after 0.13.2 is rolled
-    // out on mainnet.
     pub fn verify(
         &self,
         public_key: PublicKey,
         block_hash: BlockHash,
-        state_diff_commitment: StateDiffCommitment,
-    ) -> Result<(), SignatureError> {
-        self.verify_0_13_2(public_key, block_hash)
-            .or_else(|_| self.verify_pre_0_13_2(public_key, block_hash, state_diff_commitment))
-    }
-
-    fn verify_pre_0_13_2(
-        &self,
-        public_key: PublicKey,
-        block_hash: BlockHash,
-        state_diff_commitment: StateDiffCommitment,
-    ) -> Result<(), SignatureError> {
-        let msg = Felt::from(poseidon_hash_many(&[
-            block_hash.0.into(),
-            state_diff_commitment.0.into(),
-        ]));
-        ecdsa_verify_partial(public_key.0, msg, self.r.0, self.s.0)
-    }
-
-    fn verify_0_13_2(
-        &self,
-        public_key: PublicKey,
-        block_hash: BlockHash,
-    ) -> Result<(), SignatureError> {
-        ecdsa_verify_partial(public_key.0, block_hash.0, self.r.0, self.s.0)
+    ) -> Result<(), pathfinder_crypto::signature::SignatureError> {
+        pathfinder_crypto::signature::ecdsa_verify_partial(
+            public_key.0,
+            block_hash.0,
+            self.r.0,
+            self.s.0,
+        )
     }
 }
 
 #[cfg(test)]
 mod test {
     use crate::macro_prelude::*;
-    use crate::{BlockCommitmentSignature, StateDiffCommitment};
-
-    #[test]
-    fn pre_0_13_2_verification_method() {
-        // From https://alpha-mainnet.starknet.io/feeder_gateway/get_public_key
-        let public_key =
-            public_key!("0x48253ff2c3bed7af18bde0b611b083b39445959102d4947c51c4db6aa4f4e58");
-        // From https://alpha-mainnet.starknet.io/feeder_gateway/get_signature?blockNumber=635000
-        let block_hash =
-            block_hash!("0x164685e53f274ecb60a3941303a6ee913aeb9016fbca5ba65c1cb8bdaee17a0");
-        let state_diff_commitment = state_diff_commitment!(
-            "0x620efa2bd1149abe485486efa35c29571b4883f9f54a7f4938389276b0579ff"
-        );
-        let signature = BlockCommitmentSignature {
-            r: block_commitment_signature_elem!(
-                "0x222679bdc9007386f5c2de62e89839b442799f356b24657af77e2a8aa87e74d"
-            ),
-            s: block_commitment_signature_elem!(
-                "0x16c9d0bab74fe4f268705559e16ebb36a5326e75c6a580e6ad3194fb9a0b1ed"
-            ),
-        };
-
-        signature
-            .verify(public_key, block_hash, state_diff_commitment)
-            .unwrap();
-    }
+    use crate::BlockCommitmentSignature;
 
     #[test]
     fn _0_13_2_verification_method_for_the_last_0_13_1_1_block() {
@@ -96,9 +48,7 @@ mod test {
         // Use some fake state diff commitment which should be ignored by the
         // verification method because there should be no fallback to the
         // pre-0.13.2 verification method in this case.
-        signature
-            .verify(public_key, block_hash, StateDiffCommitment::ZERO)
-            .unwrap();
+        signature.verify(public_key, block_hash).unwrap();
     }
 
     #[test]
@@ -121,8 +71,6 @@ mod test {
         // Use some fake state diff commitment which should be ignored by the
         // verification method because there should be no fallback to the
         // pre-0.13.2 verification method in this case.
-        signature
-            .verify(public_key, block_hash, StateDiffCommitment::ZERO)
-            .unwrap();
+        signature.verify(public_key, block_hash).unwrap();
     }
 }

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -1164,7 +1164,7 @@ mod tests {
             let (_jh, url) = setup([(
                 "/feeder_gateway/get_signature?blockNumber=350000",
                 (
-                    starknet_gateway_test_fixtures::v0_12_2::signature::BLOCK_350000,
+                    starknet_gateway_test_fixtures::v0_13_2::signature::SEPOLIA_INTEGRATION_35748,
                     200,
                 ),
             )]);

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -2204,55 +2204,16 @@ pub mod add_transaction {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, serde::Serialize)]
-#[serde(untagged)]
-pub enum BlockSignature {
-    /// Starknet <=0.13.1.1
-    // TODO V0 does not say much, is V_0_13_1_1 a better name?
-    V0(BlockSignatureV0),
-    /// Starknet >= 0.13.2
-    // TODO V1 does not say much, is V_0_13_2 a better name?
-    V1(BlockSignatureV1),
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, serde::Serialize)]
-pub struct BlockSignatureV1 {
+pub struct BlockSignature {
     pub block_hash: BlockHash,
     pub signature: [BlockCommitmentSignatureElem; 2],
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, serde::Serialize)]
-pub struct BlockSignatureV0 {
-    pub block_number: BlockNumber,
-    pub signature: [BlockCommitmentSignatureElem; 2],
-    pub signature_input: BlockSignatureInput,
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, serde::Serialize)]
-pub struct BlockSignatureInput {
-    pub block_hash: BlockHash,
-    pub state_diff_commitment: StateDiffCommitment,
 }
 
 impl BlockSignature {
-    pub fn block_hash(&self) -> BlockHash {
-        match self {
-            BlockSignature::V0(v0) => v0.signature_input.block_hash,
-            BlockSignature::V1(v1) => v1.block_hash,
-        }
-    }
-
     pub fn signature(&self) -> pathfinder_common::BlockCommitmentSignature {
-        let s = match self {
-            BlockSignature::V0(v0) => v0.signature,
-            BlockSignature::V1(v1) => v1.signature,
-        };
-        pathfinder_common::BlockCommitmentSignature { r: s[0], s: s[1] }
-    }
-
-    pub fn state_diff_commitment(&self) -> Option<StateDiffCommitment> {
-        match self {
-            BlockSignature::V0(v0) => Some(v0.signature_input.state_diff_commitment),
-            BlockSignature::V1(_) => None,
+        pathfinder_common::BlockCommitmentSignature {
+            r: self.signature[0],
+            s: self.signature[1],
         }
     }
 }
@@ -2427,57 +2388,16 @@ mod tests {
     }
 
     mod block_signature {
-        use pathfinder_common::{
-            block_commitment_signature_elem,
-            block_hash,
-            state_diff_commitment,
-            BlockNumber,
-            StarknetVersion,
-        };
+        use pathfinder_common::{block_commitment_signature_elem, block_hash};
 
-        use super::super::{
-            BlockSignature,
-            BlockSignatureInput,
-            BlockSignatureV0,
-            BlockSignatureV1,
-            StateUpdate,
-        };
-
-        #[test]
-        fn parse_pre_starknet_0_13_2() {
-            let json = starknet_gateway_test_fixtures::v0_12_2::signature::BLOCK_350000;
-
-            let expected = BlockSignature::V0(BlockSignatureV0 {
-                block_number: BlockNumber::new_or_panic(350000),
-                signature: [
-                    block_commitment_signature_elem!(
-                        "0x95e98f5b91d39ae2b1bf77447a4fc01725352ae8b0b2c0a3fe09d43d1d9e57"
-                    ),
-                    block_commitment_signature_elem!(
-                        "0x541b2db8dae6d5ae24b34e427d251edc2e94dcffddd85f207e1b51f2f4bb1ef"
-                    ),
-                ],
-                signature_input: BlockSignatureInput {
-                    block_hash: block_hash!(
-                        "0x6f7342a680d7f99bdfdd859f587c75299e7ffabe62c071ded3a6d8a34cb132c"
-                    ),
-                    state_diff_commitment: state_diff_commitment!(
-                        "0x432e8e2ad833548e1c1077fc298991b055ba1e6f7a17dd332db98f4f428c56c"
-                    ),
-                },
-            });
-
-            let signature: BlockSignature = serde_json::from_str(json).unwrap();
-
-            assert_eq!(signature, expected);
-        }
+        use super::super::BlockSignature;
 
         #[test]
         fn parse_starknet_0_13_2() {
             let json =
                 starknet_gateway_test_fixtures::v0_13_2::signature::SEPOLIA_INTEGRATION_35748;
 
-            let expected = BlockSignature::V1(BlockSignatureV1 {
+            let expected = BlockSignature {
                 block_hash: block_hash!(
                     "0x1ea2a9cfa3df5297d58c0a04d09d276bc68d40fe64701305bbe2ed8f417e869"
                 ),
@@ -2489,28 +2409,11 @@ mod tests {
                         "0x3e67cfbc5b179ba55a3b687228d8fe40626233f6691b4aabe308fcd6d71dcdb"
                     ),
                 ],
-            });
+            };
 
             let signature: BlockSignature = serde_json::from_str(json).unwrap();
 
             assert_eq!(signature, expected);
-        }
-
-        #[test]
-        fn state_diff_commitment() {
-            let signature_json = starknet_gateway_test_fixtures::v0_12_2::signature::BLOCK_350000;
-            let signature: BlockSignature = serde_json::from_str(signature_json).unwrap();
-
-            let state_update_json =
-                starknet_gateway_test_fixtures::v0_12_2::state_update::BLOCK_350000;
-            let state_update: StateUpdate = serde_json::from_str(state_update_json).unwrap();
-
-            let state_update = pathfinder_common::StateUpdate::from(state_update);
-
-            assert_eq!(
-                state_update.compute_state_diff_commitment(StarknetVersion::new(0, 12, 2, 0)),
-                signature.state_diff_commitment().unwrap()
-            )
         }
     }
 }

--- a/crates/pathfinder/examples/compute_pre0132_hashes.rs
+++ b/crates/pathfinder/examples/compute_pre0132_hashes.rs
@@ -103,7 +103,7 @@ fn main() -> anyhow::Result<()> {
         let state_update = tx
             .state_update(block_id)?
             .context("Fetching state update")?;
-        header.state_diff_commitment = state_update.compute_state_diff_commitment(VERSION_CUTOFF);
+        header.state_diff_commitment = state_update.compute_state_diff_commitment();
 
         drop(tx);
 

--- a/crates/pathfinder/examples/feeder_gateway.rs
+++ b/crates/pathfinder/examples/feeder_gateway.rs
@@ -492,12 +492,10 @@ fn resolve_signature(
             s: BlockCommitmentSignatureElem::ZERO,
         });
 
-    Ok(starknet_gateway_types::reply::BlockSignature::V1(
-        starknet_gateway_types::reply::BlockSignatureV1 {
-            block_hash: header.hash,
-            signature: [signature.r, signature.s],
-        },
-    ))
+    Ok(starknet_gateway_types::reply::BlockSignature {
+        block_hash: header.hash,
+        signature: [signature.r, signature.s],
+    })
 }
 
 #[tracing::instrument(level = "trace", skip(tx))]

--- a/crates/pathfinder/examples/recompute_state_diff_length.rs
+++ b/crates/pathfinder/examples/recompute_state_diff_length.rs
@@ -27,9 +27,6 @@ fn main() -> anyhow::Result<()> {
     for block_number in 0..latest_block_number.get() {
         let block_number = BlockNumber::new_or_panic(block_number);
         let block_id = pathfinder_storage::BlockId::Number(block_number);
-        let version = tx
-            .block_version(block_number)?
-            .context("Fetching block version")?;
         let state_update = tx
             .state_update(block_id)?
             .context("Fetching state update")?;
@@ -38,7 +35,7 @@ fn main() -> anyhow::Result<()> {
             .context("Fetching block header")?;
 
         let state_diff_length = state_update.state_diff_length();
-        let state_diff_commitment = state_update.compute_state_diff_commitment(version);
+        let state_diff_commitment = state_update.compute_state_diff_commitment();
 
         if state_diff_length != header.state_diff_length
             || state_diff_commitment != header.state_diff_commitment

--- a/crates/pathfinder/src/state/block_hash.rs
+++ b/crates/pathfinder/src/state/block_hash.rs
@@ -1083,8 +1083,7 @@ mod tests {
             serde_json::from_str(v0_13_2::state_update::SEPOLIA_INTEGRATION_35748).unwrap();
         let state_update: pathfinder_common::StateUpdate = state_update.into();
         let state_diff_length = state_update.state_diff_length();
-        let state_diff_commitment =
-            state_update.compute_state_diff_commitment(StarknetVersion::new(0, 13, 2, 0));
+        let state_diff_commitment = state_update.compute_state_diff_commitment();
 
         assert_eq!(state_diff_length, block.state_diff_length.unwrap());
         assert_eq!(state_diff_commitment, block.state_diff_commitment.unwrap());

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -274,56 +274,14 @@ where
 
         // An extra sanity check for the signature API.
         anyhow::ensure!(
-            block.block_hash == signature.block_hash(),
+            block.block_hash == signature.block_hash,
             "Signature block hash mismatch, actual {:x}, expected {:x}",
-            signature.block_hash().0,
+            signature.block_hash.0,
             block.block_hash.0,
         );
 
-        // Always compute the state diff commitment from the state update.
-        // If any of the feeder gateway replies (block or signature) contain a state
-        // diff commitment, check if the value matches. If it doesn't, just log the
-        // fact.
-        let version = block.starknet_version;
-        let (computed_state_diff_commitment, state_update) =
-            tokio::task::spawn_blocking(move || {
-                let commitment = state_update.compute_state_diff_commitment(version);
-                (commitment, state_update)
-            })
-            .await?;
-
-        let fgw_state_diff_commitment = match (
-            block.state_diff_commitment,
-            signature.state_diff_commitment(),
-        ) {
-            (Some(x), None) | (None, Some(x)) => Some(x),
-            // This should never happen, but if it does, we treat it as a sanity check for the API.
-            (Some(x), Some(y)) => {
-                anyhow::ensure!(
-                    x == y,
-                    "Conflicting feeder gateway responses: state diff commitment in block {:x} vs \
-                     in signature {:x}",
-                    y.0,
-                    x.0,
-                );
-                Some(x)
-            }
-            _ => None,
-        };
-
-        if let Some(x) = fgw_state_diff_commitment {
-            if x != computed_state_diff_commitment {
-                tracing::warn!(
-                    "State diff commitment mismatch: computed {:x}, feeder gateway {:x}",
-                    computed_state_diff_commitment.0,
-                    x.0
-                );
-            }
-        }
-
-        let signature = signature.signature();
-
         // Check block commitment signature
+        let signature: BlockCommitmentSignature = signature.signature();
         let (signature, state_update) = match block_validation_mode {
             BlockValidationMode::Strict => {
                 let block_hash = block.block_hash;
@@ -332,7 +290,6 @@ where
                         .verify(
                             sequencer_public_key,
                             block_hash,
-                            computed_state_diff_commitment,
                         );
                     (verify_result, signature, state_update)
                 }).await?;
@@ -343,6 +300,15 @@ where
             }
             BlockValidationMode::AllowMismatch => (signature, state_update),
         };
+
+        // Always compute the state diff commitment from the state update.
+        let version = block.starknet_version;
+        let (computed_state_diff_commitment, state_update) =
+            tokio::task::spawn_blocking(move || {
+                let commitment = state_update.compute_state_diff_commitment(version);
+                (commitment, state_update)
+            })
+            .await?;
 
         head = Some((next, block.block_hash, state_update.state_commitment));
         blocks.push(next, block.block_hash, state_update.state_commitment);
@@ -699,7 +665,6 @@ where
                         )| {
                             verify_signature(
                                 block.block_hash,
-                                state_diff_commitment,
                                 &signature,
                                 sequencer_public_key,
                                 BlockValidationMode::AllowMismatch,
@@ -1027,16 +992,13 @@ fn verify_transaction_hashes(
 /// Check block commitment signature.
 fn verify_signature(
     block_hash: BlockHash,
-    state_diff_commitment: StateDiffCommitment,
     signature: &BlockSignature,
     sequencer_public_key: PublicKey,
     mode: BlockValidationMode,
 ) -> Result<(), pathfinder_crypto::signature::SignatureError> {
     let signature = signature.signature();
     match mode {
-        BlockValidationMode::Strict => {
-            signature.verify(sequencer_public_key, block_hash, state_diff_commitment)
-        }
+        BlockValidationMode::Strict => signature.verify(sequencer_public_key, block_hash),
         BlockValidationMode::AllowMismatch => Ok(()),
     }
 }
@@ -1196,113 +1158,64 @@ mod tests {
         const STORAGE_VAL0_V2: StorageValue = storage_value_bytes!(b"contract 0 storage val 0 v2");
         const STORAGE_VAL1: StorageValue = storage_value_bytes!(b"contract 1 storage val 0");
 
-        const BLOCK0_SIGNATURE: reply::BlockSignature =
-            reply::BlockSignature::V0(reply::BlockSignatureV0 {
-                block_number: BLOCK0_NUMBER,
-                signature: [
-                    block_commitment_signature_elem_bytes!(b"block 0 signature r"),
-                    block_commitment_signature_elem_bytes!(b"block 0 signature s"),
-                ],
-                signature_input: reply::BlockSignatureInput {
-                    block_hash: BLOCK0_HASH,
-                    state_diff_commitment: state_diff_commitment_bytes!(
-                        b"block 0 state diff commitment"
-                    ),
-                },
-            });
+        const BLOCK0_SIGNATURE: reply::BlockSignature = reply::BlockSignature {
+            block_hash: BLOCK0_HASH,
+            signature: [
+                block_commitment_signature_elem_bytes!(b"block 0 signature r"),
+                block_commitment_signature_elem_bytes!(b"block 0 signature s"),
+            ],
+        };
         // const BLOCK0_COMMITMENT_SIGNATURE: BlockCommitmentSignature =
         // BlockCommitmentSignature {     r: BLOCK0_SIGNATURE.signature[0],
         //     s: BLOCK0_SIGNATURE.signature[1],
         // };
-        const BLOCK0_SIGNATURE_V2: reply::BlockSignature =
-            reply::BlockSignature::V0(reply::BlockSignatureV0 {
-                block_number: BLOCK0_NUMBER,
-                signature: [
-                    block_commitment_signature_elem_bytes!(b"block 0 signature r 2"),
-                    block_commitment_signature_elem_bytes!(b"block 0 signature s 2"),
-                ],
-                signature_input: reply::BlockSignatureInput {
-                    block_hash: BLOCK0_HASH_V2,
-                    state_diff_commitment: state_diff_commitment_bytes!(
-                        b"block 0 state diff commitment 2"
-                    ),
-                },
-            });
+        const BLOCK0_SIGNATURE_V2: reply::BlockSignature = reply::BlockSignature {
+            block_hash: BLOCK0_HASH_V2,
+            signature: [
+                block_commitment_signature_elem_bytes!(b"block 0 signature r 2"),
+                block_commitment_signature_elem_bytes!(b"block 0 signature s 2"),
+            ],
+        };
 
-        const BLOCK1_SIGNATURE: reply::BlockSignature =
-            reply::BlockSignature::V0(reply::BlockSignatureV0 {
-                block_number: BLOCK1_NUMBER,
-                signature: [
-                    block_commitment_signature_elem_bytes!(b"block 1 signature r"),
-                    block_commitment_signature_elem_bytes!(b"block 1 signature s"),
-                ],
-                signature_input: reply::BlockSignatureInput {
-                    block_hash: BLOCK1_HASH,
-                    state_diff_commitment: state_diff_commitment_bytes!(
-                        b"block 1 state diff commitment"
-                    ),
-                },
-            });
+        const BLOCK1_SIGNATURE: reply::BlockSignature = reply::BlockSignature {
+            block_hash: BLOCK1_HASH,
+            signature: [
+                block_commitment_signature_elem_bytes!(b"block 1 signature r"),
+                block_commitment_signature_elem_bytes!(b"block 1 signature s"),
+            ],
+        };
         // const BLOCK1_COMMITMENT_SIGNATURE: BlockCommitmentSignature =
         // BlockCommitmentSignature {     r: BLOCK1_SIGNATURE.signature[0],
         //     s: BLOCK1_SIGNATURE.signature[1],
         // };
-        const BLOCK1_SIGNATURE_V2: reply::BlockSignature =
-            reply::BlockSignature::V0(reply::BlockSignatureV0 {
-                block_number: BLOCK1_NUMBER,
-                signature: [
-                    block_commitment_signature_elem_bytes!(b"block 1 signature r 2"),
-                    block_commitment_signature_elem_bytes!(b"block 1 signature s 2"),
-                ],
-                signature_input: reply::BlockSignatureInput {
-                    block_hash: BLOCK1_HASH_V2,
-                    state_diff_commitment: state_diff_commitment_bytes!(
-                        b"block 1 state diff commitment 2"
-                    ),
-                },
-            });
-        const BLOCK2_SIGNATURE: reply::BlockSignature =
-            reply::BlockSignature::V0(reply::BlockSignatureV0 {
-                block_number: BLOCK2_NUMBER,
-                signature: [
-                    block_commitment_signature_elem_bytes!(b"block 2 signature r"),
-                    block_commitment_signature_elem_bytes!(b"block 2 signature s"),
-                ],
-                signature_input: reply::BlockSignatureInput {
-                    block_hash: BLOCK2_HASH,
-                    state_diff_commitment: state_diff_commitment_bytes!(
-                        b"block 2 state diff commitment"
-                    ),
-                },
-            });
-        const BLOCK2_SIGNATURE_V2: reply::BlockSignature =
-            reply::BlockSignature::V0(reply::BlockSignatureV0 {
-                block_number: BLOCK2_NUMBER,
-                signature: [
-                    block_commitment_signature_elem_bytes!(b"block 2 signature r 2"),
-                    block_commitment_signature_elem_bytes!(b"block 2 signature s 2"),
-                ],
-                signature_input: reply::BlockSignatureInput {
-                    block_hash: BLOCK2_HASH_V2,
-                    state_diff_commitment: state_diff_commitment_bytes!(
-                        b"block 2 state diff commitment 2"
-                    ),
-                },
-            });
-        const BLOCK3_SIGNATURE: reply::BlockSignature =
-            reply::BlockSignature::V0(reply::BlockSignatureV0 {
-                block_number: BLOCK3_NUMBER,
-                signature: [
-                    block_commitment_signature_elem_bytes!(b"block 3 signature r"),
-                    block_commitment_signature_elem_bytes!(b"block 3 signature s"),
-                ],
-                signature_input: reply::BlockSignatureInput {
-                    block_hash: BLOCK3_HASH,
-                    state_diff_commitment: state_diff_commitment_bytes!(
-                        b"block 3 state diff commitment"
-                    ),
-                },
-            });
+        const BLOCK1_SIGNATURE_V2: reply::BlockSignature = reply::BlockSignature {
+            block_hash: BLOCK1_HASH_V2,
+            signature: [
+                block_commitment_signature_elem_bytes!(b"block 1 signature r 2"),
+                block_commitment_signature_elem_bytes!(b"block 1 signature s 2"),
+            ],
+        };
+        const BLOCK2_SIGNATURE: reply::BlockSignature = reply::BlockSignature {
+            block_hash: BLOCK2_HASH,
+            signature: [
+                block_commitment_signature_elem_bytes!(b"block 2 signature r"),
+                block_commitment_signature_elem_bytes!(b"block 2 signature s"),
+            ],
+        };
+        const BLOCK2_SIGNATURE_V2: reply::BlockSignature = reply::BlockSignature {
+            block_hash: BLOCK2_HASH_V2,
+            signature: [
+                block_commitment_signature_elem_bytes!(b"block 2 signature r 2"),
+                block_commitment_signature_elem_bytes!(b"block 2 signature s 2"),
+            ],
+        };
+        const BLOCK3_SIGNATURE: reply::BlockSignature = reply::BlockSignature {
+            block_hash: BLOCK3_HASH,
+            signature: [
+                block_commitment_signature_elem_bytes!(b"block 3 signature r"),
+                block_commitment_signature_elem_bytes!(b"block 3 signature s"),
+            ],
+        };
 
         fn spawn_sync_default(
             tx_event: mpsc::Sender<SyncEvent>,

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -302,10 +302,9 @@ where
         };
 
         // Always compute the state diff commitment from the state update.
-        let version = block.starknet_version;
         let (computed_state_diff_commitment, state_update) =
             tokio::task::spawn_blocking(move || {
-                let commitment = state_update.compute_state_diff_commitment(version);
+                let commitment = state_update.compute_state_diff_commitment();
                 (commitment, state_update)
             })
             .await?;
@@ -484,8 +483,8 @@ async fn download_block(
 
             // Check if commitments and block hash are correct
             let verify_hash = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
-                let state_diff_commitment = StateUpdateData::from(state_update.clone())
-                    .compute_state_diff_commitment(block.starknet_version);
+                let state_diff_commitment =
+                    StateUpdateData::from(state_update.clone()).compute_state_diff_commitment();
                 let state_update = Box::new(state_update);
                 let state_diff_length = state_update.state_diff_length();
 
@@ -909,8 +908,8 @@ fn verify_block_and_state_update(
     StateDiffCommitment,
 )> {
     // Check if commitments and block hash are correct
-    let state_diff_commitment = StateUpdateData::from(state_update.clone())
-        .compute_state_diff_commitment(block.starknet_version);
+    let state_diff_commitment =
+        StateUpdateData::from(state_update.clone()).compute_state_diff_commitment();
     let state_diff_length = state_update.state_diff_length();
 
     let verify_result = verify_gateway_block_commitments_and_hash(
@@ -949,8 +948,7 @@ fn verify_block_and_state_update(
     // If any of the feeder gateway replies (block or signature) contain a state
     // diff commitment, check if the value matches. If it doesn't, just log the
     // fact.
-    let version = block.starknet_version;
-    let computed_state_diff_commitment = state_update.compute_state_diff_commitment(version);
+    let computed_state_diff_commitment = state_update.compute_state_diff_commitment();
 
     if let Some(x) = block.state_diff_commitment {
         if x != computed_state_diff_commitment {

--- a/crates/pathfinder/src/sync/checkpoint/fixture.rs
+++ b/crates/pathfinder/src/sync/checkpoint/fixture.rs
@@ -84,7 +84,7 @@ pub fn blocks() -> [Block; 2] {
                     event_count: 0,
                     l1_da_mode: L1DataAvailabilityMode::Calldata,
                     receipt_commitment: receipt_commitment!("0x0200A173F6AECAB11A7166EFB0BF8F4362A8403CA32292695A37B322793F1302"),
-                    state_diff_commitment: state_diff_commitment!("0x06C4A7559B57CADED12AD2275F78C4AC310FF54B2E233D25C9CF4891C251B450"),
+                    state_diff_commitment: state_diff_commitment!("0x00A8AC20EF93DBE185D09AE31DE4EA3372ECF753F14EBAAE97ADAB22B1AB72F2"),
                     state_diff_length: 25,
                 },
                 signature: BlockCommitmentSignature {
@@ -1200,7 +1200,7 @@ pub fn blocks() -> [Block; 2] {
                     event_count: 0,
                     l1_da_mode: L1DataAvailabilityMode::Calldata,
                     receipt_commitment: receipt_commitment!("0x00FB6833B56FCA428975B0DF7875F35B7EADBD26B517DAF1B9702E1D85665065"),
-                    state_diff_commitment: state_diff_commitment!("0x013BEED68D79C0FF1D6B465660BCF245A7F0EC11AF5E9C6564FBA30543705FE3"),
+                    state_diff_commitment: state_diff_commitment!("0x05D83BBEEDF35B7D310A43B11F3623DD5D705FF09A7FBC8B634222E083433CAE"),
                     state_diff_length: 12,
                 },
                 signature: BlockCommitmentSignature {

--- a/crates/pathfinder/src/sync/headers.rs
+++ b/crates/pathfinder/src/sync/headers.rs
@@ -296,11 +296,7 @@ impl VerifyHashAndSignature {
     fn verify_signature(&self, header: &SignedBlockHeader) -> bool {
         header
             .signature
-            .verify(
-                self.public_key,
-                header.header.hash,
-                header.header.state_diff_commitment,
-            )
+            .verify(self.public_key, header.header.hash)
             .is_ok()
     }
 }

--- a/crates/pathfinder/src/sync/track.rs
+++ b/crates/pathfinder/src/sync/track.rs
@@ -514,14 +514,7 @@ struct StateDiffSource<P> {
 }
 
 impl<P> StateDiffSource<P> {
-    fn spawn(
-        self,
-    ) -> SyncReceiver<(
-        StateUpdateData,
-        BlockNumber,
-        StarknetVersion,
-        StateDiffCommitment,
-    )>
+    fn spawn(self) -> SyncReceiver<(StateUpdateData, BlockNumber, StateDiffCommitment)>
     where
         P: Clone + BlockClient + Send + 'static,
     {
@@ -557,7 +550,6 @@ impl<P> StateDiffSource<P> {
                         (
                             state_diff,
                             header.header.number,
-                            header.header.starknet_version,
                             header.header.state_diff_commitment,
                         ),
                     )))

--- a/crates/storage/src/fake.rs
+++ b/crates/storage/src/fake.rs
@@ -383,7 +383,6 @@ pub mod init {
                     SignedBlockHeader {
                         header:
                             BlockHeader {
-                                starknet_version,
                                 state_diff_length,
                                 state_diff_commitment,
                                 ..
@@ -424,8 +423,7 @@ pub mod init {
                 cairo_defs.extend(implicitly_declared);
 
                 *state_diff_length = state_update.state_diff_length();
-                *state_diff_commitment =
-                    state_update.compute_state_diff_commitment(*starknet_version);
+                *state_diff_commitment = state_update.compute_state_diff_commitment();
             }
 
             // Compute the block hash, update parent block hash with the correct value


### PR DESCRIPTION
Now that all networks have been upgraded to 0.13.2 we can remove support for pre-0.13.2 block signatures and the pre-0.13.2 state diff commitment calculation arguments used to verify those signatures.

Now we _always_ calculate, store and verify the new (0.13.2-style) state diff commitment values.