### PR TITLE
JSON-RPC: implement SerializeForVersion for RpcResponse

### DIFF
--- a/crates/rpc/src/jsonrpc/error.rs
+++ b/crates/rpc/src/jsonrpc/error.rs
@@ -1,7 +1,8 @@
 use std::borrow::Cow;
 
-use serde::Serialize;
 use serde_json::{json, Value};
+
+use crate::dto::serialize;
 
 #[derive(Debug)]
 pub enum RpcError {
@@ -73,19 +74,17 @@ impl RpcError {
     }
 }
 
-impl Serialize for RpcError {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeMap;
-
-        let mut obj = serializer.serialize_map(Some(2))?;
-        obj.serialize_entry("code", &self.code())?;
-        obj.serialize_entry("message", &self.message())?;
+impl serialize::SerializeForVersion for RpcError {
+    fn serialize(
+        &self,
+        serializer: serialize::Serializer,
+    ) -> Result<serialize::Ok, serialize::Error> {
+        let mut obj = serializer.serialize_struct()?;
+        obj.serialize_field("code", &self.code())?;
+        obj.serialize_field("message", &self.message())?;
 
         if let Some(data) = self.data() {
-            obj.serialize_entry("data", &data)?;
+            obj.serialize_field("data", &data)?;
         }
 
         obj.end()

--- a/crates/rpc/src/jsonrpc/response.rs
+++ b/crates/rpc/src/jsonrpc/response.rs
@@ -1,75 +1,104 @@
 use axum::response::IntoResponse;
-use serde::Serialize;
 use serde_json::Value;
 
+use crate::dto::serialize::{self, SerializeForVersion};
 use crate::error::ApplicationError;
 use crate::jsonrpc::error::RpcError;
 use crate::jsonrpc::RequestId;
+use crate::RpcVersion;
 
 #[derive(Debug, PartialEq)]
 pub struct RpcResponse {
     pub output: RpcResult,
     pub id: RequestId,
+    pub version: RpcVersion,
 }
 
 impl RpcResponse {
-    pub const fn parse_error(error: String) -> RpcResponse {
+    pub const fn parse_error(error: String, version: RpcVersion) -> RpcResponse {
         Self {
             output: Err(RpcError::ParseError(error)),
             id: RequestId::Null,
+            version,
         }
     }
 
-    pub const fn invalid_request(error: String) -> RpcResponse {
+    pub const fn invalid_request(error: String, version: RpcVersion) -> RpcResponse {
         Self {
             output: Err(RpcError::InvalidRequest(error)),
             id: RequestId::Null,
+            version,
         }
     }
 
-    pub const fn method_not_found(id: RequestId) -> RpcResponse {
+    pub const fn method_not_found(id: RequestId, version: RpcVersion) -> RpcResponse {
         Self {
             output: Err(RpcError::MethodNotFound),
             id,
+            version,
         }
     }
 
-    pub const fn invalid_params(id: RequestId, error: String) -> RpcResponse {
+    pub const fn invalid_params(id: RequestId, error: String, version: RpcVersion) -> RpcResponse {
         Self {
             output: Err(RpcError::InvalidParams(error)),
             id,
+            version,
         }
     }
 
-    pub fn internal_error(id: RequestId, error: String) -> RpcResponse {
+    pub fn internal_error(id: RequestId, error: String, version: RpcVersion) -> RpcResponse {
         Self {
             output: Err(RpcError::InternalError(anyhow::Error::msg(error))),
             id,
+            version,
         }
     }
 }
 
 pub type RpcResult = Result<Value, RpcError>;
 
-impl Serialize for RpcResponse {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeMap;
-
-        let mut obj = serializer.serialize_map(Some(3))?;
-        obj.serialize_entry("jsonrpc", "2.0")?;
+impl serialize::SerializeForVersion for RpcResponse {
+    fn serialize(
+        &self,
+        serializer: serialize::Serializer,
+    ) -> Result<serialize::Ok, serialize::Error> {
+        let mut obj = serializer.serialize_struct()?;
+        obj.serialize_field("jsonrpc", &"2.0")?;
 
         match &self.output {
-            Ok(x) => obj.serialize_entry("result", &x)?,
-            Err(e) => obj.serialize_entry("error", &e)?,
+            Ok(x) => obj.serialize_field("result", &x)?,
+            Err(e) => obj.serialize_field("error", e)?,
         };
 
         match &self.id {
-            RequestId::Number(x) => obj.serialize_entry("id", &x)?,
-            RequestId::String(x) => obj.serialize_entry("id", &x)?,
-            RequestId::Null => obj.serialize_entry("id", &Value::Null)?,
+            RequestId::Number(x) => obj.serialize_field("id", &x)?,
+            RequestId::String(x) => obj.serialize_field("id", &x)?,
+            RequestId::Null => obj.serialize_field("id", &Value::Null)?,
+            RequestId::Notification => {}
+        };
+
+        obj.end()
+    }
+}
+
+impl serialize::SerializeForVersion for &RpcResponse {
+    fn serialize(
+        &self,
+        serializer: serialize::Serializer,
+    ) -> Result<serialize::Ok, serialize::Error> {
+        let mut obj = serializer.serialize_struct()?;
+        obj.serialize_field("jsonrpc", &"2.0")?;
+
+        match &self.output {
+            Ok(x) => obj.serialize_field("result", &x)?,
+            Err(e) => obj.serialize_field("error", e)?,
+        };
+
+        match &self.id {
+            RequestId::Number(x) => obj.serialize_field("id", &x)?,
+            RequestId::String(x) => obj.serialize_field("id", &x)?,
+            RequestId::Null => obj.serialize_field("id", &Value::Null)?,
             RequestId::Notification => {}
         };
 
@@ -91,7 +120,13 @@ impl IntoResponse for RpcResponse {
             _ => {}
         }
 
-        serde_json::to_vec(&self).unwrap().into_response()
+        serde_json::to_vec(
+            &self
+                .serialize(serialize::Serializer::new(self.version))
+                .unwrap(),
+        )
+        .unwrap()
+        .into_response()
     }
 }
 
@@ -109,10 +144,13 @@ mod tests {
         let response = RpcResponse {
             output: Err(RpcError::InvalidParams(parsing_err.clone())),
             id: RequestId::Number(1),
+            version: RpcVersion::V07,
         };
         let parsing_err = RpcError::InvalidParams(parsing_err);
 
-        let serialized = serde_json::to_value(&response).unwrap();
+        let serialized = response
+            .serialize(serialize::Serializer::new(RpcVersion::V07))
+            .unwrap();
 
         let expected = json!({
             "jsonrpc": "2.0",
@@ -129,10 +167,12 @@ mod tests {
 
     #[test]
     fn output_is_ok() {
-        let serialized = serde_json::to_value(&RpcResponse {
+        let serialized = RpcResponse {
             output: Ok(Value::String("foobar".to_owned())),
             id: RequestId::Number(1),
-        })
+            version: RpcVersion::V07,
+        }
+        .serialize(serialize::Serializer::new(RpcVersion::V07))
         .unwrap();
 
         let expected = json!({

--- a/crates/rpc/src/method/add_declare_transaction.rs
+++ b/crates/rpc/src/method/add_declare_transaction.rs
@@ -379,7 +379,8 @@ mod tests {
             use serde_json::json;
 
             use super::super::*;
-            use crate::dto::DeserializeForVersion;
+            use crate::dto::serialize::SerializeForVersion;
+            use crate::dto::{serialize, DeserializeForVersion};
             use crate::v02::types::request::BroadcastedDeclareTransactionV1;
             use crate::RpcVersion;
 
@@ -458,7 +459,9 @@ mod tests {
                 let error = AddDeclareTransactionError::from(starknet_error);
                 let error = crate::error::ApplicationError::from(error);
                 let error = crate::jsonrpc::RpcError::from(error);
-                let error = serde_json::to_value(error).unwrap();
+                let error = error
+                    .serialize(serialize::Serializer::new(RpcVersion::V07))
+                    .unwrap();
 
                 let expected = json!({
                     "code": 63,

--- a/crates/rpc/src/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/method/add_deploy_account_transaction.rs
@@ -245,6 +245,7 @@ mod tests {
     };
 
     use super::*;
+    use crate::dto::serialize::{self, SerializeForVersion};
     use crate::v02::types::request::BroadcastedDeployAccountTransactionV3;
     use crate::v02::types::{DataAvailabilityMode, ResourceBound, ResourceBounds};
 
@@ -303,7 +304,9 @@ mod tests {
         let error = AddDeployAccountTransactionError::from(starknet_error);
         let error = crate::error::ApplicationError::from(error);
         let error = crate::jsonrpc::RpcError::from(error);
-        let error = serde_json::to_value(error).unwrap();
+        let error = error
+            .serialize(serialize::Serializer::new(crate::RpcVersion::V07))
+            .unwrap();
 
         let expected = serde_json::json!({
             "code": 63,

--- a/crates/rpc/src/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/method/add_invoke_transaction.rs
@@ -252,6 +252,7 @@ mod tests {
         use serde_json::json;
 
         use super::*;
+        use crate::dto::serialize::{self, SerializeForVersion};
         use crate::dto::DeserializeForVersion;
 
         #[test]
@@ -340,7 +341,9 @@ mod tests {
             let error = AddInvokeTransactionError::from(starknet_error);
             let error = crate::error::ApplicationError::from(error);
             let error = crate::jsonrpc::RpcError::from(error);
-            let error = serde_json::to_value(error).unwrap();
+            let error = error
+                .serialize(serialize::Serializer::new(crate::RpcVersion::V07))
+                .unwrap();
 
             let expected = json!({
                 "code": 63,

--- a/crates/rpc/src/v06/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v06/method/add_declare_transaction.rs
@@ -351,6 +351,7 @@ mod tests {
             use serde_json::json;
 
             use super::super::*;
+            use crate::dto::serialize::{self, SerializeForVersion};
             use crate::v02::types::request::BroadcastedDeclareTransactionV1;
 
             fn test_declare_txn() -> Transaction {
@@ -427,7 +428,9 @@ mod tests {
                 let error = AddDeclareTransactionError::from(starknet_error);
                 let error = crate::error::ApplicationError::from(error);
                 let error = crate::jsonrpc::RpcError::from(error);
-                let error = serde_json::to_value(error).unwrap();
+                let error = error
+                    .serialize(serialize::Serializer::new(crate::RpcVersion::V07))
+                    .unwrap();
 
                 let expected = json!({
                     "code": 63,

--- a/crates/rpc/src/v06/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/v06/method/add_deploy_account_transaction.rs
@@ -217,6 +217,7 @@ mod tests {
     };
 
     use super::*;
+    use crate::dto::serialize::{self, SerializeForVersion};
     use crate::v02::types::request::BroadcastedDeployAccountTransactionV3;
     use crate::v02::types::{DataAvailabilityMode, ResourceBound, ResourceBounds};
 
@@ -271,7 +272,9 @@ mod tests {
         let error = AddDeployAccountTransactionError::from(starknet_error);
         let error = crate::error::ApplicationError::from(error);
         let error = crate::jsonrpc::RpcError::from(error);
-        let error = serde_json::to_value(error).unwrap();
+        let error = error
+            .serialize(serialize::Serializer::new(crate::RpcVersion::V07))
+            .unwrap();
 
         let expected = serde_json::json!({
             "code": 63,

--- a/crates/rpc/src/v06/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/v06/method/add_invoke_transaction.rs
@@ -227,6 +227,7 @@ mod tests {
         use serde_json::json;
 
         use super::*;
+        use crate::dto::serialize::{self, SerializeForVersion};
 
         #[test]
         fn positional_args() {
@@ -311,7 +312,9 @@ mod tests {
             let error = AddInvokeTransactionError::from(starknet_error);
             let error = crate::error::ApplicationError::from(error);
             let error = crate::jsonrpc::RpcError::from(error);
-            let error = serde_json::to_value(error).unwrap();
+            let error = error
+                .serialize(serialize::Serializer::new(crate::RpcVersion::V07))
+                .unwrap();
 
             let expected = json!({
                 "code": 63,


### PR DESCRIPTION
There are multiple changes in the JSON-RPC 0.8.0 specification that require us to change the _error_ types we're returning.

Currently we use `SerializeForVersion` to implement version-dependent serialization of JSON-RPC results -- but we don't have that facility for error types.

This PR adds `SerializeForVersion` to RPC errors (and results in general) that makes implementing version-dependent behavior in error types easier.