### PR TITLE
Audit p2p sync errors

### DIFF
--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -1560,10 +1560,10 @@ async fn try_next<T>(
 ) -> Result<T, anyhow::Error> {
     match count_stream.next().await {
         Some(Ok(cnt)) => Ok(cnt),
-        // This is a non-recovarable error, because "Counter" streams fail only if the underlying
+        // This is a non-recoverable error, because "Counter" streams fail only if the underlying
         // database fails.
         Some(Err(e)) => Err(e),
-        // This is a non-recovarable error, because we expect all the necessary headers that are the
+        // This is a non-recoverable error, because we expect all the necessary headers that are the
         // source of the stream to be in the database.
         None => Err(anyhow::anyhow!("Count stream terminated prematurely")),
     }

--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -1561,6 +1561,8 @@ async fn try_next<T>(
     match count_stream.next().await {
         Some(Ok(cnt)) => Ok(cnt),
         Some(Err(e)) => Err(PeerData::new(PeerId::random(), e)),
+        // This is a non-recovarable error, the stream is expected to yield the correct number of
+        // items and then terminate. Otherwise it's a DB error.
         None => Err(PeerData::new(
             PeerId::random(),
             anyhow::anyhow!("Count stream terminated prematurely"),

--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -779,9 +779,9 @@ mod transaction_stream {
         tracing::trace!(?start, ?stop, "Streaming Transactions");
 
         make_stream::from_future(move |tx| async move {
-            let mut counts_and_commitments_stream = Box::pin(counts_stream);
+            let mut expected_transaction_counts_stream = Box::pin(counts_stream);
 
-            let cnt = match try_next(&mut counts_and_commitments_stream).await {
+            let cnt = match try_next(&mut expected_transaction_counts_stream).await {
                 Ok(x) => x,
                 Err(e) => {
                     _ = tx.send(Err(e)).await;
@@ -826,7 +826,7 @@ mod transaction_stream {
                         if yield_block(
                             peer,
                             &mut progress,
-                            &mut counts_and_commitments_stream,
+                            &mut expected_transaction_counts_stream,
                             transactions,
                             &mut start,
                             stop,

--- a/crates/p2p/src/client/peer_agnostic/traits.rs
+++ b/crates/p2p/src/client/peer_agnostic/traits.rs
@@ -16,7 +16,7 @@ use crate::client::types::{
 };
 use crate::PeerData;
 
-pub type StreamItem<T> = Result<PeerData<T>, PeerData<anyhow::Error>>;
+pub type StreamItem<T> = Result<PeerData<T>, anyhow::Error>;
 
 pub trait HeaderStream {
     fn header_stream(

--- a/crates/p2p/src/peer_data.rs
+++ b/crates/p2p/src/peer_data.rs
@@ -13,12 +13,6 @@ impl<T> PeerData<T> {
         Self { peer, data }
     }
 
-    pub fn from_result<E>(peer: PeerId, result: Result<T, E>) -> Result<PeerData<T>, PeerData<E>> {
-        result
-            .map(|x| Self::new(peer, x))
-            .map_err(|e| PeerData::<E>::new(peer, e))
-    }
-
     pub fn for_tests(data: T) -> Self {
         Self {
             peer: PeerId::random(),

--- a/crates/pathfinder/examples/compute_pre0132_hashes.rs
+++ b/crates/pathfinder/examples/compute_pre0132_hashes.rs
@@ -126,7 +126,7 @@ fn main() -> anyhow::Result<()> {
 
         // Compute the block hash in the 0.13.2 style
         let header_data = get_header_data(&header);
-        let new_block_hash = compute_final_hash(&header_data).context("Computing block hash")?;
+        let new_block_hash = compute_final_hash(&header_data);
 
         // Write to the CSV file
         writeln!(csv_file, "{},{}", block_number, new_block_hash)?;

--- a/crates/pathfinder/src/state/block_hash.rs
+++ b/crates/pathfinder/src/state/block_hash.rs
@@ -253,7 +253,7 @@ pub fn verify_block_hash(
             false
         }
     } else {
-        let computed_hash = compute_final_hash(&header)?;
+        let computed_hash = compute_final_hash(&header);
         computed_hash == header.hash
     };
 
@@ -405,7 +405,7 @@ fn compute_final_hash_pre_0_13_2(header: &BlockHeaderData) -> BlockHash {
     BlockHash(chain.finalize())
 }
 
-fn compute_final_hash_v0(header: &BlockHeaderData) -> Result<BlockHash> {
+fn compute_final_hash_v0(header: &BlockHeaderData) -> BlockHash {
     // Hash the block header.
     let mut hasher = PoseidonHasher::new();
     hasher.write(felt_bytes!(b"STARKNET_BLOCK_HASH0").into());
@@ -429,12 +429,12 @@ fn compute_final_hash_v0(header: &BlockHeaderData) -> Result<BlockHash> {
     );
     hasher.write(MontFelt::ZERO);
     hasher.write(header.parent_hash.0.into());
-    Ok(BlockHash(hasher.finish().into()))
+    BlockHash(hasher.finish().into())
 }
 
 // Bumps the initial STARKNET_BLOCK_HASH0 to STARKNET_BLOCK_HASH1,
 // replaces gas price elements with gas_prices_hash.
-fn compute_final_hash_v1(header: &BlockHeaderData) -> Result<BlockHash> {
+fn compute_final_hash_v1(header: &BlockHeaderData) -> BlockHash {
     // Hash the block header.
     let mut hasher = PoseidonHasher::new();
     hasher.write(felt_bytes!(b"STARKNET_BLOCK_HASH1").into());
@@ -455,10 +455,10 @@ fn compute_final_hash_v1(header: &BlockHeaderData) -> Result<BlockHash> {
     );
     hasher.write(MontFelt::ZERO);
     hasher.write(header.parent_hash.0.into());
-    Ok(BlockHash(hasher.finish().into()))
+    BlockHash(hasher.finish().into())
 }
 
-pub fn compute_final_hash(header: &BlockHeaderData) -> Result<BlockHash> {
+pub fn compute_final_hash(header: &BlockHeaderData) -> BlockHash {
     if header.starknet_version < StarknetVersion::V_0_13_4 {
         compute_final_hash_v0(header)
     } else {
@@ -927,7 +927,7 @@ mod tests {
             }
         });
 
-        assert_eq!(compute_final_hash(&block_header).unwrap(), expected_hash);
+        assert_eq!(compute_final_hash(&block_header), expected_hash);
     }
 
     #[test]
@@ -1235,7 +1235,7 @@ mod tests {
         let expected_hash = BlockHash(felt!(
             "0x061e4998d51a248f1d0288d7e17f6287757b0e5e6c5e1e58ddf740616e312134"
         ));
-        assert_eq!(compute_final_hash(&header).unwrap(), expected_hash);
+        assert_eq!(compute_final_hash(&header), expected_hash);
     }
 
     // Source
@@ -1271,9 +1271,6 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(
-            compute_final_hash(&block_header_data).unwrap(),
-            expected_hash
-        );
+        assert_eq!(compute_final_hash(&block_header_data), expected_hash);
     }
 }

--- a/crates/pathfinder/src/sync.rs
+++ b/crates/pathfinder/src/sync.rs
@@ -127,11 +127,11 @@ impl Sync {
                     continue_from
                 }
                 Err(SyncError::Fatal(mut error)) => {
-                    tracing::error!(?error, "Stopping checkpoint sync");
+                    tracing::error!(%error, "Stopping checkpoint sync");
                     return Err(error.take_or_deep_clone());
                 }
                 Err(error) => {
-                    tracing::debug!(?error, "Restarting checkpoint sync");
+                    tracing::debug!(%error, "Restarting checkpoint sync");
                     self.handle_recoverable_error(&error).await;
                     continue;
                 }
@@ -183,12 +183,12 @@ impl Sync {
             match result {
                 Ok(_) => tracing::debug!("Restarting track sync: unexpected end of Block stream"),
                 Err(SyncError::Fatal(mut error)) => {
-                    tracing::error!(?error, "Stopping track sync");
+                    tracing::error!(%error, "Stopping track sync");
                     use pathfinder_common::error::AnyhowExt;
                     return Err(error.take_or_deep_clone());
                 }
                 Err(error) => {
-                    tracing::debug!(?error, "Restarting track sync");
+                    tracing::debug!(%error, "Restarting track sync");
                     self.handle_recoverable_error(&error).await;
                 }
             }

--- a/crates/pathfinder/src/sync.rs
+++ b/crates/pathfinder/src/sync.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
-use error::{SyncError, SyncError2};
+use error::SyncError;
 use futures::{pin_mut, Stream, StreamExt};
 use p2p::client::peer_agnostic::Client as P2PClient;
 use p2p::PeerData;
@@ -63,7 +63,7 @@ impl Sync {
         self.track_sync(next, parent_hash).await
     }
 
-    async fn handle_recoverable_error(&self, err: &PeerData<error::SyncError2>) {
+    async fn handle_recoverable_error(&self, err: &error::SyncError) {
         // TODO
         tracing::debug!(?err, "Log and punish as appropriate");
     }
@@ -126,13 +126,13 @@ impl Sync {
                     tracing::debug!(?continue_from, "Checkpoint sync complete");
                     continue_from
                 }
-                Err(SyncError::Fatal(error)) => {
+                Err(SyncError::Fatal(mut error)) => {
                     tracing::error!(?error, "Stopping checkpoint sync");
-                    return Err(error);
+                    return Err(error.take_or_deep_clone());
                 }
                 Err(error) => {
                     tracing::debug!(?error, "Restarting checkpoint sync");
-                    self.handle_recoverable_error(&error.into_v2()).await;
+                    self.handle_recoverable_error(&error).await;
                     continue;
                 }
             };
@@ -180,19 +180,16 @@ impl Sync {
             .run(next, parent_hash, self.fgw_client.clone())
             .await;
 
-            match &mut result {
+            match result {
                 Ok(_) => tracing::debug!("Restarting track sync: unexpected end of Block stream"),
-                Err(PeerData {
-                    data: SyncError2::Other(error),
-                    ..
-                }) => {
+                Err(SyncError::Fatal(mut error)) => {
                     tracing::error!(?error, "Stopping track sync");
                     use pathfinder_common::error::AnyhowExt;
                     return Err(error.take_or_deep_clone());
                 }
                 Err(error) => {
-                    tracing::debug!(error=?error.data, "Restarting track sync");
-                    self.handle_recoverable_error(error).await;
+                    tracing::debug!(?error, "Restarting track sync");
+                    self.handle_recoverable_error(&error).await;
                 }
             }
         }

--- a/crates/pathfinder/src/sync.rs
+++ b/crates/pathfinder/src/sync.rs
@@ -126,7 +126,7 @@ impl Sync {
                     tracing::debug!(?continue_from, "Checkpoint sync complete");
                     continue_from
                 }
-                Err(SyncError::Other(error)) => {
+                Err(SyncError::Fatal(error)) => {
                     tracing::error!(?error, "Stopping checkpoint sync");
                     return Err(error);
                 }

--- a/crates/pathfinder/src/sync.rs
+++ b/crates/pathfinder/src/sync.rs
@@ -65,7 +65,7 @@ impl Sync {
 
     async fn handle_recoverable_error(&self, err: &error::SyncError) {
         // TODO
-        tracing::debug!(?err, "Log and punish as appropriate");
+        tracing::debug!(%err, "Log and punish as appropriate");
     }
 
     /// Retry forever until a valid L1 checkpoint is retrieved

--- a/crates/pathfinder/src/sync/checkpoint.rs
+++ b/crates/pathfinder/src/sync/checkpoint.rs
@@ -336,7 +336,7 @@ async fn handle_transaction_stream(
     // TODO
     // stream errors should not carry PeerId as only fatal errors are reported by
     // the stream and those stem from DB errors which are fatal.
-    Source::from_stream(stream.map_err(|e| e.data.into()))
+    Source::from_stream(stream.map_err(Into::into))
         .spawn()
         .pipe(
             transactions::FetchCommitmentFromDb::new(storage.connection()?),
@@ -357,7 +357,7 @@ async fn handle_state_diff_stream(
     start: BlockNumber,
     verify_tree_hashes: bool,
 ) -> Result<(), SyncError> {
-    Source::from_stream(stream.map_err(|e| e.data.into()))
+    Source::from_stream(stream.map_err(Into::into))
         .spawn()
         .pipe(
             state_updates::FetchCommitmentFromDb::new(storage.connection()?),
@@ -390,7 +390,7 @@ async fn handle_class_stream<SequencerClient: GatewayApi + Clone + Send + 'stati
         * 8;
 
     let classes_with_hashes = class_definitions
-        .map_err(|e| e.data.into())
+        .map_err(Into::into)
         .and_then(class_definitions::verify_layout)
         .try_chunks(chunk_size)
         .map_err(|e| e.1)
@@ -418,7 +418,7 @@ async fn handle_event_stream(
     storage: Storage,
 ) -> Result<(), SyncError> {
     stream
-        .map_err(|e| e.data.into())
+        .map_err(Into::into)
         .and_then(|x| events::verify_commitment(x, storage.clone()))
         .try_chunks(100)
         .map_err(|e| e.1)
@@ -692,7 +692,8 @@ async fn persist_anchor(storage: Storage, anchor: EthereumStateUpdate) -> anyhow
     .context("Joining blocking task")?
 }
 
-#[cfg(test)]
+// FIXME P2P
+#[cfg(test_FIXME)]
 mod tests {
     use super::*;
 

--- a/crates/pathfinder/src/sync/checkpoint.rs
+++ b/crates/pathfinder/src/sync/checkpoint.rs
@@ -370,7 +370,7 @@ async fn handle_state_diff_stream(
         .and_then(|x| {
             state_updates::batch_update_starknet_state(storage.clone(), verify_tree_hashes, x)
         })
-        .inspect_ok(|x| tracing::debug!(tail=%x.data, "State diff synced"))
+        .inspect_ok(|x| tracing::debug!(tail=%x.data, "State diffs chunk synced"))
         .try_fold((), |_, _| std::future::ready(Ok(())))
         .await
 }

--- a/crates/pathfinder/src/sync/checkpoint.rs
+++ b/crates/pathfinder/src/sync/checkpoint.rs
@@ -692,8 +692,7 @@ async fn persist_anchor(storage: Storage, anchor: EthereumStateUpdate) -> anyhow
     .context("Joining blocking task")?
 }
 
-// FIXME P2P
-#[cfg(test_FIXME)]
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -865,7 +864,6 @@ mod tests {
 
             pretty_assertions_sorted::assert_eq!(expected_headers, actual_headers);
         }
-
         #[tokio::test]
         async fn discontinuity() {
             let Setup {
@@ -1185,9 +1183,7 @@ mod tests {
         async fn stream_failure() {
             assert_matches!(
                 handle_transaction_stream(
-                    stream::once(std::future::ready(Err(PeerData::for_tests(
-                        anyhow::anyhow!("")
-                    )))),
+                    stream::once(std::future::ready(Err(anyhow::anyhow!("")))),
                     StorageBuilder::in_memory().unwrap(),
                     ChainId::SEPOLIA_TESTNET,
                     BlockNumber::GENESIS,
@@ -1243,7 +1239,7 @@ mod tests {
                 let streamed_state_diffs = blocks
                     .iter()
                     .map(|block| {
-                        Result::<PeerData<_>, PeerData<_>>::Ok(PeerData::for_tests((
+                        Result::<PeerData<_>, _>::Ok(PeerData::for_tests((
                             block.state_update.clone().into(),
                             block.header.header.number,
                         )))
@@ -1354,9 +1350,7 @@ mod tests {
         async fn stream_failure() {
             assert_matches!(
                 handle_state_diff_stream(
-                    stream::once(std::future::ready(Err(PeerData::for_tests(
-                        anyhow::anyhow!("")
-                    )))),
+                    stream::once(std::future::ready(Err(anyhow::anyhow!("")))),
                     StorageBuilder::in_memory().unwrap(),
                     BlockNumber::GENESIS,
                     false,
@@ -1469,7 +1463,7 @@ mod tests {
         }
 
         struct Setup {
-            pub streamed_classes: Vec<Result<PeerData<ClassDefinition>, PeerData<anyhow::Error>>>,
+            pub streamed_classes: Vec<Result<PeerData<ClassDefinition>, anyhow::Error>>,
             pub declared_classes: DeclaredClasses,
             pub expected_defs: HashMap<ClassHash, Vec<u8>>,
             pub storage: Storage,
@@ -1632,14 +1626,14 @@ mod tests {
             let expected_peer_id = data.peer;
 
             assert_matches!(
-                handle_class_stream(
-                    stream::once(std::future::ready(Ok(data))),
-                    storage,
-                    FakeFgw,
-                    Faker.fake::<DeclaredClasses>().to_stream(),
-                )
-                .await,
-                Err(SyncError::BadClassLayout(x)) => assert_eq!(x, expected_peer_id));
+                    handle_class_stream(
+                        stream::once(std::future::ready(Ok(data))),
+                        storage,
+                        FakeFgw,
+                        Faker.fake::<DeclaredClasses>().to_stream(),
+                    )
+                    .await,
+                    Err(SyncError::BadClassLayout(x)) => assert_eq!(x, expected_peer_id));
         }
 
         #[tokio::test]
@@ -1663,23 +1657,21 @@ mod tests {
             let expected_peer_id = streamed_classes.last().unwrap().as_ref().unwrap().peer;
 
             assert_matches!(
-                handle_class_stream(
-                    stream::iter(streamed_classes),
-                    storage,
-                    FakeFgw,
-                    declared_classes.to_stream(),
-                )
-                .await,
-                Err(SyncError::UnexpectedClass(x)) => assert_eq!(x, expected_peer_id));
+                    handle_class_stream(
+                        stream::iter(streamed_classes),
+                        storage,
+                        FakeFgw,
+                        declared_classes.to_stream(),
+                    )
+                    .await,
+                    Err(SyncError::UnexpectedClass(x)) => assert_eq!(x, expected_peer_id));
         }
 
         #[tokio::test]
         async fn stream_failure() {
             assert_matches!(
                 handle_class_stream(
-                    stream::once(std::future::ready(Err(PeerData::for_tests(
-                        anyhow::anyhow!("")
-                    )))),
+                    stream::once(std::future::ready(Err(anyhow::anyhow!("")))),
                     StorageBuilder::in_memory().unwrap(),
                     FakeFgw,
                     Faker.fake::<DeclaredClasses>().to_stream(),
@@ -1706,8 +1698,7 @@ mod tests {
         use crate::state::block_hash::calculate_event_commitment;
 
         struct Setup {
-            pub streamed_events:
-                Vec<Result<PeerData<EventsForBlockByTransaction>, PeerData<anyhow::Error>>>,
+            pub streamed_events: Vec<Result<PeerData<EventsForBlockByTransaction>, anyhow::Error>>,
             pub expected_events: Vec<Vec<(TransactionHash, Vec<Event>)>>,
             pub storage: Storage,
         }
@@ -1827,9 +1818,7 @@ mod tests {
         async fn stream_failure() {
             assert_matches::assert_matches!(
                 handle_event_stream(
-                    stream::once(std::future::ready(Err(PeerData::for_tests(
-                        anyhow::anyhow!("")
-                    )))),
+                    stream::once(std::future::ready(Err(anyhow::anyhow!("")))),
                     StorageBuilder::in_memory().unwrap()
                 )
                 .await
@@ -1849,6 +1838,6 @@ mod tests {
                 .unwrap_err(),
                 SyncError::Fatal(_)
             );
-        }
+        } /*  */
     }
 }

--- a/crates/pathfinder/src/sync/checkpoint.rs
+++ b/crates/pathfinder/src/sync/checkpoint.rs
@@ -333,9 +333,6 @@ async fn handle_transaction_stream(
     chain_id: ChainId,
     start: BlockNumber,
 ) -> Result<(), SyncError> {
-    // TODO
-    // stream errors should not carry PeerId as only fatal errors are reported by
-    // the stream and those stem from DB errors which are fatal.
     Source::from_stream(stream.map_err(Into::into))
         .spawn()
         .pipe(
@@ -1838,6 +1835,6 @@ mod tests {
                 .unwrap_err(),
                 SyncError::Fatal(_)
             );
-        } /*  */
+        }
     }
 }

--- a/crates/pathfinder/src/sync/checkpoint.rs
+++ b/crates/pathfinder/src/sync/checkpoint.rs
@@ -982,7 +982,7 @@ mod tests {
                     storage.clone(),
                 )
                 .await,
-                Err(SyncError::Other(_))
+                Err(SyncError::Fatal(_))
             );
         }
     }
@@ -1198,7 +1198,7 @@ mod tests {
                     BlockNumber::GENESIS,
                 )
                 .await,
-                Err(SyncError::Other(_))
+                Err(SyncError::Fatal(_))
             );
         }
 
@@ -1216,7 +1216,7 @@ mod tests {
                     BlockNumber::GENESIS,
                 )
                 .await,
-                Err(SyncError::Other(_))
+                Err(SyncError::Fatal(_))
             );
         }
     }
@@ -1367,7 +1367,7 @@ mod tests {
                     false,
                 )
                 .await,
-                Err(SyncError::Other(_))
+                Err(SyncError::Fatal(_))
             );
         }
 
@@ -1385,7 +1385,7 @@ mod tests {
                     false,
                 )
                 .await,
-                Err(SyncError::Other(_))
+                Err(SyncError::Fatal(_))
             );
         }
     }
@@ -1690,7 +1690,7 @@ mod tests {
                     Faker.fake::<DeclaredClasses>().to_stream(),
                 )
                 .await,
-                Err(SyncError::Other(_))
+                Err(SyncError::Fatal(_))
             );
         }
     }
@@ -1839,7 +1839,7 @@ mod tests {
                 )
                 .await
                 .unwrap_err(),
-                SyncError::Other(_)
+                SyncError::Fatal(_)
             );
         }
 
@@ -1852,7 +1852,7 @@ mod tests {
                 )
                 .await
                 .unwrap_err(),
-                SyncError::Other(_)
+                SyncError::Fatal(_)
             );
         }
     }

--- a/crates/pathfinder/src/sync/checkpoint.rs
+++ b/crates/pathfinder/src/sync/checkpoint.rs
@@ -365,7 +365,7 @@ async fn handle_state_diff_stream(
             state_updates::FetchCommitmentFromDb::new(storage.connection()?),
             10,
         )
-        .pipe(state_updates::VerifyCommitment2, 10)
+        .pipe(state_updates::VerifyCommitment, 10)
         .into_stream()
         .try_chunks(1000)
         .map_err(|e| SyncError::from_v2(e.1))

--- a/crates/pathfinder/src/sync/class_definitions.rs
+++ b/crates/pathfinder/src/sync/class_definitions.rs
@@ -714,7 +714,7 @@ impl ProcessStage for VerifyClassHashes {
             match class.definition {
                 CompiledClassDefinition::Cairo(_) => {
                     if !declared_classes.cairo.remove(&class.hash) {
-                        tracing::debug!(class_hash=%class.hash, "Class hash not found in declared classes");
+                        tracing::debug!(%peer, block_number=%class.block_number, class_hash=%class.hash, "Class hash not found in declared classes");
                         return Err(SyncError::ClassDefinitionsDeclarationsMismatch(*peer));
                     }
                 }
@@ -724,7 +724,7 @@ impl ProcessStage for VerifyClassHashes {
                         .sierra
                         .remove(&hash)
                         .ok_or_else(|| {
-                            tracing::debug!(class_hash=%class.hash, "Class hash not found in declared classes");
+                            tracing::debug!(%peer, block_number=%class.block_number, class_hash=%class.hash, "Class hash not found in declared classes");
                             SyncError::ClassDefinitionsDeclarationsMismatch(*peer)
                         })?;
                 }
@@ -743,7 +743,7 @@ impl ProcessStage for VerifyClassHashes {
                         .map(|casm_hash| ClassHash(casm_hash.0)),
                 )
                 .collect();
-            tracing::trace!(?missing, "Expected class definitions are missing");
+            tracing::trace!(%peer, ?missing, "Expected class definitions are missing");
             Err(SyncError::ClassDefinitionsDeclarationsMismatch(*peer))
         }
     }

--- a/crates/pathfinder/src/sync/error.rs
+++ b/crates/pathfinder/src/sync/error.rs
@@ -10,32 +10,32 @@ pub(super) enum SyncError {
     /// not result in a retry.
     #[error(transparent)]
     Fatal(#[from] anyhow::Error),
-    #[error("Header signature verification failed")]
-    BadHeaderSignature(PeerId),
     #[error("Block hash verification failed")]
     BadBlockHash(PeerId),
-    #[error("Discontinuity in header chain")]
-    Discontinuity(PeerId),
-    #[error("State diff commitment mismatch")]
-    StateDiffCommitmentMismatch(PeerId),
-    #[error("Invalid class definition layout")]
-    BadClassLayout(PeerId),
-    #[error("Class hash computation failed")]
-    ClassHashComputationError(PeerId),
-    #[error("Unexpected class definition")]
-    UnexpectedClass(PeerId),
-    #[error("Event commitment mismatch")]
-    EventCommitmentMismatch(PeerId),
-    #[error("Transaction commitment mismatch")]
-    TransactionCommitmentMismatch(PeerId),
-    #[error("State root mismatch")]
-    StateRootMismatch(PeerId),
-    #[error("Transaction hash verification failed")]
-    BadTransactionHash(PeerId),
     #[error("Class hash verification failed")]
     BadClassHash(PeerId),
+    #[error("Invalid class definition layout")]
+    BadClassLayout(PeerId),
+    #[error("Header signature verification failed")]
+    BadHeaderSignature(PeerId),
+    #[error("Transaction hash verification failed")]
+    BadTransactionHash(PeerId),
+    #[error("Class hash computation failed")]
+    ClassHashComputationError(PeerId),
+    #[error("Discontinuity in header chain")]
+    Discontinuity(PeerId),
+    #[error("Event commitment mismatch")]
+    EventCommitmentMismatch(PeerId),
     #[error("Fetching casm from feeder gateway failed")]
     FetchingCasmFailed,
+    #[error("State diff commitment mismatch")]
+    StateDiffCommitmentMismatch(PeerId),
+    #[error("State root mismatch")]
+    StateRootMismatch(PeerId),
+    #[error("Transaction commitment mismatch")]
+    TransactionCommitmentMismatch(PeerId),
+    #[error("Unexpected class definition")]
+    UnexpectedClass(PeerId),
 }
 
 impl SyncError {

--- a/crates/pathfinder/src/sync/error.rs
+++ b/crates/pathfinder/src/sync/error.rs
@@ -32,6 +32,8 @@ pub(super) enum SyncError {
     BadTransactionHash(PeerId),
     #[error("Class hash verification failed")]
     BadClassHash(PeerId),
+    #[error("Fetching casm from feeder gateway failed")]
+    FetchingCasmFailed,
 }
 
 impl PartialEq for SyncError {
@@ -65,6 +67,9 @@ impl SyncError {
             SyncError::StateRootMismatch(x) => PeerData::new(x, SyncError2::StateRootMismatch),
             SyncError::BadTransactionHash(x) => PeerData::new(x, SyncError2::BadTransactionHash),
             SyncError::BadClassHash(x) => PeerData::new(x, SyncError2::BadClassHash),
+            SyncError::FetchingCasmFailed => {
+                PeerData::new(PeerId::random(), SyncError2::FetchingCasmFailed)
+            }
         }
     }
 
@@ -87,6 +92,7 @@ impl SyncError {
             SyncError2::StateRootMismatch => SyncError::StateRootMismatch(peer),
             SyncError2::BadTransactionHash => SyncError::BadTransactionHash(peer),
             SyncError2::BadClassHash => SyncError::BadClassHash(peer),
+            SyncError2::FetchingCasmFailed => SyncError::FetchingCasmFailed,
             other => SyncError::Other(other.into()),
         }
     }
@@ -148,6 +154,8 @@ pub(super) enum SyncError2 {
     BadTransactionHash,
     #[error("Class hash verification failed")]
     BadClassHash,
+    #[error("Fetching casm from feeder gateway failed")]
+    FetchingCasmFailed,
 }
 
 impl PartialEq for SyncError2 {

--- a/crates/pathfinder/src/sync/error.rs
+++ b/crates/pathfinder/src/sync/error.rs
@@ -58,6 +58,54 @@ pub(super) enum SyncError {
     UnexpectedClass(PeerId),
 }
 
+impl PartialEq for SyncError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (SyncError::Fatal(x), SyncError::Fatal(y)) => x.to_string() == y.to_string(),
+            (SyncError::BadBlockHash(x), SyncError::BadBlockHash(y)) => x == y,
+            (SyncError::BadClassLayout(x), SyncError::BadClassLayout(y)) => x == y,
+            (SyncError::BadHeaderSignature(x), SyncError::BadHeaderSignature(y)) => x == y,
+            (SyncError::CairoDefinitionError(x), SyncError::CairoDefinitionError(y)) => x == y,
+            (
+                SyncError::ClassDefinitionsDeclarationsMismatch(x),
+                SyncError::ClassDefinitionsDeclarationsMismatch(y),
+            ) => x == y,
+            (SyncError::ClassHashComputationError(x), SyncError::ClassHashComputationError(y)) => {
+                x == y
+            }
+            (SyncError::Discontinuity(x), SyncError::Discontinuity(y)) => x == y,
+            (SyncError::EventCommitmentMismatch(x), SyncError::EventCommitmentMismatch(y)) => {
+                x == y
+            }
+            (
+                SyncError::EventsTransactionsMismatch(x),
+                SyncError::EventsTransactionsMismatch(y),
+            ) => x == y,
+            (SyncError::FetchingCasmFailed, SyncError::FetchingCasmFailed) => true,
+            (SyncError::IncorrectStateDiffCount(x), SyncError::IncorrectStateDiffCount(y)) => {
+                x == y
+            }
+            (SyncError::InvalidDto(x), SyncError::InvalidDto(y)) => x == y,
+            (SyncError::SierraDefinitionError(x), SyncError::SierraDefinitionError(y)) => x == y,
+            (
+                SyncError::StateDiffCommitmentMismatch(x),
+                SyncError::StateDiffCommitmentMismatch(y),
+            ) => x == y,
+            (SyncError::StateRootMismatch(x), SyncError::StateRootMismatch(y)) => x == y,
+            (SyncError::TooFewEvents(x), SyncError::TooFewEvents(y)) => x == y,
+            (SyncError::TooFewTransactions, SyncError::TooFewTransactions) => true,
+            (SyncError::TooManyEvents(x), SyncError::TooManyEvents(y)) => x == y,
+            (SyncError::TooManyTransactions(x), SyncError::TooManyTransactions(y)) => x == y,
+            (
+                SyncError::TransactionCommitmentMismatch(x),
+                SyncError::TransactionCommitmentMismatch(y),
+            ) => x == y,
+            (SyncError::UnexpectedClass(x), SyncError::UnexpectedClass(y)) => x == y,
+            _ => false,
+        }
+    }
+}
+
 impl SyncError {
     /// Temporary cast to allow refactoring towards SyncError2.
     pub fn into_v2(self) -> PeerData<SyncError2> {

--- a/crates/pathfinder/src/sync/error.rs
+++ b/crates/pathfinder/src/sync/error.rs
@@ -142,12 +142,6 @@ pub(super) enum SyncError2 {
     SierraDefinitionError,
     #[error("Class definitions and declarations mismatch")]
     ClassDefinitionsDeclarationsMismatch,
-    #[error("Starknet version not found in db")]
-    StarknetVersionNotFound,
-    #[error("State diff commitment not found in db")]
-    StateDiffCommitmentNotFound,
-    #[error("Transaction commitment not found in db")]
-    TransactionCommitmentNotFound,
     #[error("State root mismatch")]
     StateRootMismatch,
     #[error("Transaction hash verification failed")]

--- a/crates/pathfinder/src/sync/error.rs
+++ b/crates/pathfinder/src/sync/error.rs
@@ -4,12 +4,12 @@ use p2p::libp2p::PeerId;
 use p2p::PeerData;
 use pathfinder_common::{BlockNumber, ClassHash, SignedBlockHeader};
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, Clone)]
 pub(super) enum SyncError {
     /// This is the only variant that causes any sync process to halt and does
     /// not result in a retry.
     #[error(transparent)]
-    Fatal(#[from] anyhow::Error),
+    Fatal(#[from] Arc<anyhow::Error>),
     #[error("Block hash verification failed")]
     BadBlockHash(PeerId),
     #[error("Class hash verification failed")]
@@ -34,6 +34,8 @@ pub(super) enum SyncError {
     EventsTransactionsMismatch(PeerId),
     #[error("Fetching casm from feeder gateway failed")]
     FetchingCasmFailed,
+    #[error("Incorrect class definition count")]
+    IncorrectClassDefinitionCount(PeerId),
     #[error("Incorrect state diff count")]
     IncorrectStateDiffCount(PeerId),
     #[error("Invalid data in DTO")]
@@ -47,7 +49,7 @@ pub(super) enum SyncError {
     #[error("Too few events")]
     TooFewEvents(PeerId),
     #[error("Too few transactions")]
-    TooFewTransactions,
+    TooFewTransactions(PeerId),
     #[error("Too many events")]
     TooManyEvents(PeerId),
     #[error("Too many transactions")]
@@ -82,6 +84,10 @@ impl PartialEq for SyncError {
                 SyncError::EventsTransactionsMismatch(y),
             ) => x == y,
             (SyncError::FetchingCasmFailed, SyncError::FetchingCasmFailed) => true,
+            (
+                SyncError::IncorrectClassDefinitionCount(x),
+                SyncError::IncorrectClassDefinitionCount(y),
+            ) => x == y,
             (SyncError::IncorrectStateDiffCount(x), SyncError::IncorrectStateDiffCount(y)) => {
                 x == y
             }
@@ -93,7 +99,7 @@ impl PartialEq for SyncError {
             ) => x == y,
             (SyncError::StateRootMismatch(x), SyncError::StateRootMismatch(y)) => x == y,
             (SyncError::TooFewEvents(x), SyncError::TooFewEvents(y)) => x == y,
-            (SyncError::TooFewTransactions, SyncError::TooFewTransactions) => true,
+            (SyncError::TooFewTransactions(x), SyncError::TooFewTransactions(y)) => x == y,
             (SyncError::TooManyEvents(x), SyncError::TooManyEvents(y)) => x == y,
             (SyncError::TooManyTransactions(x), SyncError::TooManyTransactions(y)) => x == y,
             (
@@ -106,138 +112,8 @@ impl PartialEq for SyncError {
     }
 }
 
-impl SyncError {
-    /// Temporary cast to allow refactoring towards SyncError2.
-    pub fn into_v2(self) -> PeerData<SyncError2> {
-        match self {
-            SyncError::Fatal(e) => PeerData::new(PeerId::random(), SyncError2::Other(Arc::new(e))),
-            SyncError::BadHeaderSignature(x) => PeerData::new(x, SyncError2::BadHeaderSignature),
-            SyncError::BadBlockHash(x) => PeerData::new(x, SyncError2::BadBlockHash),
-            SyncError::Discontinuity(x) => PeerData::new(x, SyncError2::Discontinuity),
-            SyncError::StateDiffCommitmentMismatch(x) => {
-                PeerData::new(x, SyncError2::StateDiffCommitmentMismatch)
-            }
-            SyncError::BadClassLayout(x) => PeerData::new(x, SyncError2::BadClassLayout),
-            SyncError::ClassHashComputationError(x) => {
-                PeerData::new(x, SyncError2::ClassHashComputationError)
-            }
-            SyncError::UnexpectedClass(x) => PeerData::new(x, SyncError2::UnexpectedClass),
-            SyncError::EventCommitmentMismatch(x) => {
-                PeerData::new(x, SyncError2::EventCommitmentMismatch)
-            }
-            SyncError::TransactionCommitmentMismatch(x) => {
-                PeerData::new(x, SyncError2::TransactionCommitmentMismatch)
-            }
-            SyncError::StateRootMismatch(x) => PeerData::new(x, SyncError2::StateRootMismatch),
-            SyncError::BadTransactionHash(x) => PeerData::new(x, SyncError2::BadTransactionHash),
-            SyncError::BadClassHash(x) => PeerData::new(x, SyncError2::BadClassHash),
-            SyncError::FetchingCasmFailed => {
-                PeerData::new(PeerId::random(), SyncError2::FetchingCasmFailed)
-            }
-            _ => todo!(),
-        }
-    }
-
-    /// Temporary cast to allow refactoring towards SyncError2.
-    pub fn from_v2(v2: PeerData<SyncError2>) -> Self {
-        let PeerData { peer, data } = v2;
-
-        match data {
-            SyncError2::BadHeaderSignature => SyncError::BadHeaderSignature(peer),
-            SyncError2::BadBlockHash => SyncError::BadBlockHash(peer),
-            SyncError2::Discontinuity => SyncError::Discontinuity(peer),
-            SyncError2::StateDiffCommitmentMismatch => SyncError::StateDiffCommitmentMismatch(peer),
-            SyncError2::BadClassLayout => SyncError::BadClassLayout(peer),
-            SyncError2::ClassHashComputationError => SyncError::ClassHashComputationError(peer),
-            SyncError2::UnexpectedClass => SyncError::UnexpectedClass(peer),
-            SyncError2::EventCommitmentMismatch => SyncError::EventCommitmentMismatch(peer),
-            SyncError2::TransactionCommitmentMismatch => {
-                SyncError::TransactionCommitmentMismatch(peer)
-            }
-            SyncError2::StateRootMismatch => SyncError::StateRootMismatch(peer),
-            SyncError2::BadTransactionHash => SyncError::BadTransactionHash(peer),
-            SyncError2::BadClassHash => SyncError::BadClassHash(peer),
-            SyncError2::FetchingCasmFailed => SyncError::FetchingCasmFailed,
-            other => SyncError::Fatal(other.into()),
-        }
-    }
-}
-
-#[derive(Debug, thiserror::Error, Clone)]
-pub(super) enum SyncError2 {
-    #[error(transparent)]
-    Other(#[from] Arc<anyhow::Error>),
-    #[error("Header signature verification failed")]
-    BadHeaderSignature,
-    #[error("Block hash verification failed")]
-    BadBlockHash,
-    #[error("Discontinuity in header chain")]
-    Discontinuity,
-    #[error("State diff commitment mismatch")]
-    StateDiffCommitmentMismatch,
-    #[error("Invalid class definition layout")]
-    BadClassLayout,
-    #[error("Class hash computation failed")]
-    ClassHashComputationError,
-    #[error("Unexpected class definition")]
-    UnexpectedClass,
-    #[error("Event commitment mismatch")]
-    EventCommitmentMismatch,
-    #[error("Too many events")]
-    TooManyEvents,
-    #[error("Too few events")]
-    TooFewEvents,
-    #[error("Transaction commitment mismatch")]
-    TransactionCommitmentMismatch,
-    #[error("Too many transactions")]
-    TooManyTransactions,
-    #[error("Too few transactions")]
-    TooFewTransactions,
-    #[error("Invalid data in DTO")]
-    InvalidDto,
-    #[error("Mismatch between events and transactions")]
-    EventsTransactionsMismatch,
-    #[error("Incorrect state diff count")]
-    IncorrectStateDiffCount,
-    #[error("Incorrect class definition count")]
-    IncorrectClassDefinitionCount,
-    #[error("Incorrect cairo definition")]
-    CairoDefinitionError,
-    #[error("Incorrect sierra definition")]
-    SierraDefinitionError,
-    #[error("Class definitions and declarations mismatch")]
-    ClassDefinitionsDeclarationsMismatch,
-    #[error("State root mismatch")]
-    StateRootMismatch,
-    #[error("Transaction hash verification failed")]
-    BadTransactionHash,
-    #[error("Class hash verification failed")]
-    BadClassHash,
-    #[error("Fetching casm from feeder gateway failed")]
-    FetchingCasmFailed,
-}
-
-impl PartialEq for SyncError2 {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Other(x), Self::Other(y)) => x.to_string() == y.to_string(),
-            (SyncError2::BadHeaderSignature, SyncError2::BadHeaderSignature) => true,
-            (SyncError2::BadBlockHash, SyncError2::BadBlockHash) => true,
-            (SyncError2::Discontinuity, SyncError2::Discontinuity) => true,
-            (SyncError2::StateDiffCommitmentMismatch, SyncError2::StateDiffCommitmentMismatch) => {
-                true
-            }
-            (SyncError2::BadClassLayout, SyncError2::BadClassLayout) => true,
-            (SyncError2::ClassHashComputationError, SyncError2::ClassHashComputationError) => true,
-            (SyncError2::UnexpectedClass, SyncError2::UnexpectedClass) => true,
-            (SyncError2::EventCommitmentMismatch, SyncError2::EventCommitmentMismatch) => true,
-            _ => false,
-        }
-    }
-}
-
-impl From<anyhow::Error> for SyncError2 {
-    fn from(value: anyhow::Error) -> Self {
-        Self::Other(Arc::new(value))
+impl From<anyhow::Error> for SyncError {
+    fn from(e: anyhow::Error) -> Self {
+        Self::Fatal(Arc::new(e))
     }
 }

--- a/crates/pathfinder/src/sync/error.rs
+++ b/crates/pathfinder/src/sync/error.rs
@@ -20,18 +20,38 @@ pub(super) enum SyncError {
     BadHeaderSignature(PeerId),
     #[error("Transaction hash verification failed")]
     BadTransactionHash(PeerId),
+    #[error("Incorrect cairo definition")]
+    CairoDefinitionError(PeerId),
+    #[error("Class definitions and declarations mismatch")]
+    ClassDefinitionsDeclarationsMismatch(PeerId),
     #[error("Class hash computation failed")]
     ClassHashComputationError(PeerId),
     #[error("Discontinuity in header chain")]
     Discontinuity(PeerId),
     #[error("Event commitment mismatch")]
     EventCommitmentMismatch(PeerId),
+    #[error("Mismatch between events and transactions")]
+    EventsTransactionsMismatch(PeerId),
     #[error("Fetching casm from feeder gateway failed")]
     FetchingCasmFailed,
+    #[error("Incorrect state diff count")]
+    IncorrectStateDiffCount(PeerId),
+    #[error("Invalid data in DTO")]
+    InvalidDto(PeerId),
+    #[error("Incorrect sierra definition")]
+    SierraDefinitionError(PeerId),
     #[error("State diff commitment mismatch")]
     StateDiffCommitmentMismatch(PeerId),
     #[error("State root mismatch")]
     StateRootMismatch(PeerId),
+    #[error("Too few events")]
+    TooFewEvents(PeerId),
+    #[error("Too few transactions")]
+    TooFewTransactions,
+    #[error("Too many events")]
+    TooManyEvents(PeerId),
+    #[error("Too many transactions")]
+    TooManyTransactions(PeerId),
     #[error("Transaction commitment mismatch")]
     TransactionCommitmentMismatch(PeerId),
     #[error("Unexpected class definition")]
@@ -66,6 +86,7 @@ impl SyncError {
             SyncError::FetchingCasmFailed => {
                 PeerData::new(PeerId::random(), SyncError2::FetchingCasmFailed)
             }
+            _ => todo!(),
         }
     }
 

--- a/crates/pathfinder/src/sync/events.rs
+++ b/crates/pathfinder/src/sync/events.rs
@@ -96,6 +96,7 @@ pub(super) async fn verify_commitment(
         )
         .context("Calculating commitment")?;
         if computed != header.event_commitment {
+            tracing::debug!(%peer, %block_number, expected_commitment=%header.event_commitment, actual_commitment=%computed, "Event commitment mismatch");
             return Err(SyncError::EventCommitmentMismatch(peer));
         }
         Ok(events)

--- a/crates/pathfinder/src/sync/events.rs
+++ b/crates/pathfinder/src/sync/events.rs
@@ -167,13 +167,13 @@ impl ProcessStage for VerifyCommitment {
             }
         }
         if ordered_events.len() != events.len() {
-            tracing::debug!(expected=%ordered_events.len(), actual=%events.len(), "Number of events received does not match expected number of events");
+            tracing::debug!(%peer, expected=%ordered_events.len(), actual=%events.len(), "Number of events received does not match expected number of events");
             return Err(SyncError::EventsTransactionsMismatch(*peer));
         }
         let actual =
             calculate_event_commitment(&ordered_events, version.max(StarknetVersion::V_0_13_2))?;
         if actual != event_commitment {
-            tracing::debug!(expected=%event_commitment, actual=%actual, "Event commitment mismatch");
+            tracing::debug!(%peer, expected=%event_commitment, actual=%actual, "Event commitment mismatch");
             return Err(SyncError::EventCommitmentMismatch(*peer));
         }
         Ok(events)

--- a/crates/pathfinder/src/sync/events.rs
+++ b/crates/pathfinder/src/sync/events.rs
@@ -156,6 +156,7 @@ impl ProcessStage for VerifyCommitment {
 
     fn map(
         &mut self,
+        peer: &PeerId,
         (event_commitment, transactions, mut events, version): Self::Input,
     ) -> Result<Self::Output, super::error::SyncError> {
         let mut ordered_events = Vec::new();
@@ -167,17 +168,13 @@ impl ProcessStage for VerifyCommitment {
         }
         if ordered_events.len() != events.len() {
             tracing::debug!(expected=%ordered_events.len(), actual=%events.len(), "Number of events received does not match expected number of events");
-            // TODO
-            // Use a real peer ID here
-            return Err(SyncError::EventsTransactionsMismatch(PeerId::random()));
+            return Err(SyncError::EventsTransactionsMismatch(*peer));
         }
         let actual =
             calculate_event_commitment(&ordered_events, version.max(StarknetVersion::V_0_13_2))?;
         if actual != event_commitment {
             tracing::debug!(expected=%event_commitment, actual=%actual, "Event commitment mismatch");
-            // TODO
-            // Use a real peer ID here
-            return Err(SyncError::EventCommitmentMismatch(PeerId::random()));
+            return Err(SyncError::EventCommitmentMismatch(*peer));
         }
         Ok(events)
     }

--- a/crates/pathfinder/src/sync/headers.rs
+++ b/crates/pathfinder/src/sync/headers.rs
@@ -264,7 +264,7 @@ impl VerifyHashAndSignature {
             .as_ref()
             .and_then(|db| db.block_hash(header.number))
             .unwrap_or(header.hash);
-        match crate::state::block_hash::compute_final_hash(&BlockHeaderData {
+        let computed_hash = crate::state::block_hash::compute_final_hash(&BlockHeaderData {
             hash: header.hash,
             parent_hash: header.parent_hash,
             number: header.number,
@@ -290,17 +290,12 @@ impl VerifyHashAndSignature {
             strk_l2_gas_price: header.strk_l2_gas_price,
             receipt_commitment: header.receipt_commitment,
             l1_da_mode: header.l1_da_mode,
-        }) {
-            Ok(block_hash) => {
-                if block_hash == expected_hash {
-                    true
-                } else {
-                    tracing::debug!(block_number=%header.number, expected_block_hash=%expected_hash, actual_block_hash=%block_hash, "Block hash mismatch");
-                    false
-                }
-            }
-            Err(e) => {
-                tracing::debug!(block_number=%header.number, error = ?e, "Failed to verify block hash");
+        });
+        {
+            if computed_hash == expected_hash {
+                true
+            } else {
+                tracing::debug!(block_number=%header.number, expected_block_hash=%expected_hash, actual_block_hash=%computed_hash, "Block hash mismatch");
                 false
             }
         }

--- a/crates/pathfinder/src/sync/headers.rs
+++ b/crates/pathfinder/src/sync/headers.rs
@@ -234,7 +234,7 @@ impl ProcessStage for VerifyHashAndSignature {
 
     fn map(&mut self, peer: &PeerId, input: Self::Input) -> Result<Self::Output, SyncError> {
         if !self.verify_hash(&input.header) {
-            return Err(SyncError::BadBlockHash((*peer)));
+            return Err(SyncError::BadBlockHash(*peer));
         }
 
         if !self.verify_signature(&input) {

--- a/crates/pathfinder/src/sync/headers.rs
+++ b/crates/pathfinder/src/sync/headers.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code, unused_variables)]
 use anyhow::Context;
 use futures::StreamExt;
+use p2p::libp2p::PeerId;
 use p2p::PeerData;
 use p2p_proto::header;
 use pathfinder_common::{
@@ -19,7 +20,7 @@ use pathfinder_storage::Storage;
 use tokio::task::spawn_blocking;
 
 use crate::state::block_hash::{BlockHeaderData, VerifyResult};
-use crate::sync::error::{SyncError, SyncError2};
+use crate::sync::error::SyncError;
 use crate::sync::stream::{ProcessStage, SyncReceiver};
 
 type SignedHeaderResult = Result<PeerData<SignedBlockHeader>, SyncError>;
@@ -176,12 +177,14 @@ impl ProcessStage for ForwardContinuity {
     type Input = SignedBlockHeader;
     type Output = SignedBlockHeader;
 
-    fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError2> {
+    fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError> {
         let header = &input.header;
 
         if header.number != self.next || header.parent_hash != self.parent_hash {
             tracing::debug!(expected_block_number=%self.next, actual_block_number=%header.number, expected_parent_block_hash=%self.parent_hash, actual_parent_block_hash=%header.parent_hash, "Block chain discontinuity");
-            return Err(SyncError2::Discontinuity);
+            // TODO
+            // Use a real peer ID here
+            return Err(SyncError::Discontinuity(PeerId::random()));
         }
 
         self.next += 1;
@@ -208,12 +211,18 @@ impl ProcessStage for BackwardContinuity {
     type Input = SignedBlockHeader;
     type Output = SignedBlockHeader;
 
-    fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError2> {
-        let number = self.number.ok_or(SyncError2::Discontinuity)?;
+    fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError> {
+        // TODO
+        // Use a real peer ID here
+        let number = self
+            .number
+            .ok_or(SyncError::Discontinuity(PeerId::random()))?;
 
         if input.header.number != number || input.header.hash != self.hash {
             tracing::debug!(expected_block_number=%number, actual_block_number=%input.header.number, expected_block_hash=%self.hash, actual_block_hash=%input.header.hash, "Block chain discontinuity");
-            return Err(SyncError2::Discontinuity);
+            // TODO
+            // Use a real peer ID here
+            return Err(SyncError::Discontinuity(PeerId::random()));
         }
 
         self.number = number.parent();
@@ -228,9 +237,11 @@ impl ProcessStage for VerifyHashAndSignature {
     type Input = SignedBlockHeader;
     type Output = SignedBlockHeader;
 
-    fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError2> {
+    fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError> {
         if !self.verify_hash(&input.header) {
-            return Err(SyncError2::BadBlockHash);
+            // TODO
+            // Use a real peer ID here
+            return Err(SyncError::BadBlockHash(PeerId::random()));
         }
 
         if !self.verify_signature(&input) {
@@ -318,7 +329,7 @@ impl ProcessStage for Persist {
     type Input = Vec<SignedBlockHeader>;
     type Output = BlockNumber;
 
-    fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError2> {
+    fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError> {
         let tail = input.last().expect("not empty").header.number;
         let tx = self
             .connection

--- a/crates/pathfinder/src/sync/headers.rs
+++ b/crates/pathfinder/src/sync/headers.rs
@@ -316,9 +316,10 @@ pub struct Persist {
 impl ProcessStage for Persist {
     const NAME: &'static str = "Headers::Persist";
     type Input = Vec<SignedBlockHeader>;
-    type Output = ();
+    type Output = BlockNumber;
 
     fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError2> {
+        let tail = input.last().expect("not empty").header.number;
         let tx = self
             .connection
             .transaction()
@@ -332,6 +333,6 @@ impl ProcessStage for Persist {
         }
 
         tx.commit().context("Committing database transaction")?;
-        Ok(())
+        Ok(tail)
     }
 }

--- a/crates/pathfinder/src/sync/state_updates.rs
+++ b/crates/pathfinder/src/sync/state_updates.rs
@@ -118,27 +118,7 @@ impl<T> ProcessStage for FetchCommitmentFromDb<T> {
 pub struct VerifyCommitment;
 
 impl ProcessStage for VerifyCommitment {
-    const NAME: &'static str = "StateDiff::Verify";
-    type Input = (StateUpdateData, BlockNumber, StateDiffCommitment);
-    type Output = StateUpdateData;
-
-    fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError2> {
-        let (state_diff, block_number, expected_commitment) = input;
-        let actual_commitment = state_diff.compute_state_diff_commitment();
-
-        if actual_commitment != expected_commitment {
-            tracing::debug!(%block_number, %expected_commitment, %actual_commitment, "State diff commitment mismatch");
-            return Err(SyncError2::StateDiffCommitmentMismatch);
-        }
-
-        Ok(state_diff)
-    }
-}
-
-pub struct VerifyCommitment2;
-
-impl ProcessStage for VerifyCommitment2 {
-    const NAME: &'static str = "StateDiff::Verify2";
+    const NAME: &'static str = "StateDiff::VerifyCommitment";
     type Input = (StateUpdateData, BlockNumber, StateDiffCommitment);
     type Output = (StateUpdateData, BlockNumber);
 

--- a/crates/pathfinder/src/sync/state_updates.rs
+++ b/crates/pathfinder/src/sync/state_updates.rs
@@ -112,7 +112,9 @@ impl<T> ProcessStage for FetchCommitmentFromDb<T> {
         let commitment = db
             .state_diff_commitment(block_number)
             .context("Fetching state diff commitment")?
-            .ok_or(SyncError2::StateDiffCommitmentNotFound)?;
+            // This is a fatal error because the block header is already expected to be in the
+            // database
+            .context("State diff commitment not found")?;
         Ok((data, block_number, commitment))
     }
 }

--- a/crates/pathfinder/src/sync/state_updates.rs
+++ b/crates/pathfinder/src/sync/state_updates.rs
@@ -14,7 +14,6 @@ use pathfinder_common::state_update::{
     SystemContractUpdate,
 };
 use pathfinder_common::{
-    class_hash,
     BlockHash,
     BlockHeader,
     BlockNumber,

--- a/crates/pathfinder/src/sync/state_updates.rs
+++ b/crates/pathfinder/src/sync/state_updates.rs
@@ -280,7 +280,7 @@ pub async fn batch_update_starknet_state(
         update_starknet_state_impl(db, state_update_ref, verify_tree_hashes, tail, storage)
             .map_err(|e| match e {
                 UpdateStarknetStateError::StateRootMismatch => SyncError::StateRootMismatch(peer),
-                UpdateStarknetStateError::DBError(error) => SyncError::Other(error),
+                UpdateStarknetStateError::DBError(error) => SyncError::Fatal(error),
             })?;
 
         Ok(PeerData::new(peer, tail))

--- a/crates/pathfinder/src/sync/state_updates.rs
+++ b/crates/pathfinder/src/sync/state_updates.rs
@@ -136,7 +136,7 @@ impl ProcessStage for VerifyCommitment {
         let actual_commitment = state_diff.compute_state_diff_commitment();
 
         if actual_commitment != expected_commitment {
-            tracing::debug!(%block_number, %expected_commitment, %actual_commitment, "State diff commitment mismatch");
+            tracing::debug!(%peer, %block_number, %expected_commitment, %actual_commitment, "State diff commitment mismatch");
             return Err(SyncError::StateDiffCommitmentMismatch(*peer));
         }
 
@@ -359,6 +359,7 @@ fn update_starknet_state_impl(
         .context("State commitment not found")?;
     if state_commitment != expected_state_commitment {
         tracing::debug!(
+        %peer,
         %tail,
         actual_storage_commitment=%storage_commitment,
         actual_class_commitment=%class_commitment,

--- a/crates/pathfinder/src/sync/stream.rs
+++ b/crates/pathfinder/src/sync/stream.rs
@@ -341,7 +341,7 @@ mod tests {
     use super::*;
 
     pub fn peer_id() -> PeerId {
-        static PEER_ID: LazyLock<PeerId> = LazyLock::new(|| PeerId::random());
+        static PEER_ID: LazyLock<PeerId> = LazyLock::new(PeerId::random);
         *PEER_ID
     }
 

--- a/crates/pathfinder/src/sync/track.rs
+++ b/crates/pathfinder/src/sync/track.rs
@@ -549,8 +549,7 @@ impl<P> StateDiffSource<P> {
                             let _ = tx.send(Err(SyncError::IncorrectStateDiffCount(peer))).await;
                             return;
                         }
-                        Err(StateDiffsError::ResponseStreamFailure(peer, _error)) => {
-                            // TODO what about the _error
+                        Err(StateDiffsError::ResponseStreamFailure(peer, _)) => {
                             let _ = tx.send(Err(SyncError::InvalidDto(peer))).await;
                             return;
                         }
@@ -620,8 +619,7 @@ impl<P> ClassSource<P> {
                                 ClassDefinitionsError::SierraDefinitionError(peer) => {
                                     SyncError::SierraDefinitionError(peer)
                                 }
-                                ClassDefinitionsError::ResponseStreamFailure(peer, _error) => {
-                                    // TODO what about the _error
+                                ClassDefinitionsError::ResponseStreamFailure(peer, _) => {
                                     SyncError::InvalidDto(peer)
                                 }
                             };

--- a/crates/pathfinder/src/sync/track.rs
+++ b/crates/pathfinder/src/sync/track.rs
@@ -755,7 +755,7 @@ impl ProcessStage for StoreBlock {
     type Input = BlockData;
     type Output = ();
 
-    fn map(&mut self, input: Self::Input) -> Result<Self::Output, SyncError> {
+    fn map(&mut self, peer: &PeerId, input: Self::Input) -> Result<Self::Output, SyncError> {
         let BlockData {
             header: SignedBlockHeader { header, signature },
             mut events,
@@ -831,8 +831,7 @@ impl ProcessStage for StoreBlock {
                     actual_class_commitment=%class_commitment,
                     actual_state_commitment=%state_commitment,
                     "State root mismatch");
-            // TODO: remove placeholder
-            return Err(SyncError::StateRootMismatch(PeerId::random()));
+            return Err(SyncError::StateRootMismatch(*peer));
         }
 
         db.update_storage_and_class_commitments(block_number, storage_commitment, class_commitment)

--- a/crates/pathfinder/src/sync/transactions.rs
+++ b/crates/pathfinder/src/sync/transactions.rs
@@ -143,11 +143,13 @@ impl<T> ProcessStage for FetchCommitmentFromDb<T> {
         let version = db
             .block_version(block_number)
             .context("Fetching starknet version")?
-            .ok_or(SyncError2::StarknetVersionNotFound)?;
+            // This block header is supposed to be in the database so this is a fatal error
+            .context("Starknet version not found in db")?;
         let commitment = db
             .transaction_commitment(block_number)
             .context("Fetching transaction commitment")?
-            .ok_or(SyncError2::TransactionCommitmentNotFound)?;
+            // This block header is supposed to be in the database so this is a fatal error
+            .context("Transaction commitment not found in db")?;
         Ok((data, block_number, version, commitment))
     }
 }

--- a/crates/pathfinder/src/sync/transactions.rs
+++ b/crates/pathfinder/src/sync/transactions.rs
@@ -167,8 +167,10 @@ impl ProcessStage for VerifyCommitment {
             block_number,
         } = transactions;
         let txs: Vec<_> = transactions.iter().map(|(t, _)| t.clone()).collect();
-        let actual =
-            calculate_transaction_commitment(&txs, version.max(StarknetVersion::V_0_13_2))?;
+        // This computation can only fail in case of internal trie error which is always
+        // a fatal error
+        let actual = calculate_transaction_commitment(&txs, version.max(StarknetVersion::V_0_13_2))
+            .context("Computing transaction commitment")?;
         if actual != expected_commitment {
             tracing::debug!(%block_number, %expected_commitment, actual_commitment=%actual, "Transaction commitment mismatch");
             return Err(SyncError2::TransactionCommitmentMismatch);

--- a/crates/pathfinder/src/sync/transactions.rs
+++ b/crates/pathfinder/src/sync/transactions.rs
@@ -181,7 +181,7 @@ impl ProcessStage for VerifyCommitment {
         let actual = calculate_transaction_commitment(&txs, version.max(StarknetVersion::V_0_13_2))
             .context("Computing transaction commitment")?;
         if actual != expected_commitment {
-            tracing::debug!(%block_number, %expected_commitment, actual_commitment=%actual, "Transaction commitment mismatch");
+            tracing::debug!(%peer, %block_number, %expected_commitment, actual_commitment=%actual, "Transaction commitment mismatch");
             return Err(SyncError::TransactionCommitmentMismatch(*peer));
         }
         Ok(transactions)

--- a/crates/storage/src/fake.rs
+++ b/crates/storage/src/fake.rs
@@ -133,7 +133,7 @@ pub mod init {
 
     use super::Block;
 
-    pub type BlockHashFn = Box<dyn Fn(&BlockHeader) -> anyhow::Result<BlockHash>>;
+    pub type BlockHashFn = Box<dyn Fn(&BlockHeader) -> BlockHash>;
     pub type TransactionCommitmentFn =
         Box<dyn Fn(&[Transaction], StarknetVersion) -> anyhow::Result<TransactionCommitment>>;
     pub type ReceiptCommitmentFn = Box<dyn Fn(&[Receipt]) -> anyhow::Result<ReceiptCommitment>>;
@@ -151,7 +151,7 @@ pub mod init {
     impl Default for Config {
         fn default() -> Self {
             Self {
-                calculate_block_hash: Box::new(|_| Ok(Faker.fake())),
+                calculate_block_hash: Box::new(|_| Faker.fake()),
                 calculate_transaction_commitment: Box::new(|_, _| Ok(Faker.fake())),
                 calculate_receipt_commitment: Box::new(|_| Ok(Faker.fake())),
                 calculate_event_commitment: Box::new(|_, _| Ok(Faker.fake())),
@@ -434,7 +434,7 @@ pub mod init {
             } = init.get_mut(0).unwrap();
             header.header.parent_hash = BlockHash::ZERO;
 
-            header.header.hash = (config.calculate_block_hash)(&header.header).unwrap();
+            header.header.hash = (config.calculate_block_hash)(&header.header);
 
             state_update.block_hash = header.header.hash;
 
@@ -451,7 +451,7 @@ pub mod init {
 
                 header.header.parent_hash = parent_hash;
 
-                header.header.hash = (config.calculate_block_hash)(&header.header).unwrap();
+                header.header.hash = (config.calculate_block_hash)(&header.header);
 
                 state_update.block_hash = header.header.hash;
             }


### PR DESCRIPTION
Fixes: #2302

Some ideas from the issue :arrow_up: were not implemented or a more convenient solution was chosen (for example: log errors at source in checkpoint sync, keep variants small, allow for implicit conversion from `anyhow::Error` because only one variant uses it).
