### PR TITLE
feat(checkpoint/state_diff): merge trie updates

### DIFF
--- a/crates/make-stream/src/lib.rs
+++ b/crates/make-stream/src/lib.rs
@@ -5,6 +5,13 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::Stream;
 
 /// Use the sender to yield items to the stream.
+///
+/// ### Warning
+///
+/// Implementor of the future must ensure that the `src` future __exits if the
+/// sender fails to send an item__ (ie. fails to yield an item to the stream).
+/// Otherwise, the `src` future will never complete and will keep running,
+/// because it is detached via `tokio::spawn`.
 pub fn from_future<T, U, V>(src: U) -> impl Stream<Item = T>
 where
     U: FnOnce(Sender<T>) -> V + Send + 'static,
@@ -17,6 +24,13 @@ where
 }
 
 /// Use the sender to yield items to the stream.
+///
+/// ### Warning
+///
+/// Implementor of the closure must ensure that the `src` closure __exits if the
+/// sender fails to send an item__ (ie. fails to yield an item to the stream).
+/// Otherwise, the `src` closure will never complete and will keep running,
+/// because it is detached via `std::thread::spawn`.
 pub fn from_blocking<T, U>(src: U) -> impl Stream<Item = T>
 where
     T: Send + 'static,

--- a/crates/merkle-tree/src/contract_state.rs
+++ b/crates/merkle-tree/src/contract_state.rs
@@ -1,7 +1,5 @@
-use std::collections::HashMap;
-
 use anyhow::Context;
