### PR TITLE
fix(rpc/subscribe_transaction_status): return CALL_ON_PENDING error for pending block id

### DIFF
--- a/crates/rpc/src/method/subscribe_transaction_status.rs
+++ b/crates/rpc/src/method/subscribe_transaction_status.rs
@@ -152,7 +152,7 @@ impl RpcSubscriptionFlow for SubscribeTransactionStatus {
                         let db = conn.transaction().map_err(RpcError::InternalError)?;
                         let first_block = db
                             .block_number(first_block.try_into().map_err(|_| {
-                                RpcError::InvalidParams("block cannot be pending".to_string())
+                                RpcError::ApplicationError(ApplicationError::CallOnPending)
                             })?)
                             .map_err(RpcError::InternalError)?;
                         let l1_block_number =


### PR DESCRIPTION
Instead of an internal error error we should return the new-ish CALL_ON_PENDING error code.