### PR TITLE
chore(tagged): fix build warning in v0.14.5

### DIFF
--- a/crates/tagged/src/lib.rs
+++ b/crates/tagged/src/lib.rs
@@ -50,7 +50,9 @@ pub fn init() {
     });
 }
 
+#[cfg(debug_assertions)]
 fn lut() -> Option<LutGuard> {
+    #[allow(static_mut_refs)]
     unsafe { LUTS.as_ref() }.map(|luts| luts.lock().unwrap())
 }
 


### PR DESCRIPTION
Fixes: https://github.com/eqlabs/pathfinder/issues/2434

This PR is for review only and is meant to be merged into v0.14.5.