### PR TITLE
fix(rpc/v08): fix EXECUTION_RESOURCES serialization in transaction traces

### DIFF
--- a/crates/executor/src/simulate.rs
+++ b/crates/executor/src/simulate.rs
@@ -367,6 +367,9 @@ fn to_trace(
     let execution_resources = ExecutionResources {
         computation_resources,
         data_availability,
+        l1_gas: execution_info.transaction_receipt.gas.l1_gas,
+        l1_data_gas: execution_info.transaction_receipt.da_gas.l1_data_gas,
+        l2_gas: 0,
     };
 
     match transaction_type {

--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -261,6 +261,9 @@ pub struct ReplacedClass {
 pub struct ExecutionResources {
     pub computation_resources: ComputationResources,
     pub data_availability: DataAvailabilityResources,
+    pub l1_gas: u128,
+    pub l1_data_gas: u128,
+    pub l2_gas: u128,
 }
 
 #[derive(Debug, Default, Clone, Eq, PartialEq)]

--- a/crates/rpc/src/dto/simulation.rs
+++ b/crates/rpc/src/dto/simulation.rs
@@ -461,13 +461,24 @@ impl crate::dto::serialize::SerializeForVersion for ExecutionResources<'_> {
         &self,
         serializer: super::serialize::Serializer,
     ) -> Result<super::serialize::Ok, super::serialize::Error> {
-        let mut serializer = serializer.serialize_struct()?;
-        serializer.flatten(&ComputationResources(&self.0.computation_resources))?;
-        serializer.serialize_field(
-            "data_availability",
-            &DataAvailabilityResources(&self.0.data_availability),
-        )?;
-        serializer.end()
+        match serializer.version {
+            RpcVersion::V08 => {
+                let mut serializer = serializer.serialize_struct()?;
+                serializer.serialize_field("l1_gas", &self.0.l1_gas)?;
+                serializer.serialize_field("l1_data_gas", &self.0.l1_data_gas)?;
+                serializer.serialize_field("l2_gas", &self.0.l2_gas)?;
+                serializer.end()
+            }
+            _ => {
+                let mut serializer = serializer.serialize_struct()?;
+                serializer.flatten(&ComputationResources(&self.0.computation_resources))?;
+                serializer.serialize_field(
+                    "data_availability",
+                    &DataAvailabilityResources(&self.0.data_availability),
+                )?;
+                serializer.end()
+            }
+        }
     }
 }
 

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -273,10 +273,37 @@ pub(crate) fn map_gateway_trace(
             .try_into()
             .unwrap(),
     };
+    let l1_gas = validate_invocation_resources
+        .total_gas_consumed
+        .unwrap_or_default()
+        .l1_gas
+        + function_invocation_resources
+            .total_gas_consumed
+            .unwrap_or_default()
+            .l1_gas
+        + fee_transfer_invocation_resources
+            .total_gas_consumed
+            .unwrap_or_default()
+            .l1_gas;
+    let l1_data_gas = validate_invocation_resources
+        .total_gas_consumed
+        .unwrap_or_default()
+        .l1_data_gas
+        + function_invocation_resources
+            .total_gas_consumed
+            .unwrap_or_default()
+            .l1_data_gas
+        + fee_transfer_invocation_resources
+            .total_gas_consumed
+            .unwrap_or_default()
+            .l1_data_gas;
     let execution_resources = pathfinder_executor::types::ExecutionResources {
         computation_resources,
         // These values are not available in the gateway trace.
         data_availability: Default::default(),
+        l1_gas,
+        l1_data_gas,
+        l2_gas: 0,
     };
 
     use pathfinder_common::transaction::TransactionVariant;


### PR DESCRIPTION
EXECUTION_RESOURCES should contain gas info exclusively now.

Closes: #2359