### PR TITLE
chore(doc/rpc): add 0.8.0-rc0 JSON-RPC specification

### DIFF
--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -869,6 +869,43 @@ mod tests {
     // get_transaction_status is now part of the official spec, so we are phasing it out.
     #[case::root_pathfinder("/", "pathfinder_rpc_api.json", &["pathfinder_version", "pathfinder_getTransactionStatus"])]
 
+    #[case::v0_8_api  ("/rpc/v0_8", "v08/starknet_api_openrpc.json", &[
+        "starknet_getBlockWithTxHashes",
+        "starknet_getBlockWithTxs",
+        "starknet_getBlockWithReceipts",
+        "starknet_getStateUpdate",
+        "starknet_getStorageAt",
+        "starknet_getMessagesStatus",
+        "starknet_getTransactionByHash",
+        "starknet_getTransactionByBlockIdAndIndex",
+        "starknet_getTransactionReceipt",
+        "starknet_getClass",
+        "starknet_getClassHashAt",
+        "starknet_getClassAt",
+        "starknet_getBlockTransactionCount",
+        "starknet_call",
+        "starknet_estimateFee",
+        "starknet_estimateMessageFee",
+        "starknet_blockNumber",
+        "starknet_blockHashAndNumber",
+        "starknet_chainId",
+        "starknet_getEvents",
+        "starknet_getNonce",
+        "starknet_getStorageProof",
+    ])]
+    #[case::v0_8_trace("/rpc/v0_8", "v08/starknet_trace_api_openrpc.json", &[
+        "starknet_traceTransaction",
+        "starknet_simulateTransactions",
+        "starknet_traceBlockTransactions"
+    ])]
+    #[case::v0_8_write("/rpc/v0_8", "v08/starknet_write_api.json", &[
+        "starknet_addInvokeTransaction",
+        "starknet_addDeclareTransaction",
+        "starknet_addDeployAccountTransaction"
+    ])]
+    // get_transaction_status is now part of the official spec, so we are phasing it out.
+    #[case::v0_8_pathfinder("/rpc/v0_8", "pathfinder_rpc_api.json", &["pathfinder_version", "pathfinder_getTransactionStatus"])]
+
     #[case::v0_7_api  ("/rpc/v0_7", "v07/starknet_api_openrpc.json", &[])]
     #[case::v0_7_trace("/rpc/v0_7", "v07/starknet_trace_api_openrpc.json", &[])]
     #[case::v0_7_write("/rpc/v0_7", "v07/starknet_write_api.json", &[])]

--- a/crates/rpc/src/v08.rs
+++ b/crates/rpc/src/v08.rs
@@ -12,4 +12,6 @@ pub fn register_routes() -> RpcRouterBuilder {
         .register("starknet_subscribePendingTransactions", SubscribePendingTransactions)
         .register("starknet_subscribeEvents",              SubscribeEvents)
         .register("starknet_specVersion",                  || "0.8.0-rc0")
+
+        .register("pathfinder_getProof",                   crate::pathfinder::methods::get_proof)
 }

