### PR TITLE
chore: fix new clippy warnings (rust 1.82.0)

### DIFF
--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -153,6 +153,7 @@ pub struct DeployAccountTransactionTrace {
 }
 
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum ExecuteInvocation {
     FunctionInvocation(Option<FunctionInvocation>),
     RevertedReason(String),

--- a/crates/rpc/src/v06/method/simulate_transactions.rs
+++ b/crates/rpc/src/v06/method/simulate_transactions.rs
@@ -591,6 +591,7 @@ pub mod dto {
 
     #[derive(Clone, Debug, Default, Serialize, Eq, PartialEq)]
     #[serde(untagged)]
+    #[allow(clippy::large_enum_variant)]
     pub enum ExecuteInvocation {
         #[default]
         Empty,


### PR DESCRIPTION
Ignore new clippy warnings after recent update to rust stable