### PR TITLE
chore(ci): use typos 1.26.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: crate-ci/typos@v1.16.23
+      - uses: crate-ci/typos@v1.26.0
         with:
           files: .
 

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-/// This trait is a workaround for [anyhow::Error] not being clonable.
+/// This trait is a workaround for [anyhow::Error] not being cloneable.
 ///
 /// Most of the time you can use `Arc<anyhow::Error>` instead of `anyhow::Error`
 /// to circumvent `anyhow::Error` not being `Clone`. However, in some cases, you

--- a/crates/common/src/header.rs
+++ b/crates/common/src/header.rs
@@ -81,8 +81,8 @@ impl BlockHeaderBuilder {
         self
     }
 
-    pub fn state_commitment(mut self, state_commmitment: StateCommitment) -> Self {
-        self.0.state_commitment = state_commmitment;
+    pub fn state_commitment(mut self, state_commitment: StateCommitment) -> Self {
+        self.0.state_commitment = state_commitment;
         self
     }
 

--- a/doc/rpc/v03/starknet_api_openrpc.json
+++ b/doc/rpc/v03/starknet_api_openrpc.json
@@ -518,7 +518,7 @@
                 "schema": {
                     "title": "Estimation",
                     "type": "array",
-                    "description": "a sequence of fee estimatione where the i'th estimate corresponds to the i'th transaction",
+                    "description": "a sequence of fee estimation where the i'th estimate corresponds to the i'th transaction",
                     "items": {
                         "$ref": "#/components/schemas/FEE_ESTIMATE"
                     }

--- a/doc/rpc/v03/starknet_trace_api_openrpc.json
+++ b/doc/rpc/v03/starknet_trace_api_openrpc.json
@@ -75,7 +75,7 @@
             ],
             "result": {
                 "name": "simulated_transactions",
-                "description": "The execution trace and consuemd resources of the required transactions",
+                "description": "The execution trace and consumed resources of the required transactions",
                 "schema": {
                     "type": "array",
                     "items": {

--- a/doc/rpc/v04/starknet_api_openrpc.json
+++ b/doc/rpc/v04/starknet_api_openrpc.json
@@ -563,7 +563,7 @@
                 "schema": {
                     "title": "Estimation",
                     "type": "array",
-                    "description": "a sequence of fee estimatione where the i'th estimate corresponds to the i'th transaction",
+                    "description": "a sequence of fee estimation where the i'th estimate corresponds to the i'th transaction",
                     "items": {
                         "$ref": "#/components/schemas/FEE_ESTIMATE"
                     }

--- a/doc/rpc/v04/starknet_trace_api_openrpc.json
+++ b/doc/rpc/v04/starknet_trace_api_openrpc.json
@@ -88,7 +88,7 @@
             ],
             "result": {
                 "name": "simulated_transactions",
-                "description": "The execution trace and consuemd resources of the required transactions",
+                "description": "The execution trace and consumed resources of the required transactions",
                 "schema": {
                     "type": "array",
                     "items": {

--- a/doc/rpc/v06/starknet_api_openrpc.json
+++ b/doc/rpc/v06/starknet_api_openrpc.json
@@ -624,7 +624,7 @@
                 "schema": {
                     "title": "Estimation",
                     "type": "array",
-                    "description": "a sequence of fee estimatione where the i'th estimate corresponds to the i'th transaction",
+                    "description": "a sequence of fee estimation where the i'th estimate corresponds to the i'th transaction",
                     "items": {
                         "$ref": "#/components/schemas/FEE_ESTIMATE"
                     }
@@ -3705,7 +3705,7 @@
             "DA_MODE": {
                 "title": "DA mode",
                 "type": "string",
-                "description": "Specifies a storage domain in Starknet. Each domain has different gurantess regarding availability",
+                "description": "Specifies a storage domain in Starknet. Each domain has different guarantees regarding availability",
                 "enum": [
                     "L1",
                     "L2"

--- a/doc/rpc/v06/starknet_trace_api_openrpc.json
+++ b/doc/rpc/v06/starknet_trace_api_openrpc.json
@@ -75,7 +75,7 @@
             ],
             "result": {
                 "name": "simulated_transactions",
-                "description": "The execution trace and consuemd resources of the required transactions",
+                "description": "The execution trace and consumed resources of the required transactions",
                 "schema": {
                     "type": "array",
                     "items": {

--- a/doc/rpc/v07/starknet_api_openrpc.json
+++ b/doc/rpc/v07/starknet_api_openrpc.json
@@ -653,7 +653,7 @@
                 "schema": {
                     "title": "Estimation",
                     "type": "array",
-                    "description": "a sequence of fee estimatione where the i'th estimate corresponds to the i'th transaction",
+                    "description": "a sequence of fee estimation where the i'th estimate corresponds to the i'th transaction",
                     "items": {
                         "$ref": "#/components/schemas/FEE_ESTIMATE"
                     }
@@ -3710,7 +3710,7 @@
             "DA_MODE": {
                 "title": "DA mode",
                 "type": "string",
-                "description": "Specifies a storage domain in Starknet. Each domain has different gurantess regarding availability",
+                "description": "Specifies a storage domain in Starknet. Each domain has different guarantees regarding availability",
                 "enum": [
                     "L1",
                     "L2"

--- a/doc/rpc/v07/starknet_trace_api_openrpc.json
+++ b/doc/rpc/v07/starknet_trace_api_openrpc.json
@@ -75,7 +75,7 @@
             ],
             "result": {
                 "name": "simulated_transactions",
-                "description": "The execution trace and consuemd resources of the required transactions",
+                "description": "The execution trace and consumed resources of the required transactions",
                 "schema": {
                     "type": "array",
                     "items": {

--- a/doc/rpc/v08/starknet_api_openrpc.json
+++ b/doc/rpc/v08/starknet_api_openrpc.json
@@ -681,7 +681,7 @@
         "schema": {
           "title": "Estimation",
           "type": "array",
-          "description": "a sequence of fee estimatione where the i'th estimate corresponds to the i'th transaction",
+          "description": "a sequence of fee estimation where the i'th estimate corresponds to the i'th transaction",
           "items": {
             "$ref": "#/components/schemas/FEE_ESTIMATE"
           }
@@ -3556,7 +3556,7 @@
       "DA_MODE": {
         "title": "DA mode",
         "type": "string",
-        "description": "Specifies a storage domain in Starknet. Each domain has different gurantess regarding availability",
+        "description": "Specifies a storage domain in Starknet. Each domain has different guarantees regarding availability",
         "enum": ["L1", "L2"]
       },
       "RESOURCE_BOUNDS_MAPPING": {

--- a/doc/rpc/v08/starknet_trace_api_openrpc.json
+++ b/doc/rpc/v08/starknet_trace_api_openrpc.json
@@ -75,7 +75,7 @@
       ],
       "result": {
         "name": "simulated_transactions",
-        "description": "The execution trace and consuemd resources of the required transactions",
+        "description": "The execution trace and consumed resources of the required transactions",
         "schema": {
           "type": "array",
           "items": {


### PR DESCRIPTION
And also fix all typos that are found by the new version.