--- a/doc/rpc/v08/starknet_api_openrpc.json
+++ b/doc/rpc/v08/starknet_api_openrpc.json
@@ -3685,7 +3685,7 @@
     },
     "CONTRACT_EXECUTION_ERROR": {
         "description": "structured error that can later be processed by wallets or sdks",
-        "titel": "contract execution error",
+        "title": "contract execution error",
         "oneOf": [
           {
             "type": "object",

--- a/doc/rpc/v08/starknet_api_openrpc.json
+++ b/doc/rpc/v08/starknet_api_openrpc.json
@@ -1,0 +1,3797 @@
+{
+  "openrpc": "1.0.0-rc1",
+  "info": {
+    "version": "0.7.1",
+    "title": "StarkNet Node API",
+    "license": {}
+  },
+  "servers": [],
+  "methods": [
+    {
+      "name": "starknet_specVersion",
+      "summary": "Returns the version of the Starknet JSON-RPC specification being used",
+      "params": [],
+      "result": {
+        "name": "result",
+        "description": "Semver of Starknet's JSON-RPC spec being used",
+        "required": true,
+        "schema": {
+          "title": "JSON-RPC spec version",
+          "type": "string"
+        }
+      }
+    },
+    {
+      "name": "starknet_getBlockWithTxHashes",
+      "summary": "Get block information with transaction hashes given the block id",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The resulting block information with transaction hashes",
+        "schema": {
+          "title": "Starknet get block hash with tx hashes result",
+          "oneOf": [
+            {
+              "title": "Block with transaction hashes",
+              "$ref": "#/components/schemas/BLOCK_WITH_TX_HASHES"
+            },
+            {
+              "title": "Pending block with transaction hashes",
+              "$ref": "#/components/schemas/PENDING_BLOCK_WITH_TX_HASHES"
+            }
+          ]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getBlockWithTxs",
+      "summary": "Get block information with full transactions given the block id",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The resulting block information with full transactions",
+        "schema": {
+          "title": "Starknet get block with txs result",
+          "oneOf": [
+            {
+              "title": "Block with transactions",
+              "$ref": "#/components/schemas/BLOCK_WITH_TXS"
+            },
+            {
+              "title": "Pending block with transactions",
+              "$ref": "#/components/schemas/PENDING_BLOCK_WITH_TXS"
+            }
+          ]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getBlockWithReceipts",
+      "summary": "Get block information with full transactions and receipts given the block id",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The resulting block information with full transactions",
+        "schema": {
+          "title": "Starknet get block with txs and receipts result",
+          "oneOf": [
+            {
+              "title": "Block with transactions",
+              "$ref": "#/components/schemas/BLOCK_WITH_RECEIPTS"
+            },
+            {
+              "title": "Pending block with transactions",
+              "$ref": "#/components/schemas/PENDING_BLOCK_WITH_RECEIPTS"
+            }
+          ]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getStateUpdate",
+      "summary": "Get the information about the result of executing the requested block",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The information about the state update of the requested block",
+        "schema": {
+          "title": "Starknet get state update result",
+          "oneOf": [
+            {
+              "title": "State update",
+              "$ref": "#/components/schemas/STATE_UPDATE"
+            },
+            {
+              "title": "Pending state update",
+              "$ref": "#/components/schemas/PENDING_STATE_UPDATE"
+            }
+          ]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getStorageAt",
+      "summary": "Get the value of the storage at the given address and key",
+      "params": [
+        {
+          "name": "contract_address",
+          "description": "The address of the contract to read from",
+          "summary": "The address of the contract to read from",
+          "required": true,
+          "schema": {
+            "title": "Address",
+            "$ref": "#/components/schemas/ADDRESS"
+          }
+        },
+        {
+          "name": "key",
+          "description": "The key to the storage value for the given contract",
+          "summary": "The key to the storage value for the given contract",
+          "required": true,
+          "schema": {
+            "title": "Storage key",
+            "$ref": "#/components/schemas/STORAGE_KEY"
+          }
+        },
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The value at the given key for the given contract. 0 if no value is found",
+        "summary": "The value at the given key for the given contract.",
+        "schema": {
+          "title": "Field element",
+          "$ref": "#/components/schemas/FELT"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/CONTRACT_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getTransactionStatus",
+      "summary": "Gets the transaction status (possibly reflecting that the tx is still in the mempool, or dropped from it)",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "transaction_hash",
+          "summary": "The hash of the requested transaction",
+          "required": true,
+          "schema": {
+            "title": "Transaction hash",
+            "$ref": "#/components/schemas/TXN_HASH"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "schema": {
+          "$ref": "#/components/schemas/TXN_STATUS_RESULT"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/TXN_HASH_NOT_FOUND"
+        }
+      ]
+    },
+    {
+        "name": "starknet_getMessagesStatus",
+        "summary": "Given an l1 tx hash, returns the associated l1_handler tx hashes and statuses for all L1 -> L2 messages sent by the l1 ransaction, ordered by the l1 tx sending order",
+        "paramStructure": "by-name",
+        "params": [
+            {
+            "name": "transaction_hash",
+            "summary": "The hash of the L1 transaction that sent L1->L2 messages",
+            "required": true,
+            "schema": {
+                "title": "Transaction hash",
+                "$ref": "#/components/schemas/L1_TXN_HASH"
+            }
+            }
+        ],
+        "result": {
+            "name": "result",
+            "schema": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "title": "status",
+                    "properties": {
+                    "transaction_hash": {
+                        "$ref": "#/components/schemas/TXN_HASH"
+                    },
+                    "finality_status": {
+                        "title": "finality status",
+                        "$ref": "#/components/schemas/TXN_STATUS"
+                    },
+                    "failure_reason": {
+                        "title": "failure reason",
+                        "description": "the failure reason, only appears if finality_status is REJECTED",
+                        "type": "string"
+                    }
+                    },
+                    "required": ["transaction_hash", "finality_status"]
+                }
+            }
+        },
+        "errors": [
+            {
+            "$ref": "#/components/errors/TXN_HASH_NOT_FOUND"
+            }
+        ]
+    },
+    {
+      "name": "starknet_getTransactionByHash",
+      "summary": "Get the details and status of a submitted transaction",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "transaction_hash",
+          "summary": "The hash of the requested transaction",
+          "required": true,
+          "schema": {
+            "title": "Transaction hash",
+            "$ref": "#/components/schemas/TXN_HASH"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "schema": {
+          "title": "Transaction",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/TXN"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "transaction_hash": {
+                  "title": "transaction hash",
+                  "$ref": "#/components/schemas/TXN_HASH"
+                }
+              },
+              "required": ["transaction_hash"]
+            }
+          ]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/TXN_HASH_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getTransactionByBlockIdAndIndex",
+      "summary": "Get the details of a transaction by a given block id and index",
+      "description": "Get the details of the transaction given by the identified block and index in that block. If no transaction is found, null is returned.",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        },
+        {
+          "name": "index",
+          "summary": "The index in the block to search for the transaction",
+          "required": true,
+          "schema": {
+            "title": "Index",
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      ],
+      "result": {
+        "name": "transactionResult",
+        "schema": {
+          "title": "Transaction",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/TXN"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "transaction_hash": {
+                  "title": "transaction hash",
+                  "$ref": "#/components/schemas/TXN_HASH"
+                }
+              },
+              "required": ["transaction_hash"]
+            }
+          ]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/INVALID_TXN_INDEX"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getTransactionReceipt",
+      "summary": "Get the transaction receipt by the transaction hash",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "transaction_hash",
+          "summary": "The hash of the requested transaction",
+          "required": true,
+          "schema": {
+            "title": "Transaction hash",
+            "$ref": "#/components/schemas/TXN_HASH"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "schema": {
+          "title": "Transaction receipt with block info",
+          "$ref": "#/components/schemas/TXN_RECEIPT_WITH_BLOCK_INFO"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/TXN_HASH_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getClass",
+      "summary": "Get the contract class definition in the given block associated with the given hash",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        },
+        {
+          "name": "class_hash",
+          "description": "The hash of the requested contract class",
+          "required": true,
+          "schema": {
+            "title": "Field element",
+            "$ref": "#/components/schemas/FELT"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The contract class, if found",
+        "schema": {
+          "title": "Starknet get class result",
+          "oneOf": [
+            {
+              "title": "Deprecated contract class",
+              "$ref": "#/components/schemas/DEPRECATED_CONTRACT_CLASS"
+            },
+            {
+              "title": "Contract class",
+              "$ref": "#/components/schemas/CONTRACT_CLASS"
+            }
+          ]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/CLASS_HASH_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getClassHashAt",
+      "summary": "Get the contract class hash in the given block for the contract deployed at the given address",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        },
+        {
+          "name": "contract_address",
+          "description": "The address of the contract whose class hash will be returned",
+          "required": true,
+          "schema": {
+            "title": "Address",
+            "$ref": "#/components/schemas/ADDRESS"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The class hash of the given contract",
+        "schema": {
+          "title": "Field element",
+          "$ref": "#/components/schemas/FELT"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/CONTRACT_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getClassAt",
+      "summary": "Get the contract class definition in the given block at the given address",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        },
+        {
+          "name": "contract_address",
+          "description": "The address of the contract whose class definition will be returned",
+          "required": true,
+          "schema": {
+            "title": "Address",
+            "$ref": "#/components/schemas/ADDRESS"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The contract class",
+        "schema": {
+          "title": "Starknet get class at result",
+          "oneOf": [
+            {
+              "title": "Deprecated contract class",
+              "$ref": "#/components/schemas/DEPRECATED_CONTRACT_CLASS"
+            },
+            {
+              "title": "Contract class",
+              "$ref": "#/components/schemas/CONTRACT_CLASS"
+            }
+          ]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/CONTRACT_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getBlockTransactionCount",
+      "summary": "Get the number of transactions in a block given a block id",
+      "description": "Returns the number of transactions in the designated block.",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The number of transactions in the designated block",
+        "summary": "The number of transactions in the designated block",
+        "schema": {
+          "title": "Block transaction count",
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_call",
+      "summary": "call a starknet function without creating a StarkNet transaction",
+      "description": "Calls a function in a contract and returns the return value.  Using this call will not create a transaction; hence, will not change the state",
+      "params": [
+        {
+          "name": "request",
+          "summary": "The details of the function call",
+          "schema": {
+            "title": "Function call",
+            "$ref": "#/components/schemas/FUNCTION_CALL"
+          },
+          "required": true
+        },
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag, for the block referencing the state or call the transaction on.",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "summary": "The function's return value",
+        "description": "The function's return value, as defined in the Cairo output",
+        "schema": {
+          "type": "array",
+          "title": "Field element",
+          "items": {
+            "$ref": "#/components/schemas/FELT"
+          }
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/CONTRACT_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/CONTRACT_ERROR"
+        },
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_estimateFee",
+      "summary": "estimate the fee for of StarkNet transactions",
+      "description": "Estimates the resources required by a given sequence of transactions when applied on a given state. If one of the transactions reverts or fails due to any reason (e.g. validation failure or an internal error), a TRANSACTION_EXECUTION_ERROR is returned. For v0-2 transactions the estimate is given in wei, and for v3 transactions it is given in fri.",
+      "params": [
+        {
+          "name": "request",
+          "summary": "The transaction to estimate",
+          "schema": {
+            "type": "array",
+            "description": "a sequence of transactions to estimate, running each transaction on the state resulting from applying all the previous ones",
+            "title": "Transaction",
+            "items": {
+              "$ref": "#/components/schemas/BROADCASTED_TXN"
+            }
+          },
+          "required": true
+        },
+        {
+          "name": "simulation_flags",
+          "description": "describes what parts of the transaction should be executed",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SIMULATION_FLAG_FOR_ESTIMATE_FEE"
+            }
+          }
+        },
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag, for the block referencing the state or call the transaction on.",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "the fee estimations",
+        "schema": {
+          "title": "Estimation",
+          "type": "array",
+          "description": "a sequence of fee estimatione where the i'th estimate corresponds to the i'th transaction",
+          "items": {
+            "$ref": "#/components/schemas/FEE_ESTIMATE"
+          }
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/TRANSACTION_EXECUTION_ERROR"
+        },
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_estimateMessageFee",
+      "summary": "estimate the L2 fee of a message sent on L1",
+      "description": "estimates the resources required by the l1_handler transaction induced by the message",
+      "params": [
+        {
+          "name": "message",
+          "description": "the message's parameters",
+          "schema": {
+            "$ref": "#/components/schemas/MSG_FROM_L1"
+          },
+          "required": true
+        },
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag, for the block referencing the state or call the transaction on.",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "the fee estimation",
+        "schema": {
+          "$ref": "#/components/schemas/FEE_ESTIMATE"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/CONTRACT_ERROR"
+        },
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_blockNumber",
+      "summary": "Get the most recent accepted block number",
+      "params": [],
+      "result": {
+        "name": "result",
+        "description": "The latest block number",
+        "schema": {
+          "title": "Block number",
+          "$ref": "#/components/schemas/BLOCK_NUMBER"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/NO_BLOCKS"
+        }
+      ]
+    },
+    {
+      "name": "starknet_blockHashAndNumber",
+      "summary": "Get the most recent accepted block hash and number",
+      "params": [],
+      "result": {
+        "name": "result",
+        "description": "The latest block hash and number",
+        "schema": {
+          "title": "Starknet block hash and number result",
+          "type": "object",
+          "properties": {
+            "block_hash": {
+              "title": "Block hash",
+              "$ref": "#/components/schemas/BLOCK_HASH"
+            },
+            "block_number": {
+              "title": "Block number",
+              "$ref": "#/components/schemas/BLOCK_NUMBER"
+            }
+          },
+          "required": ["block_hash", "block_number"]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/NO_BLOCKS"
+        }
+      ]
+    },
+    {
+      "name": "starknet_chainId",
+      "summary": "Return the currently configured StarkNet chain id",
+      "params": [],
+      "result": {
+        "name": "result",
+        "description": "The chain id this node is connected to",
+        "schema": {
+          "title": "Chain id",
+          "$ref": "#/components/schemas/CHAIN_ID"
+        }
+      }
+    },
+    {
+      "name": "starknet_syncing",
+      "summary": "Returns an object about the sync status, or false if the node is not synching",
+      "params": [],
+      "result": {
+        "name": "syncing",
+        "summary": "The state of the synchronization, or false if the node is not synchronizing",
+        "description": "The status of the node, if it is currently synchronizing state. FALSE otherwise",
+        "schema": {
+          "title": "SyncingStatus",
+          "oneOf": [
+            {
+              "type": "boolean",
+              "title": "False",
+              "description": "only legal value is FALSE here"
+            },
+            {
+              "title": "Sync status",
+              "$ref": "#/components/schemas/SYNC_STATUS"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "starknet_getEvents",
+      "summary": "Returns all events matching the given filter",
+      "description": "Returns all event objects matching the conditions in the provided filter",
+      "params": [
+        {
+          "name": "filter",
+          "summary": "The conditions used to filter the returned events",
+          "required": true,
+          "schema": {
+            "title": "Events request",
+            "allOf": [
+              {
+                "title": "Event filter",
+                "$ref": "#/components/schemas/EVENT_FILTER"
+              },
+              {
+                "title": "Result page request",
+                "$ref": "#/components/schemas/RESULT_PAGE_REQUEST"
+              }
+            ]
+          }
+        }
+      ],
+      "result": {
+        "name": "events",
+        "description": "All the event objects matching the filter",
+        "schema": {
+          "title": "Events chunk",
+          "$ref": "#/components/schemas/EVENTS_CHUNK"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/PAGE_SIZE_TOO_BIG"
+        },
+        {
+          "$ref": "#/components/errors/INVALID_CONTINUATION_TOKEN"
+        },
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/TOO_MANY_KEYS_IN_FILTER"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getNonce",
+      "summary": "Get the nonce associated with the given address in the given block",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        },
+        {
+          "name": "contract_address",
+          "description": "The address of the contract whose nonce we're seeking",
+          "required": true,
+          "schema": {
+            "title": "Address",
+            "$ref": "#/components/schemas/ADDRESS"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The contract's nonce at the requested state",
+        "schema": {
+          "title": "Field element",
+          "$ref": "#/components/schemas/FELT"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/CONTRACT_NOT_FOUND"
+        }
+      ]
+    },
+    {
+        "name": "starknet_getStorageProof",
+        "summary": "get merkle paths in one of the state tries: global state, classes, individual contract",
+        "params": [
+          {
+            "name": "class_hashes",
+            "description": "a list of the class hashes for which we want to prove membership in the classes trie",
+            "required": false,
+            "schema": {
+              "title": "classes",
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/FELT"
+              }
+            }
+          },
+          {
+            "name": "contract_addresses",
+            "description": "a list of contracts for which we want to prove membership in the global state trie",
+            "required": false,
+            "schema": {
+              "title": "contracts",
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ADDRESS"
+              }
+            }
+          },
+          {
+            "name": "contracts_storage_keys",
+            "description": "a list of (contract_address, storage_keys) pairs",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "contract_address": {
+                    "$ref": "#/components/schemas/ADDRESS"
+                  },
+                  "storage_keys": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/FELT"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "result": {
+          "name": "result",
+          "description": "The contract's nonce at the requested state",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "classes_proof": {
+                "$ref": "#/components/schemas/NODE_HASH_TO_NODE_MAPPING"
+              },
+              "contracts_proof": {
+                "$ref": "#/components/schemas/NODE_HASH_TO_NODE_MAPPING"
+              },
+              "contracts_storage_proofs": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/NODE_HASH_TO_NODE_MAPPING"
+                }
+              }
+            }
+          }
+        }
+      }
+  ],
+  "components": {
+    "contentDescriptors": {},
+    "schemas": {
+      "EVENTS_CHUNK": {
+        "title": "Events chunk",
+        "type": "object",
+        "properties": {
+          "events": {
+            "type": "array",
+            "title": "Matching Events",
+            "items": {
+              "$ref": "#/components/schemas/EMITTED_EVENT"
+            }
+          },
+          "continuation_token": {
+            "title": "Continuation token",
+            "description": "Use this token in a subsequent query to obtain the next page. Should not appear if there are no more pages.",
+            "type": "string"
+          }
+        },
+        "required": ["events"]
+      },
+      "RESULT_PAGE_REQUEST": {
+        "title": "Result page request",
+        "type": "object",
+        "properties": {
+          "continuation_token": {
+            "title": "Continuation token",
+            "description": "The token returned from the previous query. If no token is provided the first page is returned.",
+            "type": "string"
+          },
+          "chunk_size": {
+            "title": "Chunk size",
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        "required": ["chunk_size"]
+      },
+      "EMITTED_EVENT": {
+        "title": "Emitted event",
+        "description": "Event information decorated with metadata on where it was emitted / An event emitted as a result of transaction execution",
+        "allOf": [
+          {
+            "title": "Event",
+            "description": "The event information",
+            "$ref": "#/components/schemas/EVENT"
+          },
+          {
+            "title": "Event context",
+            "description": "The event emission information",
+            "type": "object",
+            "properties": {
+              "block_hash": {
+                "title": "Block hash",
+                "description": "The hash of the block in which the event was emitted",
+                "$ref": "#/components/schemas/BLOCK_HASH"
+              },
+              "block_number": {
+                "title": "Block number",
+                "description": "The number of the block in which the event was emitted",
+                "$ref": "#/components/schemas/BLOCK_NUMBER"
+              },
+              "transaction_hash": {
+                "title": "Transaction hash",
+                "description": "The transaction that emitted the event",
+                "$ref": "#/components/schemas/TXN_HASH"
+              }
+            },
+            "required": ["transaction_hash"]
+          }
+        ]
+      },
+      "EVENT": {
+        "title": "Event",
+        "description": "A StarkNet event",
+        "allOf": [
+          {
+            "title": "Event emitter",
+            "type": "object",
+            "properties": {
+              "from_address": {
+                "title": "From address",
+                "$ref": "#/components/schemas/ADDRESS"
+              }
+            },
+            "required": ["from_address"]
+          },
+          {
+            "title": "Event content",
+            "$ref": "#/components/schemas/EVENT_CONTENT"
+          }
+        ]
+      },
+      "EVENT_CONTENT": {
+        "title": "Event content",
+        "description": "The content of an event",
+        "type": "object",
+        "properties": {
+          "keys": {
+            "type": "array",
+            "title": "Keys",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            }
+          },
+          "data": {
+            "type": "array",
+            "title": "Data",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            }
+          }
+        },
+        "required": ["keys", "data"]
+      },
+      "EVENT_KEYS": {
+        "title": "Keys",
+        "description": "The keys to filter over",
+        "type": "array",
+        "items": {
+          "title": "Keys",
+          "description": "Per key (by position), designate the possible values to be matched for events to be returned. Empty array designates 'any' value",
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/FELT"
+          }
+        }
+      },
+      "EVENT_FILTER": {
+        "title": "Event filter",
+        "description": "An event filter/query",
+        "type": "object",
+        "properties": {
+          "from_block": {
+            "title": "from block",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          },
+          "to_block": {
+            "title": "to block",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          },
+          "address": {
+            "title": "from contract",
+            "$ref": "#/components/schemas/ADDRESS"
+          },
+          "keys": {
+            "title": "event keys",
+            "description": "The keys to filter over",
+            "$ref": "#/components/schemas/EVENT_KEYS"
+
+          }
+        },
+        "required": []
+      },
+      "BLOCK_ID": {
+        "title": "Block id",
+        "description": "Block hash, number or tag",
+        "oneOf": [
+          {
+            "title": "Block hash",
+            "type": "object",
+            "properties": {
+              "block_hash": {
+                "title": "Block hash",
+                "$ref": "#/components/schemas/BLOCK_HASH"
+              }
+            },
+            "required": ["block_hash"]
+          },
+          {
+            "title": "Block number",
+            "type": "object",
+            "properties": {
+              "block_number": {
+                "title": "Block number",
+                "$ref": "#/components/schemas/BLOCK_NUMBER"
+              }
+            },
+            "required": ["block_number"]
+          },
+          {
+            "title": "Block tag",
+            "$ref": "#/components/schemas/BLOCK_TAG"
+          }
+        ]
+      },
+      "BLOCK_TAG": {
+        "title": "Block tag",
+        "type": "string",
+        "description": "A tag specifying a dynamic reference to a block",
+        "enum": ["latest", "pending"]
+      },
+      "SYNC_STATUS": {
+        "title": "Sync status",
+        "type": "object",
+        "description": "An object describing the node synchronization status",
+        "properties": {
+          "starting_block_hash": {
+            "title": "Starting block hash",
+            "description": "The hash of the block from which the sync started",
+            "$ref": "#/components/schemas/BLOCK_HASH"
+          },
+          "starting_block_num": {
+            "title": "Starting block number",
+            "description": "The number (height) of the block from which the sync started",
+            "$ref": "#/components/schemas/BLOCK_NUMBER"
+          },
+          "current_block_hash": {
+            "title": "Current block hash",
+            "description": "The hash of the current block being synchronized",
+            "$ref": "#/components/schemas/BLOCK_HASH"
+          },
+          "current_block_num": {
+            "title": "Current block number",
+            "description": "The number (height) of the current block being synchronized",
+            "$ref": "#/components/schemas/BLOCK_NUMBER"
+          },
+          "highest_block_hash": {
+            "title": "Highest block hash",
+            "description": "The hash of the estimated highest block to be synchronized",
+            "$ref": "#/components/schemas/BLOCK_HASH"
+          },
+          "highest_block_num": {
+            "title": "Highest block number",
+            "description": "The number (height) of the estimated highest block to be synchronized",
+            "$ref": "#/components/schemas/BLOCK_NUMBER"
+          }
+        },
+        "required": [
+          "starting_block_hash",
+          "starting_block_num",
+          "current_block_hash",
+          "current_block_num",
+          "highest_block_hash",
+          "highest_block_num"
+        ]
+      },
+      "NUM_AS_HEX": {
+        "title": "Number as hex",
+        "description": "An integer number in hex format (0x...)",
+        "type": "string",
+        "pattern": "^0x[a-fA-F0-9]+$"
+      },
+      "u64": {
+        "type": "string",
+        "title": "u64",
+        "description": "64 bit integers, represented by hex string of length at most 16",
+        "pattern": "^0x(0|[a-fA-F1-9]{1}[a-fA-F0-9]{0,15})$"
+      },
+      "u128": {
+        "type": "string",
+        "title": "u128",
+        "description": "64 bit integers, represented by hex string of length at most 32",
+        "pattern": "^0x(0|[a-fA-F1-9]{1}[a-fA-F0-9]{0,31})$"
+      },
+      "CHAIN_ID": {
+        "title": "Chain id",
+        "description": "StarkNet chain id, given in hex representation.",
+        "type": "string",
+        "pattern": "^0x[a-fA-F0-9]+$"
+      },
+      "STATE_DIFF": {
+        "description": "The change in state applied in this block, given as a mapping of addresses to the new values and/or new contracts",
+        "type": "object",
+        "properties": {
+          "storage_diffs": {
+            "title": "Storage diffs",
+            "type": "array",
+            "items": {
+              "description": "The changes in the storage per contract address",
+              "$ref": "#/components/schemas/CONTRACT_STORAGE_DIFF_ITEM"
+            }
+          },
+          "deprecated_declared_classes": {
+            "title": "Deprecated declared classes",
+            "type": "array",
+            "items": {
+              "description": "The hash of the declared class",
+              "$ref": "#/components/schemas/FELT"
+            }
+          },
+          "declared_classes": {
+            "title": "Declared classes",
+            "type": "array",
+            "items": {
+              "title": "New classes",
+              "type": "object",
+              "description": "The declared class hash and compiled class hash",
+              "properties": {
+                "class_hash": {
+                  "title": "Class hash",
+                  "description": "The hash of the declared class",
+                  "$ref": "#/components/schemas/FELT"
+                },
+                "compiled_class_hash": {
+                  "title": "Compiled class hash",
+                  "description": "The Cairo assembly hash corresponding to the declared class",
+                  "$ref": "#/components/schemas/FELT"
+                }
+              }
+            }
+          },
+          "deployed_contracts": {
+            "title": "Deployed contracts",
+            "type": "array",
+            "items": {
+              "description": "A new contract deployed as part of the state update",
+              "$ref": "#/components/schemas/DEPLOYED_CONTRACT_ITEM"
+            }
+          },
+          "replaced_classes": {
+            "title": "Replaced classes",
+            "type": "array",
+            "items": {
+              "description": "The list of contracts whose class was replaced",
+              "title": "Replaced class",
+              "type": "object",
+              "properties": {
+                "contract_address": {
+                  "title": "Contract address",
+                  "description": "The address of the contract whose class was replaced",
+                  "$ref": "#/components/schemas/ADDRESS"
+                },
+                "class_hash": {
+                  "title": "Class hash",
+                  "description": "The new class hash",
+                  "$ref": "#/components/schemas/FELT"
+                }
+              }
+            }
+          },
+          "nonces": {
+            "title": "Nonces",
+            "type": "array",
+            "items": {
+              "title": "Nonce update",
+              "description": "The updated nonce per contract address",
+              "type": "object",
+              "properties": {
+                "contract_address": {
+                  "title": "Contract address",
+                  "description": "The address of the contract",
+                  "$ref": "#/components/schemas/ADDRESS"
+                },
+                "nonce": {
+                  "title": "Nonce",
+                  "description": "The nonce for the given address at the end of the block",
+                  "$ref": "#/components/schemas/FELT"
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "storage_diffs",
+          "deprecated_declared_classes",
+          "declared_classes",
+          "replaced_classes",
+          "deployed_contracts",
+          "nonces"
+        ]
+      },
+      "PENDING_STATE_UPDATE": {
+        "title": "Pending state update",
+        "description": "Pending state update",
+        "type": "object",
+        "properties": {
+          "old_root": {
+            "title": "Old root",
+            "description": "The previous global state root",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "state_diff": {
+            "title": "State diff",
+            "$ref": "#/components/schemas/STATE_DIFF"
+          }
+        },
+        "required": ["old_root", "state_diff"],
+        "additionalProperties": false
+      },
+      "STATE_UPDATE": {
+        "title": "State update",
+        "type": "object",
+        "properties": {
+          "block_hash": {
+            "title": "Block hash",
+            "$ref": "#/components/schemas/BLOCK_HASH"
+          },
+          "old_root": {
+            "title": "Old root",
+            "description": "The previous global state root",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "new_root": {
+            "title": "New root",
+            "description": "The new global state root",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "state_diff": {
+            "title": "State diff",
+            "$ref": "#/components/schemas/STATE_DIFF"
+          }
+        },
+        "required": ["state_diff", "block_hash", "old_root", "new_root"]
+      },
+      "ADDRESS": {
+        "title": "Address",
+        "$ref": "#/components/schemas/FELT"
+      },
+      "STORAGE_KEY": {
+        "type": "string",
+        "title": "Storage key",
+        "$comment": "A storage key, represented as a string of hex digits",
+        "description": "A storage key. Represented as up to 62 hex digits, 3 bits, and 5 leading zeroes.",
+        "pattern": "^0x(0|[0-7]{1}[a-fA-F0-9]{0,62}$)"
+      },
+      "ETH_ADDRESS": {
+        "title": "Ethereum address",
+        "type": "string",
+        "$comment": "An ethereum address",
+        "description": "an ethereum address represented as 40 hex digits",
+        "pattern": "^0x[a-fA-F0-9]{40}$"
+      },
+      "TXN_HASH": {
+        "$ref": "#/components/schemas/FELT",
+        "description": "The hash of a Starknet transaction",
+        "title": "Transaction hash"
+      },
+      "L1_TXN_HASH": {
+        "$ref": "#/components/schemas/NUM_AS_HEX",
+        "description": "The hash of an Ethereum transaction"
+      },
+      "FELT": {
+        "type": "string",
+        "title": "Field element",
+        "description": "A field element. represented by at most 63 hex digits",
+        "pattern": "^0x(0|[a-fA-F1-9]{1}[a-fA-F0-9]{0,62})$"
+      },
+      "BLOCK_NUMBER": {
+        "title": "Block number",
+        "description": "The block's number (its height)",
+        "type": "integer",
+        "minimum": 0
+      },
+      "BLOCK_HASH": {
+        "title": "Block hash",
+        "$ref": "#/components/schemas/FELT"
+      },
+      "BLOCK_BODY_WITH_TX_HASHES": {
+        "title": "Block body with transaction hashes",
+        "type": "object",
+        "properties": {
+          "transactions": {
+            "title": "Transaction hashes",
+            "description": "The hashes of the transactions included in this block",
+            "type": "array",
+            "items": {
+              "description": "The hash of a single transaction",
+              "$ref": "#/components/schemas/TXN_HASH"
+            }
+          }
+        },
+        "required": ["transactions"]
+      },
+      "BLOCK_BODY_WITH_TXS": {
+        "title": "Block body with transactions",
+        "type": "object",
+        "properties": {
+          "transactions": {
+            "title": "Transactions",
+            "description": "The transactions in this block",
+            "type": "array",
+            "items": {
+              "title": "transactions in block",
+              "type": "object",
+              "allOf": [
+                {
+                  "title": "transaction",
+                  "$ref": "#/components/schemas/TXN"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "transaction_hash": {
+                      "title": "transaction hash",
+                      "$ref": "#/components/schemas/TXN_HASH"
+                    }
+                  },
+                  "required": ["transaction_hash"]
+                }
+              ]
+            }
+          }
+        },
+        "required": ["transactions"]
+      },
+      "BLOCK_BODY_WITH_RECEIPTS": {
+        "title": "Block body with transactions and receipts",
+        "type": "object",
+        "properties": {
+          "transactions": {
+            "title": "Transactions",
+            "description": "The transactions in this block",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "title": "transaction and receipt",
+              "properties": {
+                "transaction": {
+                  "title": "transaction",
+                  "$ref": "#/components/schemas/TXN"
+                },
+                "receipt": {
+                  "title": "receipt",
+                  "$ref": "#/components/schemas/TXN_RECEIPT"
+                }
+              },
+              "required": ["transaction", "receipt"]
+            }
+          }
+        },
+        "required": ["transactions"]
+      },
+      "BLOCK_HEADER": {
+        "title": "Block header",
+        "type": "object",
+        "properties": {
+          "block_hash": {
+            "title": "Block hash",
+            "$ref": "#/components/schemas/BLOCK_HASH"
+          },
+          "parent_hash": {
+            "title": "Parent hash",
+            "description": "The hash of this block's parent",
+            "$ref": "#/components/schemas/BLOCK_HASH"
+          },
+          "block_number": {
+            "title": "Block number",
+            "description": "The block number (its height)",
+            "$ref": "#/components/schemas/BLOCK_NUMBER"
+          },
+          "new_root": {
+            "title": "New root",
+            "description": "The new global state root",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "timestamp": {
+            "title": "Timestamp",
+            "description": "The time in which the block was created, encoded in Unix time",
+            "type": "integer",
+            "minimum": 0
+          },
+          "sequencer_address": {
+            "title": "Sequencer address",
+            "description": "The StarkNet identity of the sequencer submitting this block",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "l1_gas_price": {
+            "title": "L1 gas price",
+            "description": "The price of l1 gas in the block",
+            "$ref": "#/components/schemas/RESOURCE_PRICE"
+          },
+          "l2_gas_price": {
+            "title": "L2 gas price",
+            "description": "The price of l2 gas in the block",
+            "$ref": "#/components/schemas/RESOURCE_PRICE"
+          },
+          "l1_data_gas_price": {
+            "title": "L1 data gas price",
+            "description": "The price of l1 data gas in the block",
+            "$ref": "#/components/schemas/RESOURCE_PRICE"
+          },
+          "l1_da_mode": {
+            "title": "L1 da mode",
+            "type": "string",
+            "description": "specifies whether the data of this block is published via blob data or calldata",
+            "enum": ["BLOB", "CALLDATA"]
+          },
+          "starknet_version": {
+            "title": "Starknet version",
+            "description": "Semver of the current Starknet protocol",
+            "type": "string"
+          }
+        },
+        "required": [
+          "block_hash",
+          "parent_hash",
+          "block_number",
+          "new_root",
+          "timestamp",
+          "sequencer_address",
+          "l1_gas_price",
+          "l1_data_gas_price",
+          "l1_da_mode",
+          "starknet_version"
+        ]
+      },
+      "PENDING_BLOCK_HEADER": {
+        "title": "Pending block header",
+        "type": "object",
+        "properties": {
+          "parent_hash": {
+            "title": "Parent hash",
+            "description": "The hash of this block's parent",
+            "$ref": "#/components/schemas/BLOCK_HASH"
+          },
+          "timestamp": {
+            "title": "Timestamp",
+            "description": "The time in which the block was created, encoded in Unix time",
+            "type": "integer",
+            "minimum": 0
+          },
+          "sequencer_address": {
+            "title": "Sequencer address",
+            "description": "The StarkNet identity of the sequencer submitting this block",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "l1_gas_price": {
+            "title": "L1 gas price",
+            "description": "The price of l1 gas in the block",
+            "$ref": "#/components/schemas/RESOURCE_PRICE"
+          },
+          "l1_data_gas_price": {
+            "title": "L1 data gas price",
+            "description": "The price of l1 data gas in the block",
+            "$ref": "#/components/schemas/RESOURCE_PRICE"
+          },
+          "l1_da_mode": {
+            "title": "L1 da mode",
+            "type": "string",
+            "description": "specifies whether the data of this block is published via blob data or calldata",
+            "enum": ["BLOB", "CALLDATA"]
+          },
+          "starknet_version": {
+            "title": "Starknet version",
+            "description": "Semver of the current Starknet protocol",
+            "type": "string"
+          }
+        },
+        "required": [
+          "parent_hash",
+          "timestamp",
+          "sequencer_address",
+          "l1_gas_price",
+          "l1_data_gas_price",
+          "l1_da_mode",
+          "starknet_version"
+        ],
+        "not": {
+          "required": ["block_hash", "block_number", "new_root"]
+        }
+      },
+      "BLOCK_WITH_TX_HASHES": {
+        "title": "Block with transaction hashes",
+        "description": "The block object",
+        "allOf": [
+          {
+            "title": "Block status",
+            "type": "object",
+            "properties": {
+              "status": {
+                "title": "Status",
+                "$ref": "#/components/schemas/BLOCK_STATUS"
+              }
+            },
+            "required": ["status"]
+          },
+          {
+            "title": "Block header",
+            "$ref": "#/components/schemas/BLOCK_HEADER"
+          },
+          {
+            "title": "Block body with transaction hashes",
+            "$ref": "#/components/schemas/BLOCK_BODY_WITH_TX_HASHES"
+          }
+        ]
+      },
+      "BLOCK_WITH_TXS": {
+        "title": "Block with transactions",
+        "description": "The block object",
+        "allOf": [
+          {
+            "title": "block with txs",
+            "type": "object",
+            "properties": {
+              "status": {
+                "title": "Status",
+                "$ref": "#/components/schemas/BLOCK_STATUS"
+              }
+            },
+            "required": ["status"]
+          },
+          {
+            "title": "Block header",
+            "$ref": "#/components/schemas/BLOCK_HEADER"
+          },
+          {
+            "title": "Block body with transactions",
+            "$ref": "#/components/schemas/BLOCK_BODY_WITH_TXS"
+          }
+        ]
+      },
+      "BLOCK_WITH_RECEIPTS": {
+        "title": "Block with transactions and receipts",
+        "description": "The block object",
+        "allOf": [
+          {
+            "title": "block with txs",
+            "type": "object",
+            "properties": {
+              "status": {
+                "title": "Status",
+                "$ref": "#/components/schemas/BLOCK_STATUS"
+              }
+            },
+            "required": ["status"]
+          },
+          {
+            "title": "Block header",
+            "$ref": "#/components/schemas/BLOCK_HEADER"
+          },
+          {
+            "title": "Block body with transactions and receipts",
+            "$ref": "#/components/schemas/BLOCK_BODY_WITH_RECEIPTS"
+          }
+        ]
+      },
+      "PENDING_BLOCK_WITH_TX_HASHES": {
+        "title": "Pending block with transaction hashes",
+        "description": "The dynamic block being constructed by the sequencer. Note that this object will be deprecated upon decentralization.",
+        "allOf": [
+          {
+            "title": "Block body with transactions hashes",
+            "$ref": "#/components/schemas/BLOCK_BODY_WITH_TX_HASHES"
+          },
+          {
+            "title": "Pending block header",
+            "$ref": "#/components/schemas/PENDING_BLOCK_HEADER"
+          }
+        ]
+      },
+      "PENDING_BLOCK_WITH_TXS": {
+        "title": "Pending block with transactions",
+        "description": "The dynamic block being constructed by the sequencer. Note that this object will be deprecated upon decentralization.",
+        "allOf": [
+          {
+            "title": "Block body with transactions",
+            "$ref": "#/components/schemas/BLOCK_BODY_WITH_TXS"
+          },
+          {
+            "title": "Pending block header",
+            "$ref": "#/components/schemas/PENDING_BLOCK_HEADER"
+          }
+        ]
+      },
+      "PENDING_BLOCK_WITH_RECEIPTS": {
+        "title": "Pending block with transactions and receipts",
+        "description": "The dynamic block being constructed by the sequencer. Note that this object will be deprecated upon decentralization.",
+        "allOf": [
+          {
+            "title": "Block body with transactions and receipts",
+            "$ref": "#/components/schemas/BLOCK_BODY_WITH_RECEIPTS"
+          },
+          {
+            "title": "Pending block header",
+            "$ref": "#/components/schemas/PENDING_BLOCK_HEADER"
+          }
+        ]
+      },
+      "DEPLOYED_CONTRACT_ITEM": {
+        "title": "Deployed contract item",
+        "type": "object",
+        "properties": {
+          "address": {
+            "title": "Address",
+            "description": "The address of the contract",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "class_hash": {
+            "title": "Class hash",
+            "description": "The hash of the contract code",
+            "$ref": "#/components/schemas/FELT"
+          }
+        },
+        "required": ["address", "class_hash"]
+      },
+      "CONTRACT_STORAGE_DIFF_ITEM": {
+        "title": "Contract storage diff item",
+        "type": "object",
+        "properties": {
+          "address": {
+            "title": "Address",
+            "description": "The contract address for which the storage changed",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "storage_entries": {
+            "title": "Storage entries",
+            "description": "The changes in the storage of the contract",
+            "type": "array",
+            "items": {
+              "title": "Storage diff item",
+              "type": "object",
+              "properties": {
+                "key": {
+                  "title": "Key",
+                  "description": "The key of the changed value",
+                  "$ref": "#/components/schemas/FELT"
+                },
+                "value": {
+                  "title": "Value",
+                  "description": "The new value applied to the given address",
+                  "$ref": "#/components/schemas/FELT"
+                }
+              }
+            }
+          }
+        },
+        "required": ["address", "storage_entries"]
+      },
+      "TXN": {
+        "title": "Transaction",
+        "description": "The transaction schema, as it appears inside a block",
+        "oneOf": [
+          {
+            "title": "Invoke transaction",
+            "$ref": "#/components/schemas/INVOKE_TXN"
+          },
+          {
+            "title": "L1 handler transaction",
+            "$ref": "#/components/schemas/L1_HANDLER_TXN"
+          },
+          {
+            "title": "Declare transaction",
+            "$ref": "#/components/schemas/DECLARE_TXN"
+          },
+          {
+            "title": "Deploy transaction",
+            "$ref": "#/components/schemas/DEPLOY_TXN"
+          },
+          {
+            "title": "Deploy account transaction",
+            "$ref": "#/components/schemas/DEPLOY_ACCOUNT_TXN"
+          }
+        ]
+      },
+      "SIGNATURE": {
+        "title": "Signature",
+        "description": "A transaction signature",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/FELT"
+        }
+      },
+      "DECLARE_TXN": {
+        "title": "Declare transaction",
+        "oneOf": [
+          {
+            "title": "Declare transaction V0",
+            "$ref": "#/components/schemas/DECLARE_TXN_V0"
+          },
+          {
+            "title": "Declare transaction V1",
+            "$ref": "#/components/schemas/DECLARE_TXN_V1"
+          },
+          {
+            "title": "Declare transaction V2",
+            "$ref": "#/components/schemas/DECLARE_TXN_V2"
+          },
+          {
+            "title": "Declare transaction V3",
+            "$ref": "#/components/schemas/DECLARE_TXN_V3"
+          }
+        ]
+      },
+      "DECLARE_TXN_V0": {
+        "title": "Declare Contract Transaction V0",
+        "description": "Declare Contract Transaction V0",
+        "allOf": [
+          {
+            "type": "object",
+            "title": "Declare txn v0",
+            "properties": {
+              "type": {
+                "title": "Declare",
+                "type": "string",
+                "enum": ["DECLARE"]
+              },
+              "sender_address": {
+                "title": "Sender address",
+                "description": "The address of the account contract sending the declaration transaction",
+                "$ref": "#/components/schemas/ADDRESS"
+              },
+              "max_fee": {
+                "title": "Max fee",
+                "$ref": "#/components/schemas/FELT",
+                "description": "The maximal fee that can be charged for including the transaction"
+              },
+              "version": {
+                "title": "Version",
+                "description": "Version of the transaction scheme",
+                "type": "string",
+                "enum": ["0x0", "0x100000000000000000000000000000000"]
+              },
+              "signature": {
+                "title": "Signature",
+                "$ref": "#/components/schemas/SIGNATURE"
+              },
+              "class_hash": {
+                "title": "Class hash",
+                "description": "The hash of the declared class",
+                "$ref": "#/components/schemas/FELT"
+              }
+            },
+            "required": ["type", "sender_address", "max_fee", "version", "signature", "class_hash"]
+          }
+        ]
+      },
+      "DECLARE_TXN_V1": {
+        "title": "Declare Contract Transaction V1",
+        "description": "Declare Contract Transaction V1",
+        "allOf": [
+          {
+            "type": "object",
+            "title": "Declare txn v1",
+            "properties": {
+              "type": {
+                "title": "Declare",
+                "type": "string",
+                "enum": ["DECLARE"]
+              },
+              "sender_address": {
+                "title": "Sender address",
+                "description": "The address of the account contract sending the declaration transaction",
+                "$ref": "#/components/schemas/ADDRESS"
+              },
+              "max_fee": {
+                "title": "Max fee",
+                "$ref": "#/components/schemas/FELT",
+                "description": "The maximal fee that can be charged for including the transaction"
+              },
+              "version": {
+                "title": "Version",
+                "description": "Version of the transaction scheme",
+                "type": "string",
+                "enum": ["0x1", "0x100000000000000000000000000000001"]
+              },
+              "signature": {
+                "title": "Signature",
+                "$ref": "#/components/schemas/SIGNATURE"
+              },
+              "nonce": {
+                "title": "Nonce",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "class_hash": {
+                "title": "Class hash",
+                "description": "The hash of the declared class",
+                "$ref": "#/components/schemas/FELT"
+              }
+            },
+            "required": ["type", "sender_address", "max_fee", "version", "signature", "nonce", "class_hash"]
+          }
+        ]
+      },
+      "DECLARE_TXN_V2": {
+        "title": "Declare Transaction V2",
+        "description": "Declare Contract Transaction V2",
+        "allOf": [
+          {
+            "type": "object",
+            "title": "Declare txn v2",
+            "properties": {
+              "type": {
+                "title": "Declare",
+                "type": "string",
+                "enum": ["DECLARE"]
+              },
+              "sender_address": {
+                "title": "Sender address",
+                "description": "The address of the account contract sending the declaration transaction",
+                "$ref": "#/components/schemas/ADDRESS"
+              },
+              "compiled_class_hash": {
+                "title": "Compiled class hash",
+                "description": "The hash of the Cairo assembly resulting from the Sierra compilation",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "max_fee": {
+                "title": "Max fee",
+                "$ref": "#/components/schemas/FELT",
+                "description": "The maximal fee that can be charged for including the transaction"
+              },
+              "version": {
+                "title": "Version",
+                "description": "Version of the transaction scheme",
+                "type": "string",
+                "enum": ["0x2", "0x100000000000000000000000000000002"]
+              },
+              "signature": {
+                "title": "Signature",
+                "$ref": "#/components/schemas/SIGNATURE"
+              },
+              "nonce": {
+                "title": "Nonce",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "class_hash": {
+                "title": "Class hash",
+                "description": "The hash of the declared class",
+                "$ref": "#/components/schemas/FELT"
+              }
+            },
+            "required": [
+              "type",
+              "sender_address",
+              "compiled_class_hash",
+              "max_fee",
+              "version",
+              "signature",
+              "nonce",
+              "class_hash"
+            ]
+          }
+        ]
+      },
+      "DECLARE_TXN_V3": {
+        "title": "Declare Transaction V3",
+        "description": "Declare Contract Transaction V3",
+        "allOf": [
+          {
+            "type": "object",
+            "title": "Declare txn v3",
+            "properties": {
+              "type": {
+                "title": "Declare",
+                "type": "string",
+                "enum": ["DECLARE"]
+              },
+              "sender_address": {
+                "title": "Sender address",
+                "description": "The address of the account contract sending the declaration transaction",
+                "$ref": "#/components/schemas/ADDRESS"
+              },
+              "compiled_class_hash": {
+                "title": "Compiled class hash",
+                "description": "The hash of the Cairo assembly resulting from the Sierra compilation",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "version": {
+                "title": "Version",
+                "description": "Version of the transaction scheme",
+                "type": "string",
+                "enum": ["0x3", "0x100000000000000000000000000000003"]
+              },
+              "signature": {
+                "title": "Signature",
+                "$ref": "#/components/schemas/SIGNATURE"
+              },
+              "nonce": {
+                "title": "Nonce",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "class_hash": {
+                "title": "Class hash",
+                "description": "The hash of the declared class",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "resource_bounds": {
+                "title": "Resource bounds",
+                "description": "resource bounds for the transaction execution",
+                "$ref": "#/components/schemas/RESOURCE_BOUNDS_MAPPING"
+              },
+              "tip": {
+                "title": "Tip",
+                "$ref": "#/components/schemas/u64",
+                "description": "the tip for the transaction"
+              },
+              "paymaster_data": {
+                "title": "Paymaster data",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FELT"
+                },
+                "description": "data needed to allow the paymaster to pay for the transaction in native tokens"
+              },
+              "account_deployment_data": {
+                "title": "Account deployment data",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FELT"
+                },
+                "description": "data needed to deploy the account contract from which this tx will be initiated"
+              },
+              "nonce_data_availability_mode": {
+                "title": "Nonce DA mode",
+                "description": "The storage domain of the account's nonce (an account has a nonce per DA mode)",
+                "$ref": "#/components/schemas/DA_MODE"
+              },
+              "fee_data_availability_mode": {
+                "title": "Fee DA mode",
+                "description": "The storage domain of the account's balance from which fee will be charged",
+                "$ref": "#/components/schemas/DA_MODE"
+              }
+            },
+            "required": [
+              "type",
+              "sender_address",
+              "compiled_class_hash",
+              "version",
+              "signature",
+              "nonce",
+              "class_hash",
+              "resource_bounds",
+              "tip",
+              "paymaster_data",
+              "account_deployment_data",
+              "nonce_data_availability_mode",
+              "fee_data_availability_mode"
+            ]
+          }
+        ]
+      },
+      "BROADCASTED_TXN": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BROADCASTED_INVOKE_TXN"
+          },
+          {
+            "$ref": "#/components/schemas/BROADCASTED_DECLARE_TXN"
+          },
+          {
+            "$ref": "#/components/schemas/BROADCASTED_DEPLOY_ACCOUNT_TXN"
+          }
+        ]
+      },
+      "BROADCASTED_INVOKE_TXN": {
+        "title": "Broadcasted invoke transaction",
+        "$ref": "#/components/schemas/INVOKE_TXN"
+      },
+      "BROADCASTED_DEPLOY_ACCOUNT_TXN": {
+        "title": "Broadcasted deploy account transaction",
+        "$ref": "#/components/schemas/DEPLOY_ACCOUNT_TXN"
+      },
+      "BROADCASTED_DECLARE_TXN": {
+        "title": "Broadcasted declare transaction",
+        "oneOf": [
+          {
+            "title": "Broadcasted declare transaction V1",
+            "$ref": "#/components/schemas/BROADCASTED_DECLARE_TXN_V1"
+          },
+          {
+            "title": "Broadcasted declare transaction V2",
+            "$ref": "#/components/schemas/BROADCASTED_DECLARE_TXN_V2"
+          },
+          {
+            "title": "Broadcasted declare transaction V3",
+            "$ref": "#/components/schemas/BROADCASTED_DECLARE_TXN_V3"
+          }
+        ]
+      },
+      "BROADCASTED_DECLARE_TXN_V1": {
+        "title": "Broadcasted declare contract transaction V1",
+        "allOf": [
+          {
+            "type": "object",
+            "title": "Declare txn v1",
+            "properties": {
+              "type": {
+                "title": "Declare",
+                "type": "string",
+                "enum": ["DECLARE"]
+              },
+              "sender_address": {
+                "title": "Sender address",
+                "description": "The address of the account contract sending the declaration transaction",
+                "$ref": "#/components/schemas/ADDRESS"
+              },
+              "max_fee": {
+                "title": "Max fee",
+                "$ref": "#/components/schemas/FELT",
+                "description": "The maximal fee that can be charged for including the transaction"
+              },
+              "version": {
+                "title": "Version",
+                "description": "Version of the transaction scheme",
+                "type": "string",
+                "enum": ["0x1", "0x100000000000000000000000000000001"]
+              },
+              "signature": {
+                "title": "Signature",
+                "$ref": "#/components/schemas/SIGNATURE"
+              },
+              "nonce": {
+                "title": "Nonce",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "contract_class": {
+                "title": "Contract class",
+                "description": "The class to be declared",
+                "$ref": "#/components/schemas/DEPRECATED_CONTRACT_CLASS"
+              }
+            },
+            "required": ["type", "sender_address", "max_fee", "version", "signature", "nonce", "contract_class"]
+          }
+        ]
+      },
+      "BROADCASTED_DECLARE_TXN_V2": {
+        "title": "Broadcasted declare Transaction V2",
+        "description": "Broadcasted declare Contract Transaction V2",
+        "allOf": [
+          {
+            "type": "object",
+            "title": "Declare txn v2",
+            "properties": {
+              "type": {
+                "title": "Declare",
+                "type": "string",
+                "enum": ["DECLARE"]
+              },
+              "sender_address": {
+                "title": "Sender address",
+                "description": "The address of the account contract sending the declaration transaction",
+                "$ref": "#/components/schemas/ADDRESS"
+              },
+              "compiled_class_hash": {
+                "title": "Compiled class hash",
+                "description": "The hash of the Cairo assembly resulting from the Sierra compilation",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "max_fee": {
+                "title": "Max fee",
+                "$ref": "#/components/schemas/FELT",
+                "description": "The maximal fee that can be charged for including the transaction"
+              },
+              "version": {
+                "title": "Version",
+                "description": "Version of the transaction scheme",
+                "type": "string",
+                "enum": ["0x2", "0x100000000000000000000000000000002"]
+              },
+              "signature": {
+                "title": "Signature",
+                "$ref": "#/components/schemas/SIGNATURE"
+              },
+              "nonce": {
+                "title": "Nonce",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "contract_class": {
+                "title": "Contract class",
+                "description": "The class to be declared",
+                "$ref": "#/components/schemas/CONTRACT_CLASS"
+              }
+            },
+            "required": [
+              "type",
+              "sender_address",
+              "compiled_class_hash",
+              "max_fee",
+              "version",
+              "signature",
+              "nonce",
+              "contract_class"
+            ]
+          }
+        ]
+      },
+      "BROADCASTED_DECLARE_TXN_V3": {
+        "title": "Broadcasted declare Transaction V3",
+        "description": "Broadcasted declare Contract Transaction V3",
+        "allOf": [
+          {
+            "type": "object",
+            "title": "Declare txn v3",
+            "properties": {
+              "type": {
+                "title": "Declare",
+                "type": "string",
+                "enum": ["DECLARE"]
+              },
+              "sender_address": {
+                "title": "Sender address",
+                "description": "The address of the account contract sending the declaration transaction",
+                "$ref": "#/components/schemas/ADDRESS"
+              },
+              "compiled_class_hash": {
+                "title": "Compiled class hash",
+                "description": "The hash of the Cairo assembly resulting from the Sierra compilation",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "version": {
+                "title": "Version",
+                "description": "Version of the transaction scheme",
+                "type": "string",
+                "enum": ["0x3", "0x100000000000000000000000000000003"]
+              },
+              "signature": {
+                "title": "Signature",
+                "$ref": "#/components/schemas/SIGNATURE"
+              },
+              "nonce": {
+                "title": "Nonce",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "contract_class": {
+                "title": "Contract class",
+                "description": "The class to be declared",
+                "$ref": "#/components/schemas/CONTRACT_CLASS"
+              },
+              "resource_bounds": {
+                "title": "Resource bounds",
+                "description": "resource bounds for the transaction execution",
+                "$ref": "#/components/schemas/RESOURCE_BOUNDS_MAPPING"
+              },
+              "tip": {
+                "title": "Tip",
+                "$ref": "#/components/schemas/u64",
+                "description": "the tip for the transaction"
+              },
+              "paymaster_data": {
+                "title": "Paymaster data",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FELT"
+                },
+                "description": "data needed to allow the paymaster to pay for the transaction in native tokens"
+              },
+              "account_deployment_data": {
+                "title": "Account deployment data",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FELT"
+                },
+                "description": "data needed to deploy the account contract from which this tx will be initiated"
+              },
+              "nonce_data_availability_mode": {
+                "title": "Nonce DA mode",
+                "description": "The storage domain of the account's nonce (an account has a nonce per DA mode)",
+                "$ref": "#/components/schemas/DA_MODE"
+              },
+              "fee_data_availability_mode": {
+                "title": "Fee DA mode",
+                "description": "The storage domain of the account's balance from which fee will be charged",
+                "$ref": "#/components/schemas/DA_MODE"
+              }
+            },
+            "required": [
+              "type",
+              "sender_address",
+              "compiled_class_hash",
+              "version",
+              "signature",
+              "nonce",
+              "contract_class",
+              "resource_bounds",
+              "tip",
+              "paymaster_data",
+              "account_deployment_data",
+              "nonce_data_availability_mode",
+              "fee_data_availability_mode"
+            ]
+          }
+        ]
+      },
+      "DEPLOY_ACCOUNT_TXN": {
+        "title": "Deploy account transaction",
+        "description": "deploys a new account contract",
+        "oneOf": [
+          {
+            "title": "Deploy account V1",
+            "$ref": "#/components/schemas/DEPLOY_ACCOUNT_TXN_V1"
+          },
+          {
+            "title": "Deploy account V3",
+            "$ref": "#/components/schemas/DEPLOY_ACCOUNT_TXN_V3"
+          }
+        ]
+      },
+      "DEPLOY_ACCOUNT_TXN_V1": {
+        "title": "Deploy account transaction",
+        "description": "Deploys an account contract, charges fee from the pre-funded account addresses",
+        "type": "object",
+        "properties": {
+          "type": {
+            "title": "Deploy account",
+            "type": "string",
+            "enum": ["DEPLOY_ACCOUNT"]
+          },
+          "max_fee": {
+            "title": "Max fee",
+            "$ref": "#/components/schemas/FELT",
+            "description": "The maximal fee that can be charged for including the transaction"
+          },
+          "version": {
+            "title": "Version",
+            "description": "Version of the transaction scheme",
+            "type": "string",
+            "enum": ["0x1", "0x100000000000000000000000000000001"]
+          },
+          "signature": {
+            "title": "Signature",
+            "$ref": "#/components/schemas/SIGNATURE"
+          },
+          "nonce": {
+            "title": "Nonce",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "contract_address_salt": {
+            "title": "Contract address salt",
+            "description": "The salt for the address of the deployed contract",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "constructor_calldata": {
+            "type": "array",
+            "description": "The parameters passed to the constructor",
+            "title": "Constructor calldata",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            }
+          },
+          "class_hash": {
+            "title": "Class hash",
+            "description": "The hash of the deployed contract's class",
+            "$ref": "#/components/schemas/FELT"
+          }
+        },
+        "required": [
+          "max_fee",
+          "version",
+          "signature",
+          "nonce",
+          "type",
+          "contract_address_salt",
+          "constructor_calldata",
+          "class_hash"
+        ]
+      },
+      "DEPLOY_ACCOUNT_TXN_V3": {
+        "title": "Deploy account transaction",
+        "description": "Deploys an account contract, charges fee from the pre-funded account addresses",
+        "type": "object",
+        "properties": {
+          "type": {
+            "title": "Deploy account",
+            "type": "string",
+            "enum": ["DEPLOY_ACCOUNT"]
+          },
+          "version": {
+            "title": "Version",
+            "description": "Version of the transaction scheme",
+            "type": "string",
+            "enum": ["0x3", "0x100000000000000000000000000000003"]
+          },
+          "signature": {
+            "title": "Signature",
+            "$ref": "#/components/schemas/SIGNATURE"
+          },
+          "nonce": {
+            "title": "Nonce",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "contract_address_salt": {
+            "title": "Contract address salt",
+            "description": "The salt for the address of the deployed contract",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "constructor_calldata": {
+            "type": "array",
+            "description": "The parameters passed to the constructor",
+            "title": "Constructor calldata",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            }
+          },
+          "class_hash": {
+            "title": "Class hash",
+            "description": "The hash of the deployed contract's class",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "resource_bounds": {
+            "title": "Resource bounds",
+            "description": "resource bounds for the transaction execution",
+            "$ref": "#/components/schemas/RESOURCE_BOUNDS_MAPPING"
+          },
+          "tip": {
+            "title": "Tip",
+            "$ref": "#/components/schemas/u64",
+            "description": "the tip for the transaction"
+          },
+          "paymaster_data": {
+            "title": "Paymaster data",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            },
+            "description": "data needed to allow the paymaster to pay for the transaction in native tokens"
+          },
+          "nonce_data_availability_mode": {
+            "title": "Nonce DA mode",
+            "description": "The storage domain of the account's nonce (an account has a nonce per DA mode)",
+            "$ref": "#/components/schemas/DA_MODE"
+          },
+          "fee_data_availability_mode": {
+            "title": "Fee DA mode",
+            "description": "The storage domain of the account's balance from which fee will be charged",
+            "$ref": "#/components/schemas/DA_MODE"
+          }
+        },
+        "required": [
+          "version",
+          "signature",
+          "nonce",
+          "type",
+          "contract_address_salt",
+          "constructor_calldata",
+          "class_hash",
+          "resource_bounds",
+          "tip",
+          "paymaster_data",
+          "nonce_data_availability_mode",
+          "fee_data_availability_mode"
+        ]
+      },
+      "DEPLOY_TXN": {
+        "title": "Deploy Contract Transaction",
+        "description": "The structure of a deploy transaction. Note that this transaction type is deprecated and will no longer be supported in future versions",
+        "allOf": [
+          {
+            "type": "object",
+            "title": "Deploy txn",
+            "properties": {
+              "version": {
+                "title": "Version",
+                "description": "Version of the transaction scheme",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "type": {
+                "title": "Deploy",
+                "type": "string",
+                "enum": ["DEPLOY"]
+              },
+              "contract_address_salt": {
+                "description": "The salt for the address of the deployed contract",
+                "title": "Contract address salt",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "constructor_calldata": {
+                "type": "array",
+                "title": "Constructor calldata",
+                "description": "The parameters passed to the constructor",
+                "items": {
+                  "$ref": "#/components/schemas/FELT"
+                }
+              },
+              "class_hash": {
+                "title": "Class hash",
+                "description": "The hash of the deployed contract's class",
+                "$ref": "#/components/schemas/FELT"
+              }
+            },
+            "required": ["version", "type", "constructor_calldata", "contract_address_salt", "class_hash"]
+          }
+        ]
+      },
+      "INVOKE_TXN_V0": {
+        "title": "Invoke transaction V0",
+        "description": "invokes a specific function in the desired contract (not necessarily an account)",
+        "type": "object",
+        "properties": {
+          "type": {
+            "title": "Type",
+            "type": "string",
+            "enum": ["INVOKE"]
+          },
+          "max_fee": {
+            "title": "Max fee",
+            "$ref": "#/components/schemas/FELT",
+            "description": "The maximal fee that can be charged for including the transaction"
+          },
+          "version": {
+            "title": "Version",
+            "description": "Version of the transaction scheme",
+            "type": "string",
+            "enum": ["0x0", "0x100000000000000000000000000000000"]
+          },
+          "signature": {
+            "title": "Signature",
+            "$ref": "#/components/schemas/SIGNATURE"
+          },
+          "contract_address": {
+            "title": "Contract address",
+            "$ref": "#/components/schemas/ADDRESS"
+          },
+          "entry_point_selector": {
+            "title": "Entry point selector",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "calldata": {
+            "title": "Calldata",
+            "type": "array",
+            "description": "The parameters passed to the function",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            }
+          }
+        },
+        "required": ["type", "contract_address", "entry_point_selector", "calldata", "max_fee", "version", "signature"]
+      },
+      "INVOKE_TXN_V1": {
+        "title": "Invoke transaction V1",
+        "description": "initiates a transaction from a given account",
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "title": "Type",
+                "type": "string",
+                "enum": ["INVOKE"]
+              },
+              "sender_address": {
+                "title": "sender address",
+                "$ref": "#/components/schemas/ADDRESS"
+              },
+              "calldata": {
+                "type": "array",
+                "title": "calldata",
+                "description": "The data expected by the account's `execute` function (in most usecases, this includes the called contract address and a function selector)",
+                "items": {
+                  "$ref": "#/components/schemas/FELT"
+                }
+              },
+              "max_fee": {
+                "title": "Max fee",
+                "$ref": "#/components/schemas/FELT",
+                "description": "The maximal fee that can be charged for including the transaction"
+              },
+              "version": {
+                "title": "Version",
+                "description": "Version of the transaction scheme",
+                "type": "string",
+                "enum": ["0x1", "0x100000000000000000000000000000001"]
+              },
+              "signature": {
+                "title": "Signature",
+                "$ref": "#/components/schemas/SIGNATURE"
+              },
+              "nonce": {
+                "title": "Nonce",
+                "$ref": "#/components/schemas/FELT"
+              }
+            },
+            "required": ["type", "sender_address", "calldata", "max_fee", "version", "signature", "nonce"]
+          }
+        ]
+      },
+      "INVOKE_TXN_V3": {
+        "title": "Invoke transaction V3",
+        "description": "initiates a transaction from a given account",
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "title": "Type",
+                "type": "string",
+                "enum": ["INVOKE"]
+              },
+              "sender_address": {
+                "title": "sender address",
+                "$ref": "#/components/schemas/ADDRESS"
+              },
+              "calldata": {
+                "type": "array",
+                "title": "calldata",
+                "description": "The data expected by the account's `execute` function (in most usecases, this includes the called contract address and a function selector)",
+                "items": {
+                  "$ref": "#/components/schemas/FELT"
+                }
+              },
+              "version": {
+                "title": "Version",
+                "description": "Version of the transaction scheme",
+                "type": "string",
+                "enum": ["0x3", "0x100000000000000000000000000000003"]
+              },
+              "signature": {
+                "title": "Signature",
+                "$ref": "#/components/schemas/SIGNATURE"
+              },
+              "nonce": {
+                "title": "Nonce",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "resource_bounds": {
+                "title": "Resource bounds",
+                "description": "resource bounds for the transaction execution",
+                "$ref": "#/components/schemas/RESOURCE_BOUNDS_MAPPING"
+              },
+              "tip": {
+                "title": "Tip",
+                "$ref": "#/components/schemas/u64",
+                "description": "the tip for the transaction"
+              },
+              "paymaster_data": {
+                "title": "Paymaster data",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FELT"
+                },
+                "description": "data needed to allow the paymaster to pay for the transaction in native tokens"
+              },
+              "account_deployment_data": {
+                "title": "Account deployment data",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FELT"
+                },
+                "description": "data needed to deploy the account contract from which this tx will be initiated"
+              },
+              "nonce_data_availability_mode": {
+                "title": "Nonce DA mode",
+                "description": "The storage domain of the account's nonce (an account has a nonce per DA mode)",
+                "$ref": "#/components/schemas/DA_MODE"
+              },
+              "fee_data_availability_mode": {
+                "title": "Fee DA mode",
+                "description": "The storage domain of the account's balance from which fee will be charged",
+                "$ref": "#/components/schemas/DA_MODE"
+              }
+            },
+            "required": [
+              "type",
+              "sender_address",
+              "calldata",
+              "version",
+              "signature",
+              "nonce",
+              "resource_bounds",
+              "tip",
+              "paymaster_data",
+              "account_deployment_data",
+              "nonce_data_availability_mode",
+              "fee_data_availability_mode"
+            ]
+          }
+        ]
+      },
+      "INVOKE_TXN": {
+        "title": "Invoke transaction",
+        "description": "Initiate a transaction from an account",
+        "oneOf": [
+          {
+            "title": "Invoke transaction V0",
+            "$ref": "#/components/schemas/INVOKE_TXN_V0"
+          },
+          {
+            "title": "Invoke transaction V1",
+            "$ref": "#/components/schemas/INVOKE_TXN_V1"
+          },
+          {
+            "title": "Invoke transaction V3",
+            "$ref": "#/components/schemas/INVOKE_TXN_V3"
+          }
+        ]
+      },
+      "L1_HANDLER_TXN": {
+        "title": "L1 Handler transaction",
+        "allOf": [
+          {
+            "type": "object",
+            "title": "L1 handler transaction",
+            "description": "a call to an l1_handler on an L2 contract induced by a message from L1",
+            "properties": {
+              "version": {
+                "title": "Version",
+                "description": "Version of the transaction scheme",
+                "type": "string",
+                "enum": ["0x0"]
+              },
+              "type": {
+                "title": "type",
+                "type": "string",
+                "enum": ["L1_HANDLER"]
+              },
+              "nonce": {
+                "title": "Nonce",
+                "description": "The L1->L2 message nonce field of the SN Core L1 contract at the time the transaction was sent",
+                "$ref": "#/components/schemas/NUM_AS_HEX"
+              }
+            },
+            "required": ["version", "type", "nonce"]
+          },
+          {
+            "title": "Function call",
+            "$ref": "#/components/schemas/FUNCTION_CALL"
+          }
+        ]
+      },
+      "COMMON_RECEIPT_PROPERTIES": {
+        "allOf": [
+          {
+            "title": "Common receipt properties",
+            "description": "Common properties for a transaction receipt",
+            "type": "object",
+            "properties": {
+              "transaction_hash": {
+                "title": "Transaction hash",
+                "$ref": "#/components/schemas/TXN_HASH",
+                "description": "The hash identifying the transaction"
+              },
+              "actual_fee": {
+                "title": "Actual fee",
+                "$ref": "#/components/schemas/FEE_PAYMENT",
+                "description": "The fee that was charged by the sequencer"
+              },
+              "finality_status": {
+                "title": "Finality status",
+                "description": "finality status of the tx",
+                "$ref": "#/components/schemas/TXN_FINALITY_STATUS"
+              },
+              "messages_sent": {
+                "type": "array",
+                "title": "Messages sent",
+                "items": {
+                  "$ref": "#/components/schemas/MSG_TO_L1"
+                }
+              },
+              "events": {
+                "description": "The events emitted as part of this transaction",
+                "title": "Events",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EVENT"
+                }
+              },
+              "execution_resources": {
+                "title": "Execution resources",
+                "description": "The resources consumed by the transaction",
+                "$ref": "#/components/schemas/EXECUTION_RESOURCES"
+              }
+            },
+            "required": [
+              "transaction_hash",
+              "actual_fee",
+              "finality_status",
+              "messages_sent",
+              "events",
+              "execution_resources"
+            ]
+          },
+          {
+            "oneOf": [
+              {
+                "title": "Successful Common receipt properties",
+                "description": "Common properties for a transaction receipt that was executed successfully",
+                "type": "object",
+                "properties": {
+                  "execution_status": {
+                    "title": "Execution status",
+                    "type": "string",
+                    "enum": ["SUCCEEDED"],
+                    "description": "The execution status of the transaction"
+                  }
+                },
+                "required": ["execution_status"]
+              },
+              {
+                "title": "Reverted Common receipt properties",
+                "description": "Common properties for a transaction receipt that was reverted",
+                "type": "object",
+                "properties": {
+                  "execution_status": {
+                    "title": "Execution status",
+                    "type": "string",
+                    "enum": ["REVERTED"],
+                    "description": "The execution status of the transaction"
+                  },
+                  "revert_reason": {
+                    "title": "Revert reason",
+                    "name": "revert reason",
+                    "description": "the revert reason for the failed execution",
+                    "type": "string"
+                  }
+                },
+                "required": ["execution_status", "revert_reason"]
+              }
+            ]
+          }
+        ]
+      },
+      "INVOKE_TXN_RECEIPT": {
+        "title": "Invoke Transaction Receipt",
+        "allOf": [
+          {
+            "title": "Type",
+            "type": "object",
+            "properties": {
+              "type": {
+                "title": "Type",
+                "type": "string",
+                "enum": ["INVOKE"]
+              }
+            },
+            "required": ["type"]
+          },
+          {
+            "title": "Common receipt properties",
+            "$ref": "#/components/schemas/COMMON_RECEIPT_PROPERTIES"
+          }
+        ]
+      },
+      "DECLARE_TXN_RECEIPT": {
+        "title": "Declare Transaction Receipt",
+        "allOf": [
+          {
+            "title": "Declare txn receipt",
+            "type": "object",
+            "properties": {
+              "type": {
+                "title": "Declare",
+                "type": "string",
+                "enum": ["DECLARE"]
+              }
+            },
+            "required": ["type"]
+          },
+          {
+            "title": "Common receipt properties",
+            "$ref": "#/components/schemas/COMMON_RECEIPT_PROPERTIES"
+          }
+        ]
+      },
+      "DEPLOY_ACCOUNT_TXN_RECEIPT": {
+        "title": "Deploy Account Transaction Receipt",
+        "allOf": [
+          {
+            "title": "Common receipt properties",
+            "$ref": "#/components/schemas/COMMON_RECEIPT_PROPERTIES"
+          },
+          {
+            "title": "DeployAccount txn receipt",
+            "type": "object",
+            "properties": {
+              "type": {
+                "title": "Deploy account",
+                "type": "string",
+                "enum": ["DEPLOY_ACCOUNT"]
+              },
+              "contract_address": {
+                "title": "Contract address",
+                "description": "The address of the deployed contract",
+                "$ref": "#/components/schemas/FELT"
+              }
+            },
+            "required": ["type", "contract_address"]
+          }
+        ]
+      },
+      "DEPLOY_TXN_RECEIPT": {
+        "title": "Deploy Transaction Receipt",
+        "allOf": [
+          {
+            "title": "Common receipt properties",
+            "$ref": "#/components/schemas/COMMON_RECEIPT_PROPERTIES"
+          },
+          {
+            "title": "Deploy txn receipt",
+            "type": "object",
+            "properties": {
+              "type": {
+                "title": "Deploy",
+                "type": "string",
+                "enum": ["DEPLOY"]
+              },
+              "contract_address": {
+                "title": "Contract address",
+                "description": "The address of the deployed contract",
+                "$ref": "#/components/schemas/FELT"
+              }
+            },
+            "required": ["type", "contract_address"]
+          }
+        ]
+      },
+      "L1_HANDLER_TXN_RECEIPT": {
+        "title": "L1 Handler Transaction Receipt",
+        "description": "receipt for l1 handler transaction",
+        "allOf": [
+          {
+            "title": "Transaction type",
+            "type": "object",
+            "properties": {
+              "type": {
+                "title": "type",
+                "type": "string",
+                "enum": ["L1_HANDLER"]
+              },
+              "message_hash": {
+                "title": "Message hash",
+                "description": "The message hash as it appears on the L1 core contract",
+                "$ref": "#/components/schemas/NUM_AS_HEX"
+              }
+            },
+            "required": ["type", "message_hash"]
+          },
+          {
+            "title": "Common receipt properties",
+            "$ref": "#/components/schemas/COMMON_RECEIPT_PROPERTIES"
+          }
+        ]
+      },
+      "TXN_RECEIPT": {
+        "title": "Transaction Receipt",
+        "oneOf": [
+          {
+            "title": "Invoke transaction receipt",
+            "$ref": "#/components/schemas/INVOKE_TXN_RECEIPT"
+          },
+          {
+            "title": "L1 handler transaction receipt",
+            "$ref": "#/components/schemas/L1_HANDLER_TXN_RECEIPT"
+          },
+          {
+            "title": "Declare transaction receipt",
+            "$ref": "#/components/schemas/DECLARE_TXN_RECEIPT"
+          },
+          {
+            "title": "Deploy transaction receipt",
+            "$ref": "#/components/schemas/DEPLOY_TXN_RECEIPT"
+          },
+          {
+            "title": "Deploy account transaction receipt",
+            "$ref": "#/components/schemas/DEPLOY_ACCOUNT_TXN_RECEIPT"
+          }
+        ]
+      },
+      "TXN_RECEIPT_WITH_BLOCK_INFO": {
+        "title": "Transaction receipt with block info",
+        "allOf": [
+          {
+            "title": "Transaction receipt",
+            "$ref": "#/components/schemas/TXN_RECEIPT"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "block_hash": {
+                "title": "Block hash",
+                "$ref": "#/components/schemas/BLOCK_HASH",
+                "description": "If this field is missing, it means the receipt belongs to the pending block"
+              },
+              "block_number": {
+                "title": "Block number",
+                "$ref": "#/components/schemas/BLOCK_NUMBER",
+                "description": "If this field is missing, it means the receipt belongs to the pending block"
+              }
+            }
+          }
+        ]
+      },
+      "MSG_TO_L1": {
+        "title": "Message to L1",
+        "type": "object",
+        "properties": {
+          "from_address": {
+            "description": "The address of the L2 contract sending the message",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "to_address": {
+            "title": "To address",
+            "description": "The target L1 address the message is sent to",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "payload": {
+            "description": "The payload of the message",
+            "title": "Payload",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            }
+          }
+        },
+        "required": ["from_address", "to_address", "payload"]
+      },
+      "MSG_FROM_L1": {
+        "title": "Message from L1",
+        "type": "object",
+        "properties": {
+          "from_address": {
+            "description": "The address of the L1 contract sending the message",
+            "$ref": "#/components/schemas/ETH_ADDRESS"
+          },
+          "to_address": {
+            "title": "To address",
+            "description": "The target L2 address the message is sent to",
+            "$ref": "#/components/schemas/ADDRESS"
+          },
+          "entry_point_selector": {
+            "title": "Selector",
+            "description": "The selector of the l1_handler in invoke in the target contract",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "payload": {
+            "description": "The payload of the message",
+            "title": "Payload",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            }
+          }
+        },
+        "required": ["from_address", "to_address", "payload", "entry_point_selector"]
+      },
+      "TXN_STATUS_RESULT": {
+        "title": "Transaction status result",
+        "description": "Transaction status result, including finality status and execution status",
+        "schema": {
+          "title": "Transaction status result",
+          "type": "object",
+          "properties": {
+            "finality_status": {
+              "title": "finality status",
+              "$ref": "#/components/schemas/TXN_STATUS"
+            },
+            "execution_status": {
+              "title": "execution status",
+              "$ref": "#/components/schemas/TXN_EXECUTION_STATUS"
+            },
+            "failure_reason": {
+                "title": "failure reason",
+                "description": "the failure reason, only appears if finality_status is REJECTED or execution_status is REVERTED",
+                "type": "string"
+            }
+          },
+          "required": ["finality_status"]
+        }
+      },
+      "TXN_STATUS": {
+        "title": "Transaction status",
+        "type": "string",
+        "enum": ["RECEIVED", "REJECTED", "ACCEPTED_ON_L2", "ACCEPTED_ON_L1"],
+        "description": "The finality status of the transaction, including the case the txn is still in the mempool or failed validation during the block construction phase"
+      },
+      "TXN_FINALITY_STATUS": {
+        "title": "Finality status",
+        "type": "string",
+        "enum": ["ACCEPTED_ON_L2", "ACCEPTED_ON_L1"],
+        "description": "The finality status of the transaction"
+      },
+      "TXN_EXECUTION_STATUS": {
+        "title": "Execution status",
+        "type": "string",
+        "enum": ["SUCCEEDED", "REVERTED"],
+        "description": "The execution status of the transaction"
+      },
+      "TXN_TYPE": {
+        "title": "Transaction type",
+        "type": "string",
+        "enum": ["DECLARE", "DEPLOY", "DEPLOY_ACCOUNT", "INVOKE", "L1_HANDLER"],
+        "description": "The type of the transaction"
+      },
+      "BLOCK_STATUS": {
+        "title": "Block status",
+        "type": "string",
+        "enum": ["PENDING", "ACCEPTED_ON_L2", "ACCEPTED_ON_L1", "REJECTED"],
+        "description": "The status of the block"
+      },
+      "FUNCTION_CALL": {
+        "title": "Function call",
+        "type": "object",
+        "description": "Function call information",
+        "properties": {
+          "contract_address": {
+            "title": "Contract address",
+            "$ref": "#/components/schemas/ADDRESS"
+          },
+          "entry_point_selector": {
+            "title": "Entry point selector",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "calldata": {
+            "title": "Calldata",
+            "type": "array",
+            "description": "The parameters passed to the function",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            }
+          }
+        },
+        "required": ["contract_address", "entry_point_selector", "calldata"]
+      },
+      "CONTRACT_CLASS": {
+        "title": "Contract class",
+        "type": "object",
+        "properties": {
+          "sierra_program": {
+            "title": "Sierra program",
+            "type": "array",
+            "description": "The list of Sierra instructions of which the program consists",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            }
+          },
+          "contract_class_version": {
+            "title": "Contract class version",
+            "type": "string",
+            "description": "The version of the contract class object. Currently, the Starknet OS supports version 0.1.0"
+          },
+          "entry_points_by_type": {
+            "title": "Entry points by type",
+            "type": "object",
+            "properties": {
+              "CONSTRUCTOR": {
+                "type": "array",
+                "title": "Constructor",
+                "items": {
+                  "$ref": "#/components/schemas/SIERRA_ENTRY_POINT"
+                }
+              },
+              "EXTERNAL": {
+                "title": "External",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SIERRA_ENTRY_POINT"
+                }
+              },
+              "L1_HANDLER": {
+                "title": "L1 handler",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SIERRA_ENTRY_POINT"
+                }
+              }
+            },
+            "required": ["CONSTRUCTOR", "EXTERNAL", "L1_HANDLER"]
+          },
+          "abi": {
+            "title": "ABI",
+            "type": "string",
+            "description": "The class ABI, as supplied by the user declaring the class"
+          }
+        },
+        "required": ["sierra_program", "contract_class_version", "entry_points_by_type"]
+      },
+      "DEPRECATED_CONTRACT_CLASS": {
+        "title": "Deprecated contract class",
+        "description": "The definition of a StarkNet contract class",
+        "type": "object",
+        "properties": {
+          "program": {
+            "type": "string",
+            "title": "Program",
+            "description": "A base64 representation of the compressed program code",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$"
+          },
+          "entry_points_by_type": {
+            "type": "object",
+            "title": "Deprecated entry points by type",
+            "properties": {
+              "CONSTRUCTOR": {
+                "type": "array",
+                "title": "Deprecated constructor",
+                "items": {
+                  "$ref": "#/components/schemas/DEPRECATED_CAIRO_ENTRY_POINT"
+                }
+              },
+              "EXTERNAL": {
+                "type": "array",
+                "title": "Deprecated external",
+                "items": {
+                  "$ref": "#/components/schemas/DEPRECATED_CAIRO_ENTRY_POINT"
+                }
+              },
+              "L1_HANDLER": {
+                "type": "array",
+                "title": "Deprecated L1 handler",
+                "items": {
+                  "$ref": "#/components/schemas/DEPRECATED_CAIRO_ENTRY_POINT"
+                }
+              }
+            }
+          },
+          "abi": {
+            "title": "Contract ABI",
+            "$ref": "#/components/schemas/CONTRACT_ABI"
+          }
+        },
+        "required": ["program", "entry_points_by_type"]
+      },
+      "DEPRECATED_CAIRO_ENTRY_POINT": {
+        "title": "Deprecated Cairo entry point",
+        "type": "object",
+        "properties": {
+          "offset": {
+            "title": "Offset",
+            "description": "The offset of the entry point in the program",
+            "$ref": "#/components/schemas/NUM_AS_HEX"
+          },
+          "selector": {
+            "title": "Selector",
+            "description": "A unique identifier of the entry point (function) in the program",
+            "$ref": "#/components/schemas/FELT"
+          }
+        },
+        "required": ["offset", "selector"]
+      },
+      "SIERRA_ENTRY_POINT": {
+        "title": "Sierra entry point",
+        "type": "object",
+        "properties": {
+          "selector": {
+            "title": "Selector",
+            "description": "A unique identifier of the entry point (function) in the program",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "function_idx": {
+            "title": "Function index",
+            "description": "The index of the function in the program",
+            "type": "integer"
+          }
+        },
+        "required": ["selector", "function_idx"]
+      },
+      "CONTRACT_ABI": {
+        "title": "Contract ABI",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/CONTRACT_ABI_ENTRY"
+        }
+      },
+      "CONTRACT_ABI_ENTRY": {
+        "title": "Contract ABI entry",
+        "oneOf": [
+          {
+            "title": "Function ABI entry",
+            "$ref": "#/components/schemas/FUNCTION_ABI_ENTRY"
+          },
+          {
+            "title": "Event ABI entry",
+            "$ref": "#/components/schemas/EVENT_ABI_ENTRY"
+          },
+          {
+            "title": "Struct ABI entry",
+            "$ref": "#/components/schemas/STRUCT_ABI_ENTRY"
+          }
+        ]
+      },
+      "STRUCT_ABI_TYPE": {
+        "title": "Struct ABI type",
+        "type": "string",
+        "enum": ["struct"]
+      },
+      "EVENT_ABI_TYPE": {
+        "title": "Event ABI type",
+        "type": "string",
+        "enum": ["event"]
+      },
+      "FUNCTION_ABI_TYPE": {
+        "title": "Function ABI type",
+        "type": "string",
+        "enum": ["function", "l1_handler", "constructor"]
+      },
+      "STRUCT_ABI_ENTRY": {
+        "title": "Struct ABI entry",
+        "type": "object",
+        "properties": {
+          "type": {
+            "title": "Struct ABI type",
+            "$ref": "#/components/schemas/STRUCT_ABI_TYPE"
+          },
+          "name": {
+            "title": "Struct name",
+            "description": "The struct name",
+            "type": "string"
+          },
+          "size": {
+            "title": "Size",
+            "type": "integer",
+            "minimum": 1
+          },
+          "members": {
+            "type": "array",
+            "title": "Members",
+            "items": {
+              "$ref": "#/components/schemas/STRUCT_MEMBER"
+            }
+          }
+        },
+        "required": ["type", "name", "size", "members"]
+      },
+      "STRUCT_MEMBER": {
+        "title": "Struct member",
+        "allOf": [
+          {
+            "title": "Typed parameter",
+            "$ref": "#/components/schemas/TYPED_PARAMETER"
+          },
+          {
+            "type": "object",
+            "title": "Offset",
+            "properties": {
+              "offset": {
+                "title": "Offset",
+                "description": "offset of this property within the struct",
+                "type": "integer"
+              }
+            }
+          }
+        ]
+      },
+      "EVENT_ABI_ENTRY": {
+        "title": "Event ABI entry",
+        "type": "object",
+        "properties": {
+          "type": {
+            "title": "Event ABI type",
+            "$ref": "#/components/schemas/EVENT_ABI_TYPE"
+          },
+          "name": {
+            "title": "Event name",
+            "description": "The event name",
+            "type": "string"
+          },
+          "keys": {
+            "type": "array",
+            "title": "Typed parameter",
+            "items": {
+              "$ref": "#/components/schemas/TYPED_PARAMETER"
+            }
+          },
+          "data": {
+            "type": "array",
+            "title": "Typed parameter",
+            "items": {
+              "$ref": "#/components/schemas/TYPED_PARAMETER"
+            }
+          }
+        },
+        "required": ["type", "name", "keys", "data"]
+      },
+      "FUNCTION_STATE_MUTABILITY": {
+        "title": "Function state mutability type",
+        "type": "string",
+        "enum": ["view"]
+      },
+      "FUNCTION_ABI_ENTRY": {
+        "title": "Function ABI entry",
+        "type": "object",
+        "properties": {
+          "type": {
+            "title": "Function ABI type",
+            "$ref": "#/components/schemas/FUNCTION_ABI_TYPE"
+          },
+          "name": {
+            "title": "Function name",
+            "description": "The function name",
+            "type": "string"
+          },
+          "inputs": {
+            "type": "array",
+            "title": "Typed parameter",
+            "items": {
+              "$ref": "#/components/schemas/TYPED_PARAMETER"
+            }
+          },
+          "outputs": {
+            "type": "array",
+            "title": "Typed parameter",
+            "items": {
+              "$ref": "#/components/schemas/TYPED_PARAMETER"
+            }
+          },
+          "stateMutability": {
+            "title": "Function state mutability",
+            "$ref": "#/components/schemas/FUNCTION_STATE_MUTABILITY"
+          }
+        },
+        "required": ["type", "name", "inputs", "outputs"]
+      },
+      "TYPED_PARAMETER": {
+        "title": "Typed parameter",
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Parameter name",
+            "description": "The parameter's name",
+            "type": "string"
+          },
+          "type": {
+            "title": "Parameter type",
+            "description": "The parameter's type",
+            "type": "string"
+          }
+        },
+        "required": ["name", "type"]
+      },
+      "SIMULATION_FLAG_FOR_ESTIMATE_FEE": {
+        "type": "string",
+        "enum": ["SKIP_VALIDATE"],
+        "description": "Flags that indicate how to simulate a given transaction. By default, the sequencer behavior is replicated locally"
+      },
+      "PRICE_UNIT": {
+        "title": "price unit",
+        "type": "string",
+        "enum": ["WEI", "FRI"]
+      },
+      "FEE_ESTIMATE": {
+        "title": "Fee estimation",
+        "type": "object",
+        "properties": {
+          "l1_gas_consumed": {
+            "title": "L1 gas consumed",
+            "description": "The Ethereum gas consumption of the transaction, charged for L1->L2 messages and, depending on the block's DA_MODE, state diffs",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "l1_gas_price": {
+            "title": "L1 gas price",
+            "description": "The gas price (in wei or fri, depending on the tx version) that was used in the cost estimation",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "l2_gas_consumed": {
+            "title": "L2 gas consumed",
+            "description": "The L2 gas consumption of the transaction",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "l2_gas_price": {
+            "title": "L2 gas price",
+            "description": "The L2 gas price (in wei or fri, depending on the tx version) that was used in the cost estimation",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "l1_data_gas_consumed": {
+            "title": "L1 data gas consumed",
+            "description": "The Ethereum data gas consumption of the transaction",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "l1_data_gas_price": {
+            "title": "L1 data gas price",
+            "description": "The data gas price (in wei or fri, depending on the tx version) that was used in the cost estimation",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "overall_fee": {
+            "title": "Overall fee",
+            "description": "The estimated fee for the transaction (in wei or fri, depending on the tx version), equals to gas_consumed*gas_price + data_gas_consumed*data_gas_price",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "unit": {
+            "title": "Fee unit",
+            "description": "units in which the fee is given",
+            "$ref": "#/components/schemas/PRICE_UNIT"
+          }
+        },
+        "required": ["gas_consumed", "gas_price", "data_gas_consumed", "data_gas_price", "overall_fee", "unit"]
+      },
+      "FEE_PAYMENT": {
+        "title": "Fee Payment",
+        "description": "fee payment info as it appears in receipts",
+        "type": "object",
+        "properties": {
+          "amount": {
+            "title": "Amount",
+            "description": "amount paid",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "unit": {
+            "title": "Fee unit",
+            "description": "units in which the fee is given",
+            "$ref": "#/components/schemas/PRICE_UNIT"
+          }
+        },
+        "required": ["amount", "unit"]
+      },
+      "DA_MODE": {
+        "title": "DA mode",
+        "type": "string",
+        "description": "Specifies a storage domain in Starknet. Each domain has different gurantess regarding availability",
+        "enum": ["L1", "L2"]
+      },
+      "RESOURCE_BOUNDS_MAPPING": {
+        "type": "object",
+        "properties": {
+          "l1_gas": {
+            "title": "L1 Gas",
+            "description": "The max amount and max price per unit of L1 gas used in this tx",
+            "$ref": "#/components/schemas/RESOURCE_BOUNDS"
+          },
+          "l2_gas": {
+            "title": "L2 Gas",
+            "description": "The max amount and max price per unit of L2 gas used in this tx",
+            "$ref": "#/components/schemas/RESOURCE_BOUNDS"
+          }
+        },
+        "required": ["l1_gas", "l2_gas"]
+      },
+      "RESOURCE_BOUNDS": {
+        "type": "object",
+        "properties": {
+          "max_amount": {
+            "title": "max amount",
+            "description": "the max amount of the resource that can be used in the tx",
+            "$ref": "#/components/schemas/u64"
+          },
+          "max_price_per_unit": {
+            "title": "max price",
+            "description": "the max price per unit of this resource for this tx",
+            "$ref": "#/components/schemas/u128"
+          }
+        },
+        "required": ["max_amount", "max_price_per_unit"]
+      },
+      "RESOURCE_PRICE": {
+        "type": "object",
+        "properties": {
+          "price_in_fri": {
+            "title": "price in fri",
+            "description": "the price of one unit of the given resource, denominated in fri (10^-18 strk)",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "price_in_wei": {
+            "title": "price in wei",
+            "description": "the price of one unit of the given resource, denominated in wei",
+            "$ref": "#/components/schemas/FELT"
+          }
+        },
+        "required": ["price_in_wei", "price_in_fri"]
+      },
+      "EXECUTION_RESOURCES": {
+        "type": "object",
+        "title": "Execution resources",
+        "description": "the resources consumed by the transaction",
+        "properties": {
+          "l1_gas": {
+            "title": "L1Gas",
+            "description": "l1 gas consumed by this transaction, used for l2-->l1 messages and state updates if blobs are not used",
+            "type": "integer"
+          },
+          "l1_data_gas": {
+            "title": "L1DataGas",
+            "description": "data gas consumed by this transaction, 0 if blobs are not used",
+            "type": "integer"
+          },
+          "l2_gas": {
+            "title": "L2Gas",
+            "description": "l2 gas consumed by this transaction, used for computation and calldata",
+            "type": "integer"
+          }
+        }
+      },
+      "MERKLE_NODE": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "integer"
+          },
+          "length": {
+            "type": "integer"
+          },
+          "value": {
+            "$ref": "#/components/schemas/FELT"
+          },
+          "children_hashes": {
+            "type": "object",
+            "description": "the hash of the child nodes, if not present then the node is a leaf",
+            "properties": {
+              "left": {
+                "$ref": "#/components/schemas/FELT"
+              },
+              "right": {
+                "$ref": "#/components/schemas/FELT"
+              }
+            },
+            "required": [
+              "left",
+              "right"
+            ]
+          }
+        },
+        "required": [
+          "path",
+          "length",
+          "value"
+        ]
+      },
+      "NODE_HASH_TO_NODE_MAPPING": {
+        "description": "a node_hash -> node mapping of all the nodes in the union of the paths between the requested leaves and the root (for each node present, its sibling is also present)",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "node_hash": {
+              "$ref": "#/components/schemas/FELT"
+            },
+            "node": {
+              "$ref": "#/components/schemas/MERKLE_NODE"
+            }
+          },
+          "required": [
+            "node_hash",
+            "node"
+          ]
+        }
+    },
+    "CONTRACT_EXECUTION_ERROR": {
+        "description": "structured error that can later be processed by wallets or sdks",
+        "titel": "contract execution error",
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "inner call",
+            "description": "error frame",
+            "properties": {
+              "contract_address": {
+                "$ref": "#/components/schemas/ADDRESS"
+              },
+              "class_hash": {
+                "$ref": "#/components/schemas/FELT"
+              },
+              "selector": {
+                "$ref": "#/components/schemas/FELT"
+              },
+              "error": {
+                "$ref": "#/components/schemas/CONTRACT_EXECUTION_ERROR"
+              }
+            }
+          },
+          {
+            "title": "error message",
+            "description": "the error raised during execution",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "errors": {
+      "FAILED_TO_RECEIVE_TXN": {
+        "code": 1,
+        "message": "Failed to write transaction"
+      },
+      "CONTRACT_NOT_FOUND": {
+        "code": 20,
+        "message": "Contract not found"
+      },
+      "BLOCK_NOT_FOUND": {
+        "code": 24,
+        "message": "Block not found"
+      },
+      "INVALID_TXN_INDEX": {
+        "code": 27,
+        "message": "Invalid transaction index in a block"
+      },
+      "CLASS_HASH_NOT_FOUND": {
+        "code": 28,
+        "message": "Class hash not found"
+      },
+      "TXN_HASH_NOT_FOUND": {
+        "code": 29,
+        "message": "Transaction hash not found"
+      },
+      "PAGE_SIZE_TOO_BIG": {
+        "code": 31,
+        "message": "Requested page size is too big"
+      },
+      "NO_BLOCKS": {
+        "code": 32,
+        "message": "There are no blocks"
+      },
+      "INVALID_CONTINUATION_TOKEN": {
+        "code": 33,
+        "message": "The supplied continuation token is invalid or unknown"
+      },
+      "TOO_MANY_KEYS_IN_FILTER": {
+        "code": 34,
+        "message": "Too many keys provided in a filter"
+      },
+      "CONTRACT_ERROR": {
+        "code": 40,
+        "message": "Contract error",
+        "data": {
+          "type": "object",
+          "description": "More data about the execution failure",
+          "properties": {
+            "revert_error": {
+              "title": "revert error",
+              "description": "the execution trace up to the point of failure",
+              "$ref": "#/components/schemas/CONTRACT_EXECUTION_ERROR"
+            }
+          },
+          "required": "revert_error"
+        }
+      },
+      "TRANSACTION_EXECUTION_ERROR": {
+        "code": 41,
+        "message": "Transaction execution error",
+        "data": {
+          "type": "object",
+          "description": "More data about the execution failure",
+          "properties": {
+            "transaction_index": {
+              "title": "Transaction index",
+              "description": "The index of the first transaction failing in a sequence of given transactions",
+              "type": "integer"
+            },
+            "execution_error": {
+              "title": "revert error",
+              "description": "the execution trace up to the point of failure",
+              "$ref": "#/components/schemas/CONTRACT_EXECUTION_ERROR"
+            }
+          },
+          "required": ["transaction_index", "execution_error"]
+        }
+      }
+    }
+  }
+}

--- a/doc/rpc/v08/starknet_trace_api_openrpc.json
+++ b/doc/rpc/v08/starknet_trace_api_openrpc.json
@@ -1,0 +1,480 @@
+{
+  "openrpc": "1.0.0-rc1",
+  "info": {
+    "version": "0.7.1",
+    "title": "StarkNet Trace API",
+    "license": {}
+  },
+  "servers": [],
+  "methods": [
+    {
+      "name": "starknet_traceTransaction",
+      "summary": "For a given executed transaction, return the trace of its execution, including internal calls",
+      "description": "Returns the execution trace of the transaction designated by the input hash",
+      "params": [
+        {
+          "name": "transaction_hash",
+          "summary": "The hash of the transaction to trace",
+          "required": true,
+          "schema": {
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN_HASH"
+          }
+        }
+      ],
+      "result": {
+        "name": "trace",
+        "description": "The function call trace of the transaction designated by the given hash",
+        "schema": {
+          "$ref": "#/components/schemas/TRANSACTION_TRACE"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/TXN_HASH_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/NO_TRACE_AVAILABLE"
+        }
+      ]
+    },
+    {
+      "name": "starknet_simulateTransactions",
+      "summary": "Simulate a given sequence of transactions on the requested state, and generate the execution traces. Note that some of the transactions may revert, in which case no error is thrown, but revert details can be seen on the returned trace object. . Note that some of the transactions may revert, this will be reflected by the revert_error property in the trace. Other types of failures (e.g. unexpected error or failure in the validation phase) will result in TRANSACTION_EXECUTION_ERROR.",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag, for the block referencing the state or call the transaction on.",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        },
+        {
+          "name": "transactions",
+          "description": "The transactions to simulate",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "description": "a sequence of transactions to simulate, running each transaction on the state resulting from applying all the previous ones",
+            "items": {
+              "$ref": "#/components/schemas/BROADCASTED_TXN"
+            }
+          }
+        },
+        {
+          "name": "simulation_flags",
+          "description": "describes what parts of the transaction should be executed",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SIMULATION_FLAG"
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "simulated_transactions",
+        "description": "The execution trace and consuemd resources of the required transactions",
+        "schema": {
+          "type": "array",
+          "items": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "transaction_trace": {
+                  "title": "the transaction's trace",
+                  "$ref": "#/components/schemas/TRANSACTION_TRACE"
+                },
+                "fee_estimation": {
+                  "title": "the transaction's resources and fee",
+                  "$ref": "#/components/schemas/FEE_ESTIMATE"
+                }
+              }
+            }
+          }
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/TRANSACTION_EXECUTION_ERROR"
+        }
+      ]
+    },
+    {
+      "name": "starknet_traceBlockTransactions",
+      "summary": "Retrieve traces for all transactions in the given block",
+      "description": "Returns the execution traces of all transactions included in the given block",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "traces",
+        "description": "The traces of all transactions in the block",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "A single pair of transaction hash and corresponding trace",
+            "properties": {
+              "transaction_hash": {
+                "$ref": "#/components/schemas/FELT"
+              },
+              "trace_root": {
+                "$ref": "#/components/schemas/TRANSACTION_TRACE"
+              }
+            }
+          }
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        }
+      ]
+    }
+  ],
+  "components": {
+    "contentDescriptors": {},
+    "schemas": {
+      "TRANSACTION_TRACE": {
+        "oneOf": [
+          {
+            "name": "INVOKE_TXN_TRACE",
+            "type": "object",
+            "description": "the execution trace of an invoke transaction",
+            "properties": {
+              "validate_invocation": {
+                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+              },
+              "execute_invocation": {
+                "description": "the trace of the __execute__ call or constructor call, depending on the transaction type (none for declare transactions)",
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "revert_reason": {
+                        "name": "revert reason",
+                        "description": "the revert reason for the failed execution",
+                        "type": "string"
+                      }
+                    },
+                    "required": ["revert_reason"]
+                  }
+                ]
+              },
+              "fee_transfer_invocation": {
+                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+              },
+              "state_diff": {
+                "title": "state_diff",
+                "description": "the state diffs induced by the transaction",
+                "$ref": "#/components/schemas/STATE_DIFF"
+              },
+              "execution_resources": {
+                "title": "Execution resources",
+                "description": "the resources consumed by the transaction, includes both computation and data",
+                "$ref": "#/components/schemas/EXECUTION_RESOURCES"
+              },
+              "type": {
+                "title": "Type",
+                "type": "string",
+                "enum": ["INVOKE"]
+              }
+            },
+            "required": ["type", "execute_invocation", "execution_resources"]
+          },
+          {
+            "name": "DECLARE_TXN_TRACE",
+            "type": "object",
+            "description": "the execution trace of a declare transaction",
+            "properties": {
+              "validate_invocation": {
+                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+              },
+              "fee_transfer_invocation": {
+                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+              },
+              "state_diff": {
+                "title": "state_diff",
+                "description": "the state diffs induced by the transaction",
+                "$ref": "#/components/schemas/STATE_DIFF"
+              },
+              "execution_resources": {
+                "title": "Execution resources",
+                "description": "the resources consumed by the transaction, includes both computation and data",
+                "$ref": "#/components/schemas/EXECUTION_RESOURCES"
+              },
+              "type": {
+                "title": "Type",
+                "type": "string",
+                "enum": ["DECLARE"]
+              }
+            },
+            "required": ["type", "execution_resources"]
+          },
+          {
+            "name": "DEPLOY_ACCOUNT_TXN_TRACE",
+            "type": "object",
+            "description": "the execution trace of a deploy account transaction",
+            "properties": {
+              "validate_invocation": {
+                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+              },
+              "constructor_invocation": {
+                "description": "the trace of the __execute__ call or constructor call, depending on the transaction type (none for declare transactions)",
+                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+              },
+              "fee_transfer_invocation": {
+                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+              },
+              "state_diff": {
+                "title": "state_diff",
+                "description": "the state diffs induced by the transaction",
+                "$ref": "#/components/schemas/STATE_DIFF"
+              },
+              "execution_resources": {
+                "title": "Execution resources",
+                "description": "the resources consumed by the transaction, includes both computation and data",
+                "$ref": "#/components/schemas/EXECUTION_RESOURCES"
+              },
+              "type": {
+                "title": "Type",
+                "type": "string",
+                "enum": ["DEPLOY_ACCOUNT"]
+              }
+            },
+            "required": ["type", "execution_resources", "constructor_invocation"]
+          },
+          {
+            "name": "L1_HANDLER_TXN_TRACE",
+            "type": "object",
+            "description": "the execution trace of an L1 handler transaction",
+            "properties": {
+              "function_invocation": {
+                "description": "the trace of the __execute__ call or constructor call, depending on the transaction type (none for declare transactions)",
+                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+              },
+              "state_diff": {
+                "title": "state_diff",
+                "description": "the state diffs induced by the transaction",
+                "$ref": "#/components/schemas/STATE_DIFF"
+              },
+              "execution_resources": {
+                "title": "Execution resources",
+                "description": "the resources consumed by the transaction, includes both computation and data",
+                "$ref": "#/components/schemas/EXECUTION_RESOURCES"
+              },
+              "type": {
+                "title": "Type",
+                "type": "string",
+                "enum": ["L1_HANDLER"]
+              }
+            },
+            "required": ["type", "function_invocation", "execution_resources"]
+          }
+        ]
+      },
+      "SIMULATION_FLAG": {
+        "type": "string",
+        "enum": ["SKIP_VALIDATE", "SKIP_FEE_CHARGE"],
+        "description": "Flags that indicate how to simulate a given transaction. By default, the sequencer behavior is replicated locally (enough funds are expected to be in the account, and fee will be deducted from the balance before the simulation of the next transaction). To skip the fee charge, use the SKIP_FEE_CHARGE flag."
+      },
+      "NESTED_CALL": {
+        "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+      },
+      "FUNCTION_INVOCATION": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FUNCTION_CALL"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "caller_address": {
+                "title": "Caller Address",
+                "description": "The address of the invoking contract. 0 for the root invocation",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "class_hash": {
+                "title": "Class hash",
+                "description": "The hash of the class being called",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "entry_point_type": {
+                "$ref": "#/components/schemas/ENTRY_POINT_TYPE"
+              },
+              "call_type": {
+                "$ref": "#/components/schemas/CALL_TYPE"
+              },
+              "result": {
+                "title": "Invocation Result",
+                "description": "The value returned from the function invocation",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FELT"
+                }
+              },
+              "calls": {
+                "title": "Nested Calls",
+                "description": "The calls made by this invocation",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/NESTED_CALL"
+                }
+              },
+              "events": {
+                "title": "Invocation Events",
+                "description": "The events emitted in this invocation",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ORDERED_EVENT"
+                }
+              },
+              "messages": {
+                "title": "L1 Messages",
+                "description": "The messages sent by this invocation to L1",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ORDERED_MESSAGE"
+                }
+              },
+              "execution_resources": {
+                "title": "Computation resources",
+                "description": "Resources consumed by the internal call. This is named execution_resources for legacy reasons",
+                "$ref": "#/components/schemas/COMPUTATION_RESOURCES"
+              }
+            },
+            "required": [
+              "caller_address",
+              "class_hash",
+              "entry_point_type",
+              "call_type",
+              "result",
+              "calls",
+              "events",
+              "messages",
+              "execution_resources"
+            ]
+          }
+        ]
+      },
+      "ENTRY_POINT_TYPE": {
+        "type": "string",
+        "enum": ["EXTERNAL", "L1_HANDLER", "CONSTRUCTOR"]
+      },
+      "CALL_TYPE": {
+        "type": "string",
+        "enum": ["LIBRARY_CALL", "CALL", "DELEGATE"]
+      },
+      "ORDERED_EVENT": {
+        "type": "object",
+        "title": "orderedEvent",
+        "description": "an event alongside its order within the transaction",
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "order": {
+                "title": "order",
+                "description": "the order of the event within the transaction",
+                "type": "integer"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/EVENT"
+          }
+        ]
+      },
+      "ORDERED_MESSAGE": {
+        "type": "object",
+        "title": "orderedMessage",
+        "description": "a message alongside its order within the transaction",
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "order": {
+                "title": "order",
+                "description": "the order of the message within the transaction",
+                "type": "integer"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/MSG_TO_L1"
+          }
+        ]
+      },
+      "FELT": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/FELT"
+      },
+      "FUNCTION_CALL": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/FUNCTION_CALL"
+      },
+      "EVENT": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/EVENT_CONTENT"
+      },
+      "MSG_TO_L1": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/MSG_TO_L1"
+      },
+      "BLOCK_ID": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_ID"
+      },
+      "FEE_ESTIMATE": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/FEE_ESTIMATE"
+      },
+      "BROADCASTED_TXN": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BROADCASTED_TXN"
+      },
+      "STATE_DIFF": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/STATE_DIFF"
+      },
+      "COMPUTATION_RESOURCES": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/COMPUTATION_RESOURCES"
+      },
+      "EXECUTION_RESOURCES": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/EXECUTION_RESOURCES"
+      }
+    },
+    "errors": {
+      "NO_TRACE_AVAILABLE": {
+        "code": 10,
+        "message": "No trace available for transaction",
+        "data": {
+          "type": "object",
+          "description": "Extra information on why trace is not available. Either it wasn't executed yet (RECEIVED), or the transaction failed (REJECTED)",
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": ["RECEIVED", "REJECTED"]
+            }
+          }
+        }
+      },
+      "TXN_HASH_NOT_FOUND": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/errors/TXN_HASH_NOT_FOUND"
+      },
+      "BLOCK_NOT_FOUND": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/errors/BLOCK_NOT_FOUND"
+      },
+      "TRANSACTION_EXECUTION_ERROR": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/errors/TRANSACTION_EXECUTION_ERROR"
+      }
+    }
+  }
+}

