### PR TITLE
feat(trie): avoid node hash recalculation when generating proofs

### DIFF
--- a/crates/rpc/src/pathfinder/methods/get_proof.rs
+++ b/crates/rpc/src/pathfinder/methods/get_proof.rs
@@ -273,7 +273,10 @@ pub async fn get_proof(
             header.number,
             &input.contract_address,
             storage_root_idx,
-        )?;
+        )?
+        .into_iter()
+        .map(|(node, _)| node)
+        .collect();
 
         let contract_proof = ProofNodes(contract_proof);
 
@@ -318,7 +321,10 @@ pub async fn get_proof(
                     header.number,
                     k.view_bits(),
                     root,
-                )?;
+                )?
+                .into_iter()
+                .map(|(node, _)| node)
+                .collect();
 
                 storage_proofs.push(ProofNodes(proof));
             } else {
@@ -393,7 +399,10 @@ pub async fn get_proof_class(
         // Generate a proof for this class. If the class does not exist, this will
         // be a "non membership" proof.
         let class_proof =
-            ClassCommitmentTree::get_proof(&tx, header.number, input.class_hash, class_root_idx)?;
+            ClassCommitmentTree::get_proof(&tx, header.number, input.class_hash, class_root_idx)?
+                .into_iter()
+                .map(|(node, _)| node)
+                .collect();
 
         let class_proof = ProofNodes(class_proof);
 


### PR DESCRIPTION
Closes https://github.com/eqlabs/pathfinder/issues/2320.