### PR TITLE
feat(rpc): Decouple `v07` from `v06` types and methods

### DIFF
--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -217,7 +217,7 @@ pub struct MsgToL1 {
     pub from_address: Felt,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct InnerCallExecutionResources {
     pub l1_gas: u128,
     pub l2_gas: u128,

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -86,7 +86,7 @@ Examples:
         default_value = "v07",
         env = "PATHFINDER_RPC_ROOT_VERSION"
     )]
-    rpc_root_version: RpcVersion,
+    rpc_root_version: RootRpcVersion,
 
     #[arg(
         long = "rpc.execution-concurrency",
@@ -334,8 +334,7 @@ impl Color {
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq)]
-pub enum RpcVersion {
-    V06,
+pub enum RootRpcVersion {
     V07,
 }
 
@@ -692,7 +691,7 @@ pub struct Config {
     pub ethereum: Ethereum,
     pub rpc_address: SocketAddr,
     pub rpc_cors_domains: Option<AllowedOrigins>,
-    pub rpc_root_version: RpcVersion,
+    pub rpc_root_version: RootRpcVersion,
     pub websocket: WebsocketConfig,
     pub monitor_address: Option<SocketAddr>,
     pub network: Option<NetworkConfig>,

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -247,8 +247,7 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
     };
 
     let default_version = match config.rpc_root_version {
-        config::RpcVersion::V06 => pathfinder_rpc::RpcVersion::V06,
-        config::RpcVersion::V07 => pathfinder_rpc::RpcVersion::V07,
+        config::RootRpcVersion::V07 => pathfinder_rpc::RpcVersion::V07,
     };
 
     let rpc_server = pathfinder_rpc::RpcServer::new(config.rpc_address, context, default_version);

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -171,9 +171,8 @@ impl ApplicationError {
     pub fn message(&self, version: RpcVersion) -> String {
         match self {
             ApplicationError::InsufficientResourcesForValidate => match version {
-                RpcVersion::V06 | RpcVersion::V07 => "Max fee is smaller than the minimal \
-                                                      transaction cost (validation plus fee \
-                                                      transfer)"
+                RpcVersion::V07 => "Max fee is smaller than the minimal transaction cost \
+                                    (validation plus fee transfer)"
                     .to_string(),
                 _ => self.to_string(),
             },

--- a/crates/rpc/src/method/call.rs
+++ b/crates/rpc/src/method/call.rs
@@ -74,7 +74,7 @@ pub struct Input {
     pub block_id: BlockId,
 }
 
-#[derive(serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct FunctionCall {
     pub contract_address: ContractAddress,

--- a/crates/rpc/src/method/get_transaction_by_block_id_and_index.rs
+++ b/crates/rpc/src/method/get_transaction_by_block_id_and_index.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use pathfinder_common::{BlockId, TransactionIndex};
 
 use crate::context::RpcContext;
-use crate::v06::types::TransactionWithHash;
+use crate::types::transaction::TransactionWithHash;
 
 #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -4,13 +4,34 @@ use pathfinder_executor::TransactionExecutionError;
 
 use crate::context::RpcContext;
 use crate::executor::ExecutionStateError;
-use crate::v06::method::simulate_transactions as v06;
+use crate::types::request::BroadcastedTransaction;
+
+#[derive(Debug)]
+pub struct SimulateTransactionInput {
+    pub block_id: BlockId,
+    pub transactions: Vec<BroadcastedTransaction>,
+    pub simulation_flags: crate::dto::SimulationFlags,
+}
+
+impl crate::dto::DeserializeForVersion for SimulateTransactionInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_map(|value| {
+            Ok(Self {
+                block_id: value.deserialize("block_id")?,
+                transactions: value.deserialize_array("transactions", |value| {
+                    BroadcastedTransaction::deserialize(value)
+                })?,
+                simulation_flags: value.deserialize("simulation_flags")?,
+            })
+        })
+    }
+}
 
 pub struct Output(Vec<pathfinder_executor::types::TransactionSimulation>);
 
 pub async fn simulate_transactions(
     context: RpcContext,
-    input: v06::SimulateTransactionInput,
+    input: SimulateTransactionInput,
 ) -> Result<Output, SimulateTransactionError> {
     let span = tracing::Span::current();
     tokio::task::spawn_blocking(move || {
@@ -20,13 +41,13 @@ pub async fn simulate_transactions(
             .simulation_flags
             .0
             .iter()
-            .any(|flag| flag == &v06::dto::SimulationFlag::SkipValidate);
+            .any(|flag| flag == &crate::dto::SimulationFlag::SkipValidate);
 
         let skip_fee_charge = input
             .simulation_flags
             .0
             .iter()
-            .any(|flag| flag == &v06::dto::SimulationFlag::SkipFeeCharge);
+            .any(|flag| flag == &crate::dto::SimulationFlag::SkipFeeCharge);
 
         let mut db = context
             .execution_storage
@@ -102,7 +123,7 @@ impl crate::dto::serialize::SerializeForVersion for TransactionSimulation<'_> {
         serializer.serialize_field(
             "transaction_trace",
             &crate::dto::TransactionTrace {
-                trace: &self.0.trace,
+                trace: self.0.trace.clone(),
                 include_state_diff: true,
             },
         )?;
@@ -177,19 +198,23 @@ impl From<ExecutionStateError> for SimulateTransactionError {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use std::collections::{BTreeMap, HashSet};
+
     use pathfinder_common::macro_prelude::*;
     use pathfinder_common::{
         felt,
+        BlockHeader,
         BlockId,
-        CallParam,
         ClassHash,
+        ContractAddress,
         EntryPoint,
         StarknetVersion,
+        StorageAddress,
         StorageValue,
         TransactionVersion,
     };
     use pathfinder_crypto::Felt;
-    use serde::Deserialize;
+    use pathfinder_storage::Storage;
     use starknet_gateway_test_fixtures::class_definitions::{
         DUMMY_ACCOUNT_CLASS_HASH,
         ERC20_CONTRACT_DEFINITION_CLASS_HASH,
@@ -198,18 +223,46 @@ pub(crate) mod tests {
     use super::simulate_transactions;
     use crate::context::RpcContext;
     use crate::dto::serialize::{SerializeForVersion, Serializer};
-    use crate::method::get_state_update::types::{DeployedContract, Nonce, StateDiff};
+    use crate::dto::DeserializeForVersion;
+    use crate::method::simulate_transactions::SimulateTransactionInput;
     use crate::types::request::{
         BroadcastedDeclareTransaction,
         BroadcastedDeclareTransactionV1,
         BroadcastedTransaction,
     };
-    use crate::types::ContractClass;
-    use crate::v06::method::call::FunctionCall;
-    use crate::v06::method::simulate_transactions::tests::setup_storage_with_starknet_version;
-    use crate::v06::method::simulate_transactions::{dto, SimulateTransactionInput};
-    use crate::v06::types::PriceUnit;
     use crate::RpcVersion;
+
+    pub(crate) async fn setup_storage_with_starknet_version(
+        version: StarknetVersion,
+    ) -> (
+        Storage,
+        BlockHeader,
+        ContractAddress,
+        ContractAddress,
+        StorageValue,
+    ) {
+        let test_storage_key = StorageAddress::from_name(b"my_storage_var");
+        let test_storage_value = storage_value!("0x09");
+
+        // set test storage variable
+        let (storage, last_block_header, account_contract_address, universal_deployer_address) =
+            crate::test_setup::test_storage(version, |state_update| {
+                state_update.with_storage_update(
+                    fixtures::DEPLOYED_CONTRACT_ADDRESS,
+                    test_storage_key,
+                    test_storage_value,
+                )
+            })
+            .await;
+
+        (
+            storage,
+            last_block_header,
+            account_contract_address,
+            universal_deployer_address,
+            test_storage_value,
+        )
+    }
 
     #[tokio::test]
     async fn test_simulate_transaction_with_skip_fee_charge() {
@@ -231,97 +284,95 @@ pub(crate) mod tests {
             ],
             "simulation_flags": ["SKIP_FEE_CHARGE"]
         });
-        let input = SimulateTransactionInput::deserialize(&input_json).unwrap();
 
-        let expected: Vec<dto::SimulatedTransaction> = {
-            use dto::*;
-            let tx =
-            SimulatedTransaction {
-                fee_estimation:
-                    FeeEstimate {
-                        gas_consumed: 19.into(),
-                        gas_price: 1.into(),
-                        data_gas_consumed: Some(160.into()),
-                        data_gas_price: Some(2.into()),
-                        overall_fee: 339.into(),
-                        unit: PriceUnit::Wei,
-                    }
-                ,
-                transaction_trace:
-                    TransactionTrace::DeployAccount(
-                        DeployAccountTxnTrace {
-                            constructor_invocation: FunctionInvocation {
-                                    call_type: CallType::Call,
-                                    caller_address: felt!("0x0"),
-                                    calls: vec![],
-                                    class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
-                                    entry_point_type: EntryPointType::Constructor,
-                                    events: vec![],
-                                    function_call: FunctionCall {
-                                        calldata: vec![],
-                                        contract_address: contract_address!("0x00798C1BFDAF2077F4900E37C8815AFFA8D217D46DB8A84C3FBA1838C8BD4A65"),
-                                        entry_point_selector: entry_point!("0x028FFE4FF0F226A9107253E17A904099AA4F63A02A5621DE0576E5AA71BC5194"),
-                                    },
-                                    messages: vec![],
-                                    result: vec![],
-                                    execution_resources: ComputationResources::default(),
-                                },
-                            validate_invocation: Some(
-                                FunctionInvocation {
-                                    call_type: CallType::Call,
-                                    caller_address: felt!("0x0"),
-                                    calls: vec![],
-                                    class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
-                                    entry_point_type: EntryPointType::External,
-                                    events: vec![],
-                                    function_call: FunctionCall {
-                                        calldata: vec![
-                                            CallParam(DUMMY_ACCOUNT_CLASS_HASH.0),
-                                            call_param!("0x046C0D4ABF0192A788ACA261E58D7031576F7D8EA5229F452B0F23E691DD5971"),
-                                        ],
-                                        contract_address: contract_address!("0x00798C1BFDAF2077F4900E37C8815AFFA8D217D46DB8A84C3FBA1838C8BD4A65"),
-                                        entry_point_selector: entry_point!("0x036FCBF06CD96843058359E1A75928BEACFAC10727DAB22A3972F0AF8AA92895"),
-                                    },
-                                    messages: vec![],
-                                    result: vec![],
-                                    execution_resources: ComputationResources {
-                                        steps: 13,
-                                        ..Default::default()
-                                    },
-                                },
-                            ),
-                            fee_transfer_invocation: None,
-                            state_diff: Some(StateDiff {
-                                storage_diffs: vec![],
-                                deprecated_declared_classes: vec![],
-                                declared_classes: vec![],
-                                deployed_contracts: vec![
-                                    DeployedContract {
-                                        address: contract_address!("0x00798C1BFDAF2077F4900E37C8815AFFA8D217D46DB8A84C3FBA1838C8BD4A65"),
-                                        class_hash: DUMMY_ACCOUNT_CLASS_HASH
-                                    }
-                                ],
-                                replaced_classes: vec![],
-                                nonces: vec![
-                                    Nonce {
-                                        contract_address: contract_address!("0x00798C1BFDAF2077F4900E37C8815AFFA8D217D46DB8A84C3FBA1838C8BD4A65"),
-                                        nonce: contract_nonce!("0x1")
-                                    }
-                                ]
+        let value = crate::dto::Value::new(input_json, RpcVersion::V07);
+        let input = SimulateTransactionInput::deserialize(value).unwrap();
+
+        let expected = crate::method::simulate_transactions::Output(vec![
+            pathfinder_executor::types::TransactionSimulation{
+                fee_estimation: pathfinder_executor::types::FeeEstimate {
+                    l1_gas_consumed: 19.into(),
+                    l1_gas_price: 1.into(),
+                    l1_data_gas_consumed: 160.into(),
+                    l1_data_gas_price: 2.into(),
+                    l2_gas_consumed: 0.into(),
+                    l2_gas_price: 0.into(),
+                    overall_fee: 339.into(),
+                    unit: pathfinder_executor::types::PriceUnit::Wei,
+                },
+                trace: pathfinder_executor::types::TransactionTrace::DeployAccount(
+                    pathfinder_executor::types::DeployAccountTransactionTrace {
+                        constructor_invocation: Some(pathfinder_executor::types::FunctionInvocation {
+                                call_type: pathfinder_executor::types::CallType::Call,
+                                caller_address: felt!("0x0"),
+                                class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
+                                entry_point_type: pathfinder_executor::types::EntryPointType::Constructor,
+                                events: vec![],
+                                calldata: vec![],
+                                contract_address: contract_address!("0x00798C1BFDAF2077F4900E37C8815AFFA8D217D46DB8A84C3FBA1838C8BD4A65"),
+                                selector: entry_point!("0x028FFE4FF0F226A9107253E17A904099AA4F63A02A5621DE0576E5AA71BC5194").0,
+                                messages: vec![],
+                                result: vec![],
+                                execution_resources: pathfinder_executor::types::InnerCallExecutionResources::default(),
+                                internal_calls: vec![],
+                                computation_resources: pathfinder_executor::types::ComputationResources::default(),
                             }),
-                            execution_resources: Some(ExecutionResources {
-                                computation_resources: ComputationResources {
+                        validate_invocation: Some(
+                            pathfinder_executor::types::FunctionInvocation {
+                                call_type: pathfinder_executor::types::CallType::Call,
+                                caller_address: felt!("0x0"),
+                                class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
+                                entry_point_type: pathfinder_executor::types::EntryPointType::External,
+                                events: vec![],
+                                calldata: vec![
+                                    DUMMY_ACCOUNT_CLASS_HASH.0,
+                                    call_param!("0x046C0D4ABF0192A788ACA261E58D7031576F7D8EA5229F452B0F23E691DD5971").0,
+                                ],
+                                contract_address: contract_address!("0x00798C1BFDAF2077F4900E37C8815AFFA8D217D46DB8A84C3FBA1838C8BD4A65"),
+                                selector: entry_point!("0x036FCBF06CD96843058359E1A75928BEACFAC10727DAB22A3972F0AF8AA92895").0,
+                                messages: vec![],
+                                result: vec![],
+                                execution_resources: pathfinder_executor::types::InnerCallExecutionResources {
+                                    l1_gas: 0,
+                                    l2_gas: 0,
+                                },
+                                internal_calls: vec![],
+                                computation_resources: pathfinder_executor::types::ComputationResources{
                                     steps: 13,
                                     ..Default::default()
-                                },
-                                data_availability: DataAvailabilityResources { l1_gas: 0, l1_data_gas: 160 }
-                            }),
+                                }
+                            },
+                        ),
+                        fee_transfer_invocation: None,
+                        state_diff: pathfinder_executor::types::StateDiff {
+                            storage_diffs: BTreeMap::new(),
+                            deprecated_declared_classes: HashSet::new(),
+                            declared_classes: vec![],
+                            deployed_contracts: vec![
+                                pathfinder_executor::types::DeployedContract {
+                                    address: contract_address!("0x00798C1BFDAF2077F4900E37C8815AFFA8D217D46DB8A84C3FBA1838C8BD4A65"),
+                                    class_hash: DUMMY_ACCOUNT_CLASS_HASH
+                                }
+                            ],
+                            replaced_classes: vec![],
+                            nonces: BTreeMap::from([(
+                                contract_address!("0x00798C1BFDAF2077F4900E37C8815AFFA8D217D46DB8A84C3FBA1838C8BD4A65"),
+                                contract_nonce!("0x1"),
+                            )]),
                         },
-                    ),
-            };
-            vec![tx]
-        };
-        let expected = serde_json::to_value(expected).unwrap();
+                        execution_resources: pathfinder_executor::types::ExecutionResources {
+                            computation_resources: pathfinder_executor::types::ComputationResources{steps:13, ..Default::default()},
+                            data_availability: pathfinder_executor::types::DataAvailabilityResources{l1_gas:0,l1_data_gas:160},
+                            l1_gas: 0,
+                            l1_data_gas: 160,
+                            l2_gas: 0,
+                        },
+                    },
+                ),
+            }
+        ]).serialize(Serializer {
+            version: RpcVersion::V07,
+        }).unwrap();
 
         let result = simulate_transactions(context, input).await.expect("result");
         let result = result
@@ -340,7 +391,7 @@ pub(crate) mod tests {
         pub const CAIRO0_HASH: ClassHash =
             class_hash!("02c52e7084728572ea940b4df708a2684677c19fa6296de2ea7ba5327e3a84ef");
 
-        let contract_class = ContractClass::from_definition_bytes(CAIRO0_DEFINITION)
+        let contract_class = crate::types::ContractClass::from_definition_bytes(CAIRO0_DEFINITION)
             .unwrap()
             .as_cairo()
             .unwrap();
@@ -365,161 +416,296 @@ pub(crate) mod tests {
         let input = SimulateTransactionInput {
             block_id: last_block_header.number.into(),
             transactions: vec![declare],
-            simulation_flags: dto::SimulationFlags(vec![]),
+            simulation_flags: crate::dto::SimulationFlags(vec![]),
         };
 
-        let result = simulate_transactions(context, input).await.unwrap();
-
         const OVERALL_FEE: u64 = 15720;
-        use dto::*;
 
-        use crate::method::get_state_update::types::{StorageDiff, StorageEntry};
-
-        pretty_assertions_sorted::assert_eq!(
-            result.serialize(Serializer {
-                version: RpcVersion::V07,
-            }).unwrap(),
-            serde_json::to_value(
-                vec![SimulatedTransaction {
-                    fee_estimation: FeeEstimate {
-                        gas_consumed: 15464.into(),
-                        gas_price: 1.into(),
-                        data_gas_consumed: Some(128.into()),
-                        data_gas_price: Some(2.into()),
-                        overall_fee: 15720.into(),
-                        unit: PriceUnit::Wei,
-                    },
-                    transaction_trace: TransactionTrace::Declare(DeclareTxnTrace {
-                        fee_transfer_invocation: Some(
-                            FunctionInvocation {
-                                call_type: CallType::Call,
-                                caller_address: *account_contract_address.get(),
-                                calls: vec![],
-                                class_hash: Some(ERC20_CONTRACT_DEFINITION_CLASS_HASH.0),
-                                entry_point_type: EntryPointType::External,
-                                events: vec![OrderedEvent {
-                                    order: 0,
-                                    data: vec![
-                                        *account_contract_address.get(),
-                                        last_block_header.sequencer_address.0,
-                                        Felt::from_u64(OVERALL_FEE),
-                                        felt!("0x0"),
-                                    ],
-                                    keys: vec![felt!(
-                                        "0x0099CD8BDE557814842A3121E8DDFD433A539B8C9F14BF31EBF108D12E6196E9"
-                                    )],
-                                }],
-                                function_call: FunctionCall {
-                                    calldata: vec![
-                                        CallParam(last_block_header.sequencer_address.0),
-                                        CallParam(Felt::from_u64(OVERALL_FEE)),
-                                        call_param!("0x0"),
-                                    ],
-                                    contract_address: pathfinder_executor::ETH_FEE_TOKEN_ADDRESS,
-                                    entry_point_selector: EntryPoint::hashed(b"transfer"),
-                                },
-                                messages: vec![],
-                                result: vec![felt!("0x1")],
-                                execution_resources: ComputationResources {
-                                    steps: 1354,
-                                    memory_holes: 59,
-                                    range_check_builtin_applications: 31,
-                                    pedersen_builtin_applications: 4,
-                                    ..Default::default()
-                                },
-                            }
-                        ),
-                        validate_invocation: Some(
-                            FunctionInvocation {
-                                call_type: CallType::Call,
-                                caller_address: felt!("0x0"),
-                                calls: vec![],
-                                class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
-                                entry_point_type: EntryPointType::External,
-                                events: vec![],
-                                function_call: FunctionCall {
-                                    contract_address: account_contract_address,
-                                    entry_point_selector: EntryPoint::hashed(b"__validate_declare__"),
-                                    calldata: vec![CallParam(CAIRO0_HASH.0)],
-                                },
-                                messages: vec![],
-                                result: vec![],
-                                execution_resources: ComputationResources {
-                                    steps: 12,
-                                    ..Default::default()
-                                },
-                            }
-                        ),
-                        state_diff: Some(StateDiff {
-                            storage_diffs: vec![StorageDiff {
-                                address: pathfinder_executor::ETH_FEE_TOKEN_ADDRESS,
-                                storage_entries: vec![
-                                    StorageEntry {
-                                        key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                                        value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffffc298")
-                                    },
-                                    StorageEntry {
-                                        key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
-                                        value: StorageValue(OVERALL_FEE.into()),
-                                    },
+        let expected = crate::method::simulate_transactions::Output(vec![
+            pathfinder_executor::types::TransactionSimulation{
+                trace: pathfinder_executor::types::TransactionTrace::Declare(pathfinder_executor::types::DeclareTransactionTrace {
+                    validate_invocation: Some(
+                        pathfinder_executor::types::FunctionInvocation {
+                            call_type: pathfinder_executor::types::CallType::Call,
+                            caller_address: felt!("0x0"),
+                            class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
+                            entry_point_type: pathfinder_executor::types::EntryPointType::External,
+                            events: vec![],
+                            contract_address: account_contract_address,
+                            selector: EntryPoint::hashed(b"__validate_declare__").0,
+                            calldata: vec![CAIRO0_HASH.0],
+                            messages: vec![],
+                            result: vec![],
+                            execution_resources: pathfinder_executor::types::InnerCallExecutionResources::default(),
+                            internal_calls: vec![],
+                            computation_resources: pathfinder_executor::types::ComputationResources{
+                                steps: 12,
+                                ..Default::default()
+                            },
+                        }
+                    ),
+                    fee_transfer_invocation: Some(
+                        pathfinder_executor::types::FunctionInvocation {
+                            call_type: pathfinder_executor::types::CallType::Call,
+                            caller_address: *account_contract_address.get(),
+                            class_hash: Some(ERC20_CONTRACT_DEFINITION_CLASS_HASH.0),
+                            entry_point_type: pathfinder_executor::types::EntryPointType::External,
+                            events: vec![pathfinder_executor::types::Event {
+                                order: 0,
+                                data: vec![
+                                    *account_contract_address.get(),
+                                    last_block_header.sequencer_address.0,
+                                    Felt::from_u64(OVERALL_FEE),
+                                    felt!("0x0"),
                                 ],
+                                keys: vec![felt!(
+                                    "0x0099CD8BDE557814842A3121E8DDFD433A539B8C9F14BF31EBF108D12E6196E9"
+                                )],
                             }],
-                            deprecated_declared_classes: vec![
-                                CAIRO0_HASH
+                            calldata: vec![
+                                last_block_header.sequencer_address.0,
+                                Felt::from_u64(OVERALL_FEE),
+                                call_param!("0x0").0,
                             ],
-                            declared_classes: vec![],
-                            deployed_contracts: vec![],
-                            replaced_classes: vec![],
-                            nonces: vec![Nonce {
-                                contract_address: account_contract_address,
-                                nonce: contract_nonce!("0x1"),
-                            }],
-                        }),
-                        execution_resources: Some(ExecutionResources {
-                            computation_resources: ComputationResources {
-                                steps: 1366,
+                            contract_address: pathfinder_executor::ETH_FEE_TOKEN_ADDRESS,
+                            selector: EntryPoint::hashed(b"transfer").0,
+                            messages: vec![],
+                            result: vec![felt!("0x1")],
+                            execution_resources: pathfinder_executor::types::InnerCallExecutionResources::default(),
+                            internal_calls: vec![],
+                            computation_resources: pathfinder_executor::types::ComputationResources{
+                                steps: 1354,
                                 memory_holes: 59,
                                 range_check_builtin_applications: 31,
                                 pedersen_builtin_applications: 4,
                                 ..Default::default()
                             },
-                            data_availability: DataAvailabilityResources {
-                                l1_gas: 0,
-                                l1_data_gas: 128,
-                            }
-                        }),
-                    }),
-                }]
-            ).unwrap()
+                        }
+                    ),
+                    state_diff: pathfinder_executor::types::StateDiff {
+                        storage_diffs: BTreeMap::from([
+                            (pathfinder_executor::ETH_FEE_TOKEN_ADDRESS, vec![
+                                pathfinder_executor::types::StorageDiff {
+                                    key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
+                                    value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffffc298"),
+                                },
+                                pathfinder_executor::types::StorageDiff {
+                                    key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
+                                    value: StorageValue(OVERALL_FEE.into()),
+                                },
+                            ]),
+                        ]),
+                        deprecated_declared_classes: HashSet::from([
+                            CAIRO0_HASH
+                        ]),
+                        declared_classes: vec![],
+                        deployed_contracts: vec![],
+                        replaced_classes: vec![],
+                        nonces: BTreeMap::from([
+                            (account_contract_address, contract_nonce!("0x1")),
+                        ]),
+                    },
+                    execution_resources: pathfinder_executor::types::ExecutionResources{
+                        computation_resources: pathfinder_executor::types::ComputationResources{
+                            steps: 1366,
+                            memory_holes: 59,
+                            range_check_builtin_applications: 31,
+                            pedersen_builtin_applications: 4,
+                            ..Default::default()
+                        },
+                        data_availability: pathfinder_executor::types::DataAvailabilityResources{
+                            l1_gas: 0,
+                            l1_data_gas: 128,
+                        },
+                        l1_gas: 0,
+                        l1_data_gas: 128,
+                        l2_gas: 0,
+                    },
+                }),
+                fee_estimation: pathfinder_executor::types::FeeEstimate {
+                    l1_gas_consumed: 15464.into(),
+                    l1_gas_price: 1.into(),
+                    l1_data_gas_consumed: 128.into(),
+                    l1_data_gas_price: 2.into(),
+                    l2_gas_consumed: 0.into(),
+                    l2_gas_price: 0.into(),
+                    overall_fee: 15720.into(),
+                    unit: pathfinder_executor::types::PriceUnit::Wei,
+                }
+            }
+        ]).serialize(Serializer {
+            version: RpcVersion::V07,
+        }).unwrap();
+
+        let result = simulate_transactions(context, input).await.unwrap();
+
+        pretty_assertions_sorted::assert_eq!(
+            result
+                .serialize(Serializer {
+                    version: RpcVersion::V07,
+                })
+                .unwrap(),
+            expected
         );
     }
 
     pub(crate) mod fixtures {
-        use super::*;
-        pub use crate::v06::method::simulate_transactions::tests::fixtures::{
-            CASM_DEFINITION,
-            CASM_HASH,
-            DEPLOYED_CONTRACT_ADDRESS,
-            SIERRA_DEFINITION,
-            SIERRA_HASH,
-            UNIVERSAL_DEPLOYER_CLASS_HASH,
-        };
+        use pathfinder_common::{CasmHash, ContractAddress, Fee};
 
-        // The input transactions are the same as in v06.
+        use super::*;
+
+        pub const SIERRA_DEFINITION: &[u8] =
+            include_bytes!("../../fixtures/contracts/storage_access.json");
+        pub const SIERRA_HASH: ClassHash =
+            class_hash!("0544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90");
+        pub const CASM_HASH: CasmHash =
+            casm_hash!("0x069032ff71f77284e1a0864a573007108ca5cc08089416af50f03260f5d6d4d8");
+        pub const CASM_DEFINITION: &[u8] =
+            include_bytes!("../../fixtures/contracts/storage_access.casm");
+        const MAX_FEE: Fee = Fee(Felt::from_u64(10_000_000));
+        pub const DEPLOYED_CONTRACT_ADDRESS: ContractAddress =
+            contract_address!("0x012592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7");
+        pub const UNIVERSAL_DEPLOYER_CLASS_HASH: ClassHash =
+            class_hash!("0x06f38fb91ddbf325a0625533576bb6f6eafd9341868a9ec3faa4b01ce6c4f4dc");
+
+        // The input transactions are the same as in v04.
         pub mod input {
-            pub use crate::v06::method::simulate_transactions::tests::fixtures::input::*;
+            use pathfinder_common::{
+                CallParam,
+                EntryPoint,
+                ResourceAmount,
+                ResourcePricePerUnit,
+                Tip,
+            };
+
+            use super::*;
+            use crate::types::request::{
+                BroadcastedDeclareTransactionV2,
+                BroadcastedInvokeTransaction,
+                BroadcastedInvokeTransactionV1,
+                BroadcastedInvokeTransactionV3,
+                BroadcastedTransaction,
+            };
+            use crate::types::{ResourceBound, ResourceBounds};
+
+            pub fn declare(account_contract_address: ContractAddress) -> BroadcastedTransaction {
+                let contract_class =
+                    crate::types::ContractClass::from_definition_bytes(SIERRA_DEFINITION)
+                        .unwrap()
+                        .as_sierra()
+                        .unwrap();
+
+                assert_eq!(contract_class.class_hash().unwrap().hash(), SIERRA_HASH);
+
+                BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V2(
+                    BroadcastedDeclareTransactionV2 {
+                        version: TransactionVersion::TWO,
+                        max_fee: MAX_FEE,
+                        signature: vec![],
+                        nonce: transaction_nonce!("0x0"),
+                        contract_class,
+                        sender_address: account_contract_address,
+                        compiled_class_hash: CASM_HASH,
+                    },
+                ))
+            }
+
+            pub fn universal_deployer(
+                account_contract_address: ContractAddress,
+                universal_deployer_address: ContractAddress,
+            ) -> BroadcastedTransaction {
+                BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(
+                    BroadcastedInvokeTransactionV1 {
+                        nonce: transaction_nonce!("0x1"),
+                        version: TransactionVersion::ONE,
+                        max_fee: MAX_FEE,
+                        signature: vec![],
+                        sender_address: account_contract_address,
+                        calldata: vec![
+                            CallParam(*universal_deployer_address.get()),
+                            // Entry point selector for the called contract, i.e.
+                            // AccountCallArray::selector
+                            CallParam(EntryPoint::hashed(b"deployContract").0),
+                            // Length of the call data for the called contract, i.e.
+                            // AccountCallArray::data_len
+                            call_param!("4"),
+                            // classHash
+                            CallParam(SIERRA_HASH.0),
+                            // salt
+                            call_param!("0x0"),
+                            // unique
+                            call_param!("0x0"),
+                            // calldata_len
+                            call_param!("0x0"),
+                        ],
+                    },
+                ))
+            }
+
+            pub fn invoke(account_contract_address: ContractAddress) -> BroadcastedTransaction {
+                BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(
+                    BroadcastedInvokeTransactionV1 {
+                        nonce: transaction_nonce!("0x2"),
+                        version: TransactionVersion::ONE,
+                        max_fee: MAX_FEE,
+                        signature: vec![],
+                        sender_address: account_contract_address,
+                        calldata: vec![
+                            CallParam(*DEPLOYED_CONTRACT_ADDRESS.get()),
+                            // Entry point selector for the called contract, i.e.
+                            // AccountCallArray::selector
+                            CallParam(EntryPoint::hashed(b"get_data").0),
+                            // Length of the call data for the called contract, i.e.
+                            // AccountCallArray::data_len
+                            call_param!("0"),
+                        ],
+                    },
+                ))
+            }
+
+            pub fn invoke_v3(account_contract_address: ContractAddress) -> BroadcastedTransaction {
+                BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V3(
+                    BroadcastedInvokeTransactionV3 {
+                        version: TransactionVersion::THREE,
+                        signature: vec![],
+                        nonce: transaction_nonce!("0x3"),
+                        resource_bounds: ResourceBounds {
+                            l1_gas: ResourceBound {
+                                max_amount: ResourceAmount(10000),
+                                max_price_per_unit: ResourcePricePerUnit(100000000),
+                            },
+                            l2_gas: ResourceBound {
+                                max_amount: ResourceAmount(10000),
+                                max_price_per_unit: ResourcePricePerUnit(100000000),
+                            },
+                            l1_data_gas: None,
+                        },
+                        tip: Tip(0),
+                        paymaster_data: vec![],
+                        account_deployment_data: vec![],
+                        nonce_data_availability_mode: crate::types::DataAvailabilityMode::L1,
+                        fee_data_availability_mode: crate::types::DataAvailabilityMode::L1,
+                        sender_address: account_contract_address,
+                        calldata: vec![
+                            CallParam(*DEPLOYED_CONTRACT_ADDRESS.get()),
+                            // Entry point selector for the called contract, i.e.
+                            // AccountCallArray::selector
+                            CallParam(EntryPoint::hashed(b"get_data").0),
+                            // Length of the call data for the called contract, i.e.
+                            // AccountCallArray::data_len
+                            call_param!("0"),
+                        ],
+                    },
+                ))
+            }
         }
 
         pub mod expected_output_0_13_1_1 {
+
             use pathfinder_common::{BlockHeader, ContractAddress, SierraHash, StorageValue};
 
-            use super::dto::*;
             use super::*;
-            use crate::method::get_state_update::types::{
-                DeclaredSierraClass,
-                StorageDiff,
-                StorageEntry,
-            };
+            use crate::method::get_state_update::types::{StorageDiff, StorageEntry};
 
             const DECLARE_OVERALL_FEE: u64 = 1262;
             const DECLARE_GAS_CONSUMED: u64 = 878;
@@ -528,108 +714,134 @@ pub(crate) mod tests {
             pub fn declare(
                 account_contract_address: ContractAddress,
                 last_block_header: &BlockHeader,
-            ) -> SimulatedTransaction {
-                SimulatedTransaction {
-                    fee_estimation: FeeEstimate {
-                        gas_consumed: DECLARE_GAS_CONSUMED.into(),
-                        gas_price: 1.into(),
-                        data_gas_consumed: Some(DECLARE_DATA_GAS_CONSUMED.into()),
-                        data_gas_price: Some(2.into()),
+            ) -> pathfinder_executor::types::TransactionSimulation {
+                pathfinder_executor::types::TransactionSimulation {
+                    fee_estimation: pathfinder_executor::types::FeeEstimate {
+                        l1_gas_consumed: DECLARE_GAS_CONSUMED.into(),
+                        l1_gas_price: 1.into(),
+                        l1_data_gas_consumed: DECLARE_DATA_GAS_CONSUMED.into(),
+                        l1_data_gas_price: 2.into(),
+                        l2_gas_consumed: 0.into(),
+                        l2_gas_price: 0.into(),
                         overall_fee: DECLARE_OVERALL_FEE.into(),
-                        unit: PriceUnit::Wei,
+                        unit: pathfinder_executor::types::PriceUnit::Wei,
                     },
-                    transaction_trace: TransactionTrace::Declare(DeclareTxnTrace {
-                        fee_transfer_invocation: Some(declare_fee_transfer(
-                            account_contract_address,
-                            last_block_header,
-                        )),
-                        validate_invocation: Some(declare_validate(account_contract_address)),
-                        state_diff: Some(declare_state_diff(
-                            account_contract_address,
-                            declare_fee_transfer_storage_diffs(),
-                        )),
-                        execution_resources: Some(ExecutionResources {
-                            computation_resources: declare_validate_computation_resources()
-                                + declare_fee_transfer_computation_resources(),
-                            data_availability: DataAvailabilityResources {
+                    trace: pathfinder_executor::types::TransactionTrace::Declare(
+                        pathfinder_executor::types::DeclareTransactionTrace {
+                            fee_transfer_invocation: Some(declare_fee_transfer(
+                                account_contract_address,
+                                last_block_header,
+                            )),
+                            validate_invocation: Some(declare_validate(account_contract_address)),
+                            state_diff: declare_state_diff(
+                                account_contract_address,
+                                declare_fee_transfer_storage_diffs(),
+                            ),
+                            execution_resources: pathfinder_executor::types::ExecutionResources {
+                                computation_resources: declare_validate_computation_resources()
+                                    + declare_fee_transfer_computation_resources(),
+                                data_availability:
+                                    pathfinder_executor::types::DataAvailabilityResources {
+                                        l1_gas: 0,
+                                        l1_data_gas: 192,
+                                    },
                                 l1_gas: 0,
                                 l1_data_gas: 192,
+                                l2_gas: 0,
                             },
-                        }),
-                    }),
+                        },
+                    ),
                 }
             }
 
             pub fn declare_without_fee_transfer(
                 account_contract_address: ContractAddress,
-            ) -> SimulatedTransaction {
-                SimulatedTransaction {
-                    fee_estimation: FeeEstimate {
-                        gas_consumed: DECLARE_GAS_CONSUMED.into(),
-                        gas_price: 1.into(),
-                        data_gas_consumed: Some(DECLARE_DATA_GAS_CONSUMED.into()),
-                        data_gas_price: Some(2.into()),
+            ) -> pathfinder_executor::types::TransactionSimulation {
+                pathfinder_executor::types::TransactionSimulation {
+                    fee_estimation: pathfinder_executor::types::FeeEstimate {
+                        l1_gas_consumed: DECLARE_GAS_CONSUMED.into(),
+                        l1_gas_price: 1.into(),
+                        l1_data_gas_consumed: DECLARE_DATA_GAS_CONSUMED.into(),
+                        l1_data_gas_price: 2.into(),
+                        l2_gas_consumed: 0.into(),
+                        l2_gas_price: 0.into(),
                         overall_fee: DECLARE_OVERALL_FEE.into(),
-                        unit: PriceUnit::Wei,
+                        unit: pathfinder_executor::types::PriceUnit::Wei,
                     },
-                    transaction_trace: TransactionTrace::Declare(DeclareTxnTrace {
-                        fee_transfer_invocation: None,
-                        validate_invocation: Some(declare_validate(account_contract_address)),
-                        state_diff: Some(declare_state_diff(account_contract_address, vec![])),
-                        execution_resources: Some(ExecutionResources {
-                            computation_resources: declare_validate_computation_resources(),
-                            data_availability: DataAvailabilityResources {
+                    trace: pathfinder_executor::types::TransactionTrace::Declare(
+                        pathfinder_executor::types::DeclareTransactionTrace {
+                            fee_transfer_invocation: None,
+                            validate_invocation: Some(declare_validate(account_contract_address)),
+                            state_diff: declare_state_diff(account_contract_address, vec![]),
+                            execution_resources: pathfinder_executor::types::ExecutionResources {
+                                computation_resources: declare_validate_computation_resources(),
+                                data_availability:
+                                    pathfinder_executor::types::DataAvailabilityResources {
+                                        l1_gas: 0,
+                                        l1_data_gas: 192,
+                                    },
                                 l1_gas: 0,
                                 l1_data_gas: 192,
+                                l2_gas: 0,
                             },
-                        }),
-                    }),
+                        },
+                    ),
                 }
             }
 
             pub fn declare_without_validate(
                 account_contract_address: ContractAddress,
                 last_block_header: &BlockHeader,
-            ) -> SimulatedTransaction {
-                SimulatedTransaction {
-                    fee_estimation: FeeEstimate {
-                        gas_consumed: DECLARE_GAS_CONSUMED.into(),
-                        gas_price: 1.into(),
-                        data_gas_consumed: Some(DECLARE_DATA_GAS_CONSUMED.into()),
-                        data_gas_price: Some(2.into()),
+            ) -> pathfinder_executor::types::TransactionSimulation {
+                pathfinder_executor::types::TransactionSimulation {
+                    fee_estimation: pathfinder_executor::types::FeeEstimate {
+                        l1_gas_consumed: DECLARE_GAS_CONSUMED.into(),
+                        l1_gas_price: 1.into(),
+                        l1_data_gas_consumed: DECLARE_DATA_GAS_CONSUMED.into(),
+                        l1_data_gas_price: 2.into(),
+                        l2_gas_consumed: 0.into(),
+                        l2_gas_price: 0.into(),
                         overall_fee: DECLARE_OVERALL_FEE.into(),
-                        unit: PriceUnit::Wei,
+                        unit: pathfinder_executor::types::PriceUnit::Wei,
                     },
-                    transaction_trace: TransactionTrace::Declare(DeclareTxnTrace {
-                        fee_transfer_invocation: Some(declare_fee_transfer(
-                            account_contract_address,
-                            last_block_header,
-                        )),
-                        validate_invocation: None,
-                        state_diff: Some(declare_state_diff(
-                            account_contract_address,
-                            declare_fee_transfer_storage_diffs(),
-                        )),
-                        execution_resources: Some(ExecutionResources {
-                            computation_resources: declare_fee_transfer_computation_resources(),
-                            data_availability: DataAvailabilityResources {
+                    trace: pathfinder_executor::types::TransactionTrace::Declare(
+                        pathfinder_executor::types::DeclareTransactionTrace {
+                            fee_transfer_invocation: Some(declare_fee_transfer(
+                                account_contract_address,
+                                last_block_header,
+                            )),
+                            validate_invocation: None,
+                            state_diff: declare_state_diff(
+                                account_contract_address,
+                                declare_fee_transfer_storage_diffs(),
+                            ),
+                            execution_resources: pathfinder_executor::types::ExecutionResources {
+                                computation_resources: declare_fee_transfer_computation_resources(),
+                                data_availability:
+                                    pathfinder_executor::types::DataAvailabilityResources {
+                                        l1_gas: 0,
+                                        l1_data_gas: 192,
+                                    },
                                 l1_gas: 0,
                                 l1_data_gas: 192,
+                                l2_gas: 0,
                             },
-                        }),
-                    }),
+                        },
+                    ),
                 }
             }
 
-            fn declare_validate_computation_resources() -> ComputationResources {
-                ComputationResources {
+            fn declare_validate_computation_resources(
+            ) -> pathfinder_executor::types::ComputationResources {
+                pathfinder_executor::types::ComputationResources {
                     steps: 12,
                     ..Default::default()
                 }
             }
 
-            fn declare_fee_transfer_computation_resources() -> ComputationResources {
-                ComputationResources {
+            fn declare_fee_transfer_computation_resources(
+            ) -> pathfinder_executor::types::ComputationResources {
+                pathfinder_executor::types::ComputationResources {
                     steps: 1354,
                     memory_holes: 59,
                     range_check_builtin_applications: 31,
@@ -641,20 +853,33 @@ pub(crate) mod tests {
             fn declare_state_diff(
                 account_contract_address: ContractAddress,
                 storage_diffs: Vec<StorageDiff>,
-            ) -> StateDiff {
-                StateDiff {
-                    storage_diffs,
-                    deprecated_declared_classes: vec![],
-                    declared_classes: vec![DeclaredSierraClass {
+            ) -> pathfinder_executor::types::StateDiff {
+                pathfinder_executor::types::StateDiff {
+                    storage_diffs: BTreeMap::from_iter(
+                        storage_diffs
+                            .into_iter()
+                            .map(|diff| {
+                                (
+                                    diff.address,
+                                    diff.storage_entries
+                                        .into_iter()
+                                        .map(|entry| pathfinder_executor::types::StorageDiff {
+                                            key: entry.key,
+                                            value: entry.value,
+                                        })
+                                        .collect(),
+                                )
+                            })
+                            .collect::<Vec<_>>(),
+                    ),
+                    deprecated_declared_classes: HashSet::new(),
+                    declared_classes: vec![pathfinder_executor::types::DeclaredSierraClass {
                         class_hash: SierraHash(SIERRA_HASH.0),
                         compiled_class_hash: CASM_HASH,
                     }],
                     deployed_contracts: vec![],
                     replaced_classes: vec![],
-                    nonces: vec![Nonce {
-                        contract_address: account_contract_address,
-                        nonce: contract_nonce!("0x1"),
-                    }],
+                    nonces: BTreeMap::from([(account_contract_address, contract_nonce!("0x1"))]),
                 }
             }
 
@@ -677,14 +902,13 @@ pub(crate) mod tests {
             fn declare_fee_transfer(
                 account_contract_address: ContractAddress,
                 last_block_header: &BlockHeader,
-            ) -> FunctionInvocation {
-                FunctionInvocation {
-                    call_type: CallType::Call,
+            ) -> pathfinder_executor::types::FunctionInvocation {
+                pathfinder_executor::types::FunctionInvocation {
+                    call_type: pathfinder_executor::types::CallType::Call,
                     caller_address: *account_contract_address.get(),
-                    calls: vec![],
                     class_hash: Some(ERC20_CONTRACT_DEFINITION_CLASS_HASH.0),
-                    entry_point_type: EntryPointType::External,
-                    events: vec![OrderedEvent {
+                    entry_point_type: pathfinder_executor::types::EntryPointType::External,
+                    events: vec![pathfinder_executor::types::Event {
                         order: 0,
                         data: vec![
                             *account_contract_address.get(),
@@ -696,37 +920,40 @@ pub(crate) mod tests {
                             "0x0099CD8BDE557814842A3121E8DDFD433A539B8C9F14BF31EBF108D12E6196E9"
                         )],
                     }],
-                    function_call: FunctionCall {
-                        calldata: vec![
-                            CallParam(last_block_header.sequencer_address.0),
-                            CallParam(Felt::from_u64(DECLARE_OVERALL_FEE)),
-                            call_param!("0x0"),
-                        ],
-                        contract_address: pathfinder_executor::ETH_FEE_TOKEN_ADDRESS,
-                        entry_point_selector: EntryPoint::hashed(b"transfer"),
-                    },
+                    calldata: vec![
+                        last_block_header.sequencer_address.0,
+                        Felt::from_u64(DECLARE_OVERALL_FEE),
+                        felt!("0x0"),
+                    ],
+                    contract_address: pathfinder_executor::ETH_FEE_TOKEN_ADDRESS,
+                    selector: EntryPoint::hashed(b"transfer").0,
+                    internal_calls: vec![],
                     messages: vec![],
                     result: vec![felt!("0x1")],
-                    execution_resources: declare_fee_transfer_computation_resources(),
+                    computation_resources: declare_fee_transfer_computation_resources(),
+                    execution_resources:
+                        pathfinder_executor::types::InnerCallExecutionResources::default(),
                 }
             }
 
-            fn declare_validate(account_contract_address: ContractAddress) -> FunctionInvocation {
-                FunctionInvocation {
-                    call_type: CallType::Call,
+            fn declare_validate(
+                account_contract_address: ContractAddress,
+            ) -> pathfinder_executor::types::FunctionInvocation {
+                pathfinder_executor::types::FunctionInvocation {
+                    call_type: pathfinder_executor::types::CallType::Call,
                     caller_address: felt!("0x0"),
-                    calls: vec![],
                     class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
-                    entry_point_type: EntryPointType::External,
+                    entry_point_type: pathfinder_executor::types::EntryPointType::External,
                     events: vec![],
-                    function_call: FunctionCall {
-                        contract_address: account_contract_address,
-                        entry_point_selector: EntryPoint::hashed(b"__validate_declare__"),
-                        calldata: vec![CallParam(SIERRA_HASH.0)],
-                    },
+                    contract_address: account_contract_address,
+                    selector: EntryPoint::hashed(b"__validate_declare__").0,
+                    calldata: vec![SIERRA_HASH.0],
+                    internal_calls: vec![],
                     messages: vec![],
                     result: vec![],
-                    execution_resources: declare_validate_computation_resources(),
+                    computation_resources: declare_validate_computation_resources(),
+                    execution_resources:
+                        pathfinder_executor::types::InnerCallExecutionResources::default(),
                 }
             }
 
@@ -738,88 +965,106 @@ pub(crate) mod tests {
                 account_contract_address: ContractAddress,
                 last_block_header: &BlockHeader,
                 universal_deployer_address: ContractAddress,
-            ) -> SimulatedTransaction {
-                SimulatedTransaction {
-                    fee_estimation: FeeEstimate {
-                        gas_consumed: UNIVERSAL_DEPLOYER_GAS_CONSUMED.into(),
-                        gas_price: 1.into(),
-                        data_gas_consumed: Some(UNIVERSAL_DEPLOYER_DATA_GAS_CONSUMED.into()),
-                        data_gas_price: Some(2.into()),
+            ) -> pathfinder_executor::types::TransactionSimulation {
+                pathfinder_executor::types::TransactionSimulation {
+                    fee_estimation: pathfinder_executor::types::FeeEstimate {
+                        l1_gas_consumed: UNIVERSAL_DEPLOYER_GAS_CONSUMED.into(),
+                        l1_gas_price: 1.into(),
+                        l1_data_gas_consumed: UNIVERSAL_DEPLOYER_DATA_GAS_CONSUMED.into(),
+                        l1_data_gas_price: 2.into(),
+                        l2_gas_consumed: 0.into(),
+                        l2_gas_price: 0.into(),
                         overall_fee: UNIVERSAL_DEPLOYER_OVERALL_FEE.into(),
-                        unit: PriceUnit::Wei,
+                        unit: pathfinder_executor::types::PriceUnit::Wei,
                     },
-                    transaction_trace: TransactionTrace::Invoke(InvokeTxnTrace {
-                        validate_invocation: Some(universal_deployer_validate(
-                            account_contract_address,
-                            universal_deployer_address,
-                        )),
-                        execute_invocation: ExecuteInvocation::FunctionInvocation(
-                            universal_deployer_execute(
+                    trace: pathfinder_executor::types::TransactionTrace::Invoke(
+                        pathfinder_executor::types::InvokeTransactionTrace {
+                            validate_invocation: Some(universal_deployer_validate(
                                 account_contract_address,
                                 universal_deployer_address,
+                            )),
+                            execute_invocation:
+                                pathfinder_executor::types::ExecuteInvocation::FunctionInvocation(
+                                    Some(universal_deployer_execute(
+                                        account_contract_address,
+                                        universal_deployer_address,
+                                    )),
+                                ),
+                            fee_transfer_invocation: Some(universal_deployer_fee_transfer(
+                                account_contract_address,
+                                last_block_header,
+                            )),
+                            state_diff: universal_deployer_state_diff(
+                                account_contract_address,
+                                universal_deployer_fee_transfer_storage_diffs(),
                             ),
-                        ),
-                        fee_transfer_invocation: Some(universal_deployer_fee_transfer(
-                            account_contract_address,
-                            last_block_header,
-                        )),
-                        state_diff: Some(universal_deployer_state_diff(
-                            account_contract_address,
-                            universal_deployer_fee_transfer_storage_diffs(),
-                        )),
-                        execution_resources: Some(ExecutionResources {
-                            computation_resources: universal_deployer_validate_computation_resources(
-                            )
-                                + universal_deployer_execute_computation_resources()
-                                + universal_deployer_fee_transfer_computation_resources(),
-                            data_availability: DataAvailabilityResources {
+                            execution_resources: pathfinder_executor::types::ExecutionResources {
+                                computation_resources:
+                                    universal_deployer_validate_computation_resources()
+                                        + universal_deployer_execute_computation_resources()
+                                        + universal_deployer_fee_transfer_computation_resources(),
+                                data_availability:
+                                    pathfinder_executor::types::DataAvailabilityResources {
+                                        l1_gas: 0,
+                                        l1_data_gas: 224,
+                                    },
                                 l1_gas: 0,
                                 l1_data_gas: 224,
+                                l2_gas: 0,
                             },
-                        }),
-                    }),
+                        },
+                    ),
                 }
             }
 
             pub fn universal_deployer_without_fee_transfer(
                 account_contract_address: ContractAddress,
                 universal_deployer_address: ContractAddress,
-            ) -> SimulatedTransaction {
-                SimulatedTransaction {
-                    fee_estimation: FeeEstimate {
-                        gas_consumed: UNIVERSAL_DEPLOYER_GAS_CONSUMED.into(),
-                        gas_price: 1.into(),
-                        data_gas_consumed: Some(UNIVERSAL_DEPLOYER_DATA_GAS_CONSUMED.into()),
-                        data_gas_price: Some(2.into()),
+            ) -> pathfinder_executor::types::TransactionSimulation {
+                pathfinder_executor::types::TransactionSimulation {
+                    fee_estimation: pathfinder_executor::types::FeeEstimate {
+                        l1_gas_consumed: UNIVERSAL_DEPLOYER_GAS_CONSUMED.into(),
+                        l1_gas_price: 1.into(),
+                        l1_data_gas_consumed: UNIVERSAL_DEPLOYER_DATA_GAS_CONSUMED.into(),
+                        l1_data_gas_price: 2.into(),
+                        l2_gas_consumed: 0.into(),
+                        l2_gas_price: 0.into(),
                         overall_fee: UNIVERSAL_DEPLOYER_OVERALL_FEE.into(),
-                        unit: PriceUnit::Wei,
+                        unit: pathfinder_executor::types::PriceUnit::Wei,
                     },
-                    transaction_trace: TransactionTrace::Invoke(InvokeTxnTrace {
-                        validate_invocation: Some(universal_deployer_validate(
-                            account_contract_address,
-                            universal_deployer_address,
-                        )),
-                        execute_invocation: ExecuteInvocation::FunctionInvocation(
-                            universal_deployer_execute(
+                    trace: pathfinder_executor::types::TransactionTrace::Invoke(
+                        pathfinder_executor::types::InvokeTransactionTrace {
+                            validate_invocation: Some(universal_deployer_validate(
                                 account_contract_address,
                                 universal_deployer_address,
+                            )),
+                            execute_invocation:
+                                pathfinder_executor::types::ExecuteInvocation::FunctionInvocation(
+                                    Some(universal_deployer_execute(
+                                        account_contract_address,
+                                        universal_deployer_address,
+                                    )),
+                                ),
+                            fee_transfer_invocation: None,
+                            state_diff: universal_deployer_state_diff(
+                                account_contract_address,
+                                vec![],
                             ),
-                        ),
-                        fee_transfer_invocation: None,
-                        state_diff: Some(universal_deployer_state_diff(
-                            account_contract_address,
-                            vec![],
-                        )),
-                        execution_resources: Some(ExecutionResources {
-                            computation_resources: universal_deployer_validate_computation_resources(
-                            )
-                                + universal_deployer_execute_computation_resources(),
-                            data_availability: DataAvailabilityResources {
+                            execution_resources: pathfinder_executor::types::ExecutionResources {
+                                computation_resources:
+                                    universal_deployer_validate_computation_resources()
+                                        + universal_deployer_execute_computation_resources(),
+                                data_availability:
+                                    pathfinder_executor::types::DataAvailabilityResources {
+                                        l1_gas: 0,
+                                        l1_data_gas: 224,
+                                    },
                                 l1_gas: 0,
                                 l1_data_gas: 224,
+                                l2_gas: 0,
                             },
-                        }),
-                    }),
+                        },
+                    ),
                 }
             }
 
@@ -827,55 +1072,66 @@ pub(crate) mod tests {
                 account_contract_address: ContractAddress,
                 last_block_header: &BlockHeader,
                 universal_deployer_address: ContractAddress,
-            ) -> SimulatedTransaction {
-                SimulatedTransaction {
-                    fee_estimation: FeeEstimate {
-                        gas_consumed: UNIVERSAL_DEPLOYER_GAS_CONSUMED.into(),
-                        gas_price: 1.into(),
-                        data_gas_consumed: Some(UNIVERSAL_DEPLOYER_DATA_GAS_CONSUMED.into()),
-                        data_gas_price: Some(2.into()),
+            ) -> pathfinder_executor::types::TransactionSimulation {
+                pathfinder_executor::types::TransactionSimulation {
+                    fee_estimation: pathfinder_executor::types::FeeEstimate {
+                        l1_gas_consumed: UNIVERSAL_DEPLOYER_GAS_CONSUMED.into(),
+                        l1_gas_price: 1.into(),
+                        l1_data_gas_consumed: UNIVERSAL_DEPLOYER_DATA_GAS_CONSUMED.into(),
+                        l1_data_gas_price: 2.into(),
+                        l2_gas_consumed: 0.into(),
+                        l2_gas_price: 0.into(),
                         overall_fee: UNIVERSAL_DEPLOYER_OVERALL_FEE.into(),
-                        unit: PriceUnit::Wei,
+                        unit: pathfinder_executor::types::PriceUnit::Wei,
                     },
-                    transaction_trace: TransactionTrace::Invoke(InvokeTxnTrace {
-                        validate_invocation: None,
-                        execute_invocation: ExecuteInvocation::FunctionInvocation(
-                            universal_deployer_execute(
+                    trace: pathfinder_executor::types::TransactionTrace::Invoke(
+                        pathfinder_executor::types::InvokeTransactionTrace {
+                            validate_invocation: None,
+                            execute_invocation:
+                                pathfinder_executor::types::ExecuteInvocation::FunctionInvocation(
+                                    Some(universal_deployer_execute(
+                                        account_contract_address,
+                                        universal_deployer_address,
+                                    )),
+                                ),
+                            fee_transfer_invocation: Some(universal_deployer_fee_transfer(
                                 account_contract_address,
-                                universal_deployer_address,
+                                last_block_header,
+                            )),
+                            state_diff: universal_deployer_state_diff(
+                                account_contract_address,
+                                universal_deployer_fee_transfer_storage_diffs(),
                             ),
-                        ),
-                        fee_transfer_invocation: Some(universal_deployer_fee_transfer(
-                            account_contract_address,
-                            last_block_header,
-                        )),
-                        state_diff: Some(universal_deployer_state_diff(
-                            account_contract_address,
-                            universal_deployer_fee_transfer_storage_diffs(),
-                        )),
-                        execution_resources: Some(ExecutionResources {
-                            computation_resources:
-                                universal_deployer_fee_transfer_computation_resources()
-                                    + universal_deployer_execute_computation_resources(),
-                            data_availability: DataAvailabilityResources {
+                            execution_resources: pathfinder_executor::types::ExecutionResources {
+                                computation_resources:
+                                    universal_deployer_fee_transfer_computation_resources()
+                                        + universal_deployer_execute_computation_resources(),
+                                data_availability:
+                                    pathfinder_executor::types::DataAvailabilityResources {
+                                        l1_gas: 0,
+                                        l1_data_gas: 224,
+                                    },
                                 l1_gas: 0,
                                 l1_data_gas: 224,
+                                l2_gas: 0,
                             },
-                        }),
-                    }),
+                        },
+                    ),
                 }
             }
 
-            fn universal_deployer_validate_computation_resources() -> ComputationResources {
-                ComputationResources {
+            fn universal_deployer_validate_computation_resources(
+            ) -> pathfinder_executor::types::ComputationResources {
+                pathfinder_executor::types::ComputationResources {
                     steps: 21,
                     range_check_builtin_applications: 1,
                     ..Default::default()
                 }
             }
 
-            fn universal_deployer_execute_computation_resources() -> ComputationResources {
-                ComputationResources {
+            fn universal_deployer_execute_computation_resources(
+            ) -> pathfinder_executor::types::ComputationResources {
+                pathfinder_executor::types::ComputationResources {
                     steps: 2061,
                     memory_holes: 2,
                     range_check_builtin_applications: 44,
@@ -884,8 +1140,9 @@ pub(crate) mod tests {
                 }
             }
 
-            fn universal_deployer_fee_transfer_computation_resources() -> ComputationResources {
-                ComputationResources {
+            fn universal_deployer_fee_transfer_computation_resources(
+            ) -> pathfinder_executor::types::ComputationResources {
+                pathfinder_executor::types::ComputationResources {
                     steps: 1354,
                     memory_holes: 59,
                     range_check_builtin_applications: 31,
@@ -897,20 +1154,33 @@ pub(crate) mod tests {
             fn universal_deployer_state_diff(
                 account_contract_address: ContractAddress,
                 storage_diffs: Vec<StorageDiff>,
-            ) -> StateDiff {
-                StateDiff {
-                    storage_diffs,
-                    deprecated_declared_classes: vec![],
+            ) -> pathfinder_executor::types::StateDiff {
+                pathfinder_executor::types::StateDiff {
+                    storage_diffs: BTreeMap::from_iter(
+                        storage_diffs
+                            .into_iter()
+                            .map(|diff| {
+                                (
+                                    diff.address,
+                                    diff.storage_entries
+                                        .into_iter()
+                                        .map(|entry| pathfinder_executor::types::StorageDiff {
+                                            key: entry.key,
+                                            value: entry.value,
+                                        })
+                                        .collect(),
+                                )
+                            })
+                            .collect::<Vec<_>>(),
+                    ),
+                    deprecated_declared_classes: HashSet::new(),
                     declared_classes: vec![],
-                    deployed_contracts: vec![DeployedContract {
+                    deployed_contracts: vec![pathfinder_executor::types::DeployedContract {
                         address: DEPLOYED_CONTRACT_ADDRESS,
                         class_hash: SIERRA_HASH,
                     }],
                     replaced_classes: vec![],
-                    nonces: vec![Nonce {
-                        contract_address: account_contract_address,
-                        nonce: contract_nonce!("0x2"),
-                    }],
+                    nonces: BTreeMap::from([(account_contract_address, contract_nonce!("0x2"))]),
                 }
             }
 
@@ -933,71 +1203,70 @@ pub(crate) mod tests {
             fn universal_deployer_validate(
                 account_contract_address: ContractAddress,
                 universal_deployer_address: ContractAddress,
-            ) -> FunctionInvocation {
-                FunctionInvocation {
-                    call_type: CallType::Call,
+            ) -> pathfinder_executor::types::FunctionInvocation {
+                pathfinder_executor::types::FunctionInvocation {
+                    call_type: pathfinder_executor::types::CallType::Call,
                     caller_address: felt!("0x0"),
-                    calls: vec![],
                     class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
-                    entry_point_type: EntryPointType::External,
+                    entry_point_type: pathfinder_executor::types::EntryPointType::External,
+                    internal_calls: vec![],
                     events: vec![],
-                    function_call: FunctionCall {
-                        contract_address: account_contract_address,
-                        entry_point_selector: EntryPoint::hashed(b"__validate__"),
-                        calldata: vec![
-                            CallParam(universal_deployer_address.0),
-                            CallParam(EntryPoint::hashed(b"deployContract").0),
-                            // calldata_len
-                            call_param!("0x4"),
-                            // classHash
-                            CallParam(SIERRA_HASH.0),
-                            // salt
-                            call_param!("0x0"),
-                            // unique
-                            call_param!("0x0"),
-                            // calldata_len
-                            call_param!("0x0"),
-                        ],
-                    },
+                    contract_address: account_contract_address,
+                    selector: EntryPoint::hashed(b"__validate__").0,
+                    calldata: vec![
+                        universal_deployer_address.0,
+                        EntryPoint::hashed(b"deployContract").0,
+                        // calldata_len
+                        call_param!("0x4").0,
+                        // classHash
+                        SIERRA_HASH.0,
+                        // salt
+                        call_param!("0x0").0,
+                        // unique
+                        call_param!("0x0").0,
+                        // calldata_len
+                        call_param!("0x0").0,
+                    ],
                     messages: vec![],
                     result: vec![],
-                    execution_resources: universal_deployer_validate_computation_resources(),
+                    computation_resources: universal_deployer_validate_computation_resources(),
+                    execution_resources:
+                        pathfinder_executor::types::InnerCallExecutionResources::default(),
                 }
             }
 
             fn universal_deployer_execute(
                 account_contract_address: ContractAddress,
                 universal_deployer_address: ContractAddress,
-            ) -> FunctionInvocation {
-                FunctionInvocation {
-                    call_type: CallType::Call,
+            ) -> pathfinder_executor::types::FunctionInvocation {
+                pathfinder_executor::types::FunctionInvocation {
+                    call_type: pathfinder_executor::types::CallType::Call,
                     caller_address: felt!("0x0"),
-                    calls: vec![
-                        FunctionInvocation {
-                            call_type: CallType::Call,
+                    internal_calls: vec![
+                        pathfinder_executor::types::FunctionInvocation {
+                            call_type: pathfinder_executor::types::CallType::Call,
                             caller_address: *account_contract_address.get(),
-                            calls: vec![
-                                FunctionInvocation {
-                                    call_type: CallType::Call,
+                            internal_calls: vec![
+                                pathfinder_executor::types::FunctionInvocation {
+                                    call_type: pathfinder_executor::types::CallType::Call,
                                     caller_address: *universal_deployer_address.get(),
-                                    calls: vec![],
+                                    internal_calls: vec![],
                                     class_hash: Some(SIERRA_HASH.0),
-                                    entry_point_type: EntryPointType::Constructor,
+                                    entry_point_type: pathfinder_executor::types::EntryPointType::Constructor,
                                     events: vec![],
-                                    function_call: FunctionCall {
-                                        contract_address: DEPLOYED_CONTRACT_ADDRESS,
-                                        entry_point_selector: EntryPoint::hashed(b"constructor"),
-                                        calldata: vec![],
-                                    },
+                                    contract_address: DEPLOYED_CONTRACT_ADDRESS,
+                                    selector: EntryPoint::hashed(b"constructor").0,
+                                    calldata: vec![],
                                     messages: vec![],
                                     result: vec![],
-                                    execution_resources: ComputationResources::default(),
+                                    computation_resources: pathfinder_executor::types::ComputationResources::default(),
+                                    execution_resources: pathfinder_executor::types::InnerCallExecutionResources::default(),
                                 },
                             ],
                             class_hash: Some(UNIVERSAL_DEPLOYER_CLASS_HASH.0),
-                            entry_point_type: EntryPointType::External,
+                            entry_point_type: pathfinder_executor::types::EntryPointType::External,
                             events: vec![
-                                OrderedEvent {
+                                pathfinder_executor::types::Event {
                                     order: 0,
                                     data: vec![
                                         *DEPLOYED_CONTRACT_ADDRESS.get(),
@@ -1012,72 +1281,70 @@ pub(crate) mod tests {
                                     ]
                                 },
                             ],
-                            function_call: FunctionCall {
-                                contract_address: universal_deployer_address,
-                                entry_point_selector: EntryPoint::hashed(b"deployContract"),
-                                calldata: vec![
-                                    // classHash
-                                    CallParam(SIERRA_HASH.0),
-                                    // salt
-                                    call_param!("0x0"),
-                                    // unique
-                                    call_param!("0x0"),
-                                    //  calldata_len
-                                    call_param!("0x0"),
-                                ],
-                            },
+                            contract_address: universal_deployer_address,
+                            selector: EntryPoint::hashed(b"deployContract").0,
+                            calldata: vec![
+                                // classHash
+                                SIERRA_HASH.0,
+                                // salt
+                                call_param!("0x0").0,
+                                // unique
+                                call_param!("0x0").0,
+                                //  calldata_len
+                                call_param!("0x0").0,
+                            ],
                             messages: vec![],
                             result: vec![
                                 *DEPLOYED_CONTRACT_ADDRESS.get(),
                             ],
-                            execution_resources: ComputationResources {
+                            computation_resources: pathfinder_executor::types::ComputationResources {
                                 steps: 1262,
                                 memory_holes: 2,
                                 range_check_builtin_applications: 23,
                                 pedersen_builtin_applications: 7,
                                 ..Default::default()
                             },
+                            execution_resources: pathfinder_executor::types::InnerCallExecutionResources::default(),
                         }
                     ],
                     class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
-                    entry_point_type: EntryPointType::External,
+                    entry_point_type: pathfinder_executor::types::EntryPointType::External,
                     events: vec![],
-                    function_call: FunctionCall {
-                        contract_address: account_contract_address,
-                        entry_point_selector: EntryPoint::hashed(b"__execute__"),
-                        calldata: vec![
-                            CallParam(universal_deployer_address.0),
-                            CallParam(EntryPoint::hashed(b"deployContract").0),
-                            call_param!("0x4"),
-                            // classHash
-                            CallParam(SIERRA_HASH.0),
-                            // salt
-                            call_param!("0x0"),
-                            // unique
-                            call_param!("0x0"),
-                            // calldata_len
-                            call_param!("0x0"),
-                        ],
-                    },
+                    contract_address: account_contract_address,
+                    selector: EntryPoint::hashed(b"__execute__").0,
+                    calldata: vec![
+                        universal_deployer_address.0,
+                        EntryPoint::hashed(b"deployContract").0,
+                        call_param!("0x4").0,
+                        // classHash
+                        SIERRA_HASH.0,
+                        // salt
+                        call_param!("0x0").0,
+                        // unique
+                        call_param!("0x0").0,
+                        // calldata_len
+                        call_param!("0x0").0,
+                    ],
                     messages: vec![],
                     result: vec![
                         *DEPLOYED_CONTRACT_ADDRESS.get(),
                     ],
-                    execution_resources: universal_deployer_execute_computation_resources(),
+                    computation_resources: universal_deployer_execute_computation_resources(),
+                    execution_resources: pathfinder_executor::types::InnerCallExecutionResources::default(),
                 }
             }
 
             fn universal_deployer_fee_transfer(
                 account_contract_address: ContractAddress,
                 last_block_header: &BlockHeader,
-            ) -> FunctionInvocation {
-                FunctionInvocation {
-                    call_type: CallType::Call,
+            ) -> pathfinder_executor::types::FunctionInvocation {
+                pathfinder_executor::types::FunctionInvocation {
+                    call_type: pathfinder_executor::types::CallType::Call,
                     caller_address: *account_contract_address.get(),
-                    calls: vec![],
+                    internal_calls: vec![],
                     class_hash: Some(ERC20_CONTRACT_DEFINITION_CLASS_HASH.0),
-                    entry_point_type: EntryPointType::External,
-                    events: vec![OrderedEvent {
+                    entry_point_type: pathfinder_executor::types::EntryPointType::External,
+                    events: vec![pathfinder_executor::types::Event {
                         order: 0,
                         data: vec![
                             *account_contract_address.get(),
@@ -1089,19 +1356,19 @@ pub(crate) mod tests {
                             "0x0099CD8BDE557814842A3121E8DDFD433A539B8C9F14BF31EBF108D12E6196E9"
                         )],
                     }],
-                    function_call: FunctionCall {
-                        calldata: vec![
-                            CallParam(last_block_header.sequencer_address.0),
-                            CallParam(Felt::from_u64(UNIVERSAL_DEPLOYER_OVERALL_FEE)),
-                            // calldata_len
-                            call_param!("0x0"),
-                        ],
-                        contract_address: pathfinder_executor::ETH_FEE_TOKEN_ADDRESS,
-                        entry_point_selector: EntryPoint::hashed(b"transfer"),
-                    },
+                    calldata: vec![
+                        last_block_header.sequencer_address.0,
+                        Felt::from_u64(UNIVERSAL_DEPLOYER_OVERALL_FEE),
+                        // calldata_len
+                        call_param!("0x0").0,
+                    ],
+                    contract_address: pathfinder_executor::ETH_FEE_TOKEN_ADDRESS,
+                    selector: EntryPoint::hashed(b"transfer").0,
                     messages: vec![],
                     result: vec![felt!("0x1")],
-                    execution_resources: universal_deployer_fee_transfer_computation_resources(),
+                    computation_resources: universal_deployer_fee_transfer_computation_resources(),
+                    execution_resources:
+                        pathfinder_executor::types::InnerCallExecutionResources::default(),
                 }
             }
 
@@ -1113,73 +1380,95 @@ pub(crate) mod tests {
                 account_contract_address: ContractAddress,
                 last_block_header: &BlockHeader,
                 test_storage_value: StorageValue,
-            ) -> SimulatedTransaction {
-                SimulatedTransaction {
-                    fee_estimation: FeeEstimate {
-                        gas_consumed: INVOKE_GAS_CONSUMED.into(),
-                        gas_price: 1.into(),
-                        data_gas_consumed: Some(INVOKE_DATA_GAS_CONSUMED.into()),
-                        data_gas_price: Some(2.into()),
+            ) -> pathfinder_executor::types::TransactionSimulation {
+                pathfinder_executor::types::TransactionSimulation {
+                    fee_estimation: pathfinder_executor::types::FeeEstimate {
+                        l1_gas_consumed: INVOKE_GAS_CONSUMED.into(),
+                        l1_gas_price: 1.into(),
+                        l1_data_gas_consumed: INVOKE_DATA_GAS_CONSUMED.into(),
+                        l1_data_gas_price: 2.into(),
+                        l2_gas_consumed: 0.into(),
+                        l2_gas_price: 0.into(),
                         overall_fee: INVOKE_OVERALL_FEE.into(),
-                        unit: PriceUnit::Wei,
+                        unit: pathfinder_executor::types::PriceUnit::Wei,
                     },
-                    transaction_trace: TransactionTrace::Invoke(InvokeTxnTrace {
-                        validate_invocation: Some(invoke_validate(account_contract_address)),
-                        execute_invocation: ExecuteInvocation::FunctionInvocation(invoke_execute(
-                            account_contract_address,
-                            test_storage_value,
-                        )),
-                        fee_transfer_invocation: Some(invoke_fee_transfer(
-                            account_contract_address,
-                            last_block_header,
-                        )),
-                        state_diff: Some(invoke_state_diff(
-                            account_contract_address,
-                            invoke_fee_transfer_storage_diffs(),
-                        )),
-                        execution_resources: Some(ExecutionResources {
-                            computation_resources: invoke_validate_computation_resources()
-                                + invoke_execute_computation_resources()
-                                + invoke_fee_transfer_computation_resources(),
-                            data_availability: DataAvailabilityResources {
+                    trace: pathfinder_executor::types::TransactionTrace::Invoke(
+                        pathfinder_executor::types::InvokeTransactionTrace {
+                            validate_invocation: Some(invoke_validate(account_contract_address)),
+                            execute_invocation:
+                                pathfinder_executor::types::ExecuteInvocation::FunctionInvocation(
+                                    Some(invoke_execute(
+                                        account_contract_address,
+                                        test_storage_value,
+                                    )),
+                                ),
+                            fee_transfer_invocation: Some(invoke_fee_transfer(
+                                account_contract_address,
+                                last_block_header,
+                            )),
+                            state_diff: invoke_state_diff(
+                                account_contract_address,
+                                invoke_fee_transfer_storage_diffs(),
+                            ),
+                            execution_resources: pathfinder_executor::types::ExecutionResources {
+                                computation_resources: invoke_validate_computation_resources()
+                                    + invoke_execute_computation_resources()
+                                    + invoke_fee_transfer_computation_resources(),
+                                data_availability:
+                                    pathfinder_executor::types::DataAvailabilityResources {
+                                        l1_gas: 0,
+                                        l1_data_gas: 128,
+                                    },
                                 l1_gas: 0,
                                 l1_data_gas: 128,
+                                l2_gas: 0,
                             },
-                        }),
-                    }),
+                        },
+                    ),
                 }
             }
 
             pub fn invoke_without_fee_transfer(
                 account_contract_address: ContractAddress,
                 test_storage_value: StorageValue,
-            ) -> SimulatedTransaction {
-                SimulatedTransaction {
-                    fee_estimation: FeeEstimate {
-                        gas_consumed: INVOKE_GAS_CONSUMED.into(),
-                        gas_price: 1.into(),
-                        data_gas_consumed: Some(INVOKE_DATA_GAS_CONSUMED.into()),
-                        data_gas_price: Some(2.into()),
+            ) -> pathfinder_executor::types::TransactionSimulation {
+                pathfinder_executor::types::TransactionSimulation {
+                    fee_estimation: pathfinder_executor::types::FeeEstimate {
+                        l1_gas_consumed: INVOKE_GAS_CONSUMED.into(),
+                        l1_gas_price: 1.into(),
+                        l1_data_gas_consumed: INVOKE_DATA_GAS_CONSUMED.into(),
+                        l1_data_gas_price: 2.into(),
+                        l2_gas_consumed: 0.into(),
+                        l2_gas_price: 0.into(),
                         overall_fee: INVOKE_OVERALL_FEE.into(),
-                        unit: PriceUnit::Wei,
+                        unit: pathfinder_executor::types::PriceUnit::Wei,
                     },
-                    transaction_trace: TransactionTrace::Invoke(InvokeTxnTrace {
-                        validate_invocation: Some(invoke_validate(account_contract_address)),
-                        execute_invocation: ExecuteInvocation::FunctionInvocation(invoke_execute(
-                            account_contract_address,
-                            test_storage_value,
-                        )),
-                        fee_transfer_invocation: None,
-                        state_diff: Some(invoke_state_diff(account_contract_address, vec![])),
-                        execution_resources: Some(ExecutionResources {
-                            computation_resources: invoke_execute_computation_resources()
-                                + invoke_validate_computation_resources(),
-                            data_availability: DataAvailabilityResources {
-                                l1_gas: 0,
+                    trace: pathfinder_executor::types::TransactionTrace::Invoke(
+                        pathfinder_executor::types::InvokeTransactionTrace {
+                            validate_invocation: Some(invoke_validate(account_contract_address)),
+                            execute_invocation:
+                                pathfinder_executor::types::ExecuteInvocation::FunctionInvocation(
+                                    Some(invoke_execute(
+                                        account_contract_address,
+                                        test_storage_value,
+                                    )),
+                                ),
+                            fee_transfer_invocation: None,
+                            state_diff: invoke_state_diff(account_contract_address, vec![]),
+                            execution_resources: pathfinder_executor::types::ExecutionResources {
+                                computation_resources: invoke_execute_computation_resources()
+                                    + invoke_validate_computation_resources(),
+                                data_availability:
+                                    pathfinder_executor::types::DataAvailabilityResources {
+                                        l1_gas: 0,
+                                        l1_data_gas: 128,
+                                    },
+                                l1_gas: 12,
                                 l1_data_gas: 128,
+                                l2_gas: 0,
                             },
-                        }),
-                    }),
+                        },
+                    ),
                 }
             }
 
@@ -1187,60 +1476,74 @@ pub(crate) mod tests {
                 account_contract_address: ContractAddress,
                 last_block_header: &BlockHeader,
                 test_storage_value: StorageValue,
-            ) -> SimulatedTransaction {
-                SimulatedTransaction {
-                    fee_estimation: FeeEstimate {
-                        gas_consumed: INVOKE_GAS_CONSUMED.into(),
-                        gas_price: 1.into(),
-                        data_gas_consumed: Some(INVOKE_DATA_GAS_CONSUMED.into()),
-                        data_gas_price: Some(2.into()),
+            ) -> pathfinder_executor::types::TransactionSimulation {
+                pathfinder_executor::types::TransactionSimulation {
+                    fee_estimation: pathfinder_executor::types::FeeEstimate {
+                        l1_gas_consumed: INVOKE_GAS_CONSUMED.into(),
+                        l1_gas_price: 1.into(),
+                        l1_data_gas_consumed: INVOKE_DATA_GAS_CONSUMED.into(),
+                        l1_data_gas_price: 2.into(),
+                        l2_gas_consumed: 0.into(),
+                        l2_gas_price: 0.into(),
                         overall_fee: INVOKE_OVERALL_FEE.into(),
-                        unit: PriceUnit::Wei,
+                        unit: pathfinder_executor::types::PriceUnit::Wei,
                     },
-                    transaction_trace: TransactionTrace::Invoke(InvokeTxnTrace {
-                        validate_invocation: None,
-                        execute_invocation: ExecuteInvocation::FunctionInvocation(invoke_execute(
-                            account_contract_address,
-                            test_storage_value,
-                        )),
-                        fee_transfer_invocation: Some(invoke_fee_transfer(
-                            account_contract_address,
-                            last_block_header,
-                        )),
-                        state_diff: Some(invoke_state_diff(
-                            account_contract_address,
-                            invoke_fee_transfer_storage_diffs(),
-                        )),
-                        execution_resources: Some(ExecutionResources {
-                            computation_resources: invoke_execute_computation_resources()
-                                + invoke_fee_transfer_computation_resources(),
-                            data_availability: DataAvailabilityResources {
+                    trace: pathfinder_executor::types::TransactionTrace::Invoke(
+                        pathfinder_executor::types::InvokeTransactionTrace {
+                            validate_invocation: None,
+                            execute_invocation:
+                                pathfinder_executor::types::ExecuteInvocation::FunctionInvocation(
+                                    Some(invoke_execute(
+                                        account_contract_address,
+                                        test_storage_value,
+                                    )),
+                                ),
+                            fee_transfer_invocation: Some(invoke_fee_transfer(
+                                account_contract_address,
+                                last_block_header,
+                            )),
+                            state_diff: invoke_state_diff(
+                                account_contract_address,
+                                invoke_fee_transfer_storage_diffs(),
+                            ),
+                            execution_resources: pathfinder_executor::types::ExecutionResources {
+                                computation_resources: invoke_execute_computation_resources()
+                                    + invoke_fee_transfer_computation_resources(),
+                                data_availability:
+                                    pathfinder_executor::types::DataAvailabilityResources {
+                                        l1_gas: 0,
+                                        l1_data_gas: 128,
+                                    },
                                 l1_gas: 0,
                                 l1_data_gas: 128,
+                                l2_gas: 0,
                             },
-                        }),
-                    }),
+                        },
+                    ),
                 }
             }
 
-            fn invoke_validate_computation_resources() -> ComputationResources {
-                ComputationResources {
+            fn invoke_validate_computation_resources(
+            ) -> pathfinder_executor::types::ComputationResources {
+                pathfinder_executor::types::ComputationResources {
                     steps: 21,
                     range_check_builtin_applications: 1,
                     ..Default::default()
                 }
             }
 
-            fn invoke_execute_computation_resources() -> ComputationResources {
-                ComputationResources {
+            fn invoke_execute_computation_resources(
+            ) -> pathfinder_executor::types::ComputationResources {
+                pathfinder_executor::types::ComputationResources {
                     steps: 964,
                     range_check_builtin_applications: 24,
                     ..Default::default()
                 }
             }
 
-            fn invoke_fee_transfer_computation_resources() -> ComputationResources {
-                ComputationResources {
+            fn invoke_fee_transfer_computation_resources(
+            ) -> pathfinder_executor::types::ComputationResources {
+                pathfinder_executor::types::ComputationResources {
                     steps: 1354,
                     memory_holes: 59,
                     range_check_builtin_applications: 31,
@@ -1252,17 +1555,30 @@ pub(crate) mod tests {
             fn invoke_state_diff(
                 account_contract_address: ContractAddress,
                 storage_diffs: Vec<StorageDiff>,
-            ) -> StateDiff {
-                StateDiff {
-                    storage_diffs,
-                    deprecated_declared_classes: vec![],
+            ) -> pathfinder_executor::types::StateDiff {
+                pathfinder_executor::types::StateDiff {
+                    storage_diffs: BTreeMap::from_iter(
+                        storage_diffs
+                            .into_iter()
+                            .map(|diff| {
+                                (
+                                    diff.address,
+                                    diff.storage_entries
+                                        .into_iter()
+                                        .map(|entry| pathfinder_executor::types::StorageDiff {
+                                            key: entry.key,
+                                            value: entry.value,
+                                        })
+                                        .collect(),
+                                )
+                            })
+                            .collect::<Vec<_>>(),
+                    ),
+                    deprecated_declared_classes: HashSet::new(),
                     declared_classes: vec![],
                     deployed_contracts: vec![],
                     replaced_classes: vec![],
-                    nonces: vec![Nonce {
-                        contract_address: account_contract_address,
-                        nonce: contract_nonce!("0x3"),
-                    }],
+                    nonces: BTreeMap::from([(account_contract_address, contract_nonce!("0x3"))]),
                 }
             }
 
@@ -1282,87 +1598,89 @@ pub(crate) mod tests {
                 }]
             }
 
-            fn invoke_validate(account_contract_address: ContractAddress) -> FunctionInvocation {
-                FunctionInvocation {
-                    call_type: CallType::Call,
+            fn invoke_validate(
+                account_contract_address: ContractAddress,
+            ) -> pathfinder_executor::types::FunctionInvocation {
+                pathfinder_executor::types::FunctionInvocation {
+                    call_type: pathfinder_executor::types::CallType::Call,
                     caller_address: felt!("0x0"),
-                    calls: vec![],
                     class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
-                    entry_point_type: EntryPointType::External,
+                    entry_point_type: pathfinder_executor::types::EntryPointType::External,
+                    internal_calls: vec![],
                     events: vec![],
-                    function_call: FunctionCall {
-                        contract_address: account_contract_address,
-                        entry_point_selector: EntryPoint::hashed(b"__validate__"),
-                        calldata: vec![
-                            CallParam(DEPLOYED_CONTRACT_ADDRESS.0),
-                            CallParam(EntryPoint::hashed(b"get_data").0),
-                            // calldata_len
-                            call_param!("0x0"),
-                        ],
-                    },
+                    contract_address: account_contract_address,
+                    selector: EntryPoint::hashed(b"__validate__").0,
+                    calldata: vec![
+                        DEPLOYED_CONTRACT_ADDRESS.0,
+                        EntryPoint::hashed(b"get_data").0,
+                        // calldata_len
+                        call_param!("0x0").0,
+                    ],
                     messages: vec![],
                     result: vec![],
-                    execution_resources: invoke_validate_computation_resources(),
+                    execution_resources:
+                        pathfinder_executor::types::InnerCallExecutionResources::default(),
+                    computation_resources: invoke_validate_computation_resources(),
                 }
             }
 
             fn invoke_execute(
                 account_contract_address: ContractAddress,
                 test_storage_value: StorageValue,
-            ) -> FunctionInvocation {
-                FunctionInvocation {
-                    call_type: CallType::Call,
+            ) -> pathfinder_executor::types::FunctionInvocation {
+                pathfinder_executor::types::FunctionInvocation {
+                    call_type: pathfinder_executor::types::CallType::Call,
                     caller_address: felt!("0x0"),
-                    calls: vec![FunctionInvocation {
-                        call_type: CallType::Call,
+                    internal_calls: vec![pathfinder_executor::types::FunctionInvocation {
+                        call_type: pathfinder_executor::types::CallType::Call,
                         caller_address: *account_contract_address.get(),
-                        calls: vec![],
                         class_hash: Some(SIERRA_HASH.0),
-                        entry_point_type: EntryPointType::External,
+                        entry_point_type: pathfinder_executor::types::EntryPointType::External,
                         events: vec![],
-                        function_call: FunctionCall {
-                            contract_address: DEPLOYED_CONTRACT_ADDRESS,
-                            entry_point_selector: EntryPoint::hashed(b"get_data"),
-                            calldata: vec![],
-                        },
+                        internal_calls: vec![],
+                        contract_address: DEPLOYED_CONTRACT_ADDRESS,
+                        selector: EntryPoint::hashed(b"get_data").0,
+                        calldata: vec![],
                         messages: vec![],
                         result: vec![test_storage_value.0],
-                        execution_resources: ComputationResources {
+                        computation_resources: pathfinder_executor::types::ComputationResources {
                             steps: 165,
                             range_check_builtin_applications: 3,
                             ..Default::default()
                         },
+                        execution_resources:
+                            pathfinder_executor::types::InnerCallExecutionResources::default(),
                     }],
                     class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
-                    entry_point_type: EntryPointType::External,
+                    entry_point_type: pathfinder_executor::types::EntryPointType::External,
                     events: vec![],
-                    function_call: FunctionCall {
-                        contract_address: account_contract_address,
-                        entry_point_selector: EntryPoint::hashed(b"__execute__"),
-                        calldata: vec![
-                            CallParam(DEPLOYED_CONTRACT_ADDRESS.0),
-                            CallParam(EntryPoint::hashed(b"get_data").0),
-                            // calldata_len
-                            call_param!("0x0"),
-                        ],
-                    },
+                    contract_address: account_contract_address,
+                    selector: EntryPoint::hashed(b"__execute__").0,
+                    calldata: vec![
+                        DEPLOYED_CONTRACT_ADDRESS.0,
+                        EntryPoint::hashed(b"get_data").0,
+                        // calldata_len
+                        call_param!("0x0").0,
+                    ],
                     messages: vec![],
                     result: vec![test_storage_value.0],
-                    execution_resources: invoke_execute_computation_resources(),
+                    computation_resources: invoke_execute_computation_resources(),
+                    execution_resources:
+                        pathfinder_executor::types::InnerCallExecutionResources::default(),
                 }
             }
 
             fn invoke_fee_transfer(
                 account_contract_address: ContractAddress,
                 last_block_header: &BlockHeader,
-            ) -> FunctionInvocation {
-                FunctionInvocation {
-                    call_type: CallType::Call,
+            ) -> pathfinder_executor::types::FunctionInvocation {
+                pathfinder_executor::types::FunctionInvocation {
+                    call_type: pathfinder_executor::types::CallType::Call,
                     caller_address: *account_contract_address.get(),
-                    calls: vec![],
                     class_hash: Some(ERC20_CONTRACT_DEFINITION_CLASS_HASH.0),
-                    entry_point_type: EntryPointType::External,
-                    events: vec![OrderedEvent {
+                    entry_point_type: pathfinder_executor::types::EntryPointType::External,
+                    internal_calls: vec![],
+                    events: vec![pathfinder_executor::types::Event {
                         order: 0,
                         data: vec![
                             *account_contract_address.get(),
@@ -1374,18 +1692,18 @@ pub(crate) mod tests {
                             "0x0099CD8BDE557814842A3121E8DDFD433A539B8C9F14BF31EBF108D12E6196E9"
                         )],
                     }],
-                    function_call: FunctionCall {
-                        calldata: vec![
-                            CallParam(last_block_header.sequencer_address.0),
-                            CallParam(Felt::from_u64(INVOKE_OVERALL_FEE)),
-                            call_param!("0x0"),
-                        ],
-                        contract_address: pathfinder_executor::ETH_FEE_TOKEN_ADDRESS,
-                        entry_point_selector: EntryPoint::hashed(b"transfer"),
-                    },
+                    calldata: vec![
+                        last_block_header.sequencer_address.0,
+                        Felt::from_u64(INVOKE_OVERALL_FEE),
+                        call_param!("0x0").0,
+                    ],
+                    contract_address: pathfinder_executor::ETH_FEE_TOKEN_ADDRESS,
+                    selector: EntryPoint::hashed(b"transfer").0,
                     messages: vec![],
                     result: vec![felt!("0x1")],
-                    execution_resources: invoke_fee_transfer_computation_resources(),
+                    computation_resources: invoke_fee_transfer_computation_resources(),
+                    execution_resources:
+                        pathfinder_executor::types::InnerCallExecutionResources::default(),
                 }
             }
 
@@ -1397,73 +1715,95 @@ pub(crate) mod tests {
                 account_contract_address: ContractAddress,
                 last_block_header: &BlockHeader,
                 test_storage_value: StorageValue,
-            ) -> SimulatedTransaction {
-                SimulatedTransaction {
-                    fee_estimation: FeeEstimate {
-                        gas_consumed: INVOKE_V3_GAS_CONSUMED.into(),
-                        gas_price: 2.into(),
-                        data_gas_consumed: Some(INVOKE_V3_DATA_GAS_CONSUMED.into()),
-                        data_gas_price: Some(2.into()),
+            ) -> pathfinder_executor::types::TransactionSimulation {
+                pathfinder_executor::types::TransactionSimulation {
+                    fee_estimation: pathfinder_executor::types::FeeEstimate {
+                        l1_gas_consumed: INVOKE_V3_GAS_CONSUMED.into(),
+                        l1_gas_price: 2.into(),
+                        l1_data_gas_consumed: INVOKE_V3_DATA_GAS_CONSUMED.into(),
+                        l1_data_gas_price: 2.into(),
+                        l2_gas_consumed: 0.into(),
+                        l2_gas_price: 0.into(),
                         overall_fee: INVOKE_V3_OVERALL_FEE.into(),
-                        unit: PriceUnit::Fri,
+                        unit: pathfinder_executor::types::PriceUnit::Fri,
                     },
-                    transaction_trace: TransactionTrace::Invoke(InvokeTxnTrace {
-                        validate_invocation: Some(invoke_validate(account_contract_address)),
-                        execute_invocation: ExecuteInvocation::FunctionInvocation(invoke_execute(
-                            account_contract_address,
-                            test_storage_value,
-                        )),
-                        fee_transfer_invocation: Some(invoke_v3_fee_transfer(
-                            account_contract_address,
-                            last_block_header,
-                        )),
-                        state_diff: Some(invoke_v3_state_diff(
-                            account_contract_address,
-                            invoke_v3_fee_transfer_storage_diffs(),
-                        )),
-                        execution_resources: Some(ExecutionResources {
-                            computation_resources: invoke_validate_computation_resources()
-                                + invoke_execute_computation_resources()
-                                + invoke_fee_transfer_computation_resources(),
-                            data_availability: DataAvailabilityResources {
+                    trace: pathfinder_executor::types::TransactionTrace::Invoke(
+                        pathfinder_executor::types::InvokeTransactionTrace {
+                            validate_invocation: Some(invoke_validate(account_contract_address)),
+                            execute_invocation:
+                                pathfinder_executor::types::ExecuteInvocation::FunctionInvocation(
+                                    Some(invoke_execute(
+                                        account_contract_address,
+                                        test_storage_value,
+                                    )),
+                                ),
+                            fee_transfer_invocation: Some(invoke_v3_fee_transfer(
+                                account_contract_address,
+                                last_block_header,
+                            )),
+                            state_diff: invoke_v3_state_diff(
+                                account_contract_address,
+                                invoke_v3_fee_transfer_storage_diffs(),
+                            ),
+                            execution_resources: pathfinder_executor::types::ExecutionResources {
+                                computation_resources: invoke_validate_computation_resources()
+                                    + invoke_execute_computation_resources()
+                                    + invoke_fee_transfer_computation_resources(),
+                                data_availability:
+                                    pathfinder_executor::types::DataAvailabilityResources {
+                                        l1_gas: 0,
+                                        l1_data_gas: 128,
+                                    },
                                 l1_gas: 0,
                                 l1_data_gas: 128,
+                                l2_gas: 0,
                             },
-                        }),
-                    }),
+                        },
+                    ),
                 }
             }
 
             pub fn invoke_v3_without_fee_transfer(
                 account_contract_address: ContractAddress,
                 test_storage_value: StorageValue,
-            ) -> SimulatedTransaction {
-                SimulatedTransaction {
-                    fee_estimation: FeeEstimate {
-                        gas_consumed: INVOKE_V3_GAS_CONSUMED.into(),
-                        gas_price: 2.into(),
-                        data_gas_consumed: Some(INVOKE_V3_DATA_GAS_CONSUMED.into()),
-                        data_gas_price: Some(2.into()),
+            ) -> pathfinder_executor::types::TransactionSimulation {
+                pathfinder_executor::types::TransactionSimulation {
+                    fee_estimation: pathfinder_executor::types::FeeEstimate {
+                        l1_gas_consumed: INVOKE_V3_GAS_CONSUMED.into(),
+                        l1_gas_price: 2.into(),
+                        l1_data_gas_consumed: INVOKE_V3_DATA_GAS_CONSUMED.into(),
+                        l1_data_gas_price: 2.into(),
+                        l2_gas_consumed: 0.into(),
+                        l2_gas_price: 0.into(),
                         overall_fee: INVOKE_V3_OVERALL_FEE.into(),
-                        unit: PriceUnit::Fri,
+                        unit: pathfinder_executor::types::PriceUnit::Fri,
                     },
-                    transaction_trace: TransactionTrace::Invoke(InvokeTxnTrace {
-                        validate_invocation: Some(invoke_validate(account_contract_address)),
-                        execute_invocation: ExecuteInvocation::FunctionInvocation(invoke_execute(
-                            account_contract_address,
-                            test_storage_value,
-                        )),
-                        fee_transfer_invocation: None,
-                        state_diff: Some(invoke_v3_state_diff(account_contract_address, vec![])),
-                        execution_resources: Some(ExecutionResources {
-                            computation_resources: invoke_validate_computation_resources()
-                                + invoke_execute_computation_resources(),
-                            data_availability: DataAvailabilityResources {
+                    trace: pathfinder_executor::types::TransactionTrace::Invoke(
+                        pathfinder_executor::types::InvokeTransactionTrace {
+                            validate_invocation: Some(invoke_validate(account_contract_address)),
+                            execute_invocation:
+                                pathfinder_executor::types::ExecuteInvocation::FunctionInvocation(
+                                    Some(invoke_execute(
+                                        account_contract_address,
+                                        test_storage_value,
+                                    )),
+                                ),
+                            fee_transfer_invocation: None,
+                            state_diff: invoke_v3_state_diff(account_contract_address, vec![]),
+                            execution_resources: pathfinder_executor::types::ExecutionResources {
+                                computation_resources: invoke_validate_computation_resources()
+                                    + invoke_execute_computation_resources(),
+                                data_availability:
+                                    pathfinder_executor::types::DataAvailabilityResources {
+                                        l1_gas: 0,
+                                        l1_data_gas: 128,
+                                    },
                                 l1_gas: 0,
                                 l1_data_gas: 128,
+                                l2_gas: 0,
                             },
-                        }),
-                    }),
+                        },
+                    ),
                 }
             }
 
@@ -1471,53 +1811,64 @@ pub(crate) mod tests {
                 account_contract_address: ContractAddress,
                 last_block_header: &BlockHeader,
                 test_storage_value: StorageValue,
-            ) -> SimulatedTransaction {
-                SimulatedTransaction {
-                    fee_estimation: FeeEstimate {
-                        gas_consumed: INVOKE_V3_GAS_CONSUMED.into(),
-                        gas_price: 2.into(),
-                        data_gas_consumed: Some(INVOKE_V3_DATA_GAS_CONSUMED.into()),
-                        data_gas_price: Some(2.into()),
+            ) -> pathfinder_executor::types::TransactionSimulation {
+                pathfinder_executor::types::TransactionSimulation {
+                    fee_estimation: pathfinder_executor::types::FeeEstimate {
+                        l1_gas_consumed: INVOKE_V3_GAS_CONSUMED.into(),
+                        l1_gas_price: 2.into(),
+                        l1_data_gas_consumed: INVOKE_V3_DATA_GAS_CONSUMED.into(),
+                        l1_data_gas_price: 2.into(),
+                        l2_gas_consumed: 0.into(),
+                        l2_gas_price: 0.into(),
                         overall_fee: INVOKE_V3_OVERALL_FEE.into(),
-                        unit: PriceUnit::Fri,
+                        unit: pathfinder_executor::types::PriceUnit::Fri,
                     },
-                    transaction_trace: TransactionTrace::Invoke(InvokeTxnTrace {
-                        validate_invocation: None,
-                        execute_invocation: ExecuteInvocation::FunctionInvocation(invoke_execute(
-                            account_contract_address,
-                            test_storage_value,
-                        )),
-                        fee_transfer_invocation: Some(invoke_v3_fee_transfer(
-                            account_contract_address,
-                            last_block_header,
-                        )),
-                        state_diff: Some(invoke_v3_state_diff(
-                            account_contract_address,
-                            invoke_v3_fee_transfer_storage_diffs(),
-                        )),
-                        execution_resources: Some(ExecutionResources {
-                            computation_resources: invoke_execute_computation_resources()
-                                + invoke_fee_transfer_computation_resources(),
-                            data_availability: DataAvailabilityResources {
+                    trace: pathfinder_executor::types::TransactionTrace::Invoke(
+                        pathfinder_executor::types::InvokeTransactionTrace {
+                            validate_invocation: None,
+                            execute_invocation:
+                                pathfinder_executor::types::ExecuteInvocation::FunctionInvocation(
+                                    Some(invoke_execute(
+                                        account_contract_address,
+                                        test_storage_value,
+                                    )),
+                                ),
+                            fee_transfer_invocation: Some(invoke_v3_fee_transfer(
+                                account_contract_address,
+                                last_block_header,
+                            )),
+                            state_diff: invoke_v3_state_diff(
+                                account_contract_address,
+                                invoke_v3_fee_transfer_storage_diffs(),
+                            ),
+                            execution_resources: pathfinder_executor::types::ExecutionResources {
+                                computation_resources: invoke_execute_computation_resources()
+                                    + invoke_fee_transfer_computation_resources(),
+                                data_availability:
+                                    pathfinder_executor::types::DataAvailabilityResources {
+                                        l1_gas: 0,
+                                        l1_data_gas: 128,
+                                    },
                                 l1_gas: 0,
                                 l1_data_gas: 128,
+                                l2_gas: 0,
                             },
-                        }),
-                    }),
+                        },
+                    ),
                 }
             }
 
             fn invoke_v3_fee_transfer(
                 account_contract_address: ContractAddress,
                 last_block_header: &BlockHeader,
-            ) -> FunctionInvocation {
-                FunctionInvocation {
-                    call_type: CallType::Call,
+            ) -> pathfinder_executor::types::FunctionInvocation {
+                pathfinder_executor::types::FunctionInvocation {
+                    call_type: pathfinder_executor::types::CallType::Call,
                     caller_address: *account_contract_address.get(),
-                    calls: vec![],
                     class_hash: Some(ERC20_CONTRACT_DEFINITION_CLASS_HASH.0),
-                    entry_point_type: EntryPointType::External,
-                    events: vec![OrderedEvent {
+                    entry_point_type: pathfinder_executor::types::EntryPointType::External,
+                    internal_calls: vec![],
+                    events: vec![pathfinder_executor::types::Event {
                         order: 0,
                         data: vec![
                             *account_contract_address.get(),
@@ -1529,35 +1880,48 @@ pub(crate) mod tests {
                             "0x0099CD8BDE557814842A3121E8DDFD433A539B8C9F14BF31EBF108D12E6196E9"
                         )],
                     }],
-                    function_call: FunctionCall {
-                        calldata: vec![
-                            CallParam(last_block_header.sequencer_address.0),
-                            CallParam(Felt::from_u64(INVOKE_V3_OVERALL_FEE)),
-                            call_param!("0x0"),
-                        ],
-                        contract_address: pathfinder_executor::STRK_FEE_TOKEN_ADDRESS,
-                        entry_point_selector: EntryPoint::hashed(b"transfer"),
-                    },
+                    calldata: vec![
+                        last_block_header.sequencer_address.0,
+                        Felt::from_u64(INVOKE_V3_OVERALL_FEE),
+                        felt!("0x0"),
+                    ],
+                    contract_address: pathfinder_executor::STRK_FEE_TOKEN_ADDRESS,
+                    selector: EntryPoint::hashed(b"transfer").0,
                     messages: vec![],
                     result: vec![felt!("0x1")],
-                    execution_resources: invoke_fee_transfer_computation_resources(),
+                    computation_resources: invoke_fee_transfer_computation_resources(),
+                    execution_resources:
+                        pathfinder_executor::types::InnerCallExecutionResources::default(),
                 }
             }
 
             fn invoke_v3_state_diff(
                 account_contract_address: ContractAddress,
                 storage_diffs: Vec<StorageDiff>,
-            ) -> StateDiff {
-                StateDiff {
-                    storage_diffs,
-                    deprecated_declared_classes: vec![],
+            ) -> pathfinder_executor::types::StateDiff {
+                pathfinder_executor::types::StateDiff {
+                    storage_diffs: BTreeMap::from_iter(
+                        storage_diffs
+                            .into_iter()
+                            .map(|diff| {
+                                (
+                                    diff.address,
+                                    diff.storage_entries
+                                        .into_iter()
+                                        .map(|entry| pathfinder_executor::types::StorageDiff {
+                                            key: entry.key,
+                                            value: entry.value,
+                                        })
+                                        .collect(),
+                                )
+                            })
+                            .collect::<Vec<_>>(),
+                    ),
+                    deprecated_declared_classes: HashSet::new(),
                     declared_classes: vec![],
                     deployed_contracts: vec![],
                     replaced_classes: vec![],
-                    nonces: vec![Nonce {
-                        contract_address: account_contract_address,
-                        nonce: contract_nonce!("0x4"),
-                    }],
+                    nonces: BTreeMap::from([(account_contract_address, contract_nonce!("0x4"))]),
                 }
             }
 
@@ -1601,39 +1965,60 @@ pub(crate) mod tests {
                 fixtures::input::invoke_v3(account_contract_address),
             ],
             block_id: BlockId::Number(last_block_header.number),
-            simulation_flags: dto::SimulationFlags(vec![]),
+            simulation_flags: crate::dto::SimulationFlags(vec![]),
         };
         let result = simulate_transactions(context, input).await.unwrap();
 
-        pretty_assertions_sorted::assert_eq!(
-            result
-                .serialize(Serializer {
-                    version: RpcVersion::V07
-                })
-                .unwrap(),
-            serde_json::to_value(vec![
-                fixtures::expected_output_0_13_1_1::declare(
-                    account_contract_address,
-                    &last_block_header
-                ),
-                fixtures::expected_output_0_13_1_1::universal_deployer(
-                    account_contract_address,
-                    &last_block_header,
-                    universal_deployer_address,
-                ),
-                fixtures::expected_output_0_13_1_1::invoke(
-                    account_contract_address,
-                    &last_block_header,
-                    test_storage_value,
-                ),
-                fixtures::expected_output_0_13_1_1::invoke_v3(
-                    account_contract_address,
-                    &last_block_header,
-                    test_storage_value,
-                ),
-            ])
-            .unwrap()
-        );
+        let serializer = crate::dto::serialize::Serializer {
+            version: RpcVersion::V07,
+        };
+
+        let result_serializable = result
+            .0
+            .into_iter()
+            .map(crate::dto::SimulatedTransaction)
+            .collect::<Vec<_>>();
+
+        let result_serialized = serializer
+            .serialize_iter(
+                result_serializable.len(),
+                &mut result_serializable.into_iter(),
+            )
+            .unwrap();
+
+        let expected_serializable = vec![
+            fixtures::expected_output_0_13_1_1::declare(
+                account_contract_address,
+                &last_block_header,
+            ),
+            fixtures::expected_output_0_13_1_1::universal_deployer(
+                account_contract_address,
+                &last_block_header,
+                universal_deployer_address,
+            ),
+            fixtures::expected_output_0_13_1_1::invoke(
+                account_contract_address,
+                &last_block_header,
+                test_storage_value,
+            ),
+            fixtures::expected_output_0_13_1_1::invoke_v3(
+                account_contract_address,
+                &last_block_header,
+                test_storage_value,
+            ),
+        ]
+        .into_iter()
+        .map(crate::dto::SimulatedTransaction)
+        .collect::<Vec<_>>();
+
+        let expected_serialized = serializer
+            .serialize_iter(
+                expected_serializable.len(),
+                &mut expected_serializable.into_iter(),
+            )
+            .unwrap();
+
+        pretty_assertions_sorted::assert_eq!(result_serialized, expected_serialized,);
     }
 
     #[test_log::test(tokio::test)]
@@ -1658,9 +2043,29 @@ pub(crate) mod tests {
                 fixtures::input::invoke_v3(account_contract_address),
             ],
             block_id: BlockId::Number(last_block_header.number),
-            simulation_flags: dto::SimulationFlags(vec![dto::SimulationFlag::SkipFeeCharge]),
+            simulation_flags: crate::dto::SimulationFlags(vec![
+                crate::dto::SimulationFlag::SkipFeeCharge,
+            ]),
         };
         let result = simulate_transactions(context, input).await.unwrap();
+
+        let expected = super::Output(vec![
+            fixtures::expected_output_0_13_1_1::declare_without_fee_transfer(
+                account_contract_address,
+            ),
+            fixtures::expected_output_0_13_1_1::universal_deployer_without_fee_transfer(
+                account_contract_address,
+                universal_deployer_address,
+            ),
+            fixtures::expected_output_0_13_1_1::invoke_without_fee_transfer(
+                account_contract_address,
+                test_storage_value,
+            ),
+            fixtures::expected_output_0_13_1_1::invoke_v3_without_fee_transfer(
+                account_contract_address,
+                test_storage_value,
+            ),
+        ]);
 
         pretty_assertions_sorted::assert_eq!(
             result
@@ -1668,24 +2073,11 @@ pub(crate) mod tests {
                     version: RpcVersion::V07
                 })
                 .unwrap(),
-            serde_json::to_value(vec![
-                fixtures::expected_output_0_13_1_1::declare_without_fee_transfer(
-                    account_contract_address
-                ),
-                fixtures::expected_output_0_13_1_1::universal_deployer_without_fee_transfer(
-                    account_contract_address,
-                    universal_deployer_address,
-                ),
-                fixtures::expected_output_0_13_1_1::invoke_without_fee_transfer(
-                    account_contract_address,
-                    test_storage_value,
-                ),
-                fixtures::expected_output_0_13_1_1::invoke_v3_without_fee_transfer(
-                    account_contract_address,
-                    test_storage_value,
-                ),
-            ])
-            .unwrap()
+            expected
+                .serialize(Serializer {
+                    version: RpcVersion::V07
+                })
+                .unwrap(),
         );
     }
 
@@ -1711,8 +2103,33 @@ pub(crate) mod tests {
                 fixtures::input::invoke_v3(account_contract_address),
             ],
             block_id: BlockId::Number(last_block_header.number),
-            simulation_flags: dto::SimulationFlags(vec![dto::SimulationFlag::SkipValidate]),
+            simulation_flags: crate::dto::SimulationFlags(vec![
+                crate::dto::SimulationFlag::SkipValidate,
+            ]),
         };
+
+        let expected = super::Output(vec![
+            fixtures::expected_output_0_13_1_1::declare_without_validate(
+                account_contract_address,
+                &last_block_header,
+            ),
+            fixtures::expected_output_0_13_1_1::universal_deployer_without_validate(
+                account_contract_address,
+                &last_block_header,
+                universal_deployer_address,
+            ),
+            fixtures::expected_output_0_13_1_1::invoke_without_validate(
+                account_contract_address,
+                &last_block_header,
+                test_storage_value,
+            ),
+            fixtures::expected_output_0_13_1_1::invoke_v3_without_validate(
+                account_contract_address,
+                &last_block_header,
+                test_storage_value,
+            ),
+        ]);
+
         let result = simulate_transactions(context, input).await.unwrap();
 
         pretty_assertions_sorted::assert_eq!(
@@ -1721,28 +2138,11 @@ pub(crate) mod tests {
                     version: RpcVersion::V07
                 })
                 .unwrap(),
-            serde_json::to_value(vec![
-                fixtures::expected_output_0_13_1_1::declare_without_validate(
-                    account_contract_address,
-                    &last_block_header,
-                ),
-                fixtures::expected_output_0_13_1_1::universal_deployer_without_validate(
-                    account_contract_address,
-                    &last_block_header,
-                    universal_deployer_address,
-                ),
-                fixtures::expected_output_0_13_1_1::invoke_without_validate(
-                    account_contract_address,
-                    &last_block_header,
-                    test_storage_value,
-                ),
-                fixtures::expected_output_0_13_1_1::invoke_v3_without_validate(
-                    account_contract_address,
-                    &last_block_header,
-                    test_storage_value,
-                ),
-            ])
-            .unwrap()
+            expected
+                .serialize(Serializer {
+                    version: RpcVersion::V07
+                })
+                .unwrap(),
         );
     }
 }

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -997,15 +997,14 @@ pub(crate) mod tests {
         let mut connection = context.storage.connection().unwrap();
         let transaction = connection.transaction().unwrap();
 
-        // Need to avoid skipping blocks for `insert_transaction_data`.
+        // Need to avoid skipping blocks for `insert_transaction_data`
+        // so that there is no gap in event filters.
         (0..619596)
-            .collect::<Vec<_>>()
-            .chunks(pathfinder_storage::BLOCK_RANGE_LEN as usize)
-            .map(|range| *range.last().unwrap() as u64)
-            .for_each(|block| {
-                let block = BlockNumber::new_or_panic(block);
+            .step_by(pathfinder_storage::BLOCK_RANGE_LEN as usize)
+            .for_each(|block: u64| {
+                let block = BlockNumber::new_or_panic(block.saturating_sub(1));
                 transaction
-                    .insert_transaction_data(block, &[], None)
+                    .insert_transaction_data(block, &[], Some(&[]))
                     .unwrap();
             });
 

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -10,9 +10,23 @@ use crate::executor::{
     ExecutionStateError,
     VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEWAY,
 };
-use crate::v06::method::trace_block_transactions as v06;
 
-pub struct Output {
+#[derive(Debug, Clone)]
+pub struct TraceBlockTransactionsInput {
+    pub block_id: BlockId,
+}
+
+impl crate::dto::DeserializeForVersion for TraceBlockTransactionsInput {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_map(|value| {
+            Ok(Self {
+                block_id: value.deserialize("block_id")?,
+            })
+        })
+    }
+}
+
+pub struct TraceBlockTransactionsOutput {
     traces: Vec<(
         pathfinder_common::TransactionHash,
         pathfinder_executor::types::TransactionTrace,
@@ -22,10 +36,10 @@ pub struct Output {
 
 pub async fn trace_block_transactions(
     context: RpcContext,
-    input: v06::TraceBlockTransactionsInput,
-) -> Result<Output, TraceBlockTransactionsError> {
+    input: TraceBlockTransactionsInput,
+) -> Result<TraceBlockTransactionsOutput, TraceBlockTransactionsError> {
     enum LocalExecution {
-        Success(Output),
+        Success(TraceBlockTransactionsOutput),
         Unsupported(Vec<pathfinder_common::transaction::Transaction>),
     }
 
@@ -115,7 +129,7 @@ pub async fn trace_block_transactions(
             .map(|(hash, trace)| Ok((hash, trace)))
             .collect::<Result<Vec<_>, TraceBlockTransactionsError>>()?;
 
-        Ok(LocalExecution::Success(Output {
+        Ok(LocalExecution::Success(TraceBlockTransactionsOutput {
             traces,
             include_state_diffs: true,
         }))
@@ -135,7 +149,7 @@ pub async fn trace_block_transactions(
         .context("Forwarding to feeder gateway")
         .map_err(TraceBlockTransactionsError::from)
         .map(|trace| {
-            Ok(Output {
+            Ok(TraceBlockTransactionsOutput {
                 traces: trace
                     .traces
                     .into_iter()
@@ -515,7 +529,7 @@ fn map_gateway_computation_resources(
     }
 }
 
-impl crate::dto::serialize::SerializeForVersion for Output {
+impl crate::dto::serialize::SerializeForVersion for TraceBlockTransactionsOutput {
     fn serialize(
         &self,
         serializer: crate::dto::serialize::Serializer,
@@ -532,9 +546,9 @@ impl crate::dto::serialize::SerializeForVersion for Output {
 }
 
 struct Trace<'a> {
-    transaction_hash: &'a pathfinder_common::TransactionHash,
-    transaction_trace: &'a pathfinder_executor::types::TransactionTrace,
-    include_state_diff: bool,
+    pub transaction_hash: &'a pathfinder_common::TransactionHash,
+    pub transaction_trace: &'a pathfinder_executor::types::TransactionTrace,
+    pub include_state_diff: bool,
 }
 
 impl crate::dto::serialize::SerializeForVersion for Trace<'_> {
@@ -550,7 +564,7 @@ impl crate::dto::serialize::SerializeForVersion for Trace<'_> {
         serializer.serialize_field(
             "trace_root",
             &crate::dto::TransactionTrace {
-                trace: self.transaction_trace,
+                trace: self.transaction_trace.clone(),
                 include_state_diff: self.include_state_diff,
             },
         )?;
@@ -614,27 +628,36 @@ pub(crate) mod tests {
     use pathfinder_common::receipt::Receipt;
     use pathfinder_common::{
         block_hash,
-        transaction_hash,
+        felt,
         BlockHeader,
-        BlockId,
+        BlockNumber,
+        Chain,
         GasPrice,
-        L1DataAvailabilityMode,
+        SequencerAddress,
         SierraHash,
         StarknetVersion,
+        TransactionHash,
         TransactionIndex,
     };
-    use starknet_gateway_types::reply::GasPrices;
-    use tokio::task::JoinSet;
+    use pathfinder_crypto::Felt;
+    use starknet_gateway_types::reply::{GasPrices, L1DataAvailabilityMode};
 
-    use super::v06::{Trace, TraceBlockTransactionsInput, TraceBlockTransactionsOutput};
-    use super::{trace_block_transactions, RpcContext};
+    use super::*;
     use crate::dto::serialize::{SerializeForVersion, Serializer};
-    use crate::v06::method::simulate_transactions::tests::setup_storage_with_starknet_version;
     use crate::RpcVersion;
+
+    #[derive(Debug)]
+    pub struct Trace {
+        pub transaction_hash: TransactionHash,
+        pub trace_root: pathfinder_executor::types::TransactionTrace,
+    }
 
     pub(crate) async fn setup_multi_tx_trace_test(
     ) -> anyhow::Result<(RpcContext, BlockHeader, Vec<Trace>)> {
-        use super::super::simulate_transactions::tests::fixtures;
+        use super::super::simulate_transactions::tests::{
+            fixtures,
+            setup_storage_with_starknet_version,
+        };
 
         let (
             storage,
@@ -659,20 +682,17 @@ pub(crate) mod tests {
             fixtures::expected_output_0_13_1_1::declare(
                 account_contract_address,
                 &last_block_header,
-            )
-            .transaction_trace,
+            ),
             fixtures::expected_output_0_13_1_1::universal_deployer(
                 account_contract_address,
                 &last_block_header,
                 universal_deployer_address,
-            )
-            .transaction_trace,
+            ),
             fixtures::expected_output_0_13_1_1::invoke(
                 account_contract_address,
                 &last_block_header,
                 test_storage_value,
-            )
-            .transaction_trace,
+            ),
         ];
 
         let next_block_header = {
@@ -695,12 +715,12 @@ pub(crate) mod tests {
                 .sequencer_address(last_block_header.sequencer_address)
                 .timestamp(last_block_header.timestamp)
                 .starknet_version(StarknetVersion::new(0, 13, 1, 1))
-                .l1_da_mode(L1DataAvailabilityMode::Blob)
+                .l1_da_mode(pathfinder_common::L1DataAvailabilityMode::Blob)
                 .finalize_with_hash(block_hash!("0x1"));
             tx.insert_block_header(&next_block_header)?;
 
             let dummy_receipt = Receipt {
-                transaction_hash: transaction_hash!("0x1"),
+                transaction_hash: TransactionHash(felt!("0x1")),
                 transaction_index: TransactionIndex::new_or_panic(0),
                 ..Default::default()
             };
@@ -721,15 +741,15 @@ pub(crate) mod tests {
         let traces = vec![
             Trace {
                 transaction_hash: transactions[0].hash,
-                trace_root: traces[0].clone(),
+                trace_root: traces[0].trace.clone(),
             },
             Trace {
                 transaction_hash: transactions[1].hash,
-                trace_root: traces[1].clone(),
+                trace_root: traces[1].trace.clone(),
             },
             Trace {
                 transaction_hash: transactions[2].hash,
-                trace_root: traces[2].clone(),
+                trace_root: traces[2].trace.clone(),
             },
         ];
 
@@ -744,15 +764,25 @@ pub(crate) mod tests {
             block_id: next_block_header.hash.into(),
         };
         let output = trace_block_transactions(context, input).await.unwrap();
-        let expected = TraceBlockTransactionsOutput(traces);
+        let expected = TraceBlockTransactionsOutput {
+            traces: traces
+                .into_iter()
+                .map(|t| (t.transaction_hash, t.trace_root))
+                .collect(),
+            include_state_diffs: true,
+        };
 
         pretty_assertions_sorted::assert_eq!(
             output
                 .serialize(Serializer {
-                    version: RpcVersion::V06,
+                    version: RpcVersion::V07,
                 })
                 .unwrap(),
-            serde_json::to_value(expected).unwrap()
+            expected
+                .serialize(Serializer {
+                    version: RpcVersion::V07,
+                })
+                .unwrap(),
         );
         Ok(())
     }
@@ -769,7 +799,7 @@ pub(crate) mod tests {
         let input = TraceBlockTransactionsInput {
             block_id: next_block_header.hash.into(),
         };
-        let mut joins = JoinSet::new();
+        let mut joins = tokio::task::JoinSet::new();
         for _ in 0..NUM_REQUESTS {
             let input = input.clone();
             let context = context.clone();
@@ -781,24 +811,38 @@ pub(crate) mod tests {
                 output
                     .unwrap()
                     .serialize(Serializer {
-                        version: RpcVersion::V06,
+                        version: RpcVersion::V07,
                     })
                     .unwrap(),
             );
         }
         let mut expected = Vec::new();
         for _ in 0..NUM_REQUESTS {
-            expected
-                .push(serde_json::to_value(TraceBlockTransactionsOutput(traces.clone())).unwrap());
+            expected.push(
+                TraceBlockTransactionsOutput {
+                    traces: traces
+                        .iter()
+                        .map(|t| (t.transaction_hash, t.trace_root.clone()))
+                        .collect(),
+                    include_state_diffs: true,
+                }
+                .serialize(Serializer {
+                    version: RpcVersion::V07,
+                })
+                .unwrap(),
+            );
         }
 
         pretty_assertions_sorted::assert_eq!(outputs, expected);
         Ok(())
     }
 
-    pub(crate) async fn setup_multi_tx_trace_pending_test(
+    pub(crate) async fn setup_multi_tx_trace_pending_test<'a>(
     ) -> anyhow::Result<(RpcContext, Vec<Trace>)> {
-        use super::super::simulate_transactions::tests::fixtures;
+        use super::super::simulate_transactions::tests::{
+            fixtures,
+            setup_storage_with_starknet_version,
+        };
 
         let (
             storage,
@@ -823,20 +867,17 @@ pub(crate) mod tests {
             fixtures::expected_output_0_13_1_1::declare(
                 account_contract_address,
                 &last_block_header,
-            )
-            .transaction_trace,
+            ),
             fixtures::expected_output_0_13_1_1::universal_deployer(
                 account_contract_address,
                 &last_block_header,
                 universal_deployer_address,
-            )
-            .transaction_trace,
+            ),
             fixtures::expected_output_0_13_1_1::invoke(
                 account_contract_address,
                 &last_block_header,
                 test_storage_value,
-            )
-            .transaction_trace,
+            ),
         ];
 
         let pending_block = {
@@ -851,7 +892,7 @@ pub(crate) mod tests {
             )?;
 
             let dummy_receipt = Receipt {
-                transaction_hash: transaction_hash!("0x1"),
+                transaction_hash: TransactionHash(felt!("0x1")),
                 transaction_index: TransactionIndex::new_or_panic(0),
                 ..Default::default()
             };
@@ -878,7 +919,7 @@ pub(crate) mod tests {
                 transaction_receipts,
                 transactions: transactions.iter().cloned().map(Into::into).collect(),
                 starknet_version: last_block_header.starknet_version,
-                l1_da_mode: starknet_gateway_types::reply::L1DataAvailabilityMode::Blob,
+                l1_da_mode: L1DataAvailabilityMode::Blob,
             };
 
             tx.commit()?;
@@ -900,15 +941,15 @@ pub(crate) mod tests {
         let traces = vec![
             Trace {
                 transaction_hash: transactions[0].hash,
-                trace_root: traces[0].clone(),
+                trace_root: traces[0].trace.clone(),
             },
             Trace {
                 transaction_hash: transactions[1].hash,
-                trace_root: traces[1].clone(),
+                trace_root: traces[1].trace.clone(),
             },
             Trace {
                 transaction_hash: transactions[2].hash,
-                trace_root: traces[2].clone(),
+                trace_root: traces[2].trace.clone(),
             },
         ];
 
@@ -923,16 +964,121 @@ pub(crate) mod tests {
             block_id: BlockId::Pending,
         };
         let output = trace_block_transactions(context, input).await.unwrap();
-        let expected = TraceBlockTransactionsOutput(traces);
+
+        let expected = TraceBlockTransactionsOutput {
+            traces: traces
+                .into_iter()
+                .map(|t| (t.transaction_hash, t.trace_root))
+                .collect(),
+            include_state_diffs: true,
+        };
 
         pretty_assertions_sorted::assert_eq!(
             output
                 .serialize(Serializer {
-                    version: RpcVersion::V06,
+                    version: RpcVersion::V07,
                 })
                 .unwrap(),
-            serde_json::to_value(expected).unwrap()
+            expected
+                .serialize(Serializer {
+                    version: RpcVersion::V07,
+                })
+                .unwrap(),
         );
+
         Ok(())
+    }
+
+    /// Test that tracing succeeds for a block that is not backwards-compatible
+    /// with blockifier.
+    #[tokio::test]
+    async fn mainnet_blockifier_backwards_incompatible_transaction_tracing() {
+        let context = RpcContext::for_tests_on(Chain::Mainnet);
+        let mut connection = context.storage.connection().unwrap();
+        let transaction = connection.transaction().unwrap();
+
+        // Need to avoid skipping blocks for `insert_transaction_data`.
+        (0..619596)
+            .collect::<Vec<_>>()
+            .chunks(pathfinder_storage::BLOCK_RANGE_LEN as usize)
+            .map(|range| *range.last().unwrap() as u64)
+            .for_each(|block| {
+                let block = BlockNumber::new_or_panic(block);
+                transaction
+                    .insert_transaction_data(block, &[], None)
+                    .unwrap();
+            });
+
+        let block: starknet_gateway_types::reply::Block =
+            serde_json::from_str(include_str!("../../fixtures/mainnet-619596.json")).unwrap();
+        let transaction_count = block.transactions.len();
+        let event_count = block
+            .transaction_receipts
+            .iter()
+            .map(|(_, events)| events.len())
+            .sum();
+        let header = BlockHeader {
+            hash: block.block_hash,
+            parent_hash: block.parent_block_hash,
+            number: block.block_number,
+            timestamp: block.timestamp,
+            eth_l1_gas_price: block.l1_gas_price.price_in_wei,
+            strk_l1_gas_price: block.l1_gas_price.price_in_fri,
+            eth_l1_data_gas_price: block.l1_data_gas_price.price_in_wei,
+            strk_l1_data_gas_price: block.l1_data_gas_price.price_in_fri,
+            eth_l2_gas_price: GasPrice(0), // TODO: Fix when we get l2_gas_price in the gateway
+            strk_l2_gas_price: GasPrice(0), // TODO: Fix when we get l2_gas_price in the gateway
+            sequencer_address: block
+                .sequencer_address
+                .unwrap_or(SequencerAddress(Felt::ZERO)),
+            starknet_version: block.starknet_version,
+            class_commitment: Default::default(),
+            event_commitment: Default::default(),
+            state_commitment: Default::default(),
+            storage_commitment: Default::default(),
+            transaction_commitment: Default::default(),
+            transaction_count,
+            event_count,
+            l1_da_mode: block.l1_da_mode.into(),
+            receipt_commitment: Default::default(),
+            state_diff_commitment: Default::default(),
+            state_diff_length: 0,
+        };
+        transaction
+            .insert_block_header(&BlockHeader {
+                number: block.block_number - 1,
+                hash: block.parent_block_hash,
+                ..header.clone()
+            })
+            .unwrap();
+        transaction
+            .insert_block_header(&BlockHeader {
+                number: block.block_number - 10,
+                hash: block_hash!("0x1"),
+                ..header.clone()
+            })
+            .unwrap();
+        transaction.insert_block_header(&header).unwrap();
+        let (transactions_data, events_data) = block
+            .transactions
+            .into_iter()
+            .zip(block.transaction_receipts.into_iter())
+            .map(|(tx, (receipt, events))| ((tx, receipt), events))
+            .unzip::<_, _, Vec<_>, Vec<_>>();
+        transaction
+            .insert_transaction_data(header.number, &transactions_data, Some(&events_data))
+            .unwrap();
+        transaction.commit().unwrap();
+        drop(connection);
+
+        // The tracing succeeds.
+        trace_block_transactions(
+            context.clone(),
+            TraceBlockTransactionsInput {
+                block_id: BlockId::Number(block.block_number),
+            },
+        )
+        .await
+        .unwrap();
     }
 }

--- a/crates/rpc/src/method/trace_transaction.rs
+++ b/crates/rpc/src/method/trace_transaction.rs
@@ -1,26 +1,48 @@
 use anyhow::Context;
+use pathfinder_common::TransactionHash;
 use pathfinder_executor::TransactionExecutionError;
 use starknet_gateway_client::GatewayApi;
 
 use crate::compose_executor_transaction;
 use crate::context::RpcContext;
+use crate::dto::TransactionTrace;
 use crate::error::{ApplicationError, TraceError};
 use crate::executor::{
     ExecutionStateError,
     VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEWAY,
 };
 use crate::method::trace_block_transactions::map_gateway_trace;
-use crate::v06::method::trace_transaction as v06;
 
 #[derive(Debug)]
-pub struct Output {
-    trace: pathfinder_executor::types::TransactionTrace,
-    include_state_diff: bool,
+pub struct Input {
+    pub transaction_hash: TransactionHash,
 }
 
-pub async fn trace_transaction(
+impl crate::dto::DeserializeForVersion for Input {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        value.deserialize_map(|value| {
+            Ok(Self {
+                transaction_hash: value.deserialize("transaction_hash").map(TransactionHash)?,
+            })
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct Output(TransactionTrace);
+
+impl crate::dto::serialize::SerializeForVersion for Output {
+    fn serialize(
+        &self,
+        serializer: crate::dto::serialize::Serializer,
+    ) -> Result<crate::dto::serialize::Ok, crate::dto::serialize::Error> {
+        self.0.serialize(serializer)
+    }
+}
+
+pub async fn trace_transaction<'a>(
     context: RpcContext,
-    input: v06::TraceTransactionInput,
+    input: Input,
 ) -> Result<Output, TraceTransactionError> {
     #[allow(clippy::large_enum_variant)]
     enum LocalExecution {
@@ -147,10 +169,10 @@ pub async fn trace_transaction(
 
     let transaction = match local {
         LocalExecution::Success(trace) => {
-            return Ok(Output {
-                trace,
-                include_state_diff: true,
-            })
+            return Ok(Output(TransactionTrace {
+                trace: trace.clone(),
+                include_state_diff: false,
+            }));
         }
         LocalExecution::Unsupported(tx) => tx,
     };
@@ -163,24 +185,11 @@ pub async fn trace_transaction(
 
     let trace = map_gateway_trace(transaction, trace)?;
 
-    Ok(Output {
-        trace,
+    Ok(Output(TransactionTrace {
+        trace: trace.clone(),
         // State diffs are not available for traces fetched from the gateway.
         include_state_diff: false,
-    })
-}
-
-impl crate::dto::serialize::SerializeForVersion for Output {
-    fn serialize(
-        &self,
-        serializer: crate::dto::serialize::Serializer,
-    ) -> Result<crate::dto::serialize::Ok, crate::dto::serialize::Error> {
-        crate::dto::TransactionTrace {
-            trace: &self.trace,
-            include_state_diff: self.include_state_diff,
-        }
-        .serialize(serializer)
-    }
+    }))
 }
 
 #[derive(Debug)]
@@ -251,12 +260,12 @@ impl From<TraceTransactionError> for ApplicationError {
 
 #[cfg(test)]
 pub mod tests {
+
     use super::super::trace_block_transactions::tests::{
         setup_multi_tx_trace_pending_test,
         setup_multi_tx_trace_test,
     };
-    use super::v06::{TraceTransactionInput, TraceTransactionOutput};
-    use super::*;
+    use super::{trace_transaction, Input, Output};
     use crate::dto::serialize::{SerializeForVersion, Serializer};
     use crate::RpcVersion;
 
@@ -265,18 +274,25 @@ pub mod tests {
         let (context, _, traces) = setup_multi_tx_trace_test().await?;
 
         for trace in traces {
-            let input = TraceTransactionInput {
+            let input = Input {
                 transaction_hash: trace.transaction_hash,
             };
             let output = trace_transaction(context.clone(), input).await.unwrap();
-            let expected = TraceTransactionOutput(trace.trace_root);
+            let expected = Output(crate::dto::TransactionTrace {
+                trace: trace.trace_root,
+                include_state_diff: false,
+            });
             pretty_assertions_sorted::assert_eq!(
                 output
                     .serialize(Serializer {
-                        version: RpcVersion::V06
+                        version: RpcVersion::V07
                     })
                     .unwrap(),
-                serde_json::to_value(expected).unwrap()
+                expected
+                    .serialize(Serializer {
+                        version: RpcVersion::V07
+                    })
+                    .unwrap()
             );
         }
 
@@ -288,18 +304,25 @@ pub mod tests {
         let (context, traces) = setup_multi_tx_trace_pending_test().await?;
 
         for trace in traces {
-            let input = TraceTransactionInput {
+            let input = Input {
                 transaction_hash: trace.transaction_hash,
             };
             let output = trace_transaction(context.clone(), input).await.unwrap();
-            let expected = TraceTransactionOutput(trace.trace_root);
+            let expected = Output(crate::dto::TransactionTrace {
+                trace: trace.trace_root,
+                include_state_diff: false,
+            });
             pretty_assertions_sorted::assert_eq!(
                 output
                     .serialize(Serializer {
-                        version: RpcVersion::V06
+                        version: RpcVersion::V07
                     })
                     .unwrap(),
-                serde_json::to_value(expected).unwrap()
+                expected
+                    .serialize(Serializer {
+                        version: RpcVersion::V07
+                    })
+                    .unwrap()
             );
         }
 

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -1,7 +1,9 @@
 //! Common data structures used by the JSON-RPC API methods.
 
 pub(crate) mod class;
+pub(crate) mod receipt;
 pub mod syncing;
+pub(crate) mod transaction;
 
 pub use class::*;
 use pathfinder_common::{ResourceAmount, ResourcePricePerUnit};

--- a/crates/rpc/src/types/receipt.rs
+++ b/crates/rpc/src/types/receipt.rs
@@ -1,0 +1,166 @@
+use pathfinder_common::{ContractAddress, EventData, EventKey, L2ToL1MessagePayloadElem};
+use serde::Serialize;
+use serde_with::serde_as;
+
+use crate::felt::{RpcFelt, RpcFelt251};
+use crate::types::reply::BlockStatus;
+
+#[derive(Clone, Debug, Default, Serialize, PartialEq, Eq)]
+#[cfg_attr(test, derive(serde::Deserialize))]
+pub struct ExecutionResourcesProperties {
+    pub steps: u64,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub memory_holes: u64,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub range_check_builtin_applications: u64,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub pedersen_builtin_applications: u64,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub poseidon_builtin_applications: u64,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub ec_op_builtin_applications: u64,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub ecdsa_builtin_applications: u64,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub bitwise_builtin_applications: u64,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub keccak_builtin_applications: u64,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub segment_arena_builtin: u64,
+}
+
+fn is_zero(value: &u64) -> bool {
+    *value == 0
+}
+
+impl From<pathfinder_common::receipt::ExecutionResources> for ExecutionResourcesProperties {
+    fn from(value: pathfinder_common::receipt::ExecutionResources) -> Self {
+        let pathfinder_common::receipt::ExecutionResources {
+            builtins:
+                pathfinder_common::receipt::BuiltinCounters {
+                    // Absent from the OpenRPC spec
+                    output: _,
+                    pedersen: pedersen_builtin,
+                    range_check: range_check_builtin,
+                    ecdsa: ecdsa_builtin,
+                    bitwise: bitwise_builtin,
+                    ec_op: ec_op_builtin,
+                    keccak: keccak_builtin,
+                    poseidon: poseidon_builtin,
+                    segment_arena: segment_arena_builtin,
+                    ..
+                },
+            n_steps,
+            n_memory_holes,
+            ..
+        } = value;
+
+        Self {
+            steps: n_steps,
+            memory_holes: n_memory_holes,
+            range_check_builtin_applications: range_check_builtin,
+            pedersen_builtin_applications: pedersen_builtin,
+            poseidon_builtin_applications: poseidon_builtin,
+            ec_op_builtin_applications: ec_op_builtin,
+            ecdsa_builtin_applications: ecdsa_builtin,
+            bitwise_builtin_applications: bitwise_builtin,
+            keccak_builtin_applications: keccak_builtin,
+            segment_arena_builtin,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[cfg_attr(test, derive(serde::Deserialize))]
+pub enum ExecutionStatus {
+    Succeeded,
+    Reverted,
+}
+
+impl From<pathfinder_common::receipt::ExecutionStatus> for ExecutionStatus {
+    fn from(value: pathfinder_common::receipt::ExecutionStatus) -> Self {
+        match value {
+            pathfinder_common::receipt::ExecutionStatus::Succeeded => Self::Succeeded,
+            pathfinder_common::receipt::ExecutionStatus::Reverted { .. } => Self::Reverted,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[cfg_attr(test, derive(serde::Deserialize))]
+pub enum FinalityStatus {
+    AcceptedOnL2,
+    //AcceptedOnL1,
+}
+
+/// Message sent from L2 to L1.
+#[serde_as]
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[cfg_attr(test, derive(serde::Deserialize))]
+#[serde(deny_unknown_fields)]
+pub struct MessageToL1 {
+    pub from_address: ContractAddress,
+    pub to_address: ContractAddress,
+    #[serde_as(as = "Vec<RpcFelt>")]
+    pub payload: Vec<L2ToL1MessagePayloadElem>,
+}
+
+impl From<pathfinder_common::receipt::L2ToL1Message> for MessageToL1 {
+    fn from(value: pathfinder_common::receipt::L2ToL1Message) -> Self {
+        Self {
+            from_address: value.from_address,
+            to_address: value.to_address,
+            payload: value.payload,
+        }
+    }
+}
+
+/// Event emitted as a part of a transaction.
+#[serde_as]
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[cfg_attr(test, derive(serde::Deserialize))]
+#[serde(deny_unknown_fields)]
+pub struct Event {
+    #[serde_as(as = "RpcFelt251")]
+    pub from_address: ContractAddress,
+    #[serde_as(as = "Vec<RpcFelt>")]
+    pub keys: Vec<EventKey>,
+    #[serde_as(as = "Vec<RpcFelt>")]
+    pub data: Vec<EventData>,
+}
+
+impl From<pathfinder_common::event::Event> for Event {
+    fn from(e: pathfinder_common::event::Event) -> Self {
+        Self {
+            from_address: e.from_address,
+            keys: e.keys,
+            data: e.data,
+        }
+    }
+}
+
+/// Represents transaction status.
+#[derive(Copy, Clone, Debug, Serialize, PartialEq, Eq)]
+#[cfg_attr(test, derive(serde::Deserialize))]
+#[serde(deny_unknown_fields)]
+pub enum TransactionStatus {
+    #[serde(rename = "ACCEPTED_ON_L2")]
+    AcceptedOnL2,
+    #[serde(rename = "ACCEPTED_ON_L1")]
+    AcceptedOnL1,
+    #[serde(rename = "REJECTED")]
+    Rejected,
+}
+
+impl From<BlockStatus> for TransactionStatus {
+    fn from(status: BlockStatus) -> Self {
+        match status {
+            BlockStatus::Pending => TransactionStatus::AcceptedOnL2,
+            BlockStatus::AcceptedOnL2 => TransactionStatus::AcceptedOnL2,
+            BlockStatus::AcceptedOnL1 => TransactionStatus::AcceptedOnL1,
+            BlockStatus::Rejected => TransactionStatus::Rejected,
+        }
+    }
+}

--- a/crates/rpc/src/types/transaction.rs
+++ b/crates/rpc/src/types/transaction.rs
@@ -1,0 +1,836 @@
+use pathfinder_common::transaction::{
+    DataAvailabilityMode,
+    DeclareTransactionV0V1,
+    DeclareTransactionV2,
+    DeclareTransactionV3,
+    DeployAccountTransactionV1,
+    DeployAccountTransactionV3,
+    DeployTransactionV0,
+    DeployTransactionV1,
+    InvokeTransactionV0,
+    InvokeTransactionV1,
+    InvokeTransactionV3,
+    L1HandlerTransaction,
+    ResourceBound,
+    ResourceBounds,
+};
+use pathfinder_common::{
+    ResourceAmount,
+    ResourcePricePerUnit,
+    Tip,
+    TransactionHash,
+    TransactionVersion,
+};
+use serde::ser::SerializeStruct;
+use serde::Serialize;
+
+/// Equivalent to the TXN type from the specification.
+#[derive(PartialEq, Debug, Clone, Eq)]
+pub struct Transaction(pub pathfinder_common::transaction::TransactionVariant);
+
+/// A transaction and its hash, a common structure used in the spec.
+#[derive(serde::Serialize, PartialEq, Debug, Clone, Eq)]
+pub struct TransactionWithHash {
+    pub transaction_hash: TransactionHash,
+    #[serde(flatten)]
+    pub txn: Transaction,
+}
+
+impl From<pathfinder_common::transaction::Transaction> for TransactionWithHash {
+    fn from(value: pathfinder_common::transaction::Transaction) -> Self {
+        Self {
+            transaction_hash: value.hash,
+            txn: Transaction(value.variant),
+        }
+    }
+}
+
+impl Serialize for Transaction {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use pathfinder_common::transaction::TransactionVariant;
+        match &self.0 {
+            TransactionVariant::DeclareV0(x) => DeclareV0Helper(x).serialize(serializer),
+            TransactionVariant::DeclareV1(x) => DeclareV1Helper(x).serialize(serializer),
+            TransactionVariant::DeclareV2(x) => DeclareV2Helper(x).serialize(serializer),
+            TransactionVariant::DeclareV3(x) => DeclareV3Helper(x).serialize(serializer),
+            TransactionVariant::DeployV0(x) => DeployV0Helper(x).serialize(serializer),
+            TransactionVariant::DeployV1(x) => DeployV1Helper(x).serialize(serializer),
+            TransactionVariant::DeployAccountV1(x) => {
+                DeployAccountV1Helper(x).serialize(serializer)
+            }
+            TransactionVariant::DeployAccountV3(x) => {
+                DeployAccountV3Helper(x).serialize(serializer)
+            }
+            TransactionVariant::InvokeV0(x) => InvokeV0Helper(x).serialize(serializer),
+            TransactionVariant::InvokeV1(x) => InvokeV1Helper(x).serialize(serializer),
+            TransactionVariant::InvokeV3(x) => InvokeV3Helper(x).serialize(serializer),
+            TransactionVariant::L1Handler(x) => L1HandlerHelper(x).serialize(serializer),
+        }
+    }
+}
+
+struct DeclareV0Helper<'a>(&'a DeclareTransactionV0V1);
+struct DeclareV1Helper<'a>(&'a DeclareTransactionV0V1);
+struct DeclareV2Helper<'a>(&'a DeclareTransactionV2);
+struct DeclareV3Helper<'a>(&'a DeclareTransactionV3);
+struct DeployV0Helper<'a>(&'a DeployTransactionV0);
+struct DeployV1Helper<'a>(&'a DeployTransactionV1);
+
+struct DeployAccountV1Helper<'a>(&'a DeployAccountTransactionV1);
+struct DeployAccountV3Helper<'a>(&'a DeployAccountTransactionV3);
+struct InvokeV0Helper<'a>(&'a InvokeTransactionV0);
+struct InvokeV1Helper<'a>(&'a InvokeTransactionV1);
+struct InvokeV3Helper<'a>(&'a InvokeTransactionV3);
+struct L1HandlerHelper<'a>(&'a L1HandlerTransaction);
+struct TransactionVersionHelper<'a>(&'a TransactionVersion);
+struct ResourceBoundsHelper<'a>(&'a ResourceBounds);
+struct ResourceBoundHelper<'a>(&'a ResourceBound);
+struct ResourceAmountHelper<'a>(&'a ResourceAmount);
+struct ResourcePricePerUnitHelper<'a>(&'a ResourcePricePerUnit);
+struct DataAvailabilityModeHelper<'a>(&'a DataAvailabilityMode);
+struct TipHelper<'a>(&'a Tip);
+
+impl Serialize for DeclareV0Helper<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut s = serializer.serialize_struct("DeclareV0", 6)?;
+        s.serialize_field("type", "DECLARE")?;
+        s.serialize_field("sender_address", &self.0.sender_address)?;
+        s.serialize_field("max_fee", &self.0.max_fee)?;
+        s.serialize_field("version", "0x0")?;
+        s.serialize_field("signature", &self.0.signature)?;
+        s.serialize_field("class_hash", &self.0.class_hash)?;
+        s.end()
+    }
+}
+
+impl Serialize for DeclareV1Helper<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut s = serializer.serialize_struct("DeclareV1", 7)?;
+        s.serialize_field("type", "DECLARE")?;
+        s.serialize_field("sender_address", &self.0.sender_address)?;
+        s.serialize_field("max_fee", &self.0.max_fee)?;
+        s.serialize_field("version", "0x1")?;
+        s.serialize_field("signature", &self.0.signature)?;
+        s.serialize_field("nonce", &self.0.nonce)?;
+        s.serialize_field("class_hash", &self.0.class_hash)?;
+        s.end()
+    }
+}
+
+impl Serialize for DeclareV2Helper<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut s = serializer.serialize_struct("DeclareV2", 8)?;
+        s.serialize_field("type", "DECLARE")?;
+        s.serialize_field("sender_address", &self.0.sender_address)?;
+        s.serialize_field("compiled_class_hash", &self.0.compiled_class_hash)?;
+        s.serialize_field("max_fee", &self.0.max_fee)?;
+        s.serialize_field("version", "0x2")?;
+        s.serialize_field("signature", &self.0.signature)?;
+        s.serialize_field("nonce", &self.0.nonce)?;
+        s.serialize_field("class_hash", &self.0.class_hash)?;
+        s.end()
+    }
+}
+
+impl Serialize for DeclareV3Helper<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut s = serializer.serialize_struct("DeclareV3", 13)?;
+        s.serialize_field("type", "DECLARE")?;
+        s.serialize_field("sender_address", &self.0.sender_address)?;
+        s.serialize_field("compiled_class_hash", &self.0.compiled_class_hash)?;
+        s.serialize_field("version", "0x3")?;
+        s.serialize_field("signature", &self.0.signature)?;
+        s.serialize_field("nonce", &self.0.nonce)?;
+        s.serialize_field("class_hash", &self.0.class_hash)?;
+        s.serialize_field(
+            "resource_bounds",
+            &ResourceBoundsHelper(&self.0.resource_bounds),
+        )?;
+        s.serialize_field("tip", &TipHelper(&self.0.tip))?;
+        s.serialize_field("paymaster_data", &self.0.paymaster_data)?;
+        s.serialize_field("account_deployment_data", &self.0.account_deployment_data)?;
+        s.serialize_field(
+            "nonce_data_availability_mode",
+            &DataAvailabilityModeHelper(&self.0.nonce_data_availability_mode),
+        )?;
+        s.serialize_field(
+            "fee_data_availability_mode",
+            &DataAvailabilityModeHelper(&self.0.fee_data_availability_mode),
+        )?;
+        s.end()
+    }
+}
+
+impl Serialize for DeployV0Helper<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut s = serializer.serialize_struct("Deploy", 5)?;
+        s.serialize_field(
+            "version",
+            &TransactionVersionHelper(&TransactionVersion::ZERO),
+        )?;
+        s.serialize_field("type", "DEPLOY")?;
+        s.serialize_field("contract_address_salt", &self.0.contract_address_salt)?;
+        s.serialize_field("constructor_calldata", &self.0.constructor_calldata)?;
+        s.serialize_field("class_hash", &self.0.class_hash)?;
+        s.end()
+    }
+}
+
+impl Serialize for DeployV1Helper<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut s = serializer.serialize_struct("Deploy", 5)?;
+        s.serialize_field(
+            "version",
+            &TransactionVersionHelper(&TransactionVersion::ONE),
+        )?;
+        s.serialize_field("type", "DEPLOY")?;
+        s.serialize_field("contract_address_salt", &self.0.contract_address_salt)?;
+        s.serialize_field("constructor_calldata", &self.0.constructor_calldata)?;
+        s.serialize_field("class_hash", &self.0.class_hash)?;
+        s.end()
+    }
+}
+
+impl Serialize for DeployAccountV1Helper<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut s = serializer.serialize_struct("DeployAccount", 8)?;
+        s.serialize_field("type", "DEPLOY_ACCOUNT")?;
+        s.serialize_field("max_fee", &self.0.max_fee)?;
+        s.serialize_field("version", "0x1")?;
+        s.serialize_field("signature", &self.0.signature)?;
+        s.serialize_field("nonce", &self.0.nonce)?;
+        s.serialize_field("contract_address_salt", &self.0.contract_address_salt)?;
+        s.serialize_field("constructor_calldata", &self.0.constructor_calldata)?;
+        s.serialize_field("class_hash", &self.0.class_hash)?;
+        s.end()
+    }
+}
+
+impl Serialize for DeployAccountV3Helper<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut s = serializer.serialize_struct("DeployAccount", 12)?;
+        s.serialize_field("type", "DEPLOY_ACCOUNT")?;
+        s.serialize_field("version", "0x3")?;
+        s.serialize_field("signature", &self.0.signature)?;
+        s.serialize_field("nonce", &self.0.nonce)?;
+        s.serialize_field("contract_address_salt", &self.0.contract_address_salt)?;
+        s.serialize_field("constructor_calldata", &self.0.constructor_calldata)?;
+        s.serialize_field("class_hash", &self.0.class_hash)?;
+        s.serialize_field(
+            "resource_bounds",
+            &ResourceBoundsHelper(&self.0.resource_bounds),
+        )?;
+        s.serialize_field("tip", &TipHelper(&self.0.tip))?;
+        s.serialize_field("paymaster_data", &self.0.paymaster_data)?;
+        s.serialize_field(
+            "nonce_data_availability_mode",
+            &DataAvailabilityModeHelper(&self.0.nonce_data_availability_mode),
+        )?;
+        s.serialize_field(
+            "fee_data_availability_mode",
+            &DataAvailabilityModeHelper(&self.0.fee_data_availability_mode),
+        )?;
+        s.end()
+    }
+}
+
+impl Serialize for InvokeV0Helper<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut s = serializer.serialize_struct("InvokeV0", 7)?;
+        s.serialize_field("type", "INVOKE")?;
+        s.serialize_field("max_fee", &self.0.max_fee)?;
+        s.serialize_field("version", "0x0")?;
+        s.serialize_field("signature", &self.0.signature)?;
+        s.serialize_field("contract_address", &self.0.sender_address)?;
+        s.serialize_field("entry_point_selector", &self.0.entry_point_selector)?;
+        s.serialize_field("calldata", &self.0.calldata)?;
+        s.end()
+    }
+}
+
+impl Serialize for InvokeV1Helper<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut s = serializer.serialize_struct("InvokeV1", 7)?;
+        s.serialize_field("type", "INVOKE")?;
+        s.serialize_field("sender_address", &self.0.sender_address)?;
+        s.serialize_field("calldata", &self.0.calldata)?;
+        s.serialize_field("max_fee", &self.0.max_fee)?;
+        s.serialize_field("version", "0x1")?;
+        s.serialize_field("signature", &self.0.signature)?;
+        s.serialize_field("nonce", &self.0.nonce)?;
+        s.end()
+    }
+}
+
+impl Serialize for InvokeV3Helper<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut s = serializer.serialize_struct("InvokeV3", 12)?;
+        s.serialize_field("type", "INVOKE")?;
+        s.serialize_field("sender_address", &self.0.sender_address)?;
+        s.serialize_field("calldata", &self.0.calldata)?;
+        s.serialize_field("version", "0x3")?;
+        s.serialize_field("signature", &self.0.signature)?;
+        s.serialize_field("nonce", &self.0.nonce)?;
+        s.serialize_field(
+            "resource_bounds",
+            &ResourceBoundsHelper(&self.0.resource_bounds),
+        )?;
+        s.serialize_field("tip", &TipHelper(&self.0.tip))?;
+        s.serialize_field("paymaster_data", &self.0.paymaster_data)?;
+        s.serialize_field("account_deployment_data", &self.0.account_deployment_data)?;
+        s.serialize_field(
+            "nonce_data_availability_mode",
+            &DataAvailabilityModeHelper(&self.0.nonce_data_availability_mode),
+        )?;
+        s.serialize_field(
+            "fee_data_availability_mode",
+            &DataAvailabilityModeHelper(&self.0.fee_data_availability_mode),
+        )?;
+        s.end()
+    }
+}
+
+impl Serialize for L1HandlerHelper<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut s = serializer.serialize_struct("L1Handler", 6)?;
+        s.serialize_field(
+            "version",
+            &TransactionVersionHelper(&TransactionVersion::ZERO),
+        )?;
+        s.serialize_field("type", "L1_HANDLER")?;
+        s.serialize_field("nonce", &self.0.nonce)?;
+        s.serialize_field("contract_address", &self.0.contract_address)?;
+        s.serialize_field("entry_point_selector", &self.0.entry_point_selector)?;
+        s.serialize_field("calldata", &self.0.calldata)?;
+        s.end()
+    }
+}
+
+impl Serialize for TransactionVersionHelper<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use pathfinder_serde::bytes_to_hex_str;
+        serializer.serialize_str(&bytes_to_hex_str(self.0 .0.as_be_bytes()))
+    }
+}
+
+impl Serialize for ResourceBoundsHelper<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut s = serializer.serialize_struct("ResourceBounds", 2)?;
+        s.serialize_field("l1_gas", &ResourceBoundHelper(&self.0.l1_gas))?;
+        s.serialize_field("l2_gas", &ResourceBoundHelper(&self.0.l2_gas))?;
+        s.end()
+    }
+}
+
+impl Serialize for ResourceBoundHelper<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut s = serializer.serialize_struct("ResourceBound", 2)?;
+        s.serialize_field("max_amount", &ResourceAmountHelper(&self.0.max_amount))?;
+        s.serialize_field(
+            "max_price_per_unit",
+            &ResourcePricePerUnitHelper(&self.0.max_price_per_unit),
+        )?;
+        s.end()
+    }
+}
+
+impl Serialize for ResourceAmountHelper<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use pathfinder_serde::bytes_to_hex_str;
+        serializer.serialize_str(&bytes_to_hex_str(&self.0 .0.to_be_bytes()))
+    }
+}
+
+impl Serialize for ResourcePricePerUnitHelper<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use pathfinder_serde::bytes_to_hex_str;
+        serializer.serialize_str(&bytes_to_hex_str(&self.0 .0.to_be_bytes()))
+    }
+}
+
+impl Serialize for DataAvailabilityModeHelper<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.0 {
+            DataAvailabilityMode::L1 => serializer.serialize_str("L1"),
+            DataAvailabilityMode::L2 => serializer.serialize_str("L2"),
+        }
+    }
+}
+
+impl Serialize for TipHelper<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use pathfinder_serde::bytes_to_hex_str;
+        serializer.serialize_str(&bytes_to_hex_str(&self.0 .0.to_be_bytes()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pathfinder_common::macro_prelude::*;
+
+    use super::*;
+
+    mod serialization {
+        use pathfinder_common::transaction::*;
+        use pathfinder_common::{ResourceAmount, ResourcePricePerUnit, Tip};
+        use pretty_assertions_sorted::assert_eq;
+        use serde_json::json;
+
+        use super::*;
+
+        #[test]
+        fn declare_v0() {
+            let original = DeclareTransactionV0V1 {
+                class_hash: class_hash!("0x123"),
+                max_fee: fee!("0x1111"),
+                nonce: transaction_nonce!("0xaabbcc"),
+                sender_address: contract_address!("0xabc"),
+                signature: vec![
+                    transaction_signature_elem!("0xa1b1"),
+                    transaction_signature_elem!("0x1a1b"),
+                ],
+            };
+
+            let expected = json!({
+                "type": "DECLARE",
+                "version": "0x0",
+                "sender_address": "0xabc",
+                "max_fee": "0x1111",
+                "signature": ["0xa1b1", "0x1a1b"],
+                "class_hash": "0x123",
+            });
+            let uut = Transaction(TransactionVariant::DeclareV0(original));
+            let result = serde_json::to_value(uut).unwrap();
+
+            assert_eq!(result, expected);
+        }
+
+        #[test]
+        fn declare_v1() {
+            let original = DeclareTransactionV0V1 {
+                class_hash: class_hash!("0x123"),
+                max_fee: fee!("0x1111"),
+                nonce: transaction_nonce!("0xaabbcc"),
+                sender_address: contract_address!("0xabc"),
+                signature: vec![
+                    transaction_signature_elem!("0xa1b1"),
+                    transaction_signature_elem!("0x1a1b"),
+                ],
+            };
+
+            let expected = json!({
+                "type": "DECLARE",
+                "version": "0x1",
+                "sender_address": "0xabc",
+                "max_fee": "0x1111",
+                "signature": ["0xa1b1", "0x1a1b"],
+                "class_hash": "0x123",
+                "nonce": "0xaabbcc",
+            });
+            let uut = Transaction(TransactionVariant::DeclareV1(original));
+            let result = serde_json::to_value(uut).unwrap();
+
+            assert_eq!(result, expected);
+        }
+
+        #[test]
+        fn declare_v2() {
+            let original: TransactionVariant = DeclareTransactionV2 {
+                class_hash: class_hash!("0x123"),
+                max_fee: fee!("0x1111"),
+                nonce: transaction_nonce!("0xaabbcc"),
+                sender_address: contract_address!("0xabc"),
+                signature: vec![
+                    transaction_signature_elem!("0xa1b1"),
+                    transaction_signature_elem!("0x1a1b"),
+                ],
+                compiled_class_hash: casm_hash!("0xbbbbb"),
+            }
+            .into();
+
+            let expected = json!({
+                "type": "DECLARE",
+                "version": "0x2",
+                "sender_address": "0xabc",
+                "max_fee": "0x1111",
+                "signature": ["0xa1b1", "0x1a1b"],
+                "class_hash": "0x123",
+                "nonce": "0xaabbcc",
+                "compiled_class_hash": "0xbbbbb",
+            });
+            let uut = Transaction(original);
+            let result = serde_json::to_value(uut).unwrap();
+
+            assert_eq!(result, expected);
+        }
+
+        #[test]
+        fn declare_v3() {
+            let original: TransactionVariant = DeclareTransactionV3 {
+                class_hash: class_hash!("0x123"),
+                nonce: transaction_nonce!("0xaabbcc"),
+                sender_address: contract_address!("0xabc"),
+                signature: vec![
+                    transaction_signature_elem!("0xa1b1"),
+                    transaction_signature_elem!("0x1a1b"),
+                ],
+                compiled_class_hash: casm_hash!("0xbbbbb"),
+                nonce_data_availability_mode: DataAvailabilityMode::L1,
+                fee_data_availability_mode: DataAvailabilityMode::L1,
+                resource_bounds: ResourceBounds {
+                    l1_gas: ResourceBound {
+                        max_amount: ResourceAmount(256),
+                        max_price_per_unit: ResourcePricePerUnit(10),
+                    },
+                    l2_gas: Default::default(),
+                    l1_data_gas: Default::default(),
+                },
+                tip: Tip(5),
+                paymaster_data: vec![],
+                account_deployment_data: vec![],
+            }
+            .into();
+
+            let expected = json!({
+                "type": "DECLARE",
+                "version": "0x3",
+                "sender_address": "0xabc",
+                "signature": ["0xa1b1", "0x1a1b"],
+                "class_hash": "0x123",
+                "nonce": "0xaabbcc",
+                "compiled_class_hash": "0xbbbbb",
+                "nonce_data_availability_mode": "L1",
+                "fee_data_availability_mode": "L1",
+                "resource_bounds": {
+                    "l1_gas": {
+                        "max_amount": "0x100",
+                        "max_price_per_unit": "0xa",
+                    },
+                    "l2_gas": {
+                        "max_amount": "0x0",
+                        "max_price_per_unit": "0x0",
+                    }
+                },
+                "tip": "0x5",
+                "paymaster_data": [],
+                "account_deployment_data": [],
+            });
+            let uut = Transaction(original);
+            let result = serde_json::to_value(uut).unwrap();
+
+            assert_eq!(result, expected);
+        }
+
+        #[test]
+        fn deploy() {
+            let original: TransactionVariant = DeployTransactionV0 {
+                contract_address: contract_address!("0xabc"),
+                contract_address_salt: contract_address_salt!("0xeeee"),
+                class_hash: class_hash!("0x123"),
+                constructor_calldata: vec![
+                    constructor_param!("0xbbb0"),
+                    constructor_param!("0xbbb1"),
+                ],
+            }
+            .into();
+
+            let expected = json!({
+                "type": "DEPLOY",
+                "contract_address_salt": "0xeeee",
+                "class_hash": "0x123",
+                "constructor_calldata": ["0xbbb0","0xbbb1"],
+                "version": "0x0",
+            });
+            let uut = Transaction(original);
+            let result = serde_json::to_value(uut).unwrap();
+
+            assert_eq!(result, expected);
+        }
+
+        #[test]
+        fn deploy_account_v1() {
+            let original: TransactionVariant = DeployAccountTransactionV1 {
+                contract_address: contract_address!("0xabc"),
+                max_fee: fee!("0x1111"),
+                signature: vec![
+                    transaction_signature_elem!("0xa1b1"),
+                    transaction_signature_elem!("0x1a1b"),
+                ],
+                nonce: transaction_nonce!("0xaabbcc"),
+                contract_address_salt: contract_address_salt!("0xeeee"),
+                constructor_calldata: vec![call_param!("0xbbb0"), call_param!("0xbbb1")],
+                class_hash: class_hash!("0x123"),
+            }
+            .into();
+
+            let expected = json!({
+                "type": "DEPLOY_ACCOUNT",
+                "max_fee": "0x1111",
+                "version": "0x1",
+                "signature": ["0xa1b1", "0x1a1b"],
+                "nonce": "0xaabbcc",
+                "contract_address_salt": "0xeeee",
+                "constructor_calldata": ["0xbbb0","0xbbb1"],
+                "class_hash": "0x123",
+            });
+            let uut = Transaction(original);
+            let result = serde_json::to_value(uut).unwrap();
+
+            assert_eq!(result, expected);
+        }
+
+        #[test]
+        fn deploy_account_v3() {
+            let original: TransactionVariant = DeployAccountTransactionV3 {
+                contract_address: contract_address!("0xabc"),
+                signature: vec![
+                    transaction_signature_elem!("0xa1b1"),
+                    transaction_signature_elem!("0x1a1b"),
+                ],
+                nonce: transaction_nonce!("0xaabbcc"),
+                contract_address_salt: contract_address_salt!("0xeeee"),
+                constructor_calldata: vec![call_param!("0xbbb0"), call_param!("0xbbb1")],
+                class_hash: class_hash!("0x123"),
+                nonce_data_availability_mode: DataAvailabilityMode::L1,
+                fee_data_availability_mode: DataAvailabilityMode::L1,
+                resource_bounds: ResourceBounds {
+                    l1_gas: ResourceBound {
+                        max_amount: ResourceAmount(256),
+                        max_price_per_unit: ResourcePricePerUnit(10),
+                    },
+                    l2_gas: Default::default(),
+                    l1_data_gas: Default::default(),
+                },
+                tip: Tip(5),
+                paymaster_data: vec![],
+            }
+            .into();
+
+            let expected = json!({
+                "type": "DEPLOY_ACCOUNT",
+                "version": "0x3",
+                "signature": ["0xa1b1", "0x1a1b"],
+                "nonce": "0xaabbcc",
+                "contract_address_salt": "0xeeee",
+                "constructor_calldata": ["0xbbb0","0xbbb1"],
+                "class_hash": "0x123",
+                "nonce_data_availability_mode": "L1",
+                "fee_data_availability_mode": "L1",
+                "resource_bounds": {
+                    "l1_gas": {
+                        "max_amount": "0x100",
+                        "max_price_per_unit": "0xa",
+                    },
+                    "l2_gas": {
+                        "max_amount": "0x0",
+                        "max_price_per_unit": "0x0",
+                    }
+                },
+                "tip": "0x5",
+                "paymaster_data": [],
+            });
+            let uut = Transaction(original);
+            let result = serde_json::to_value(uut).unwrap();
+
+            assert_eq!(result, expected);
+        }
+
+        #[test]
+        fn invoke_v0() {
+            let original: TransactionVariant = InvokeTransactionV0 {
+                calldata: vec![call_param!("0xfff1"), call_param!("0xfff0")],
+                sender_address: contract_address!("0xabc"),
+                entry_point_selector: entry_point!("0xdead"),
+                entry_point_type: Some(EntryPointType::External),
+                max_fee: fee!("0x1111"),
+                signature: vec![
+                    transaction_signature_elem!("0xa1b1"),
+                    transaction_signature_elem!("0x1a1b"),
+                ],
+            }
+            .into();
+
+            let expected = json!({
+                "type": "INVOKE",
+                "version": "0x0",
+                "calldata": ["0xfff1","0xfff0"],
+                "contract_address": "0xabc",
+                "entry_point_selector": "0xdead",
+                "max_fee": "0x1111",
+                "signature": ["0xa1b1", "0x1a1b"],
+            });
+            let uut = Transaction(original);
+            let result = serde_json::to_value(uut).unwrap();
+
+            assert_eq!(result, expected);
+        }
+
+        #[test]
+        fn invoke_v1() {
+            let original: TransactionVariant = InvokeTransactionV1 {
+                calldata: vec![call_param!("0xfff1"), call_param!("0xfff0")],
+                sender_address: contract_address!("0xabc"),
+                max_fee: fee!("0x1111"),
+                signature: vec![
+                    transaction_signature_elem!("0xa1b1"),
+                    transaction_signature_elem!("0x1a1b"),
+                ],
+                nonce: transaction_nonce!("0xaabbcc"),
+            }
+            .into();
+
+            let expected = json!({
+                "type": "INVOKE",
+                "version": "0x1",
+                "calldata": ["0xfff1","0xfff0"],
+                "sender_address": "0xabc",
+                "max_fee": "0x1111",
+                "signature": ["0xa1b1", "0x1a1b"],
+                "nonce": "0xaabbcc",
+            });
+            let uut = Transaction(original);
+            let result = serde_json::to_value(uut).unwrap();
+
+            assert_eq!(result, expected);
+        }
+
+        #[test]
+        fn invoke_v3() {
+            let original: TransactionVariant = InvokeTransactionV3 {
+                calldata: vec![call_param!("0xfff1"), call_param!("0xfff0")],
+                sender_address: contract_address!("0xabc"),
+                signature: vec![
+                    transaction_signature_elem!("0xa1b1"),
+                    transaction_signature_elem!("0x1a1b"),
+                ],
+                nonce: transaction_nonce!("0xaabbcc"),
+                nonce_data_availability_mode: DataAvailabilityMode::L1,
+                fee_data_availability_mode: DataAvailabilityMode::L1,
+                resource_bounds: ResourceBounds {
+                    l1_gas: ResourceBound {
+                        max_amount: ResourceAmount(256),
+                        max_price_per_unit: ResourcePricePerUnit(10),
+                    },
+                    l2_gas: Default::default(),
+                    l1_data_gas: Default::default(),
+                },
+                tip: Tip(5),
+                paymaster_data: vec![],
+                account_deployment_data: vec![],
+            }
+            .into();
+
+            let expected = json!({
+                "type": "INVOKE",
+                "version": "0x3",
+                "calldata": ["0xfff1","0xfff0"],
+                "sender_address": "0xabc",
+                "signature": ["0xa1b1", "0x1a1b"],
+                "nonce": "0xaabbcc",
+                "nonce_data_availability_mode": "L1",
+                "fee_data_availability_mode": "L1",
+                "resource_bounds": {
+                    "l1_gas": {
+                        "max_amount": "0x100",
+                        "max_price_per_unit": "0xa",
+                    },
+                    "l2_gas": {
+                        "max_amount": "0x0",
+                        "max_price_per_unit": "0x0",
+                    }
+                },
+                "tip": "0x5",
+                "paymaster_data": [],
+                "account_deployment_data": [],
+            });
+            let uut = Transaction(original);
+            let result = serde_json::to_value(uut).unwrap();
+
+            assert_eq!(result, expected);
+        }
+
+        #[test]
+        fn l1_handler() {
+            let original: TransactionVariant = L1HandlerTransaction {
+                contract_address: contract_address!("0xabc"),
+                entry_point_selector: entry_point!("0xdead"),
+                nonce: transaction_nonce!("0xaabbcc"),
+                calldata: vec![call_param!("0xfff1"), call_param!("0xfff0")],
+            }
+            .into();
+
+            let expected = json!({
+                "type": "L1_HANDLER",
+                "contract_address": "0xabc",
+                "entry_point_selector": "0xdead",
+                "nonce": "0xaabbcc",
+                "calldata": ["0xfff1","0xfff0"],
+                "version": "0x0",
+            });
+            let uut = Transaction(original);
+            let result = serde_json::to_value(uut).unwrap();
+
+            assert_eq!(result, expected);
+        }
+    }
+}

--- a/crates/rpc/src/v06/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v06/method/trace_block_transactions.rs
@@ -641,7 +641,8 @@ pub(crate) mod tests {
         let mut connection = context.storage.connection().unwrap();
         let transaction = connection.transaction().unwrap();
 
-        // Need to avoid skipping blocks for `insert_transaction_data`.
+        // Need to avoid skipping blocks for `insert_transaction_data`
+        // so that there is no gap in event filters.
         (0..619596)
             .step_by(pathfinder_storage::BLOCK_RANGE_LEN as usize)
             .for_each(|block: u64| {

--- a/crates/rpc/src/v07/dto/receipt.rs
+++ b/crates/rpc/src/v07/dto/receipt.rs
@@ -2,8 +2,8 @@ use pathfinder_common::prelude::*;
 use pathfinder_serde::H256AsNoLeadingZerosHexStr;
 use serde::Serialize;
 
+use crate::types::receipt;
 use crate::types::reply::BlockStatus;
-use crate::v06::method::get_transaction_receipt::types as v06;
 use crate::PendingData;
 
 #[derive(Serialize)]
@@ -37,7 +37,7 @@ impl From<PendingData> for PendingBlockWithReceipts {
             .map(|(t, (r, e))| (t.clone(), r.clone(), e.clone()))
             .collect::<Vec<_>>();
 
-        let body = BlockBodyWithReceipts::from_common(body, v06::FinalityStatus::AcceptedOnL2);
+        let body = BlockBodyWithReceipts::from_common(body, receipt::FinalityStatus::AcceptedOnL2);
 
         Self {
             header: value.header().into(),
@@ -54,7 +54,7 @@ struct BlockBodyWithReceipts {
 impl BlockBodyWithReceipts {
     fn from_common(
         value: Vec<(CommonTransaction, CommonReceipt, Vec<CommonEvent>)>,
-        finality_status: v06::FinalityStatus,
+        finality_status: receipt::FinalityStatus,
     ) -> Self {
         let transactions = value
             .into_iter()
@@ -68,7 +68,7 @@ impl BlockBodyWithReceipts {
 #[derive(Serialize)]
 // Inner type of block with receipts
 struct TransactionWithReceipt {
-    transaction: crate::v06::types::TransactionWithHash,
+    transaction: crate::types::transaction::TransactionWithHash,
     receipt: PendingTxnReceipt,
 }
 
@@ -77,7 +77,7 @@ impl TransactionWithReceipt {
         transaction: CommonTransaction,
         receipt: CommonReceipt,
         events: Vec<CommonEvent>,
-        finality_status: v06::FinalityStatus,
+        finality_status: receipt::FinalityStatus,
     ) -> Self {
         let receipt =
             PendingTxnReceipt::from_common(&transaction, receipt, events, finality_status);
@@ -155,7 +155,7 @@ impl PendingTxnReceipt {
         transaction: &CommonTransaction,
         receipt: CommonReceipt,
         events: Vec<CommonEvent>,
-        finality_status: v06::FinalityStatus,
+        finality_status: receipt::FinalityStatus,
     ) -> Self {
         let common = PendingCommonReceiptProperties::from_common(
             transaction,
@@ -198,11 +198,11 @@ impl PendingTxnReceipt {
 }
 
 #[derive(Serialize)]
-pub struct ComputationResources(v06::ExecutionResourcesProperties);
+pub struct ComputationResources(receipt::ExecutionResourcesProperties);
 
 impl From<pathfinder_common::receipt::ExecutionResources> for ComputationResources {
     fn from(value: pathfinder_common::receipt::ExecutionResources) -> Self {
-        Self(v06::ExecutionResourcesProperties {
+        Self(receipt::ExecutionResourcesProperties {
             steps: value.n_steps,
             memory_holes: value.n_memory_holes,
             range_check_builtin_applications: value.builtins.range_check,
@@ -255,26 +255,26 @@ pub struct CommonReceiptProperties {
     actual_fee: FeePayment,
     block_hash: BlockHash,
     block_number: BlockNumber,
-    messages_sent: Vec<v06::MessageToL1>,
-    events: Vec<v06::Event>,
+    messages_sent: Vec<receipt::MessageToL1>,
+    events: Vec<receipt::Event>,
     #[serde(skip_serializing_if = "Option::is_none")]
     revert_reason: Option<String>,
     execution_resources: ExecutionResources,
-    execution_status: v06::ExecutionStatus,
-    finality_status: v06::FinalityStatus,
+    execution_status: receipt::ExecutionStatus,
+    finality_status: receipt::FinalityStatus,
 }
 
 #[derive(Serialize)]
 pub struct PendingCommonReceiptProperties {
     transaction_hash: TransactionHash,
     actual_fee: FeePayment,
-    messages_sent: Vec<v06::MessageToL1>,
-    events: Vec<v06::Event>,
+    messages_sent: Vec<receipt::MessageToL1>,
+    events: Vec<receipt::Event>,
     #[serde(skip_serializing_if = "Option::is_none")]
     revert_reason: Option<String>,
-    execution_status: v06::ExecutionStatus,
+    execution_status: receipt::ExecutionStatus,
     execution_resources: ExecutionResources,
-    finality_status: v06::FinalityStatus,
+    finality_status: receipt::FinalityStatus,
 }
 
 impl PendingCommonReceiptProperties {
@@ -282,7 +282,7 @@ impl PendingCommonReceiptProperties {
         transaction: &CommonTransaction,
         receipt: CommonReceipt,
         events: Vec<CommonEvent>,
-        finality_status: v06::FinalityStatus,
+        finality_status: receipt::FinalityStatus,
     ) -> Self {
         let actual_fee = FeePayment {
             amount: receipt.actual_fee,
@@ -381,7 +381,7 @@ mod tests {
                 revert_reason: None,
                 execution_resources: ExecutionResources {
                     computation_resources: ComputationResources(
-                        v06::ExecutionResourcesProperties {
+                        receipt::ExecutionResourcesProperties {
                             steps: 10,
                             memory_holes: 0,
                             range_check_builtin_applications: 0,
@@ -399,8 +399,8 @@ mod tests {
                         l1_data_gas: 0,
                     },
                 },
-                execution_status: v06::ExecutionStatus::Succeeded,
-                finality_status: v06::FinalityStatus::AcceptedOnL2,
+                execution_status: receipt::ExecutionStatus::Succeeded,
+                finality_status: receipt::FinalityStatus::AcceptedOnL2,
             },
         };
 
@@ -442,7 +442,7 @@ mod tests {
                 revert_reason: None,
                 execution_resources: ExecutionResources {
                     computation_resources: ComputationResources(
-                        v06::ExecutionResourcesProperties {
+                        receipt::ExecutionResourcesProperties {
                             steps: 10,
                             memory_holes: 0,
                             range_check_builtin_applications: 0,
@@ -460,8 +460,8 @@ mod tests {
                         l1_data_gas: 0,
                     },
                 },
-                execution_status: v06::ExecutionStatus::Succeeded,
-                finality_status: v06::FinalityStatus::AcceptedOnL2,
+                execution_status: receipt::ExecutionStatus::Succeeded,
+                finality_status: receipt::FinalityStatus::AcceptedOnL2,
             },
         };
 


### PR DESCRIPTION
This PR is part of #2220 

### Summary

This PR removes the existing dependencies the current RPC versions (v07 and beyond) have on the legacy v06 RPC version, effectively decoupling the two. 

Key changes include:

- **Migration of types:** All relevant types, methods and tests from v06 have been migrated to common modules, allowing for reusability on newer RPC versions.

- **DTO Removal:** A number of data transfer objects (DTOs) from the v06 version have been removed and replaced with the actual types they were wrapping. This simplifies the code by eliminating unnecessary abstraction. The `SerializeForVersion` is implemented in the `Input` and `Output` DTO types for every method.

- **V06 Module Disabled:** The v06 module is now fully disabled and will no longer be built as part of the project. This sets the stage for its future removal. The `V06` variant from the multiple `RpcVersion` enums has been removed, as well as version-specific routing tests.

This PR helps streamline the codebase and ensures future versions of the RPC system are independent of the outdated v06 implementation.


### Next steps

- **V06 Module Deletion:** The v06 module will be deleted in an upcoming PR to keep this one focused and avoid making it too large.

- #2181 

- DTO cleanup, review of leftover `serde` derives and `deserialize_serde` calls