### PR TITLE
feat: added l2_gas to P2P & DTO ExecutionResources

### DIFF
--- a/crates/p2p/src/client/conv.rs
+++ b/crates/p2p/src/client/conv.rs
@@ -32,6 +32,7 @@ use pathfinder_common::receipt::{
     ExecutionResources,
     ExecutionStatus,
     L1Gas,
+    L2Gas,
     L2ToL1Message,
     Receipt,
 };
@@ -340,6 +341,7 @@ impl ToDto<p2p_proto::receipt::Receipt> for (&TransactionVariant, Receipt) {
                     l1_data_gas: Some(da.l1_data_gas.into()),
                     total_l1_gas: Some(total.l1_gas.into()),
                     total_l1_data_gas: Some(total.l1_data_gas.into()),
+                    l2_gas: Some(e.l2_gas.0.into()),
                 }
             },
             revert_reason,
@@ -760,8 +762,10 @@ impl TryFrom<(p2p_proto::receipt::Receipt, TransactionIndex)> for crate::client:
                         )?
                         .0,
                     },
-                    // TODO: Fix this when we have a way to get L2 gas from the gateway
-                    l2_gas: Default::default(),
+                    l2_gas: L2Gas(
+                        GasPrice::try_from(common.execution_resources.l2_gas.unwrap_or_default())?
+                            .0,
+                    ),
                 },
                 l2_to_l1_messages: common
                     .messages_sent

--- a/crates/p2p_proto/proto/receipt.proto
+++ b/crates/p2p_proto/proto/receipt.proto
@@ -41,6 +41,7 @@ message Receipt {
     starknet.common.Felt252 l1_data_gas = 5;
     starknet.common.Felt252 total_l1_gas = 6;
     starknet.common.Felt252 total_l1_data_gas = 7;
+    starknet.common.Felt252 l2_gas = 8;
   }
 
   message Common {

--- a/crates/p2p_proto/src/receipt.rs
+++ b/crates/p2p_proto/src/receipt.rs
@@ -37,6 +37,8 @@ pub struct ExecutionResources {
     pub total_l1_gas: Option<Felt>,
     #[optional]
     pub total_l1_data_gas: Option<Felt>,
+    #[optional]
+    pub l2_gas: Option<Felt>,
 }
 
 pub mod execution_resources {

--- a/crates/storage/src/fake.rs
+++ b/crates/storage/src/fake.rs
@@ -270,7 +270,7 @@ pub mod generate {
                 let transaction_hash = t.variant.calculate_hash(ChainId::SEPOLIA_TESTNET, false);
                 t.hash = transaction_hash;
 
-                let r: Receipt = crate::connection::transaction::dto::ReceiptV2 {
+                let r: Receipt = crate::connection::transaction::dto::ReceiptV3 {
                     transaction_hash: transaction_hash.as_inner().to_owned().into(),
                     transaction_index: TransactionIndex::new_or_panic(
                         i.try_into().expect("u64 is at least as wide as usize"),


### PR DESCRIPTION
Common execution resources already had it. Fixes #2413.

Note that the change to DTO is backwards-incompatible with the previous version, and should be considered atomic with https://github.com/eqlabs/pathfinder/commit/71ab4f3fe9d2496bc4ad279aeff01a665006f7ea (which _is_ compatible with its previous versions).
