### PR TITLE
feat(rpc): restore `starknet_getBlockWithReceipts` in v08 routes

### DIFF
--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -904,7 +904,6 @@ mod tests {
     #[case::root_pathfinder("/", "pathfinder_rpc_api.json", &["pathfinder_version", "pathfinder_getTransactionStatus"])]
 
     #[case::v0_8_api  ("/rpc/v0_8", "v08/starknet_api_openrpc.json", &[
-        "starknet_getBlockWithReceipts",
         "starknet_getTransactionReceipt",
     ])]
     #[case::v0_8_trace("/rpc/v0_8", "v08/starknet_trace_api_openrpc.json", &[])]

--- a/crates/rpc/src/v08.rs
+++ b/crates/rpc/src/v08.rs
@@ -31,6 +31,7 @@ pub fn register_routes() -> RpcRouterBuilder {
         .register("starknet_getTransactionByBlockIdAndIndex",     crate::method::get_transaction_by_block_id_and_index)
         .register("starknet_getTransactionByHash",                crate::method::get_transaction_by_hash)
         .register("starknet_getTransactionStatus",                crate::method::get_transaction_status)
+        .register("starknet_getBlockWithReceipts",                crate::method::get_block_with_receipts)
         .register("starknet_simulateTransactions",                crate::method::simulate_transactions)
         .register("starknet_subscribeNewHeads",                   SubscribeNewHeads)
         .register("starknet_subscribePendingTransactions",        SubscribePendingTransactions)


### PR DESCRIPTION
Restores `starknet_getBlockWithReceipts` in RPC v08 routes

Closes #2345