### PR TITLE
feat(sync/track): update storage and class tries

### DIFF
--- a/crates/pathfinder/src/sync.rs
+++ b/crates/pathfinder/src/sync.rs
@@ -129,6 +129,7 @@ impl Sync {
             chain_id: self.chain_id,
             public_key: self.public_key,
             block_hash_db: Some(pathfinder_block_hashes::BlockHashDb::new(self.chain)),
+            verify_tree_hashes: self.verify_tree_hashes,
         }
         .run(next, parent_hash, self.fgw_client.clone())
         .await;


### PR DESCRIPTION
This PR adds storage and class trie updates to tracking sync.

So far I tested the change in the following manner:
1. sync via p2p from a pathfinder proxy, starting at block ~219k till block 220007, this involves checkpoint sync till 219218.
2. sync from the fgw using db from previous point (at block 220007) till 220053.

The assumption in the test is that fgw sync (2) would not be possible if the tracking p2p sync does not update the state tries as we would soon encounter a state commitment mismatch.

The same test performed with pathfinder form `main` fails instantly in (2).