--- a/doc/rpc/v08/starknet_write_api.json
+++ b/doc/rpc/v08/starknet_write_api.json
@@ -1,0 +1,291 @@
+{
+  "openrpc": "1.0.0-rc1",
+  "info": {
+    "version": "0.7.1",
+    "title": "StarkNet Node Write API",
+    "license": {}
+  },
+  "servers": [],
+  "methods": [
+    {
+      "name": "starknet_addInvokeTransaction",
+      "summary": "Submit a new transaction to be added to the chain",
+      "params": [
+        {
+          "name": "invoke_transaction",
+          "description": "The information needed to invoke the function (or account, for version 1 transactions)",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/BROADCASTED_INVOKE_TXN"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The result of the transaction submission",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "transaction_hash": {
+              "title": "The hash of the invoke transaction",
+              "$ref": "#/components/schemas/TXN_HASH"
+            }
+          },
+          "required": ["transaction_hash"]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/INSUFFICIENT_ACCOUNT_BALANCE"
+        },
+        {
+          "$ref": "#/components/errors/INSUFFICIENT_RESOURCES_FOR_VALIDATE"
+        },
+        {
+          "$ref": "#/components/errors/INVALID_TRANSACTION_NONCE"
+        },
+        {
+          "$ref": "#/components/errors/VALIDATION_FAILURE"
+        },
+        {
+          "$ref": "#/components/errors/NON_ACCOUNT"
+        },
+        {
+          "$ref": "#/components/errors/DUPLICATE_TX"
+        },
+        {
+          "$ref": "#/components/errors/UNSUPPORTED_TX_VERSION"
+        },
+        {
+          "$ref": "#/components/errors/UNEXPECTED_ERROR"
+        }
+      ]
+    },
+    {
+      "name": "starknet_addDeclareTransaction",
+      "summary": "Submit a new class declaration transaction",
+      "params": [
+        {
+          "name": "declare_transaction",
+          "description": "Declare transaction required to declare a new class on Starknet",
+          "required": true,
+          "schema": {
+            "title": "Declare transaction",
+            "$ref": "#/components/schemas/BROADCASTED_DECLARE_TXN"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The result of the transaction submission",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "transaction_hash": {
+              "title": "The hash of the declare transaction",
+              "$ref": "#/components/schemas/TXN_HASH"
+            },
+            "class_hash": {
+              "title": "The hash of the declared class",
+              "$ref": "#/components/schemas/FELT"
+            }
+          },
+          "required": ["transaction_hash", "class_hash"]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/CLASS_ALREADY_DECLARED"
+        },
+        {
+          "$ref": "#/components/errors/COMPILATION_FAILED"
+        },
+        {
+          "$ref": "#/components/errors/COMPILED_CLASS_HASH_MISMATCH"
+        },
+        {
+          "$ref": "#/components/errors/INSUFFICIENT_ACCOUNT_BALANCE"
+        },
+        {
+          "$ref": "#/components/errors/INSUFFICIENT_RESOURCES_FOR_VALIDATE"
+        },
+        {
+          "$ref": "#/components/errors/INVALID_TRANSACTION_NONCE"
+        },
+        {
+          "$ref": "#/components/errors/VALIDATION_FAILURE"
+        },
+        {
+          "$ref": "#/components/errors/NON_ACCOUNT"
+        },
+        {
+          "$ref": "#/components/errors/DUPLICATE_TX"
+        },
+        {
+          "$ref": "#/components/errors/CONTRACT_CLASS_SIZE_IS_TOO_LARGE"
+        },
+        {
+          "$ref": "#/components/errors/UNSUPPORTED_TX_VERSION"
+        },
+        {
+          "$ref": "#/components/errors/UNSUPPORTED_CONTRACT_CLASS_VERSION"
+        },
+        {
+          "$ref": "#/components/errors/UNEXPECTED_ERROR"
+        }
+      ]
+    },
+    {
+      "name": "starknet_addDeployAccountTransaction",
+      "summary": "Submit a new deploy account transaction",
+      "params": [
+        {
+          "name": "deploy_account_transaction",
+          "description": "The deploy account transaction",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/BROADCASTED_DEPLOY_ACCOUNT_TXN"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The result of the transaction submission",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "transaction_hash": {
+              "title": "The hash of the deploy transaction",
+              "$ref": "#/components/schemas/TXN_HASH"
+            },
+            "contract_address": {
+              "title": "The address of the new contract",
+              "$ref": "#/components/schemas/FELT"
+            }
+          },
+          "required": ["transaction_hash", "contract_address"]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/INSUFFICIENT_ACCOUNT_BALANCE"
+        },
+        {
+          "$ref": "#/components/errors/INSUFFICIENT_RESOURCES_FOR_VALIDATE"
+        },
+        {
+          "$ref": "#/components/errors/INVALID_TRANSACTION_NONCE"
+        },
+        {
+          "$ref": "#/components/errors/VALIDATION_FAILURE"
+        },
+        {
+          "$ref": "#/components/errors/NON_ACCOUNT"
+        },
+        {
+          "$ref": "#/components/errors/CLASS_HASH_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/DUPLICATE_TX"
+        },
+        {
+          "$ref": "#/components/errors/UNSUPPORTED_TX_VERSION"
+        },
+        {
+          "$ref": "#/components/errors/UNEXPECTED_ERROR"
+        }
+      ]
+    }
+  ],
+  "components": {
+    "contentDescriptors": {},
+    "schemas": {
+      "NUM_AS_HEX": {
+        "title": "An integer number in hex format (0x...)",
+        "type": "string",
+        "pattern": "^0x[a-fA-F0-9]+$"
+      },
+      "SIGNATURE": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/SIGNATURE"
+      },
+      "FELT": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/FELT"
+      },
+      "TXN_HASH": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN_HASH"
+      },
+      "BROADCASTED_INVOKE_TXN": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BROADCASTED_INVOKE_TXN"
+      },
+      "BROADCASTED_DECLARE_TXN": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BROADCASTED_DECLARE_TXN"
+      },
+      "BROADCASTED_DEPLOY_ACCOUNT_TXN": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BROADCASTED_DEPLOY_ACCOUNT_TXN"
+      },
+      "FUNCTION_CALL": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/FUNCTION_CALL"
+      }
+    },
+    "errors": {
+      "CLASS_HASH_NOT_FOUND": {
+        "code": 28,
+        "message": "Class hash not found"
+      },
+      "CLASS_ALREADY_DECLARED": {
+        "code": 51,
+        "message": "Class already declared"
+      },
+      "INVALID_TRANSACTION_NONCE": {
+        "code": 52,
+        "message": "Invalid transaction nonce"
+      },
+      "INSUFFICIENT_RESOURCES_FOR_VALIDATE": {
+        "code": 53,
+        "message": "The transaction's resources don't cover validation or the minimal transaction fee"
+      },
+      "INSUFFICIENT_ACCOUNT_BALANCE": {
+        "code": 54,
+        "message": "Account balance is smaller than the transaction's max_fee"
+      },
+      "VALIDATION_FAILURE": {
+        "code": 55,
+        "message": "Account validation failed",
+        "data": "string"
+      },
+      "COMPILATION_FAILED": {
+        "code": 56,
+        "message": "Compilation failed"
+      },
+      "CONTRACT_CLASS_SIZE_IS_TOO_LARGE": {
+        "code": 57,
+        "message": "Contract class size it too large"
+      },
+      "NON_ACCOUNT": {
+        "code": 58,
+        "message": "Sender address in not an account contract"
+      },
+      "DUPLICATE_TX": {
+        "code": 59,
+        "message": "A transaction with the same hash already exists in the mempool"
+      },
+      "COMPILED_CLASS_HASH_MISMATCH": {
+        "code": 60,
+        "message": "the compiled class hash did not match the one supplied in the transaction"
+      },
+      "UNSUPPORTED_TX_VERSION": {
+        "code": 61,
+        "message": "the transaction version is not supported"
+      },
+      "UNSUPPORTED_CONTRACT_CLASS_VERSION": {
+        "code": 62,
+        "message": "the contract class version is not supported"
+      },
+      "UNEXPECTED_ERROR": {
+        "code": 63,
+        "message": "An unexpected error occurred",
+        "data": "string"
+      }
+    }
+  }
+}