-use pathfinder_common::state_update::ReverseContractUpdate;
+use pathfinder_common::state_update::{ReverseContractUpdate, StorageRef};
 use pathfinder_common::{
     BlockNumber,
     ClassHash,
@@ -9,8 +7,6 @@ use pathfinder_common::{
     ContractNonce,
     ContractRoot,
     ContractStateHash,
-    StorageAddress,
-    StorageValue,
 };
 use pathfinder_crypto::hash::pedersen_hash;
 use pathfinder_crypto::Felt;
@@ -51,9 +47,9 @@ impl ContractStateUpdateResult {
 
 /// Updates a contract's state with and returns the resulting
 /// [ContractStateHash].
-pub fn update_contract_state(
+pub fn update_contract_state<'a>(
     contract_address: ContractAddress,
-    updates: &HashMap<StorageAddress, StorageValue>,
+    updates: StorageRef<'a>,
     new_nonce: Option<ContractNonce>,
     new_class_hash: Option<ClassHash>,
     transaction: &Transaction<'_>,
@@ -70,7 +66,7 @@ pub fn update_contract_state(
         }
         .with_verify_hashes(verify_hashes);
 
-        for (key, value) in updates {
+        for (key, value) in &updates {
             contract_tree
                 .set(*key, *value)
                 .context("Update contract storage tree")?;
@@ -99,7 +95,12 @@ pub fn update_contract_state(
         transaction
             .contract_class_hash(block.into(), contract_address)
             .context("Querying contract's class hash")?
-            .context("Contract's class hash is missing")?
+            .with_context(|| {
+                format!(
+                    "Contract's class hash is missing, block: {block}, contract_address: \
+                     {contract_address}"
+                )
+            })?
     };
 
     let nonce = if let Some(nonce) = new_nonce {

--- a/crates/merkle-tree/src/contract_state.rs
+++ b/crates/merkle-tree/src/contract_state.rs
@@ -47,9 +47,9 @@ impl ContractStateUpdateResult {
 
 /// Updates a contract's state with and returns the resulting
 /// [ContractStateHash].
-pub fn update_contract_state<'a>(
+pub fn update_contract_state(
     contract_address: ContractAddress,
-    updates: StorageRef<'a>,
+    updates: StorageRef<'_>,
     new_nonce: Option<ContractNonce>,
     new_class_hash: Option<ClassHash>,
     transaction: &Transaction<'_>,

--- a/crates/p2p/src/builder.rs
+++ b/crates/p2p/src/builder.rs
@@ -57,7 +57,7 @@ impl Builder {
             behaviour,
             local_peer_id,
             swarm::Config::with_tokio_executor()
-                .with_idle_connection_timeout(Duration::from_secs(3600 * 365)), // A YEAR
+                .with_idle_connection_timeout(Duration::from_secs(60)),
         );
 
         let (event_sender, event_receiver) = mpsc::channel(1);

--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -685,11 +685,14 @@ mod header_stream {
             Ok(BlockHeadersResponse::Header(hdr)) => match SignedBlockHeader::try_from_dto(*hdr) {
                 Ok(hdr) => {
                     if done(direction, *start, stop) {
-                        tracing::debug!(%peer, "Header stream Fin missing, got extra header instead");
+                        tracing::debug!(%peer, "Header stream Fin missing, got extra header instead, terminating");
                         return Action::TerminateStream;
                     }
 
-                    _ = tx.send(PeerData::new(peer, hdr)).await;
+                    if let Err(_) = tx.send(PeerData::new(peer, hdr)).await {
+                        tracing::debug!(%peer, "Failed to yield to stream, terminating");
+                        return Action::TerminateStream;
+                    }
 
                     *start = match direction {
                         Direction::Forward => *start + 1,
@@ -699,7 +702,7 @@ mod header_stream {
                     Action::NextResponse
                 }
                 Err(error) => {
-                    tracing::debug!(%peer, %error, "Header stream failed");
+                    tracing::debug!(%peer, %error, "Header stream failed, terminating");
                     if done(direction, *start, stop) {
                         return Action::TerminateStream;
                     }
@@ -716,7 +719,7 @@ mod header_stream {
                 Action::NextPeer
             }
             Err(error) => {
-                tracing::debug!(%peer, %error, "Header stream failed");
+                tracing::debug!(%peer, %error, "Header stream failed, terminating");
                 if done(direction, *start, stop) {
                     return Action::TerminateStream;
                 }
@@ -906,9 +909,13 @@ mod transaction_stream {
     ) -> bool {
         tracing::trace!(block_number=%start, "All transactions received for block");
 
-        _ = tx
+        if let Err(_) = tx
             .send(Ok(PeerData::new(peer, (transactions, *start))))
-            .await;
+            .await
+        {
+            tracing::debug!(%peer, "Failed to yield to stream, terminating");
+            return true;
+        }
 
         if *start == stop {
             return true;
@@ -1125,7 +1132,10 @@ mod state_diff_stream {
     ) -> bool {
         tracing::trace!(block_number=%start, "State diff received for block");
 
-        _ = tx.send(Ok(PeerData::new(peer, (state_diff, *start)))).await;
+        if let Err(_) = tx.send(Ok(PeerData::new(peer, (state_diff, *start)))).await {
+            tracing::debug!(%peer, "Failed to yield to stream, terminating");
+            return true;
+        }
 
         if *start == stop {
             return true;
@@ -1307,7 +1317,10 @@ mod class_definition_stream {
         tracing::trace!(block_number=%start, "All classes received for block");
 
         for class_definition in class_definitions {
-            _ = tx.send(Ok(PeerData::new(peer, class_definition))).await;
+            if let Err(_) = tx.send(Ok(PeerData::new(peer, class_definition))).await {
+                tracing::debug!(%peer, "Failed to yield to stream, terminating");
+                return true;
+            }
         }
 
         if *start == stop {
@@ -1489,7 +1502,10 @@ mod event_stream {
     ) -> bool {
         tracing::trace!(block_number=%start, "All events received for block");
 
-        _ = tx.send(Ok(PeerData::new(peer, (*start, events)))).await;
+        if let Err(_) = tx.send(Ok(PeerData::new(peer, (*start, events)))).await {
+            tracing::debug!(%peer, "Failed to yield to stream, terminating");
+            return true;
+        }
 
         if *start == stop {
             return true;

--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -689,7 +689,7 @@ mod header_stream {
                         return Action::TerminateStream;
                     }
 
-                    if let Err(_) = tx.send(PeerData::new(peer, hdr)).await {
+                    if tx.send(PeerData::new(peer, hdr)).await.is_err() {
                         tracing::debug!(%peer, "Failed to yield to stream, terminating");
                         return Action::TerminateStream;
                     }
@@ -909,9 +909,10 @@ mod transaction_stream {
     ) -> bool {
         tracing::trace!(block_number=%start, "All transactions received for block");
 
-        if let Err(_) = tx
+        if tx
             .send(Ok(PeerData::new(peer, (transactions, *start))))
             .await
+            .is_err()
         {
             tracing::debug!(%peer, "Failed to yield to stream, terminating");
             return true;
@@ -1132,7 +1133,11 @@ mod state_diff_stream {
     ) -> bool {
         tracing::trace!(block_number=%start, "State diff received for block");
 
-        if let Err(_) = tx.send(Ok(PeerData::new(peer, (state_diff, *start)))).await {
+        if tx
+            .send(Ok(PeerData::new(peer, (state_diff, *start))))
+            .await
+            .is_err()
+        {
             tracing::debug!(%peer, "Failed to yield to stream, terminating");
             return true;
         }
@@ -1317,7 +1322,11 @@ mod class_definition_stream {
         tracing::trace!(block_number=%start, "All classes received for block");
 
         for class_definition in class_definitions {
-            if let Err(_) = tx.send(Ok(PeerData::new(peer, class_definition))).await {
+            if tx
+                .send(Ok(PeerData::new(peer, class_definition)))
+                .await
+                .is_err()
+            {
                 tracing::debug!(%peer, "Failed to yield to stream, terminating");
                 return true;
             }
@@ -1502,7 +1511,11 @@ mod event_stream {
     ) -> bool {
         tracing::trace!(block_number=%start, "All events received for block");
 
-        if let Err(_) = tx.send(Ok(PeerData::new(peer, (*start, events)))).await {
+        if tx
+            .send(Ok(PeerData::new(peer, (*start, events))))
+            .await
+            .is_err()
+        {
             tracing::debug!(%peer, "Failed to yield to stream, terminating");
             return true;
         }

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -8,7 +8,6 @@ pub use sync::{
     sync,
     update_starknet_state,
     Gossiper,
-    StarknetStateUpdate,
     SyncContext,
     RESET_DELAY_ON_FAILURE,
 };

--- a/crates/pathfinder/src/sync.rs
+++ b/crates/pathfinder/src/sync.rs
@@ -127,11 +127,11 @@ impl Sync {
                     continue_from
                 }
                 Err(SyncError::Other(error)) => {
-                    tracing::error!(%error, "Stopping checkpoint sync");
+                    tracing::error!(?error, "Stopping checkpoint sync");
                     return Err(error);
                 }
                 Err(error) => {
-                    tracing::debug!(%error, "Restarting checkpoint sync");
+                    tracing::debug!(?error, "Restarting checkpoint sync");
                     self.handle_recoverable_error(&error.into_v2()).await;
                     continue;
                 }
@@ -186,12 +186,12 @@ impl Sync {
                     data: SyncError2::Other(error),
                     ..
                 }) => {
-                    tracing::error!(%error, "Stopping track sync");
+                    tracing::error!(?error, "Stopping track sync");
                     use pathfinder_common::error::AnyhowExt;
                     return Err(error.take_or_deep_clone());
                 }
                 Err(error) => {
-                    tracing::debug!(error=%error.data, "Restarting track sync");
+                    tracing::debug!(error=?error.data, "Restarting track sync");
                     self.handle_recoverable_error(error).await;
                 }
             }

--- a/crates/pathfinder/src/sync/checkpoint.rs
+++ b/crates/pathfinder/src/sync/checkpoint.rs
@@ -364,21 +364,17 @@ async fn handle_state_diff_stream(
             state_updates::FetchCommitmentFromDb::new(storage.connection()?),
             10,
         )
-        .pipe(state_updates::VerifyCommitment, 10)
-        .pipe(
-            state_updates::UpdateStarknetState {
-                storage: storage.clone(),
-                connection: storage.connection()?,
-                current_block: start,
-                verify_tree_hashes,
-            },
-            10,
-        )
+        .pipe(state_updates::VerifyCommitment2, 10)
         .into_stream()
+        .try_chunks(1000)
+        .map_err(|e| e.1)
+        .map_err(|e| SyncError::from_v2(e))
+        .and_then(|x| {
+            state_updates::batch_update_starknet_state(storage.clone(), verify_tree_hashes, x)
+        })
         .inspect_ok(|x| tracing::debug!(tail=%x.data, "State diff synced"))
         .try_fold((), |_, _| std::future::ready(Ok(())))
-        .await
-        .map_err(SyncError::from_v2)?;
+        .await?;
     Ok(())
 }
 

--- a/crates/pathfinder/src/sync/checkpoint.rs
+++ b/crates/pathfinder/src/sync/checkpoint.rs
@@ -367,8 +367,7 @@ async fn handle_state_diff_stream(
         .pipe(state_updates::VerifyCommitment2, 10)
         .into_stream()
         .try_chunks(1000)
-        .map_err(|e| e.1)
-        .map_err(|e| SyncError::from_v2(e))
+        .map_err(|e| SyncError::from_v2(e.1))
         .and_then(|x| {
             state_updates::batch_update_starknet_state(storage.clone(), verify_tree_hashes, x)
         })

--- a/crates/pathfinder/src/sync/error.rs
+++ b/crates/pathfinder/src/sync/error.rs
@@ -26,6 +26,8 @@ pub(super) enum SyncError {
     EventCommitmentMismatch(PeerId),
     #[error("Transaction commitment mismatch")]
     TransactionCommitmentMismatch(PeerId),
+    #[error("State root mismatch")]
+    StateRootMismatch(PeerId),
 }
 
 impl PartialEq for SyncError {
@@ -56,6 +58,7 @@ impl SyncError {
             SyncError::TransactionCommitmentMismatch(x) => {
                 PeerData::new(x, SyncError2::TransactionCommitmentMismatch)
             }
+            SyncError::StateRootMismatch(x) => PeerData::new(x, SyncError2::StateRootMismatch),
         }
     }
 
@@ -75,6 +78,7 @@ impl SyncError {
             SyncError2::TransactionCommitmentMismatch => {
                 SyncError::TransactionCommitmentMismatch(peer)
             }
+            SyncError2::StateRootMismatch => SyncError::StateRootMismatch(peer),
             other => SyncError::Other(other.into()),
         }
     }

--- a/crates/pathfinder/src/sync/track.rs
+++ b/crates/pathfinder/src/sync/track.rs
@@ -46,7 +46,7 @@ use tokio_stream::wrappers::ReceiverStream;
 
 use super::class_definitions::CompiledClass;
 use super::{state_updates, transactions};
-use crate::state::{update_starknet_state, StarknetStateUpdate};
+use crate::state::update_starknet_state;
 use crate::sync::class_definitions::{self, ClassWithLayout};
 use crate::sync::error::SyncError2;
 use crate::sync::stream::{ProcessStage, SyncReceiver, SyncResult};
@@ -817,11 +817,7 @@ impl ProcessStage for StoreBlock {
 
         let (storage_commitment, class_commitment) = update_starknet_state(
             &db,
-            StarknetStateUpdate {
-                contract_updates: &state_diff.contract_updates,
-                system_contract_updates: &state_diff.system_contract_updates,
-                declared_sierra_classes: &state_diff.declared_sierra_classes,
-            },
+            (&state_diff).into(),
             self.verify_tree_hashes,
             block_number,
             self.storage.clone(),

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -354,7 +354,7 @@ pub mod test_utils {
         // Update block 0
         let update_results = update_contract_state(
             contract0_addr,
-            &contract0_update,
+            (&contract0_update).into(),
             Some(contract_nonce!("0x1")),
             Some(class0_hash),
             &db_txn,
@@ -397,7 +397,7 @@ pub mod test_utils {
             .unwrap();
         let update_results = update_contract_state(
             contract1_addr,
-            &contract1_update1,
+            (&contract1_update1).into(),
             None,
             Some(class1_hash),
             &db_txn,
@@ -438,7 +438,7 @@ pub mod test_utils {
             StorageCommitmentTree::load(&db_txn, BlockNumber::GENESIS + 1).unwrap();
         let update_results = update_contract_state(
             contract1_addr,
-            &contract1_update2,
+            (&contract1_update2).into(),
             Some(contract_nonce!("0x10")),
             None,
             &db_txn,
@@ -483,7 +483,7 @@ pub mod test_utils {
 
         let update_results = update_contract_state(
             contract2_addr,
-            &HashMap::new(),
+            (&HashMap::new()).into(),
             Some(contract_nonce!("0xfeed")),
             Some(class2_hash),
             &db_txn,


### PR DESCRIPTION
The `*Ref<'_>` structs were necessary to achieve an acceptable equilibrium:
- use the same impl of applying state update for both single- and multi-block state updates,
- avoid generics explosion when trying to use `[Parallel]Iterator` trying to achieve above (with which I eventually failed anyway),
- keep number of allocations low.