### PR TITLE
chore: remove explicit initialization of env_logger in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4399,6 +4399,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4413,15 +4422,14 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.2"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
 dependencies = [
- "humantime",
- "is-terminal",
+ "anstream",
+ "anstyle",
+ "env_filter",
  "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -7137,7 +7145,6 @@ dependencies = [
  "async-trait",
  "base64 0.13.1",
  "clap",
- "env_logger 0.10.2",
  "fake",
  "flate2",
  "futures",
@@ -9805,6 +9812,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93"
 dependencies = [
+ "env_logger 0.11.5",
  "test-log-macros",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ const-decoder = "0.3.0"
 const_format = "0.2.31"
 criterion = "0.5.1"
 dashmap = "6.1"
-env_logger = "0.10.0"
 fake = "2.8.0"
 ff = "0.13"
 flate2 = "1.0.27"
@@ -131,7 +130,7 @@ starknet_api = { git = "https://github.com/eqlabs/sequencer", branch = "eqlabs/m
 starknet-types-core = "=0.1.5"
 syn = "1.0"
 tempfile = "3.8"
-test-log = { version = "0.2.12", default-features = false }
+test-log = { version = "0.2.12", features = ["trace"] }
 thiserror = "1.0.48"
 time = "0.3.36"
 tokio = "1.37.0"

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -60,12 +60,11 @@ zeroize = { workspace = true }
 
 [dev-dependencies]
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
-env_logger = { workspace = true }
 hex = { workspace = true }
 rand = { workspace = true }
 rstest = { workspace = true }
 tagged = { path = "../tagged" }
 tagged-debug-derive = { path = "../tagged-debug-derive" }
-test-log = { workspace = true, features = ["trace"] }
+test-log = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/crates/p2p/src/client/peer_agnostic/tests.rs
+++ b/crates/p2p/src/client/peer_agnostic/tests.rs
@@ -112,8 +112,6 @@ async fn make_header_stream(
     #[case] responses: Vec<Result<(TestPeer, Vec<BlockHeadersResponse>), TestPeer>>,
     #[case] expected_stream: Vec<(TestPeer, SignedBlockHeader)>,
 ) {
-    let _ = env_logger::builder().is_test(true).try_init();
-
     for (reverse, direction) in [(false, "forward"), (true, "backward")] {
         let (peers, responses) = unzip_fixtures(responses.clone());
         let get_peers = move || {
@@ -295,7 +293,6 @@ async fn make_transaction_stream(
     #[case] num_txns_per_block: Vec<usize>,
     #[case] expected_stream: Vec<Result<(TestPeer, Vec<TestTxn>), ()>>,
 ) {
-    let _ = env_logger::builder().is_test(true).try_init();
     let (peers, responses) = unzip_fixtures(responses);
     let get_peers = move || {
         let peers = peers.clone();
@@ -518,7 +515,6 @@ async fn make_state_diff_stream(
     #[case] state_diff_len_per_block: Vec<usize>,
     #[case] expected_stream: Vec<Result<(TestPeer, StateUpdateData), ()>>,
 ) {
-    let _ = env_logger::builder().is_test(true).try_init();
     let (peers, responses) = unzip_fixtures(responses);
     let get_peers = move || {
         let peers = peers.clone();
@@ -713,7 +709,6 @@ async fn make_class_definition_stream(
     #[case] declared_classes_per_block: Vec<usize>,
     #[case] expected_stream: Vec<Result<(TestPeer, ClassDefinition), ()>>,
 ) {
-    let _ = env_logger::builder().is_test(true).try_init();
     let (peers, responses) = unzip_fixtures(responses);
     let get_peers = move || {
         let peers = peers.clone();
@@ -904,7 +899,6 @@ async fn make_event_stream(
     #[case] events_per_block: Vec<usize>,
     #[case] expected_stream: Vec<Result<(TestPeer, TaggedEventsForBlockByTransaction), ()>>,
 ) {
-    let _ = env_logger::builder().is_test(true).try_init();
     let (peers, responses) = unzip_fixtures(responses);
     let get_peers = move || {
         let peers = peers.clone();

--- a/crates/p2p/src/tests.rs
+++ b/crates/p2p/src/tests.rs
@@ -98,7 +98,6 @@ async fn client_to_server() -> (TestPeer, TestPeer) {
 
 #[test_log::test(tokio::test)]
 async fn dial() {
-    let _ = env_logger::builder().is_test(true).try_init();
     // tokio::time::pause() does not make a difference
     let mut peer1 = TestPeer::default();
     let mut peer2 = TestPeer::default();
@@ -119,8 +118,6 @@ async fn dial() {
 
 #[test_log::test(tokio::test)]
 async fn disconnect() {
-    let _ = env_logger::builder().is_test(true).try_init();
-
     let mut peer1 = TestPeer::default();
     let mut peer2 = TestPeer::default();
 
@@ -157,8 +154,6 @@ async fn disconnect() {
 
 #[test_log::test(tokio::test)]
 async fn periodic_bootstrap() {
-    let _ = env_logger::builder().is_test(true).try_init();
-
     const BOOTSTRAP_PERIOD: Duration = Duration::from_millis(500);
     let cfg = Config {
         bootstrap_period: Some(BOOTSTRAP_PERIOD),
@@ -785,7 +780,6 @@ async fn rate_limit() {
 #[case::client_to_server(client_to_server().await)]
 #[test_log::test(tokio::test)]
 async fn provide_capability(#[case] peers: (TestPeer, TestPeer)) {
-    let _ = env_logger::builder().is_test(true).try_init();
     let (peer1, peer2) = peers;
 
     let mut peer1_started_providing = filter_events(peer1.event_receiver, |event| match event {
@@ -811,7 +805,6 @@ async fn provide_capability(#[case] peers: (TestPeer, TestPeer)) {
 #[case::client_to_server(client_to_server().await)]
 #[test_log::test(tokio::test)]
 async fn subscription_and_propagation(#[case] peers: (TestPeer, TestPeer)) {
-    let _ = env_logger::builder().is_test(true).try_init();
     let (peer1, peer2) = peers;
 
     let mut peer2_subscribed_to_peer1 = filter_events(peer1.event_receiver, |event| match event {
@@ -855,7 +848,6 @@ mod successful_sync {
             #[case::client_to_server(client_to_server().await)]
             #[test_log::test(tokio::test)]
             async fn $test_name(#[case] peers: (TestPeer, TestPeer)) {
-                let _ = env_logger::builder().is_test(true).try_init();
                 let (peer1, peer2) = peers;
                 // Fake some request for peer2 to send to peer1
                 let expected_request = Faker.fake::<$req_type>();


### PR DESCRIPTION
test_log attribute already does that.

Fixes #2398.
