### PR TITLE
Add --log-output-json CLI option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--disable-version-update-check` CLI option has been added to disable the periodic checking for a new version.
 - Add `pathfinder_getClassProof` endpoint to retrieve the Merkle proof of any class hash in the class trie.
 - add `process_start_time_seconds` metric showing the unix timestamp when the process started.
+- `--log-output-json` CLI option has been added to output the Pathfinder log in line-delimited JSON.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10125,6 +10125,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10134,6 +10144,8 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -10141,6 +10153,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ tokio-tungstenite = "0.21"
 tower = { version = "0.4.13", default-features = false }
 tower-http = { version = "0.5.2", default-features = false }
 tracing = "0.1.37"
-tracing-subscriber = "0.3.18"
+tracing-subscriber = { version = "0.3.18", features = ["json"] }
 unsigned-varint = "0.8.0"
 url = "2.4.1"
 vergen = { version = "8", default-features = false }

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -150,6 +150,15 @@ Examples:
     color: Color,
 
     #[arg(
+        long = "log-output-json",
+        long_help = "This flag controls when to use colors in the output logs.",
+        default_value = "false",
+        env = "PATHFINDER_LOG_OUTPUT_JSON",
+        value_name = "BOOL"
+    )]
+    log_output_json: bool,
+
+    #[arg(
         long = "disable-version-update-check",
         long_help = "Disable the periodic version update check.",
         default_value = "false",
@@ -682,6 +691,7 @@ pub struct Config {
     pub poll_interval: std::time::Duration,
     pub l1_poll_interval: std::time::Duration,
     pub color: Color,
+    pub log_output_json: bool,
     pub disable_version_update_check: bool,
     pub p2p: P2PConfig,
     pub debug: DebugConfig,
@@ -971,6 +981,7 @@ impl Config {
             poll_interval: Duration::from_secs(cli.poll_interval.get()),
             l1_poll_interval: Duration::from_secs(cli.l1_poll_interval.get()),
             color: cli.color,
+            log_output_json: cli.log_output_json,
             disable_version_update_check: cli.disable_version_update_check,
             p2p: P2PConfig::parse_or_exit(cli.p2p),
             debug: DebugConfig::parse(cli.debug),


### PR DESCRIPTION
Enable JSON logging.

---------------------------

This adds a `--log-output-json` CLI option which outputs log entries in JSON.  This is useful for feeding to structured logging systems, as well as making it easier to search for and output particular log entries.

Note that this adds a new dependency (or at least a change to an existing dependency).  I'm unsure if there are additional steps here to carry out in this situation.