### PR TITLE
feat: computing new block hash

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -465,6 +465,10 @@ impl StarknetVersion {
     }
 
     pub const V_0_13_2: Self = Self::new(0, 13, 2, 0);
+
+    // TODO: version at which block hash definition changes taken from
+    // Starkware implementation but might yet change
+    pub const V_0_13_4: Self = Self::new(0, 13, 4, 0);
 }
 
 impl FromStr for StarknetVersion {

--- a/crates/pathfinder/examples/compute_pre0132_hashes.rs
+++ b/crates/pathfinder/examples/compute_pre0132_hashes.rs
@@ -163,6 +163,8 @@ fn get_header_data(header: &BlockHeader) -> BlockHeaderData {
         strk_l1_gas_price: header.strk_l1_gas_price,
         eth_l1_data_gas_price: header.eth_l1_data_gas_price,
         strk_l1_data_gas_price: header.strk_l1_data_gas_price,
+        eth_l2_gas_price: header.eth_l2_gas_price,
+        strk_l2_gas_price: header.strk_l2_gas_price,
         receipt_commitment: header.receipt_commitment,
         l1_da_mode: header.l1_da_mode,
     }

--- a/crates/pathfinder/src/sync/headers.rs
+++ b/crates/pathfinder/src/sync/headers.rs
@@ -286,6 +286,8 @@ impl VerifyHashAndSignature {
             strk_l1_gas_price: header.strk_l1_gas_price,
             eth_l1_data_gas_price: header.eth_l1_data_gas_price,
             strk_l1_data_gas_price: header.strk_l1_data_gas_price,
+            eth_l2_gas_price: header.eth_l2_gas_price,
+            strk_l2_gas_price: header.strk_l2_gas_price,
             receipt_commitment: header.receipt_commitment,
             l1_da_mode: header.l1_da_mode,
         }) {


### PR DESCRIPTION
As specified in #2328, for Starknet version from 0.13.4 (subject to change). Also missing L2 prices for the hash calculation from Starknet gateway reply block (they aren't there yet).

Fixes  #2328.