### PR TITLE
feat: add config option to skip casm compilation and download from fg…

### DIFF
--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -291,6 +291,15 @@ This should only be enabled for debugging purposes as it adds substantial proces
         env = "PATHFINDER_RPC_CUSTOM_VERSIONED_CONSTANTS_JSON_PATH"
     )]
     custom_versioned_constants_path: Option<PathBuf>,
+
+    #[arg(
+        long = "sync.fetch-casm-from-fgw",
+        long_help = "Do not compile classes locally, instead fetch them from the feeder gateway",
+        env = "PATHFINDER_SYNC_FETCH_CASM_FROM_FGW",
+        default_value = "false",
+        action=ArgAction::Set
+    )]
+    fetch_casm_from_fgw: bool,
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq)]
@@ -697,6 +706,7 @@ pub struct Config {
     pub state_tries: Option<StateTries>,
     pub custom_versioned_constants: Option<VersionedConstants>,
     pub feeder_gateway_fetch_concurrency: NonZeroUsize,
+    pub fetch_casm_from_fgw: bool,
 }
 
 pub struct Ethereum {
@@ -989,6 +999,7 @@ impl Config {
             custom_versioned_constants: cli
                 .custom_versioned_constants_path
                 .map(parse_versioned_constants_or_exit),
+            fetch_casm_from_fgw: cli.fetch_casm_from_fgw,
         }
     }
 }

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -599,6 +599,7 @@ fn start_feeder_gateway_sync(
         gossiper,
         sequencer_public_key: gateway_public_key,
         fetch_concurrency: config.feeder_gateway_fetch_concurrency,
+        fetch_casm_from_fgw: config.fetch_casm_from_fgw,
     };
 
     tokio::spawn(state::sync(sync_context, state::l1::sync, state::l2::sync))

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -92,6 +92,7 @@ pub struct SyncContext<G, E> {
     pub gossiper: Gossiper,
     pub sequencer_public_key: PublicKey,
     pub fetch_concurrency: std::num::NonZeroUsize,
+    pub fetch_casm_from_fgw: bool,
 }
 
 impl<G, E> From<&SyncContext<G, E>> for L1SyncContext<E>
@@ -121,6 +122,7 @@ where
             storage: value.storage.clone(),
             sequencer_public_key: value.sequencer_public_key,
             fetch_concurrency: value.fetch_concurrency,
+            fetch_casm_from_fgw: value.fetch_casm_from_fgw,
         }
     }
 }
@@ -201,6 +203,7 @@ where
         gossiper,
         sequencer_public_key: _,
         fetch_concurrency: _,
+        fetch_casm_from_fgw,
     } = context;
 
     let mut db_conn = storage
@@ -284,6 +287,7 @@ where
         storage.clone(),
         rx_latest.clone(),
         rx_current.clone(),
+        fetch_casm_from_fgw,
     ));
 
     /// Delay before restarting L1 or L2 tasks if they fail. This delay helps
@@ -305,6 +309,7 @@ where
                     storage.clone(),
                     rx_latest.clone(),
                     rx_current.clone(),
+                    fetch_casm_from_fgw,
                 ));
             },
             _ = &mut latest_handle => {

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -17,6 +17,7 @@ pub async fn poll_pending<S: GatewayApi + Clone + Send + 'static>(
     storage: Storage,
     latest: watch::Receiver<(BlockNumber, BlockHash)>,
     current: watch::Receiver<(BlockNumber, BlockHash)>,
+    fetch_casm_from_fgw: bool,
 ) {
     let mut prev_tx_count = 0;
     let mut prev_hash = BlockHash::default();
@@ -56,7 +57,14 @@ pub async fn poll_pending<S: GatewayApi + Clone + Send + 'static>(
         // fail when querying a desync'd feeder gateway which isn't aware of the
         // new pending classes. In this case, ignore the new pending data as it
         // is incomplete.
-        match super::l2::download_new_classes(&state_update, &sequencer, storage.clone()).await {
+        match super::l2::download_new_classes(
+            &state_update,
+            &sequencer,
+            storage.clone(),
+            fetch_casm_from_fgw,
+        )
+        .await
+        {
             Err(e) => tracing::debug!(reason=?e, "Failed to download pending classes"),
             Ok(downloaded_classes) => {
                 if let Err(e) = super::l2::emit_events_for_downloaded_classes(
@@ -197,6 +205,7 @@ mod tests {
                 StorageBuilder::in_memory().unwrap(),
                 latest,
                 current,
+                false,
             )
             .await
         });
@@ -269,6 +278,7 @@ mod tests {
                 StorageBuilder::in_memory().unwrap(),
                 rx_latest,
                 rx_current,
+                false,
             )
             .await
         });


### PR DESCRIPTION
…w instead

I treat this as an "emergency" option in case we ever need to resync from scratch and time is of essence. I'm comparing if this helps with resync speed at all and will close the PR if it does not. Feel free to down-vote the PR regardless.