### PR TITLE
fix: extra `l2_gas_price` in rpc v0.7 block headers

### DIFF
--- a/crates/rpc/src/dto/block.rs
+++ b/crates/rpc/src/dto/block.rs
@@ -2,7 +2,7 @@ use pathfinder_common::{GasPrice, L1DataAvailabilityMode};
 use serde::de::Error;
 
 use super::serialize::SerializeStruct;
-use crate::Reorg;
+use crate::{Reorg, RpcVersion};
 
 #[derive(Debug)]
 pub struct BlockHeader<'a>(pub &'a pathfinder_common::BlockHeader);
@@ -70,13 +70,15 @@ impl crate::dto::serialize::SerializeForVersion for BlockHeader<'_> {
                 price_in_fri: self.0.strk_l1_data_gas_price,
             },
         )?;
-        serializer.serialize_field(
-            "l2_gas_price",
-            &ResourcePrice {
-                price_in_wei: self.0.eth_l2_gas_price,
-                price_in_fri: self.0.strk_l2_gas_price,
-            },
-        )?;
+        if serializer.version == RpcVersion::V08 {
+            serializer.serialize_field(
+                "l2_gas_price",
+                &ResourcePrice {
+                    price_in_wei: self.0.eth_l2_gas_price,
+                    price_in_fri: self.0.strk_l2_gas_price,
+                },
+            )?;
+        }
         serializer.serialize_field(
             "l1_da_mode",
             &match self.0.l1_da_mode {
@@ -115,13 +117,15 @@ impl crate::dto::serialize::SerializeForVersion for PendingBlockHeader<'_> {
                 price_in_fri: self.0.l1_data_gas_price.price_in_fri,
             },
         )?;
-        serializer.serialize_field(
-            "l2_gas_price",
-            &ResourcePrice {
-                price_in_wei: self.0.l2_gas_price.price_in_wei,
-                price_in_fri: self.0.l2_gas_price.price_in_fri,
-            },
-        )?;
+        if serializer.version == RpcVersion::V08 {
+            serializer.serialize_field(
+                "l2_gas_price",
+                &ResourcePrice {
+                    price_in_wei: self.0.l2_gas_price.price_in_wei,
+                    price_in_fri: self.0.l2_gas_price.price_in_fri,
+                },
+            )?;
+        }
         serializer.serialize_field(
             "l1_da_mode",
             &match self.0.l1_da_mode {

--- a/crates/rpc/src/method/get_block_with_receipts.rs
+++ b/crates/rpc/src/method/get_block_with_receipts.rs
@@ -216,10 +216,6 @@ mod tests {
                 "price_in_fri": "0x7374726b20676173207072696365",
                 "price_in_wei": "0x676173207072696365",
             },
-            "l2_gas_price": {
-                "price_in_fri": "0x7374726b206c32676173207072696365",
-                "price_in_wei": "0x6c3220676173207072696365",
-            },
             "parent_hash": "0x6c6174657374",
             "sequencer_address": "0x70656e64696e672073657175656e6365722061646472657373",
             "starknet_version": "0.11.0",
@@ -373,10 +369,6 @@ mod tests {
             "l1_gas_price": {
                 "price_in_fri": "0x0",
                 "price_in_wei": "0x2",
-            },
-            "l2_gas_price": {
-                "price_in_fri": "0x0",
-                "price_in_wei": "0x0",
             },
             "new_root": "0x57b695c82af81429fdc8966088b0196105dfb5aa22b54cbc86fc95dc3b3ece1",
             "parent_hash": "0x626c6f636b2031",


### PR DESCRIPTION
Fixes #2424. Tested and the field is gone in `/rpc/v0_7` as expected.