### PR TITLE
fix(pathfinder/block_hash): fix transaction commitment calculation for empty signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Pathfinder stops syncing Sepolia testnet at block 218484 because of a block hash mismatch.
+
 ## [0.14.3] - 2024-09-23
 
 ### Fixed

--- a/crates/pathfinder/examples/verify_transaction_commitment.rs
+++ b/crates/pathfinder/examples/verify_transaction_commitment.rs
@@ -1,0 +1,76 @@
+use std::num::NonZeroU32;
+
+use anyhow::Context;
+use pathfinder_common::BlockNumber;
+
+/// Verify transaction hashes in a pathfinder database.
+///
+/// Iterates over all blocks in the database and verifies if the computed
+/// transaction hashes match values we store for the block.
+///
+/// Usage:
+/// `cargo run --release -p pathfinder --example verify_transaction_hashes
+/// mainnet ./mainnet.sqlite 100`
+fn main() -> anyhow::Result<()> {
+    let database_path = std::env::args().nth(1).unwrap();
+    let start_block = std::env::args().nth(2).unwrap_or("0".into());
+
+    let start_block = start_block
+        .parse::<u64>()
+        .context("Parse start block number")?;
+
+    let storage = pathfinder_storage::StorageBuilder::file(database_path.into())
+        .migrate()?
+        .create_pool(NonZeroU32::new(1).unwrap())
+        .unwrap();
+    let mut db = storage
+        .connection()
+        .context("Opening database connection")?;
+
+    let latest_block_number = {
+        let tx = db.transaction().unwrap();
+        tx.block_id(pathfinder_storage::BlockId::Latest)
+            .context("Fetching latest block number")?
+            .context("Latest block number does not exist")?
+            .0
+    };
+
+    println!("Verifying transaction commitments...");
+
+    for block_number in start_block..latest_block_number.get() {
+        if block_number % 10 == 0 {
+            println!("Block: {block_number}")
+        }
+
+        let tx = db.transaction().unwrap();
+        let block_id = pathfinder_storage::BlockId::Number(BlockNumber::new_or_panic(block_number));
+        let header = tx
+            .block_header(block_id)
+            .context("Fetching block header")?
+            .context("Block header missing")?;
+        let transactions = tx
+            .transaction_data_for_block(block_id)?
+            .context("Transaction data missing")?;
+        drop(tx);
+
+        let transactions = transactions
+            .into_iter()
+            .map(|(tx, _, _)| tx)
+            .collect::<Vec<_>>();
+        let computed_transaction_commitment =
+            pathfinder_lib::state::block_hash::calculate_transaction_commitment(
+                &transactions,
+                header.starknet_version,
+            )?;
+
+        if computed_transaction_commitment != header.transaction_commitment {
+            println!(
+                "Mismatch: block {block_number}, calculated {computed_transaction_commitment}",
+            );
+        }
+    }
+
+    println!("Done.");
+
+    Ok(())
+}

--- a/crates/pathfinder/src/state/block_hash.rs
+++ b/crates/pathfinder/src/state/block_hash.rs
@@ -677,7 +677,13 @@ fn calculate_transaction_hash_with_signature(tx: &Transaction) -> Felt {
         TransactionVariant::InvokeV3(tx) => tx.signature.as_slice(),
         TransactionVariant::DeployV0(_)
         | TransactionVariant::DeployV1(_)
-        | TransactionVariant::L1Handler(_) => &[TransactionSignatureElem::ZERO],
+        | TransactionVariant::L1Handler(_) => &[],
+    };
+
+    let signature = if signature.is_empty() {
+        &[TransactionSignatureElem::ZERO]
+    } else {
+        signature
     };
 
     let mut hasher = PoseidonHasher::new();


### PR DESCRIPTION
Turns out our 0.13.2 transaction commitment calculation algorithm was slightly different compared to the one used by the sequencer: for transaction types that _do_ have a signature field but it's empty we are required to use `[0]` as the signature when calculating the commitment leaf value.

This issue was triggered in Sepolia testnet block 218484 that contains an Invoke v1 transaction with an empty signature field.

Closes: #2282