### PR TITLE
Handle getProof without storage root idx

### DIFF
--- a/crates/rpc/src/pathfinder/methods/get_proof.rs
+++ b/crates/rpc/src/pathfinder/methods/get_proof.rs
@@ -267,7 +267,8 @@ pub async fn get_proof(
 
         let contract_proof = storage_root_idx
             .map(|idx| {
-                // Generate a proof for this contract, creating a "non-membership" proof if the contract does not exist.
+                // Generate a proof for this contract, creating a "non-membership" proof if the
+                // contract does not exist.
                 StorageCommitmentTree::get_proof(&tx, header.number, &input.contract_address, idx)
                     .unwrap_or_default()
                     .into_iter()

--- a/crates/rpc/src/pathfinder/methods/get_proof.rs
+++ b/crates/rpc/src/pathfinder/methods/get_proof.rs
@@ -263,20 +263,23 @@ pub async fn get_proof(
 
         let storage_root_idx = tx
             .storage_root_index(header.number)
-            .context("Querying storage root index")?
-            .ok_or(GetProofError::ProofMissing)?;
+            .context("Querying storage root index")?;
 
-        // Generate a proof for this contract. If the contract does not exist, this will
-        // be a "non membership" proof.
-        let contract_proof = StorageCommitmentTree::get_proof(
-            &tx,
-            header.number,
-            &input.contract_address,
-            storage_root_idx,
-        )?
-        .into_iter()
-        .map(|(node, _)| node)
-        .collect();
+        let contract_proof = if let Some(storage_root_idx) = storage_root_idx {
+            // Generate a proof for this contract. If the contract does not exist, this will
+            // be a "non membership" proof.
+            StorageCommitmentTree::get_proof(
+                &tx,
+                header.number,
+                &input.contract_address,
+                storage_root_idx,
+            )?
+            .into_iter()
+            .map(|(node, _)| node)
+            .collect()
+        } else {
+            Vec::new()
+        };
 
         let contract_proof = ProofNodes(contract_proof);
 

--- a/crates/rpc/src/pathfinder/methods/get_proof.rs
+++ b/crates/rpc/src/pathfinder/methods/get_proof.rs
@@ -270,11 +270,9 @@ pub async fn get_proof(
                 // Generate a proof for this contract, creating a "non-membership" proof if the
                 // contract does not exist.
                 StorageCommitmentTree::get_proof(&tx, header.number, &input.contract_address, idx)
-                    .unwrap_or_default()
-                    .into_iter()
-                    .map(|(node, _)| node)
-                    .collect()
+                    .map(|proof| proof.into_iter().map(|(node, _)| node).collect())
             })
+            .transpose()?
             .unwrap_or_default();
 
         let contract_proof = ProofNodes(contract_proof);


### PR DESCRIPTION
Pathfinder encounters an error when querying the `storage_root_idx` results in `None`. This PR addresses these cases by handling the error and populating contract_proof with an empty vector instead.

---------------------------

While working with a devnet on Madara, we discovered a condition that occurs only in the initial blocks of the chain. From block 1 to block 9, the `storage_root_idx` query returns `None`, causing Pathfinder to immediately throw an error.
This error is propagated instead of being handled appropriately at the application layer, specifically in SNOS. Returning an empty vector allows us to continue with our workflow and handle this situation more gracefully.

On the other hand, the error received is not descriptive, forcing SNOS to interrupt execution. For example:

``` json
{"error":{"code":-32603,"message":"Internal error"},"id":1,"jsonrpc":"2.0"}
```

**Steps to reproduce:**

1. Clone repositories
``` bash
git clone git@github.com:eqlabs/pathfinder.git
git clone git@github.com:madara-alliance/madara
```

2. Run Madara
``` bash
cd madara
cargo run --release -- \
    --name madara \
    --base-path $(pwd)/madara-db \
    --rpc-port 9944 \
    --rpc-cors "*" \
    --rpc-external \
    --sequencer \
    --chain-config-path configs/presets/devnet.yaml \
    --feeder-gateway-enable \
    --gateway-enable \
    --gateway-external \
    --gas-price 1234 \
    --blob-gas-price 10 \
    --rpc-methods unsafe \
    --no-l1-sync
```

3. Start Pathfinder
``` bash
cd ../pathfinder
cargo run --bin pathfinder -- \
    --network custom \
    --chain-id MADARA_DEVNET \
    --ethereum.url wss://eth-sepolia.g.alchemy.com/v2/WIUR5JUZXieEBkze6Xs3IOXWhsS840TX \
    --gateway-url http://localhost:8080/gateway \
    --feeder-gateway-url http://localhost:8080/feeder_gateway \
    --storage.state-tries archive \
    --data-directory ~/pathfinder/data \
    --http-rpc 127.0.0.1:9545
```

4. Retrieve a storage proof using curl from any block between 1 and 9
``` bash
curl --request POST \
    --url http://127.0.0.1:9545/rpc/pathfinder/v0.1 \
    --header 'accept: application/json' \
    --header 'content-type: application/json' \
    --data '
{
  "id": 1,
  "jsonrpc": "2.0",
  "method": "pathfinder_getProof",
  "params": [
    { "block_number": 5 }, "0x1", ["0x0"]
  ]
}
'
```
