### PR TITLE
feat(rpc): add L2 gas data to `FeeEstimate`

### DIFF
--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -18,10 +18,12 @@ use super::felt::IntoFelt;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct FeeEstimate {
-    pub gas_consumed: primitive_types::U256,
-    pub gas_price: primitive_types::U256,
-    pub data_gas_consumed: primitive_types::U256,
-    pub data_gas_price: primitive_types::U256,
+    pub l1_gas_consumed: primitive_types::U256,
+    pub l1_gas_price: primitive_types::U256,
+    pub l1_data_gas_consumed: primitive_types::U256,
+    pub l1_data_gas_price: primitive_types::U256,
+    pub l2_gas_consumed: primitive_types::U256,
+    pub l2_gas_price: primitive_types::U256,
     pub overall_fee: primitive_types::U256,
     pub unit: PriceUnit,
 }
@@ -35,23 +37,23 @@ impl FeeEstimate {
         minimal_l1_gas_amount_vector: &Option<GasVector>,
     ) -> FeeEstimate {
         tracing::trace!(resources=?tx_info.transaction_receipt.resources, "Transaction resources");
-        let gas_price = block_info
+        let l1_gas_price = block_info
             .gas_prices
             .get_gas_price_by_fee_type(&fee_type)
             .get();
-        let data_gas_price = block_info
+        let l1_data_gas_price = block_info
             .gas_prices
             .get_data_gas_price_by_fee_type(&fee_type)
             .get();
 
         let minimal_l1_gas_amount_vector = minimal_l1_gas_amount_vector.unwrap_or_default();
 
-        let gas_consumed = tx_info
+        let l1_gas_consumed = tx_info
             .transaction_receipt
             .gas
             .l1_gas
             .max(minimal_l1_gas_amount_vector.l1_gas);
-        let data_gas_consumed = tx_info
+        let l1_data_gas_consumed = tx_info
             .transaction_receipt
             .gas
             .l1_data_gas
@@ -63,18 +65,20 @@ impl FeeEstimate {
         let overall_fee = blockifier::fee::fee_utils::get_fee_by_gas_vector(
             block_info,
             GasVector {
-                l1_gas: gas_consumed,
-                l1_data_gas: data_gas_consumed,
+                l1_gas: l1_gas_consumed,
+                l1_data_gas: l1_data_gas_consumed,
             },
             &fee_type,
         )
         .0;
 
         FeeEstimate {
-            gas_consumed: gas_consumed.into(),
-            gas_price: gas_price.into(),
-            data_gas_consumed: data_gas_consumed.into(),
-            data_gas_price: data_gas_price.into(),
+            l1_gas_consumed: l1_gas_consumed.into(),
+            l1_gas_price: l1_gas_price.into(),
+            l1_data_gas_consumed: l1_data_gas_consumed.into(),
+            l1_data_gas_price: l1_data_gas_price.into(),
+            l2_gas_consumed: 0.into(), // TODO: Fix when we have l2 gas price
+            l2_gas_price: 0.into(),    // TODO: Fix when we have l2 gas price
             overall_fee: overall_fee.into(),
             unit: fee_type.into(),
         }

--- a/crates/pathfinder/examples/re_execute.rs
+++ b/crates/pathfinder/examples/re_execute.rs
@@ -193,8 +193,8 @@ fn execute(storage: &mut Storage, chain_id: ChainId, work: Work) {
                         receipt.execution_resources.total_gas_consumed.l1_gas
                     };
 
-                let estimated_gas_consumed = estimate.gas_consumed.as_u128();
-                let estimated_data_gas_consumed = estimate.data_gas_consumed.as_u128();
+                let estimated_gas_consumed = estimate.l1_gas_consumed.as_u128();
+                let estimated_data_gas_consumed = estimate.l1_data_gas_consumed.as_u128();
 
                 let gas_diff = actual_gas_consumed.abs_diff(estimated_gas_consumed);
                 let data_gas_diff = actual_data_gas_consumed.abs_diff(estimated_data_gas_consumed);

--- a/crates/rpc/src/dto/fee.rs
+++ b/crates/rpc/src/dto/fee.rs
@@ -9,12 +9,29 @@ impl crate::dto::serialize::SerializeForVersion for FeeEstimate<'_> {
         serializer: crate::dto::serialize::Serializer,
     ) -> Result<crate::dto::serialize::Ok, crate::dto::serialize::Error> {
         let mut serializer = serializer.serialize_struct()?;
-        serializer.serialize_field("gas_consumed", &U256Hex(self.0.gas_consumed))?;
-        serializer.serialize_field("gas_price", &U256Hex(self.0.gas_price))?;
-        serializer.serialize_field("data_gas_consumed", &U256Hex(self.0.data_gas_consumed))?;
-        serializer.serialize_field("data_gas_price", &U256Hex(self.0.data_gas_price))?;
-        serializer.serialize_field("overall_fee", &U256Hex(self.0.overall_fee))?;
-        serializer.serialize_field("unit", &PriceUnit(&self.0.unit))?;
+
+        if serializer.version >= crate::dto::RpcVersion::V08 {
+            serializer.serialize_field("l1_gas_consumed", &U256Hex(self.0.l1_gas_consumed))?;
+            serializer.serialize_field("l1_gas_price", &U256Hex(self.0.l1_gas_price))?;
+            serializer.serialize_field(
+                "l1_data_gas_consumed",
+                &U256Hex(self.0.l1_data_gas_consumed),
+            )?;
+            serializer.serialize_field("l1_data_gas_price", &U256Hex(self.0.l1_data_gas_price))?;
+            serializer.serialize_field("l2_gas_consumed", &U256Hex(self.0.l2_gas_consumed))?;
+            serializer.serialize_field("l2_gas_price", &U256Hex(self.0.l2_gas_price))?;
+            serializer.serialize_field("overall_fee", &U256Hex(self.0.overall_fee))?;
+            serializer.serialize_field("unit", &PriceUnit(&self.0.unit))?;
+        } else {
+            serializer.serialize_field("gas_price", &U256Hex(self.0.l1_gas_price))?;
+            serializer.serialize_field("gas_consumed", &U256Hex(self.0.l1_gas_consumed))?;
+            serializer
+                .serialize_field("data_gas_consumed", &U256Hex(self.0.l1_data_gas_consumed))?;
+            serializer.serialize_field("data_gas_price", &U256Hex(self.0.l1_data_gas_price))?;
+            serializer.serialize_field("overall_fee", &U256Hex(self.0.overall_fee))?;
+            serializer.serialize_field("unit", &PriceUnit(&self.0.unit))?;
+        }
+
         serializer.end()
     }
 }

