### PR TITLE
feat: check class & transaction hashes

### DIFF
--- a/crates/p2p/src/client/conv.rs
+++ b/crates/p2p/src/client/conv.rs
@@ -50,6 +50,7 @@ use pathfinder_common::transaction::{
     L1HandlerTransaction,
     ResourceBound,
     ResourceBounds,
+    Transaction,
     TransactionVariant,
 };
 use pathfinder_common::{
@@ -679,6 +680,18 @@ impl TryFromDto<p2p_proto::transaction::TransactionVariant> for TransactionVaria
                 nonce: TransactionNonce(x.nonce),
                 calldata: x.calldata.into_iter().map(CallParam).collect(),
             }),
+        })
+    }
+}
+
+impl TryFromDto<p2p_proto::transaction::Transaction> for Transaction {
+    fn try_from_dto(dto: p2p_proto::transaction::Transaction) -> anyhow::Result<Self>
+    where
+        Self: Sized,
+    {
+        Ok(Transaction {
+            hash: TransactionHash(dto.transaction_hash.0),
+            variant: TransactionVariant::try_from_dto(dto.txn)?,
         })
     }
 }

--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -513,25 +513,27 @@ impl BlockClient for Client {
                     Ok(ClassesResponse::Class(p2p_proto::class::Class::Cairo0 {
                         class,
                         domain: _,
-                        class_hash: _,
+                        class_hash,
                     })) => {
                         let definition = CairoDefinition::try_from_dto(class)
                             .map_err(|_| ClassDefinitionsError::CairoDefinitionError(peer))?;
                         class_definitions.push(ClassDefinition::Cairo {
                             block_number: block,
                             definition: definition.0,
+                            hash: ClassHash(class_hash.0),
                         });
                     }
                     Ok(ClassesResponse::Class(p2p_proto::class::Class::Cairo1 {
                         class,
                         domain: _,
-                        class_hash: _,
+                        class_hash,
                     })) => {
                         let definition = SierraDefinition::try_from_dto(class)
                             .map_err(|_| ClassDefinitionsError::SierraDefinitionError(peer))?;
                         class_definitions.push(ClassDefinition::Sierra {
                             block_number: block,
                             sierra_definition: definition.0,
+                            hash: SierraHash(class_hash.0),
                         });
                     }
                     Ok(ClassesResponse::Fin) => {
@@ -1277,7 +1279,7 @@ mod class_definition_stream {
             Ok(ClassesResponse::Class(p2p_proto::class::Class::Cairo0 {
                 class,
                 domain: _,
-                class_hash: _,
+                class_hash,
             })) => {
                 let Ok(CairoDefinition(definition)) = CairoDefinition::try_from_dto(class) else {
                     // TODO punish the peer
@@ -1288,12 +1290,13 @@ mod class_definition_stream {
                 Some(ClassDefinition::Cairo {
                     block_number,
                     definition,
+                    hash: ClassHash(class_hash.0),
                 })
             }
             Ok(ClassesResponse::Class(p2p_proto::class::Class::Cairo1 {
                 class,
                 domain: _,
-                class_hash: _,
+                class_hash,
             })) => {
                 let Ok(SierraDefinition(definition)) = SierraDefinition::try_from_dto(class) else {
                     // TODO punish the peer
@@ -1304,6 +1307,7 @@ mod class_definition_stream {
                 Some(ClassDefinition::Sierra {
                     block_number,
                     sierra_definition: definition,
+                    hash: SierraHash(class_hash.0),
                 })
             }
             Ok(ClassesResponse::Fin) => {

--- a/crates/p2p/src/client/peer_agnostic/fixtures.rs
+++ b/crates/p2p/src/client/peer_agnostic/fixtures.rs
@@ -26,7 +26,6 @@ use pathfinder_common::{
     TransactionHash,
     TransactionIndex,
 };
-use pathfinder_crypto::Felt;
 use tagged::Tagged;
 use tagged_debug_derive::TaggedDebug;
 use tokio::sync::Mutex;
@@ -288,7 +287,7 @@ pub fn class_resp(tag: i32) -> ClassesResponse {
             ClassDefinition::Cairo(c) => Class::Cairo0 {
                 class: c.to_dto(),
                 domain: 0,
-                class_hash: Hash(Felt::default()),
+                class_hash: Faker.fake(),
             },
         }
     })
@@ -300,18 +299,28 @@ pub fn class_resp(tag: i32) -> ClassesResponse {
 pub fn class(tag: i32, block_number: u64) -> ClassDefinition {
     let block_number = BlockNumber::new_or_panic(block_number);
     match class_resp(tag) {
-        ClassesResponse::Class(Class::Cairo0 { class, .. }) => {
+        ClassesResponse::Class(Class::Cairo0 {
+            class,
+            domain: _,
+            class_hash,
+        }) => {
             Tagged::get(format!("class {tag}"), || ClassDefinition::Cairo {
                 block_number,
                 definition: CairoDefinition::try_from_dto(class).unwrap().0,
+                hash: ClassHash(class_hash.0),
             })
             .unwrap()
             .data
         }
-        ClassesResponse::Class(Class::Cairo1 { class, .. }) => {
+        ClassesResponse::Class(Class::Cairo1 {
+            class,
+            domain: _,
+            class_hash,
+        }) => {
             Tagged::get(format!("class {tag}"), || ClassDefinition::Sierra {
                 block_number,
                 sierra_definition: SierraDefinition::try_from_dto(class).unwrap().0,
+                hash: SierraHash(class_hash.0),
             })
             .unwrap()
             .data

--- a/crates/p2p/src/client/peer_agnostic/tests.rs
+++ b/crates/p2p/src/client/peer_agnostic/tests.rs
@@ -319,7 +319,11 @@ async fn make_transaction_stream(
     .map_ok(|x| {
         (
             TestPeer(x.peer),
-            x.data.0.into_iter().map(TestTxn::new).collect(),
+            x.data
+                .0
+                .into_iter()
+                .map(|(t, r)| TestTxn::new((t.variant, r)))
+                .collect(),
         )
     })
     .map_err(|_| ())

--- a/crates/p2p/src/client/peer_agnostic/traits.rs
+++ b/crates/p2p/src/client/peer_agnostic/traits.rs
@@ -2,7 +2,7 @@ use futures::{Future, Stream};
 use libp2p::PeerId;
 use pathfinder_common::event::Event;
 use pathfinder_common::state_update::StateUpdateData;
-use pathfinder_common::transaction::TransactionVariant;
+use pathfinder_common::transaction::Transaction;
 use pathfinder_common::{BlockNumber, SignedBlockHeader, TransactionHash};
 
 use crate::client::types::{
@@ -82,7 +82,7 @@ pub trait BlockClient {
     ) -> impl Future<
         Output = Option<(
             PeerId,
-            impl Stream<Item = anyhow::Result<(TransactionVariant, Receipt)>> + Send,
+            impl Stream<Item = anyhow::Result<(Transaction, Receipt)>> + Send,
         )>,
     > + Send;
 

--- a/crates/p2p/src/client/types.rs
+++ b/crates/p2p/src/client/types.rs
@@ -3,7 +3,7 @@ use fake::Dummy;
 use libp2p::PeerId;
 use pathfinder_common::event::Event;
 use pathfinder_common::receipt::{ExecutionResources, ExecutionStatus, L2ToL1Message};
-use pathfinder_common::transaction::TransactionVariant;
+use pathfinder_common::transaction::Transaction;
 use pathfinder_common::{
     BlockCommitmentSignature,
     BlockCommitmentSignatureElem,
@@ -75,7 +75,7 @@ impl From<pathfinder_common::receipt::Receipt> for Receipt {
     }
 }
 
-pub type TransactionData = Vec<(TransactionVariant, Receipt)>;
+pub type TransactionData = Vec<(Transaction, Receipt)>;
 
 pub type EventsForBlockByTransaction = (BlockNumber, Vec<(TransactionHash, Vec<Event>)>);
 

--- a/crates/p2p/src/client/types.rs
+++ b/crates/p2p/src/client/types.rs
@@ -12,11 +12,13 @@ use pathfinder_common::{
     BlockNumber,
     BlockTimestamp,
     ClassCommitment,
+    ClassHash,
     EventCommitment,
     Fee,
     GasPrice,
     ReceiptCommitment,
     SequencerAddress,
+    SierraHash,
     SignedBlockHeader,
     StateCommitment,
     StateDiffCommitment,
@@ -35,10 +37,12 @@ pub enum ClassDefinition {
     Cairo {
         block_number: BlockNumber,
         definition: Vec<u8>,
+        hash: ClassHash,
     },
     Sierra {
         block_number: BlockNumber,
         sierra_definition: Vec<u8>,
+        hash: SierraHash,
     },
 }
 

--- a/crates/pathfinder/src/sync/checkpoint.rs
+++ b/crates/pathfinder/src/sync/checkpoint.rs
@@ -1520,14 +1520,17 @@ mod tests {
                     Ok(PeerData::for_tests(ClassDefinition::Cairo {
                         block_number: BlockNumber::GENESIS + 1,
                         definition: CAIRO.to_vec(),
+                        hash: cairo_hash,
                     })),
                     Ok(PeerData::for_tests(ClassDefinition::Sierra {
                         block_number: BlockNumber::GENESIS + 1,
                         sierra_definition: SIERRA0.to_vec(),
+                        hash: sierra0_hash,
                     })),
                     Ok(PeerData::for_tests(ClassDefinition::Sierra {
                         block_number: BlockNumber::GENESIS + 1,
                         sierra_definition: SIERRA2.to_vec(),
+                        hash: sierra2_hash,
                     })),
                 ];
 
@@ -1618,11 +1621,13 @@ mod tests {
         #[rstest::rstest]
         #[case::cairo(ClassDefinition::Cairo {
             block_number: BlockNumber::GENESIS + 1,
-            definition: Default::default()
+            definition: Default::default(),
+            hash: Default::default(),
         })]
         #[case::sierra(ClassDefinition::Sierra {
             block_number: BlockNumber::GENESIS + 1,
             sierra_definition: Default::default(),
+            hash: Default::default(),
         })]
         #[tokio::test]
         async fn bad_layout(#[case] class: ClassDefinition) {

--- a/crates/pathfinder/src/sync/error.rs
+++ b/crates/pathfinder/src/sync/error.rs
@@ -28,6 +28,8 @@ pub(super) enum SyncError {
     TransactionCommitmentMismatch(PeerId),
     #[error("State root mismatch")]
     StateRootMismatch(PeerId),
+    #[error("Transaction hash verification failed")]
+    BadTransactionHash(PeerId),
 }
 
 impl PartialEq for SyncError {
@@ -59,6 +61,7 @@ impl SyncError {
                 PeerData::new(x, SyncError2::TransactionCommitmentMismatch)
             }
             SyncError::StateRootMismatch(x) => PeerData::new(x, SyncError2::StateRootMismatch),
+            SyncError::BadTransactionHash(x) => PeerData::new(x, SyncError2::BadTransactionHash),
         }
     }
 
@@ -79,6 +82,7 @@ impl SyncError {
                 SyncError::TransactionCommitmentMismatch(peer)
             }
             SyncError2::StateRootMismatch => SyncError::StateRootMismatch(peer),
+            SyncError2::BadTransactionHash => SyncError::BadTransactionHash(peer),
             other => SyncError::Other(other.into()),
         }
     }
@@ -136,6 +140,8 @@ pub(super) enum SyncError2 {
     TransactionCommitmentNotFound,
     #[error("State root mismatch")]
     StateRootMismatch,
+    #[error("Transaction hash verification failed")]
+    BadTransactionHash,
 }
 
 impl PartialEq for SyncError2 {

--- a/crates/pathfinder/src/sync/error.rs
+++ b/crates/pathfinder/src/sync/error.rs
@@ -30,6 +30,8 @@ pub(super) enum SyncError {
     StateRootMismatch(PeerId),
     #[error("Transaction hash verification failed")]
     BadTransactionHash(PeerId),
+    #[error("Class hash verification failed")]
+    BadClassHash(PeerId),
 }
 
 impl PartialEq for SyncError {
@@ -62,6 +64,7 @@ impl SyncError {
             }
             SyncError::StateRootMismatch(x) => PeerData::new(x, SyncError2::StateRootMismatch),
             SyncError::BadTransactionHash(x) => PeerData::new(x, SyncError2::BadTransactionHash),
+            SyncError::BadClassHash(x) => PeerData::new(x, SyncError2::BadClassHash),
         }
     }
 
@@ -83,6 +86,7 @@ impl SyncError {
             }
             SyncError2::StateRootMismatch => SyncError::StateRootMismatch(peer),
             SyncError2::BadTransactionHash => SyncError::BadTransactionHash(peer),
+            SyncError2::BadClassHash => SyncError::BadClassHash(peer),
             other => SyncError::Other(other.into()),
         }
     }
@@ -142,6 +146,8 @@ pub(super) enum SyncError2 {
     StateRootMismatch,
     #[error("Transaction hash verification failed")]
     BadTransactionHash,
+    #[error("Class hash verification failed")]
+    BadClassHash,
 }
 
 impl PartialEq for SyncError2 {

--- a/crates/pathfinder/src/sync/track.rs
+++ b/crates/pathfinder/src/sync/track.rs
@@ -1040,7 +1040,7 @@ mod tests {
             block: BlockNumber,
         ) -> Option<(
             PeerId,
-            impl Stream<Item = anyhow::Result<(TransactionVariant, P2PReceipt)>> + Send,
+            impl Stream<Item = anyhow::Result<(Transaction, P2PReceipt)>> + Send,
         )> {
             let tr = self
                 .blocks
@@ -1049,8 +1049,8 @@ mod tests {
                 .unwrap()
                 .transaction_data
                 .iter()
-                .map(|(t, r, e)| Ok((t.variant.clone(), P2PReceipt::from(r.clone()))))
-                .collect::<Vec<anyhow::Result<(TransactionVariant, P2PReceipt)>>>();
+                .map(|(t, r, e)| Ok((t.clone(), P2PReceipt::from(r.clone()))))
+                .collect::<Vec<anyhow::Result<(Transaction, P2PReceipt)>>>();
 
             Some((PeerId::random(), stream::iter(tr)))
         }

--- a/crates/pathfinder/src/sync/track.rs
+++ b/crates/pathfinder/src/sync/track.rs
@@ -14,7 +14,6 @@ use p2p::client::types::{
     TransactionData,
 };
 use p2p::PeerData;
-use pathfinder_common::class_definition::ClassDefinition;
 use pathfinder_common::event::Event;
 use pathfinder_common::receipt::Receipt;
 use pathfinder_common::state_update::{DeclaredClasses, StateUpdateData};
@@ -1087,16 +1086,18 @@ mod tests {
             let defs = b
                 .cairo_defs
                 .iter()
-                .map(|(_, x)| ClassDefinition::Cairo {
+                .map(|(h, x)| ClassDefinition::Cairo {
                     block_number: block,
                     definition: x.clone(),
+                    hash: *h,
                 })
                 .chain(
                     b.sierra_defs
                         .iter()
-                        .map(|(_, x, _)| ClassDefinition::Sierra {
+                        .map(|(h, x, _)| ClassDefinition::Sierra {
                             block_number: block,
                             sierra_definition: x.clone(),
+                            hash: *h,
                         }),
                 )
                 .collect::<Vec<ClassDefinition>>();


### PR DESCRIPTION
for equality with locally-computed hashes (and fail on mismatch).

Fixes #2346.
