### PR TITLE
feat(rpc/v08): rename INSUFFICIENT_MAX_FEE error and add `starknet_addXYZTransaction`methods

### DIFF
--- a/crates/rpc/src/jsonrpc/error.rs
+++ b/crates/rpc/src/jsonrpc/error.rs
@@ -42,14 +42,14 @@ impl RpcError {
         }
     }
 
-    pub fn message(&self) -> Cow<'_, str> {
+    pub fn message(&self, version: RpcVersion) -> Cow<'_, str> {
         match self {
             RpcError::ParseError(..) => "Parse error".into(),
             RpcError::InvalidRequest(..) => "Invalid request".into(),
             RpcError::MethodNotFound { .. } => "Method not found".into(),
             RpcError::InvalidParams(..) => "Invalid params".into(),
             RpcError::InternalError(_) => "Internal error".into(),
-            RpcError::ApplicationError(e) => e.to_string().into(),
+            RpcError::ApplicationError(e) => e.message(version).into(),
             RpcError::WebsocketSubscriptionClosed { .. } => "Websocket subscription closed".into(),
         }
     }
@@ -82,7 +82,7 @@ impl serialize::SerializeForVersion for RpcError {
     ) -> Result<serialize::Ok, serialize::Error> {
         let mut obj = serializer.serialize_struct()?;
         obj.serialize_field("code", &self.code())?;
-        obj.serialize_field("message", &self.message())?;
+        obj.serialize_field("message", &self.message(serializer.version))?;
 
         if let Some(data) = self.data(serializer.version) {
             obj.serialize_field("data", &data)?;

--- a/crates/rpc/src/jsonrpc/response.rs
+++ b/crates/rpc/src/jsonrpc/response.rs
@@ -156,7 +156,7 @@ mod tests {
             "jsonrpc": "2.0",
             "error": {
                 "code": parsing_err.code(),
-                "message": parsing_err.message(),
+                "message": parsing_err.message(RpcVersion::V07),
                 "data": parsing_err.data(RpcVersion::V07),
             },
             "id": 1,

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -905,11 +905,7 @@ mod tests {
         "starknet_getTransactionReceipt",
     ])]
     #[case::v0_8_trace("/rpc/v0_8", "v08/starknet_trace_api_openrpc.json", &[])]
-    #[case::v0_8_write("/rpc/v0_8", "v08/starknet_write_api.json", &[
-        "starknet_addInvokeTransaction",
-        "starknet_addDeclareTransaction",
-        "starknet_addDeployAccountTransaction"
-    ])]
+    #[case::v0_8_write("/rpc/v0_8", "v08/starknet_write_api.json", &[])]
     // get_transaction_status is now part of the official spec, so we are phasing it out.
     #[case::v0_8_pathfinder("/rpc/v0_8", "pathfinder_rpc_api.json", &["pathfinder_version", "pathfinder_getTransactionStatus"])]
 

