### PR TITLE
feat(rpc): add starknet subs errors to ws endpoints

### DIFF
--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -99,6 +99,12 @@ pub enum ApplicationError {
     StorageProofNotSupported,
     #[error("Proof is missing")]
     ProofMissing,
+    #[error("Invalid subscription id")]
+    InvalidSubscriptionID,
+    #[error("Too many addresses in filter sender_address filter")]
+    TooManyAddressesInFilter,
+    #[error("This method does not support being called on the pending block")]
+    CallOnPending,
     /// Internal errors are errors whose details we don't want to show to the
     /// end user. These are logged, and a simple "internal error" message is
     /// shown to the end user.
@@ -151,6 +157,10 @@ impl ApplicationError {
             ApplicationError::ProofMissing => 10001,
             ApplicationError::SubscriptionTransactionHashNotFound { .. } => 10029,
             ApplicationError::SubscriptionGatewayDown { .. } => 10030,
+            // doc/rpc/starknet_ws_api.json
+            ApplicationError::InvalidSubscriptionID => 66,
+            ApplicationError::TooManyAddressesInFilter => 67,
+            ApplicationError::CallOnPending => 69,
             // https://www.jsonrpc.org/specification#error_object
             ApplicationError::GatewayError(_)
             | ApplicationError::Internal(_)
@@ -200,6 +210,9 @@ impl ApplicationError {
             ApplicationError::CompiledClassHashMismatch => None,
             ApplicationError::UnsupportedTxVersion => None,
             ApplicationError::UnsupportedContractClassVersion => None,
+            ApplicationError::InvalidSubscriptionID => None,
+            ApplicationError::TooManyAddressesInFilter => None,
+            ApplicationError::CallOnPending => None,
             ApplicationError::GatewayError(error) => Some(json!({
                 "error": error,
             })),

--- a/crates/rpc/src/jsonrpc/router/subscription.rs
+++ b/crates/rpc/src/jsonrpc/router/subscription.rs
@@ -165,9 +165,7 @@ where
 
         let mut current_block = match first_block {
             BlockId::Pending => {
-                return Err(RpcError::InvalidParams(
-                    "Pending block not supported".to_string(),
-                ));
+                return Err(RpcError::ApplicationError(ApplicationError::CallOnPending));
             }
             BlockId::Latest => {
                 // No need to catch up. The code below will subscribe to new blocks.
@@ -616,12 +614,12 @@ async fn handle_request(
             })?;
         let (_, handle) = subscriptions
             .remove(&params.subscription_id)
-            .ok_or_else(|| {
-                RpcResponse::invalid_params(
-                    req_id.clone(),
-                    "Subscription not found".to_string(),
-                    state.version,
-                )
+            .ok_or_else(|| RpcResponse {
+                output: Err(RpcError::ApplicationError(
+                    ApplicationError::InvalidSubscriptionID,
+                )),
+                id: req_id.clone(),
+                version: state.version,
             })?;
         handle.abort();
         metrics::increment_counter!("rpc_method_calls_total", "method" => "starknet_unsubscribe", "version" => state.version.to_str());

--- a/crates/rpc/src/method/subscribe_events.rs
+++ b/crates/rpc/src/method/subscribe_events.rs
@@ -68,6 +68,9 @@ impl RpcSubscriptionFlow for SubscribeEvents {
 
     fn validate_params(params: &Self::Params) -> Result<(), RpcError> {
         if let Some(params) = params {
+            if let Some(BlockId::Pending) = params.block_id {
+                return Err(RpcError::ApplicationError(ApplicationError::CallOnPending));
+            }
             if let Some(keys) = &params.keys {
                 if keys.len() > EVENT_KEY_FILTER_LIMIT {
                     return Err(RpcError::ApplicationError(
@@ -638,6 +641,47 @@ mod tests {
                         "last_block_number": 2
                     },
                     "subscription_id": subscription_id
+                }
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn subscribe_with_pending_block() {
+        let router = setup(0).await;
+        let (sender_tx, mut sender_rx) = mpsc::channel(1024);
+        let (receiver_tx, receiver_rx) = mpsc::channel(1024);
+        handle_json_rpc_socket(router.clone(), sender_tx, receiver_rx);
+
+        // Send subscription request with pending block
+        receiver_tx
+            .send(Ok(Message::Text(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "starknet_subscribeEvents",
+                    "params": {"block_id": "pending"}
+                })
+                .to_string(),
+            )))
+            .await
+            .unwrap();
+
+        // Expect error response
+        let res = sender_rx.recv().await.unwrap().unwrap();
+        let json: serde_json::Value = match res {
+            Message::Text(json) => serde_json::from_str(&json).unwrap(),
+            _ => panic!("Expected text message"),
+        };
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {
+                    "code": 69,
+                    "message": "This method does not support being called on the pending block"
                 }
             })
         );


### PR DESCRIPTION
Adds the newly introduced `CALL_ON_PENDING` subscription error.

Also added the other missing errors on the subscription endpoints.