### PR TITLE
fix: fix get_storage_proof

### DIFF
--- a/crates/rpc/src/method/get_storage_proof.rs
+++ b/crates/rpc/src/method/get_storage_proof.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use anyhow::Context;
 use pathfinder_common::trie::TrieNode;
 use pathfinder_common::{
@@ -378,7 +376,7 @@ fn get_class_proofs(
                 node_hash,
                 node: ProofNode(node),
             })
-            .collect::<HashSet<_>>()
+            .collect::<Vec<_>>()
             .into_iter()
             .collect();
     let classes_proof = NodeHashToNodeMappings(nodes);
@@ -423,7 +421,7 @@ fn get_contract_proofs(
                 node_hash,
                 node: ProofNode(node),
             })
-            .collect::<HashSet<_>>()
+            .collect::<Vec<_>>()
             .into_iter()
             .collect();
 
@@ -476,7 +474,7 @@ fn get_contract_storage_proofs(
                     .context("Querying contract root index")?;
 
                 if let Some(root) = root {
-                    let nodes: Vec<NodeHashToNodeMapping> = ContractsStorageTree::get_proofs(
+                    ContractsStorageTree::get_proofs(
                         &tx,
                         csk.contract_address,
                         block_number,
@@ -484,16 +482,16 @@ fn get_contract_storage_proofs(
                         root,
                     )?
                     .into_iter()
-                    .flatten()
-                    .map(|(node, node_hash)| NodeHashToNodeMapping {
-                        node_hash,
-                        node: ProofNode(node),
-                    })
-                    .collect::<HashSet<_>>()
-                    .into_iter()
-                    .collect();
-
-                    proofs.push(NodeHashToNodeMappings(nodes));
+                    .for_each(|vec_nodes| {
+                        let nodes = vec_nodes
+                            .into_iter()
+                            .map(|(node, node_hash)| NodeHashToNodeMapping {
+                                node_hash,
+                                node: ProofNode(node),
+                            })
+                            .collect::<Vec<_>>();
+                        proofs.push(NodeHashToNodeMappings(nodes));
+                    });
                 } else {
                     proofs.push(NodeHashToNodeMappings(vec![]));
                 }


### PR DESCRIPTION
The storage proofs were being returned out of order, and certain use cases of the endpoint where there are no storage keys but the root was still needed were not implemented.

Fixes #2458 

---------------------------

**Unable to Request Contract Storage State Root Without Storage Values in RPC v0.8**

**Problem Statement**
In RPC v0.8, it is not possible to request a contract's storage state root without also requesting storage values. This is a regression from previous functionality and breaks certain use cases where only the root hash is needed.

**Previous Behavior (pathfinder_getStorageProof)**
The ContractData struct previously provided both pieces of information:
```
pub struct ContractData {
    pub root: Felt,
    pub storage_proofs: Vec<Vec<TrieNode>>,
}
```
Importantly, the endpoint accepted an empty array of keys, making it possible to retrieve just the root for contracts without storage keys (e.g., newly deployed but unused contracts).

**Current Implementation (v0.8)**
The new modular approach separates proofs into distinct components:
```
pub struct StorageProof {
    pub classes_proof: Vec<NodeHashToNodeMappingItem>,
    pub contracts_proof: ContractsProof,
    pub contracts_storage_proofs: Vec<Vec<NodeHashToNodeMappingItem>>,
    pub global_roots: GlobalRoots,
}
```

**Issue Details**
In the current implementation there's no way to retrieve the root when there are no storage keys to request
This limitation breaks functionality for cases where:
- Only the contract state root is needed
- Working with newly deployed contracts without storage
- Verifying contract existence without needing storage values


