### PR TITLE
fix(storage/block): fix reorg storage problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Pathfinder fails to properly do a reorg due to a SQL statement referring a table that does not exist.
+
 ## [0.15.1] - 2024-12-02
 
 ### Fixed

--- a/crates/storage/src/connection/block.rs
+++ b/crates/storage/src/connection/block.rs
@@ -116,15 +116,18 @@ impl Transaction<'_> {
     ///
     /// This includes block header, block body and state update information.
     pub fn purge_block(&self, block: BlockNumber) -> anyhow::Result<()> {
-        self.inner()
-            .execute(
-                r"
+        #[cfg(feature = "aggregate_bloom")]
+        {
+            self.inner()
+                .execute(
+                    r"
                 DELETE FROM starknet_events_filters_aggregate 
                 WHERE from_block <= :block AND to_block >= :block
                 ",
-                named_params![":block": &block],
-            )
-            .context("Deleting aggregate bloom filter")?;
+                    named_params![":block": &block],
+                )
+                .context("Deleting aggregate bloom filter")?;
+        }
         self.inner()
             .execute(
                 "DELETE FROM starknet_events_filters WHERE block_number = ?",


### PR DESCRIPTION
As part of the still-in-development "aggregate bloom filters feature we have added a SQL statement to `purge_block()` that causes issues during a reorg because it references a non-existent table when compiling Pathfinder _without_ the "aggregate_bloom" feature.

This change fixes that by gating the SQL statement behind the feature.

Closes: #2430 