--- a/crates/rpc/src/method/add_declare_transaction.rs
+++ b/crates/rpc/src/method/add_declare_transaction.rs
@@ -14,7 +14,7 @@ use crate::v02::types::request::BroadcastedDeclareTransaction;
 pub enum AddDeclareTransactionError {
     ClassAlreadyDeclared,
     InvalidTransactionNonce,
-    InsufficientMaxFee,
+    InsufficientResourcesForValidate,
     InsufficientAccountBalance,
     ValidationFailure(String),
     CompilationFailed,
@@ -32,7 +32,9 @@ impl From<AddDeclareTransactionError> for crate::error::ApplicationError {
         match value {
             AddDeclareTransactionError::ClassAlreadyDeclared => Self::ClassAlreadyDeclared,
             AddDeclareTransactionError::InvalidTransactionNonce => Self::InvalidTransactionNonce,
-            AddDeclareTransactionError::InsufficientMaxFee => Self::InsufficientMaxFee,
+            AddDeclareTransactionError::InsufficientResourcesForValidate => {
+                Self::InsufficientResourcesForValidate
+            }
             AddDeclareTransactionError::InsufficientAccountBalance => {
                 Self::InsufficientAccountBalance
             }
@@ -100,7 +102,7 @@ impl From<SequencerError> for AddDeclareTransactionError {
                 AddDeclareTransactionError::InsufficientAccountBalance
             }
             SequencerError::StarknetError(e) if e.code == InsufficientMaxFee.into() => {
-                AddDeclareTransactionError::InsufficientMaxFee
+                AddDeclareTransactionError::InsufficientResourcesForValidate
             }
             SequencerError::StarknetError(e) if e.code == InvalidTransactionNonce.into() => {
                 AddDeclareTransactionError::InvalidTransactionNonce

--- a/crates/rpc/src/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/method/add_deploy_account_transaction.rs
@@ -51,7 +51,7 @@ pub struct Output {
 pub enum AddDeployAccountTransactionError {
     ClassHashNotFound,
     InvalidTransactionNonce,
-    InsufficientMaxFee,
+    InsufficientResourcesForValidate,
     InsufficientAccountBalance,
     ValidationFailure(String),
     DuplicateTransaction,
@@ -66,7 +66,7 @@ impl From<AddDeployAccountTransactionError> for crate::error::ApplicationError {
         match value {
             ClassHashNotFound => Self::ClassHashNotFound,
             InvalidTransactionNonce => Self::InvalidTransactionNonce,
-            InsufficientMaxFee => Self::InsufficientMaxFee,
+            InsufficientResourcesForValidate => Self::InsufficientResourcesForValidate,
             InsufficientAccountBalance => Self::InsufficientAccountBalance,
             ValidationFailure(message) => Self::ValidationFailureV06(message),
             DuplicateTransaction => Self::DuplicateTransaction,
@@ -100,7 +100,7 @@ impl From<SequencerError> for AddDeployAccountTransactionError {
                 AddDeployAccountTransactionError::InsufficientAccountBalance
             }
             SequencerError::StarknetError(e) if e.code == InsufficientMaxFee.into() => {
-                AddDeployAccountTransactionError::InsufficientMaxFee
+                AddDeployAccountTransactionError::InsufficientResourcesForValidate
             }
             SequencerError::StarknetError(e) if e.code == InvalidTransactionNonce.into() => {
                 AddDeployAccountTransactionError::InvalidTransactionNonce

--- a/crates/rpc/src/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/method/add_invoke_transaction.rs
@@ -46,7 +46,7 @@ pub struct Output {
 #[derive(Debug)]
 pub enum AddInvokeTransactionError {
     InvalidTransactionNonce,
-    InsufficientMaxFee,
+    InsufficientResourcesForValidate,
     InsufficientAccountBalance,
     ValidationFailure(String),
     DuplicateTransaction,
@@ -59,7 +59,9 @@ impl From<AddInvokeTransactionError> for crate::error::ApplicationError {
     fn from(value: AddInvokeTransactionError) -> Self {
         match value {
             AddInvokeTransactionError::InvalidTransactionNonce => Self::InvalidTransactionNonce,
-            AddInvokeTransactionError::InsufficientMaxFee => Self::InsufficientMaxFee,
+            AddInvokeTransactionError::InsufficientResourcesForValidate => {
+                Self::InsufficientResourcesForValidate
+            }
             AddInvokeTransactionError::InsufficientAccountBalance => {
                 Self::InsufficientAccountBalance
             }
@@ -93,7 +95,7 @@ impl From<SequencerError> for AddInvokeTransactionError {
                 AddInvokeTransactionError::InsufficientAccountBalance
             }
             SequencerError::StarknetError(e) if e.code == InsufficientMaxFee.into() => {
-                AddInvokeTransactionError::InsufficientMaxFee
+                AddInvokeTransactionError::InsufficientResourcesForValidate
             }
             SequencerError::StarknetError(e) if e.code == InvalidTransactionNonce.into() => {
                 AddInvokeTransactionError::InvalidTransactionNonce

--- a/crates/rpc/src/v06/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v06/method/add_declare_transaction.rs
@@ -15,7 +15,7 @@ use crate::v02::types::request::BroadcastedDeclareTransaction;
 pub enum AddDeclareTransactionError {
     ClassAlreadyDeclared,
     InvalidTransactionNonce,
-    InsufficientMaxFee,
+    InsufficientResourcesForValidate,
     InsufficientAccountBalance,
     ValidationFailure(String),
     CompilationFailed,
@@ -33,7 +33,9 @@ impl From<AddDeclareTransactionError> for crate::error::ApplicationError {
         match value {
             AddDeclareTransactionError::ClassAlreadyDeclared => Self::ClassAlreadyDeclared,
             AddDeclareTransactionError::InvalidTransactionNonce => Self::InvalidTransactionNonce,
-            AddDeclareTransactionError::InsufficientMaxFee => Self::InsufficientMaxFee,
+            AddDeclareTransactionError::InsufficientResourcesForValidate => {
+                Self::InsufficientResourcesForValidate
+            }
             AddDeclareTransactionError::InsufficientAccountBalance => {
                 Self::InsufficientAccountBalance
             }
@@ -101,7 +103,7 @@ impl From<SequencerError> for AddDeclareTransactionError {
                 AddDeclareTransactionError::InsufficientAccountBalance
             }
             SequencerError::StarknetError(e) if e.code == InsufficientMaxFee.into() => {
-                AddDeclareTransactionError::InsufficientMaxFee
+                AddDeclareTransactionError::InsufficientResourcesForValidate
             }
             SequencerError::StarknetError(e) if e.code == InvalidTransactionNonce.into() => {
                 AddDeclareTransactionError::InvalidTransactionNonce

--- a/crates/rpc/src/v06/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/v06/method/add_deploy_account_transaction.rs
@@ -41,7 +41,7 @@ pub struct AddDeployAccountTransactionOutput {
 pub enum AddDeployAccountTransactionError {
     ClassHashNotFound,
     InvalidTransactionNonce,
-    InsufficientMaxFee,
+    InsufficientResourcesForValidate,
     InsufficientAccountBalance,
     ValidationFailure(String),
     DuplicateTransaction,
@@ -56,7 +56,7 @@ impl From<AddDeployAccountTransactionError> for crate::error::ApplicationError {
         match value {
             ClassHashNotFound => Self::ClassHashNotFound,
             InvalidTransactionNonce => Self::InvalidTransactionNonce,
-            InsufficientMaxFee => Self::InsufficientMaxFee,
+            InsufficientResourcesForValidate => Self::InsufficientResourcesForValidate,
             InsufficientAccountBalance => Self::InsufficientAccountBalance,
             ValidationFailure(message) => Self::ValidationFailureV06(message),
             DuplicateTransaction => Self::DuplicateTransaction,
@@ -90,7 +90,7 @@ impl From<SequencerError> for AddDeployAccountTransactionError {
                 AddDeployAccountTransactionError::InsufficientAccountBalance
             }
             SequencerError::StarknetError(e) if e.code == InsufficientMaxFee.into() => {
-                AddDeployAccountTransactionError::InsufficientMaxFee
+                AddDeployAccountTransactionError::InsufficientResourcesForValidate
             }
             SequencerError::StarknetError(e) if e.code == InvalidTransactionNonce.into() => {
                 AddDeployAccountTransactionError::InvalidTransactionNonce

--- a/crates/rpc/src/v06/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/v06/method/add_invoke_transaction.rs
@@ -35,7 +35,7 @@ pub struct AddInvokeTransactionOutput {
 #[derive(Debug)]
 pub enum AddInvokeTransactionError {
     InvalidTransactionNonce,
-    InsufficientMaxFee,
+    InsufficientResourcesForValidate,
     InsufficientAccountBalance,
     ValidationFailure(String),
     DuplicateTransaction,
@@ -48,7 +48,9 @@ impl From<AddInvokeTransactionError> for crate::error::ApplicationError {
     fn from(value: AddInvokeTransactionError) -> Self {
         match value {
             AddInvokeTransactionError::InvalidTransactionNonce => Self::InvalidTransactionNonce,
-            AddInvokeTransactionError::InsufficientMaxFee => Self::InsufficientMaxFee,
+            AddInvokeTransactionError::InsufficientResourcesForValidate => {
+                Self::InsufficientResourcesForValidate
+            }
             AddInvokeTransactionError::InsufficientAccountBalance => {
                 Self::InsufficientAccountBalance
             }
@@ -82,7 +84,7 @@ impl From<SequencerError> for AddInvokeTransactionError {
                 AddInvokeTransactionError::InsufficientAccountBalance
             }
             SequencerError::StarknetError(e) if e.code == InsufficientMaxFee.into() => {
-                AddInvokeTransactionError::InsufficientMaxFee
+                AddInvokeTransactionError::InsufficientResourcesForValidate
             }
             SequencerError::StarknetError(e) if e.code == InvalidTransactionNonce.into() => {
                 AddInvokeTransactionError::InvalidTransactionNonce

--- a/crates/rpc/src/v08.rs
+++ b/crates/rpc/src/v08.rs
@@ -6,6 +6,9 @@ use crate::method::subscribe_pending_transactions::SubscribePendingTransactions;
 #[rustfmt::skip]
 pub fn register_routes() -> RpcRouterBuilder {
     RpcRouter::builder(crate::RpcVersion::V08)
+        .register("starknet_addDeclareTransaction",               crate::method::add_declare_transaction)
+        .register("starknet_addDeployAccountTransaction",         crate::method::add_deploy_account_transaction)
+        .register("starknet_addInvokeTransaction",                crate::method::add_invoke_transaction)
         .register("starknet_blockHashAndNumber",                  crate::method::block_hash_and_number)
         .register("starknet_blockNumber",                         crate::method::block_number)
         .register("starknet_call",                                crate::method::call)


### PR DESCRIPTION
This PR follow up a change in the JSON-RPC 0.8.0 specification that renames the error (and changes its message). This was the only change for the `starknet_addXYZTransaction` methods so we now also add those to the JSON-RPC 0.8.0 API.

Closes #2263