--- a/doc/rpc/v08/starknet_ws_api.json
+++ b/doc/rpc/v08/starknet_ws_api.json
@@ -1,0 +1,358 @@
+{
+  "openrpc": "1.3.2",
+  "info": {
+    "version": "0.8.0-rc0",
+    "title": "StarkNet WebSocket PRC API",
+    "license": {}
+  },
+  "methods": [
+    {
+      "name": "starknet_subscribeNewHeads",
+      "summary": "New block headers subscription",
+      "description": "Creates a WebSocket stream which will fire events for new block headers",
+      "params": [
+        {
+          "name": "block",
+          "summary": "The block to get notifications from, default is latest, limited to 1024 blocks back",
+          "required": false,
+          "schema": {
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "subscription_id",
+        "schema": {
+          "$ref": "#/components/schemas/SUBSCRIPTION_ID"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/TOO_MANY_BLOCKS_BACK"
+        }
+      ]
+    },
+    {
+      "name": "starknet_subscriptionNewHeads",
+      "summary": "New block headers notification",
+      "description": "Notification to the client of a new block header",
+      "params": [
+        {
+          "name": "subscription_id",
+          "schema": {
+            "$ref": "#/components/schemas/SUBSCRIPTION_ID"
+          }
+        },
+        {
+          "name": "result",
+          "schema": {
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_HEADER"
+          }
+        }
+      ],
+      "errors": []
+    },
+    {
+      "name": "starknet_subscribeEvents",
+      "summary": "Events subscription",
+      "description": "Creates a WebSocket stream which will fire events for new Starknet events with applied filters",
+      "params": [
+        {
+          "name": "from_address",
+          "summary": "Filter events by from_address which emitted the event",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/ADDRESS"
+          }
+        },
+        {
+          "name": "keys",
+          "summary": "The keys to filter events by",
+          "required": false,
+          "schema": {
+            "title": "event keys",
+            "$ref": "#/components/schemas/EVENT_KEYS"
+          }
+        },
+        {
+          "name": "block",
+          "summary": "The block to get notifications from, default is latest, limited to 1024 blocks back",
+          "required": false,
+          "schema": {
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "subscription_id",
+        "schema": {
+          "$ref": "#/components/schemas/SUBSCRIPTION_ID"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "./api/starknet_api_openrpc.json#/components/errors/TOO_MANY_KEYS_IN_FILTER"
+        },
+        {
+          "$ref": "#/components/errors/TOO_MANY_BLOCKS_BACK"
+        }
+      ]
+    },
+    {
+      "name": "starknet_subscriptionEvents",
+      "summary": "New events notification",
+      "description": "Notification to the client of a new event",
+      "params": [
+        {
+          "name": "subscription_id",
+          "schema": {
+            "$ref": "#/components/schemas/SUBSCRIPTION_ID"
+          }
+        },
+        {
+          "name": "result",
+          "schema": {
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/EMITTED_EVENT"
+          }
+        }
+      ],
+      "errors": []
+    },
+    {
+      "name": "starknet_subscribeTransactionStatus",
+      "summary": "Transaction Status subscription",
+      "description": "Creates a WebSocket stream which will fire events when a transaction status is updated",
+      "params": [
+        {
+          "name": "transaction_hash",
+          "summary": "The transaction hash to fetch status updates for",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/FELT"
+          }
+        },
+        {
+          "name": "block",
+          "summary": "The block to get notifications from, default is latest, limited to 1024 blocks back",
+          "required": false,
+          "schema": {
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "subscription_id",
+        "schema": {
+          "$ref": "#/components/schemas/SUBSCRIPTION_ID"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/TOO_MANY_BLOCKS_BACK"
+        }
+      ]
+    },
+    {
+      "name": "starknet_subscriptionTransactionsStatus",
+      "summary": "New transaction status notification",
+      "description": "Notification to the client of a new transaction status",
+      "params": [
+        {
+          "name": "subscription_id",
+          "schema": {
+            "$ref": "#/components/schemas/SUBSCRIPTION_ID"
+          }
+        },
+        {
+          "name": "result",
+          "schema": {
+            "$ref": "#/components/schemas/NEW_TXN_STATUS"
+          }
+        }
+      ],
+      "errors": []
+    },
+    {
+      "name": "starknet_subscribePendingTransactions",
+      "summary": "New Pending Transactions subscription",
+      "description": "Creates a WebSocket stream which will fire events when a new pending transaction is added. While there is no mempool, this notifies of transactions in the pending block",
+      "params": [
+        {
+          "name": "transaction_details",
+          "summary": "Get all transaction details, and not only the hash. If not provided, only hash is returned. Default is false",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "sender_address",
+          "summary": "Filter transactions to only receive notification from address list",
+          "required": false,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ADDRESS"
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "subscription_id",
+        "schema": {
+          "$ref": "#/components/schemas/SUBSCRIPTION_ID"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/TOO_MANY_ADDRESSES_IN_FILTER"
+        }
+      ]
+    },
+    {
+      "name": "starknet_subscriptionPendingTransactions",
+      "summary": "New pending transaction notification",
+      "description": "Notification to the client of a new pending transaction",
+      "params": [
+        {
+          "name": "subscription_id",
+          "schema": {
+            "$ref": "#/components/schemas/SUBSCRIPTION_ID"
+          }
+        },
+        {
+          "name": "result",
+          "description": "Either a tranasaction hash or full transaction details, based on subscription",
+          "schema": {
+            "oneOf": [
+              {
+                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN_HASH"
+              },
+              {
+                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN"
+              }
+            ]
+          }
+        }
+      ],
+      "errors": []
+    },
+    {
+      "name": "starknet_subscriptionReorg",
+      "description": "Notifies the subscriber of a reorganization of the chain",
+      "summary": "Can be received from subscribing to newHeads, Events, TransactionStatus",
+      "params": [
+        {
+          "name": "subscription_id",
+          "schema": {
+            "$ref": "#/components/schemas/REORG_DATA"
+          }
+        }
+      ]
+    },
+    {
+      "name": "starknet_unsubscribe",
+      "summary": "Closes a websocket subscription",
+      "description": "Close a previously opened ws stream, with the corresponding subscription id",
+      "params": [
+        {
+          "name": "subscription_id",
+          "summary": "The subscription to close",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ],
+      "result": {
+        "name": "Unsubscription result",
+        "description": "True if the unsubscription was successful",
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/INVALID_SUBSCRIPTION_ID"
+        }
+      ]
+    }
+  ],
+
+  "components": {
+    "schemas": {
+      "FELT": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/FELT"
+      },
+      "ADDRESS": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/ADDRESS"
+      },
+      "NEW_TXN_STATUS": {
+        "title": "New transaction Status",
+        "type": "object",
+        "properties": {
+          "transaction_hash": {
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN_HASH"
+          },
+          "status": {
+            "schema": {
+              "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN_STATUS_RESULT"
+            }
+          }
+        }
+      },
+      "SUBSCRIPTION_ID": {
+        "name": "subscription id",
+        "description": "An identifier for this subscription stream used to associate events with this subscription.",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "REORG_DATA": {
+        "name": "Reorg Data",
+        "description": "Data about reorganized blocks, starting and ending block number and hash",
+        "properties": {
+          "starting_block_hash": {
+            "title": "Starting Block Hash",
+            "description": "Hash of the first known block of the orphaned chain",
+            "schema": {
+              "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_HASH"
+            }
+          },
+          "starting_block_number": {
+            "title": "Starting Block Number",
+            "description": "Number of the first known block of the orphaned chain",
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_NUMBER"
+          },
+          "ending_block_hash": {
+            "title": "Ending Block",
+            "description": "The last known block of the orphaned chain",
+            "schema": {
+              "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_HASH"
+            }
+          },
+          "ending_block_number": {
+            "title": "Ending Block Number",
+            "description": "Number of the last known block of the orphaned chain",
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_NUMBER"
+          }
+        },
+        "required": ["starting_block_hash", "starting_block_number", "ending_block_hash", "ending_block_number"]
+      }
+    },
+    "errors": {
+      "INVALID_SUBSCRIPTION_ID": {
+        "code": 66,
+        "message": "Invalid subscription id"
+      },
+      "TOO_MANY_ADDRESSES_IN_FILTER": {
+        "code": 67,
+        "message": "Too many addresses in filter sender_address filter"
+      },
+      "TOO_MANY_BLOCKS_BACK": {
+        "code": 68,
+        "message": "Cannot go back more than 1024 blocks"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the OpenRPC specification for 0.8.0-rc0 to our source tree along with some tests that we implement all methods from the specification. Missing methods are whitelisted for now.

Websocket subscriptions are _not_ tested currently -- to do that we would need some additional tests as those are only available via a Websocket connection.

It also adds the `pathfinder_getProof` method since we do support that Pathfinder-specific extension for all versions of the JSON-RPC API.