### PR TITLE
fix(rpc/v08): fix spec compliance in `starknet_getBlockWithReceipts` response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- `starknet_getBlockWithReceipts` returns `transaction_hash` within the `transaction` object making the response not strictly spec compliant. Fixed on the JSON-RPC 0.8 interface.
+
 ## [0.15.0] - 2024-11-21
 
 ### Added

--- a/crates/rpc/src/method/get_block_with_receipts.rs
+++ b/crates/rpc/src/method/get_block_with_receipts.rs
@@ -158,7 +158,18 @@ impl crate::dto::serialize::SerializeForVersion for TransactionWithReceipt<'_> {
         serializer: crate::dto::serialize::Serializer,
     ) -> Result<crate::dto::serialize::Ok, crate::dto::serialize::Error> {
         let mut serializer = serializer.serialize_struct()?;
-        serializer.serialize_field("transaction", &crate::dto::Transaction(self.transaction))?;
+        match serializer.version {
+            crate::RpcVersion::V07 => {
+                serializer.serialize_field(
+                    "transaction",
+                    &crate::dto::TransactionWithHash(self.transaction),
+                )?;
+            }
+            _ => {
+                serializer
+                    .serialize_field("transaction", &crate::dto::Transaction(self.transaction))?;
+            }
+        }
         serializer.serialize_field(
             "receipt",
             &crate::dto::TxnReceipt {

--- a/crates/rpc/src/method/get_block_with_txs.rs
+++ b/crates/rpc/src/method/get_block_with_txs.rs
@@ -115,7 +115,7 @@ impl crate::dto::serialize::SerializeForVersion for Output {
                 serializer.serialize_iter(
                     "transactions",
                     transactions.len(),
-                    &mut transactions.iter().map(crate::dto::Transaction),
+                    &mut transactions.iter().map(crate::dto::TransactionWithHash),
                 )?;
                 serializer.end()
             }
@@ -129,7 +129,7 @@ impl crate::dto::serialize::SerializeForVersion for Output {
                 serializer.serialize_iter(
                     "transactions",
                     transactions.len(),
-                    &mut transactions.iter().map(crate::dto::Transaction),
+                    &mut transactions.iter().map(crate::dto::TransactionWithHash),
                 )?;
                 serializer.serialize_field(
                     "status",

--- a/crates/rpc/src/method/get_transaction_by_hash.rs
+++ b/crates/rpc/src/method/get_transaction_by_hash.rs
@@ -72,7 +72,7 @@ impl crate::dto::serialize::SerializeForVersion for Output {
         &self,
         serializer: crate::dto::serialize::Serializer,
     ) -> Result<crate::dto::serialize::Ok, crate::dto::serialize::Error> {
-        serializer.serialize(&crate::dto::Transaction(&self.0))
+        serializer.serialize(&crate::dto::TransactionWithHash(&self.0))
     }
 }
 

--- a/crates/rpc/src/method/subscribe_pending_transactions.rs
+++ b/crates/rpc/src/method/subscribe_pending_transactions.rs
@@ -47,7 +47,7 @@ impl crate::dto::serialize::SerializeForVersion for Notification {
     ) -> Result<crate::dto::serialize::Ok, crate::dto::serialize::Error> {
         match self {
             Notification::Transaction(transaction) => {
-                crate::dto::Transaction(transaction).serialize(serializer)
+                crate::dto::TransactionWithHash(transaction).serialize(serializer)
             }
             Notification::TransactionHash(transaction_hash) => {
                 transaction_hash.0.serialize(serializer)


### PR DESCRIPTION
The OpenRPC specification requires sending an array of {transaction, receipt} objects.

Note that the transaction in this schema is #/components/schemas/TXN, which does not contain a transaction_hash property. We're always serializing transactions with the transaction_hash property present which makes our responses to starknet_getBlockWithReceipts not compliant with the specification.

Closes: #2420
