### PR TITLE
doc(pathfinder_rpc_api): PROOF_MISSING is 10001

### DIFF
--- a/doc/rpc/pathfinder_rpc_api.json
+++ b/doc/rpc/pathfinder_rpc_api.json
@@ -293,7 +293,7 @@
                 }
             },
             "PROOF_MISSING": {
-                "code": 10000,
+                "code": 10001,
                 "message": "Merkle trie proof is not available"
             },
             "SUBSCRIPTION_TXN_HASH_NOT_FOUND": {


### PR DESCRIPTION
Looks like there is a copy-paste error in the pathfinder rpc spec.