--- a/crates/rpc/src/method/estimate_fee.rs
+++ b/crates/rpc/src/method/estimate_fee.rs
@@ -380,45 +380,55 @@ mod tests {
         };
         let result = estimate_fee(context, input).await.unwrap();
         let declare_expected = FeeEstimate {
-            gas_consumed: 23817.into(),
-            gas_price: 1.into(),
+            l1_gas_consumed: 23817.into(),
+            l1_gas_price: 1.into(),
+            l1_data_gas_consumed: 192.into(),
+            l1_data_gas_price: 2.into(),
+            l2_gas_consumed: 0.into(),
+            l2_gas_price: 0.into(),
             overall_fee: 24201.into(),
             unit: PriceUnit::Wei,
-            data_gas_consumed: 192.into(),
-            data_gas_price: 2.into(),
         };
         let deploy_expected = FeeEstimate {
-            gas_consumed: 16.into(),
-            gas_price: 1.into(),
+            l1_gas_consumed: 16.into(),
+            l1_gas_price: 1.into(),
+            l1_data_gas_consumed: 224.into(),
+            l1_data_gas_price: 2.into(),
+            l2_gas_consumed: 0.into(),
+            l2_gas_price: 0.into(),
             overall_fee: 464.into(),
             unit: PriceUnit::Wei,
-            data_gas_consumed: 224.into(),
-            data_gas_price: 2.into(),
         };
         let invoke_expected = FeeEstimate {
-            gas_consumed: 12.into(),
-            gas_price: 1.into(),
+            l1_gas_consumed: 12.into(),
+            l1_gas_price: 1.into(),
+            l1_data_gas_consumed: 128.into(),
+            l1_data_gas_price: 2.into(),
+            l2_gas_consumed: 0.into(),
+            l2_gas_price: 0.into(),
             overall_fee: 268.into(),
             unit: PriceUnit::Wei,
-            data_gas_consumed: 128.into(),
-            data_gas_price: 2.into(),
         };
         let invoke_v0_expected = FeeEstimate {
-            gas_consumed: 10.into(),
-            gas_price: 1.into(),
+            l1_gas_consumed: 10.into(),
+            l1_gas_price: 1.into(),
+            l1_data_gas_consumed: 128.into(),
+            l1_data_gas_price: 2.into(),
+            l2_gas_consumed: 0.into(),
+            l2_gas_price: 0.into(),
             overall_fee: 266.into(),
             unit: PriceUnit::Wei,
-            data_gas_consumed: 128.into(),
-            data_gas_price: 2.into(),
         };
         let invoke_v3_expected = FeeEstimate {
-            gas_consumed: 12.into(),
+            l1_gas_consumed: 12.into(),
             // STRK gas price is 2
-            gas_price: 2.into(),
+            l1_gas_price: 2.into(),
+            l1_data_gas_consumed: 128.into(),
+            l1_data_gas_price: 2.into(),
+            l2_gas_consumed: 0.into(),
+            l2_gas_price: 0.into(),
             overall_fee: 280.into(),
             unit: PriceUnit::Fri,
-            data_gas_consumed: 128.into(),
-            data_gas_price: 2.into(),
         };
         assert_eq!(
             result,
@@ -465,45 +475,55 @@ mod tests {
         };
         let result = estimate_fee(context, input).await.unwrap();
         let declare_expected = FeeEstimate {
-            gas_consumed: 878.into(),
-            gas_price: 1.into(),
+            l1_gas_consumed: 878.into(),
+            l1_gas_price: 1.into(),
+            l1_data_gas_consumed: 192.into(),
+            l1_data_gas_price: 2.into(),
+            l2_gas_consumed: 0.into(),
+            l2_gas_price: 0.into(),
             overall_fee: 1262.into(),
             unit: PriceUnit::Wei,
-            data_gas_consumed: 192.into(),
-            data_gas_price: 2.into(),
         };
         let deploy_expected = FeeEstimate {
-            gas_consumed: 16.into(),
-            gas_price: 1.into(),
+            l1_gas_consumed: 16.into(),
+            l1_gas_price: 1.into(),
+            l1_data_gas_consumed: 224.into(),
+            l1_data_gas_price: 2.into(),
+            l2_gas_consumed: 0.into(),
+            l2_gas_price: 0.into(),
             overall_fee: 464.into(),
             unit: PriceUnit::Wei,
-            data_gas_consumed: 224.into(),
-            data_gas_price: 2.into(),
         };
         let invoke_expected = FeeEstimate {
-            gas_consumed: 12.into(),
-            gas_price: 1.into(),
+            l1_gas_consumed: 12.into(),
+            l1_gas_price: 1.into(),
+            l1_data_gas_consumed: 128.into(),
+            l1_data_gas_price: 2.into(),
+            l2_gas_consumed: 0.into(),
+            l2_gas_price: 0.into(),
             overall_fee: 268.into(),
             unit: PriceUnit::Wei,
-            data_gas_consumed: 128.into(),
-            data_gas_price: 2.into(),
         };
         let invoke_v0_expected = FeeEstimate {
-            gas_consumed: 10.into(),
-            gas_price: 1.into(),
+            l1_gas_consumed: 10.into(),
+            l1_gas_price: 1.into(),
+            l1_data_gas_consumed: 128.into(),
+            l1_data_gas_price: 2.into(),
+            l2_gas_consumed: 0.into(),
+            l2_gas_price: 0.into(),
             overall_fee: 266.into(),
             unit: PriceUnit::Wei,
-            data_gas_consumed: 128.into(),
-            data_gas_price: 2.into(),
         };
         let invoke_v3_expected = FeeEstimate {
-            gas_consumed: 12.into(),
+            l1_gas_consumed: 12.into(),
             // STRK gas price is 2
-            gas_price: 2.into(),
+            l1_gas_price: 2.into(),
+            l1_data_gas_consumed: 128.into(),
+            l1_data_gas_price: 2.into(),
+            l2_gas_consumed: 0.into(),
+            l2_gas_price: 0.into(),
             overall_fee: 280.into(),
             unit: PriceUnit::Fri,
-            data_gas_consumed: 128.into(),
-            data_gas_price: 2.into(),
         };
         assert_eq!(
             result,
@@ -550,45 +570,55 @@ mod tests {
         };
         let result = super::estimate_fee(context, input).await.unwrap();
         let declare_expected = FeeEstimate {
-            gas_consumed: 23819.into(),
-            gas_price: 1.into(),
+            l1_gas_consumed: 23819.into(),
+            l1_gas_price: 1.into(),
+            l1_data_gas_consumed: 192.into(),
+            l1_data_gas_price: 2.into(),
+            l2_gas_consumed: 0.into(),
+            l2_gas_price: 0.into(),
             overall_fee: 24203.into(),
             unit: PriceUnit::Wei,
-            data_gas_consumed: 192.into(),
-            data_gas_price: 2.into(),
         };
         let deploy_expected = FeeEstimate {
-            gas_consumed: 19.into(),
-            gas_price: 1.into(),
+            l1_gas_consumed: 19.into(),
+            l1_gas_price: 1.into(),
+            l1_data_gas_consumed: 224.into(),
+            l1_data_gas_price: 2.into(),
+            l2_gas_consumed: 0.into(),
+            l2_gas_price: 0.into(),
             overall_fee: 467.into(),
             unit: PriceUnit::Wei,
-            data_gas_consumed: 224.into(),
-            data_gas_price: 2.into(),
         };
         let invoke_expected = FeeEstimate {
-            gas_consumed: 14.into(),
-            gas_price: 1.into(),
+            l1_gas_consumed: 14.into(),
+            l1_gas_price: 1.into(),
+            l1_data_gas_consumed: 128.into(),
+            l1_data_gas_price: 2.into(),
+            l2_gas_consumed: 0.into(),
+            l2_gas_price: 0.into(),
             overall_fee: 270.into(),
             unit: PriceUnit::Wei,
-            data_gas_consumed: 128.into(),
-            data_gas_price: 2.into(),
         };
         let invoke_v0_expected = FeeEstimate {
-            gas_consumed: 11.into(),
-            gas_price: 1.into(),
+            l1_gas_consumed: 11.into(),
+            l1_gas_price: 1.into(),
+            l1_data_gas_consumed: 128.into(),
+            l1_data_gas_price: 2.into(),
+            l2_gas_consumed: 0.into(),
+            l2_gas_price: 0.into(),
             overall_fee: 267.into(),
             unit: PriceUnit::Wei,
-            data_gas_consumed: 128.into(),
-            data_gas_price: 2.into(),
         };
         let invoke_v3_expected = FeeEstimate {
-            gas_consumed: 14.into(),
+            l1_gas_consumed: 14.into(),
             // STRK gas price is 2
-            gas_price: 2.into(),
+            l1_gas_price: 2.into(),
+            l1_data_gas_consumed: 128.into(),
+            l1_data_gas_price: 2.into(),
+            l2_gas_consumed: 0.into(),
+            l2_gas_price: 0.into(),
             overall_fee: 284.into(),
             unit: PriceUnit::Fri,
-            data_gas_consumed: 128.into(),
-            data_gas_price: 2.into(),
         };
         assert_eq!(
             result,
@@ -635,45 +665,55 @@ mod tests {
         };
         let result = super::estimate_fee(context, input).await.unwrap();
         let declare_expected = FeeEstimate {
-            gas_consumed: 880.into(),
-            gas_price: 1.into(),
+            l1_gas_consumed: 880.into(),
+            l1_gas_price: 1.into(),
+            l1_data_gas_consumed: 192.into(),
+            l1_data_gas_price: 2.into(),
+            l2_gas_consumed: 0.into(),
+            l2_gas_price: 0.into(),
             overall_fee: 1264.into(),
             unit: PriceUnit::Wei,
-            data_gas_consumed: 192.into(),
-            data_gas_price: 2.into(),
         };
         let deploy_expected = FeeEstimate {
-            gas_consumed: 19.into(),
-            gas_price: 1.into(),
+            l1_gas_consumed: 19.into(),
+            l1_gas_price: 1.into(),
+            l1_data_gas_consumed: 224.into(),
+            l1_data_gas_price: 2.into(),
+            l2_gas_consumed: 0.into(),
+            l2_gas_price: 0.into(),
             overall_fee: 467.into(),
             unit: PriceUnit::Wei,
-            data_gas_consumed: 224.into(),
-            data_gas_price: 2.into(),
         };
         let invoke_expected = FeeEstimate {
-            gas_consumed: 14.into(),
-            gas_price: 1.into(),
+            l1_gas_consumed: 14.into(),
+            l1_gas_price: 1.into(),
+            l1_data_gas_consumed: 128.into(),
+            l1_data_gas_price: 2.into(),
+            l2_gas_consumed: 0.into(),
+            l2_gas_price: 0.into(),
             overall_fee: 270.into(),
             unit: PriceUnit::Wei,
-            data_gas_consumed: 128.into(),
-            data_gas_price: 2.into(),
         };
         let invoke_v0_expected = FeeEstimate {
-            gas_consumed: 11.into(),
-            gas_price: 1.into(),
+            l1_gas_consumed: 11.into(),
+            l1_gas_price: 1.into(),
+            l1_data_gas_consumed: 128.into(),
+            l1_data_gas_price: 2.into(),
+            l2_gas_consumed: 0.into(),
+            l2_gas_price: 0.into(),
             overall_fee: 267.into(),
             unit: PriceUnit::Wei,
-            data_gas_consumed: 128.into(),
-            data_gas_price: 2.into(),
         };
         let invoke_v3_expected = FeeEstimate {
-            gas_consumed: 14.into(),
+            l1_gas_consumed: 14.into(),
             // STRK gas price is 2
-            gas_price: 2.into(),
+            l1_gas_price: 2.into(),
+            l1_data_gas_consumed: 128.into(),
+            l1_data_gas_price: 2.into(),
+            l2_gas_consumed: 0.into(),
+            l2_gas_price: 0.into(),
             overall_fee: 284.into(),
             unit: PriceUnit::Fri,
-            data_gas_consumed: 128.into(),
-            data_gas_price: 2.into(),
         };
         assert_eq!(
             result,

--- a/crates/rpc/src/method/estimate_message_fee.rs
+++ b/crates/rpc/src/method/estimate_message_fee.rs
@@ -78,12 +78,14 @@ pub async fn estimate_message_fee(
     let result = result.pop().unwrap();
 
     Ok(Output(pathfinder_executor::types::FeeEstimate {
-        gas_consumed: result.gas_consumed,
-        gas_price: result.gas_price,
+        l1_gas_consumed: result.l1_gas_consumed,
+        l1_gas_price: result.l1_gas_price,
+        l1_data_gas_consumed: result.l1_data_gas_consumed,
+        l1_data_gas_price: result.l1_data_gas_price,
+        l2_gas_consumed: result.l2_gas_consumed,
+        l2_gas_price: result.l2_gas_price,
         overall_fee: result.overall_fee,
         unit: result.unit,
-        data_gas_consumed: result.data_gas_consumed,
-        data_gas_price: result.data_gas_price,
     }))
 }
 
@@ -311,10 +313,12 @@ mod tests {
     #[tokio::test]
     async fn test_estimate_message_fee() {
         let expected = super::Output(pathfinder_executor::types::FeeEstimate {
-            gas_consumed: 14647.into(),
-            gas_price: 2.into(),
-            data_gas_consumed: 128.into(),
-            data_gas_price: 1.into(),
+            l1_gas_consumed: 14647.into(),
+            l1_gas_price: 2.into(),
+            l1_data_gas_consumed: 128.into(),
+            l1_data_gas_price: 1.into(),
+            l2_gas_consumed: 0.into(),
+            l2_gas_price: 0.into(),
             overall_fee: 29422.into(),
             unit: pathfinder_executor::types::PriceUnit::Wei,
         });

--- a/crates/rpc/src/v06/method/estimate_fee.rs
+++ b/crates/rpc/src/v06/method/estimate_fee.rs
@@ -98,15 +98,19 @@ impl From<EstimateFeeError> for ApplicationError {
 #[derive(Clone, Debug, serde::Serialize, PartialEq, Eq)]
 pub struct FeeEstimate {
     #[serde_as(as = "pathfinder_serde::U256AsHexStr")]
-    pub gas_consumed: primitive_types::U256,
+    pub l1_gas_consumed: primitive_types::U256,
     #[serde_as(as = "pathfinder_serde::U256AsHexStr")]
-    pub gas_price: primitive_types::U256,
+    pub l1_gas_price: primitive_types::U256,
     #[serde_as(as = "Option<pathfinder_serde::U256AsHexStr>")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub data_gas_consumed: Option<primitive_types::U256>,
+    pub l1_data_gas_consumed: Option<primitive_types::U256>,
     #[serde_as(as = "Option<pathfinder_serde::U256AsHexStr>")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub data_gas_price: Option<primitive_types::U256>,
+    pub l1_data_gas_price: Option<primitive_types::U256>,
+    #[serde_as(as = "pathfinder_serde::U256AsHexStr")]
+    pub l2_gas_consumed: primitive_types::U256,
+    #[serde_as(as = "pathfinder_serde::U256AsHexStr")]
+    pub l2_gas_price: primitive_types::U256,
     #[serde_as(as = "pathfinder_serde::U256AsHexStr")]
     pub overall_fee: primitive_types::U256,
     pub unit: PriceUnit,
@@ -115,20 +119,22 @@ pub struct FeeEstimate {
 impl From<pathfinder_executor::types::FeeEstimate> for FeeEstimate {
     fn from(value: pathfinder_executor::types::FeeEstimate) -> Self {
         Self {
-            gas_consumed: value.gas_consumed,
-            gas_price: value.gas_price,
+            l1_gas_consumed: value.l1_gas_consumed,
+            l1_gas_price: value.l1_gas_price,
+            l1_data_gas_consumed: Some(value.l1_data_gas_consumed),
+            l1_data_gas_price: Some(value.l1_data_gas_price),
+            l2_gas_consumed: value.l2_gas_consumed,
+            l2_gas_price: value.l2_gas_price,
             overall_fee: value.overall_fee,
             unit: value.unit.into(),
-            data_gas_consumed: Some(value.data_gas_consumed),
-            data_gas_price: Some(value.data_gas_price),
         }
     }
 }
 
 impl FeeEstimate {
     pub fn with_v06_format(&mut self) {
-        self.data_gas_consumed = None;
-        self.data_gas_price = None;
+        self.l1_data_gas_consumed = None;
+        self.l1_data_gas_price = None;
     }
 }
 
@@ -467,45 +473,54 @@ pub(crate) mod tests {
             };
             let result = estimate_fee(context, input).await.unwrap();
             let declare_expected = FeeEstimate {
-                gas_consumed: 2768.into(),
-                gas_price: 1.into(),
+                l1_gas_consumed: 2768.into(),
+                l1_gas_price: 1.into(),
+                l1_data_gas_consumed: None,
+                l1_data_gas_price: None,
+                l2_gas_consumed: 0.into(),
+                l2_gas_price: 0.into(),
                 overall_fee: 2768.into(),
                 unit: PriceUnit::Wei,
-                data_gas_consumed: None,
-                data_gas_price: None,
             };
             let deploy_expected = FeeEstimate {
-                gas_consumed: 3020.into(),
-                gas_price: 1.into(),
+                l1_gas_consumed: 3020.into(),
+                l1_gas_price: 1.into(),
+                l1_data_gas_consumed: None,
+                l1_data_gas_price: None,
+                l2_gas_consumed: 0.into(),
+                l2_gas_price: 0.into(),
                 overall_fee: 3020.into(),
                 unit: PriceUnit::Wei,
-                data_gas_consumed: None,
-                data_gas_price: None,
             };
             let invoke_expected = FeeEstimate {
-                gas_consumed: 1674.into(),
-                gas_price: 1.into(),
+                l1_gas_consumed: 1674.into(),
+                l1_gas_price: 1.into(),
+                l1_data_gas_consumed: None,
+                l1_data_gas_price: None,
+                l2_gas_consumed: 0.into(),
+                l2_gas_price: 0.into(),
                 overall_fee: 1674.into(),
                 unit: PriceUnit::Wei,
-                data_gas_consumed: None,
-                data_gas_price: None,
             };
             let invoke_v0_expected = FeeEstimate {
-                gas_consumed: 1669.into(),
-                gas_price: 1.into(),
+                l1_gas_consumed: 1669.into(),
+                l1_gas_price: 1.into(),
+                l1_data_gas_consumed: None,
+                l1_data_gas_price: None,
+                l2_gas_consumed: 0.into(),
+                l2_gas_price: 0.into(),
                 overall_fee: 1669.into(),
                 unit: PriceUnit::Wei,
-                data_gas_consumed: None,
-                data_gas_price: None,
             };
             let invoke_v3_expected = FeeEstimate {
-                gas_consumed: 1674.into(),
-                // STRK gas price is 2
-                gas_price: 2.into(),
+                l1_gas_consumed: 1674.into(),
+                l1_gas_price: 2.into(),
+                l1_data_gas_consumed: None,
+                l1_data_gas_price: None,
+                l2_gas_consumed: 0.into(),
+                l2_gas_price: 0.into(),
                 overall_fee: 3348.into(),
                 unit: PriceUnit::Fri,
-                data_gas_consumed: None,
-                data_gas_price: None,
             };
             assert_eq!(
                 result,

--- a/crates/rpc/src/v06/method/estimate_message_fee.rs
+++ b/crates/rpc/src/v06/method/estimate_message_fee.rs
@@ -109,12 +109,14 @@ pub async fn estimate_message_fee(
         estimate_message_fee_impl(context, input, L1BlobDataAvailability::Disabled).await?;
 
     Ok(FeeEstimate {
-        gas_consumed: result.gas_consumed,
-        gas_price: result.gas_price,
+        l1_gas_consumed: result.l1_gas_consumed,
+        l1_gas_price: result.l1_gas_price,
+        l1_data_gas_consumed: Some(result.l1_data_gas_consumed),
+        l1_data_gas_price: Some(result.l1_data_gas_price),
+        l2_gas_consumed: result.l2_gas_consumed,
+        l2_gas_price: result.l2_gas_price,
         overall_fee: result.overall_fee,
         unit: result.unit.into(),
-        data_gas_consumed: None,
-        data_gas_price: None,
     })
 }
 
@@ -405,12 +407,14 @@ mod tests {
     #[tokio::test]
     async fn test_estimate_message_fee() {
         let expected = FeeEstimate {
-            gas_consumed: 16302.into(),
-            gas_price: 1.into(),
+            l1_gas_consumed: 16302.into(),
+            l1_gas_price: 1.into(),
+            l1_data_gas_consumed: Some(0.into()),
+            l1_data_gas_price: Some(1.into()),
+            l2_gas_consumed: 0.into(),
+            l2_gas_price: 0.into(),
             overall_fee: 16302.into(),
             unit: PriceUnit::Wei,
-            data_gas_consumed: None,
-            data_gas_price: None,
         };
 
         let rpc = setup(Setup::Full).await.expect("RPC context");

--- a/crates/rpc/src/v06/method/simulate_transactions.rs
+++ b/crates/rpc/src/v06/method/simulate_transactions.rs
@@ -227,10 +227,10 @@ pub mod dto {
     impl From<pathfinder_executor::types::FeeEstimate> for FeeEstimate {
         fn from(value: pathfinder_executor::types::FeeEstimate) -> Self {
             Self {
-                gas_consumed: value.gas_consumed,
-                gas_price: value.gas_price,
-                data_gas_consumed: Some(value.data_gas_consumed),
-                data_gas_price: Some(value.data_gas_price),
+                gas_consumed: value.l1_gas_consumed,
+                gas_price: value.l1_gas_price,
+                data_gas_consumed: Some(value.l1_data_gas_consumed),
+                data_gas_price: Some(value.l1_data_gas_price),
                 overall_fee: value.overall_fee,
                 unit: value.unit.into(),
             }


### PR DESCRIPTION
Adjusts `FeeEstimate` to match new Starknet spec, including new L2 gas data and renaming the L1 fields.

Maintains backwards compatibility.

Closes #2310