### PR TITLE
fix(storage): work around in-memory DB locking issues

### DIFF
--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -1390,7 +1390,11 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn block_updates() {
-        let storage = StorageBuilder::in_memory().unwrap();
+        let storage = StorageBuilder::in_memory_with_trie_pruning_and_pool_size(
+            pathfinder_storage::TriePruneMode::Archive,
+            std::num::NonZeroU32::new(5).unwrap(),
+        )
+        .unwrap();
         let mut connection = storage.connection().unwrap();
 
         let (event_tx, event_rx) = tokio::sync::mpsc::channel(100);
@@ -1439,7 +1443,11 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn reorg() {
-        let storage = StorageBuilder::in_memory().unwrap();
+        let storage = StorageBuilder::in_memory_with_trie_pruning_and_pool_size(
+            pathfinder_storage::TriePruneMode::Archive,
+            std::num::NonZeroU32::new(5).unwrap(),
+        )
+        .unwrap();
         let mut connection = storage.connection().unwrap();
 
         let (event_tx, event_rx) = tokio::sync::mpsc::channel(100);
@@ -1491,7 +1499,11 @@ mod tests {
         // A bug caused reorg'd block numbers to be skipped. This
         // was due to the expected block number not being updated
         // when handling the reorg.
-        let storage = StorageBuilder::in_memory().unwrap();
+        let storage = StorageBuilder::in_memory_with_trie_pruning_and_pool_size(
+            pathfinder_storage::TriePruneMode::Archive,
+            std::num::NonZeroU32::new(5).unwrap(),
+        )
+        .unwrap();
         let mut connection = storage.connection().unwrap();
 
         let (event_tx, event_rx) = tokio::sync::mpsc::channel(100);
@@ -1552,7 +1564,11 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn reorg_to_genesis() {
-        let storage = StorageBuilder::in_memory().unwrap();
+        let storage = StorageBuilder::in_memory_with_trie_pruning_and_pool_size(
+            pathfinder_storage::TriePruneMode::Archive,
+            std::num::NonZeroU32::new(5).unwrap(),
+        )
+        .unwrap();
         let mut connection = storage.connection().unwrap();
 
         let (event_tx, event_rx) = tokio::sync::mpsc::channel(100);
@@ -1591,7 +1607,11 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn new_cairo_contract() {
-        let storage = StorageBuilder::in_memory().unwrap();
+        let storage = StorageBuilder::in_memory_with_trie_pruning_and_pool_size(
+            pathfinder_storage::TriePruneMode::Archive,
+            std::num::NonZeroU32::new(5).unwrap(),
+        )
+        .unwrap();
         let mut connection = storage.connection().unwrap();
 
         let (event_tx, event_rx) = tokio::sync::mpsc::channel(1);
@@ -1630,7 +1650,11 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn new_sierra_contract() {
-        let storage = StorageBuilder::in_memory().unwrap();
+        let storage = StorageBuilder::in_memory_with_trie_pruning_and_pool_size(
+            pathfinder_storage::TriePruneMode::Archive,
+            std::num::NonZeroU32::new(5).unwrap(),
+        )
+        .unwrap();
         let mut connection = storage.connection().unwrap();
 
         let (event_tx, event_rx) = tokio::sync::mpsc::channel(1);
@@ -1671,7 +1695,11 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn consumer_should_ignore_duplicate_blocks() {
-        let storage = StorageBuilder::in_memory().unwrap();
+        let storage = StorageBuilder::in_memory_with_trie_pruning_and_pool_size(
+            pathfinder_storage::TriePruneMode::Archive,
+            std::num::NonZeroU32::new(5).unwrap(),
+        )
+        .unwrap();
 
         let (event_tx, event_rx) = tokio::sync::mpsc::channel(5);
 

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -1171,6 +1171,7 @@ async fn reorg(
 #[cfg(test)]
 mod tests {
     mod sync {
+        use std::num::NonZeroU32;
         use std::sync::LazyLock;
 
         use assert_matches::assert_matches;
@@ -1330,7 +1331,11 @@ mod tests {
             tx_event: mpsc::Sender<SyncEvent>,
             sequencer: MockGatewayApi,
         ) -> JoinHandle<anyhow::Result<()>> {
-            let storage = StorageBuilder::in_memory().unwrap();
+            let storage = StorageBuilder::in_memory_with_trie_pruning_and_pool_size(
+                pathfinder_storage::TriePruneMode::Archive,
+                NonZeroU32::new(5).unwrap(),
+            )
+            .unwrap();
             let sequencer = std::sync::Arc::new(sequencer);
             let context = L2SyncContext {
                 sequencer,
@@ -1358,7 +1363,11 @@ mod tests {
             tx_event: mpsc::Sender<SyncEvent>,
             sequencer: MockGatewayApi,
         ) -> JoinHandle<anyhow::Result<Option<(BlockNumber, BlockHash, StateCommitment)>>> {
-            let storage = StorageBuilder::in_memory().unwrap();
+            let storage = StorageBuilder::in_memory_with_trie_pruning_and_pool_size(
+                pathfinder_storage::TriePruneMode::Archive,
+                NonZeroU32::new(5).unwrap(),
+            )
+            .unwrap();
             let sequencer = std::sync::Arc::new(sequencer);
             let context = L2SyncContext {
                 sequencer,
@@ -1844,7 +1853,11 @@ mod tests {
                     chain: Chain::SepoliaTestnet,
                     chain_id: ChainId::SEPOLIA_TESTNET,
                     block_validation_mode: MODE,
-                    storage: StorageBuilder::in_memory().unwrap(),
+                    storage: StorageBuilder::in_memory_with_trie_pruning_and_pool_size(
+                        pathfinder_storage::TriePruneMode::Archive,
+                        NonZeroU32::new(5).unwrap(),
+                    )
+                    .unwrap(),
                     sequencer_public_key: PublicKey::ZERO,
                     fetch_concurrency: std::num::NonZeroUsize::new(1).unwrap(),
                     fetch_casm_from_fgw: false,

--- a/crates/pathfinder/src/sync/checkpoint.rs
+++ b/crates/pathfinder/src/sync/checkpoint.rs
@@ -810,7 +810,11 @@ mod tests {
                     .map(PeerData::for_tests)
                     .collect::<Vec<_>>(),
                 expected_headers,
-                storage: StorageBuilder::in_memory().unwrap(),
+                storage: StorageBuilder::in_memory_with_trie_pruning_and_pool_size(
+                    pathfinder_storage::TriePruneMode::Archive,
+                    std::num::NonZeroU32::new(5).unwrap(),
+                )
+                .unwrap(),
                 // https://alpha-sepolia.starknet.io/feeder_gateway/get_public_key
                 public_key: public_key!(
                     "0x1252b6bce1351844c677869c6327e80eae1535755b611c66b8f46e595b40eea"
@@ -1046,7 +1050,11 @@ mod tests {
                     b.transaction_data = Default::default();
                 });
 
-                let storage = StorageBuilder::in_memory().unwrap();
+                let storage = StorageBuilder::in_memory_with_trie_pruning_and_pool_size(
+                    pathfinder_storage::TriePruneMode::Archive,
+                    std::num::NonZeroU32::new(5).unwrap(),
+                )
+                .unwrap();
                 fake_storage::fill(&storage, &blocks);
                 Setup {
                     streamed_transactions,
@@ -1082,7 +1090,11 @@ mod tests {
                     b.transaction_data = Default::default();
                 });
 
-                let storage = StorageBuilder::in_memory().unwrap();
+                let storage = StorageBuilder::in_memory_with_trie_pruning_and_pool_size(
+                    pathfinder_storage::TriePruneMode::Archive,
+                    std::num::NonZeroU32::new(5).unwrap(),
+                )
+                .unwrap();
                 fake_storage::fill(&storage, &blocks);
                 Setup {
                     streamed_transactions,
@@ -1267,7 +1279,11 @@ mod tests {
                     })
                     .collect::<Vec<_>>();
 
-                let storage = StorageBuilder::in_memory().unwrap();
+                let storage = StorageBuilder::in_memory_with_trie_pruning_and_pool_size(
+                    pathfinder_storage::TriePruneMode::Archive,
+                    std::num::NonZeroU32::new(5).unwrap(),
+                )
+                .unwrap();
                 fake_storage::fill(&storage, &blocks);
                 Setup {
                     streamed_state_diffs,

--- a/crates/pathfinder/src/sync/track.rs
+++ b/crates/pathfinder/src/sync/track.rs
@@ -928,7 +928,11 @@ mod tests {
             blocks: blocks.clone(),
         };
 
-        let storage = StorageBuilder::in_memory().unwrap();
+        let storage = StorageBuilder::in_memory_with_trie_pruning_and_pool_size(
+            pathfinder_storage::TriePruneMode::Archive,
+            std::num::NonZeroU32::new(5).unwrap(),
+        )
+        .unwrap();
 
         let sync = Sync {
             latest: futures::stream::iter(vec![latest]),

--- a/crates/rpc/src/method/call.rs
+++ b/crates/rpc/src/method/call.rs
@@ -294,6 +294,7 @@ mod tests {
                 .unwrap();
 
             tx.commit().unwrap();
+            drop(db);
 
             let context =
                 RpcContext::for_tests_on(pathfinder_common::Chain::Mainnet).with_storage(storage);
@@ -501,6 +502,7 @@ mod tests {
             tx.insert_state_update(block_number, &state_update).unwrap();
 
             tx.commit().unwrap();
+            drop(connection);
 
             let input = Input {
                 request: FunctionCall {

--- a/crates/rpc/src/pathfinder/methods/get_proof.rs
+++ b/crates/rpc/src/pathfinder/methods/get_proof.rs
@@ -468,6 +468,7 @@ mod tests {
         )
         .unwrap();
         tx.commit().unwrap();
+        drop(conn);
 
         let input = GetProofInput {
             block_id: BlockId::Latest,

--- a/crates/rpc/src/test_setup.rs
+++ b/crates/rpc/src/test_setup.rs
@@ -20,7 +20,11 @@ pub async fn test_storage<F: FnOnce(StateUpdate) -> StateUpdate>(
     version: StarknetVersion,
     customize_state_update: F,
 ) -> (Storage, BlockHeader, ContractAddress, ContractAddress) {
-    let storage = pathfinder_storage::StorageBuilder::in_memory().unwrap();
+    let storage = pathfinder_storage::StorageBuilder::in_memory_with_trie_pruning_and_pool_size(
+        pathfinder_storage::TriePruneMode::Archive,
+        std::num::NonZeroU32::new(2).unwrap(),
+    )
+    .unwrap();
     let mut db = storage.connection().unwrap();
     let tx = db.transaction().unwrap();
 

--- a/crates/rpc/src/v06/method/call.rs
+++ b/crates/rpc/src/v06/method/call.rs
@@ -275,6 +275,7 @@ mod tests {
                 .unwrap();
 
             tx.commit().unwrap();
+            drop(db);
 
             let context =
                 RpcContext::for_tests_on(pathfinder_common::Chain::Mainnet).with_storage(storage);
@@ -484,6 +485,7 @@ mod tests {
             tx.insert_state_update(block_number, &state_update).unwrap();
 
             tx.commit().unwrap();
+            drop(connection);
 
             let input = CallInput {
                 request: FunctionCall {

--- a/crates/rpc/src/v06/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v06/method/trace_block_transactions.rs
@@ -713,6 +713,7 @@ pub(crate) mod tests {
             .insert_transaction_data(header.number, &transactions_data, Some(&events_data))
             .unwrap();
         transaction.commit().unwrap();
+        drop(connection);
 
         // The tracing succeeds.
         trace_block_transactions(

--- a/crates/rpc/src/v06/method/trace_transaction.rs
+++ b/crates/rpc/src/v06/method/trace_transaction.rs
@@ -385,6 +385,7 @@ pub mod tests {
             .insert_transaction_data(header.number, &transactions_data, Some(&events_data))
             .unwrap();
         transaction.commit().unwrap();
+        drop(connection);
 
         // The tracing succeeds.
         trace_transaction(


### PR DESCRIPTION
We're using shared cache mode with our in-memory DB to allow multiple connections from within the same process. This means that in contrast to a file-based DB we immediately get locking errors in case of concurrent writes -- a pool size of one avoids this.

There are certain tests that _do_ need multiple connections to the in-memory DB though so we add a constructor that allows specifying the size of the pool we require.
