### PR TITLE
Handling Mutex.lock() failures by calling unwrap()

### DIFF
--- a/crates/executor/src/state_reader.rs
+++ b/crates/executor/src/state_reader.rs
@@ -230,7 +230,7 @@ impl StateReader for PathfinderStateReader<'_> {
             tracing::trace_span!("get_compiled_contract_class", class_hash=%pathfinder_class_hash)
                 .entered();
 
-        if let Some(entry) = GLOBAL_CACHE.get(&class_hash)? {
+        if let Some(entry) = GLOBAL_CACHE.get(&class_hash) {
             if let Some(reader_block_number) = self.block_number {
                 if entry.height <= reader_block_number {
                     tracing::trace!("Global class cache hit");
@@ -243,7 +243,7 @@ impl StateReader for PathfinderStateReader<'_> {
             self.non_cached_compiled_contract_class(pathfinder_class_hash, &class_hash)?;
 
         if let Some(block_number) = definition_block_number {
-            GLOBAL_CACHE.set(class_hash, contract_class.clone(), block_number)?;
+            GLOBAL_CACHE.set(class_hash, contract_class.clone(), block_number);
         }
 
         Ok(contract_class)

--- a/crates/storage/src/bloom.rs
+++ b/crates/storage/src/bloom.rs
@@ -392,7 +392,7 @@ impl Cache {
     }
 
     fn locked_cache(&self) -> MutexGuard<'_, SizedCache<CacheKey, BloomFilter>> {
-        self.0.lock().unwrap_or_else(|e| e.into_inner())
+        self.0.lock().unwrap()
     }
 
     pub fn get(

--- a/crates/storage/src/connection/event.rs
+++ b/crates/storage/src/connection/event.rs
@@ -89,13 +89,7 @@ impl Transaction<'_> {
             ",
         )?;
 
-        let mut running_aggregate = match self.running_aggregate.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => {
-                tracing::error!("Poisoned lock in upsert_block_events_aggregate");
-                poisoned.into_inner()
-            }
-        };
+        let mut running_aggregate = self.running_aggregate.lock().unwrap();
 
         let mut bloom = BloomFilter::new();
         for event in events {


### PR DESCRIPTION
Replacing the existing ad-hoc error handling.

Fixes #2381.
