### PR TITLE
fix(rpc/v08): follow-up spec change for inner call execution resources

### DIFF
--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -202,6 +202,7 @@ pub struct FunctionInvocation {
     pub messages: Vec<MsgToL1>,
     pub result: Vec<Felt>,
     pub computation_resources: ComputationResources,
+    pub execution_resources: InnerCallExecutionResources,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -210,6 +211,12 @@ pub struct MsgToL1 {
     pub payload: Vec<Felt>,
     pub to_address: Felt,
     pub from_address: Felt,
+}
+
+#[derive(Debug, Clone)]
+pub struct InnerCallExecutionResources {
+    pub l1_gas: u128,
+    pub l2_gas: u128,
 }
 
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
@@ -343,6 +350,11 @@ impl From<blockifier::execution::call_info::CallInfo> for FunctionInvocation {
             messages,
             result,
             computation_resources: call_info.resources.into(),
+            execution_resources: InnerCallExecutionResources {
+                l1_gas: call_info.execution.gas_consumed.into(),
+                // TODO: Use proper l2_gas value for Starknet 0.13.3
+                l2_gas: 0,
+            },
         }
     }
 }

--- a/crates/rpc/src/dto/simulation.rs
+++ b/crates/rpc/src/dto/simulation.rs
@@ -3,6 +3,7 @@ use pathfinder_common::{ContractAddress, ContractNonce};
 use serde::ser::Error;
 
 use super::serialize::SerializeStruct;
+use crate::RpcVersion;
 
 #[derive(Debug)]
 pub struct TransactionTrace<'a> {
@@ -176,10 +177,16 @@ impl crate::dto::serialize::SerializeForVersion for FunctionInvocation<'_> {
             self.0.result.len(),
             &mut self.0.result.iter().map(crate::dto::Felt),
         )?;
-        serializer.serialize_field(
-            "execution_resources",
-            &ComputationResources(&self.0.computation_resources),
-        )?;
+        match serializer.version {
+            RpcVersion::V08 => serializer.serialize_field(
+                "execution_resources",
+                &InnerCallExecutionResources(&self.0.execution_resources),
+            )?,
+            _ => serializer.serialize_field(
+                "execution_resources",
+                &ComputationResources(&self.0.computation_resources),
+            )?,
+        }
         serializer.end()
     }
 }
@@ -284,6 +291,20 @@ impl crate::dto::serialize::SerializeForVersion for ComputationResources<'_> {
         if self.0.segment_arena_builtin != 0 {
             serializer.serialize_field("segment_arena_builtin", &self.0.segment_arena_builtin)?;
         }
+        serializer.end()
+    }
+}
+
+struct InnerCallExecutionResources<'a>(&'a pathfinder_executor::types::InnerCallExecutionResources);
+
+impl crate::dto::serialize::SerializeForVersion for InnerCallExecutionResources<'_> {
+    fn serialize(
+        &self,
+        serializer: super::serialize::Serializer,
+    ) -> Result<super::serialize::Ok, super::serialize::Error> {
+        let mut serializer = serializer.serialize_struct()?;
+        serializer.serialize_field("l1_gas", &self.0.l1_gas)?;
+        serializer.serialize_field("l2_gas", &self.0.l2_gas)?;
         serializer.end()
     }
 }

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -428,10 +428,14 @@ fn map_gateway_function_invocation(
         result: invocation.result,
         computation_resources: map_gateway_computation_resources(invocation.execution_resources),
         execution_resources: InnerCallExecutionResources {
-            l1_gas: invocation.execution_resources.total_gas_consumed.map(|gas| gas.l1_gas).unwrap_or_default(),
+            l1_gas: invocation
+                .execution_resources
+                .total_gas_consumed
+                .map(|gas| gas.l1_gas)
+                .unwrap_or_default(),
             // TODO: Use proper l1_gas value for Starknet 0.13.3
             l2_gas: 0,
-        }
+        },
     })
 }
 

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -1,5 +1,6 @@
 use anyhow::Context;
 use pathfinder_common::BlockId;
+use pathfinder_executor::types::InnerCallExecutionResources;
 use pathfinder_executor::TransactionExecutionError;
 use starknet_gateway_client::GatewayApi;
 
@@ -426,6 +427,11 @@ fn map_gateway_function_invocation(
             .collect(),
         result: invocation.result,
         computation_resources: map_gateway_computation_resources(invocation.execution_resources),
+        execution_resources: InnerCallExecutionResources {
+            l1_gas: invocation.execution_resources.total_gas_consumed.map(|gas| gas.l1_gas).unwrap_or_default(),
+            // TODO: Use proper l1_gas value for Starknet 0.13.3
+            l2_gas: 0,
+        }
     })
 }
 


### PR DESCRIPTION
This PR implements https://github.com/starkware-libs/starknet-specs/pull/233 so that we don't expose compute resources for inner calls only L1 and L2 gas.

Closes #2322 