### PR TITLE
feat(rpc): remove `deserialize_serde` for primitives and common types

### DIFF
--- a/crates/rpc/src/dto/block.rs
+++ b/crates/rpc/src/dto/block.rs
@@ -13,7 +13,7 @@ pub struct PendingBlockHeader<'a>(pub &'a starknet_gateway_types::reply::Pending
 impl crate::dto::DeserializeForVersion for pathfinder_common::BlockId {
     fn deserialize(value: super::Value) -> Result<Self, serde_json::Error> {
         if value.is_string() {
-            let value: String = value.deserialize_serde()?;
+            let value: String = value.deserialize()?;
             match value.as_str() {
                 "latest" => Ok(Self::Latest),
                 "pending" => Ok(Self::Pending),
@@ -23,10 +23,8 @@ impl crate::dto::DeserializeForVersion for pathfinder_common::BlockId {
             value.deserialize_map(|value| {
                 if value.contains_key("block_number") {
                     Ok(Self::Number(
-                        pathfinder_common::BlockNumber::new(
-                            value.deserialize_serde("block_number")?,
-                        )
-                        .ok_or_else(|| serde_json::Error::custom("Invalid block number"))?,
+                        pathfinder_common::BlockNumber::new(value.deserialize("block_number")?)
+                            .ok_or_else(|| serde_json::Error::custom("Invalid block number"))?,
                     ))
                 } else if value.contains_key("block_hash") {
                     Ok(Self::Hash(pathfinder_common::BlockHash(

--- a/crates/rpc/src/dto/primitives.rs
+++ b/crates/rpc/src/dto/primitives.rs
@@ -152,14 +152,82 @@ pub mod hex_str {
         Ok(buf)
     }
 }
+impl DeserializeForVersion for u64 {
+    fn deserialize(value: Value) -> Result<Self, serde_json::Error> {
+        match &value.data {
+            serde_json::Value::Number(n) => n
+                .as_u64()
+                .ok_or_else(|| serde_json::Error::custom("invalid u64 value")),
+            _ => Err(serde_json::Error::custom("expected number")),
+        }
+    }
+}
+
+impl DeserializeForVersion for u32 {
+    fn deserialize(value: Value) -> Result<Self, serde_json::Error> {
+        match &value.data {
+            serde_json::Value::Number(n) => n
+                .as_u64()
+                .and_then(|n| u32::try_from(n).ok())
+                .ok_or_else(|| serde_json::Error::custom("value is too large for u32")),
+            _ => Err(serde_json::Error::custom("expected number")),
+        }
+    }
+}
+
+impl DeserializeForVersion for i32 {
+    fn deserialize(value: Value) -> Result<Self, serde_json::Error> {
+        match &value.data {
+            serde_json::Value::Number(n) => n
+                .as_i64()
+                .and_then(|n| i32::try_from(n).ok())
+                .ok_or_else(|| serde_json::Error::custom("value is outside i32 range")),
+            _ => Err(serde_json::Error::custom("expected number")),
+        }
+    }
+}
+
+impl DeserializeForVersion for usize {
+    fn deserialize(value: Value) -> Result<Self, serde_json::Error> {
+        match &value.data {
+            serde_json::Value::Number(n) => n
+                .as_u64()
+                .and_then(|n| usize::try_from(n).ok())
+                .ok_or_else(|| serde_json::Error::custom("value is outside usize range")),
+            _ => Err(serde_json::Error::custom("expected number")),
+        }
+    }
+}
+
+impl DeserializeForVersion for bool {
+    fn deserialize(value: Value) -> Result<Self, serde_json::Error> {
+        match &value.data {
+            serde_json::Value::Bool(b) => Ok(*b),
+            _ => Err(serde_json::Error::custom("expected boolean")),
+        }
+    }
+}
+
+impl DeserializeForVersion for String {
+    fn deserialize(value: Value) -> Result<Self, serde_json::Error> {
+        match &value.data {
+            serde_json::Value::String(s) => Ok(s.clone()),
+            _ => Err(serde_json::Error::custom("expected string")),
+        }
+    }
+}
 
 impl DeserializeForVersion for U64Hex {
     fn deserialize(value: Value) -> Result<Self, serde_json::Error> {
-        let hex_str: String = value.deserialize_serde()?;
-        let bytes = hex_str::bytes_from_hex_str_stripped::<8>(&hex_str).map_err(|e| {
-            serde_json::Error::custom(format!("failed to parse hex string as u64: {}", e))
-        })?;
-        Ok(Self(u64::from_be_bytes(bytes)))
+        match &value.data {
+            serde_json::Value::String(s) => {
+                let bytes = hex_str::bytes_from_hex_str_stripped::<8>(s).map_err(|e| {
+                    serde_json::Error::custom(format!("failed to parse hex string as u64: {}", e))
+                })?;
+                Ok(Self(u64::from_be_bytes(bytes)))
+            }
+            _ => Err(serde_json::Error::custom("expected hex string")),
+        }
     }
 }
 
@@ -185,10 +253,15 @@ impl SerializeForVersion for Felt<'_> {
 
 impl DeserializeForVersion for pathfinder_crypto::Felt {
     fn deserialize(value: Value) -> Result<Self, serde_json::Error> {
-        let hex_str: String = value.deserialize_serde()?;
-        let bytes = hex_str::bytes_from_hex_str_stripped::<32>(&hex_str)
-            .map_err(|e| serde_json::Error::custom(format!("failed to parse hex string: {}", e)))?;
-        Self::from_be_bytes(bytes).map_err(|e| serde_json::Error::custom("felt overflow"))
+        match &value.data {
+            serde_json::Value::String(hex_str) => {
+                let bytes = hex_str::bytes_from_hex_str_stripped::<32>(hex_str).map_err(|e| {
+                    serde_json::Error::custom(format!("failed to parse hex string: {}", e))
+                })?;
+                Self::from_be_bytes(bytes).map_err(|_| serde_json::Error::custom("felt overflow"))
+            }
+            _ => Err(serde_json::Error::custom("expected hex string")),
+        }
     }
 }
 
@@ -211,12 +284,6 @@ impl SerializeForVersion for BlockNumber {
     }
 }
 
-impl DeserializeForVersion for u64 {
-    fn deserialize(value: Value) -> Result<Self, serde_json::Error> {
-        value.deserialize_serde()
-    }
-}
-
 impl SerializeForVersion for U64Hex {
     fn serialize(&self, serializer: Serializer) -> Result<serialize::Ok, serialize::Error> {
         serializer.serialize_str(&hex_str::bytes_to_hex_str_stripped(&self.0.to_be_bytes()))
@@ -231,11 +298,15 @@ impl SerializeForVersion for U128Hex {
 
 impl DeserializeForVersion for U128Hex {
     fn deserialize(value: Value) -> Result<Self, serde_json::Error> {
-        let hex_str: String = value.deserialize_serde()?;
-        let bytes = hex_str::bytes_from_hex_str_stripped::<16>(&hex_str).map_err(|e| {
-            serde_json::Error::custom(format!("failed to parse hex string as u128: {}", e))
-        })?;
-        Ok(Self(u128::from_be_bytes(bytes)))
+        match &value.data {
+            serde_json::Value::String(s) => {
+                let bytes = hex_str::bytes_from_hex_str_stripped::<16>(s).map_err(|e| {
+                    serde_json::Error::custom(format!("failed to parse hex string as u128: {}", e))
+                })?;
+                Ok(Self(u128::from_be_bytes(bytes)))
+            }
+            _ => Err(serde_json::Error::custom("expected hex string")),
+        }
     }
 }
 
@@ -255,24 +326,32 @@ impl SerializeForVersion for U256Hex {
 
 impl DeserializeForVersion for H256 {
     fn deserialize(value: Value) -> Result<Self, serde_json::Error> {
-        let hex_str: String = value.deserialize_serde()?;
-        let bytes = hex_str::bytes_from_hex_str_stripped::<32>(&hex_str).map_err(|e| {
-            serde_json::Error::custom(format!("failed to parse hex string as u256: {}", e))
-        })?;
-        Ok(H256(bytes))
+        match &value.data {
+            serde_json::Value::String(hex_str) => {
+                let bytes = hex_str::bytes_from_hex_str_stripped::<32>(hex_str).map_err(|e| {
+                    serde_json::Error::custom(format!("failed to parse hex string as u256: {}", e))
+                })?;
+                Ok(H256(bytes))
+            }
+            _ => Err(serde_json::Error::custom("expected hex string")),
+        }
     }
 }
 
 impl DeserializeForVersion for pathfinder_common::EthereumAddress {
     fn deserialize(value: Value) -> Result<Self, serde_json::Error> {
-        let hex_str: String = value.deserialize_serde()?;
-        let bytes = hex_str::bytes_from_hex_str_stripped::<20>(&hex_str).map_err(|e| {
-            serde_json::Error::custom(format!(
-                "failed to parse hex string as ethereum address: {}",
-                e
-            ))
-        })?;
-        Ok(Self(H160::from(bytes)))
+        match &value.data {
+            serde_json::Value::String(hex_str) => {
+                let bytes = hex_str::bytes_from_hex_str_stripped::<20>(hex_str).map_err(|e| {
+                    serde_json::Error::custom(format!(
+                        "failed to parse hex string as ethereum address: {}",
+                        e
+                    ))
+                })?;
+                Ok(Self(H160::from(bytes)))
+            }
+            _ => Err(serde_json::Error::custom("expected hex string")),
+        }
     }
 }
 

--- a/crates/rpc/src/dto/simulation.rs
+++ b/crates/rpc/src/dto/simulation.rs
@@ -562,7 +562,7 @@ pub enum SimulationFlag {
 
 impl crate::dto::DeserializeForVersion for SimulationFlag {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        let value: String = value.deserialize_serde()?;
+        let value: String = value.deserialize()?;
         match value.as_str() {
             "SKIP_FEE_CHARGE" => Ok(Self::SkipFeeCharge),
             "SKIP_VALIDATE" => Ok(Self::SkipValidate),

--- a/crates/rpc/src/dto/transaction.rs
+++ b/crates/rpc/src/dto/transaction.rs
@@ -319,7 +319,7 @@ impl SerializeForVersion for DataAvailabilityMode<'_> {
 
 impl DeserializeForVersion for pathfinder_common::TransactionIndex {
     fn deserialize(value: dto::Value) -> Result<Self, serde_json::Error> {
-        let idx = value.deserialize_serde()?;
+        let idx = value.deserialize()?;
         Self::new(idx).ok_or_else(|| serde_json::Error::custom("Invalid transaction index"))
     }
 }

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -455,8 +455,8 @@ mod tests {
                 fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
                     value.deserialize_map(|value| {
                         Ok(Self {
-                            minuend: value.deserialize_serde("minuend")?,
-                            subtrahend: value.deserialize_serde("subtrahend")?,
+                            minuend: value.deserialize("minuend")?,
+                            subtrahend: value.deserialize("subtrahend")?,
                         })
                     })
                 }
@@ -471,9 +471,7 @@ mod tests {
 
             impl DeserializeForVersion for SumInput {
                 fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-                    Ok(Self(
-                        value.deserialize_array(|value| value.deserialize_serde())?,
-                    ))
+                    Ok(Self(value.deserialize_array(|value| value.deserialize())?))
                 }
             }
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -251,7 +251,7 @@ impl crate::dto::serialize::SerializeForVersion for SubscriptionId {
 
 impl crate::dto::DeserializeForVersion for SubscriptionId {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        let id: u32 = value.deserialize_serde()?;
+        let id: u32 = value.deserialize()?;
         Ok(Self(id))
     }
 }

--- a/crates/rpc/src/method/add_declare_transaction.rs
+++ b/crates/rpc/src/method/add_declare_transaction.rs
@@ -135,7 +135,7 @@ pub enum Transaction {
 impl crate::dto::DeserializeForVersion for Transaction {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
         value.deserialize_map(|value| {
-            let tag: String = value.deserialize_serde("type")?;
+            let tag: String = value.deserialize("type")?;
             if tag != "DECLARE" {
                 return Err(serde::de::Error::custom("Invalid transaction type"));
             }

--- a/crates/rpc/src/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/method/add_deploy_account_transaction.rs
@@ -17,7 +17,7 @@ pub enum Transaction {
 impl crate::dto::DeserializeForVersion for Transaction {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
         value.deserialize_map(|value| {
-            let tag: String = value.deserialize_serde("type")?;
+            let tag: String = value.deserialize("type")?;
             if tag != "DEPLOY_ACCOUNT" {
                 return Err(serde_json::Error::custom("Invalid transaction type"));
             }

--- a/crates/rpc/src/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/method/add_invoke_transaction.rs
@@ -14,7 +14,7 @@ pub enum Transaction {
 impl crate::dto::DeserializeForVersion for Transaction {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
         value.deserialize_map(|value| {
-            let tag: String = value.deserialize_serde("type")?;
+            let tag: String = value.deserialize("type")?;
             if tag != "INVOKE" {
                 return Err(serde_json::Error::custom("Invalid transaction type"));
             }

--- a/crates/rpc/src/method/call.rs
+++ b/crates/rpc/src/method/call.rs
@@ -98,7 +98,7 @@ impl crate::dto::DeserializeForVersion for Input {
         value.deserialize_map(|value| {
             Ok(Self {
                 request: value.deserialize("request")?,
-                block_id: value.deserialize_serde("block_id")?,
+                block_id: value.deserialize("block_id")?,
             })
         })
     }

--- a/crates/rpc/src/method/estimate_fee.rs
+++ b/crates/rpc/src/method/estimate_fee.rs
@@ -21,7 +21,7 @@ impl crate::dto::DeserializeForVersion for Input {
                 request: value.deserialize_array("request", BroadcastedTransaction::deserialize)?,
                 simulation_flags: value
                     .deserialize_array("simulation_flags", SimulationFlag::deserialize)?,
-                block_id: value.deserialize_serde("block_id")?,
+                block_id: value.deserialize("block_id")?,
             })
         })
     }
@@ -34,7 +34,7 @@ pub enum SimulationFlag {
 
 impl crate::dto::DeserializeForVersion for SimulationFlag {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        let value: String = value.deserialize_serde()?;
+        let value: String = value.deserialize()?;
         match value.as_str() {
             "SKIP_VALIDATE" => Ok(Self::SkipValidate),
             _ => Err(serde_json::Error::custom("Invalid flag")),

--- a/crates/rpc/src/method/get_block_with_receipts.rs
+++ b/crates/rpc/src/method/get_block_with_receipts.rs
@@ -27,7 +27,7 @@ impl crate::dto::DeserializeForVersion for Input {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
         value.deserialize_map(|value| {
             Ok(Self {
-                block_id: value.deserialize_serde("block_id")?,
+                block_id: value.deserialize("block_id")?,
             })
         })
     }

--- a/crates/rpc/src/method/get_events.rs
+++ b/crates/rpc/src/method/get_events.rs
@@ -91,7 +91,7 @@ impl crate::dto::DeserializeForVersion for EventFilter {
                         value.deserialize_array(|value| value.deserialize().map(EventKey))
                     })?
                     .unwrap_or_default(),
-                chunk_size: value.deserialize_serde("chunk_size")?,
+                chunk_size: value.deserialize("chunk_size")?,
                 continuation_token: value.deserialize_optional_serde("continuation_token")?,
             })
         })

--- a/crates/rpc/src/method/get_messages_status.rs
+++ b/crates/rpc/src/method/get_messages_status.rs
@@ -47,7 +47,7 @@ impl crate::dto::serialize::SerializeForVersion for FinalityStatus {
 
 impl crate::dto::DeserializeForVersion for FinalityStatus {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        let status_str: String = value.deserialize_serde()?;
+        let status_str: String = value.deserialize()?;
         match status_str.as_str() {
             "RECEIVED" => Ok(Self::Received),
             "REJECTED" => Ok(Self::Rejected),

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -135,7 +135,7 @@ impl crate::dto::serialize::SerializeForVersion for DataAvailabilityMode {
 
 impl crate::dto::DeserializeForVersion for DataAvailabilityMode {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        let value: String = value.deserialize_serde()?;
+        let value: String = value.deserialize()?;
         match value.as_str() {
             "L1" => Ok(Self::L1),
             "L2" => Ok(Self::L2),
@@ -220,7 +220,7 @@ pub mod request {
     impl crate::dto::DeserializeForVersion for BroadcastedTransaction {
         fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
             value.deserialize_map(|value| {
-                let tag: String = value.deserialize_serde("type")?;
+                let tag: String = value.deserialize("type")?;
                 match tag.as_str() {
                     "DECLARE" => Ok(Self::Declare(BroadcastedDeclareTransaction::deserialize(
                         value,

--- a/crates/rpc/src/types/receipt.rs
+++ b/crates/rpc/src/types/receipt.rs
@@ -176,7 +176,7 @@ impl crate::dto::serialize::SerializeForVersion for FinalityStatus {
 
 impl crate::dto::DeserializeForVersion for FinalityStatus {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        let s: String = value.deserialize_serde()?;
+        let s: String = value.deserialize()?;
         match s.as_str() {
             "ACCEPTED_ON_L2" => Ok(Self::AcceptedOnL2),
             _ => Err(serde::de::Error::unknown_variant(

--- a/crates/rpc/src/v06/method/add_declare_transaction.rs
+++ b/crates/rpc/src/v06/method/add_declare_transaction.rs
@@ -147,7 +147,7 @@ pub struct AddDeclareTransactionInput {
 
 impl crate::dto::DeserializeForVersion for AddDeclareTransactionInput {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        value.deserialize_serde()
+        value.deserialize()
     }
 }
 

--- a/crates/rpc/src/v06/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/v06/method/add_deploy_account_transaction.rs
@@ -24,7 +24,7 @@ pub struct AddDeployAccountTransactionInput {
 
 impl crate::dto::DeserializeForVersion for AddDeployAccountTransactionInput {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        value.deserialize_serde()
+        value.deserialize()
     }
 }
 

--- a/crates/rpc/src/v06/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/v06/method/add_invoke_transaction.rs
@@ -21,7 +21,7 @@ pub struct AddInvokeTransactionInput {
 
 impl crate::dto::DeserializeForVersion for AddInvokeTransactionInput {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        value.deserialize_serde()
+        value.deserialize()
     }
 }
 

--- a/crates/rpc/src/v06/method/call.rs
+++ b/crates/rpc/src/v06/method/call.rs
@@ -77,7 +77,7 @@ pub struct CallInput {
 
 impl crate::dto::DeserializeForVersion for CallInput {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        value.deserialize_serde()
+        value.deserialize()
     }
 }
 

--- a/crates/rpc/src/v06/method/estimate_fee.rs
+++ b/crates/rpc/src/v06/method/estimate_fee.rs
@@ -18,7 +18,7 @@ pub struct EstimateFeeInput {
 
 impl crate::dto::DeserializeForVersion for EstimateFeeInput {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        value.deserialize_serde()
+        value.deserialize()
     }
 }
 

--- a/crates/rpc/src/v06/method/estimate_message_fee.rs
+++ b/crates/rpc/src/v06/method/estimate_message_fee.rs
@@ -89,7 +89,7 @@ pub struct EstimateMessageFeeInput {
 
 impl crate::dto::DeserializeForVersion for EstimateMessageFeeInput {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        value.deserialize_serde()
+        value.deserialize()
     }
 }
 

--- a/crates/rpc/src/v06/method/get_block_with_tx_hashes.rs
+++ b/crates/rpc/src/v06/method/get_block_with_tx_hashes.rs
@@ -14,7 +14,7 @@ pub struct GetBlockInput {
 
 impl crate::dto::DeserializeForVersion for GetBlockInput {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        value.deserialize_serde()
+        value.deserialize()
     }
 }
 

--- a/crates/rpc/src/v06/method/get_block_with_txs.rs
+++ b/crates/rpc/src/v06/method/get_block_with_txs.rs
@@ -15,7 +15,7 @@ pub struct GetBlockInput {
 
 impl crate::dto::DeserializeForVersion for GetBlockInput {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        value.deserialize_serde()
+        value.deserialize()
     }
 }
 

--- a/crates/rpc/src/v06/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/v06/method/get_transaction_receipt.rs
@@ -11,7 +11,7 @@ pub struct GetTransactionReceiptInput {
 
 impl crate::dto::DeserializeForVersion for GetTransactionReceiptInput {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        value.deserialize_serde()
+        value.deserialize()
     }
 }
 

--- a/crates/rpc/src/v06/method/get_transaction_status.rs
+++ b/crates/rpc/src/v06/method/get_transaction_status.rs
@@ -11,7 +11,7 @@ pub struct GetTransactionStatusInput {
 
 impl crate::dto::DeserializeForVersion for GetTransactionStatusInput {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        value.deserialize_serde()
+        value.deserialize()
     }
 }
 

--- a/crates/rpc/src/v06/method/simulate_transactions.rs
+++ b/crates/rpc/src/v06/method/simulate_transactions.rs
@@ -20,7 +20,7 @@ pub struct SimulateTransactionInput {
 
 impl crate::dto::DeserializeForVersion for SimulateTransactionInput {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        value.deserialize_serde()
+        value.deserialize()
     }
 }
 

--- a/crates/rpc/src/v06/method/trace_block_transactions.rs
+++ b/crates/rpc/src/v06/method/trace_block_transactions.rs
@@ -31,7 +31,7 @@ pub struct TraceBlockTransactionsInput {
 
 impl crate::dto::DeserializeForVersion for TraceBlockTransactionsInput {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        value.deserialize_serde()
+        value.deserialize()
     }
 }
 

--- a/crates/rpc/src/v06/method/trace_transaction.rs
+++ b/crates/rpc/src/v06/method/trace_transaction.rs
@@ -23,7 +23,7 @@ pub struct TraceTransactionInput {
 
 impl crate::dto::DeserializeForVersion for TraceTransactionInput {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        value.deserialize_serde()
+        value.deserialize()
     }
 }
 


### PR DESCRIPTION
This PR is part of https://github.com/eqlabs/pathfinder/issues/2220

### Summary

Remove all `.deserialize_serde()` calls for primitive types and common types when possible.

Implementations of `DeserializeForVersion` for primitive types and some common types.

Using `deserialize_serde` on some types (mostly in `class.rs`) is still required.