### PR TITLE
chore(doc/rpc/v08): upgrade OpenRPC specs to 0.8.0-rc1

### DIFF
--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -903,6 +903,8 @@ mod tests {
     // get_transaction_status is now part of the official spec, so we are phasing it out.
     #[case::root_pathfinder("/", "pathfinder_rpc_api.json", &["pathfinder_version", "pathfinder_getTransactionStatus"])]
 
+    #[case::v0_8_api("/rpc/v0_8", "v08/starknet_api_openrpc.json", &[])]
+    #[case::v0_8_executables("/rpc/v0_8", "v08/starknet_executables.json", &[])]
     #[case::v0_8_trace("/rpc/v0_8", "v08/starknet_trace_api_openrpc.json", &[])]
     #[case::v0_8_write("/rpc/v0_8", "v08/starknet_write_api.json", &[])]
 

--- a/doc/rpc/v08/starknet_api_openrpc.json
+++ b/doc/rpc/v08/starknet_api_openrpc.json
@@ -3628,13 +3628,18 @@
             "description": "The max amount and max price per unit of L1 gas used in this tx",
             "$ref": "#/components/schemas/RESOURCE_BOUNDS"
           },
+          "l1_data_gas": {
+            "title": "L1 Data Gas",
+            "description": "The max amount and max price per unit of L1 blob gas used in this tx",
+            "$ref": "#/components/schemas/RESOURCE_BOUNDS"
+          },
           "l2_gas": {
             "title": "L2 Gas",
             "description": "The max amount and max price per unit of L2 gas used in this tx",
             "$ref": "#/components/schemas/RESOURCE_BOUNDS"
           }
         },
-        "required": ["l1_gas", "l2_gas"]
+        "required": ["l1_gas", "l1_data_gas", "l2_gas"]
       },
       "RESOURCE_BOUNDS": {
         "type": "object",

--- a/doc/rpc/v08/starknet_executables.json
+++ b/doc/rpc/v08/starknet_executables.json
@@ -34,7 +34,7 @@
                     "$ref": "#/components/errors/COMPILATION_ERROR"
                 },
                 {
-                    "$ref": "#/components/errors/CLASS_HASH_NOT_FOUND"
+                    "$ref": "./api/starknet_api_openrpc.json#/components/errors/CLASS_HASH_NOT_FOUND"
                 }
             ]
         }
@@ -128,21 +128,23 @@
                 ]
             },
             "CASM_ENTRY_POINT": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/DEPRECATED_CAIRO_ENTRY_POINT"
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "builtins": {
-                                "type": "array",
-                                "items": "string"
-                            }
+                "schema": {
+                    "allOf": [
+                        {
+                            "$ref": "#/components/schemas/DEPRECATED_CAIRO_ENTRY_POINT"
                         },
-                        "required": "builtins"
-                    }
-                ]
+                        {
+                            "type": "object",
+                            "properties": {
+                                "builtins": {
+                                    "type": "array",
+                                    "items": "string"
+                                }
+                            },
+                            "required": "builtins"
+                        }
+                    ]
+                }
             },
             "CellRef": {
                 "title": "CellRef",
@@ -1335,20 +1337,19 @@
                 ]
             },
             "FELT": {
-                "$ref": "./starknet_api_openrpc.json#/components/schemas/FELT"
+                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/FELT"
             },
             "NUM_AS_HEX": {
-                "$ref": "./starknet_api_openrpc.json#/components/schemas/NUM_AS_HEX"
+                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/NUM_AS_HEX"
             },
             "DEPRECATED_CAIRO_ENTRY_POINT": {
-                "$ref": "./starknet_api_openrpc.json#/components/schemas/DEPRECATED_CAIRO_ENTRY_POINT"
+                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/DEPRECATED_CAIRO_ENTRY_POINT"
             }
         },
         "errors": {
-            "CLASS_HASH_NOT_FOUND": {
-                "$ref": "./api/starknet_api_openrpc.json#/components/errors/CLASS_HASH_NOT_FOUND"
-            },
             "COMPILATION_ERROR": {
+                "code": 100,
+                "message": "Failed to compile the contract",
                 "data": {
                     "type": "object",
                     "description": "More data about the compilation failure",

--- a/doc/rpc/v08/starknet_ws_api.json
+++ b/doc/rpc/v08/starknet_ws_api.json
@@ -12,7 +12,7 @@
       "description": "Creates a WebSocket stream which will fire events for new block headers",
       "params": [
         {
-          "name": "block",
+          "name": "block_id",
           "summary": "The block to get notifications from, default is latest, limited to 1024 blocks back",
           "required": false,
           "schema": {
@@ -32,6 +32,9 @@
         },
         {
           "$ref": "./api/starknet_api_openrpc.json#/components/errors/BLOCK_NOT_FOUND"
+        },
+        {
+            "$ref": "#/components/errors/CALL_ON_PENDING"
         }
       ]
     },
@@ -74,11 +77,11 @@
           "required": false,
           "schema": {
             "title": "event keys",
-            "$ref": "#/components/schemas/EVENT_KEYS"
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/EVENT_KEYS"
           }
         },
         {
-          "name": "block",
+          "name": "block_id",
           "summary": "The block to get notifications from, default is latest, limited to 1024 blocks back",
           "required": false,
           "schema": {
@@ -101,6 +104,9 @@
         },
         {
           "$ref": "./api/starknet_api_openrpc.json#/components/errors/BLOCK_NOT_FOUND"
+        },
+        {
+            "$ref": "#/components/errors/CALL_ON_PENDING"
         }
       ]
     },
@@ -138,7 +144,7 @@
           }
         },
         {
-          "name": "block",
+          "name": "block_id",
           "summary": "The block to get notifications from, default is latest, limited to 1024 blocks back",
           "required": false,
           "schema": {
@@ -254,6 +260,12 @@
         {
           "name": "subscription_id",
           "schema": {
+            "$ref": "#/components/schemas/SUBSCRIPTION_ID"
+          }
+        },
+        {
+          "name": "result",
+          "schema": {
             "$ref": "#/components/schemas/REORG_DATA"
           }
         }
@@ -361,6 +373,10 @@
       "TOO_MANY_BLOCKS_BACK": {
         "code": 68,
         "message": "Cannot go back more than 1024 blocks"
+      },
+      "CALL_ON_PENDING": {
+        "code": 69,
+        "message": "This method does not support being called on the pending block"
       }
     }
   }


### PR DESCRIPTION
This PR just updates our in-repo specs with the 0.8.0-rc1 ones and makes sure that we use all of those in the RPC routing tests.
