### PR TITLE
fix(sync): fix sync status starting block when starting with empty storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Use aggregate Bloom filters for `starknet_getEvents` to improve performance.
-
 ### Fixed
 
 - `pathfinder_getProof`, `pathfinder_getClassProof` return `ProofMissing` (10001) when Pathfinder is in `archive` mode and queried block's tries are empty.
 - `starknet_getStorageProof` returns `StorageProofNotSupported` (42) when Pathfinder is in `archive` mode and queried block's tries are empty.
+- `starknet_syncing` returns `u64::MAX` as the starting block number when starting from scratch.
+
+### Changed
+
+- Use aggregate Bloom filters for `starknet_getEvents` to improve performance.
 
 ## [0.15.2] - 2024-12-04
 

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -240,8 +240,8 @@ where
 
     // Start update sync-status process.
     let (starting_block_num, starting_block_hash, _) = l2_head.unwrap_or((
-        // Seems a better choice for an invalid block number than 0
-        BlockNumber::MAX,
+        // start from genesis if storage is empty
+        BlockNumber::GENESIS,
         BlockHash(Felt::ZERO),
         StateCommitment(Felt::ZERO),
     ));


### PR DESCRIPTION
The starting block number is used exclusively for serving the `starknet_syncing` JSON-RPC method -- so using zero unstead of `u64::MAX` is more appropriate.

Closes: #2443 