### PR TITLE
fix(rpc/v08/get_compiled_casm): omit `bytecode_segment_lengths` if missing

### DIFF
--- a/crates/common/src/casm_class.rs
+++ b/crates/common/src/casm_class.rs
@@ -9,6 +9,7 @@ use crate::EntryPoint;
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct CasmContractClass {
     pub bytecode: Vec<Felt>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bytecode_segment_lengths: Option<NestedIntList>,
     pub compiler_version: String,
     pub hints: serde_json::Value,


### PR DESCRIPTION
`bytecode_segment_lengths` isn't a required property in the response so it's actually better to just skip serializing it. `null` is not a valid value according to the spec.
