### PR TITLE
Rate limit peers, DoS protection: max_concurrent_streams should be 1

### DIFF
--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -418,13 +418,14 @@ struct P2PCli {
     identity_config_file: Option<std::path::PathBuf>,
     #[arg(
         long = "p2p.listen-on",
-        long_help = "The multiaddress on which to listen for incoming p2p connections. If not \
-                     provided, default route on randomly assigned port will be used.",
-        value_name = "MULTIADDRESS",
+        long_help = "The list of multiaddresses on which to listen for incoming p2p connections. \
+                     If not provided, default route on randomly assigned port will be used.",
+        value_name = "MULTIADDRESS_LIST",
+        value_delimiter = ',',
         default_value = "/ip4/0.0.0.0/tcp/0",
         env = "PATHFINDER_P2P_LISTEN_ON"
     )]
-    listen_on: Multiaddr,
+    listen_on: Vec<String>,
     #[arg(
         long = "p2p.bootstrap-addresses",
         long_help = r#"Comma separated list of multiaddresses to use as bootstrap nodes. Each multiaddress must contain a peer ID.
@@ -520,9 +521,9 @@ Example:
     #[arg(
         long = "p2p.experimental.max-concurrent-streams",
         long_help = "Maximum allowed number of concurrent streams per each \
-                     request/response-stream protocol.",
+                     request/response-stream protocol per connection.",
         value_name = "LIMIT",
-        default_value = "100",
+        default_value = "1",
         env = "PATHFINDER_P2P_EXPERIMENTAL_MAX_CONCURRENT_STREAMS"
     )]
     max_concurrent_streams: usize,
@@ -741,7 +742,7 @@ pub enum NetworkConfig {
 pub struct P2PConfig {
     pub proxy: bool,
     pub identity_config_file: Option<std::path::PathBuf>,
-    pub listen_on: Multiaddr,
+    pub listen_on: Vec<Multiaddr>,
     pub bootstrap_addresses: Vec<Multiaddr>,
     pub predefined_peers: Vec<Multiaddr>,
     pub max_inbound_direct_connections: usize,
@@ -891,7 +892,7 @@ impl P2PConfig {
             max_outbound_connections: args.max_outbound_connections.try_into().unwrap(),
             proxy: args.proxy,
             identity_config_file: args.identity_config_file,
-            listen_on: args.listen_on,
+            listen_on: parse_multiaddr_vec("p2p.listen-on", args.listen_on),
             bootstrap_addresses: parse_multiaddr_vec(
                 "p2p.bootstrap-addresses",
                 args.bootstrap_addresses,


### PR DESCRIPTION
This PR introduces 2 changes in pathfinder config:
1. Set the default for `max_concurrent_streams` to 1 (was: 100 :fearful:), which fixes https://github.com/eqlabs/pathfinder/issues/2334 .

2. Allow listening on more than 1 address|port, which allows for easier testing with more than 1 peer without the need to use a bootstrap node.

-----

### Rationale for `max_concurrent_streams` defaulting to 1

## Problematic scenario
1. Pathfinder no.1 (Alice) serves as a proxy node.
2. Pathfinder no.2 (Bob) is a p2p client.
3. Bob encounters a block hash mismatch during sync.
4. Bob's `make_stream` is faulty and the producer future does not stop when the receiver end of the stream is dropped because of the error.
5. Bob restarts sync and uses the first available random peer (Alice) to retry.
6. Another producer future is detached. 4. & 5. repeat many times over, numerous concurrent header sync streams are open in the connection between Bob and Alice.
7. Alice's `max_concurrent_streams` is by default 100, which means that she's serving all the requesting streams, regardless of the fact that all of them do not consume the data sent by Alice. Ultimately Alice's libp2p stack is choked and grinds to a halt.
8. Bob is starting to experience timeouts.
9. Any other peer (e.g. Charlie & Dan) that would attempt to connect to Alice to sync block data fails to connect.

## Solution

"Rate limit" each requesting peer, which can be easily done by allowing at most 1 future that serves the data for a given peer (connection) on a given sync protocol. (This is not exactly rate limiting per se but testing has shown this is sufficient to solve the problem.)

## Testing

Prepare 3 pathfinder nodes:
- Alice, the proxy,
- Bob, the faulty node that experiences a simulated block hash mismatch to force sync restarts and has a bug that allows for detaching the producer futures in `make_stream`,
- Charlie, a correctly functioning node which does not detach the producer future in `make_stream`.

Expected result:
- Alice is serving both Bob and Charlie,
- Charlie is progressing in his sync, while
- Bob is spinning, restarting his sync process to no avail because the newer and newer streams opened with his consecutive requests are dropped because the limit on Alice's side for Bob is 1 stream for the header sync.


