### PR TITLE
fix: typos in documentation files

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@ Short description of what this PR does.
 
 ---------------------------
 
-A longer description, include motivation and intent if possible. Detail any caveats or follow-up steps still required.
+A longer description, including motivation and intent if possible. Detail any caveats or follow-up steps still required.
 
 ---------------------------
 


### PR DESCRIPTION
Corrected `include` to `including`