### PR TITLE
p2p sync: restart on recoverable error

### DIFF
--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -1,0 +1,94 @@
+use std::sync::Arc;
+
+/// This trait is a workaround for [anyhow::Error] not being clonable.
+///
+/// Most of the time you can use `Arc<anyhow::Error>` instead of `anyhow::Error`
+/// to circumvent `anyhow::Error` not being `Clone`. However, in some cases, you
+/// might need to "unwrap" the Arc-ed error. This trait provides a way to do
+/// that.
+pub trait AnyhowExt {
+    /// Clones the error by doing `to_string` on each item in the chain.
+    fn deep_clone(&self) -> anyhow::Error;
+    /// Swaps the Arc-ed error for an empty instance using [`Arc::get_mut`] and
+    /// if unsuccessful clones the error using
+    /// [`AnyhowExt::deep_clone`].
+    fn take_or_deep_clone(self: &mut Arc<Self>) -> anyhow::Error;
+}
+
+impl AnyhowExt for anyhow::Error {
+    fn deep_clone(&self) -> anyhow::Error {
+        let mut chain = self.chain().rev();
+        let first = chain
+            .next()
+            .expect("at least one error is always in the chain");
+
+        let mut cloned = anyhow::Error::msg(first.to_string());
+
+        for cause in chain {
+            cloned = cloned.context(cause.to_string());
+        }
+
+        cloned
+    }
+
+    fn take_or_deep_clone(self: &mut Arc<Self>) -> anyhow::Error {
+        if let Some(e) = Arc::get_mut(self) {
+            let mut taken = anyhow::Error::msg("");
+            std::mem::swap(e, &mut taken);
+            taken
+        } else {
+            // The strong ref count is greater than 1
+            self.deep_clone()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> (anyhow::Error, anyhow::Error) {
+        (
+            anyhow::anyhow!("root")
+                .context("level 1")
+                .context("level 2")
+                .context("level 3"),
+            anyhow::anyhow!("root")
+                .context("level 1")
+                .context("level 2")
+                .context("level 3"),
+        )
+    }
+
+    #[test]
+    fn take_if_refcount_eq1() {
+        let (src0, src) = fixture();
+
+        let mut arced = std::sync::Arc::new(src0);
+        assert_eq!(Arc::strong_count(&arced), 1);
+
+        // Strong ref count is 1, taking the error should work
+        let taken = arced.take_or_deep_clone();
+        assert_eq!(format!("{}", taken), format!("{}", src));
+        assert_eq!(format!("{:?}", taken), format!("{:?}", src));
+
+        assert!(arced.to_string().is_empty());
+    }
+
+    #[test]
+    fn clone_if_refcount_gt1() {
+        let (src0, src) = fixture();
+
+        let mut arced = std::sync::Arc::new(src0);
+        let arc_clone = arced.clone();
+        assert_eq!(Arc::strong_count(&arc_clone), 2);
+
+        // Strong ref count is 2, only a poor-man's clone is possible
+        let cloned = arced.take_or_deep_clone();
+        assert_eq!(format!("{}", cloned), format!("{}", src));
+        assert_eq!(format!("{:?}", cloned), format!("{:?}", src));
+
+        assert_eq!(format!("{}", arced), format!("{}", src));
+        assert_eq!(format!("{:?}", arced), format!("{:?}", src));
+    }
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 
 pub mod class_definition;
 pub mod consts;
+pub mod error;
 pub mod event;
 pub mod hash;
 mod header;

--- a/crates/pathfinder/src/lib.rs
+++ b/crates/pathfinder/src/lib.rs
@@ -1,7 +1,6 @@
 #![deny(rust_2018_idioms)]
 
 pub mod monitoring;
+pub mod p2p_network;
 pub mod state;
 pub mod sync;
-
-pub mod p2p_network;

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -10,4 +10,5 @@ pub use sync::{
     Gossiper,
     StarknetStateUpdate,
     SyncContext,
+    RESET_DELAY_ON_FAILURE,
 };

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -36,6 +36,13 @@ use tokio::sync::watch::Sender as WatchSender;
 use crate::state::l1::L1SyncContext;
 use crate::state::l2::{BlockChain, L2SyncContext};
 
+/// Delay before restarting L1 or L2 tasks if they fail. This delay helps
+/// prevent DoS if these tasks are crashing.
+#[cfg(not(test))]
+pub const RESET_DELAY_ON_FAILURE: std::time::Duration = std::time::Duration::from_secs(60);
+#[cfg(test)]
+pub const RESET_DELAY_ON_FAILURE: std::time::Duration = std::time::Duration::ZERO;
+
 #[derive(Debug)]
 pub enum SyncEvent {
     L1Update(EthereumStateUpdate),
@@ -289,13 +296,6 @@ where
         rx_current.clone(),
         fetch_casm_from_fgw,
     ));
-
-    /// Delay before restarting L1 or L2 tasks if they fail. This delay helps
-    /// prevent DoS if these tasks are crashing.
-    #[cfg(not(test))]
-    const RESET_DELAY_ON_FAILURE: std::time::Duration = std::time::Duration::from_secs(60);
-    #[cfg(test)]
-    const RESET_DELAY_ON_FAILURE: std::time::Duration = std::time::Duration::ZERO;
 
     loop {
         tokio::select! {


### PR DESCRIPTION
This PR plugs a few holes in the p2p sync logic:

|Sync Type|Was|Now|
|------------|----|----|
|Checkpoint|bails without retrying, if L1 API fails|Loop forever until L1 API returns some valid checkpoint, then proceed with checkpoint sync iteration|
|Checkpoint|retry on every error % L1 (see :arrow_up:) |bail on fatal errors, retry on other|
|Track|bail on first error|retry if error is recoverable|

_Fatal errors_  fall in the `SyncError[2]::Other` category, which means for example DB, or runtime related.
All other errors are recoverable assuming that config is valid. These errors stem from temporary problems like network partition (which is indistinguishable from increased latency, hence peers unavailable) or outright malicious or _sloopy_ peers (ie. who treat the protocol standard without enough attention to detail but most of the time are good enough, bugs also fall into this category).

I also added a tiny utility to handle `Arc<anyhow::Error>` in a more convenient way in cases when we want to "unwrap" to avoid Arc-ing the error at the caller. Lemme know if you reckon this could be a standalone crate not to pollute `pathfinder-common`.

Testing:
- I did some manual tests so far with some hacked L1 api which fails a few times in a row
- I did the same with recoverable and non-recoverable errors
- I raised an issue for some ["proper" tests](https://github.com/eqlabs/pathfinder/issues/2300) too