### PR TITLE
feat: Add StorageIndex newtype

### DIFF
--- a/crates/merkle-tree/src/merkle_node.rs
+++ b/crates/merkle-tree/src/merkle_node.rs
@@ -12,6 +12,7 @@ use bitvec::prelude::BitVec;
 use bitvec::slice::BitSlice;
 use pathfinder_common::hash::FeltHash;
 use pathfinder_crypto::Felt;
+use pathfinder_storage::Storage;
 
 /// A node in a Binary Merkle-Patricia Tree graph.
 #[derive(Clone, Debug, PartialEq)]
@@ -28,11 +29,27 @@ pub enum InternalNode {
     Leaf,
 }
 
+/// A newtype for the storage index of a trie node.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct StorageIndex(u64);
+
+impl StorageIndex {
+    /// Create a new StorageIndex.
+    pub fn new(index: u64) -> Self {
+        Self(index)
+    }
+
+    /// Get the inner u64 value.
+    pub fn value(&self) -> u64 {
+        self.0
+    }
+}
+
 /// Describes the [InternalNode::Binary] variant.
 #[derive(Clone, Debug, PartialEq)]
 pub struct BinaryNode {
     /// The storage index of this node (if it was loaded from storage).
-    pub storage_index: Option<u64>,
+    pub storage_index: Option<StorageIndex>,
     /// The height of this node in the tree.
     pub height: usize,
     /// [Left](Direction::Left) child.
@@ -44,7 +61,7 @@ pub struct BinaryNode {
 #[derive(Clone, Debug, PartialEq)]
 pub struct EdgeNode {
     /// The storage index of this node (if it was loaded from storage).
-    pub storage_index: Option<u64>,
+    pub storage_index: Option<StorageIndex>,
     /// The starting height of this node in the tree.
     pub height: usize,
     /// The path this edge takes.
@@ -144,9 +161,9 @@ impl InternalNode {
         matches!(self, InternalNode::Leaf)
     }
 
-    pub fn storage_index(&self) -> Option<u64> {
+    pub fn storage_index(&self) -> Option<StorageIndex> {
         match self {
-            InternalNode::Unresolved(storage_index) => Some(*storage_index),
+            InternalNode::Unresolved(storage_index) => Some(StorageIndex::new(*storage_index)),
             InternalNode::Binary(binary) => binary.storage_index,
             InternalNode::Edge(edge) => edge.storage_index,
             InternalNode::Leaf => None,

--- a/crates/merkle-tree/src/tree.rs
+++ b/crates/merkle-tree/src/tree.rs
@@ -1583,11 +1583,7 @@ mod tests {
 
     mod real_world {
         use pathfinder_common::{
-            class_commitment,
-            class_commitment_leaf_hash,
-            felt,
-            sierra_hash,
-            BlockNumber,
+            class_commitment, class_commitment_leaf_hash, felt, sierra_hash, BlockNumber,
             ClassCommitmentLeafHash,
         };
         use pathfinder_storage::RootIndexUpdate;


### PR DESCRIPTION
Short description of what this PR does.

Sets a new Type `StorageIndex` for the unique index for the trie nodes
---------------------------

A longer description, include motivation and intent if possible. Detail any caveats or follow-up steps still required.

Ref https://github.com/eqlabs/pathfinder/issues/2332
Adds a new explicit type StorageIndex to store the unique index for the trie nodes in the database.
---------------------------

Consider motivating any new dependencies.

---------------------------

