### PR TITLE
feat(rpc/v08): add `l1_data_gas` to v3 transaction resource bounds

### DIFF
--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -800,6 +800,14 @@ pub mod transaction {
         pub l1_gas: ResourceBound,
         #[serde(rename = "L2_GAS")]
         pub l2_gas: ResourceBound,
+        // Introduced in Starknet v0.13.4. This has to be optional because not sending it to the
+        // gateway is not equivalent to sending an explicit zero bound.
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            rename = "L1_DATA_GAS"
+        )]
+        pub l1_data_gas: Option<ResourceBound>,
     }
 
     impl From<ResourceBounds> for pathfinder_common::transaction::ResourceBounds {
@@ -816,6 +824,8 @@ pub mod transaction {
             Self {
                 l1_gas: value.l1_gas.into(),
                 l2_gas: value.l2_gas.into(),
+                // TODO: add this when adding support for Starknet 0.13.4
+                l1_data_gas: None,
             }
         }
     }

--- a/crates/rpc/fixtures/0.6.0/broadcasted_transactions.json
+++ b/crates/rpc/fixtures/0.6.0/broadcasted_transactions.json
@@ -183,6 +183,10 @@
         ],
         "nonce": "0x8",
         "resource_bounds": {
+            "l1_data_gas": {
+                "max_amount": "0x3333",
+                "max_price_per_unit": "0x4444"
+            },
             "l1_gas": {
                 "max_amount": "0x1111",
                 "max_price_per_unit": "0x2222"

--- a/crates/rpc/src/method/add_declare_transaction.rs
+++ b/crates/rpc/src/method/add_declare_transaction.rs
@@ -743,6 +743,7 @@ mod tests {
                     max_amount: ResourceAmount(0),
                     max_price_per_unit: ResourcePricePerUnit(0),
                 },
+                l1_data_gas: None,
             },
             tip: Tip(0),
             paymaster_data: vec![],

--- a/crates/rpc/src/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/method/add_deploy_account_transaction.rs
@@ -389,6 +389,7 @@ mod tests {
                     max_amount: ResourceAmount(0),
                     max_price_per_unit: ResourcePricePerUnit(0),
                 },
+                l1_data_gas: None,
             },
             tip: Tip(0),
             paymaster_data: vec![],

--- a/crates/rpc/src/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/method/add_invoke_transaction.rs
@@ -424,6 +424,7 @@ mod tests {
                     max_amount: ResourceAmount(0),
                     max_price_per_unit: ResourcePricePerUnit(0),
                 },
+                l1_data_gas: None,
             },
             tip: Tip(0),
             paymaster_data: vec![],

--- a/crates/rpc/src/v02/types.rs
+++ b/crates/rpc/src/v02/types.rs
@@ -13,6 +13,8 @@ pub mod syncing;
 pub struct ResourceBounds {
     pub l1_gas: ResourceBound,
     pub l2_gas: ResourceBound,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub l1_data_gas: Option<ResourceBound>,
 }
 
 impl crate::dto::DeserializeForVersion for ResourceBounds {
@@ -21,6 +23,7 @@ impl crate::dto::DeserializeForVersion for ResourceBounds {
             Ok(Self {
                 l1_gas: value.deserialize("l1_gas")?,
                 l2_gas: value.deserialize("l2_gas")?,
+                l1_data_gas: value.deserialize_optional("l1_data_gas")?,
             })
         })
     }
@@ -907,6 +910,7 @@ pub mod request {
                                     max_amount: ResourceAmount(0),
                                     max_price_per_unit: ResourcePricePerUnit(0),
                                 },
+                                l1_data_gas: None,
                             },
                             tip: Tip(0x1234),
                             paymaster_data: vec![
@@ -976,6 +980,7 @@ pub mod request {
                                     max_amount: ResourceAmount(0),
                                     max_price_per_unit: ResourcePricePerUnit(0),
                                 },
+                                l1_data_gas: None,
                             },
                             tip: Tip(0x1234),
                             paymaster_data: vec![
@@ -1006,6 +1011,10 @@ pub mod request {
                                     max_amount: ResourceAmount(0),
                                     max_price_per_unit: ResourcePricePerUnit(0),
                                 },
+                                l1_data_gas: Some(ResourceBound {
+                                    max_amount: ResourceAmount(0x3333),
+                                    max_price_per_unit: ResourcePricePerUnit(0x4444),
+                                }),
                             },
                             tip: Tip(0x1234),
                             paymaster_data: vec![

--- a/crates/rpc/src/v06/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v06/method/add_declare_transaction.rs
@@ -709,6 +709,7 @@ mod tests {
                     max_amount: ResourceAmount(0),
                     max_price_per_unit: ResourcePricePerUnit(0),
                 },
+                l1_data_gas: None,
             },
             tip: Tip(0),
             paymaster_data: vec![],

--- a/crates/rpc/src/v06/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/v06/method/add_deploy_account_transaction.rs
@@ -357,6 +357,7 @@ mod tests {
                     max_amount: ResourceAmount(0),
                     max_price_per_unit: ResourcePricePerUnit(0),
                 },
+                l1_data_gas: None,
             },
             tip: Tip(0),
             paymaster_data: vec![],

--- a/crates/rpc/src/v06/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/v06/method/add_invoke_transaction.rs
@@ -395,6 +395,7 @@ mod tests {
                     max_amount: ResourceAmount(0),
                     max_price_per_unit: ResourcePricePerUnit(0),
                 },
+                l1_data_gas: None,
             },
             tip: Tip(0),
             paymaster_data: vec![],

--- a/crates/rpc/src/v06/method/simulate_transactions.rs
+++ b/crates/rpc/src/v06/method/simulate_transactions.rs
@@ -1225,6 +1225,7 @@ pub(crate) mod tests {
                                 max_amount: ResourceAmount(10000),
                                 max_price_per_unit: ResourcePricePerUnit(100000000),
                             },
+                            l1_data_gas: None,
                         },
                         tip: Tip(0),
                         paymaster_data: vec![],


### PR DESCRIPTION
This is a partial implementation: since we don't _really_ use these new values other than passing those on to the Starknet gateway when submitting new transactions the new field is not added to the `ResourceBounds` type in the common crate.

We'll have to do that once these values need to be stored in storage and used in the P2P protocol when adding proper support for Starknet 0.13.4. I've added issue #2384 as a follow-up for this in the hope that we'll have a clearer picture around the expectations for this new field once we get there.

Closes: #2379
