### PR TITLE
chore: update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Ethereum RPC API now requires Websocket endpoints (prev. HTTP). If an HTTP url is provided instead, Pathfinder will attempt to connect vía Websocket protocol at that same url.
+- JSON-RPC 0.4.0 and 0.5.0 API support has been removed.
 - JSON-RPC API version 0.7 is now served by default on the `/` path.
 
 ### Fixed


### PR DESCRIPTION
We forgot to mention the removal of JSON-RPC 0.4 and 0.5 in the changelog...