### PR TITLE
feat(executor): upgrade blockifier for Starknet 0.13.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,7 +1621,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.0.0"
-source = "git+https://github.com/starkware-libs/sequencer?branch=main#382184285cf731b1fda3c7647908c34744af53bd"
+source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#6f09863c5189da80065bf6112e29a30b7f765858"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -1629,7 +1629,7 @@ dependencies = [
  "ark-secp256k1",
  "ark-secp256r1",
  "cached",
- "cairo-lang-casm 2.9.0-dev.0",
+ "cairo-lang-casm 2.9.2",
  "cairo-lang-runner",
  "cairo-lang-starknet-classes",
  "cairo-vm",
@@ -1881,11 +1881,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e0dcdb6358bb639dd729546611bd99bada94c86e3f262c3637855abea9a972"
+checksum = "3929a38c1d586e35e19dbdf7798b146fba3627b308417a6d373fea8939535b6b"
 dependencies = [
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.2",
  "indoc 2.0.5",
  "num-bigint 0.4.6",
  "num-traits",
@@ -1970,22 +1970,22 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8657f5a5611f341a85e80ba0b21848fc34bfdf391bfd93df0baf4516c3e4159"
+checksum = "0bed098f0c3666b3ad3a93aef6293f91fc1119bef660ce994105f6d1bc2802cf"
 dependencies = [
  "anyhow",
- "cairo-lang-defs 2.9.0-dev.0",
- "cairo-lang-diagnostics 2.9.0-dev.0",
- "cairo-lang-filesystem 2.9.0-dev.0",
- "cairo-lang-lowering 2.9.0-dev.0",
- "cairo-lang-parser 2.9.0-dev.0",
- "cairo-lang-project 2.9.0-dev.0",
- "cairo-lang-semantic 2.9.0-dev.0",
- "cairo-lang-sierra 2.9.0-dev.0",
- "cairo-lang-sierra-generator 2.9.0-dev.0",
- "cairo-lang-syntax 2.9.0-dev.0",
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-defs 2.9.2",
+ "cairo-lang-diagnostics 2.9.2",
+ "cairo-lang-filesystem 2.9.2",
+ "cairo-lang-lowering 2.9.2",
+ "cairo-lang-parser 2.9.2",
+ "cairo-lang-project 2.9.2",
+ "cairo-lang-semantic 2.9.2",
+ "cairo-lang-sierra 2.9.2",
+ "cairo-lang-sierra-generator 2.9.2",
+ "cairo-lang-syntax 2.9.2",
+ "cairo-lang-utils 2.9.2",
  "indoc 2.0.5",
  "rayon",
  "rust-analyzer-salsa",
@@ -2012,11 +2012,11 @@ checksum = "c99d41a14f98521c617c0673a0faa41fd00029d32106a4643e1291a1813340a7"
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0635aa554d297acefe6a35b495aba2795d0af5b7f97c4ab63829c7d62291ef41"
+checksum = "d7763505dcfe15f36899074c27185bf7e3494875f63fd06350c6e3ed8d1f91d5"
 dependencies = [
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.2",
 ]
 
 [[package]]
@@ -2073,16 +2073,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b356e1c09898e8b8cfdd9731579d89365a13d8b4f7e717962e0cc7d125b83c"
+checksum = "b4d29dc5a3cafe94ea4397d41b00cd54a9dffbe9bc3a3092a9ea617ea737bc6e"
 dependencies = [
- "cairo-lang-debug 2.9.0-dev.0",
- "cairo-lang-diagnostics 2.9.0-dev.0",
- "cairo-lang-filesystem 2.9.0-dev.0",
- "cairo-lang-parser 2.9.0-dev.0",
- "cairo-lang-syntax 2.9.0-dev.0",
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-debug 2.9.2",
+ "cairo-lang-diagnostics 2.9.2",
+ "cairo-lang-filesystem 2.9.2",
+ "cairo-lang-parser 2.9.2",
+ "cairo-lang-syntax 2.9.2",
+ "cairo-lang-utils 2.9.2",
  "itertools 0.12.1",
  "rust-analyzer-salsa",
  "smol_str 0.2.2",
@@ -2124,13 +2124,13 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfe7c6ff96182da29012b707a3554e34a50f19cc96013ee45b0eb36dd396ec8"
+checksum = "761d20ca9c3a3eb7025b2488aa6e0e5dc23c5d551dd95e83a989b5e87687f523"
 dependencies = [
- "cairo-lang-debug 2.9.0-dev.0",
- "cairo-lang-filesystem 2.9.0-dev.0",
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-debug 2.9.2",
+ "cairo-lang-filesystem 2.9.2",
+ "cairo-lang-utils 2.9.2",
  "itertools 0.12.1",
 ]
 
@@ -2170,11 +2170,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "723d244465309d5409e297b5486d62cbec06f2c47b05044414bb640e3f14caab"
+checksum = "d778ec864e92c82293370a512195715b12775b05981e14065d85eb5dd3dd96b6"
 dependencies = [
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.2",
  "good_lp",
 ]
 
@@ -2219,12 +2219,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237030772ae5368f19a9247e1f63f753f8ad8de963477166e402f4825c0a141d"
+checksum = "d9dc486c554e2df3be8e84c47e30fe55b59d2349b680fbe992bfba801ef93ff5"
 dependencies = [
- "cairo-lang-debug 2.9.0-dev.0",
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-debug 2.9.2",
+ "cairo-lang-utils 2.9.2",
  "path-clean 1.0.1",
  "rust-analyzer-salsa",
  "semver 1.0.23",
@@ -2235,16 +2235,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-formatter"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b71f0eb3a36a6cb5f7f07843926783c4c17e44c9516b53171727a108782f3eb"
+checksum = "675d281a3c9aa365055ce6e201d5dd91534dfccfd2929a41b7397f665c80293c"
 dependencies = [
  "anyhow",
- "cairo-lang-diagnostics 2.9.0-dev.0",
- "cairo-lang-filesystem 2.9.0-dev.0",
- "cairo-lang-parser 2.9.0-dev.0",
- "cairo-lang-syntax 2.9.0-dev.0",
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-diagnostics 2.9.2",
+ "cairo-lang-filesystem 2.9.2",
+ "cairo-lang-parser 2.9.2",
+ "cairo-lang-syntax 2.9.2",
+ "cairo-lang-utils 2.9.2",
  "diffy",
  "ignore",
  "itertools 0.12.1",
@@ -2328,19 +2328,19 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d095d78e2f1de499429c95655d6135a3d24c384b36d8de9f84e0aa4e07ee152"
+checksum = "d880470c94f94fac08c2150bc0ce4af930b6760956a56966e47612de376d57ec"
 dependencies = [
- "cairo-lang-debug 2.9.0-dev.0",
- "cairo-lang-defs 2.9.0-dev.0",
- "cairo-lang-diagnostics 2.9.0-dev.0",
- "cairo-lang-filesystem 2.9.0-dev.0",
- "cairo-lang-parser 2.9.0-dev.0",
- "cairo-lang-proc-macros 2.9.0-dev.0",
- "cairo-lang-semantic 2.9.0-dev.0",
- "cairo-lang-syntax 2.9.0-dev.0",
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-debug 2.9.2",
+ "cairo-lang-defs 2.9.2",
+ "cairo-lang-diagnostics 2.9.2",
+ "cairo-lang-filesystem 2.9.2",
+ "cairo-lang-parser 2.9.2",
+ "cairo-lang-proc-macros 2.9.2",
+ "cairo-lang-semantic 2.9.2",
+ "cairo-lang-syntax 2.9.2",
+ "cairo-lang-utils 2.9.2",
  "id-arena",
  "itertools 0.12.1",
  "log",
@@ -2411,15 +2411,15 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb828af7f948a3ef7fa65de14e3f639daedefb046dfefcad6e3116d2cb0f89a0"
+checksum = "37e2b488f659432c8b866bf540e54ab3696a24ac0f366faac33b860c5313e78c"
 dependencies = [
- "cairo-lang-diagnostics 2.9.0-dev.0",
- "cairo-lang-filesystem 2.9.0-dev.0",
- "cairo-lang-syntax 2.9.0-dev.0",
- "cairo-lang-syntax-codegen 2.9.0-dev.0",
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-diagnostics 2.9.2",
+ "cairo-lang-filesystem 2.9.2",
+ "cairo-lang-syntax 2.9.2",
+ "cairo-lang-syntax-codegen 2.9.2",
+ "cairo-lang-utils 2.9.2",
  "colored",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
@@ -2487,22 +2487,28 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135a600043bf7030eacc6ebf2a609c2364d6ffeb04e1f3c809a2738f6b02c829"
+checksum = "13cf34fd39a1efb997455fa38dbdb6bef489a125a2d17d77ebfea1ee580559f3"
 dependencies = [
- "cairo-lang-defs 2.9.0-dev.0",
- "cairo-lang-diagnostics 2.9.0-dev.0",
- "cairo-lang-filesystem 2.9.0-dev.0",
- "cairo-lang-parser 2.9.0-dev.0",
- "cairo-lang-syntax 2.9.0-dev.0",
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-defs 2.9.2",
+ "cairo-lang-diagnostics 2.9.2",
+ "cairo-lang-filesystem 2.9.2",
+ "cairo-lang-parser 2.9.2",
+ "cairo-lang-syntax 2.9.2",
+ "cairo-lang-utils 2.9.2",
  "indent",
  "indoc 2.0.5",
  "itertools 0.12.1",
  "rust-analyzer-salsa",
  "smol_str 0.2.2",
 ]
+
+[[package]]
+name = "cairo-lang-primitive-token"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "123ac0ecadf31bacae77436d72b88fa9caef2b8e92c89ce63a125ae911a12fae"
 
 [[package]]
 name = "cairo-lang-proc-macros"
@@ -2537,11 +2543,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac857ec4b564712f3e16e3314e23cc0787ab1c05cdfee83f1c8f9989a6eee40f"
+checksum = "b3c4a161868276ce022c44ac500afbfa0d7d8371106feb40dfca34ea7be97503"
 dependencies = [
- "cairo-lang-debug 2.9.0-dev.0",
+ "cairo-lang-debug 2.9.2",
  "quote",
  "syn 2.0.87",
 ]
@@ -2585,36 +2591,52 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cc37b7f8889cdea631aeea3bcc70d5c86ac8fb1d98aabc83f16283d60f1643"
+checksum = "fde3cc9777fff4daacbfd839a6fcefa29abd660068de47f72ac6d5883fa93ccd"
 dependencies = [
- "cairo-lang-filesystem 2.9.0-dev.0",
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-filesystem 2.9.2",
+ "cairo-lang-utils 2.9.2",
  "serde",
- "smol_str 0.2.2",
  "thiserror",
  "toml 0.8.19",
 ]
 
 [[package]]
-name = "cairo-lang-runner"
-version = "2.9.0-dev.0"
+name = "cairo-lang-runnable-utils"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7474375528ffa7f47e343983d32051898e4e7b05ac0bdc48ee84b1325d8b562a"
+checksum = "872d846834c8fdc886a7dc591c1f6ddd969d25d2c88dd65452931c63dfca7acc"
+dependencies = [
+ "cairo-lang-casm 2.9.2",
+ "cairo-lang-sierra 2.9.2",
+ "cairo-lang-sierra-ap-change 2.9.2",
+ "cairo-lang-sierra-gas 2.9.2",
+ "cairo-lang-sierra-to-casm 2.9.2",
+ "cairo-lang-sierra-type-size",
+ "cairo-lang-utils 2.9.2",
+ "cairo-vm",
+ "itertools 0.12.1",
+ "thiserror",
+]
+
+[[package]]
+name = "cairo-lang-runner"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9121164a61b0a8fcadefc8b21240e372bf04e6648ea31d09f9e85701e60877a"
 dependencies = [
  "ark-ff 0.4.2",
  "ark-secp256k1",
  "ark-secp256r1",
- "cairo-lang-casm 2.9.0-dev.0",
- "cairo-lang-lowering 2.9.0-dev.0",
- "cairo-lang-sierra 2.9.0-dev.0",
- "cairo-lang-sierra-ap-change 2.9.0-dev.0",
- "cairo-lang-sierra-generator 2.9.0-dev.0",
- "cairo-lang-sierra-to-casm 2.9.0-dev.0",
- "cairo-lang-sierra-type-size",
- "cairo-lang-starknet 2.9.0-dev.0",
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-casm 2.9.2",
+ "cairo-lang-lowering 2.9.2",
+ "cairo-lang-runnable-utils",
+ "cairo-lang-sierra 2.9.2",
+ "cairo-lang-sierra-generator 2.9.2",
+ "cairo-lang-sierra-to-casm 2.9.2",
+ "cairo-lang-starknet 2.9.2",
+ "cairo-lang-utils 2.9.2",
  "cairo-vm",
  "itertools 0.12.1",
  "keccak",
@@ -2699,26 +2721,27 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c560cf4b4a89325d3a9594f490fffee38cf30e0990e808bb927619de9d0c973a"
+checksum = "8af1f92ba601fd61a994c44d0c80d711fbb3d64b2b5a1e72905fc6f581b1fadd"
 dependencies = [
- "cairo-lang-debug 2.9.0-dev.0",
- "cairo-lang-defs 2.9.0-dev.0",
- "cairo-lang-diagnostics 2.9.0-dev.0",
- "cairo-lang-filesystem 2.9.0-dev.0",
- "cairo-lang-parser 2.9.0-dev.0",
- "cairo-lang-plugins 2.9.0-dev.0",
- "cairo-lang-proc-macros 2.9.0-dev.0",
- "cairo-lang-syntax 2.9.0-dev.0",
+ "cairo-lang-debug 2.9.2",
+ "cairo-lang-defs 2.9.2",
+ "cairo-lang-diagnostics 2.9.2",
+ "cairo-lang-filesystem 2.9.2",
+ "cairo-lang-parser 2.9.2",
+ "cairo-lang-plugins 2.9.2",
+ "cairo-lang-proc-macros 2.9.2",
+ "cairo-lang-syntax 2.9.2",
  "cairo-lang-test-utils",
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.2",
  "id-arena",
  "indoc 2.0.5",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
  "num-traits",
  "rust-analyzer-salsa",
+ "sha3",
  "smol_str 0.2.2",
  "toml 0.8.19",
 ]
@@ -2792,12 +2815,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8118f55ca7d567bfc60960b445d388564d04bf48335c983b1595cb35f67a01c5"
+checksum = "075c6457642ada82b32cf657d871a8545ae7a9d61c78dd5588a794c8c905abdc"
 dependencies = [
  "anyhow",
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.2",
  "const-fnv1a-hash",
  "convert_case 0.6.0",
  "derivative",
@@ -2856,14 +2879,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2716ef8d4ce0fb700f83ed3281f3656436570e60249d41c65c79dc1ca27be002"
+checksum = "b69172fe8354b1dd564bba318ccb5233aa78f70d57145b8c92a0b1cf009fa0fc"
 dependencies = [
- "cairo-lang-eq-solver 2.9.0-dev.0",
- "cairo-lang-sierra 2.9.0-dev.0",
+ "cairo-lang-eq-solver 2.9.2",
+ "cairo-lang-sierra 2.9.2",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.2",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
  "num-traits",
@@ -2909,14 +2932,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a44da87a35845470c4f4c648225232a15e0875fe809045b6088464491f838b"
+checksum = "42b571b73d9b02103f780aeee05dbf9a71d68d8a16341a04aa1dd581d0db3ad6"
 dependencies = [
- "cairo-lang-eq-solver 2.9.0-dev.0",
- "cairo-lang-sierra 2.9.0-dev.0",
+ "cairo-lang-eq-solver 2.9.2",
+ "cairo-lang-sierra 2.9.2",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.2",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
  "num-traits",
@@ -3001,20 +3024,20 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15bc5cf9f3965a7030a114dfe3d31d183287fbfbfbf904deaaa2468cadb936aa"
+checksum = "1d3857cd98a0cb35b32cc962e70c04e6ddfcd8bf61106ac37b6cf453ec76b878"
 dependencies = [
- "cairo-lang-debug 2.9.0-dev.0",
- "cairo-lang-defs 2.9.0-dev.0",
- "cairo-lang-diagnostics 2.9.0-dev.0",
- "cairo-lang-filesystem 2.9.0-dev.0",
- "cairo-lang-lowering 2.9.0-dev.0",
- "cairo-lang-parser 2.9.0-dev.0",
- "cairo-lang-semantic 2.9.0-dev.0",
- "cairo-lang-sierra 2.9.0-dev.0",
- "cairo-lang-syntax 2.9.0-dev.0",
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-debug 2.9.2",
+ "cairo-lang-defs 2.9.2",
+ "cairo-lang-diagnostics 2.9.2",
+ "cairo-lang-filesystem 2.9.2",
+ "cairo-lang-lowering 2.9.2",
+ "cairo-lang-parser 2.9.2",
+ "cairo-lang-semantic 2.9.2",
+ "cairo-lang-sierra 2.9.2",
+ "cairo-lang-syntax 2.9.2",
+ "cairo-lang-utils 2.9.2",
  "itertools 0.12.1",
  "num-traits",
  "rust-analyzer-salsa",
@@ -3092,17 +3115,17 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b7616f1a3c41c4646094b5abf774e558428e9c1eda5d78d7b0638ec5c264e5"
+checksum = "add264b156dfb01f18292282a6037070c078acca3bccde05787da1e1c997b78c"
 dependencies = [
  "assert_matches",
- "cairo-lang-casm 2.9.0-dev.0",
- "cairo-lang-sierra 2.9.0-dev.0",
- "cairo-lang-sierra-ap-change 2.9.0-dev.0",
- "cairo-lang-sierra-gas 2.9.0-dev.0",
+ "cairo-lang-casm 2.9.2",
+ "cairo-lang-sierra 2.9.2",
+ "cairo-lang-sierra-ap-change 2.9.2",
+ "cairo-lang-sierra-gas 2.9.2",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.2",
  "indoc 2.0.5",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
@@ -3113,12 +3136,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "871077dbc08df5d134dc3975538171c14b266ba405d1298085afdb227216f0a3"
+checksum = "7bda5388ef862bc26388e999ac7ad62dd8ab3064720c3483b81fd761b051e627"
 dependencies = [
- "cairo-lang-sierra 2.9.0-dev.0",
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-sierra 2.9.2",
+ "cairo-lang-utils 2.9.2",
 ]
 
 [[package]]
@@ -3243,23 +3266,23 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f21804eb8931d41e258e7a393afc8ee8858308e95b3ed2e9b6b469ef68a6a50"
+checksum = "32d5ed4aa48fe739f643a8c503c14aec0858c31dc73ba4e6a335b77ca7438807"
 dependencies = [
  "anyhow",
- "cairo-lang-compiler 2.9.0-dev.0",
- "cairo-lang-defs 2.9.0-dev.0",
- "cairo-lang-diagnostics 2.9.0-dev.0",
- "cairo-lang-filesystem 2.9.0-dev.0",
- "cairo-lang-lowering 2.9.0-dev.0",
- "cairo-lang-plugins 2.9.0-dev.0",
- "cairo-lang-semantic 2.9.0-dev.0",
- "cairo-lang-sierra 2.9.0-dev.0",
- "cairo-lang-sierra-generator 2.9.0-dev.0",
+ "cairo-lang-compiler 2.9.2",
+ "cairo-lang-defs 2.9.2",
+ "cairo-lang-diagnostics 2.9.2",
+ "cairo-lang-filesystem 2.9.2",
+ "cairo-lang-lowering 2.9.2",
+ "cairo-lang-plugins 2.9.2",
+ "cairo-lang-semantic 2.9.2",
+ "cairo-lang-sierra 2.9.2",
+ "cairo-lang-sierra-generator 2.9.2",
  "cairo-lang-starknet-classes",
- "cairo-lang-syntax 2.9.0-dev.0",
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-syntax 2.9.2",
+ "cairo-lang-utils 2.9.2",
  "const_format",
  "indent",
  "indoc 2.0.5",
@@ -3273,14 +3296,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet-classes"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2496bccd68fa0286b35b72c98439316a3a872ef7ec6d881f0dac90b17997490"
+checksum = "fe691200b431e51e3d6cfa84f256a3dd2e8405f44d182843fbe124f803d085ff"
 dependencies = [
- "cairo-lang-casm 2.9.0-dev.0",
- "cairo-lang-sierra 2.9.0-dev.0",
- "cairo-lang-sierra-to-casm 2.9.0-dev.0",
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-casm 2.9.2",
+ "cairo-lang-sierra 2.9.2",
+ "cairo-lang-sierra-to-casm 2.9.2",
+ "cairo-lang-utils 2.9.2",
  "convert_case 0.6.0",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
@@ -3341,13 +3364,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d77ea2e35d3610098ff13e373fc519aedc6a5096ed8547081aacfc104ef4422"
+checksum = "0a38f1431f22a9487b9b0dd7aef098c9605fe6b8677e0f620547aa69195f7fb5"
 dependencies = [
- "cairo-lang-debug 2.9.0-dev.0",
- "cairo-lang-filesystem 2.9.0-dev.0",
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-debug 2.9.2",
+ "cairo-lang-filesystem 2.9.2",
+ "cairo-lang-primitive-token",
+ "cairo-lang-utils 2.9.2",
  "num-bigint 0.4.6",
  "num-traits",
  "rust-analyzer-salsa",
@@ -3391,9 +3415,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b01d505ab26ca9ce829faf3a8dd097f5d7962d2eb8f136017a260694a6a72e8"
+checksum = "fd7990586c9bb37eaa875ffeb218bdecf96f87881d03263ebf84fcd46514ca9f"
 dependencies = [
  "genco",
  "xshell",
@@ -3401,12 +3425,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-utils"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb143a22f5a3510df8c4dec76e17c1e36bbcbddcd7915601f6a51a72418c454f"
+checksum = "f2b76c55a742da177540d2a0eb39fa50d011998d0ccfdeae8b48ea0e2d7f077f"
 dependencies = [
  "cairo-lang-formatter",
- "cairo-lang-utils 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.2",
  "colored",
  "log",
  "pretty_assertions",
@@ -3463,9 +3487,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.9.0-dev.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35df943ebcf8e1db11ee9f4f46f843dde5b71639ca79ea0d8caa7973f91d8b12"
+checksum = "ff5d7609abc99c15de7d7f90b8441b27e2bd52e930a3014c95a9b620e5d3211a"
 dependencies = [
  "hashbrown 0.14.5",
  "indexmap 2.6.0",
@@ -5350,7 +5374,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -5766,7 +5790,7 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 [[package]]
 name = "infra_utils"
 version = "0.0.0"
-source = "git+https://github.com/starkware-libs/sequencer?branch=main#382184285cf731b1fda3c7647908c34744af53bd"
+source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#6f09863c5189da80065bf6112e29a30b7f765858"
 dependencies = [
  "tokio",
  "tracing",
@@ -7411,7 +7435,7 @@ dependencies = [
 [[package]]
 name = "papyrus_config"
 version = "0.0.0"
-source = "git+https://github.com/starkware-libs/sequencer?branch=main#382184285cf731b1fda3c7647908c34744af53bd"
+source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#6f09863c5189da80065bf6112e29a30b7f765858"
 dependencies = [
  "clap",
  "infra_utils",
@@ -7420,6 +7444,7 @@ dependencies = [
  "serde_json",
  "strum_macros 0.25.3",
  "thiserror",
+ "tracing",
  "validator",
 ]
 
@@ -7641,7 +7666,7 @@ dependencies = [
  "cairo-lang-starknet 1.0.0-alpha.6",
  "cairo-lang-starknet 1.0.0-rc0",
  "cairo-lang-starknet 1.1.1",
- "cairo-lang-starknet 2.9.0-dev.0",
+ "cairo-lang-starknet 2.9.2",
  "cairo-lang-starknet-classes",
  "num-bigint 0.4.6",
  "pathfinder-common",
@@ -9792,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "starknet_api"
 version = "0.0.0"
-source = "git+https://github.com/starkware-libs/sequencer?branch=main#382184285cf731b1fda3c7647908c34744af53bd"
+source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#6f09863c5189da80065bf6112e29a30b7f765858"
 dependencies = [
  "bitvec",
  "cairo-lang-runner",
@@ -9802,6 +9827,7 @@ dependencies = [
  "indexmap 2.6.0",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
+ "num-traits",
  "pretty_assertions",
  "primitive-types",
  "semver 1.0.23",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,7 +1621,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.0.0"
-source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#6f09863c5189da80065bf6112e29a30b7f765858"
+source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#7ee6f4c8a81def87402c626c9d72a33c74bc3243"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -1629,13 +1629,12 @@ dependencies = [
  "ark-secp256k1",
  "ark-secp256r1",
  "cached",
- "cairo-lang-casm 2.9.2",
+ "cairo-lang-casm 2.10.0-rc.0",
  "cairo-lang-runner",
  "cairo-lang-starknet-classes",
  "cairo-vm",
  "derive_more 0.99.18",
  "indexmap 2.6.0",
- "infra_utils",
  "itertools 0.12.1",
  "keccak",
  "log",
@@ -1652,6 +1651,8 @@ dependencies = [
  "sha2",
  "starknet-types-core",
  "starknet_api",
+ "starknet_infra_utils",
+ "starknet_sierra_compile",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "tempfile",
@@ -1881,11 +1882,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3929a38c1d586e35e19dbdf7798b146fba3627b308417a6d373fea8939535b6b"
+checksum = "31a9a437bd4015a0f888d0de9876fd4786eb24b4e17b25c86c53980865980f9d"
 dependencies = [
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-utils 2.10.0-rc.0",
  "indoc 2.0.5",
  "num-bigint 0.4.6",
  "num-traits",
@@ -1970,22 +1971,22 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bed098f0c3666b3ad3a93aef6293f91fc1119bef660ce994105f6d1bc2802cf"
+checksum = "4608693f366e8e86061c824adaca33b56bf0bd7e1cd5edc8592be7a380950322"
 dependencies = [
  "anyhow",
- "cairo-lang-defs 2.9.2",
- "cairo-lang-diagnostics 2.9.2",
- "cairo-lang-filesystem 2.9.2",
- "cairo-lang-lowering 2.9.2",
- "cairo-lang-parser 2.9.2",
- "cairo-lang-project 2.9.2",
- "cairo-lang-semantic 2.9.2",
- "cairo-lang-sierra 2.9.2",
- "cairo-lang-sierra-generator 2.9.2",
- "cairo-lang-syntax 2.9.2",
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-defs 2.10.0-rc.0",
+ "cairo-lang-diagnostics 2.10.0-rc.0",
+ "cairo-lang-filesystem 2.10.0-rc.0",
+ "cairo-lang-lowering 2.10.0-rc.0",
+ "cairo-lang-parser 2.10.0-rc.0",
+ "cairo-lang-project 2.10.0-rc.0",
+ "cairo-lang-semantic 2.10.0-rc.0",
+ "cairo-lang-sierra 2.10.0-rc.0",
+ "cairo-lang-sierra-generator 2.10.0-rc.0",
+ "cairo-lang-syntax 2.10.0-rc.0",
+ "cairo-lang-utils 2.10.0-rc.0",
  "indoc 2.0.5",
  "rayon",
  "rust-analyzer-salsa",
@@ -2012,11 +2013,11 @@ checksum = "c99d41a14f98521c617c0673a0faa41fd00029d32106a4643e1291a1813340a7"
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7763505dcfe15f36899074c27185bf7e3494875f63fd06350c6e3ed8d1f91d5"
+checksum = "4217fd373449a74efde259f8a4df501a7664f6f9c73b547c3aff632ad14feabf"
 dependencies = [
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-utils 2.10.0-rc.0",
 ]
 
 [[package]]
@@ -2073,16 +2074,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d29dc5a3cafe94ea4397d41b00cd54a9dffbe9bc3a3092a9ea617ea737bc6e"
+checksum = "dadf2d1002c9851ea17d37b83a26bbe6f0f53d5f94ba2e477a7a6e9d498f805b"
 dependencies = [
- "cairo-lang-debug 2.9.2",
- "cairo-lang-diagnostics 2.9.2",
- "cairo-lang-filesystem 2.9.2",
- "cairo-lang-parser 2.9.2",
- "cairo-lang-syntax 2.9.2",
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-debug 2.10.0-rc.0",
+ "cairo-lang-diagnostics 2.10.0-rc.0",
+ "cairo-lang-filesystem 2.10.0-rc.0",
+ "cairo-lang-parser 2.10.0-rc.0",
+ "cairo-lang-syntax 2.10.0-rc.0",
+ "cairo-lang-utils 2.10.0-rc.0",
  "itertools 0.12.1",
  "rust-analyzer-salsa",
  "smol_str 0.2.2",
@@ -2124,13 +2125,13 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761d20ca9c3a3eb7025b2488aa6e0e5dc23c5d551dd95e83a989b5e87687f523"
+checksum = "4c4ac1831e7c14e5308a66254bcc57a8d4790f18567ef8d4d6768b39ffb955a0"
 dependencies = [
- "cairo-lang-debug 2.9.2",
- "cairo-lang-filesystem 2.9.2",
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-debug 2.10.0-rc.0",
+ "cairo-lang-filesystem 2.10.0-rc.0",
+ "cairo-lang-utils 2.10.0-rc.0",
  "itertools 0.12.1",
 ]
 
@@ -2170,11 +2171,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d778ec864e92c82293370a512195715b12775b05981e14065d85eb5dd3dd96b6"
+checksum = "33c5f879bca42caef7e06f1de022d6961d36c5567db600faed8a947e2b705eaa"
 dependencies = [
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-utils 2.10.0-rc.0",
  "good_lp",
 ]
 
@@ -2219,12 +2220,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9dc486c554e2df3be8e84c47e30fe55b59d2349b680fbe992bfba801ef93ff5"
+checksum = "c632b6d3ee5f1684f757f86e04ba9cf1daa8e4e74c6a5d6c0b7773cc4465a6c6"
 dependencies = [
- "cairo-lang-debug 2.9.2",
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-debug 2.10.0-rc.0",
+ "cairo-lang-utils 2.10.0-rc.0",
  "path-clean 1.0.1",
  "rust-analyzer-salsa",
  "semver 1.0.23",
@@ -2235,16 +2236,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-formatter"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675d281a3c9aa365055ce6e201d5dd91534dfccfd2929a41b7397f665c80293c"
+checksum = "8295a3ddc62d8d92d942292f103de0434d622f47e936a3aea25eccc3eed88c58"
 dependencies = [
  "anyhow",
- "cairo-lang-diagnostics 2.9.2",
- "cairo-lang-filesystem 2.9.2",
- "cairo-lang-parser 2.9.2",
- "cairo-lang-syntax 2.9.2",
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-diagnostics 2.10.0-rc.0",
+ "cairo-lang-filesystem 2.10.0-rc.0",
+ "cairo-lang-parser 2.10.0-rc.0",
+ "cairo-lang-syntax 2.10.0-rc.0",
+ "cairo-lang-utils 2.10.0-rc.0",
  "diffy",
  "ignore",
  "itertools 0.12.1",
@@ -2328,19 +2329,19 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d880470c94f94fac08c2150bc0ce4af930b6760956a56966e47612de376d57ec"
+checksum = "b2a93c2644c64cfdbbe64b1bd6e13d9c6ed511950cfae2e738d228bc89dc5605"
 dependencies = [
- "cairo-lang-debug 2.9.2",
- "cairo-lang-defs 2.9.2",
- "cairo-lang-diagnostics 2.9.2",
- "cairo-lang-filesystem 2.9.2",
- "cairo-lang-parser 2.9.2",
- "cairo-lang-proc-macros 2.9.2",
- "cairo-lang-semantic 2.9.2",
- "cairo-lang-syntax 2.9.2",
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-debug 2.10.0-rc.0",
+ "cairo-lang-defs 2.10.0-rc.0",
+ "cairo-lang-diagnostics 2.10.0-rc.0",
+ "cairo-lang-filesystem 2.10.0-rc.0",
+ "cairo-lang-parser 2.10.0-rc.0",
+ "cairo-lang-proc-macros 2.10.0-rc.0",
+ "cairo-lang-semantic 2.10.0-rc.0",
+ "cairo-lang-syntax 2.10.0-rc.0",
+ "cairo-lang-utils 2.10.0-rc.0",
  "id-arena",
  "itertools 0.12.1",
  "log",
@@ -2411,15 +2412,15 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e2b488f659432c8b866bf540e54ab3696a24ac0f366faac33b860c5313e78c"
+checksum = "d884d9418895fef5b8ffd7458211523ab5abf4357845938b354adfbae1089fe2"
 dependencies = [
- "cairo-lang-diagnostics 2.9.2",
- "cairo-lang-filesystem 2.9.2",
- "cairo-lang-syntax 2.9.2",
- "cairo-lang-syntax-codegen 2.9.2",
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-diagnostics 2.10.0-rc.0",
+ "cairo-lang-filesystem 2.10.0-rc.0",
+ "cairo-lang-syntax 2.10.0-rc.0",
+ "cairo-lang-syntax-codegen 2.10.0-rc.0",
+ "cairo-lang-utils 2.10.0-rc.0",
  "colored",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
@@ -2487,16 +2488,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13cf34fd39a1efb997455fa38dbdb6bef489a125a2d17d77ebfea1ee580559f3"
+checksum = "b224afdc76d9890edf9009fa8ffff9a91ac15614a41049d48c77c192e8c966e3"
 dependencies = [
- "cairo-lang-defs 2.9.2",
- "cairo-lang-diagnostics 2.9.2",
- "cairo-lang-filesystem 2.9.2",
- "cairo-lang-parser 2.9.2",
- "cairo-lang-syntax 2.9.2",
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-defs 2.10.0-rc.0",
+ "cairo-lang-diagnostics 2.10.0-rc.0",
+ "cairo-lang-filesystem 2.10.0-rc.0",
+ "cairo-lang-parser 2.10.0-rc.0",
+ "cairo-lang-syntax 2.10.0-rc.0",
+ "cairo-lang-utils 2.10.0-rc.0",
  "indent",
  "indoc 2.0.5",
  "itertools 0.12.1",
@@ -2543,11 +2544,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c4a161868276ce022c44ac500afbfa0d7d8371106feb40dfca34ea7be97503"
+checksum = "0ae35a282e5f2d15f47ba6fffae5a32e8aa2f254366865339cf326e2e015b8f8"
 dependencies = [
- "cairo-lang-debug 2.9.2",
+ "cairo-lang-debug 2.10.0-rc.0",
  "quote",
  "syn 2.0.87",
 ]
@@ -2591,12 +2592,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde3cc9777fff4daacbfd839a6fcefa29abd660068de47f72ac6d5883fa93ccd"
+checksum = "4da40ba380208db0b861d8b1e6e558adaa98dd0b382177b25bdb1abf8fd8d766"
 dependencies = [
- "cairo-lang-filesystem 2.9.2",
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-filesystem 2.10.0-rc.0",
+ "cairo-lang-utils 2.10.0-rc.0",
  "serde",
  "thiserror",
  "toml 0.8.19",
@@ -2604,17 +2605,17 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runnable-utils"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872d846834c8fdc886a7dc591c1f6ddd969d25d2c88dd65452931c63dfca7acc"
+checksum = "951b72522c8a76e177119699bdcd3c4288bdc0bc784ac22dd7c0f80b2a7444d0"
 dependencies = [
- "cairo-lang-casm 2.9.2",
- "cairo-lang-sierra 2.9.2",
- "cairo-lang-sierra-ap-change 2.9.2",
- "cairo-lang-sierra-gas 2.9.2",
- "cairo-lang-sierra-to-casm 2.9.2",
+ "cairo-lang-casm 2.10.0-rc.0",
+ "cairo-lang-sierra 2.10.0-rc.0",
+ "cairo-lang-sierra-ap-change 2.10.0-rc.0",
+ "cairo-lang-sierra-gas 2.10.0-rc.0",
+ "cairo-lang-sierra-to-casm 2.10.0-rc.0",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-utils 2.10.0-rc.0",
  "cairo-vm",
  "itertools 0.12.1",
  "thiserror",
@@ -2622,21 +2623,21 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runner"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9121164a61b0a8fcadefc8b21240e372bf04e6648ea31d09f9e85701e60877a"
+checksum = "35b1d5b0e9103bea4e39ac1099ad47893a25f334c3ca2596d07b1a8920be22cb"
 dependencies = [
  "ark-ff 0.4.2",
  "ark-secp256k1",
  "ark-secp256r1",
- "cairo-lang-casm 2.9.2",
- "cairo-lang-lowering 2.9.2",
+ "cairo-lang-casm 2.10.0-rc.0",
+ "cairo-lang-lowering 2.10.0-rc.0",
  "cairo-lang-runnable-utils",
- "cairo-lang-sierra 2.9.2",
- "cairo-lang-sierra-generator 2.9.2",
- "cairo-lang-sierra-to-casm 2.9.2",
- "cairo-lang-starknet 2.9.2",
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-sierra 2.10.0-rc.0",
+ "cairo-lang-sierra-generator 2.10.0-rc.0",
+ "cairo-lang-sierra-to-casm 2.10.0-rc.0",
+ "cairo-lang-starknet 2.10.0-rc.0",
+ "cairo-lang-utils 2.10.0-rc.0",
  "cairo-vm",
  "itertools 0.12.1",
  "keccak",
@@ -2721,20 +2722,20 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8af1f92ba601fd61a994c44d0c80d711fbb3d64b2b5a1e72905fc6f581b1fadd"
+checksum = "babdf14729236dfb455519d35e7e399ba73f0eaa4f1e929474d4c37dc9ef7a29"
 dependencies = [
- "cairo-lang-debug 2.9.2",
- "cairo-lang-defs 2.9.2",
- "cairo-lang-diagnostics 2.9.2",
- "cairo-lang-filesystem 2.9.2",
- "cairo-lang-parser 2.9.2",
- "cairo-lang-plugins 2.9.2",
- "cairo-lang-proc-macros 2.9.2",
- "cairo-lang-syntax 2.9.2",
+ "cairo-lang-debug 2.10.0-rc.0",
+ "cairo-lang-defs 2.10.0-rc.0",
+ "cairo-lang-diagnostics 2.10.0-rc.0",
+ "cairo-lang-filesystem 2.10.0-rc.0",
+ "cairo-lang-parser 2.10.0-rc.0",
+ "cairo-lang-plugins 2.10.0-rc.0",
+ "cairo-lang-proc-macros 2.10.0-rc.0",
+ "cairo-lang-syntax 2.10.0-rc.0",
  "cairo-lang-test-utils",
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-utils 2.10.0-rc.0",
  "id-arena",
  "indoc 2.0.5",
  "itertools 0.12.1",
@@ -2815,12 +2816,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "075c6457642ada82b32cf657d871a8545ae7a9d61c78dd5588a794c8c905abdc"
+checksum = "74c0e4951ecd88023856e0faa9fd444647d9f1ec69ca09dfa8e3aebf9d2afdef"
 dependencies = [
  "anyhow",
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-utils 2.10.0-rc.0",
  "const-fnv1a-hash",
  "convert_case 0.6.0",
  "derivative",
@@ -2879,14 +2880,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69172fe8354b1dd564bba318ccb5233aa78f70d57145b8c92a0b1cf009fa0fc"
+checksum = "9ea9c51356e603fa38fcbd4524d19e391ac25e89e64889c3a4ef849de3d1e911"
 dependencies = [
- "cairo-lang-eq-solver 2.9.2",
- "cairo-lang-sierra 2.9.2",
+ "cairo-lang-eq-solver 2.10.0-rc.0",
+ "cairo-lang-sierra 2.10.0-rc.0",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-utils 2.10.0-rc.0",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
  "num-traits",
@@ -2932,14 +2933,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b571b73d9b02103f780aeee05dbf9a71d68d8a16341a04aa1dd581d0db3ad6"
+checksum = "1af17244a222fd2398caaf09e909f0b584abe14c77e1b5dc8f479ef35d1e8d50"
 dependencies = [
- "cairo-lang-eq-solver 2.9.2",
- "cairo-lang-sierra 2.9.2",
+ "cairo-lang-eq-solver 2.10.0-rc.0",
+ "cairo-lang-sierra 2.10.0-rc.0",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-utils 2.10.0-rc.0",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
  "num-traits",
@@ -3024,20 +3025,20 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3857cd98a0cb35b32cc962e70c04e6ddfcd8bf61106ac37b6cf453ec76b878"
+checksum = "2368d57175b18976222f844e4dda52d0025d70ce8b2dda35e0cc96efaa9bb4a5"
 dependencies = [
- "cairo-lang-debug 2.9.2",
- "cairo-lang-defs 2.9.2",
- "cairo-lang-diagnostics 2.9.2",
- "cairo-lang-filesystem 2.9.2",
- "cairo-lang-lowering 2.9.2",
- "cairo-lang-parser 2.9.2",
- "cairo-lang-semantic 2.9.2",
- "cairo-lang-sierra 2.9.2",
- "cairo-lang-syntax 2.9.2",
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-debug 2.10.0-rc.0",
+ "cairo-lang-defs 2.10.0-rc.0",
+ "cairo-lang-diagnostics 2.10.0-rc.0",
+ "cairo-lang-filesystem 2.10.0-rc.0",
+ "cairo-lang-lowering 2.10.0-rc.0",
+ "cairo-lang-parser 2.10.0-rc.0",
+ "cairo-lang-semantic 2.10.0-rc.0",
+ "cairo-lang-sierra 2.10.0-rc.0",
+ "cairo-lang-syntax 2.10.0-rc.0",
+ "cairo-lang-utils 2.10.0-rc.0",
  "itertools 0.12.1",
  "num-traits",
  "rust-analyzer-salsa",
@@ -3115,17 +3116,17 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add264b156dfb01f18292282a6037070c078acca3bccde05787da1e1c997b78c"
+checksum = "866e6cbba9e81bae1c2f6b8f8e718f702fee69980c3f22bdea1e4657f09a540c"
 dependencies = [
  "assert_matches",
- "cairo-lang-casm 2.9.2",
- "cairo-lang-sierra 2.9.2",
- "cairo-lang-sierra-ap-change 2.9.2",
- "cairo-lang-sierra-gas 2.9.2",
+ "cairo-lang-casm 2.10.0-rc.0",
+ "cairo-lang-sierra 2.10.0-rc.0",
+ "cairo-lang-sierra-ap-change 2.10.0-rc.0",
+ "cairo-lang-sierra-gas 2.10.0-rc.0",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-utils 2.10.0-rc.0",
  "indoc 2.0.5",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
@@ -3136,12 +3137,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bda5388ef862bc26388e999ac7ad62dd8ab3064720c3483b81fd761b051e627"
+checksum = "f8e797aa2f4023e984d13c5adf7068688da665328da6b055842f50fb673fb48b"
 dependencies = [
- "cairo-lang-sierra 2.9.2",
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-sierra 2.10.0-rc.0",
+ "cairo-lang-utils 2.10.0-rc.0",
 ]
 
 [[package]]
@@ -3266,23 +3267,23 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d5ed4aa48fe739f643a8c503c14aec0858c31dc73ba4e6a335b77ca7438807"
+checksum = "85c16967be9b0befaa0e21f65c9c803f8354d0db09de7adf28cdf0dc54b2c90d"
 dependencies = [
  "anyhow",
- "cairo-lang-compiler 2.9.2",
- "cairo-lang-defs 2.9.2",
- "cairo-lang-diagnostics 2.9.2",
- "cairo-lang-filesystem 2.9.2",
- "cairo-lang-lowering 2.9.2",
- "cairo-lang-plugins 2.9.2",
- "cairo-lang-semantic 2.9.2",
- "cairo-lang-sierra 2.9.2",
- "cairo-lang-sierra-generator 2.9.2",
+ "cairo-lang-compiler 2.10.0-rc.0",
+ "cairo-lang-defs 2.10.0-rc.0",
+ "cairo-lang-diagnostics 2.10.0-rc.0",
+ "cairo-lang-filesystem 2.10.0-rc.0",
+ "cairo-lang-lowering 2.10.0-rc.0",
+ "cairo-lang-plugins 2.10.0-rc.0",
+ "cairo-lang-semantic 2.10.0-rc.0",
+ "cairo-lang-sierra 2.10.0-rc.0",
+ "cairo-lang-sierra-generator 2.10.0-rc.0",
  "cairo-lang-starknet-classes",
- "cairo-lang-syntax 2.9.2",
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-syntax 2.10.0-rc.0",
+ "cairo-lang-utils 2.10.0-rc.0",
  "const_format",
  "indent",
  "indoc 2.0.5",
@@ -3296,14 +3297,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet-classes"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe691200b431e51e3d6cfa84f256a3dd2e8405f44d182843fbe124f803d085ff"
+checksum = "b0f7b0c28430c9ad477c38dba089ac5a148443bbeaa77cc3f14980de255a220e"
 dependencies = [
- "cairo-lang-casm 2.9.2",
- "cairo-lang-sierra 2.9.2",
- "cairo-lang-sierra-to-casm 2.9.2",
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-casm 2.10.0-rc.0",
+ "cairo-lang-sierra 2.10.0-rc.0",
+ "cairo-lang-sierra-to-casm 2.10.0-rc.0",
+ "cairo-lang-utils 2.10.0-rc.0",
  "convert_case 0.6.0",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
@@ -3364,14 +3365,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a38f1431f22a9487b9b0dd7aef098c9605fe6b8677e0f620547aa69195f7fb5"
+checksum = "f5adf933d378225e031200bd41c82e09cb0fde1042f5fe3f3c82d1ccd559a6f2"
 dependencies = [
- "cairo-lang-debug 2.9.2",
- "cairo-lang-filesystem 2.9.2",
+ "cairo-lang-debug 2.10.0-rc.0",
+ "cairo-lang-filesystem 2.10.0-rc.0",
  "cairo-lang-primitive-token",
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-utils 2.10.0-rc.0",
  "num-bigint 0.4.6",
  "num-traits",
  "rust-analyzer-salsa",
@@ -3415,9 +3416,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7990586c9bb37eaa875ffeb218bdecf96f87881d03263ebf84fcd46514ca9f"
+checksum = "4b34c81e723cf05fc0655aa8527f5a2730e30b31368b1b887c3eeb50a00c81c4"
 dependencies = [
  "genco",
  "xshell",
@@ -3425,12 +3426,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-utils"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b76c55a742da177540d2a0eb39fa50d011998d0ccfdeae8b48ea0e2d7f077f"
+checksum = "aa7c6930beb6f221c1bc274460fca091e93c377570994b612682da30795ed74e"
 dependencies = [
  "cairo-lang-formatter",
- "cairo-lang-utils 2.9.2",
+ "cairo-lang-utils 2.10.0-rc.0",
  "colored",
  "log",
  "pretty_assertions",
@@ -3487,9 +3488,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.9.2"
+version = "2.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff5d7609abc99c15de7d7f90b8441b27e2bd52e930a3014c95a9b620e5d3211a"
+checksum = "91b6546d9f285c7d4a2700c084f745c35e1884a1dc2e4fa54a71034cea5606aa"
 dependencies = [
  "hashbrown 0.14.5",
  "indexmap 2.6.0",
@@ -5374,7 +5375,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -5786,15 +5787,6 @@ name = "indoc"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
-
-[[package]]
-name = "infra_utils"
-version = "0.0.0"
-source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#6f09863c5189da80065bf6112e29a30b7f765858"
-dependencies = [
- "tokio",
- "tracing",
-]
 
 [[package]]
 name = "inout"
@@ -7435,13 +7427,13 @@ dependencies = [
 [[package]]
 name = "papyrus_config"
 version = "0.0.0"
-source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#6f09863c5189da80065bf6112e29a30b7f765858"
+source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#7ee6f4c8a81def87402c626c9d72a33c74bc3243"
 dependencies = [
  "clap",
- "infra_utils",
  "itertools 0.12.1",
  "serde",
  "serde_json",
+ "starknet_infra_utils",
  "strum_macros 0.25.3",
  "thiserror",
  "tracing",
@@ -7666,7 +7658,7 @@ dependencies = [
  "cairo-lang-starknet 1.0.0-alpha.6",
  "cairo-lang-starknet 1.0.0-rc0",
  "cairo-lang-starknet 1.1.1",
- "cairo-lang-starknet 2.9.2",
+ "cairo-lang-starknet 2.10.0-rc.0",
  "cairo-lang-starknet-classes",
  "num-bigint 0.4.6",
  "pathfinder-common",
@@ -8835,6 +8827,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlimit"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9817,7 +9818,7 @@ dependencies = [
 [[package]]
 name = "starknet_api"
 version = "0.0.0"
-source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#6f09863c5189da80065bf6112e29a30b7f765858"
+source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#7ee6f4c8a81def87402c626c9d72a33c74bc3243"
 dependencies = [
  "bitvec",
  "cairo-lang-runner",
@@ -9839,6 +9840,35 @@ dependencies = [
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "thiserror",
+]
+
+[[package]]
+name = "starknet_infra_utils"
+version = "0.0.0"
+source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#7ee6f4c8a81def87402c626c9d72a33c74bc3243"
+dependencies = [
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "starknet_sierra_compile"
+version = "0.0.0"
+source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#7ee6f4c8a81def87402c626c9d72a33c74bc3243"
+dependencies = [
+ "cairo-lang-sierra 2.10.0-rc.0",
+ "cairo-lang-starknet-classes",
+ "cairo-lang-utils 2.10.0-rc.0",
+ "papyrus_config",
+ "rlimit",
+ "serde",
+ "serde_json",
+ "starknet-types-core",
+ "starknet_api",
+ "starknet_infra_utils",
+ "tempfile",
+ "thiserror",
+ "validator",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,7 +1621,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.0.0"
-source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#7ee6f4c8a81def87402c626c9d72a33c74bc3243"
+source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#82b1537dcabec5aa3b46251feac172d3e762c889"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -5375,7 +5375,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -7427,7 +7427,7 @@ dependencies = [
 [[package]]
 name = "papyrus_config"
 version = "0.0.0"
-source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#7ee6f4c8a81def87402c626c9d72a33c74bc3243"
+source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#82b1537dcabec5aa3b46251feac172d3e762c889"
 dependencies = [
  "clap",
  "itertools 0.12.1",
@@ -9818,7 +9818,7 @@ dependencies = [
 [[package]]
 name = "starknet_api"
 version = "0.0.0"
-source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#7ee6f4c8a81def87402c626c9d72a33c74bc3243"
+source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#82b1537dcabec5aa3b46251feac172d3e762c889"
 dependencies = [
  "bitvec",
  "cairo-lang-runner",
@@ -9845,7 +9845,7 @@ dependencies = [
 [[package]]
 name = "starknet_infra_utils"
 version = "0.0.0"
-source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#7ee6f4c8a81def87402c626c9d72a33c74bc3243"
+source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#82b1537dcabec5aa3b46251feac172d3e762c889"
 dependencies = [
  "tokio",
  "tracing",
@@ -9854,7 +9854,7 @@ dependencies = [
 [[package]]
 name = "starknet_sierra_compile"
 version = "0.0.0"
-source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#7ee6f4c8a81def87402c626c9d72a33c74bc3243"
+source = "git+https://github.com/starkware-libs/sequencer?branch=main-v0.13.4#82b1537dcabec5aa3b46251feac172d3e762c889"
 dependencies = [
  "cairo-lang-sierra 2.10.0-rc.0",
  "cairo-lang-starknet-classes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,14 +10,14 @@ checksum = "3b2e69442aa5628ea6951fa33e24efe8313f4321a91bd729fc2f75bdfc858570"
 dependencies = [
  "num-bigint 0.3.3",
  "num-integer",
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
 name = "addr2line"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
@@ -97,15 +97,15 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
 
 [[package]]
 name = "alloy"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c37d89f69cb43901949ba29307ada8b9e3b170f94057ad4c04d6fd169d24d65f"
+checksum = "8367891bf380210abb0d6aa30c5f85a9080cb4a066c4d5c5acadad630823751b"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -123,19 +123,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.30"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b4f201b0ac8f81315fbdc55269965a8ddadbc04ab47fa65a1a468f9a40f7a5f"
+checksum = "18c5c520273946ecf715c0010b4e3503d7eba9893cd9ce6b7fff5654c4a3c470"
 dependencies = [
+ "alloy-primitives",
  "num_enum",
  "strum 0.26.3",
 ]
 
 [[package]]
 name = "alloy-consensus"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1468e3128e07c7afe4ff13c17e8170c330d12c322f8924b8bf6986a27e0aad3d"
+checksum = "629b62e38d471cc15fea534eb7283d2f8a4e8bdb1811bcc5d66dda6cfce6fae1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -147,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335d62de1a887f1b780441f8a3037f39c9fb26839cc9acd891c9b80396145cd5"
+checksum = "0eefe64fd344cffa9cf9e3435ec4e93e6e9c3481bc37269af988bf497faf4a6a"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -168,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b095eb0533144b4497e84a9cc3e44a5c2e3754a3983c0376a55a2f9183a53e"
+checksum = "47ef9e96462d0b9fee9008c53c1f3d017b9498fcdef3ad8d728db98afef47955"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -180,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4004925bff5ba0a11739ae84dbb6601a981ea692f3bd45b626935ee90a6b8471"
+checksum = "85132f2698b520fab3f54beed55a44389f7006a7b557a0261e1e69439dcc1572"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -208,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d319bb544ca6caeab58c39cea8921c55d924d4f68f2c60f24f914673f9a74a"
+checksum = "ea59dc42102bc9a1905dc57901edc6dd48b9f38115df86c7d252acba70d71d04"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -219,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c35df7b972b06f1b2f4e8b7a53328522fa788054a9d3e556faf2411c5a51d5a"
+checksum = "f923dd5fca5f67a43d81ed3ebad0880bd41f6dd0ada930030353ac356c54cd0f"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -237,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9996daf962fd0a90d3c93b388033228865953b92de7bb1959b891d78750a4091"
+checksum = "ded610181f3dad5810f6ff12d1a99994cf9b42d2fcb7709029352398a5da5ae6"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -249,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8866562186d237f1dfeaf989ef941a24764f764bf5c33311e37ead3519c6a429"
+checksum = "d3c717b5298fad078cd3a418335b266eba91b511383ca9bd497f742d5975d5ab"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -263,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe714e233f9eaf410de95a9af6bcd05d3a7f8c8de7a0817221e95a6b642a080"
+checksum = "fb3705ce7d8602132bcf5ac7a1dd293a42adc2f183abf5907c30ac535ceca049"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -284,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c5a38117974c5776a45e140226745a0b664f79736aa900995d8e4121558e064"
+checksum = "94ad40869867ed2d9cd3842b1e800889e5b49e6b92da346e93862b4a741bedf3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -296,31 +297,37 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411aff151f2a73124ee473708e82ed51b2535f68928b6a1caa8bc1246ae6f7cd"
+checksum = "fd58d377699e6cfeab52c4a9d28bdc4ef37e2bd235ff2db525071fe37a2e9af5"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
  "derive_more 1.0.0",
+ "foldhash",
+ "hashbrown 0.15.1",
  "hex-literal",
+ "indexmap 2.6.0",
  "itoa",
  "k256",
  "keccak-asm",
+ "paste",
  "proptest",
  "rand",
  "ruint",
+ "rustc-hash 2.0.0",
  "serde",
+ "sha3",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-provider"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65633d6ef83c3626913c004eaf166a6dd50406f724772ea8567135efd6dc5d3"
+checksum = "927f708dd457ed63420400ee5f06945df9632d5d101851952056840426a10dc5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -354,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949db89abae6193b44cc90ebf2eeb74eb8d2a474383c5e62b45bdcd362e84f8f"
+checksum = "2d05f63677e210d758cd5d6d1ce10f20c980c3560ccfbe79ba1997791862a04f"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -373,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26154390b1d205a4a7ac7352aa2eb4f81f391399d4e2f546fb81a2f8bb383f62"
+checksum = "da0822426598f95e45dd1ea32a738dac057529a709ee645fcc516ffa4cbde08f"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -384,20 +391,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d0f2d905ebd295e7effec65e5f6868d153936130ae718352771de3e7d03c75c"
+checksum = "2b09cae092c27b6f1bde952653a22708691802e57bfef4a2973b80bea21efd3f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fc328bb5d440599ba1b5aa44c0b9ab0625fbc3a403bb5ee94ed4a01ba23e07"
+checksum = "7d82952dca71173813d4e5733e2c986d8b04aea9e0f3b0a576664c232ad050a5"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -419,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f8ff679f94c497a8383f2cd09e2a099266e5f3d5e574bc82b4b379865707dbb"
+checksum = "64333d639f2a0cf73491813c629a405744e16343a4bc5640931be707c345ecc5"
 dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
@@ -430,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a59b1d7c86e0a653e7f3d29954f6de5a2878d8cfd1f010ff93be5c2c48cd3b1"
+checksum = "83aa984386deda02482660aa31cb8ca1e63d533f1c31a52d7d181ac5ec68e9b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -441,17 +448,19 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
+ "cfg-if",
+ "derive_more 1.0.0",
+ "hashbrown 0.14.5",
  "itertools 0.13.0",
  "serde",
  "serde_json",
- "thiserror",
 ]
 
 [[package]]
 name = "alloy-serde"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51db8a6428a2159e01b7a43ec7aac801edd0c4db1d4de06f310c288940f16fd3"
+checksum = "731f75ec5d383107fd745d781619bd9cedf145836c51ecb991623d41278e71fa"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -460,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebc1760c13592b7ba3fcd964abba546b8d6a9f10d15e8d92a8263731be33f36"
+checksum = "307324cca94354cd654d6713629f0383ec037e1ff9e3e3d547212471209860c0"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -474,42 +483,42 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0458ccb02a564228fcd76efb8eb5a520521a8347becde37b402afec9a1b83859"
+checksum = "8a1b42ac8f45e2f49f4bcdd72cbfde0bb148f5481d403774ffa546e48b83efc1"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc65475025fc1e84bf86fc840f04f63fcccdcf3cf12053c99918e4054dfbc69"
+checksum = "06318f1778e57f36333e850aa71bd1bb5e560c10279e236622faae0470c50412"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "syn-solidity",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed10f0715a0b69fde3236ff3b9ae5f6f7c97db5a387747100070d3016b9266b"
+checksum = "eaebb9b0ad61a41345a22c9279975c0cdd231b97947b10d7aad1cf0a7181e4a5"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -518,15 +527,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.77",
+ "syn 2.0.87",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3edae8ea1de519ccba896b6834dec874230f72fe695ff3c9c118e90ec7cff783"
+checksum = "12c71028bfbfec210e24106a542aad3def7caf1a70e2c05710e92a98481980d3"
 dependencies = [
  "serde",
  "winnow",
@@ -534,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eb88e4da0a1b697ed6a9f811fdba223cf4d5c21410804fd1707836af73a462b"
+checksum = "374d7fb042d68ddfe79ccb23359de3007f6d4d53c13f703b64fb0db422132111"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -547,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5dc4e902f1860d54952446d246ac05386311ad61030a2b906ae865416d36e0"
+checksum = "33616b2edf7454302a1d48084db185e52c309f73f6c10be99b0fe39354b3f1e9"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -566,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1742b94bb814f1ca6b322a6f9dd38a0252ff45a3119e40e888fb7029afa500ce"
+checksum = "a944f5310c690b62bbb3e7e5ce34527cbd36b2d18532a797af123271ce595a49"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -581,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ed861e7030001364c8ffa2db63541f7bae275a6e636de7616c20f2fd3dc0c3"
+checksum = "a9704761f6297fe482276bee7f77a93cb42bd541c2bd6c1c560b6f3a9ece672e"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -620,9 +629,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -635,43 +644,43 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.88"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1496f8fb1fbf272686b8d37f523dab3e4a7443300055e74cdaa449f3114356"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "ark-ec"
@@ -686,7 +695,7 @@ dependencies = [
  "derivative",
  "hashbrown 0.13.2",
  "itertools 0.10.5",
- "num-traits 0.2.19",
+ "num-traits",
  "zeroize",
 ]
 
@@ -702,7 +711,7 @@ dependencies = [
  "ark-std 0.3.0",
  "derivative",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "paste",
  "rustc_version 0.3.3",
  "zeroize",
@@ -722,7 +731,7 @@ dependencies = [
  "digest 0.10.7",
  "itertools 0.10.5",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "paste",
  "rustc_version 0.4.1",
  "zeroize",
@@ -743,7 +752,7 @@ dependencies = [
  "educe",
  "itertools 0.13.0",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "paste",
  "zeroize",
 ]
@@ -775,7 +784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -785,7 +794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "quote",
  "syn 1.0.109",
 ]
@@ -797,7 +806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -810,10 +819,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -902,7 +911,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
- "num-traits 0.2.19",
+ "num-traits",
  "rand",
 ]
 
@@ -912,7 +921,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
- "num-traits 0.2.19",
+ "num-traits",
  "rand",
 ]
 
@@ -922,15 +931,15 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
- "num-traits 0.2.19",
+ "num-traits",
  "rand",
 ]
 
 [[package]]
 name = "arrayref"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -957,7 +966,7 @@ dependencies = [
  "asn1-rs-impl",
  "displaydoc",
  "nom",
- "num-traits 0.2.19",
+ "num-traits",
  "rusticata-macros",
  "thiserror",
  "time",
@@ -971,7 +980,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "synstructure",
 ]
 
@@ -983,7 +992,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1043,8 +1052,8 @@ checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand 2.1.1",
- "futures-lite 2.3.0",
+ "fastrand 2.2.0",
+ "futures-lite 2.5.0",
  "slab",
 ]
 
@@ -1068,10 +1077,10 @@ checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
- "async-io 2.3.4",
+ "async-io 2.4.0",
  "async-lock 3.4.0",
  "blocking",
- "futures-lite 2.3.0",
+ "futures-lite 2.5.0",
  "once_cell",
 ]
 
@@ -1097,18 +1106,18 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8"
+checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
 dependencies = [
  "async-lock 3.4.0",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.3.0",
+ "futures-lite 2.5.0",
  "parking",
- "polling 3.7.3",
- "rustix 0.38.37",
+ "polling 3.7.4",
+ "rustix 0.38.40",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -1167,28 +1176,27 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.37",
+ "rustix 0.38.40",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "async-process"
-version = "2.2.4"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a07789659a4d385b79b18b9127fc27e1a59e1e89117c78c5ea3b806f016374"
+checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
 dependencies = [
  "async-channel 2.3.1",
- "async-io 2.3.4",
+ "async-io 2.4.0",
  "async-lock 3.4.0",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
  "event-listener 5.3.1",
- "futures-lite 2.3.0",
- "rustix 0.38.37",
+ "futures-lite 2.5.0",
+ "rustix 0.38.40",
  "tracing",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1197,13 +1205,13 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
 dependencies = [
- "async-io 2.3.4",
+ "async-io 2.4.0",
  "async-lock 3.4.0",
  "atomic-waker",
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.37",
+ "rustix 0.38.40",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -1218,14 +1226,14 @@ dependencies = [
  "async-attributes",
  "async-channel 1.9.0",
  "async-global-executor",
- "async-io 2.3.4",
+ "async-io 2.4.0",
  "async-lock 3.4.0",
- "async-process 2.2.4",
+ "async-process 2.3.0",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
  "futures-io",
- "futures-lite 2.3.0",
+ "futures-lite 2.5.0",
  "gloo-timers",
  "kv-log-macro",
  "log",
@@ -1239,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -1250,13 +1258,13 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1267,13 +1275,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1336,14 +1344,14 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
@@ -1358,7 +1366,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "itoa",
  "matchit",
  "memchr",
@@ -1375,20 +1383,20 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
 dependencies = [
  "async-trait",
- "axum-core 0.4.3",
+ "axum-core 0.4.5",
  "axum-macros",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -1404,8 +1412,8 @@ dependencies = [
  "sha1",
  "sync_wrapper 1.0.1",
  "tokio",
- "tokio-tungstenite 0.21.0",
- "tower 0.4.13",
+ "tokio-tungstenite 0.24.0",
+ "tower 0.5.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1430,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1443,7 +1451,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1451,14 +1459,13 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c055ee2d014ae5981ce1016374e8213682aa14d9bf40e48ab48b5f3ef20eaa"
+checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
- "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1613,8 +1620,8 @@ dependencies = [
 
 [[package]]
 name = "blockifier"
-version = "0.8.0-rc.3"
-source = "git+https://github.com/eqlabs/sequencer?branch=eqlabs/main-v0.13.2#2e59ae0f7c0da559cd77bd9db794309a8e3fe99a"
+version = "0.0.0"
+source = "git+https://github.com/starkware-libs/sequencer?branch=main#382184285cf731b1fda3c7647908c34744af53bd"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -1622,32 +1629,34 @@ dependencies = [
  "ark-secp256k1",
  "ark-secp256r1",
  "cached",
- "cairo-lang-casm 2.7.1",
+ "cairo-lang-casm 2.9.0-dev.0",
  "cairo-lang-runner",
  "cairo-lang-starknet-classes",
- "cairo-lang-utils 2.7.1",
  "cairo-vm",
  "derive_more 0.99.18",
- "indexmap 2.5.0",
- "itertools 0.10.5",
+ "indexmap 2.6.0",
+ "infra_utils",
+ "itertools 0.12.1",
  "keccak",
  "log",
  "num-bigint 0.4.6",
  "num-integer",
  "num-rational",
- "num-traits 0.2.19",
- "once_cell",
+ "num-traits",
+ "papyrus_config",
  "paste",
  "phf",
+ "semver 1.0.23",
  "serde",
  "serde_json",
  "sha2",
- "sha3",
  "starknet-types-core",
  "starknet_api",
  "strum 0.25.0",
  "strum_macros 0.25.3",
+ "tempfile",
  "thiserror",
+ "toml 0.8.19",
 ]
 
 [[package]]
@@ -1659,15 +1668,15 @@ dependencies = [
  "async-channel 2.3.1",
  "async-task",
  "futures-io",
- "futures-lite 2.3.0",
+ "futures-lite 2.5.0",
  "piper",
 ]
 
 [[package]]
 name = "bloomfilter"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0bdbcf2078e0ba8a74e1fe0cf36f54054a04485759b61dfd60b174658e9607"
+checksum = "c541c70a910b485670304fd420f0eab8f7bde68439db6a8d98819c3d2774d7e2"
 dependencies = [
  "bit-vec 0.7.0",
  "getrandom",
@@ -1725,9 +1734,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 dependencies = [
  "serde",
 ]
@@ -1813,7 +1822,7 @@ dependencies = [
  "lazy_static",
  "num-bigint 0.4.6",
  "num-integer",
- "num-traits 0.2.19",
+ "num-traits",
  "serde",
 ]
 
@@ -1826,7 +1835,7 @@ dependencies = [
  "lazy_static",
  "num-bigint 0.4.6",
  "num-integer",
- "num-traits 0.2.19",
+ "num-traits",
  "serde",
 ]
 
@@ -1838,7 +1847,7 @@ dependencies = [
  "cairo-lang-utils 1.0.0-alpha.6",
  "indoc 1.0.9",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "serde",
  "thiserror",
 ]
@@ -1851,7 +1860,7 @@ dependencies = [
  "cairo-lang-utils 1.0.0-rc0",
  "indoc 2.0.5",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "serde",
  "thiserror",
 ]
@@ -1865,21 +1874,21 @@ dependencies = [
  "cairo-lang-utils 1.1.1",
  "indoc 2.0.5",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4425280959f189d8a5ebf1f5363c10663bc9f843a4819253e6be87d183b583e"
+checksum = "e1e0dcdb6358bb639dd729546611bd99bada94c86e3f262c3637855abea9a972"
 dependencies = [
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-utils 2.9.0-dev.0",
  "indoc 2.0.5",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "parity-scale-codec",
  "serde",
 ]
@@ -1961,24 +1970,25 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2698e2ca73db964e6d496a648fcbb2ace5559941b5179ab3310c9a0b6872b348"
+checksum = "b8657f5a5611f341a85e80ba0b21848fc34bfdf391bfd93df0baf4516c3e4159"
 dependencies = [
  "anyhow",
- "cairo-lang-defs 2.7.1",
- "cairo-lang-diagnostics 2.7.1",
- "cairo-lang-filesystem 2.7.1",
- "cairo-lang-lowering 2.7.1",
- "cairo-lang-parser 2.7.1",
- "cairo-lang-project 2.7.1",
- "cairo-lang-semantic 2.7.1",
- "cairo-lang-sierra 2.7.1",
- "cairo-lang-sierra-generator 2.7.1",
- "cairo-lang-syntax 2.7.1",
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-defs 2.9.0-dev.0",
+ "cairo-lang-diagnostics 2.9.0-dev.0",
+ "cairo-lang-filesystem 2.9.0-dev.0",
+ "cairo-lang-lowering 2.9.0-dev.0",
+ "cairo-lang-parser 2.9.0-dev.0",
+ "cairo-lang-project 2.9.0-dev.0",
+ "cairo-lang-semantic 2.9.0-dev.0",
+ "cairo-lang-sierra 2.9.0-dev.0",
+ "cairo-lang-sierra-generator 2.9.0-dev.0",
+ "cairo-lang-syntax 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.0-dev.0",
  "indoc 2.0.5",
- "salsa",
+ "rayon",
+ "rust-analyzer-salsa",
  "semver 1.0.23",
  "smol_str 0.2.2",
  "thiserror",
@@ -2002,11 +2012,11 @@ checksum = "c99d41a14f98521c617c0673a0faa41fd00029d32106a4643e1291a1813340a7"
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac7332f2b041ca28b24b0311a0b4a35f426bb52836a2d268a8374ea262e9e6b"
+checksum = "0635aa554d297acefe6a35b495aba2795d0af5b7f97c4ab63829c7d62291ef41"
 dependencies = [
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-utils 2.9.0-dev.0",
 ]
 
 [[package]]
@@ -2063,18 +2073,18 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "079a34b560a82b463cd12ae62022d70981e8ab56b6505f9499348ebeaf460de8"
+checksum = "86b356e1c09898e8b8cfdd9731579d89365a13d8b4f7e717962e0cc7d125b83c"
 dependencies = [
- "cairo-lang-debug 2.7.1",
- "cairo-lang-diagnostics 2.7.1",
- "cairo-lang-filesystem 2.7.1",
- "cairo-lang-parser 2.7.1",
- "cairo-lang-syntax 2.7.1",
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-debug 2.9.0-dev.0",
+ "cairo-lang-diagnostics 2.9.0-dev.0",
+ "cairo-lang-filesystem 2.9.0-dev.0",
+ "cairo-lang-parser 2.9.0-dev.0",
+ "cairo-lang-syntax 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.0-dev.0",
  "itertools 0.12.1",
- "salsa",
+ "rust-analyzer-salsa",
  "smol_str 0.2.2",
 ]
 
@@ -2114,13 +2124,13 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c29625349297ad791942377763f5b04c779ea694f436488dc6ad194720b89487"
+checksum = "2dfe7c6ff96182da29012b707a3554e34a50f19cc96013ee45b0eb36dd396ec8"
 dependencies = [
- "cairo-lang-debug 2.7.1",
- "cairo-lang-filesystem 2.7.1",
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-debug 2.9.0-dev.0",
+ "cairo-lang-filesystem 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.0-dev.0",
  "itertools 0.12.1",
 ]
 
@@ -2160,11 +2170,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cb26cd75126db6eaf94d5dffe0ce750d030ac879a88de5a621551969e9b59e3"
+checksum = "723d244465309d5409e297b5486d62cbec06f2c47b05044414bb640e3f14caab"
 dependencies = [
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-utils 2.9.0-dev.0",
  "good_lp",
 ]
 
@@ -2209,37 +2219,37 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "651012f2956bea884c7a3ab9df21dc76112d7edd3f403b37ca5be62fc3f41b09"
+checksum = "237030772ae5368f19a9247e1f63f753f8ad8de963477166e402f4825c0a141d"
 dependencies = [
- "cairo-lang-debug 2.7.1",
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-debug 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.0-dev.0",
  "path-clean 1.0.1",
- "salsa",
+ "rust-analyzer-salsa",
  "semver 1.0.23",
  "serde",
  "smol_str 0.2.2",
+ "toml 0.8.19",
 ]
 
 [[package]]
 name = "cairo-lang-formatter"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d09ffb9498368cf4e95d0b28662596331aef1677e4f759ab5e609d27dfcb587"
+checksum = "5b71f0eb3a36a6cb5f7f07843926783c4c17e44c9516b53171727a108782f3eb"
 dependencies = [
  "anyhow",
- "cairo-lang-diagnostics 2.7.1",
- "cairo-lang-filesystem 2.7.1",
- "cairo-lang-parser 2.7.1",
- "cairo-lang-syntax 2.7.1",
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-diagnostics 2.9.0-dev.0",
+ "cairo-lang-filesystem 2.9.0-dev.0",
+ "cairo-lang-parser 2.9.0-dev.0",
+ "cairo-lang-syntax 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.0-dev.0",
  "diffy",
  "ignore",
  "itertools 0.12.1",
- "salsa",
+ "rust-analyzer-salsa",
  "serde",
- "smol_str 0.2.2",
  "thiserror",
 ]
 
@@ -2262,7 +2272,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "salsa",
  "smol_str 0.1.24",
 ]
@@ -2286,7 +2296,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "salsa",
  "smol_str 0.2.2",
 ]
@@ -2311,33 +2321,33 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "salsa",
  "smol_str 0.2.2",
 ]
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4ffe6c197c35dec665029fcf695422f02c55b5118b4da1142e182b9fe77f87"
+checksum = "7d095d78e2f1de499429c95655d6135a3d24c384b36d8de9f84e0aa4e07ee152"
 dependencies = [
- "cairo-lang-debug 2.7.1",
- "cairo-lang-defs 2.7.1",
- "cairo-lang-diagnostics 2.7.1",
- "cairo-lang-filesystem 2.7.1",
- "cairo-lang-parser 2.7.1",
- "cairo-lang-proc-macros 2.7.1",
- "cairo-lang-semantic 2.7.1",
- "cairo-lang-syntax 2.7.1",
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-debug 2.9.0-dev.0",
+ "cairo-lang-defs 2.9.0-dev.0",
+ "cairo-lang-diagnostics 2.9.0-dev.0",
+ "cairo-lang-filesystem 2.9.0-dev.0",
+ "cairo-lang-parser 2.9.0-dev.0",
+ "cairo-lang-proc-macros 2.9.0-dev.0",
+ "cairo-lang-semantic 2.9.0-dev.0",
+ "cairo-lang-syntax 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.0-dev.0",
  "id-arena",
  "itertools 0.12.1",
  "log",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
- "once_cell",
- "salsa",
+ "num-integer",
+ "num-traits",
+ "rust-analyzer-salsa",
  "smol_str 0.2.2",
 ]
 
@@ -2372,7 +2382,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "salsa",
  "smol_str 0.2.2",
  "unescaper",
@@ -2393,7 +2403,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "salsa",
  "smol_str 0.2.2",
  "unescaper",
@@ -2401,20 +2411,20 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f262ad5f1110ff70c93deb81cce024cf160f4a4518762e7deb2047fe73846789"
+checksum = "bb828af7f948a3ef7fa65de14e3f639daedefb046dfefcad6e3116d2cb0f89a0"
 dependencies = [
- "cairo-lang-diagnostics 2.7.1",
- "cairo-lang-filesystem 2.7.1",
- "cairo-lang-syntax 2.7.1",
- "cairo-lang-syntax-codegen 2.7.1",
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-diagnostics 2.9.0-dev.0",
+ "cairo-lang-filesystem 2.9.0-dev.0",
+ "cairo-lang-syntax 2.9.0-dev.0",
+ "cairo-lang-syntax-codegen 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.0-dev.0",
  "colored",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
- "salsa",
+ "num-traits",
+ "rust-analyzer-salsa",
  "smol_str 0.2.2",
  "unescaper",
 ]
@@ -2477,20 +2487,20 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18024b44b5edbc1f378ba85c1a4ff04e880ea465a33251053aec507f08250668"
+checksum = "135a600043bf7030eacc6ebf2a609c2364d6ffeb04e1f3c809a2738f6b02c829"
 dependencies = [
- "cairo-lang-defs 2.7.1",
- "cairo-lang-diagnostics 2.7.1",
- "cairo-lang-filesystem 2.7.1",
- "cairo-lang-parser 2.7.1",
- "cairo-lang-syntax 2.7.1",
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-defs 2.9.0-dev.0",
+ "cairo-lang-diagnostics 2.9.0-dev.0",
+ "cairo-lang-filesystem 2.9.0-dev.0",
+ "cairo-lang-parser 2.9.0-dev.0",
+ "cairo-lang-syntax 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.0-dev.0",
  "indent",
  "indoc 2.0.5",
  "itertools 0.12.1",
- "salsa",
+ "rust-analyzer-salsa",
  "smol_str 0.2.2",
 ]
 
@@ -2527,13 +2537,13 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "124402d8fad2a033bb36910dd7d0651f3100845c63dce679c58797a8cb0448c2"
+checksum = "ac857ec4b564712f3e16e3314e23cc0787ab1c05cdfee83f1c8f9989a6eee40f"
 dependencies = [
- "cairo-lang-debug 2.7.1",
+ "cairo-lang-debug 2.9.0-dev.0",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2575,12 +2585,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f37dba9653eabf4dcb43a5e1436cd6bc093b5ad6f28ff42eaaef12549014213"
+checksum = "23cc37b7f8889cdea631aeea3bcc70d5c86ac8fb1d98aabc83f16283d60f1643"
 dependencies = [
- "cairo-lang-filesystem 2.7.1",
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-filesystem 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.0-dev.0",
  "serde",
  "smol_str 0.2.2",
  "thiserror",
@@ -2589,28 +2599,28 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runner"
-version = "2.7.0"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5bbbabd509ce88abc67436973d3377e099269dbd14578fa84fce884a74fa23"
+checksum = "7474375528ffa7f47e343983d32051898e4e7b05ac0bdc48ee84b1325d8b562a"
 dependencies = [
  "ark-ff 0.4.2",
  "ark-secp256k1",
  "ark-secp256r1",
- "cairo-lang-casm 2.7.1",
- "cairo-lang-lowering 2.7.1",
- "cairo-lang-sierra 2.7.1",
- "cairo-lang-sierra-ap-change 2.7.1",
- "cairo-lang-sierra-generator 2.7.1",
- "cairo-lang-sierra-to-casm 2.7.1",
+ "cairo-lang-casm 2.9.0-dev.0",
+ "cairo-lang-lowering 2.9.0-dev.0",
+ "cairo-lang-sierra 2.9.0-dev.0",
+ "cairo-lang-sierra-ap-change 2.9.0-dev.0",
+ "cairo-lang-sierra-generator 2.9.0-dev.0",
+ "cairo-lang-sierra-to-casm 2.9.0-dev.0",
  "cairo-lang-sierra-type-size",
- "cairo-lang-starknet 2.7.0",
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-starknet 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.0-dev.0",
  "cairo-vm",
  "itertools 0.12.1",
  "keccak",
  "num-bigint 0.4.6",
  "num-integer",
- "num-traits 0.2.19",
+ "num-traits",
  "rand",
  "sha2",
  "smol_str 0.2.2",
@@ -2635,7 +2645,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "pretty_assertions",
  "salsa",
  "smol_str 0.1.24",
@@ -2659,7 +2669,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "salsa",
  "smol_str 0.2.2",
 ]
@@ -2682,34 +2692,33 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "salsa",
  "smol_str 0.2.2",
 ]
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1612476b548e9ab8ae89ee38a73d9875339f62f2f59d9ce8a719bc1761c54c3"
+checksum = "c560cf4b4a89325d3a9594f490fffee38cf30e0990e808bb927619de9d0c973a"
 dependencies = [
- "cairo-lang-debug 2.7.1",
- "cairo-lang-defs 2.7.1",
- "cairo-lang-diagnostics 2.7.1",
- "cairo-lang-filesystem 2.7.1",
- "cairo-lang-parser 2.7.1",
- "cairo-lang-plugins 2.7.1",
- "cairo-lang-proc-macros 2.7.1",
- "cairo-lang-syntax 2.7.1",
+ "cairo-lang-debug 2.9.0-dev.0",
+ "cairo-lang-defs 2.9.0-dev.0",
+ "cairo-lang-diagnostics 2.9.0-dev.0",
+ "cairo-lang-filesystem 2.9.0-dev.0",
+ "cairo-lang-parser 2.9.0-dev.0",
+ "cairo-lang-plugins 2.9.0-dev.0",
+ "cairo-lang-proc-macros 2.9.0-dev.0",
+ "cairo-lang-syntax 2.9.0-dev.0",
  "cairo-lang-test-utils",
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-utils 2.9.0-dev.0",
  "id-arena",
  "indoc 2.0.5",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
- "once_cell",
- "salsa",
+ "num-traits",
+ "rust-analyzer-salsa",
  "smol_str 0.2.2",
  "toml 0.8.19",
 ]
@@ -2727,7 +2736,7 @@ dependencies = [
  "lalrpop 0.19.12",
  "lalrpop-util 0.19.12",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "regex",
  "salsa",
  "serde",
@@ -2749,7 +2758,7 @@ dependencies = [
  "lalrpop 0.19.12",
  "lalrpop-util 0.19.12",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "regex",
  "salsa",
  "serde",
@@ -2772,7 +2781,7 @@ dependencies = [
  "lalrpop 0.19.12",
  "lalrpop-util 0.19.12",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "regex",
  "salsa",
  "serde",
@@ -2783,12 +2792,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8209be8cf22263bf8a55df334a642b74fe563beecbbbefa55cda39fa4b131a61"
+checksum = "8118f55ca7d567bfc60960b445d388564d04bf48335c983b1595cb35f67a01c5"
 dependencies = [
  "anyhow",
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-utils 2.9.0-dev.0",
  "const-fnv1a-hash",
  "convert_case 0.6.0",
  "derivative",
@@ -2797,10 +2806,9 @@ dependencies = [
  "lalrpop-util 0.20.2",
  "num-bigint 0.4.6",
  "num-integer",
- "num-traits 0.2.19",
- "once_cell",
+ "num-traits",
  "regex",
- "salsa",
+ "rust-analyzer-salsa",
  "serde",
  "serde_json",
  "sha3",
@@ -2848,17 +2856,17 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c9d1350366c23e4a9f6e18ea95939f18df52df455f06c0e3d7889f80ce18a94"
+checksum = "2716ef8d4ce0fb700f83ed3281f3656436570e60249d41c65c79dc1ca27be002"
 dependencies = [
- "cairo-lang-eq-solver 2.7.1",
- "cairo-lang-sierra 2.7.1",
+ "cairo-lang-eq-solver 2.9.0-dev.0",
+ "cairo-lang-sierra 2.9.0-dev.0",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-utils 2.9.0-dev.0",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "thiserror",
 ]
 
@@ -2901,17 +2909,17 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fe1ff15052b173537360b7dca5f9b2ccb10392b2a1c11af99add35d42632115"
+checksum = "24a44da87a35845470c4f4c648225232a15e0875fe809045b6088464491f838b"
 dependencies = [
- "cairo-lang-eq-solver 2.7.1",
- "cairo-lang-sierra 2.7.1",
+ "cairo-lang-eq-solver 2.9.0-dev.0",
+ "cairo-lang-sierra 2.9.0-dev.0",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-utils 2.9.0-dev.0",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "thiserror",
 ]
 
@@ -2993,24 +3001,23 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3802e7b6722fabc9cc0a61c86e7ad53138f6f41880aca80a60f889739fbf55"
+checksum = "15bc5cf9f3965a7030a114dfe3d31d183287fbfbfbf904deaaa2468cadb936aa"
 dependencies = [
- "cairo-lang-debug 2.7.1",
- "cairo-lang-defs 2.7.1",
- "cairo-lang-diagnostics 2.7.1",
- "cairo-lang-filesystem 2.7.1",
- "cairo-lang-lowering 2.7.1",
- "cairo-lang-parser 2.7.1",
- "cairo-lang-semantic 2.7.1",
- "cairo-lang-sierra 2.7.1",
- "cairo-lang-syntax 2.7.1",
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-debug 2.9.0-dev.0",
+ "cairo-lang-defs 2.9.0-dev.0",
+ "cairo-lang-diagnostics 2.9.0-dev.0",
+ "cairo-lang-filesystem 2.9.0-dev.0",
+ "cairo-lang-lowering 2.9.0-dev.0",
+ "cairo-lang-parser 2.9.0-dev.0",
+ "cairo-lang-semantic 2.9.0-dev.0",
+ "cairo-lang-sierra 2.9.0-dev.0",
+ "cairo-lang-syntax 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.0-dev.0",
  "itertools 0.12.1",
- "num-traits 0.2.19",
- "once_cell",
- "salsa",
+ "num-traits",
+ "rust-analyzer-salsa",
  "serde",
  "serde_json",
  "smol_str 0.2.2",
@@ -3034,7 +3041,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "thiserror",
 ]
 
@@ -3056,7 +3063,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "thiserror",
 ]
 
@@ -3079,39 +3086,39 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "thiserror",
 ]
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355bde3b0a835bac2457af133a9042a7d039c934e678905b843bb6b420884428"
+checksum = "18b7616f1a3c41c4646094b5abf774e558428e9c1eda5d78d7b0638ec5c264e5"
 dependencies = [
  "assert_matches",
- "cairo-lang-casm 2.7.1",
- "cairo-lang-sierra 2.7.1",
- "cairo-lang-sierra-ap-change 2.7.1",
- "cairo-lang-sierra-gas 2.7.1",
+ "cairo-lang-casm 2.9.0-dev.0",
+ "cairo-lang-sierra 2.9.0-dev.0",
+ "cairo-lang-sierra-ap-change 2.9.0-dev.0",
+ "cairo-lang-sierra-gas 2.9.0-dev.0",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-utils 2.9.0-dev.0",
  "indoc 2.0.5",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "starknet-types-core",
  "thiserror",
 ]
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddddaacc814e0ffda9f176c913fb2a9cd74fe6594dea789e8281eef10cac201"
+checksum = "871077dbc08df5d134dc3975538171c14b266ba405d1298085afdb227216f0a3"
 dependencies = [
- "cairo-lang-sierra 2.7.1",
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-sierra 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.0-dev.0",
 ]
 
 [[package]]
@@ -3145,7 +3152,7 @@ dependencies = [
  "log",
  "num-bigint 0.4.6",
  "num-integer",
- "num-traits 0.2.19",
+ "num-traits",
  "serde",
  "serde_json",
  "sha3",
@@ -3184,7 +3191,7 @@ dependencies = [
  "log",
  "num-bigint 0.4.6",
  "num-integer",
- "num-traits 0.2.19",
+ "num-traits",
  "once_cell",
  "serde",
  "serde_json",
@@ -3225,7 +3232,7 @@ dependencies = [
  "log",
  "num-bigint 0.4.6",
  "num-integer",
- "num-traits 0.2.19",
+ "num-traits",
  "once_cell",
  "serde",
  "serde_json",
@@ -3236,28 +3243,27 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.7.0"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f242d889180386d35935597f9d1cac07d4f3d60bd0f10558660ae4a77da701b6"
+checksum = "9f21804eb8931d41e258e7a393afc8ee8858308e95b3ed2e9b6b469ef68a6a50"
 dependencies = [
  "anyhow",
- "cairo-lang-compiler 2.7.1",
- "cairo-lang-defs 2.7.1",
- "cairo-lang-diagnostics 2.7.1",
- "cairo-lang-filesystem 2.7.1",
- "cairo-lang-lowering 2.7.1",
- "cairo-lang-plugins 2.7.1",
- "cairo-lang-semantic 2.7.1",
- "cairo-lang-sierra 2.7.1",
- "cairo-lang-sierra-generator 2.7.1",
+ "cairo-lang-compiler 2.9.0-dev.0",
+ "cairo-lang-defs 2.9.0-dev.0",
+ "cairo-lang-diagnostics 2.9.0-dev.0",
+ "cairo-lang-filesystem 2.9.0-dev.0",
+ "cairo-lang-lowering 2.9.0-dev.0",
+ "cairo-lang-plugins 2.9.0-dev.0",
+ "cairo-lang-semantic 2.9.0-dev.0",
+ "cairo-lang-sierra 2.9.0-dev.0",
+ "cairo-lang-sierra-generator 2.9.0-dev.0",
  "cairo-lang-starknet-classes",
- "cairo-lang-syntax 2.7.1",
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-syntax 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.0-dev.0",
  "const_format",
  "indent",
  "indoc 2.0.5",
  "itertools 0.12.1",
- "once_cell",
  "serde",
  "serde_json",
  "smol_str 0.2.2",
@@ -3267,20 +3273,19 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet-classes"
-version = "2.7.0"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa17b313f46fcf7ff4de32b86c250eaf584d1e2c8e37ed16db155b221721e735"
+checksum = "b2496bccd68fa0286b35b72c98439316a3a872ef7ec6d881f0dac90b17997490"
 dependencies = [
- "cairo-lang-casm 2.7.1",
- "cairo-lang-sierra 2.7.1",
- "cairo-lang-sierra-to-casm 2.7.1",
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-casm 2.9.0-dev.0",
+ "cairo-lang-sierra 2.9.0-dev.0",
+ "cairo-lang-sierra-to-casm 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.0-dev.0",
  "convert_case 0.6.0",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
  "num-integer",
- "num-traits 0.2.19",
- "once_cell",
+ "num-traits",
  "serde",
  "serde_json",
  "sha3",
@@ -3310,7 +3315,7 @@ dependencies = [
  "cairo-lang-filesystem 1.0.0-rc0",
  "cairo-lang-utils 1.0.0-rc0",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "salsa",
  "smol_str 0.2.2",
  "thiserror",
@@ -3327,7 +3332,7 @@ dependencies = [
  "cairo-lang-filesystem 1.1.1",
  "cairo-lang-utils 1.1.1",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "salsa",
  "smol_str 0.2.2",
  "thiserror",
@@ -3336,16 +3341,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a376f88d815b63505be54a6afa93d75b67cfd65835922ec648cfcbb0a5e4b4"
+checksum = "8d77ea2e35d3610098ff13e373fc519aedc6a5096ed8547081aacfc104ef4422"
 dependencies = [
- "cairo-lang-debug 2.7.1",
- "cairo-lang-filesystem 2.7.1",
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-debug 2.9.0-dev.0",
+ "cairo-lang-filesystem 2.9.0-dev.0",
+ "cairo-lang-utils 2.9.0-dev.0",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
- "salsa",
+ "num-traits",
+ "rust-analyzer-salsa",
  "smol_str 0.2.2",
  "unescaper",
 ]
@@ -3386,9 +3391,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f276bc28f6302fc63032046a12b60d18498906e65f646acb963244eed97f7c"
+checksum = "6b01d505ab26ca9ce829faf3a8dd097f5d7962d2eb8f136017a260694a6a72e8"
 dependencies = [
  "genco",
  "xshell",
@@ -3396,12 +3401,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-utils"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e90b6236439e19077ec913351a17a33c7be199dcafdacd8389c4c5199400d6"
+checksum = "eb143a22f5a3510df8c4dec76e17c1e36bbcbddcd7915601f6a51a72418c454f"
 dependencies = [
  "cairo-lang-formatter",
- "cairo-lang-utils 2.7.1",
+ "cairo-lang-utils 2.9.0-dev.0",
  "colored",
  "log",
  "pretty_assertions",
@@ -3419,7 +3424,7 @@ dependencies = [
  "log",
  "num-bigint 0.4.6",
  "num-integer",
- "num-traits 0.2.19",
+ "num-traits",
  "serde",
 ]
 
@@ -3434,7 +3439,7 @@ dependencies = [
  "log",
  "num-bigint 0.4.6",
  "num-integer",
- "num-traits 0.2.19",
+ "num-traits",
  "serde",
  "time",
 ]
@@ -3451,22 +3456,22 @@ dependencies = [
  "log",
  "num-bigint 0.4.6",
  "num-integer",
- "num-traits 0.2.19",
+ "num-traits",
  "serde",
  "time",
 ]
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.7.1"
+version = "2.9.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a394e545f1500bea093d01be40895d3234faaa24d9585d08a509c514cabd88"
+checksum = "35df943ebcf8e1db11ee9f4f46f843dde5b71639ca79ea0d8caa7973f91d8b12"
 dependencies = [
  "hashbrown 0.14.5",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "itertools 0.12.1",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "parity-scale-codec",
  "schemars",
  "serde",
@@ -3490,7 +3495,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-integer",
  "num-prime",
- "num-traits 0.2.19",
+ "num-traits",
  "rand",
  "rust_decimal",
  "serde",
@@ -3511,9 +3516,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.18"
+version = "1.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
+checksum = "40545c26d092346d8a8dab71ee48e7685a7a9cba76e634790c215b41a4a7b4cf"
 dependencies = [
  "jobserver",
  "libc",
@@ -3525,6 +3530,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -3559,7 +3570,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-traits 0.2.19",
+ "num-traits",
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
@@ -3605,9 +3616,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -3615,9 +3626,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3628,14 +3639,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3646,9 +3657,9 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "colored"
@@ -3719,9 +3730,9 @@ checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
 
 [[package]]
 name = "const-hex"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8a24a26d37e1ffd45343323dc9fe6654ceea44c12f2fcb3d7ac29e610bc6"
+checksum = "0121754e84117e65f9d90648ee6aa4882a6e63110307ab73967a4c5e7e69e586"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3804,9 +3815,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
 dependencies = [
  "libc",
 ]
@@ -3833,7 +3844,7 @@ dependencies = [
  "criterion-plot",
  "is-terminal",
  "itertools 0.10.5",
- "num-traits 0.2.19",
+ "num-traits",
  "once_cell",
  "oorandom",
  "plotters",
@@ -3952,7 +3963,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4000,7 +4011,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4022,7 +4033,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4097,7 +4108,7 @@ dependencies = [
  "displaydoc",
  "nom",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "rusticata-macros",
 ]
 
@@ -4132,7 +4143,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4152,7 +4163,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "unicode-xid",
 ]
 
@@ -4233,7 +4244,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4250,14 +4261,14 @@ checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
 name = "dummy"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e57e12b69e57fad516e01e2b3960f122696fdb13420e1a88ed8e210316f2876"
+checksum = "1cac124e13ae9aa56acc4241f8c8207501d93afdd8d8e62f0c1f2e12f6508c65"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4320,7 +4331,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4359,9 +4370,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
@@ -4375,7 +4386,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4395,7 +4406,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4488,9 +4499,9 @@ dependencies = [
 
 [[package]]
 name = "fake"
-version = "2.9.2"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c25829bde82205da46e1823b2259db6273379f626fc211f126f65654a2669be"
+checksum = "2d391ba4af7f1d93f01fcf7b2f29e2bc9348e109dfdbf4dcbdc51dfa38dab0b6"
 dependencies = [
  "deunicode",
  "dummy",
@@ -4521,9 +4532,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "fastrlp"
@@ -4559,7 +4570,7 @@ dependencies = [
  "cfg-if",
  "num-bigint 0.3.3",
  "num-integer",
- "num-traits 0.2.19",
+ "num-traits",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -4591,9 +4602,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -4605,14 +4616,14 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
 name = "flume"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "nanorand",
  "spin 0.9.8",
@@ -4623,6 +4634,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "form_urlencoded"
@@ -4647,9 +4664,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4672,9 +4689,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -4682,15 +4699,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -4700,9 +4717,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -4721,11 +4738,11 @@ dependencies = [
 
 [[package]]
 name = "futures-lite"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
 dependencies = [
- "fastrand 2.1.1",
+ "fastrand 2.2.0",
  "futures-core",
  "futures-io",
  "parking",
@@ -4734,13 +4751,13 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4756,15 +4773,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-ticker"
@@ -4785,9 +4802,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4837,7 +4854,7 @@ checksum = "553630feadf7b76442b0849fd25fdf89b860d933623aec9693fed19af0400c78"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4876,9 +4893,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
@@ -4895,8 +4912,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -4913,12 +4930,12 @@ dependencies = [
 
 [[package]]
 name = "good_lp"
-version = "1.8.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3198bd13dea84c76a64621d6ee8ee26a4960a9a0d538eca95ca8f1320a469ac9"
+checksum = "97630e1e456d7081c524488a87d8f8f7ed0fd3100ba10c55e3cfa7add5ce05c6"
 dependencies = [
  "fnv",
- "minilp",
+ "microlp",
 ]
 
 [[package]]
@@ -4944,7 +4961,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -4963,7 +4980,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -5010,6 +5027,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5028,7 +5057,7 @@ dependencies = [
  "byteorder",
  "flate2",
  "nom",
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -5260,9 +5289,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -5285,7 +5314,7 @@ dependencies = [
  "crossbeam-utils",
  "form_urlencoded",
  "futures-util",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "lazy_static",
  "levenshtein",
  "log",
@@ -5306,9 +5335,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
+version = "0.14.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -5330,9 +5359,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -5357,10 +5386,10 @@ checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "rustls",
- "rustls-native-certs 0.8.0",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -5374,7 +5403,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -5382,29 +5411,28 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "pin-project-lite",
  "socket2 0.5.7",
  "tokio",
- "tower 0.4.13",
  "tower-service",
  "tracing",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -5424,6 +5452,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5437,6 +5583,17 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
@@ -5447,12 +5604,23 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -5471,7 +5639,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6b0422c86d7ce0e97169cc42e04ae643caf278874a7a3c87b8150a220dc7e1e"
 dependencies = [
- "async-io 2.3.4",
+ "async-io 2.4.0",
  "core-foundation",
  "fnv",
  "futures",
@@ -5486,6 +5654,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "if_chain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
+
+[[package]]
 name = "igd-next"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5496,7 +5670,7 @@ dependencies = [
  "bytes",
  "futures",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "log",
  "rand",
  "tokio",
@@ -5514,7 +5688,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata 0.4.7",
+ "regex-automata 0.4.9",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -5568,12 +5742,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.1",
  "serde",
 ]
 
@@ -5588,6 +5762,15 @@ name = "indoc"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
+name = "infra_utils"
+version = "0.0.0"
+source = "git+https://github.com/starkware-libs/sequencer?branch=main#382184285cf731b1fda3c7647908c34744af53bd"
+dependencies = [
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "inout"
@@ -5632,9 +5815,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is-terminal"
@@ -5726,18 +5909,18 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "k256"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -5820,7 +6003,7 @@ dependencies = [
  "petgraph",
  "pico-args",
  "regex",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -5843,14 +6026,14 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
- "regex-automata 0.4.7",
+ "regex-automata 0.4.9",
 ]
 
 [[package]]
 name = "lambdaworks-crypto"
-version = "0.7.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb5d4f22241504f7c7b8d2c3a7d7835d7c07117f10bff2a7d96a9ef6ef217c3"
+checksum = "bbc2a4da0d9e52ccfe6306801a112e81a8fc0c76aa3e4449fefeda7fef72bb34"
 dependencies = [
  "lambdaworks-math",
  "serde",
@@ -5860,9 +6043,9 @@ dependencies = [
 
 [[package]]
 name = "lambdaworks-math"
-version = "0.7.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "358e172628e713b80a530a59654154bfc45783a6ed70ea284839800cebdf8f97"
+checksum = "d1bd2632acbd9957afc5aeec07ad39f078ae38656654043bf16e046fa2730e23"
 dependencies = [
  "serde",
  "serde_json",
@@ -5885,15 +6068,15 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libp2p"
@@ -6361,7 +6544,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6389,7 +6572,7 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad964f312c59dcfcac840acd8c555de8403e295d39edf96f5240048b5fcaa314"
 dependencies = [
- "async-io 2.3.4",
+ "async-io 2.4.0",
  "futures",
  "futures-timer",
  "if-watch",
@@ -6491,6 +6674,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6511,11 +6700,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.1",
 ]
 
 [[package]]
@@ -6552,6 +6741,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6559,10 +6754,11 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matrixmultiply"
-version = "0.2.4"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916806ba0031cd542105d916a97c8572e1fa6dd79c9c51e7eb43a09ec2dd84c1"
+checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
 dependencies = [
+ "autocfg",
  "rawpointer",
 ]
 
@@ -6589,7 +6785,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8603921e1f54ef386189335f288441af761e0fc61bcb552168d9cedfe63ebc70"
 dependencies = [
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "indexmap 1.9.3",
  "ipnet",
  "metrics",
@@ -6631,6 +6827,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "microlp"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4190b5ca62abfbc95a81d57f4a8e3e3872289d656f3eeea5820b3046a1f81d4b"
+dependencies = [
+ "log",
+ "sprs",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6644,16 +6850,6 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
-]
-
-[[package]]
-name = "minilp"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a7750a9e5076c660b7bec5e6457b4dbff402b9863c8d112891434e18fd5385"
-dependencies = [
- "log",
- "sprs",
 ]
 
 [[package]]
@@ -6730,9 +6926,9 @@ dependencies = [
 
 [[package]]
 name = "multiaddr"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b852bc02a2da5feed68cd14fa50d0774b92790a5bdbfa932a813926c8472070"
+checksum = "fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961"
 dependencies = [
  "arrayref",
  "byteorder",
@@ -6743,7 +6939,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint 0.7.2",
+ "unsigned-varint 0.8.0",
  "url",
 ]
 
@@ -6760,13 +6956,13 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076d548d76a0e2a0d4ab471d0b1c36c577786dfc4471242035d97a12a735c492"
+checksum = "cc41f430805af9d1cf4adae4ed2149c759b877b01d909a1f40256188d09345d2"
 dependencies = [
  "core2",
  "serde",
- "unsigned-varint 0.7.2",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -6800,14 +6996,16 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.13.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac06db03ec2f46ee0ecdca1a1c34a99c0d188a0d83439b84bf0cb4b386e4ab09"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
 dependencies = [
  "matrixmultiply",
  "num-complex",
  "num-integer",
- "num-traits 0.2.19",
+ "num-traits",
+ "portable-atomic 1.9.0",
+ "portable-atomic-util",
  "rawpointer",
 ]
 
@@ -6935,7 +7133,7 @@ checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -6945,19 +7143,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
- "num-traits 0.2.19",
+ "num-traits",
  "rand",
  "serde",
 ]
 
 [[package]]
 name = "num-complex"
-version = "0.2.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
- "autocfg",
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -6972,7 +7169,7 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -6983,7 +7180,7 @@ checksum = "64a5fe11d4135c3bcdf3a95b18b194afa9608a5f6ff034f5d857bc9a27fb0119"
 dependencies = [
  "num-bigint 0.4.6",
  "num-integer",
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -6998,7 +7195,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-integer",
  "num-modular",
- "num-traits 0.2.19",
+ "num-traits",
  "rand",
 ]
 
@@ -7010,17 +7207,8 @@ checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
  "num-bigint 0.4.6",
  "num-integer",
- "num-traits 0.2.19",
+ "num-traits",
  "serde",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-dependencies = [
- "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -7060,7 +7248,7 @@ checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7074,9 +7262,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
@@ -7092,9 +7280,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "oorandom"
@@ -7120,7 +7308,7 @@ version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -7149,7 +7337,7 @@ dependencies = [
  "pathfinder-crypto",
  "pretty_assertions_sorted",
  "primitive-types",
- "prost 0.13.2",
+ "prost 0.13.3",
  "rand",
  "rayon",
  "rstest",
@@ -7182,9 +7370,9 @@ dependencies = [
  "pathfinder-crypto",
  "pretty_assertions_sorted",
  "primitive-types",
- "prost 0.13.2",
+ "prost 0.13.3",
  "prost-build",
- "prost-types 0.13.2",
+ "prost-types 0.13.3",
  "rand",
  "serde_json",
  "tagged",
@@ -7218,6 +7406,21 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "void",
+]
+
+[[package]]
+name = "papyrus_config"
+version = "0.0.0"
+source = "git+https://github.com/starkware-libs/sequencer?branch=main#382184285cf731b1fda3c7647908c34744af53bd"
+dependencies = [
+ "clap",
+ "infra_utils",
+ "itertools 0.12.1",
+ "serde",
+ "serde_json",
+ "strum_macros 0.25.3",
+ "thiserror",
+ "validator",
 ]
 
 [[package]]
@@ -7295,7 +7498,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.4",
+ "redox_syscall 0.5.7",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -7336,7 +7539,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-trait",
- "axum 0.7.5",
+ "axum 0.7.7",
  "base64 0.13.1",
  "bitvec",
  "bytes",
@@ -7414,7 +7617,7 @@ dependencies = [
  "fake",
  "metrics",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "paste",
  "pathfinder-crypto",
  "primitive-types",
@@ -7438,7 +7641,7 @@ dependencies = [
  "cairo-lang-starknet 1.0.0-alpha.6",
  "cairo-lang-starknet 1.0.0-rc0",
  "cairo-lang-starknet 1.1.1",
- "cairo-lang-starknet 2.7.0",
+ "cairo-lang-starknet 2.9.0-dev.0",
  "cairo-lang-starknet-classes",
  "num-bigint 0.4.6",
  "pathfinder-common",
@@ -7496,6 +7699,7 @@ dependencies = [
  "anyhow",
  "blockifier",
  "cached",
+ "cairo-lang-starknet-classes",
  "cairo-vm",
  "pathfinder-common",
  "pathfinder-crypto",
@@ -7541,7 +7745,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-trait",
- "axum 0.7.5",
+ "axum 0.7.7",
  "base64 0.13.1",
  "bitvec",
  "bytes",
@@ -7553,7 +7757,7 @@ dependencies = [
  "hex",
  "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "metrics",
  "mime",
  "pathfinder-common",
@@ -7677,9 +7881,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.12"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c73c26c01b8c87956cea613c907c9d6ecffd8d18a2a5908e5de0adfaa185cea"
+checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
  "thiserror",
@@ -7693,7 +7897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
 ]
 
 [[package]]
@@ -7736,7 +7940,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7765,29 +7969,29 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -7802,7 +8006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
 dependencies = [
  "atomic-waker",
- "fastrand 2.1.1",
+ "fastrand 2.2.0",
  "futures-io",
 ]
 
@@ -7818,9 +8022,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plotters"
@@ -7828,7 +8032,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
- "num-traits 0.2.19",
+ "num-traits",
  "plotters-backend",
  "plotters-svg",
  "wasm-bindgen",
@@ -7868,15 +8072,15 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.7.3"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511"
+checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 0.38.37",
+ "rustix 0.38.40",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -7910,14 +8114,23 @@ version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e30165d31df606f5726b090ec7592c308a0eaf61721ff64c9a3018e344a8753e"
 dependencies = [
- "portable-atomic 1.7.0",
+ "portable-atomic 1.9.0",
 ]
 
 [[package]]
 name = "portable-atomic"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90a7d5beecc52a491b54d6dd05c7a45ba1801666a5baad9fdbfc6fef8d2d206c"
+dependencies = [
+ "portable-atomic 1.9.0",
+]
 
 [[package]]
 name = "powerfmt"
@@ -7972,9 +8185,9 @@ dependencies = [
 
 [[package]]
 name = "pretty_assertions"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
@@ -7992,12 +8205,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.22"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -8022,6 +8235,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8040,14 +8277,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -8072,7 +8309,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -8085,11 +8322,11 @@ dependencies = [
  "bit-vec 0.6.3",
  "bitflags 2.6.0",
  "lazy_static",
- "num-traits 0.2.19",
+ "num-traits",
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -8107,19 +8344,19 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2ecbe40f08db5c006b5764a2645f7f3f141ce756412ac9e1dd6087e6d32995"
+checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
 dependencies = [
  "bytes",
- "prost-derive 0.13.2",
+ "prost-derive 0.13.3",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8650aabb6c35b860610e9cff5dc1af886c9e25073b7b1712a68972af4281302"
+checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes",
  "heck 0.5.0",
@@ -8129,10 +8366,10 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.13.2",
- "prost-types 0.13.2",
+ "prost 0.13.3",
+ "prost-types 0.13.3",
  "regex",
- "syn 2.0.77",
+ "syn 2.0.87",
  "tempfile",
 ]
 
@@ -8151,15 +8388,15 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
+checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -8173,11 +8410,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60caa6738c7369b940c3d49246a8d1749323674c65cb13010134f5c9bad5b519"
+checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
 dependencies = [
- "prost 0.13.2",
+ "prost 0.13.3",
 ]
 
 [[package]]
@@ -8262,10 +8499,11 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.5"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
+checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
 dependencies = [
+ "cfg_aliases",
  "libc",
  "once_cell",
  "socket2 0.5.7",
@@ -8319,6 +8557,7 @@ dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
+ "serde",
 ]
 
 [[package]]
@@ -8407,9 +8646,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -8427,14 +8666,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -8448,13 +8687,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -8465,9 +8704,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "relative-path"
@@ -8477,9 +8716,9 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.7"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
+checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -8490,7 +8729,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-rustls",
  "hyper-util",
  "ipnet",
@@ -8502,7 +8741,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs 0.7.3",
+ "rustls-native-certs",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -8605,7 +8844,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version 0.4.1",
- "syn 2.0.77",
+ "syn 2.0.87",
  "unicode-ident",
 ]
 
@@ -8637,7 +8876,7 @@ dependencies = [
  "bytes",
  "fastrlp",
  "num-bigint 0.4.6",
- "num-traits 0.2.19",
+ "num-traits",
  "parity-scale-codec",
  "primitive-types",
  "proptest",
@@ -8670,13 +8909,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-analyzer-salsa"
+version = "0.17.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719825638c59fd26a55412a24561c7c5bcf54364c88b9a7a04ba08a6eafaba8d"
+dependencies = [
+ "indexmap 2.6.0",
+ "lock_api",
+ "oorandom",
+ "parking_lot 0.12.3",
+ "rust-analyzer-salsa-macros",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "tracing",
+ "triomphe",
+]
+
+[[package]]
+name = "rust-analyzer-salsa-macros"
+version = "0.17.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d96498e9684848c6676c399032ebc37c52da95ecbefa83d71ccc53b9f8a4a8e"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b082d80e3e3cc52b2ed634388d436fe1f4de6af5786cc2de9ba9737527bdf555"
 dependencies = [
  "arrayvec",
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -8746,9 +9014,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -8759,9 +9027,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.13"
+version = "0.23.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
 dependencies = [
  "once_cell",
  "ring 0.17.8",
@@ -8769,19 +9037,6 @@ dependencies = [
  "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "rustls-pki-types",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -8799,19 +9054,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64 0.22.1",
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-webpki"
@@ -8836,9 +9090,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "rusty-fork"
@@ -8909,9 +9163,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -8947,7 +9201,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -8991,9 +9245,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -9034,22 +9288,22 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -9060,14 +9314,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -9097,9 +9351,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -9118,15 +9372,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.9.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -9136,14 +9390,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.9.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -9360,34 +9614,21 @@ dependencies = [
 
 [[package]]
 name = "sprs"
-version = "0.7.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec63571489873d4506683915840eeb1bb16b3198ee4894cc6f2fe3013d505e56"
+checksum = "704ef26d974e8a452313ed629828cd9d4e4fa34667ca1ad9d6b1fffa43c6e166"
 dependencies = [
  "ndarray",
  "num-complex",
- "num-traits 0.1.43",
+ "num-traits",
+ "smallvec",
 ]
 
 [[package]]
-name = "starknet-crypto"
-version = "0.5.2"
+name = "stable_deref_trait"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3f2175b0b3fc24ff2ec6dc07f5a720498994effca7e78b11a6e1c1bd02cad52"
-dependencies = [
- "crypto-bigint",
- "hex",
- "hmac",
- "num-bigint 0.4.6",
- "num-integer",
- "num-traits 0.2.19",
- "rfc6979",
- "sha2",
- "starknet-crypto-codegen",
- "starknet-curve 0.3.0",
- "starknet-ff",
- "zeroize",
-]
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "starknet-crypto"
@@ -9400,12 +9641,31 @@ dependencies = [
  "hmac",
  "num-bigint 0.4.6",
  "num-integer",
- "num-traits 0.2.19",
+ "num-traits",
  "rfc6979",
  "sha2",
  "starknet-crypto-codegen",
  "starknet-curve 0.4.2",
  "starknet-ff",
+ "zeroize",
+]
+
+[[package]]
+name = "starknet-crypto"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded22ccf4cb9e572ce3f77de6066af53560cd2520d508876c83bb1e6b29d5cbc"
+dependencies = [
+ "crypto-bigint",
+ "hex",
+ "hmac",
+ "num-bigint 0.4.6",
+ "num-integer",
+ "num-traits",
+ "rfc6979",
+ "sha2",
+ "starknet-curve 0.5.1",
+ "starknet-types-core",
  "zeroize",
 ]
 
@@ -9417,16 +9677,7 @@ checksum = "bbc159a1934c7be9761c237333a57febe060ace2bc9e3b337a59a37af206d19f"
 dependencies = [
  "starknet-curve 0.4.2",
  "starknet-ff",
- "syn 2.0.77",
-]
-
-[[package]]
-name = "starknet-curve"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252610baff59e4c4332ce3569f7469c5d3f9b415a2240d698fb238b2b4fc0942"
-dependencies = [
- "starknet-ff",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -9436,6 +9687,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1c383518bb312751e4be80f53e8644034aa99a0afb29d7ac41b89a997db875b"
 dependencies = [
  "starknet-ff",
+]
+
+[[package]]
+name = "starknet-curve"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcde6bd74269b8161948190ace6cf069ef20ac6e79cd2ba09b320efa7500b6de"
+dependencies = [
+ "starknet-types-core",
 ]
 
 [[package]]
@@ -9516,39 +9776,42 @@ dependencies = [
 
 [[package]]
 name = "starknet-types-core"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6bacf0ba19bc721e518bc4bf389ff13daa8a7c5db5fd320600473b8aa9fcbd"
+checksum = "fa1b9e01ccb217ab6d475c5cda05dbb22c30029f7bb52b192a010a00d77a3d74"
 dependencies = [
  "lambdaworks-crypto",
  "lambdaworks-math",
  "lazy_static",
  "num-bigint 0.4.6",
  "num-integer",
- "num-traits 0.2.19",
+ "num-traits",
  "serde",
 ]
 
 [[package]]
 name = "starknet_api"
-version = "0.13.0-rc.1"
-source = "git+https://github.com/eqlabs/sequencer?branch=eqlabs/main-v0.13.2#2e59ae0f7c0da559cd77bd9db794309a8e3fe99a"
+version = "0.0.0"
+source = "git+https://github.com/starkware-libs/sequencer?branch=main#382184285cf731b1fda3c7647908c34744af53bd"
 dependencies = [
  "bitvec",
+ "cairo-lang-runner",
  "cairo-lang-starknet-classes",
  "derive_more 0.99.18",
  "hex",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "itertools 0.12.1",
- "once_cell",
+ "num-bigint 0.4.6",
+ "pretty_assertions",
  "primitive-types",
+ "semver 1.0.23",
  "serde",
  "serde_json",
  "sha3",
- "starknet-crypto 0.5.2",
+ "starknet-crypto 0.7.3",
  "starknet-types-core",
- "strum 0.24.1",
- "strum_macros 0.24.3",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
  "thiserror",
 ]
 
@@ -9585,12 +9848,6 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-
-[[package]]
-name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
@@ -9606,19 +9863,6 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "strum_macros"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
@@ -9627,7 +9871,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -9640,7 +9884,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -9662,9 +9906,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9673,14 +9917,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b95156f8b577cb59dc0b1df15c6f29a10afc5f8a7ac9786b0b5c68c19149278"
+checksum = "edf42e81491fb8871b74df3d222c64ae8cbc1269ea509fa768a3ed3e1b0ac8cb"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -9706,7 +9950,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -9736,6 +9980,7 @@ version = "0.15.3"
 dependencies = [
  "fake",
  "pretty_assertions_sorted",
+ "rand",
  "tagged-debug-derive",
 ]
 
@@ -9756,14 +10001,14 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
- "fastrand 2.1.1",
+ "fastrand 2.2.0",
  "once_cell",
- "rustix 0.38.37",
+ "rustix 0.38.40",
  "windows-sys 0.59.0",
 ]
 
@@ -9789,12 +10034,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+checksum = "4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef"
 dependencies = [
- "rustix 0.38.37",
- "windows-sys 0.48.0",
+ "rustix 0.38.40",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9822,27 +10067,27 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -9927,6 +10172,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9953,9 +10208,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",
@@ -9988,7 +10243,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -10054,6 +10309,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10100,11 +10367,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -10126,7 +10393,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -10169,8 +10436,10 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper 0.1.2",
+ "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -10224,7 +10493,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -10281,6 +10550,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10326,6 +10605,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10333,9 +10630,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uint"
@@ -10366,18 +10663,15 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
+checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
@@ -10387,24 +10681,24 @@ checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -10446,12 +10740,12 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
 dependencies = [
  "form_urlencoded",
- "idna 0.5.0",
+ "idna 1.0.3",
  "percent-encoding",
 ]
 
@@ -10462,10 +10756,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
 name = "utf8-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -10486,13 +10792,52 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom",
  "rand",
 ]
+
+[[package]]
+name = "validator"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d6937c33ec6039d8071bcf72933146b5bbe378d645d8fa59bdadabfc2a249"
+dependencies = [
+ "idna 0.2.3",
+ "lazy_static",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+ "validator_types",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286b4497f270f59276a89ae0ad109d5f8f18c69b613e3fb22b61201aadb0c4d"
+dependencies = [
+ "if_chain",
+ "lazy_static",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
+ "validator_types",
+]
+
+[[package]]
+name = "validator_types"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9680608df133af2c1ddd5eaf1ddce91d60d61b6bc51494ef326458365a470a"
 
 [[package]]
 name = "valuable"
@@ -10502,9 +10847,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a84c137d37ab0142f0f2ddfe332651fdbf252e7b7dbb4e67b6c1f1b2e925101"
+checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
 
 [[package]]
 name = "vcpkg"
@@ -10587,7 +10932,7 @@ dependencies = [
  "futures-util",
  "headers",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "log",
  "mime",
  "mime_guess",
@@ -10619,9 +10964,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -10630,24 +10975,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -10657,9 +11002,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -10667,28 +11012,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10706,9 +11051,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.5"
+version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd24728e5af82c6c4ec1b66ac4844bdf8156257fccda846ec58b42cd0cdbe6a"
+checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -10958,9 +11303,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
@@ -10974,6 +11319,18 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "ws_stream_wasm"
@@ -11034,9 +11391,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4e2e2f7cba5a093896c1e150fbfe177d1883e7448200efb81d40b9d339ef26"
+checksum = "af310deaae937e48a26602b730250b4949e125f468f11e6990be3e5304ddd96f"
 
 [[package]]
 name = "xmltree"
@@ -11095,9 +11452,9 @@ dependencies = [
 
 [[package]]
 name = "yansi"
-version = "0.5.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yasna"
@@ -11106,6 +11463,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
+]
+
+[[package]]
+name = "yoke"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "synstructure",
 ]
 
 [[package]]
@@ -11126,7 +11507,28 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "synstructure",
 ]
 
 [[package]]
@@ -11146,7 +11548,29 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,18 +58,18 @@ axum = "0.7.5"
 base64 = "0.13.1"
 bincode = "2.0.0-rc.3"
 bitvec = "1.0.1"
-blockifier = { git = "https://github.com/starkware-libs/sequencer", branch = "main" }
+blockifier = { git = "https://github.com/starkware-libs/sequencer", branch = "main-v0.13.4" }
 bloomfilter = "1.0.12"
 bytes = "1.4.0"
 cached = "0.44.0"
 # This one needs to match the version used by blockifier
-cairo-lang-starknet-classes = "=2.9.0-dev.0"
+cairo-lang-starknet-classes = "=2.9.2"
 # This one needs to match the version used by blockifier
 cairo-vm = "=1.0.1"
 casm-compiler-v1_0_0-alpha6 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-alpha.6" }
 casm-compiler-v1_0_0-rc0 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-rc0" }
 casm-compiler-v1_1_1 = { package = "cairo-lang-starknet", version = "=1.1.1" }
-casm-compiler-v2 = { package = "cairo-lang-starknet", version = "=2.9.0-dev.0" }
+casm-compiler-v2 = { package = "cairo-lang-starknet", version = "=2.9.2" }
 clap = "4.1.13"
 console-subscriber = "0.1.10"
 const-decoder = "0.3.0"
@@ -126,7 +126,7 @@ serde_with = "3.7.0"
 sha2 = "0.10.7"
 sha3 = "0.10"
 # This one needs to match the version used by blockifier
-starknet_api = { git = "https://github.com/starkware-libs/sequencer", branch = "main" }
+starknet_api = { git = "https://github.com/starkware-libs/sequencer", branch = "main-v0.13.4" }
 # This one needs to match the version used by blockifier
 starknet-types-core = "=0.1.7"
 syn = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,17 +58,18 @@ axum = "0.7.5"
 base64 = "0.13.1"
 bincode = "2.0.0-rc.3"
 bitvec = "1.0.1"
-blockifier = { git = "https://github.com/eqlabs/sequencer", branch = "eqlabs/main-v0.13.2" }
+blockifier = { git = "https://github.com/starkware-libs/sequencer", branch = "main" }
 bloomfilter = "1.0.12"
 bytes = "1.4.0"
 cached = "0.44.0"
-cairo-lang-starknet-classes = "=2.7.0"
+# This one needs to match the version used by blockifier
+cairo-lang-starknet-classes = "=2.9.0-dev.0"
 # This one needs to match the version used by blockifier
 cairo-vm = "=1.0.1"
-casm-compiler-v1_0_0-alpha6 = { git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-alpha.6" }
-casm-compiler-v1_0_0-rc0 = { git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-rc0" }
-casm-compiler-v1_1_1 = "=1.1.1"
-casm-compiler-v2 = "=2.7.0"
+casm-compiler-v1_0_0-alpha6 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-alpha.6" }
+casm-compiler-v1_0_0-rc0 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-rc0" }
+casm-compiler-v1_1_1 = { package = "cairo-lang-starknet", version = "=1.1.1" }
+casm-compiler-v2 = { package = "cairo-lang-starknet", version = "=2.9.0-dev.0" }
 clap = "4.1.13"
 console-subscriber = "0.1.10"
 const-decoder = "0.3.0"
@@ -125,9 +126,9 @@ serde_with = "3.7.0"
 sha2 = "0.10.7"
 sha3 = "0.10"
 # This one needs to match the version used by blockifier
-starknet_api = { git = "https://github.com/eqlabs/sequencer", branch = "eqlabs/main-v0.13.2" }
+starknet_api = { git = "https://github.com/starkware-libs/sequencer", branch = "main" }
 # This one needs to match the version used by blockifier
-starknet-types-core = "=0.1.5"
+starknet-types-core = "=0.1.7"
 syn = "1.0"
 tempfile = "3.8"
 test-log = { version = "0.2.12", features = ["trace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,13 +63,13 @@ bloomfilter = "1.0.12"
 bytes = "1.4.0"
 cached = "0.44.0"
 # This one needs to match the version used by blockifier
-cairo-lang-starknet-classes = "=2.9.2"
+cairo-lang-starknet-classes = "=2.10.0-rc.0"
 # This one needs to match the version used by blockifier
 cairo-vm = "=1.0.1"
 casm-compiler-v1_0_0-alpha6 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-alpha.6" }
 casm-compiler-v1_0_0-rc0 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-rc0" }
 casm-compiler-v1_1_1 = { package = "cairo-lang-starknet", version = "=1.1.1" }
-casm-compiler-v2 = { package = "cairo-lang-starknet", version = "=2.9.2" }
+casm-compiler-v2 = { package = "cairo-lang-starknet", version = "=2.10.0-rc.0" }
 clap = "4.1.13"
 console-subscriber = "0.1.10"
 const-decoder = "0.3.0"

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -9,10 +9,10 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 cairo-lang-starknet-classes = { workspace = true }
-casm-compiler-v1_0_0-alpha6 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-alpha.6" }
-casm-compiler-v1_0_0-rc0 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-rc0" }
-casm-compiler-v1_1_1 = { package = "cairo-lang-starknet", version = "=1.1.1" }
-casm-compiler-v2 = { package = "cairo-lang-starknet", version = "=2.7.0" }
+casm-compiler-v1_0_0-alpha6 = { workspace = true }
+casm-compiler-v1_0_0-rc0 = { workspace = true }
+casm-compiler-v1_1_1 = { workspace = true }
+casm-compiler-v2 = { workspace = true }
 num-bigint = { workspace = true }
 pathfinder-common = { path = "../common" }
 pathfinder-crypto = { path = "../crypto" }

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -10,6 +10,7 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 blockifier = { workspace = true }
 cached = { workspace = true }
+cairo-lang-starknet-classes = { workspace = true }
 cairo-vm = { workspace = true }
 pathfinder-common = { path = "../common" }
 pathfinder-crypto = { path = "../crypto" }

--- a/crates/executor/resources/versioned_constants_0_13_0.json
+++ b/crates/executor/resources/versioned_constants_0_13_0.json
@@ -4,7 +4,6 @@
         "max_contract_bytecode_size": 61440
     },
     "invoke_tx_max_n_steps": 3000000,
-    "execute_max_sierra_gas": 10000000000,
     "max_recursion_depth": 50,
     "segment_arena_cells": true,
     "disable_cairo0_redeclaration": false,
@@ -71,17 +70,21 @@
         "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
         "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "default_entry_point_selector": 0,
+        "validate_max_sierra_gas": 10000000000,
+        "execute_max_sierra_gas": 10000000000,
         "stored_block_hash_buffer": 10,
         "step_gas_cost": 100,
-        "range_check_gas_cost": 70,
-        "keccak_builtin_gas_cost": 0,
-        "pedersen_gas_cost": 0,
-        "bitwise_builtin_gas_cost": 0,
-        "ecop_gas_cost": 0,
-        "poseidon_gas_cost": 0,
-        "add_mod_gas_cost": 0,
-        "mul_mod_gas_cost": 0,
-        "ecdsa_gas_cost": 0,
+        "builtin_gas_costs": {
+            "range_check": 70,
+            "keccak": 0,
+            "pedersen": 0,
+            "bitwise": 0,
+            "ecop": 0,
+            "poseidon": 0,
+            "add_mod": 0,
+            "mul_mod": 0,
+            "ecdsa": 0
+        },
         "memory_hole_gas_cost": 10,
         "os_contract_addresses": {
             "block_hash_contract_address": 1,
@@ -100,11 +103,6 @@
         "fee_transfer_gas_cost": {
             "entry_point_initial_budget": 1,
             "step_gas_cost": 600
-        },
-        "transaction_gas_cost": {
-            "entry_point_initial_budget": 2,
-            "fee_transfer_gas_cost": 1,
-            "step_gas_cost": 1100
         },
         "error_block_number_out_of_range": "Block number out of range",
         "error_out_of_gas": "Out of gas",
@@ -167,48 +165,48 @@
             },
             "secp256k1_add": {
                 "step_gas_cost": 406,
-                "range_check_gas_cost": 29
+                "range_check": 29
             },
             "secp256k1_get_point_from_x": {
                 "step_gas_cost": 391,
-                "range_check_gas_cost": 30,
+                "range_check": 30,
                 "memory_hole_gas_cost": 20
             },
             "secp256k1_get_xy": {
                 "step_gas_cost": 239,
-                "range_check_gas_cost": 11,
+                "range_check": 11,
                 "memory_hole_gas_cost": 40
             },
             "secp256k1_mul": {
                 "step_gas_cost": 76401,
-                "range_check_gas_cost": 7045
+                "range_check": 7045
             },
             "secp256k1_new": {
                 "step_gas_cost": 475,
-                "range_check_gas_cost": 35,
+                "range_check": 35,
                 "memory_hole_gas_cost": 40
             },
             "secp256r1_add": {
                 "step_gas_cost": 589,
-                "range_check_gas_cost": 57
+                "range_check": 57
             },
             "secp256r1_get_point_from_x": {
                 "step_gas_cost": 510,
-                "range_check_gas_cost": 44,
+                "range_check": 44,
                 "memory_hole_gas_cost": 20
             },
             "secp256r1_get_xy": {
                 "step_gas_cost": 241,
-                "range_check_gas_cost": 11,
+                "range_check": 11,
                 "memory_hole_gas_cost": 40
             },
             "secp256r1_mul": {
                 "step_gas_cost": 125240,
-                "range_check_gas_cost": 13961
+                "range_check": 13961
             },
             "secp256r1_new": {
                 "step_gas_cost": 594,
-                "range_check_gas_cost": 49,
+                "range_check": 49,
                 "memory_hole_gas_cost": 40
             },
             "keccak": {
@@ -217,7 +215,7 @@
             "keccak_round_cost": 180000,
             "sha256_process_block": {
                 "step_gas_cost": 0,
-                "range_check_gas_cost": 0,
+                "range_check": 0,
                 "syscall_base_gas_cost": 0
             }
         }
@@ -566,8 +564,7 @@
         }
     },
     "validate_max_n_steps": 1000000,
-    "validate_max_sierra_gas": 10000000000,
-    "min_compiler_version_for_sierra_gas": "2.8.0",
+    "min_sierra_version_for_sierra_gas": "100.0.0",
     "vm_resource_fee_cost": {
         "builtins": {
             "add_mod_builtin": [

--- a/crates/executor/resources/versioned_constants_0_13_0.json
+++ b/crates/executor/resources/versioned_constants_0_13_0.json
@@ -100,10 +100,6 @@
         "syscall_base_gas_cost": {
             "step_gas_cost": 100
         },
-        "fee_transfer_gas_cost": {
-            "entry_point_initial_budget": 1,
-            "step_gas_cost": 600
-        },
         "error_block_number_out_of_range": "Block number out of range",
         "error_out_of_gas": "Out of gas",
         "error_entry_point_failed": "ENTRYPOINT_FAILED",
@@ -118,13 +114,11 @@
         "syscall_gas_costs": {
             "call_contract": {
                 "syscall_base_gas_cost": 1,
-                "step_gas_cost": 510,
-                "entry_point_initial_budget": 1
+                "step_gas_cost": 510
             },
             "deploy": {
                 "syscall_base_gas_cost": 1,
-                "step_gas_cost": 700,
-                "entry_point_initial_budget": 1
+                "step_gas_cost": 700
             },
             "get_block_hash": {
                 "syscall_base_gas_cost": 1,
@@ -136,8 +130,7 @@
             },
             "library_call": {
                 "syscall_base_gas_cost": 1,
-                "step_gas_cost": 510,
-                "entry_point_initial_budget": 1
+                "step_gas_cost": 510
             },
             "replace_class": {
                 "syscall_base_gas_cost": 1,
@@ -303,7 +296,7 @@
                 "n_memory_holes": 0,
                 "n_steps": 44
             },
-            "Keccak": {
+            "KeccakRound": {
                 "builtin_instance_counter": {
                     "bitwise_builtin": 6,
                     "keccak_builtin": 1,
@@ -311,6 +304,11 @@
                 },
                 "n_memory_holes": 0,
                 "n_steps": 381
+            },
+            "Keccak": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 0
             },
             "LibraryCall": {
                 "builtin_instance_counter": {

--- a/crates/executor/resources/versioned_constants_0_13_0.json
+++ b/crates/executor/resources/versioned_constants_0_13_0.json
@@ -4,8 +4,59 @@
         "max_contract_bytecode_size": 61440
     },
     "invoke_tx_max_n_steps": 3000000,
+    "execute_max_sierra_gas": 10000000000,
     "max_recursion_depth": 50,
     "segment_arena_cells": true,
+    "disable_cairo0_redeclaration": false,
+    "enable_stateful_compression": false,
+    "comprehensive_state_diff": false,
+    "allocation_cost": {
+        "blob_cost": {
+            "l1_gas": 0,
+            "l1_data_gas": 0,
+            "l2_gas": 0
+        },
+        "gas_cost": {
+            "l1_gas": 0,
+            "l1_data_gas": 0,
+            "l2_gas": 0
+        }
+    },
+    "ignore_inner_event_resources": false,
+    "enable_reverts": false,
+    "tx_event_limits": {
+        "max_data_length": 1000000000,
+        "max_keys_length": 1000000000,
+        "max_n_emitted_events": 1000000000
+    },
+    "deprecated_l2_resource_gas_costs": {
+        "gas_per_data_felt": [
+            0,
+            1
+        ],
+        "event_key_factor": [
+            0,
+            1
+        ],
+        "gas_per_code_byte": [
+            0,
+            1
+        ]
+    },
+    "archival_data_gas_costs": {
+        "gas_per_data_felt": [
+            0,
+            1
+        ],
+        "event_key_factor": [
+            0,
+            1
+        ],
+        "gas_per_code_byte": [
+            0,
+            1
+        ]
+    },
     "os_constants": {
         "nop_entry_point_offset": -1,
         "entry_point_type_external": 0,
@@ -20,12 +71,24 @@
         "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
         "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "default_entry_point_selector": 0,
-        "block_hash_contract_address": 1,
         "stored_block_hash_buffer": 10,
         "step_gas_cost": 100,
         "range_check_gas_cost": 70,
+        "keccak_builtin_gas_cost": 0,
+        "pedersen_gas_cost": 0,
+        "bitwise_builtin_gas_cost": 0,
+        "ecop_gas_cost": 0,
+        "poseidon_gas_cost": 0,
+        "add_mod_gas_cost": 0,
+        "mul_mod_gas_cost": 0,
+        "ecdsa_gas_cost": 0,
         "memory_hole_gas_cost": 10,
-        "initial_gas_cost": {
+        "os_contract_addresses": {
+            "block_hash_contract_address": 1,
+            "alias_contract_address": 2,
+            "reserved_contract_address": 3
+        },
+        "default_initial_gas_cost": {
             "step_gas_cost": 100000000
         },
         "entry_point_initial_budget": {
@@ -34,124 +97,130 @@
         "syscall_base_gas_cost": {
             "step_gas_cost": 100
         },
-        "entry_point_gas_cost": {
-            "entry_point_initial_budget": 1,
-            "step_gas_cost": 500
-        },
         "fee_transfer_gas_cost": {
-            "entry_point_gas_cost": 1,
-            "step_gas_cost": 100
+            "entry_point_initial_budget": 1,
+            "step_gas_cost": 600
         },
         "transaction_gas_cost": {
-            "entry_point_gas_cost": 2,
+            "entry_point_initial_budget": 2,
             "fee_transfer_gas_cost": 1,
-            "step_gas_cost": 100
-        },
-        "call_contract_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 10,
-            "entry_point_gas_cost": 1
-        },
-        "deploy_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 200,
-            "entry_point_gas_cost": 1
-        },
-        "get_block_hash_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 50
-        },
-        "get_execution_info_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 10
-        },
-        "library_call_gas_cost": {
-            "call_contract_gas_cost": 1
-        },
-        "replace_class_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 50
-        },
-        "storage_read_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 50
-        },
-        "storage_write_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 50
-        },
-        "emit_event_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 10
-        },
-        "send_message_to_l1_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 50
-        },
-        "secp256k1_add_gas_cost": {
-            "step_gas_cost": 406,
-            "range_check_gas_cost": 29
-        },
-        "secp256k1_get_point_from_x_gas_cost": {
-            "step_gas_cost": 391,
-            "range_check_gas_cost": 30,
-            "memory_hole_gas_cost": 20
-        },
-        "secp256k1_get_xy_gas_cost": {
-            "step_gas_cost": 239,
-            "range_check_gas_cost": 11,
-            "memory_hole_gas_cost": 40
-        },
-        "secp256k1_mul_gas_cost": {
-            "step_gas_cost": 76401,
-            "range_check_gas_cost": 7045
-        },
-        "secp256k1_new_gas_cost": {
-            "step_gas_cost": 475,
-            "range_check_gas_cost": 35,
-            "memory_hole_gas_cost": 40
-        },
-        "secp256r1_add_gas_cost": {
-            "step_gas_cost": 589,
-            "range_check_gas_cost": 57
-        },
-        "secp256r1_get_point_from_x_gas_cost": {
-            "step_gas_cost": 510,
-            "range_check_gas_cost": 44,
-            "memory_hole_gas_cost": 20
-        },
-        "secp256r1_get_xy_gas_cost": {
-            "step_gas_cost": 241,
-            "range_check_gas_cost": 11,
-            "memory_hole_gas_cost": 40
-        },
-        "secp256r1_mul_gas_cost": {
-            "step_gas_cost": 125240,
-            "range_check_gas_cost": 13961
-        },
-        "secp256r1_new_gas_cost": {
-            "step_gas_cost": 594,
-            "range_check_gas_cost": 49,
-            "memory_hole_gas_cost": 40
-        },
-        "keccak_gas_cost": {
-            "syscall_base_gas_cost": 1
-        },
-        "keccak_round_cost_gas_cost": 180000,
-        "sha256_process_block_gas_cost": {
-            "step_gas_cost": 0,
-            "range_check_gas_cost": 0,
-            "syscall_base_gas_cost": 0
+            "step_gas_cost": 1100
         },
         "error_block_number_out_of_range": "Block number out of range",
         "error_out_of_gas": "Out of gas",
+        "error_entry_point_failed": "ENTRYPOINT_FAILED",
+        "error_entry_point_not_found": "ENTRYPOINT_NOT_FOUND",
         "error_invalid_input_len": "Invalid input length",
         "error_invalid_argument": "Invalid argument",
         "validated": "VALID",
         "l1_gas": "L1_GAS",
         "l2_gas": "L2_GAS",
         "l1_gas_index": 0,
-        "l2_gas_index": 1
+        "l2_gas_index": 1,
+        "syscall_gas_costs": {
+            "call_contract": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 510,
+                "entry_point_initial_budget": 1
+            },
+            "deploy": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 700,
+                "entry_point_initial_budget": 1
+            },
+            "get_block_hash": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 50
+            },
+            "get_execution_info": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 10
+            },
+            "library_call": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 510,
+                "entry_point_initial_budget": 1
+            },
+            "replace_class": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 50
+            },
+            "storage_read": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 50
+            },
+            "storage_write": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 50
+            },
+            "get_class_hash_at": {
+                "step_gas_cost": 0,
+                "syscall_base_gas_cost": 0
+            },
+            "emit_event": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 10
+            },
+            "send_message_to_l1": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 50
+            },
+            "secp256k1_add": {
+                "step_gas_cost": 406,
+                "range_check_gas_cost": 29
+            },
+            "secp256k1_get_point_from_x": {
+                "step_gas_cost": 391,
+                "range_check_gas_cost": 30,
+                "memory_hole_gas_cost": 20
+            },
+            "secp256k1_get_xy": {
+                "step_gas_cost": 239,
+                "range_check_gas_cost": 11,
+                "memory_hole_gas_cost": 40
+            },
+            "secp256k1_mul": {
+                "step_gas_cost": 76401,
+                "range_check_gas_cost": 7045
+            },
+            "secp256k1_new": {
+                "step_gas_cost": 475,
+                "range_check_gas_cost": 35,
+                "memory_hole_gas_cost": 40
+            },
+            "secp256r1_add": {
+                "step_gas_cost": 589,
+                "range_check_gas_cost": 57
+            },
+            "secp256r1_get_point_from_x": {
+                "step_gas_cost": 510,
+                "range_check_gas_cost": 44,
+                "memory_hole_gas_cost": 20
+            },
+            "secp256r1_get_xy": {
+                "step_gas_cost": 241,
+                "range_check_gas_cost": 11,
+                "memory_hole_gas_cost": 40
+            },
+            "secp256r1_mul": {
+                "step_gas_cost": 125240,
+                "range_check_gas_cost": 13961
+            },
+            "secp256r1_new": {
+                "step_gas_cost": 594,
+                "range_check_gas_cost": 49,
+                "memory_hole_gas_cost": 40
+            },
+            "keccak": {
+                "syscall_base_gas_cost": 1
+            },
+            "keccak_round_cost": 180000,
+            "sha256_process_block": {
+                "step_gas_cost": 0,
+                "range_check_gas_cost": 0,
+                "syscall_base_gas_cost": 0
+            }
+        }
     },
     "os_resources": {
         "execute_syscalls": {
@@ -353,6 +422,11 @@
                 "builtin_instance_counter": {},
                 "n_memory_holes": 0,
                 "n_steps": 46
+            },
+            "GetClassHashAt": {
+                "n_steps": 0,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
             }
         },
         "execute_txs_inner": {
@@ -492,54 +566,58 @@
         }
     },
     "validate_max_n_steps": 1000000,
+    "validate_max_sierra_gas": 10000000000,
+    "min_compiler_version_for_sierra_gas": "2.8.0",
     "vm_resource_fee_cost": {
-        "add_mod_builtin": [
-            0,
-            1
-        ],
-        "bitwise_builtin": [
-            32,
-            100
-        ],
-        "ec_op_builtin": [
-            512,
-            100
-        ],
-        "ecdsa_builtin": [
-            1024,
-            100
-        ],
-        "keccak_builtin": [
-            1024,
-            100
-        ],
-        "mul_mod_builtin": [
-            0,
-            1
-        ],
+        "builtins": {
+            "add_mod_builtin": [
+                0,
+                1
+            ],
+            "bitwise_builtin": [
+                32,
+                100
+            ],
+            "ec_op_builtin": [
+                512,
+                100
+            ],
+            "ecdsa_builtin": [
+                1024,
+                100
+            ],
+            "keccak_builtin": [
+                1024,
+                100
+            ],
+            "mul_mod_builtin": [
+                0,
+                1
+            ],
+            "output_builtin": [
+                0,
+                1
+            ],
+            "pedersen_builtin": [
+                16,
+                100
+            ],
+            "poseidon_builtin": [
+                16,
+                100
+            ],
+            "range_check_builtin": [
+                8,
+                100
+            ],
+            "range_check96_builtin": [
+                0,
+                1
+            ]
+        },
         "n_steps": [
             5,
             1000
-        ],
-        "output_builtin": [
-            0,
-            1
-        ],
-        "pedersen_builtin": [
-            16,
-            100
-        ],
-        "poseidon_builtin": [
-            16,
-            100
-        ],
-        "range_check_builtin": [
-            8,
-            100
-        ],
-        "range_check96_builtin": [
-            0,
-            1
         ]
     }
 }

--- a/crates/executor/resources/versioned_constants_0_13_1.json
+++ b/crates/executor/resources/versioned_constants_0_13_1.json
@@ -100,10 +100,6 @@
         "syscall_base_gas_cost": {
             "step_gas_cost": 100
         },
-        "fee_transfer_gas_cost": {
-            "entry_point_initial_budget": 1,
-            "step_gas_cost": 600
-        },
         "error_block_number_out_of_range": "Block number out of range",
         "error_out_of_gas": "Out of gas",
         "error_entry_point_failed": "ENTRYPOINT_FAILED",
@@ -122,13 +118,11 @@
         "syscall_gas_costs": {
             "call_contract": {
                 "syscall_base_gas_cost": 1,
-                "step_gas_cost": 510,
-                "entry_point_initial_budget": 1
+                "step_gas_cost": 510
             },
             "deploy": {
                 "syscall_base_gas_cost": 1,
-                "step_gas_cost": 700,
-                "entry_point_initial_budget": 1
+                "step_gas_cost": 700
             },
             "get_block_hash": {
                 "syscall_base_gas_cost": 1,
@@ -140,8 +134,7 @@
             },
             "library_call": {
                 "syscall_base_gas_cost": 1,
-                "step_gas_cost": 510,
-                "entry_point_initial_budget": 1
+                "step_gas_cost": 510
             },
             "replace_class": {
                 "syscall_base_gas_cost": 1,
@@ -319,13 +312,18 @@
                 "builtin_instance_counter": {},
                 "n_memory_holes": 0
             },
-            "Keccak": {
+            "KeccakRound": {
                 "n_steps": 381,
                 "builtin_instance_counter": {
                     "bitwise_builtin": 6,
                     "keccak_builtin": 1,
                     "range_check_builtin": 56
                 },
+                "n_memory_holes": 0
+            },
+            "Keccak": {
+                "n_steps": 0,
+                "builtin_instance_counter": {},
                 "n_memory_holes": 0
             },
             "LibraryCall": {

--- a/crates/executor/resources/versioned_constants_0_13_1.json
+++ b/crates/executor/resources/versioned_constants_0_13_1.json
@@ -5,11 +5,12 @@
         "max_n_emitted_events": 1000
     },
     "gateway": {
-        "max_calldata_length": 5000,
+        "max_calldata_length": 4000,
         "max_contract_bytecode_size": 81920
     },
     "invoke_tx_max_n_steps": 4000000,
-    "l2_resource_gas_costs": {
+    "execute_max_sierra_gas": 10000000000,
+    "deprecated_l2_resource_gas_costs": {
         "gas_per_data_felt": [
             128,
             1000
@@ -19,12 +20,43 @@
             1
         ],
         "gas_per_code_byte": [
-            32,
+            875,
             1000
+        ]
+    },
+    "archival_data_gas_costs": {
+        "gas_per_data_felt": [
+            5120,
+            1
+        ],
+        "event_key_factor": [
+            2,
+            1
+        ],
+        "gas_per_code_byte": [
+            35000,
+            1
         ]
     },
     "max_recursion_depth": 50,
     "segment_arena_cells": true,
+    "disable_cairo0_redeclaration": false,
+    "enable_stateful_compression": false,
+    "comprehensive_state_diff": false,
+    "allocation_cost": {
+        "blob_cost": {
+            "l1_gas": 0,
+            "l1_data_gas": 0,
+            "l2_gas": 0
+        },
+        "gas_cost": {
+            "l1_gas": 0,
+            "l1_data_gas": 0,
+            "l2_gas": 0
+        }
+    },
+    "ignore_inner_event_resources": true,
+    "enable_reverts": false,
     "os_constants": {
         "nop_entry_point_offset": -1,
         "entry_point_type_external": 0,
@@ -39,12 +71,24 @@
         "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
         "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "default_entry_point_selector": 0,
-        "block_hash_contract_address": 1,
         "stored_block_hash_buffer": 10,
         "step_gas_cost": 100,
         "range_check_gas_cost": 70,
+        "keccak_builtin_gas_cost": 0,
+        "pedersen_gas_cost": 0,
+        "bitwise_builtin_gas_cost": 0,
+        "ecop_gas_cost": 0,
+        "poseidon_gas_cost": 0,
+        "add_mod_gas_cost": 0,
+        "mul_mod_gas_cost": 0,
+        "ecdsa_gas_cost": 0,
+        "os_contract_addresses": {
+            "block_hash_contract_address": 1,
+            "alias_contract_address": 2,
+            "reserved_contract_address": 3
+        },
         "memory_hole_gas_cost": 10,
-        "initial_gas_cost": {
+        "default_initial_gas_cost": {
             "step_gas_cost": 100000000
         },
         "entry_point_initial_budget": {
@@ -53,119 +97,19 @@
         "syscall_base_gas_cost": {
             "step_gas_cost": 100
         },
-        "entry_point_gas_cost": {
-            "entry_point_initial_budget": 1,
-            "step_gas_cost": 500
-        },
         "fee_transfer_gas_cost": {
-            "entry_point_gas_cost": 1,
-            "step_gas_cost": 100
+            "entry_point_initial_budget": 1,
+            "step_gas_cost": 600
         },
         "transaction_gas_cost": {
-            "entry_point_gas_cost": 2,
+            "entry_point_initial_budget": 2,
             "fee_transfer_gas_cost": 1,
-            "step_gas_cost": 100
-        },
-        "call_contract_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 10,
-            "entry_point_gas_cost": 1
-        },
-        "deploy_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 200,
-            "entry_point_gas_cost": 1
-        },
-        "get_block_hash_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 50
-        },
-        "get_execution_info_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 10
-        },
-        "library_call_gas_cost": {
-            "call_contract_gas_cost": 1
-        },
-        "replace_class_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 50
-        },
-        "storage_read_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 50
-        },
-        "storage_write_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 50
-        },
-        "emit_event_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 10
-        },
-        "send_message_to_l1_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 50
-        },
-        "secp256k1_add_gas_cost": {
-            "step_gas_cost": 406,
-            "range_check_gas_cost": 29
-        },
-        "secp256k1_get_point_from_x_gas_cost": {
-            "step_gas_cost": 391,
-            "range_check_gas_cost": 30,
-            "memory_hole_gas_cost": 20
-        },
-        "secp256k1_get_xy_gas_cost": {
-            "step_gas_cost": 239,
-            "range_check_gas_cost": 11,
-            "memory_hole_gas_cost": 40
-        },
-        "secp256k1_mul_gas_cost": {
-            "step_gas_cost": 76501,
-            "range_check_gas_cost": 7045,
-            "memory_hole_gas_cost": 2
-        },
-        "secp256k1_new_gas_cost": {
-            "step_gas_cost": 475,
-            "range_check_gas_cost": 35,
-            "memory_hole_gas_cost": 40
-        },
-        "secp256r1_add_gas_cost": {
-            "step_gas_cost": 589,
-            "range_check_gas_cost": 57
-        },
-        "secp256r1_get_point_from_x_gas_cost": {
-            "step_gas_cost": 510,
-            "range_check_gas_cost": 44,
-            "memory_hole_gas_cost": 20
-        },
-        "secp256r1_get_xy_gas_cost": {
-            "step_gas_cost": 241,
-            "range_check_gas_cost": 11,
-            "memory_hole_gas_cost": 40
-        },
-        "secp256r1_mul_gas_cost": {
-            "step_gas_cost": 125340,
-            "range_check_gas_cost": 13961,
-            "memory_hole_gas_cost": 2
-        },
-        "secp256r1_new_gas_cost": {
-            "step_gas_cost": 594,
-            "range_check_gas_cost": 49,
-            "memory_hole_gas_cost": 40
-        },
-        "keccak_gas_cost": {
-            "syscall_base_gas_cost": 1
-        },
-        "keccak_round_cost_gas_cost": 180000,
-        "sha256_process_block_gas_cost": {
-            "step_gas_cost": 0,
-            "range_check_gas_cost": 0,
-            "syscall_base_gas_cost": 0
+            "step_gas_cost": 1100
         },
         "error_block_number_out_of_range": "Block number out of range",
         "error_out_of_gas": "Out of gas",
+        "error_entry_point_failed": "ENTRYPOINT_FAILED",
+        "error_entry_point_not_found": "ENTRYPOINT_NOT_FOUND",
         "error_invalid_input_len": "Invalid input length",
         "error_invalid_argument": "Invalid argument",
         "validated": "VALID",
@@ -176,6 +120,112 @@
         "validate_rounding_consts": {
             "validate_block_number_rounding": 100,
             "validate_timestamp_rounding": 3600
+        },
+        "syscall_gas_costs": {
+            "call_contract": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 510,
+                "entry_point_initial_budget": 1
+            },
+            "deploy": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 700,
+                "entry_point_initial_budget": 1
+            },
+            "get_block_hash": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 50
+            },
+            "get_execution_info": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 10
+            },
+            "library_call": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 510,
+                "entry_point_initial_budget": 1
+            },
+            "replace_class": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 50
+            },
+            "storage_read": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 50
+            },
+            "storage_write": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 50
+            },
+            "get_class_hash_at": {
+                "step_gas_cost": 0,
+                "syscall_base_gas_cost": 0
+            },
+            "emit_event": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 10
+            },
+            "send_message_to_l1": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 50
+            },
+            "secp256k1_add": {
+                "step_gas_cost": 406,
+                "range_check_gas_cost": 29
+            },
+            "secp256k1_get_point_from_x": {
+                "step_gas_cost": 391,
+                "range_check_gas_cost": 30,
+                "memory_hole_gas_cost": 20
+            },
+            "secp256k1_get_xy": {
+                "step_gas_cost": 239,
+                "range_check_gas_cost": 11,
+                "memory_hole_gas_cost": 40
+            },
+            "secp256k1_mul": {
+                "step_gas_cost": 76501,
+                "range_check_gas_cost": 7045,
+                "memory_hole_gas_cost": 2
+            },
+            "secp256k1_new": {
+                "step_gas_cost": 475,
+                "range_check_gas_cost": 35,
+                "memory_hole_gas_cost": 40
+            },
+            "secp256r1_add": {
+                "step_gas_cost": 589,
+                "range_check_gas_cost": 57
+            },
+            "secp256r1_get_point_from_x": {
+                "step_gas_cost": 510,
+                "range_check_gas_cost": 44,
+                "memory_hole_gas_cost": 20
+            },
+            "secp256r1_get_xy": {
+                "step_gas_cost": 241,
+                "range_check_gas_cost": 11,
+                "memory_hole_gas_cost": 40
+            },
+            "secp256r1_mul": {
+                "step_gas_cost": 125340,
+                "range_check_gas_cost": 13961,
+                "memory_hole_gas_cost": 2
+            },
+            "secp256r1_new": {
+                "step_gas_cost": 594,
+                "range_check_gas_cost": 49,
+                "memory_hole_gas_cost": 40
+            },
+            "keccak": {
+                "syscall_base_gas_cost": 1
+            },
+            "keccak_round_cost": 180000,
+            "sha256_process_block": {
+                "step_gas_cost": 0,
+                "range_check_gas_cost": 0,
+                "syscall_base_gas_cost": 0
+            }
         }
     },
     "os_resources": {
@@ -396,6 +446,11 @@
                     "range_check_builtin": 1
                 },
                 "n_memory_holes": 0
+            },
+            "GetClassHashAt": {
+                "n_steps": 0,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
             }
         },
         "execute_txs_inner": {
@@ -547,54 +602,58 @@
         }
     },
     "validate_max_n_steps": 1000000,
+    "validate_max_sierra_gas": 10000000000,
+    "min_compiler_version_for_sierra_gas": "2.8.0",
     "vm_resource_fee_cost": {
-        "add_mod_builtin": [
-            0,
-            1
-        ],
-        "bitwise_builtin": [
-            16,
-            100
-        ],
-        "ec_op_builtin": [
-            256,
-            100
-        ],
-        "ecdsa_builtin": [
-            512,
-            100
-        ],
-        "keccak_builtin": [
-            512,
-            100
-        ],
-        "mul_mod_builtin": [
-            0,
-            1
-        ],
+        "builtins": {
+            "add_mod_builtin": [
+                0,
+                1
+            ],
+            "bitwise_builtin": [
+                16,
+                100
+            ],
+            "ec_op_builtin": [
+                256,
+                100
+            ],
+            "ecdsa_builtin": [
+                512,
+                100
+            ],
+            "keccak_builtin": [
+                512,
+                100
+            ],
+            "mul_mod_builtin": [
+                0,
+                1
+            ],
+            "output_builtin": [
+                0,
+                1
+            ],
+            "pedersen_builtin": [
+                8,
+                100
+            ],
+            "poseidon_builtin": [
+                8,
+                100
+            ],
+            "range_check_builtin": [
+                4,
+                100
+            ],
+            "range_check96_builtin": [
+                0,
+                1
+            ]
+        },
         "n_steps": [
             25,
             10000
-        ],
-        "output_builtin": [
-            0,
-            1
-        ],
-        "pedersen_builtin": [
-            8,
-            100
-        ],
-        "poseidon_builtin": [
-            8,
-            100
-        ],
-        "range_check_builtin": [
-            4,
-            100
-        ],
-        "range_check96_builtin": [
-            0,
-            1
         ]
     }
 }

--- a/crates/executor/resources/versioned_constants_0_13_1.json
+++ b/crates/executor/resources/versioned_constants_0_13_1.json
@@ -9,7 +9,6 @@
         "max_contract_bytecode_size": 81920
     },
     "invoke_tx_max_n_steps": 4000000,
-    "execute_max_sierra_gas": 10000000000,
     "deprecated_l2_resource_gas_costs": {
         "gas_per_data_felt": [
             128,
@@ -71,17 +70,21 @@
         "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
         "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "default_entry_point_selector": 0,
+        "validate_max_sierra_gas": 10000000000,
+        "execute_max_sierra_gas": 10000000000,
         "stored_block_hash_buffer": 10,
         "step_gas_cost": 100,
-        "range_check_gas_cost": 70,
-        "keccak_builtin_gas_cost": 0,
-        "pedersen_gas_cost": 0,
-        "bitwise_builtin_gas_cost": 0,
-        "ecop_gas_cost": 0,
-        "poseidon_gas_cost": 0,
-        "add_mod_gas_cost": 0,
-        "mul_mod_gas_cost": 0,
-        "ecdsa_gas_cost": 0,
+        "builtin_gas_costs": {
+            "range_check": 70,
+            "keccak": 0,
+            "pedersen": 0,
+            "bitwise": 0,
+            "ecop": 0,
+            "poseidon": 0,
+            "add_mod": 0,
+            "mul_mod": 0,
+            "ecdsa": 0
+        },
         "os_contract_addresses": {
             "block_hash_contract_address": 1,
             "alias_contract_address": 2,
@@ -100,11 +103,6 @@
         "fee_transfer_gas_cost": {
             "entry_point_initial_budget": 1,
             "step_gas_cost": 600
-        },
-        "transaction_gas_cost": {
-            "entry_point_initial_budget": 2,
-            "fee_transfer_gas_cost": 1,
-            "step_gas_cost": 1100
         },
         "error_block_number_out_of_range": "Block number out of range",
         "error_out_of_gas": "Out of gas",
@@ -171,50 +169,50 @@
             },
             "secp256k1_add": {
                 "step_gas_cost": 406,
-                "range_check_gas_cost": 29
+                "range_check": 29
             },
             "secp256k1_get_point_from_x": {
                 "step_gas_cost": 391,
-                "range_check_gas_cost": 30,
+                "range_check": 30,
                 "memory_hole_gas_cost": 20
             },
             "secp256k1_get_xy": {
                 "step_gas_cost": 239,
-                "range_check_gas_cost": 11,
+                "range_check": 11,
                 "memory_hole_gas_cost": 40
             },
             "secp256k1_mul": {
                 "step_gas_cost": 76501,
-                "range_check_gas_cost": 7045,
+                "range_check": 7045,
                 "memory_hole_gas_cost": 2
             },
             "secp256k1_new": {
                 "step_gas_cost": 475,
-                "range_check_gas_cost": 35,
+                "range_check": 35,
                 "memory_hole_gas_cost": 40
             },
             "secp256r1_add": {
                 "step_gas_cost": 589,
-                "range_check_gas_cost": 57
+                "range_check": 57
             },
             "secp256r1_get_point_from_x": {
                 "step_gas_cost": 510,
-                "range_check_gas_cost": 44,
+                "range_check": 44,
                 "memory_hole_gas_cost": 20
             },
             "secp256r1_get_xy": {
                 "step_gas_cost": 241,
-                "range_check_gas_cost": 11,
+                "range_check": 11,
                 "memory_hole_gas_cost": 40
             },
             "secp256r1_mul": {
                 "step_gas_cost": 125340,
-                "range_check_gas_cost": 13961,
+                "range_check": 13961,
                 "memory_hole_gas_cost": 2
             },
             "secp256r1_new": {
                 "step_gas_cost": 594,
-                "range_check_gas_cost": 49,
+                "range_check": 49,
                 "memory_hole_gas_cost": 40
             },
             "keccak": {
@@ -223,7 +221,7 @@
             "keccak_round_cost": 180000,
             "sha256_process_block": {
                 "step_gas_cost": 0,
-                "range_check_gas_cost": 0,
+                "range_check": 0,
                 "syscall_base_gas_cost": 0
             }
         }
@@ -602,8 +600,7 @@
         }
     },
     "validate_max_n_steps": 1000000,
-    "validate_max_sierra_gas": 10000000000,
-    "min_compiler_version_for_sierra_gas": "2.8.0",
+    "min_sierra_version_for_sierra_gas": "100.0.0",
     "vm_resource_fee_cost": {
         "builtins": {
             "add_mod_builtin": [

--- a/crates/executor/resources/versioned_constants_0_13_1_1.json
+++ b/crates/executor/resources/versioned_constants_0_13_1_1.json
@@ -100,10 +100,6 @@
         "syscall_base_gas_cost": {
             "step_gas_cost": 100
         },
-        "fee_transfer_gas_cost": {
-            "entry_point_initial_budget": 1,
-            "step_gas_cost": 600
-        },
         "error_block_number_out_of_range": "Block number out of range",
         "error_out_of_gas": "Out of gas",
         "error_entry_point_failed": "ENTRYPOINT_FAILED",
@@ -122,13 +118,11 @@
         "syscall_gas_costs": {
             "call_contract": {
                 "syscall_base_gas_cost": 1,
-                "step_gas_cost": 510,
-                "entry_point_initial_budget": 1
+                "step_gas_cost": 510
             },
             "deploy": {
                 "syscall_base_gas_cost": 1,
-                "step_gas_cost": 700,
-                "entry_point_initial_budget": 1
+                "step_gas_cost": 700
             },
             "get_block_hash": {
                 "syscall_base_gas_cost": 1,
@@ -140,8 +134,7 @@
             },
             "library_call": {
                 "syscall_base_gas_cost": 1,
-                "step_gas_cost": 510,
-                "entry_point_initial_budget": 1
+                "step_gas_cost": 510
             },
             "replace_class": {
                 "syscall_base_gas_cost": 1,
@@ -319,13 +312,18 @@
                 "builtin_instance_counter": {},
                 "n_memory_holes": 0
             },
-            "Keccak": {
+            "KeccakRound": {
                 "n_steps": 381,
                 "builtin_instance_counter": {
                     "bitwise_builtin": 6,
                     "keccak_builtin": 1,
                     "range_check_builtin": 56
                 },
+                "n_memory_holes": 0
+            },
+            "Keccak": {
+                "n_steps": 0,
+                "builtin_instance_counter": {},
                 "n_memory_holes": 0
             },
             "LibraryCall": {

--- a/crates/executor/resources/versioned_constants_0_13_1_1.json
+++ b/crates/executor/resources/versioned_constants_0_13_1_1.json
@@ -9,7 +9,6 @@
         "max_contract_bytecode_size": 81920
     },
     "invoke_tx_max_n_steps": 4000000,
-    "execute_max_sierra_gas": 10000000000,
     "deprecated_l2_resource_gas_costs": {
         "gas_per_data_felt": [
             128,
@@ -71,17 +70,21 @@
         "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
         "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "default_entry_point_selector": 0,
+        "validate_max_sierra_gas": 10000000000,
+        "execute_max_sierra_gas": 10000000000,
         "stored_block_hash_buffer": 10,
         "step_gas_cost": 100,
-        "range_check_gas_cost": 70,
-        "keccak_builtin_gas_cost": 0,
-        "pedersen_gas_cost": 0,
-        "bitwise_builtin_gas_cost": 0,
-        "ecop_gas_cost": 0,
-        "poseidon_gas_cost": 0,
-        "add_mod_gas_cost": 0,
-        "mul_mod_gas_cost": 0,
-        "ecdsa_gas_cost": 0,
+        "builtin_gas_costs": {
+            "range_check": 70,
+            "keccak": 0,
+            "pedersen": 0,
+            "bitwise": 0,
+            "ecop": 0,
+            "poseidon": 0,
+            "add_mod": 0,
+            "mul_mod": 0,
+            "ecdsa": 0
+        },
         "memory_hole_gas_cost": 10,
         "os_contract_addresses": {
             "block_hash_contract_address": 1,
@@ -100,11 +103,6 @@
         "fee_transfer_gas_cost": {
             "entry_point_initial_budget": 1,
             "step_gas_cost": 600
-        },
-        "transaction_gas_cost": {
-            "entry_point_initial_budget": 2,
-            "fee_transfer_gas_cost": 1,
-            "step_gas_cost": 1100
         },
         "error_block_number_out_of_range": "Block number out of range",
         "error_out_of_gas": "Out of gas",
@@ -171,50 +169,50 @@
             },
             "secp256k1_add": {
                 "step_gas_cost": 406,
-                "range_check_gas_cost": 29
+                "range_check": 29
             },
             "secp256k1_get_point_from_x": {
                 "step_gas_cost": 391,
-                "range_check_gas_cost": 30,
+                "range_check": 30,
                 "memory_hole_gas_cost": 20
             },
             "secp256k1_get_xy": {
                 "step_gas_cost": 239,
-                "range_check_gas_cost": 11,
+                "range_check": 11,
                 "memory_hole_gas_cost": 40
             },
             "secp256k1_mul": {
                 "step_gas_cost": 76501,
-                "range_check_gas_cost": 7045,
+                "range_check": 7045,
                 "memory_hole_gas_cost": 2
             },
             "secp256k1_new": {
                 "step_gas_cost": 475,
-                "range_check_gas_cost": 35,
+                "range_check": 35,
                 "memory_hole_gas_cost": 40
             },
             "secp256r1_add": {
                 "step_gas_cost": 589,
-                "range_check_gas_cost": 57
+                "range_check": 57
             },
             "secp256r1_get_point_from_x": {
                 "step_gas_cost": 510,
-                "range_check_gas_cost": 44,
+                "range_check": 44,
                 "memory_hole_gas_cost": 20
             },
             "secp256r1_get_xy": {
                 "step_gas_cost": 241,
-                "range_check_gas_cost": 11,
+                "range_check": 11,
                 "memory_hole_gas_cost": 40
             },
             "secp256r1_mul": {
                 "step_gas_cost": 125340,
-                "range_check_gas_cost": 13961,
+                "range_check": 13961,
                 "memory_hole_gas_cost": 2
             },
             "secp256r1_new": {
                 "step_gas_cost": 594,
-                "range_check_gas_cost": 49,
+                "range_check": 49,
                 "memory_hole_gas_cost": 40
             },
             "keccak": {
@@ -223,7 +221,7 @@
             "keccak_round_cost": 180000,
             "sha256_process_block": {
                 "step_gas_cost": 0,
-                "range_check_gas_cost": 0,
+                "range_check": 0,
                 "syscall_base_gas_cost": 0
             }
         }
@@ -602,8 +600,7 @@
         }
     },
     "validate_max_n_steps": 1000000,
-    "validate_max_sierra_gas": 10000000000,
-    "min_compiler_version_for_sierra_gas": "2.8.0",
+    "min_sierra_version_for_sierra_gas": "100.0.0",
     "vm_resource_fee_cost": {
         "builtins": {
             "add_mod_builtin": [

--- a/crates/executor/resources/versioned_constants_0_13_1_1.json
+++ b/crates/executor/resources/versioned_constants_0_13_1_1.json
@@ -5,11 +5,12 @@
         "max_n_emitted_events": 1000
     },
     "gateway": {
-        "max_calldata_length": 4000,
+        "max_calldata_length": 5000,
         "max_contract_bytecode_size": 81920
     },
     "invoke_tx_max_n_steps": 4000000,
-    "l2_resource_gas_costs": {
+    "execute_max_sierra_gas": 10000000000,
+    "deprecated_l2_resource_gas_costs": {
         "gas_per_data_felt": [
             128,
             1000
@@ -19,12 +20,43 @@
             1
         ],
         "gas_per_code_byte": [
-            875,
+            32,
             1000
+        ]
+    },
+    "archival_data_gas_costs": {
+        "gas_per_data_felt": [
+            5120,
+            1
+        ],
+        "event_key_factor": [
+            2,
+            1
+        ],
+        "gas_per_code_byte": [
+            1280,
+            1
         ]
     },
     "max_recursion_depth": 50,
     "segment_arena_cells": true,
+    "disable_cairo0_redeclaration": false,
+    "enable_stateful_compression": false,
+    "comprehensive_state_diff": false,
+    "allocation_cost": {
+        "blob_cost": {
+            "l1_gas": 0,
+            "l1_data_gas": 0,
+            "l2_gas": 0
+        },
+        "gas_cost": {
+            "l1_gas": 0,
+            "l1_data_gas": 0,
+            "l2_gas": 0
+        }
+    },
+    "ignore_inner_event_resources": false,
+    "enable_reverts": false,
     "os_constants": {
         "nop_entry_point_offset": -1,
         "entry_point_type_external": 0,
@@ -39,12 +71,24 @@
         "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
         "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "default_entry_point_selector": 0,
-        "block_hash_contract_address": 1,
         "stored_block_hash_buffer": 10,
         "step_gas_cost": 100,
         "range_check_gas_cost": 70,
+        "keccak_builtin_gas_cost": 0,
+        "pedersen_gas_cost": 0,
+        "bitwise_builtin_gas_cost": 0,
+        "ecop_gas_cost": 0,
+        "poseidon_gas_cost": 0,
+        "add_mod_gas_cost": 0,
+        "mul_mod_gas_cost": 0,
+        "ecdsa_gas_cost": 0,
         "memory_hole_gas_cost": 10,
-        "initial_gas_cost": {
+        "os_contract_addresses": {
+            "block_hash_contract_address": 1,
+            "alias_contract_address": 2,
+            "reserved_contract_address": 3
+        },
+        "default_initial_gas_cost": {
             "step_gas_cost": 100000000
         },
         "entry_point_initial_budget": {
@@ -53,119 +97,19 @@
         "syscall_base_gas_cost": {
             "step_gas_cost": 100
         },
-        "entry_point_gas_cost": {
-            "entry_point_initial_budget": 1,
-            "step_gas_cost": 500
-        },
         "fee_transfer_gas_cost": {
-            "entry_point_gas_cost": 1,
-            "step_gas_cost": 100
+            "entry_point_initial_budget": 1,
+            "step_gas_cost": 600
         },
         "transaction_gas_cost": {
-            "entry_point_gas_cost": 2,
+            "entry_point_initial_budget": 2,
             "fee_transfer_gas_cost": 1,
-            "step_gas_cost": 100
-        },
-        "call_contract_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 10,
-            "entry_point_gas_cost": 1
-        },
-        "deploy_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 200,
-            "entry_point_gas_cost": 1
-        },
-        "get_block_hash_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 50
-        },
-        "get_execution_info_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 10
-        },
-        "library_call_gas_cost": {
-            "call_contract_gas_cost": 1
-        },
-        "replace_class_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 50
-        },
-        "storage_read_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 50
-        },
-        "storage_write_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 50
-        },
-        "emit_event_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 10
-        },
-        "send_message_to_l1_gas_cost": {
-            "syscall_base_gas_cost": 1,
-            "step_gas_cost": 50
-        },
-        "secp256k1_add_gas_cost": {
-            "step_gas_cost": 406,
-            "range_check_gas_cost": 29
-        },
-        "secp256k1_get_point_from_x_gas_cost": {
-            "step_gas_cost": 391,
-            "range_check_gas_cost": 30,
-            "memory_hole_gas_cost": 20
-        },
-        "secp256k1_get_xy_gas_cost": {
-            "step_gas_cost": 239,
-            "range_check_gas_cost": 11,
-            "memory_hole_gas_cost": 40
-        },
-        "secp256k1_mul_gas_cost": {
-            "step_gas_cost": 76501,
-            "range_check_gas_cost": 7045,
-            "memory_hole_gas_cost": 2
-        },
-        "secp256k1_new_gas_cost": {
-            "step_gas_cost": 475,
-            "range_check_gas_cost": 35,
-            "memory_hole_gas_cost": 40
-        },
-        "secp256r1_add_gas_cost": {
-            "step_gas_cost": 589,
-            "range_check_gas_cost": 57
-        },
-        "secp256r1_get_point_from_x_gas_cost": {
-            "step_gas_cost": 510,
-            "range_check_gas_cost": 44,
-            "memory_hole_gas_cost": 20
-        },
-        "secp256r1_get_xy_gas_cost": {
-            "step_gas_cost": 241,
-            "range_check_gas_cost": 11,
-            "memory_hole_gas_cost": 40
-        },
-        "secp256r1_mul_gas_cost": {
-            "step_gas_cost": 125340,
-            "range_check_gas_cost": 13961,
-            "memory_hole_gas_cost": 2
-        },
-        "secp256r1_new_gas_cost": {
-            "step_gas_cost": 594,
-            "range_check_gas_cost": 49,
-            "memory_hole_gas_cost": 40
-        },
-        "keccak_gas_cost": {
-            "syscall_base_gas_cost": 1
-        },
-        "keccak_round_cost_gas_cost": 180000,
-        "sha256_process_block_gas_cost": {
-            "step_gas_cost": 0,
-            "range_check_gas_cost": 0,
-            "syscall_base_gas_cost": 0
+            "step_gas_cost": 1100
         },
         "error_block_number_out_of_range": "Block number out of range",
         "error_out_of_gas": "Out of gas",
+        "error_entry_point_failed": "ENTRYPOINT_FAILED",
+        "error_entry_point_not_found": "ENTRYPOINT_NOT_FOUND",
         "error_invalid_input_len": "Invalid input length",
         "error_invalid_argument": "Invalid argument",
         "validated": "VALID",
@@ -176,6 +120,112 @@
         "validate_rounding_consts": {
             "validate_block_number_rounding": 100,
             "validate_timestamp_rounding": 3600
+        },
+        "syscall_gas_costs": {
+            "call_contract": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 510,
+                "entry_point_initial_budget": 1
+            },
+            "deploy": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 700,
+                "entry_point_initial_budget": 1
+            },
+            "get_block_hash": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 50
+            },
+            "get_execution_info": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 10
+            },
+            "library_call": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 510,
+                "entry_point_initial_budget": 1
+            },
+            "replace_class": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 50
+            },
+            "storage_read": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 50
+            },
+            "storage_write": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 50
+            },
+            "get_class_hash_at": {
+                "step_gas_cost": 0,
+                "syscall_base_gas_cost": 0
+            },
+            "emit_event": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 10
+            },
+            "send_message_to_l1": {
+                "syscall_base_gas_cost": 1,
+                "step_gas_cost": 50
+            },
+            "secp256k1_add": {
+                "step_gas_cost": 406,
+                "range_check_gas_cost": 29
+            },
+            "secp256k1_get_point_from_x": {
+                "step_gas_cost": 391,
+                "range_check_gas_cost": 30,
+                "memory_hole_gas_cost": 20
+            },
+            "secp256k1_get_xy": {
+                "step_gas_cost": 239,
+                "range_check_gas_cost": 11,
+                "memory_hole_gas_cost": 40
+            },
+            "secp256k1_mul": {
+                "step_gas_cost": 76501,
+                "range_check_gas_cost": 7045,
+                "memory_hole_gas_cost": 2
+            },
+            "secp256k1_new": {
+                "step_gas_cost": 475,
+                "range_check_gas_cost": 35,
+                "memory_hole_gas_cost": 40
+            },
+            "secp256r1_add": {
+                "step_gas_cost": 589,
+                "range_check_gas_cost": 57
+            },
+            "secp256r1_get_point_from_x": {
+                "step_gas_cost": 510,
+                "range_check_gas_cost": 44,
+                "memory_hole_gas_cost": 20
+            },
+            "secp256r1_get_xy": {
+                "step_gas_cost": 241,
+                "range_check_gas_cost": 11,
+                "memory_hole_gas_cost": 40
+            },
+            "secp256r1_mul": {
+                "step_gas_cost": 125340,
+                "range_check_gas_cost": 13961,
+                "memory_hole_gas_cost": 2
+            },
+            "secp256r1_new": {
+                "step_gas_cost": 594,
+                "range_check_gas_cost": 49,
+                "memory_hole_gas_cost": 40
+            },
+            "keccak": {
+                "syscall_base_gas_cost": 1
+            },
+            "keccak_round_cost": 180000,
+            "sha256_process_block": {
+                "step_gas_cost": 0,
+                "range_check_gas_cost": 0,
+                "syscall_base_gas_cost": 0
+            }
         }
     },
     "os_resources": {
@@ -396,6 +446,11 @@
                     "range_check_builtin": 1
                 },
                 "n_memory_holes": 0
+            },
+            "GetClassHashAt": {
+                "n_steps": 0,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
             }
         },
         "execute_txs_inner": {
@@ -547,54 +602,58 @@
         }
     },
     "validate_max_n_steps": 1000000,
+    "validate_max_sierra_gas": 10000000000,
+    "min_compiler_version_for_sierra_gas": "2.8.0",
     "vm_resource_fee_cost": {
-        "add_mod_builtin": [
-            0,
-            1
-        ],
-        "bitwise_builtin": [
-            16,
-            100
-        ],
-        "ec_op_builtin": [
-            256,
-            100
-        ],
-        "ecdsa_builtin": [
-            512,
-            100
-        ],
-        "keccak_builtin": [
-            512,
-            100
-        ],
-        "mul_mod_builtin": [
-            0,
-            1
-        ],
+        "builtins": {
+            "add_mod_builtin": [
+                0,
+                1
+            ],
+            "bitwise_builtin": [
+                16,
+                100
+            ],
+            "ec_op_builtin": [
+                256,
+                100
+            ],
+            "ecdsa_builtin": [
+                512,
+                100
+            ],
+            "keccak_builtin": [
+                512,
+                100
+            ],
+            "mul_mod_builtin": [
+                0,
+                1
+            ],
+            "output_builtin": [
+                0,
+                1
+            ],
+            "pedersen_builtin": [
+                8,
+                100
+            ],
+            "poseidon_builtin": [
+                8,
+                100
+            ],
+            "range_check_builtin": [
+                4,
+                100
+            ],
+            "range_check96_builtin": [
+                0,
+                1
+            ]
+        },
         "n_steps": [
             25,
             10000
-        ],
-        "output_builtin": [
-            0,
-            1
-        ],
-        "pedersen_builtin": [
-            8,
-            100
-        ],
-        "poseidon_builtin": [
-            8,
-            100
-        ],
-        "range_check_builtin": [
-            4,
-            100
-        ],
-        "range_check96_builtin": [
-            0,
-            1
         ]
     }
 }

--- a/crates/executor/resources/versioned_constants_0_13_2.json
+++ b/crates/executor/resources/versioned_constants_0_13_2.json
@@ -9,7 +9,6 @@
         "max_contract_bytecode_size": 81920
     },
     "invoke_tx_max_n_steps": 10000000,
-    "execute_max_sierra_gas": 10000000000,
     "deprecated_l2_resource_gas_costs": {
         "gas_per_data_felt": [
             128,
@@ -58,7 +57,6 @@
     "max_recursion_depth": 50,
     "segment_arena_cells": false,
     "os_constants": {
-        "block_hash_contract_address": 1,
         "constructor_entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
         "default_entry_point_selector": 0,
         "entry_point_initial_budget": {
@@ -74,6 +72,7 @@
         "error_entry_point_failed": "ENTRYPOINT_FAILED",
         "error_entry_point_not_found": "ENTRYPOINT_NOT_FOUND",
         "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+        "execute_max_sierra_gas": 10000000000,
         "fee_transfer_gas_cost": {
             "entry_point_initial_budget": 1,
             "step_gas_cost": 600
@@ -93,30 +92,28 @@
             "alias_contract_address": 2,
             "reserved_contract_address": 3
         },
-        "range_check_gas_cost": 70,
-        "keccak_builtin_gas_cost": 0,
-        "pedersen_gas_cost": 0,
-        "bitwise_builtin_gas_cost": 594,
-        "ecop_gas_cost": 0,
-        "poseidon_gas_cost": 0,
-        "add_mod_gas_cost": 0,
-        "mul_mod_gas_cost": 0,
-        "ecdsa_gas_cost": 0,
+        "builtin_gas_costs": {
+            "range_check": 70,
+            "keccak": 0,
+            "pedersen": 0,
+            "bitwise": 594,
+            "ecop": 0,
+            "poseidon": 0,
+            "add_mod": 0,
+            "mul_mod": 0,
+            "ecdsa": 0
+        },
         "sierra_array_len_bound": 4294967296,
         "step_gas_cost": 100,
         "stored_block_hash_buffer": 10,
         "syscall_base_gas_cost": {
             "step_gas_cost": 100
         },
-        "transaction_gas_cost": {
-            "entry_point_initial_budget": 2,
-            "fee_transfer_gas_cost": 1,
-            "step_gas_cost": 1100
-        },
         "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "validate_declare_entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
         "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
         "validate_entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+        "validate_max_sierra_gas": 10000000000,
         "validate_rounding_consts": {
             "validate_block_number_rounding": 100,
             "validate_timestamp_rounding": 3600
@@ -156,8 +153,8 @@
             },
             "sha256_process_block": {
                 "step_gas_cost": 1852,
-                "range_check_gas_cost": 65,
-                "bitwise_builtin_gas_cost": 1115,
+                "range_check": 65,
+                "bitwise": 1115,
                 "syscall_base_gas_cost": 1
             },
             "replace_class": {
@@ -165,51 +162,51 @@
                 "syscall_base_gas_cost": 1
             },
             "secp256k1_add": {
-                "range_check_gas_cost": 29,
+                "range_check": 29,
                 "step_gas_cost": 406
             },
             "secp256k1_get_point_from_x": {
                 "memory_hole_gas_cost": 20,
-                "range_check_gas_cost": 30,
+                "range_check": 30,
                 "step_gas_cost": 391
             },
             "secp256k1_get_xy": {
                 "memory_hole_gas_cost": 40,
-                "range_check_gas_cost": 11,
+                "range_check": 11,
                 "step_gas_cost": 239
             },
             "secp256k1_mul": {
                 "memory_hole_gas_cost": 2,
-                "range_check_gas_cost": 7045,
+                "range_check": 7045,
                 "step_gas_cost": 76501
             },
             "secp256k1_new": {
                 "memory_hole_gas_cost": 40,
-                "range_check_gas_cost": 35,
+                "range_check": 35,
                 "step_gas_cost": 475
             },
             "secp256r1_add": {
-                "range_check_gas_cost": 57,
+                "range_check": 57,
                 "step_gas_cost": 589
             },
             "secp256r1_get_point_from_x": {
                 "memory_hole_gas_cost": 20,
-                "range_check_gas_cost": 44,
+                "range_check": 44,
                 "step_gas_cost": 510
             },
             "secp256r1_get_xy": {
                 "memory_hole_gas_cost": 40,
-                "range_check_gas_cost": 11,
+                "range_check": 11,
                 "step_gas_cost": 241
             },
             "secp256r1_mul": {
                 "memory_hole_gas_cost": 2,
-                "range_check_gas_cost": 13961,
+                "range_check": 13961,
                 "step_gas_cost": 125340
             },
             "secp256r1_new": {
                 "memory_hole_gas_cost": 40,
-                "range_check_gas_cost": 49,
+                "range_check": 49,
                 "step_gas_cost": 594
             },
             "send_message_to_l1": {
@@ -609,8 +606,7 @@
         }
     },
     "validate_max_n_steps": 1000000,
-    "validate_max_sierra_gas": 10000000000,
-    "min_compiler_version_for_sierra_gas": "2.8.0",
+    "min_sierra_version_for_sierra_gas": "100.0.0",
     "vm_resource_fee_cost": {
         "builtins": {
             "add_mod_builtin": [

--- a/crates/executor/resources/versioned_constants_0_13_2.json
+++ b/crates/executor/resources/versioned_constants_0_13_2.json
@@ -73,10 +73,6 @@
         "error_entry_point_not_found": "ENTRYPOINT_NOT_FOUND",
         "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
         "execute_max_sierra_gas": 10000000000,
-        "fee_transfer_gas_cost": {
-            "entry_point_initial_budget": 1,
-            "step_gas_cost": 600
-        },
         "default_initial_gas_cost": {
             "step_gas_cost": 100000000
         },
@@ -121,12 +117,10 @@
         "validated": "VALID",
         "syscall_gas_costs": {
             "call_contract": {
-                "entry_point_initial_budget": 1,
                 "step_gas_cost": 510,
                 "syscall_base_gas_cost": 1
             },
             "deploy": {
-                "entry_point_initial_budget": 1,
                 "step_gas_cost": 700,
                 "syscall_base_gas_cost": 1
             },
@@ -147,7 +141,6 @@
             },
             "keccak_round_cost": 180000,
             "library_call": {
-                "entry_point_initial_budget": 1,
                 "step_gas_cost": 510,
                 "syscall_base_gas_cost": 1
             },
@@ -320,13 +313,18 @@
                 "builtin_instance_counter": {},
                 "n_memory_holes": 0
             },
-            "Keccak": {
+            "KeccakRound": {
                 "n_steps": 381,
                 "builtin_instance_counter": {
                     "bitwise_builtin": 6,
                     "keccak_builtin": 1,
                     "range_check_builtin": 56
                 },
+                "n_memory_holes": 0
+            },
+            "Keccak": {
+                "n_steps": 0,
+                "builtin_instance_counter": {},
                 "n_memory_holes": 0
             },
             "LibraryCall": {

--- a/crates/executor/resources/versioned_constants_0_13_2.json
+++ b/crates/executor/resources/versioned_constants_0_13_2.json
@@ -9,7 +9,8 @@
         "max_contract_bytecode_size": 81920
     },
     "invoke_tx_max_n_steps": 10000000,
-    "l2_resource_gas_costs": {
+    "execute_max_sierra_gas": 10000000000,
+    "deprecated_l2_resource_gas_costs": {
         "gas_per_data_felt": [
             128,
             1000
@@ -23,31 +24,43 @@
             1000
         ]
     },
+    "archival_data_gas_costs": {
+        "gas_per_data_felt": [
+            5120,
+            1
+        ],
+        "event_key_factor": [
+            2,
+            1
+        ],
+        "gas_per_code_byte": [
+            35000,
+            1
+        ]
+    },
     "disable_cairo0_redeclaration": true,
+    "enable_stateful_compression": false,
+    "comprehensive_state_diff": false,
+    "allocation_cost": {
+        "blob_cost": {
+            "l1_gas": 0,
+            "l1_data_gas": 0,
+            "l2_gas": 0
+        },
+        "gas_cost": {
+            "l1_gas": 0,
+            "l1_data_gas": 0,
+            "l2_gas": 0
+        }
+    },
+    "ignore_inner_event_resources": false,
+    "enable_reverts": false,
     "max_recursion_depth": 50,
     "segment_arena_cells": false,
     "os_constants": {
         "block_hash_contract_address": 1,
-        "call_contract_gas_cost": {
-            "entry_point_gas_cost": 1,
-            "step_gas_cost": 10,
-            "syscall_base_gas_cost": 1
-        },
         "constructor_entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
         "default_entry_point_selector": 0,
-        "deploy_gas_cost": {
-            "entry_point_gas_cost": 1,
-            "step_gas_cost": 200,
-            "syscall_base_gas_cost": 1
-        },
-        "emit_event_gas_cost": {
-            "step_gas_cost": 10,
-            "syscall_base_gas_cost": 1
-        },
-        "entry_point_gas_cost": {
-            "entry_point_initial_budget": 1,
-            "step_gas_cost": 500
-        },
         "entry_point_initial_budget": {
             "step_gas_cost": 100
         },
@@ -58,118 +71,47 @@
         "error_invalid_input_len": "Invalid input length",
         "error_invalid_argument": "Invalid argument",
         "error_out_of_gas": "Out of gas",
+        "error_entry_point_failed": "ENTRYPOINT_FAILED",
+        "error_entry_point_not_found": "ENTRYPOINT_NOT_FOUND",
         "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
         "fee_transfer_gas_cost": {
-            "entry_point_gas_cost": 1,
-            "step_gas_cost": 100
+            "entry_point_initial_budget": 1,
+            "step_gas_cost": 600
         },
-        "get_block_hash_gas_cost": {
-            "step_gas_cost": 50,
-            "syscall_base_gas_cost": 1
-        },
-        "get_execution_info_gas_cost": {
-            "step_gas_cost": 10,
-            "syscall_base_gas_cost": 1
-        },
-        "initial_gas_cost": {
+        "default_initial_gas_cost": {
             "step_gas_cost": 100000000
         },
-        "keccak_gas_cost": {
-            "syscall_base_gas_cost": 1
-        },
-        "keccak_round_cost_gas_cost": 180000,
         "l1_gas": "L1_GAS",
         "l1_gas_index": 0,
         "l1_handler_version": 0,
         "l2_gas": "L2_GAS",
         "l2_gas_index": 1,
-        "library_call_gas_cost": {
-            "call_contract_gas_cost": 1
-        },
-        "sha256_process_block_gas_cost": {
-            "step_gas_cost": 1852,
-            "range_check_gas_cost": 65,
-            "bitwise_builtin_gas_cost": 1115,
-            "syscall_base_gas_cost": 1
-        },
         "memory_hole_gas_cost": 10,
         "nop_entry_point_offset": -1,
+        "os_contract_addresses": {
+            "block_hash_contract_address": 1,
+            "alias_contract_address": 2,
+            "reserved_contract_address": 3
+        },
         "range_check_gas_cost": 70,
+        "keccak_builtin_gas_cost": 0,
+        "pedersen_gas_cost": 0,
         "bitwise_builtin_gas_cost": 594,
-        "replace_class_gas_cost": {
-            "step_gas_cost": 50,
-            "syscall_base_gas_cost": 1
-        },
-        "secp256k1_add_gas_cost": {
-            "range_check_gas_cost": 29,
-            "step_gas_cost": 406
-        },
-        "secp256k1_get_point_from_x_gas_cost": {
-            "memory_hole_gas_cost": 20,
-            "range_check_gas_cost": 30,
-            "step_gas_cost": 391
-        },
-        "secp256k1_get_xy_gas_cost": {
-            "memory_hole_gas_cost": 40,
-            "range_check_gas_cost": 11,
-            "step_gas_cost": 239
-        },
-        "secp256k1_mul_gas_cost": {
-            "memory_hole_gas_cost": 2,
-            "range_check_gas_cost": 7045,
-            "step_gas_cost": 76501
-        },
-        "secp256k1_new_gas_cost": {
-            "memory_hole_gas_cost": 40,
-            "range_check_gas_cost": 35,
-            "step_gas_cost": 475
-        },
-        "secp256r1_add_gas_cost": {
-            "range_check_gas_cost": 57,
-            "step_gas_cost": 589
-        },
-        "secp256r1_get_point_from_x_gas_cost": {
-            "memory_hole_gas_cost": 20,
-            "range_check_gas_cost": 44,
-            "step_gas_cost": 510
-        },
-        "secp256r1_get_xy_gas_cost": {
-            "memory_hole_gas_cost": 40,
-            "range_check_gas_cost": 11,
-            "step_gas_cost": 241
-        },
-        "secp256r1_mul_gas_cost": {
-            "memory_hole_gas_cost": 2,
-            "range_check_gas_cost": 13961,
-            "step_gas_cost": 125340
-        },
-        "secp256r1_new_gas_cost": {
-            "memory_hole_gas_cost": 40,
-            "range_check_gas_cost": 49,
-            "step_gas_cost": 594
-        },
-        "send_message_to_l1_gas_cost": {
-            "step_gas_cost": 50,
-            "syscall_base_gas_cost": 1
-        },
+        "ecop_gas_cost": 0,
+        "poseidon_gas_cost": 0,
+        "add_mod_gas_cost": 0,
+        "mul_mod_gas_cost": 0,
+        "ecdsa_gas_cost": 0,
         "sierra_array_len_bound": 4294967296,
         "step_gas_cost": 100,
-        "storage_read_gas_cost": {
-            "step_gas_cost": 50,
-            "syscall_base_gas_cost": 1
-        },
-        "storage_write_gas_cost": {
-            "step_gas_cost": 50,
-            "syscall_base_gas_cost": 1
-        },
         "stored_block_hash_buffer": 10,
         "syscall_base_gas_cost": {
             "step_gas_cost": 100
         },
         "transaction_gas_cost": {
-            "entry_point_gas_cost": 2,
+            "entry_point_initial_budget": 2,
             "fee_transfer_gas_cost": 1,
-            "step_gas_cost": 100
+            "step_gas_cost": 1100
         },
         "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "validate_declare_entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
@@ -179,7 +121,114 @@
             "validate_block_number_rounding": 100,
             "validate_timestamp_rounding": 3600
         },
-        "validated": "VALID"
+        "validated": "VALID",
+        "syscall_gas_costs": {
+            "call_contract": {
+                "entry_point_initial_budget": 1,
+                "step_gas_cost": 510,
+                "syscall_base_gas_cost": 1
+            },
+            "deploy": {
+                "entry_point_initial_budget": 1,
+                "step_gas_cost": 700,
+                "syscall_base_gas_cost": 1
+            },
+            "emit_event": {
+                "step_gas_cost": 10,
+                "syscall_base_gas_cost": 1
+            },
+            "get_block_hash": {
+                "step_gas_cost": 50,
+                "syscall_base_gas_cost": 1
+            },
+            "get_execution_info": {
+                "step_gas_cost": 10,
+                "syscall_base_gas_cost": 1
+            },
+            "keccak": {
+                "syscall_base_gas_cost": 1
+            },
+            "keccak_round_cost": 180000,
+            "library_call": {
+                "entry_point_initial_budget": 1,
+                "step_gas_cost": 510,
+                "syscall_base_gas_cost": 1
+            },
+            "sha256_process_block": {
+                "step_gas_cost": 1852,
+                "range_check_gas_cost": 65,
+                "bitwise_builtin_gas_cost": 1115,
+                "syscall_base_gas_cost": 1
+            },
+            "replace_class": {
+                "step_gas_cost": 50,
+                "syscall_base_gas_cost": 1
+            },
+            "secp256k1_add": {
+                "range_check_gas_cost": 29,
+                "step_gas_cost": 406
+            },
+            "secp256k1_get_point_from_x": {
+                "memory_hole_gas_cost": 20,
+                "range_check_gas_cost": 30,
+                "step_gas_cost": 391
+            },
+            "secp256k1_get_xy": {
+                "memory_hole_gas_cost": 40,
+                "range_check_gas_cost": 11,
+                "step_gas_cost": 239
+            },
+            "secp256k1_mul": {
+                "memory_hole_gas_cost": 2,
+                "range_check_gas_cost": 7045,
+                "step_gas_cost": 76501
+            },
+            "secp256k1_new": {
+                "memory_hole_gas_cost": 40,
+                "range_check_gas_cost": 35,
+                "step_gas_cost": 475
+            },
+            "secp256r1_add": {
+                "range_check_gas_cost": 57,
+                "step_gas_cost": 589
+            },
+            "secp256r1_get_point_from_x": {
+                "memory_hole_gas_cost": 20,
+                "range_check_gas_cost": 44,
+                "step_gas_cost": 510
+            },
+            "secp256r1_get_xy": {
+                "memory_hole_gas_cost": 40,
+                "range_check_gas_cost": 11,
+                "step_gas_cost": 241
+            },
+            "secp256r1_mul": {
+                "memory_hole_gas_cost": 2,
+                "range_check_gas_cost": 13961,
+                "step_gas_cost": 125340
+            },
+            "secp256r1_new": {
+                "memory_hole_gas_cost": 40,
+                "range_check_gas_cost": 49,
+                "step_gas_cost": 594
+            },
+            "send_message_to_l1": {
+                "step_gas_cost": 50,
+                "syscall_base_gas_cost": 1
+            },
+            "storage_read": {
+                "step_gas_cost": 50,
+                "syscall_base_gas_cost": 1
+            },
+            "storage_write": {
+                "step_gas_cost": 50,
+                "syscall_base_gas_cost": 1
+            },
+            "get_class_hash_at": {
+                "step_gas_cost": 0,
+                "syscall_base_gas_cost": 0
+            }
+        }
     },
     "os_resources": {
         "execute_syscalls": {
@@ -402,6 +451,11 @@
                     "range_check_builtin": 1
                 },
                 "n_memory_holes": 0
+            },
+            "GetClassHashAt": {
+                "n_steps": 0,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
             }
         },
         "execute_txs_inner": {
@@ -555,54 +609,58 @@
         }
     },
     "validate_max_n_steps": 1000000,
+    "validate_max_sierra_gas": 10000000000,
+    "min_compiler_version_for_sierra_gas": "2.8.0",
     "vm_resource_fee_cost": {
-        "add_mod_builtin": [
-            4,
-            100
-        ],
-        "bitwise_builtin": [
-            16,
-            100
-        ],
-        "ec_op_builtin": [
-            256,
-            100
-        ],
-        "ecdsa_builtin": [
-            512,
-            100
-        ],
-        "keccak_builtin": [
-            512,
-            100
-        ],
-        "mul_mod_builtin": [
-            4,
-            100
-        ],
+        "builtins": {
+            "add_mod_builtin": [
+                4,
+                100
+            ],
+            "bitwise_builtin": [
+                16,
+                100
+            ],
+            "ec_op_builtin": [
+                256,
+                100
+            ],
+            "ecdsa_builtin": [
+                512,
+                100
+            ],
+            "keccak_builtin": [
+                512,
+                100
+            ],
+            "mul_mod_builtin": [
+                4,
+                100
+            ],
+            "output_builtin": [
+                0,
+                1
+            ],
+            "pedersen_builtin": [
+                8,
+                100
+            ],
+            "poseidon_builtin": [
+                8,
+                100
+            ],
+            "range_check_builtin": [
+                4,
+                100
+            ],
+            "range_check96_builtin": [
+                4,
+                100
+            ]
+        },
         "n_steps": [
             25,
             10000
-        ],
-        "output_builtin": [
-            0,
-            1
-        ],
-        "pedersen_builtin": [
-            8,
-            100
-        ],
-        "poseidon_builtin": [
-            8,
-            100
-        ],
-        "range_check_builtin": [
-            4,
-            100
-        ],
-        "range_check96_builtin": [
-            4,
-            100
         ]
     }
 }

--- a/crates/executor/resources/versioned_constants_0_13_2_1.json
+++ b/crates/executor/resources/versioned_constants_0_13_2_1.json
@@ -1,0 +1,666 @@
+{
+    "tx_event_limits": {
+        "max_data_length": 300,
+        "max_keys_length": 50,
+        "max_n_emitted_events": 1000
+    },
+    "gateway": {
+        "max_calldata_length": 5000,
+        "max_contract_bytecode_size": 81920
+    },
+    "invoke_tx_max_n_steps": 10000000,
+    "execute_max_sierra_gas": 10000000000,
+    "deprecated_l2_resource_gas_costs": {
+        "gas_per_data_felt": [
+            128,
+            1000
+        ],
+        "event_key_factor": [
+            2,
+            1
+        ],
+        "gas_per_code_byte": [
+            32,
+            1000
+        ]
+    },
+    "archival_data_gas_costs": {
+        "gas_per_data_felt": [
+            5120,
+            1
+        ],
+        "event_key_factor": [
+            2,
+            1
+        ],
+        "gas_per_code_byte": [
+            1280,
+            1
+        ]
+    },
+    "disable_cairo0_redeclaration": true,
+    "enable_stateful_compression": false,
+    "comprehensive_state_diff": false,
+    "allocation_cost": {
+        "blob_cost": {
+            "l1_gas": 0,
+            "l1_data_gas": 0,
+            "l2_gas": 0
+        },
+        "gas_cost": {
+            "l1_gas": 0,
+            "l1_data_gas": 0,
+            "l2_gas": 0
+        }
+    },
+    "ignore_inner_event_resources": false,
+    "max_recursion_depth": 50,
+    "enable_reverts": false,
+    "segment_arena_cells": false,
+    "os_constants": {
+        "block_hash_contract_address": 1,
+        "constructor_entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+        "default_entry_point_selector": 0,
+        "entry_point_initial_budget": {
+            "step_gas_cost": 100
+        },
+        "entry_point_type_constructor": 2,
+        "entry_point_type_external": 0,
+        "entry_point_type_l1_handler": 1,
+        "error_block_number_out_of_range": "Block number out of range",
+        "error_invalid_input_len": "Invalid input length",
+        "error_invalid_argument": "Invalid argument",
+        "error_out_of_gas": "Out of gas",
+        "error_entry_point_failed": "ENTRYPOINT_FAILED",
+        "error_entry_point_not_found": "ENTRYPOINT_NOT_FOUND",
+        "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+        "fee_transfer_gas_cost": {
+            "entry_point_initial_budget": 1,
+            "step_gas_cost": 600
+        },
+        "default_initial_gas_cost": {
+            "step_gas_cost": 100000000
+        },
+        "l1_gas": "L1_GAS",
+        "l1_gas_index": 0,
+        "l1_handler_version": 0,
+        "l2_gas": "L2_GAS",
+        "l2_gas_index": 1,
+        "memory_hole_gas_cost": 10,
+        "nop_entry_point_offset": -1,
+        "os_contract_addresses": {
+            "block_hash_contract_address": 1,
+            "alias_contract_address": 2,
+            "reserved_contract_address": 3
+        },
+        "range_check_gas_cost": 70,
+        "keccak_builtin_gas_cost": 0,
+        "pedersen_gas_cost": 0,
+        "bitwise_builtin_gas_cost": 594,
+        "ecop_gas_cost": 0,
+        "poseidon_gas_cost": 0,
+        "add_mod_gas_cost": 0,
+        "mul_mod_gas_cost": 0,
+        "ecdsa_gas_cost": 0,
+        "sierra_array_len_bound": 4294967296,
+        "step_gas_cost": 100,
+        "stored_block_hash_buffer": 10,
+        "syscall_base_gas_cost": {
+            "step_gas_cost": 100
+        },
+        "transaction_gas_cost": {
+            "entry_point_initial_budget": 2,
+            "fee_transfer_gas_cost": 1,
+            "step_gas_cost": 1100
+        },
+        "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+        "validate_declare_entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
+        "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
+        "validate_entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+        "validate_rounding_consts": {
+            "validate_block_number_rounding": 100,
+            "validate_timestamp_rounding": 3600
+        },
+        "validated": "VALID",
+        "syscall_gas_costs": {
+            "call_contract": {
+                "entry_point_initial_budget": 1,
+                "step_gas_cost": 510,
+                "syscall_base_gas_cost": 1
+            },
+            "deploy": {
+                "entry_point_initial_budget": 1,
+                "step_gas_cost": 700,
+                "syscall_base_gas_cost": 1
+            },
+            "emit_event": {
+                "step_gas_cost": 10,
+                "syscall_base_gas_cost": 1
+            },
+            "get_block_hash": {
+                "step_gas_cost": 50,
+                "syscall_base_gas_cost": 1
+            },
+            "get_execution_info": {
+                "step_gas_cost": 10,
+                "syscall_base_gas_cost": 1
+            },
+            "keccak": {
+                "syscall_base_gas_cost": 1
+            },
+            "keccak_round_cost": 180000,
+            "library_call": {
+                "entry_point_initial_budget": 1,
+                "step_gas_cost": 510,
+                "syscall_base_gas_cost": 1
+            },
+            "sha256_process_block": {
+                "step_gas_cost": 1852,
+                "range_check_gas_cost": 65,
+                "bitwise_builtin_gas_cost": 1115,
+                "syscall_base_gas_cost": 1
+            },
+            "replace_class": {
+                "step_gas_cost": 50,
+                "syscall_base_gas_cost": 1
+            },
+            "secp256k1_add": {
+                "range_check_gas_cost": 29,
+                "step_gas_cost": 406
+            },
+            "secp256k1_get_point_from_x": {
+                "memory_hole_gas_cost": 20,
+                "range_check_gas_cost": 30,
+                "step_gas_cost": 391
+            },
+            "secp256k1_get_xy": {
+                "memory_hole_gas_cost": 40,
+                "range_check_gas_cost": 11,
+                "step_gas_cost": 239
+            },
+            "secp256k1_mul": {
+                "memory_hole_gas_cost": 2,
+                "range_check_gas_cost": 7045,
+                "step_gas_cost": 76501
+            },
+            "secp256k1_new": {
+                "memory_hole_gas_cost": 40,
+                "range_check_gas_cost": 35,
+                "step_gas_cost": 475
+            },
+            "secp256r1_add": {
+                "range_check_gas_cost": 57,
+                "step_gas_cost": 589
+            },
+            "secp256r1_get_point_from_x": {
+                "memory_hole_gas_cost": 20,
+                "range_check_gas_cost": 44,
+                "step_gas_cost": 510
+            },
+            "secp256r1_get_xy": {
+                "memory_hole_gas_cost": 40,
+                "range_check_gas_cost": 11,
+                "step_gas_cost": 241
+            },
+            "secp256r1_mul": {
+                "memory_hole_gas_cost": 2,
+                "range_check_gas_cost": 13961,
+                "step_gas_cost": 125340
+            },
+            "secp256r1_new": {
+                "memory_hole_gas_cost": 40,
+                "range_check_gas_cost": 49,
+                "step_gas_cost": 594
+            },
+            "send_message_to_l1": {
+                "step_gas_cost": 50,
+                "syscall_base_gas_cost": 1
+            },
+            "storage_read": {
+                "step_gas_cost": 50,
+                "syscall_base_gas_cost": 1
+            },
+            "storage_write": {
+                "step_gas_cost": 50,
+                "syscall_base_gas_cost": 1
+            },
+            "get_class_hash_at": {
+                "step_gas_cost": 0,
+                "syscall_base_gas_cost": 0
+            }
+        }
+    },
+    "os_resources": {
+        "execute_syscalls": {
+            "CallContract": {
+                "n_steps": 827,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 15
+                },
+                "n_memory_holes": 0
+            },
+            "DelegateCall": {
+                "n_steps": 713,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 19
+                },
+                "n_memory_holes": 0
+            },
+            "DelegateL1Handler": {
+                "n_steps": 692,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 15
+                },
+                "n_memory_holes": 0
+            },
+            "Deploy": {
+                "n_steps": 1097,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 7,
+                    "range_check_builtin": 18
+                },
+                "n_memory_holes": 0
+            },
+            "EmitEvent": {
+                "n_steps": 61,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "GetBlockHash": {
+                "n_steps": 104,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 2
+                },
+                "n_memory_holes": 0
+            },
+            "GetBlockNumber": {
+                "n_steps": 40,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            },
+            "GetBlockTimestamp": {
+                "n_steps": 38,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            },
+            "GetCallerAddress": {
+                "n_steps": 64,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "GetContractAddress": {
+                "n_steps": 64,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "GetExecutionInfo": {
+                "n_steps": 64,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "GetSequencerAddress": {
+                "n_steps": 34,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            },
+            "GetTxInfo": {
+                "n_steps": 64,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "GetTxSignature": {
+                "n_steps": 44,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            },
+            "Keccak": {
+                "n_steps": 381,
+                "builtin_instance_counter": {
+                    "bitwise_builtin": 6,
+                    "keccak_builtin": 1,
+                    "range_check_builtin": 56
+                },
+                "n_memory_holes": 0
+            },
+            "LibraryCall": {
+                "n_steps": 818,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 15
+                },
+                "n_memory_holes": 0
+            },
+            "LibraryCallL1Handler": {
+                "n_steps": 659,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 15
+                },
+                "n_memory_holes": 0
+            },
+            "ReplaceClass": {
+                "n_steps": 98,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256k1Add": {
+                "n_steps": 410,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 29
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256k1GetPointFromX": {
+                "n_steps": 395,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 30
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256k1GetXy": {
+                "n_steps": 207,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 11
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256k1Mul": {
+                "n_steps": 76505,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 7045
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256k1New": {
+                "n_steps": 461,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 35
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256r1Add": {
+                "n_steps": 593,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 57
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256r1GetPointFromX": {
+                "n_steps": 514,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 44
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256r1GetXy": {
+                "n_steps": 209,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 11
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256r1Mul": {
+                "n_steps": 125344,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 13961
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256r1New": {
+                "n_steps": 580,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 49
+                },
+                "n_memory_holes": 0
+            },
+            "SendMessageToL1": {
+                "n_steps": 141,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "Sha256ProcessBlock": {
+                "n_steps": 1855,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 65,
+                    "bitwise_builtin": 1115
+                },
+                "n_memory_holes": 0
+            },
+            "StorageRead": {
+                "n_steps": 87,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "StorageWrite": {
+                "n_steps": 89,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "GetClassHashAt": {
+                "n_steps": 0,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            }
+        },
+        "execute_txs_inner": {
+            "Declare": {
+                "deprecated_resources": {
+                    "constant": {
+                        "n_steps": 2973,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 16,
+                            "range_check_builtin": 53
+                        },
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 0,
+                        "builtin_instance_counter": {},
+                        "n_memory_holes": 0
+                    }
+                },
+                "resources": {
+                    "constant": {
+                        "n_steps": 3079,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 4,
+                            "range_check_builtin": 58,
+                            "poseidon_builtin": 10
+                        },
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 0,
+                        "builtin_instance_counter": {},
+                        "n_memory_holes": 0
+                    }
+                }
+            },
+            "DeployAccount": {
+                "deprecated_resources": {
+                    "constant": {
+                        "n_steps": 4015,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 23,
+                            "range_check_builtin": 72
+                        },
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 21,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 2
+                        },
+                        "n_memory_holes": 0
+                    }
+                },
+                "resources": {
+                    "constant": {
+                        "n_steps": 4137,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 11,
+                            "range_check_builtin": 77,
+                            "poseidon_builtin": 10
+                        },
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 21,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 2
+                        },
+                        "n_memory_holes": 0
+                    }
+                }
+            },
+            "InvokeFunction": {
+                "deprecated_resources": {
+                    "constant": {
+                        "n_steps": 3763,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 14,
+                            "range_check_builtin": 69
+                        },
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 8,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 1
+                        },
+                        "n_memory_holes": 0
+                    }
+                },
+                "resources": {
+                    "constant": {
+                        "n_steps": 3904,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 4,
+                            "range_check_builtin": 74,
+                            "poseidon_builtin": 11
+                        },
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 8,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 1
+                        },
+                        "n_memory_holes": 0
+                    }
+                }
+            },
+            "L1Handler": {
+                "deprecated_resources": {
+                    "constant": {
+                        "n_steps": 1233,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 11,
+                            "range_check_builtin": 16
+                        },
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 13,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 1
+                        },
+                        "n_memory_holes": 0
+                    }
+                },
+                "resources": {
+                    "constant": {
+                        "n_steps": 0,
+                        "builtin_instance_counter": {},
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 13,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 1
+                        },
+                        "n_memory_holes": 0
+                    }
+                }
+            }
+        },
+        "compute_os_kzg_commitment_info": {
+            "n_steps": 113,
+            "builtin_instance_counter": {
+                "range_check_builtin": 17
+            },
+            "n_memory_holes": 0
+        }
+    },
+    "validate_max_n_steps": 1000000,
+    "validate_max_sierra_gas": 10000000000,
+    "min_compiler_version_for_sierra_gas": "2.8.0",
+    "vm_resource_fee_cost": {
+        "builtins": {
+            "add_mod_builtin": [
+                4,
+                100
+            ],
+            "bitwise_builtin": [
+                16,
+                100
+            ],
+            "ec_op_builtin": [
+                256,
+                100
+            ],
+            "ecdsa_builtin": [
+                512,
+                100
+            ],
+            "keccak_builtin": [
+                512,
+                100
+            ],
+            "mul_mod_builtin": [
+                4,
+                100
+            ],
+            "output_builtin": [
+                0,
+                1
+            ],
+            "pedersen_builtin": [
+                8,
+                100
+            ],
+            "poseidon_builtin": [
+                8,
+                100
+            ],
+            "range_check_builtin": [
+                4,
+                100
+            ],
+            "range_check96_builtin": [
+                4,
+                100
+            ]
+        },
+        "n_steps": [
+            25,
+            10000
+        ]
+    }
+}

--- a/crates/executor/resources/versioned_constants_0_13_2_1.json
+++ b/crates/executor/resources/versioned_constants_0_13_2_1.json
@@ -73,10 +73,6 @@
         "error_entry_point_not_found": "ENTRYPOINT_NOT_FOUND",
         "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
         "execute_max_sierra_gas": 10000000000,
-        "fee_transfer_gas_cost": {
-            "entry_point_initial_budget": 1,
-            "step_gas_cost": 600
-        },
         "default_initial_gas_cost": {
             "step_gas_cost": 100000000
         },
@@ -121,12 +117,10 @@
         "validated": "VALID",
         "syscall_gas_costs": {
             "call_contract": {
-                "entry_point_initial_budget": 1,
                 "step_gas_cost": 510,
                 "syscall_base_gas_cost": 1
             },
             "deploy": {
-                "entry_point_initial_budget": 1,
                 "step_gas_cost": 700,
                 "syscall_base_gas_cost": 1
             },
@@ -147,7 +141,6 @@
             },
             "keccak_round_cost": 180000,
             "library_call": {
-                "entry_point_initial_budget": 1,
                 "step_gas_cost": 510,
                 "syscall_base_gas_cost": 1
             },
@@ -320,13 +313,18 @@
                 "builtin_instance_counter": {},
                 "n_memory_holes": 0
             },
-            "Keccak": {
+            "KeccakRound": {
                 "n_steps": 381,
                 "builtin_instance_counter": {
                     "bitwise_builtin": 6,
                     "keccak_builtin": 1,
                     "range_check_builtin": 56
                 },
+                "n_memory_holes": 0
+            },
+            "Keccak": {
+                "n_steps": 0,
+                "builtin_instance_counter": {},
                 "n_memory_holes": 0
             },
             "LibraryCall": {

--- a/crates/executor/resources/versioned_constants_0_13_3.json
+++ b/crates/executor/resources/versioned_constants_0_13_3.json
@@ -9,7 +9,6 @@
         "max_contract_bytecode_size": 81920
     },
     "invoke_tx_max_n_steps": 10000000,
-    "execute_max_sierra_gas": 10000000000,
     "deprecated_l2_resource_gas_costs": {
         "gas_per_data_felt": [
             128,
@@ -58,7 +57,6 @@
     "enable_reverts": false,
     "segment_arena_cells": false,
     "os_constants": {
-        "block_hash_contract_address": 1,
         "constructor_entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
         "default_entry_point_selector": 0,
         "entry_point_initial_budget": {
@@ -74,6 +72,7 @@
         "error_entry_point_failed": "ENTRYPOINT_FAILED",
         "error_entry_point_not_found": "ENTRYPOINT_NOT_FOUND",
         "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+        "execute_max_sierra_gas": 10000000000,
         "fee_transfer_gas_cost": {
             "entry_point_initial_budget": 1,
             "step_gas_cost": 600
@@ -93,30 +92,28 @@
             "alias_contract_address": 2,
             "reserved_contract_address": 3
         },
-        "range_check_gas_cost": 70,
-        "keccak_builtin_gas_cost": 0,
-        "pedersen_gas_cost": 0,
-        "bitwise_builtin_gas_cost": 594,
-        "ecop_gas_cost": 0,
-        "poseidon_gas_cost": 0,
-        "add_mod_gas_cost": 0,
-        "mul_mod_gas_cost": 0,
-        "ecdsa_gas_cost": 0,
+        "builtin_gas_costs": {
+            "range_check": 70,
+            "keccak": 0,
+            "pedersen": 0,
+            "bitwise": 594,
+            "ecop": 0,
+            "poseidon": 0,
+            "add_mod": 0,
+            "mul_mod": 0,
+            "ecdsa": 0
+        },
         "sierra_array_len_bound": 4294967296,
         "step_gas_cost": 100,
         "stored_block_hash_buffer": 10,
         "syscall_base_gas_cost": {
             "step_gas_cost": 100
         },
-        "transaction_gas_cost": {
-            "entry_point_initial_budget": 2,
-            "fee_transfer_gas_cost": 1,
-            "step_gas_cost": 1100
-        },
         "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "validate_declare_entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
         "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
         "validate_entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+        "validate_max_sierra_gas": 10000000000,
         "validate_rounding_consts": {
             "validate_block_number_rounding": 100,
             "validate_timestamp_rounding": 3600
@@ -156,8 +153,8 @@
             },
             "sha256_process_block": {
                 "step_gas_cost": 1852,
-                "range_check_gas_cost": 65,
-                "bitwise_builtin_gas_cost": 1115,
+                "range_check": 65,
+                "bitwise": 1115,
                 "syscall_base_gas_cost": 1
             },
             "replace_class": {
@@ -165,51 +162,51 @@
                 "syscall_base_gas_cost": 1
             },
             "secp256k1_add": {
-                "range_check_gas_cost": 29,
+                "range_check": 29,
                 "step_gas_cost": 406
             },
             "secp256k1_get_point_from_x": {
                 "memory_hole_gas_cost": 20,
-                "range_check_gas_cost": 30,
+                "range_check": 30,
                 "step_gas_cost": 391
             },
             "secp256k1_get_xy": {
                 "memory_hole_gas_cost": 40,
-                "range_check_gas_cost": 11,
+                "range_check": 11,
                 "step_gas_cost": 239
             },
             "secp256k1_mul": {
                 "memory_hole_gas_cost": 2,
-                "range_check_gas_cost": 7045,
+                "range_check": 7045,
                 "step_gas_cost": 76501
             },
             "secp256k1_new": {
                 "memory_hole_gas_cost": 40,
-                "range_check_gas_cost": 35,
+                "range_check": 35,
                 "step_gas_cost": 475
             },
             "secp256r1_add": {
-                "range_check_gas_cost": 57,
+                "range_check": 57,
                 "step_gas_cost": 589
             },
             "secp256r1_get_point_from_x": {
                 "memory_hole_gas_cost": 20,
-                "range_check_gas_cost": 44,
+                "range_check": 44,
                 "step_gas_cost": 510
             },
             "secp256r1_get_xy": {
                 "memory_hole_gas_cost": 40,
-                "range_check_gas_cost": 11,
+                "range_check": 11,
                 "step_gas_cost": 241
             },
             "secp256r1_mul": {
                 "memory_hole_gas_cost": 2,
-                "range_check_gas_cost": 13961,
+                "range_check": 13961,
                 "step_gas_cost": 125340
             },
             "secp256r1_new": {
                 "memory_hole_gas_cost": 40,
-                "range_check_gas_cost": 49,
+                "range_check": 49,
                 "step_gas_cost": 594
             },
             "send_message_to_l1": {
@@ -609,8 +606,7 @@
         }
     },
     "validate_max_n_steps": 1000000,
-    "validate_max_sierra_gas": 10000000000,
-    "min_compiler_version_for_sierra_gas": "2.8.0",
+    "min_sierra_version_for_sierra_gas": "100.0.0",
     "vm_resource_fee_cost": {
         "builtins": {
             "add_mod_builtin": [

--- a/crates/executor/resources/versioned_constants_0_13_3.json
+++ b/crates/executor/resources/versioned_constants_0_13_3.json
@@ -1,0 +1,666 @@
+{
+    "tx_event_limits": {
+        "max_data_length": 300,
+        "max_keys_length": 50,
+        "max_n_emitted_events": 1000
+    },
+    "gateway": {
+        "max_calldata_length": 5000,
+        "max_contract_bytecode_size": 81920
+    },
+    "invoke_tx_max_n_steps": 10000000,
+    "execute_max_sierra_gas": 10000000000,
+    "deprecated_l2_resource_gas_costs": {
+        "gas_per_data_felt": [
+            128,
+            1000
+        ],
+        "event_key_factor": [
+            2,
+            1
+        ],
+        "gas_per_code_byte": [
+            32,
+            1000
+        ]
+    },
+    "archival_data_gas_costs": {
+        "gas_per_data_felt": [
+            5120,
+            1
+        ],
+        "event_key_factor": [
+            2,
+            1
+        ],
+        "gas_per_code_byte": [
+            1280,
+            1
+        ]
+    },
+    "disable_cairo0_redeclaration": true,
+    "enable_stateful_compression": false,
+    "comprehensive_state_diff": false,
+    "allocation_cost": {
+        "blob_cost": {
+            "l1_gas": 0,
+            "l1_data_gas": 0,
+            "l2_gas": 0
+        },
+        "gas_cost": {
+            "l1_gas": 0,
+            "l1_data_gas": 0,
+            "l2_gas": 0
+        }
+    },
+    "ignore_inner_event_resources": false,
+    "max_recursion_depth": 50,
+    "enable_reverts": false,
+    "segment_arena_cells": false,
+    "os_constants": {
+        "block_hash_contract_address": 1,
+        "constructor_entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+        "default_entry_point_selector": 0,
+        "entry_point_initial_budget": {
+            "step_gas_cost": 100
+        },
+        "entry_point_type_constructor": 2,
+        "entry_point_type_external": 0,
+        "entry_point_type_l1_handler": 1,
+        "error_block_number_out_of_range": "Block number out of range",
+        "error_invalid_input_len": "Invalid input length",
+        "error_invalid_argument": "Invalid argument",
+        "error_out_of_gas": "Out of gas",
+        "error_entry_point_failed": "ENTRYPOINT_FAILED",
+        "error_entry_point_not_found": "ENTRYPOINT_NOT_FOUND",
+        "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+        "fee_transfer_gas_cost": {
+            "entry_point_initial_budget": 1,
+            "step_gas_cost": 600
+        },
+        "default_initial_gas_cost": {
+            "step_gas_cost": 100000000
+        },
+        "l1_gas": "L1_GAS",
+        "l1_gas_index": 0,
+        "l1_handler_version": 0,
+        "l2_gas": "L2_GAS",
+        "l2_gas_index": 1,
+        "memory_hole_gas_cost": 10,
+        "nop_entry_point_offset": -1,
+        "os_contract_addresses": {
+            "block_hash_contract_address": 1,
+            "alias_contract_address": 2,
+            "reserved_contract_address": 3
+        },
+        "range_check_gas_cost": 70,
+        "keccak_builtin_gas_cost": 0,
+        "pedersen_gas_cost": 0,
+        "bitwise_builtin_gas_cost": 594,
+        "ecop_gas_cost": 0,
+        "poseidon_gas_cost": 0,
+        "add_mod_gas_cost": 0,
+        "mul_mod_gas_cost": 0,
+        "ecdsa_gas_cost": 0,
+        "sierra_array_len_bound": 4294967296,
+        "step_gas_cost": 100,
+        "stored_block_hash_buffer": 10,
+        "syscall_base_gas_cost": {
+            "step_gas_cost": 100
+        },
+        "transaction_gas_cost": {
+            "entry_point_initial_budget": 2,
+            "fee_transfer_gas_cost": 1,
+            "step_gas_cost": 1100
+        },
+        "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+        "validate_declare_entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
+        "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
+        "validate_entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+        "validate_rounding_consts": {
+            "validate_block_number_rounding": 100,
+            "validate_timestamp_rounding": 3600
+        },
+        "validated": "VALID",
+        "syscall_gas_costs": {
+            "call_contract": {
+                "entry_point_initial_budget": 1,
+                "step_gas_cost": 510,
+                "syscall_base_gas_cost": 1
+            },
+            "deploy": {
+                "entry_point_initial_budget": 1,
+                "step_gas_cost": 700,
+                "syscall_base_gas_cost": 1
+            },
+            "emit_event": {
+                "step_gas_cost": 10,
+                "syscall_base_gas_cost": 1
+            },
+            "get_block_hash": {
+                "step_gas_cost": 50,
+                "syscall_base_gas_cost": 1
+            },
+            "get_execution_info": {
+                "step_gas_cost": 10,
+                "syscall_base_gas_cost": 1
+            },
+            "keccak": {
+                "syscall_base_gas_cost": 1
+            },
+            "keccak_round_cost": 180000,
+            "library_call": {
+                "entry_point_initial_budget": 1,
+                "step_gas_cost": 510,
+                "syscall_base_gas_cost": 1
+            },
+            "sha256_process_block": {
+                "step_gas_cost": 1852,
+                "range_check_gas_cost": 65,
+                "bitwise_builtin_gas_cost": 1115,
+                "syscall_base_gas_cost": 1
+            },
+            "replace_class": {
+                "step_gas_cost": 50,
+                "syscall_base_gas_cost": 1
+            },
+            "secp256k1_add": {
+                "range_check_gas_cost": 29,
+                "step_gas_cost": 406
+            },
+            "secp256k1_get_point_from_x": {
+                "memory_hole_gas_cost": 20,
+                "range_check_gas_cost": 30,
+                "step_gas_cost": 391
+            },
+            "secp256k1_get_xy": {
+                "memory_hole_gas_cost": 40,
+                "range_check_gas_cost": 11,
+                "step_gas_cost": 239
+            },
+            "secp256k1_mul": {
+                "memory_hole_gas_cost": 2,
+                "range_check_gas_cost": 7045,
+                "step_gas_cost": 76501
+            },
+            "secp256k1_new": {
+                "memory_hole_gas_cost": 40,
+                "range_check_gas_cost": 35,
+                "step_gas_cost": 475
+            },
+            "secp256r1_add": {
+                "range_check_gas_cost": 57,
+                "step_gas_cost": 589
+            },
+            "secp256r1_get_point_from_x": {
+                "memory_hole_gas_cost": 20,
+                "range_check_gas_cost": 44,
+                "step_gas_cost": 510
+            },
+            "secp256r1_get_xy": {
+                "memory_hole_gas_cost": 40,
+                "range_check_gas_cost": 11,
+                "step_gas_cost": 241
+            },
+            "secp256r1_mul": {
+                "memory_hole_gas_cost": 2,
+                "range_check_gas_cost": 13961,
+                "step_gas_cost": 125340
+            },
+            "secp256r1_new": {
+                "memory_hole_gas_cost": 40,
+                "range_check_gas_cost": 49,
+                "step_gas_cost": 594
+            },
+            "send_message_to_l1": {
+                "step_gas_cost": 50,
+                "syscall_base_gas_cost": 1
+            },
+            "storage_read": {
+                "step_gas_cost": 50,
+                "syscall_base_gas_cost": 1
+            },
+            "storage_write": {
+                "step_gas_cost": 50,
+                "syscall_base_gas_cost": 1
+            },
+            "get_class_hash_at": {
+                "step_gas_cost": 0,
+                "syscall_base_gas_cost": 0
+            }
+        }
+    },
+    "os_resources": {
+        "execute_syscalls": {
+            "CallContract": {
+                "n_steps": 827,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 15
+                },
+                "n_memory_holes": 0
+            },
+            "DelegateCall": {
+                "n_steps": 713,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 19
+                },
+                "n_memory_holes": 0
+            },
+            "DelegateL1Handler": {
+                "n_steps": 692,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 15
+                },
+                "n_memory_holes": 0
+            },
+            "Deploy": {
+                "n_steps": 1097,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 7,
+                    "range_check_builtin": 18
+                },
+                "n_memory_holes": 0
+            },
+            "EmitEvent": {
+                "n_steps": 61,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "GetBlockHash": {
+                "n_steps": 104,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 2
+                },
+                "n_memory_holes": 0
+            },
+            "GetBlockNumber": {
+                "n_steps": 40,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            },
+            "GetBlockTimestamp": {
+                "n_steps": 38,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            },
+            "GetCallerAddress": {
+                "n_steps": 64,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "GetContractAddress": {
+                "n_steps": 64,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "GetExecutionInfo": {
+                "n_steps": 64,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "GetSequencerAddress": {
+                "n_steps": 34,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            },
+            "GetTxInfo": {
+                "n_steps": 64,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "GetTxSignature": {
+                "n_steps": 44,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            },
+            "Keccak": {
+                "n_steps": 381,
+                "builtin_instance_counter": {
+                    "bitwise_builtin": 6,
+                    "keccak_builtin": 1,
+                    "range_check_builtin": 56
+                },
+                "n_memory_holes": 0
+            },
+            "LibraryCall": {
+                "n_steps": 818,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 15
+                },
+                "n_memory_holes": 0
+            },
+            "LibraryCallL1Handler": {
+                "n_steps": 659,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 15
+                },
+                "n_memory_holes": 0
+            },
+            "ReplaceClass": {
+                "n_steps": 98,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256k1Add": {
+                "n_steps": 410,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 29
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256k1GetPointFromX": {
+                "n_steps": 395,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 30
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256k1GetXy": {
+                "n_steps": 207,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 11
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256k1Mul": {
+                "n_steps": 76505,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 7045
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256k1New": {
+                "n_steps": 461,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 35
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256r1Add": {
+                "n_steps": 593,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 57
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256r1GetPointFromX": {
+                "n_steps": 514,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 44
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256r1GetXy": {
+                "n_steps": 209,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 11
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256r1Mul": {
+                "n_steps": 125344,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 13961
+                },
+                "n_memory_holes": 0
+            },
+            "Secp256r1New": {
+                "n_steps": 580,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 49
+                },
+                "n_memory_holes": 0
+            },
+            "SendMessageToL1": {
+                "n_steps": 141,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "Sha256ProcessBlock": {
+                "n_steps": 1855,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 65,
+                    "bitwise_builtin": 1115
+                },
+                "n_memory_holes": 0
+            },
+            "StorageRead": {
+                "n_steps": 87,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "StorageWrite": {
+                "n_steps": 89,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
+                "n_memory_holes": 0
+            },
+            "GetClassHashAt": {
+                "n_steps": 0,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
+            }
+        },
+        "execute_txs_inner": {
+            "Declare": {
+                "deprecated_resources": {
+                    "constant": {
+                        "n_steps": 2973,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 16,
+                            "range_check_builtin": 53
+                        },
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 0,
+                        "builtin_instance_counter": {},
+                        "n_memory_holes": 0
+                    }
+                },
+                "resources": {
+                    "constant": {
+                        "n_steps": 3079,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 4,
+                            "range_check_builtin": 58,
+                            "poseidon_builtin": 10
+                        },
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 0,
+                        "builtin_instance_counter": {},
+                        "n_memory_holes": 0
+                    }
+                }
+            },
+            "DeployAccount": {
+                "deprecated_resources": {
+                    "constant": {
+                        "n_steps": 4015,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 23,
+                            "range_check_builtin": 72
+                        },
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 21,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 2
+                        },
+                        "n_memory_holes": 0
+                    }
+                },
+                "resources": {
+                    "constant": {
+                        "n_steps": 4137,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 11,
+                            "range_check_builtin": 77,
+                            "poseidon_builtin": 10
+                        },
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 21,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 2
+                        },
+                        "n_memory_holes": 0
+                    }
+                }
+            },
+            "InvokeFunction": {
+                "deprecated_resources": {
+                    "constant": {
+                        "n_steps": 3763,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 14,
+                            "range_check_builtin": 69
+                        },
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 8,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 1
+                        },
+                        "n_memory_holes": 0
+                    }
+                },
+                "resources": {
+                    "constant": {
+                        "n_steps": 3904,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 4,
+                            "range_check_builtin": 74,
+                            "poseidon_builtin": 11
+                        },
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 8,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 1
+                        },
+                        "n_memory_holes": 0
+                    }
+                }
+            },
+            "L1Handler": {
+                "deprecated_resources": {
+                    "constant": {
+                        "n_steps": 1233,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 11,
+                            "range_check_builtin": 16
+                        },
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 13,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 1
+                        },
+                        "n_memory_holes": 0
+                    }
+                },
+                "resources": {
+                    "constant": {
+                        "n_steps": 0,
+                        "builtin_instance_counter": {},
+                        "n_memory_holes": 0
+                    },
+                    "calldata_factor": {
+                        "n_steps": 13,
+                        "builtin_instance_counter": {
+                            "pedersen_builtin": 1
+                        },
+                        "n_memory_holes": 0
+                    }
+                }
+            }
+        },
+        "compute_os_kzg_commitment_info": {
+            "n_steps": 113,
+            "builtin_instance_counter": {
+                "range_check_builtin": 17
+            },
+            "n_memory_holes": 0
+        }
+    },
+    "validate_max_n_steps": 1000000,
+    "validate_max_sierra_gas": 10000000000,
+    "min_compiler_version_for_sierra_gas": "2.8.0",
+    "vm_resource_fee_cost": {
+        "builtins": {
+            "add_mod_builtin": [
+                4,
+                100
+            ],
+            "bitwise_builtin": [
+                16,
+                100
+            ],
+            "ec_op_builtin": [
+                256,
+                100
+            ],
+            "ecdsa_builtin": [
+                512,
+                100
+            ],
+            "keccak_builtin": [
+                512,
+                100
+            ],
+            "mul_mod_builtin": [
+                4,
+                100
+            ],
+            "output_builtin": [
+                0,
+                1
+            ],
+            "pedersen_builtin": [
+                8,
+                100
+            ],
+            "poseidon_builtin": [
+                8,
+                100
+            ],
+            "range_check_builtin": [
+                4,
+                100
+            ],
+            "range_check96_builtin": [
+                4,
+                100
+            ]
+        },
+        "n_steps": [
+            25,
+            10000
+        ]
+    }
+}

--- a/crates/executor/resources/versioned_constants_0_13_3.json
+++ b/crates/executor/resources/versioned_constants_0_13_3.json
@@ -73,10 +73,6 @@
         "error_entry_point_not_found": "ENTRYPOINT_NOT_FOUND",
         "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
         "execute_max_sierra_gas": 10000000000,
-        "fee_transfer_gas_cost": {
-            "entry_point_initial_budget": 1,
-            "step_gas_cost": 600
-        },
         "default_initial_gas_cost": {
             "step_gas_cost": 100000000
         },
@@ -121,12 +117,10 @@
         "validated": "VALID",
         "syscall_gas_costs": {
             "call_contract": {
-                "entry_point_initial_budget": 1,
                 "step_gas_cost": 510,
                 "syscall_base_gas_cost": 1
             },
             "deploy": {
-                "entry_point_initial_budget": 1,
                 "step_gas_cost": 700,
                 "syscall_base_gas_cost": 1
             },
@@ -147,7 +141,6 @@
             },
             "keccak_round_cost": 180000,
             "library_call": {
-                "entry_point_initial_budget": 1,
                 "step_gas_cost": 510,
                 "syscall_base_gas_cost": 1
             },
@@ -320,13 +313,18 @@
                 "builtin_instance_counter": {},
                 "n_memory_holes": 0
             },
-            "Keccak": {
+            "KeccakRound": {
                 "n_steps": 381,
                 "builtin_instance_counter": {
                     "bitwise_builtin": 6,
                     "keccak_builtin": 1,
                     "range_check_builtin": 56
                 },
+                "n_memory_holes": 0
+            },
+            "Keccak": {
+                "n_steps": 0,
+                "builtin_instance_counter": {},
                 "n_memory_holes": 0
             },
             "LibraryCall": {

--- a/crates/executor/resources/versioned_constants_0_13_4.json
+++ b/crates/executor/resources/versioned_constants_0_13_4.json
@@ -38,23 +38,23 @@
         ]
     },
     "disable_cairo0_redeclaration": true,
-    "enable_stateful_compression": false,
-    "comprehensive_state_diff": false,
+    "enable_stateful_compression": true,
+    "comprehensive_state_diff": true,
     "allocation_cost": {
         "blob_cost": {
             "l1_gas": 0,
-            "l1_data_gas": 0,
+            "l1_data_gas": 32,
             "l2_gas": 0
         },
         "gas_cost": {
-            "l1_gas": 0,
+            "l1_gas": 551,
             "l1_data_gas": 0,
             "l2_gas": 0
         }
     },
     "ignore_inner_event_resources": false,
+    "enable_reverts": true,
     "max_recursion_depth": 50,
-    "enable_reverts": false,
     "segment_arena_cells": false,
     "os_constants": {
         "constructor_entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
@@ -72,11 +72,7 @@
         "error_entry_point_failed": "ENTRYPOINT_FAILED",
         "error_entry_point_not_found": "ENTRYPOINT_NOT_FOUND",
         "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
-        "execute_max_sierra_gas": 10000000000,
-        "fee_transfer_gas_cost": {
-            "entry_point_initial_budget": 1,
-            "step_gas_cost": 600
-        },
+        "execute_max_sierra_gas": 1000000000,
         "default_initial_gas_cost": {
             "step_gas_cost": 100000000
         },
@@ -84,6 +80,8 @@
         "l1_gas_index": 0,
         "l1_handler_version": 0,
         "l2_gas": "L2_GAS",
+        "l1_data_gas": "L1_DATA",
+        "l1_data_gas_index": 2,
         "l2_gas_index": 1,
         "memory_hole_gas_cost": 10,
         "nop_entry_point_offset": -1,
@@ -94,14 +92,14 @@
         },
         "builtin_gas_costs": {
             "range_check": 70,
-            "keccak": 0,
-            "pedersen": 0,
-            "bitwise": 594,
-            "ecop": 0,
-            "poseidon": 0,
-            "add_mod": 0,
-            "mul_mod": 0,
-            "ecdsa": 0
+            "keccak": 136189,
+            "pedersen": 4050,
+            "bitwise": 583,
+            "ecop": 4085,
+            "poseidon": 491,
+            "add_mod": 230,
+            "mul_mod": 604,
+            "ecdsa": 10561
         },
         "sierra_array_len_bound": 4294967296,
         "step_gas_cost": 100,
@@ -113,7 +111,7 @@
         "validate_declare_entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
         "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
         "validate_entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
-        "validate_max_sierra_gas": 10000000000,
+        "validate_max_sierra_gas": 100000000,
         "validate_rounding_consts": {
             "validate_block_number_rounding": 100,
             "validate_timestamp_rounding": 3600
@@ -122,25 +120,26 @@
         "syscall_gas_costs": {
             "call_contract": {
                 "entry_point_initial_budget": 1,
-                "step_gas_cost": 510,
-                "syscall_base_gas_cost": 1
+                "step_gas_cost": 860,
+                "range_check": 15
             },
             "deploy": {
                 "entry_point_initial_budget": 1,
-                "step_gas_cost": 700,
-                "syscall_base_gas_cost": 1
+                "step_gas_cost": 1128,
+                "range_check": 18,
+                "pedersen": 7
             },
             "emit_event": {
-                "step_gas_cost": 10,
-                "syscall_base_gas_cost": 1
+                "step_gas_cost": 100,
+                "range_check": 1
             },
             "get_block_hash": {
-                "step_gas_cost": 50,
-                "syscall_base_gas_cost": 1
+                "step_gas_cost": 104,
+                "range_check": 2
             },
             "get_execution_info": {
-                "step_gas_cost": 10,
-                "syscall_base_gas_cost": 1
+                "step_gas_cost": 100,
+                "range_check": 1
             },
             "keccak": {
                 "syscall_base_gas_cost": 1
@@ -148,89 +147,89 @@
             "keccak_round_cost": 180000,
             "library_call": {
                 "entry_point_initial_budget": 1,
-                "step_gas_cost": 510,
-                "syscall_base_gas_cost": 1
+                "step_gas_cost": 836,
+                "range_check": 15
             },
             "sha256_process_block": {
-                "step_gas_cost": 1852,
+                "step_gas_cost": 1855,
                 "range_check": 65,
                 "bitwise": 1115,
                 "syscall_base_gas_cost": 1
             },
             "replace_class": {
-                "step_gas_cost": 50,
-                "syscall_base_gas_cost": 1
+                "step_gas_cost": 104,
+                "range_check": 1
             },
             "secp256k1_add": {
                 "range_check": 29,
-                "step_gas_cost": 406
+                "step_gas_cost": 410
             },
             "secp256k1_get_point_from_x": {
                 "memory_hole_gas_cost": 20,
                 "range_check": 30,
-                "step_gas_cost": 391
+                "step_gas_cost": 395
             },
             "secp256k1_get_xy": {
                 "memory_hole_gas_cost": 40,
                 "range_check": 11,
-                "step_gas_cost": 239
+                "step_gas_cost": 207
             },
             "secp256k1_mul": {
                 "memory_hole_gas_cost": 2,
                 "range_check": 7045,
-                "step_gas_cost": 76501
+                "step_gas_cost": 76505
             },
             "secp256k1_new": {
                 "memory_hole_gas_cost": 40,
                 "range_check": 35,
-                "step_gas_cost": 475
+                "step_gas_cost": 461
             },
             "secp256r1_add": {
                 "range_check": 57,
-                "step_gas_cost": 589
+                "step_gas_cost": 593
             },
             "secp256r1_get_point_from_x": {
                 "memory_hole_gas_cost": 20,
                 "range_check": 44,
-                "step_gas_cost": 510
+                "step_gas_cost": 514
             },
             "secp256r1_get_xy": {
                 "memory_hole_gas_cost": 40,
                 "range_check": 11,
-                "step_gas_cost": 241
+                "step_gas_cost": 209
             },
             "secp256r1_mul": {
                 "memory_hole_gas_cost": 2,
                 "range_check": 13961,
-                "step_gas_cost": 125340
+                "step_gas_cost": 125344
             },
             "secp256r1_new": {
                 "memory_hole_gas_cost": 40,
                 "range_check": 49,
-                "step_gas_cost": 594
+                "step_gas_cost": 580
             },
             "send_message_to_l1": {
-                "step_gas_cost": 50,
-                "syscall_base_gas_cost": 1
+                "step_gas_cost": 141,
+                "range_check": 1
             },
             "storage_read": {
-                "step_gas_cost": 50,
-                "syscall_base_gas_cost": 1
+                "step_gas_cost": 100,
+                "range_check": 1
             },
             "storage_write": {
-                "step_gas_cost": 50,
-                "syscall_base_gas_cost": 1
+                "step_gas_cost": 100,
+                "range_check": 1
             },
             "get_class_hash_at": {
-                "step_gas_cost": 0,
-                "syscall_base_gas_cost": 0
+                "step_gas_cost": 100,
+                "range_check": 1
             }
         }
     },
     "os_resources": {
         "execute_syscalls": {
             "CallContract": {
-                "n_steps": 827,
+                "n_steps": 866,
                 "builtin_instance_counter": {
                     "range_check_builtin": 15
                 },
@@ -251,7 +250,7 @@
                 "n_memory_holes": 0
             },
             "Deploy": {
-                "n_steps": 1097,
+                "n_steps": 1132,
                 "builtin_instance_counter": {
                     "pedersen_builtin": 7,
                     "range_check_builtin": 18
@@ -330,7 +329,7 @@
                 "n_memory_holes": 0
             },
             "LibraryCall": {
-                "n_steps": 818,
+                "n_steps": 842,
                 "builtin_instance_counter": {
                     "range_check_builtin": 15
                 },
@@ -344,7 +343,7 @@
                 "n_memory_holes": 0
             },
             "ReplaceClass": {
-                "n_steps": 98,
+                "n_steps": 104,
                 "builtin_instance_counter": {
                     "range_check_builtin": 1
                 },
@@ -428,7 +427,7 @@
                 "n_memory_holes": 0
             },
             "Sha256ProcessBlock": {
-                "n_steps": 1855,
+                "n_steps": 1865,
                 "builtin_instance_counter": {
                     "range_check_builtin": 65,
                     "bitwise_builtin": 1115
@@ -443,15 +442,17 @@
                 "n_memory_holes": 0
             },
             "StorageWrite": {
-                "n_steps": 89,
+                "n_steps": 93,
                 "builtin_instance_counter": {
                     "range_check_builtin": 1
                 },
                 "n_memory_holes": 0
             },
             "GetClassHashAt": {
-                "n_steps": 0,
-                "builtin_instance_counter": {},
+                "n_steps": 89,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 1
+                },
                 "n_memory_holes": 0
             }
         },
@@ -459,10 +460,11 @@
             "Declare": {
                 "deprecated_resources": {
                     "constant": {
-                        "n_steps": 2973,
+                        "n_steps": 3203,
                         "builtin_instance_counter": {
                             "pedersen_builtin": 16,
-                            "range_check_builtin": 53
+                            "range_check_builtin": 56,
+                            "poseidon_builtin": 4
                         },
                         "n_memory_holes": 0
                     },
@@ -474,11 +476,11 @@
                 },
                 "resources": {
                     "constant": {
-                        "n_steps": 3079,
+                        "n_steps": 3346,
                         "builtin_instance_counter": {
                             "pedersen_builtin": 4,
-                            "range_check_builtin": 58,
-                            "poseidon_builtin": 10
+                            "range_check_builtin": 64,
+                            "poseidon_builtin": 14
                         },
                         "n_memory_holes": 0
                     },
@@ -492,7 +494,7 @@
             "DeployAccount": {
                 "deprecated_resources": {
                     "constant": {
-                        "n_steps": 4015,
+                        "n_steps": 4161,
                         "builtin_instance_counter": {
                             "pedersen_builtin": 23,
                             "range_check_builtin": 72
@@ -509,10 +511,10 @@
                 },
                 "resources": {
                     "constant": {
-                        "n_steps": 4137,
+                        "n_steps": 4321,
                         "builtin_instance_counter": {
                             "pedersen_builtin": 11,
-                            "range_check_builtin": 77,
+                            "range_check_builtin": 80,
                             "poseidon_builtin": 10
                         },
                         "n_memory_holes": 0
@@ -529,7 +531,7 @@
             "InvokeFunction": {
                 "deprecated_resources": {
                     "constant": {
-                        "n_steps": 3763,
+                        "n_steps": 3918,
                         "builtin_instance_counter": {
                             "pedersen_builtin": 14,
                             "range_check_builtin": 69
@@ -546,10 +548,10 @@
                 },
                 "resources": {
                     "constant": {
-                        "n_steps": 3904,
+                        "n_steps": 4102,
                         "builtin_instance_counter": {
                             "pedersen_builtin": 4,
-                            "range_check_builtin": 74,
+                            "range_check_builtin": 77,
                             "poseidon_builtin": 11
                         },
                         "n_memory_holes": 0
@@ -566,7 +568,7 @@
             "L1Handler": {
                 "deprecated_resources": {
                     "constant": {
-                        "n_steps": 1233,
+                        "n_steps": 1279,
                         "builtin_instance_counter": {
                             "pedersen_builtin": 11,
                             "range_check_builtin": 16
@@ -606,7 +608,7 @@
         }
     },
     "validate_max_n_steps": 1000000,
-    "min_sierra_version_for_sierra_gas": "100.0.0",
+    "min_sierra_version_for_sierra_gas": "1.6.0",
     "vm_resource_fee_cost": {
         "builtins": {
             "add_mod_builtin": [

--- a/crates/executor/resources/versioned_constants_0_13_4.json
+++ b/crates/executor/resources/versioned_constants_0_13_4.json
@@ -116,115 +116,7 @@
             "validate_block_number_rounding": 100,
             "validate_timestamp_rounding": 3600
         },
-        "validated": "VALID",
-        "syscall_gas_costs": {
-            "call_contract": {
-                "entry_point_initial_budget": 1,
-                "step_gas_cost": 860,
-                "range_check": 15
-            },
-            "deploy": {
-                "entry_point_initial_budget": 1,
-                "step_gas_cost": 1128,
-                "range_check": 18,
-                "pedersen": 7
-            },
-            "emit_event": {
-                "step_gas_cost": 100,
-                "range_check": 1
-            },
-            "get_block_hash": {
-                "step_gas_cost": 104,
-                "range_check": 2
-            },
-            "get_execution_info": {
-                "step_gas_cost": 100,
-                "range_check": 1
-            },
-            "keccak": {
-                "syscall_base_gas_cost": 1
-            },
-            "keccak_round_cost": 180000,
-            "library_call": {
-                "entry_point_initial_budget": 1,
-                "step_gas_cost": 836,
-                "range_check": 15
-            },
-            "sha256_process_block": {
-                "step_gas_cost": 1855,
-                "range_check": 65,
-                "bitwise": 1115,
-                "syscall_base_gas_cost": 1
-            },
-            "replace_class": {
-                "step_gas_cost": 104,
-                "range_check": 1
-            },
-            "secp256k1_add": {
-                "range_check": 29,
-                "step_gas_cost": 410
-            },
-            "secp256k1_get_point_from_x": {
-                "memory_hole_gas_cost": 20,
-                "range_check": 30,
-                "step_gas_cost": 395
-            },
-            "secp256k1_get_xy": {
-                "memory_hole_gas_cost": 40,
-                "range_check": 11,
-                "step_gas_cost": 207
-            },
-            "secp256k1_mul": {
-                "memory_hole_gas_cost": 2,
-                "range_check": 7045,
-                "step_gas_cost": 76505
-            },
-            "secp256k1_new": {
-                "memory_hole_gas_cost": 40,
-                "range_check": 35,
-                "step_gas_cost": 461
-            },
-            "secp256r1_add": {
-                "range_check": 57,
-                "step_gas_cost": 593
-            },
-            "secp256r1_get_point_from_x": {
-                "memory_hole_gas_cost": 20,
-                "range_check": 44,
-                "step_gas_cost": 514
-            },
-            "secp256r1_get_xy": {
-                "memory_hole_gas_cost": 40,
-                "range_check": 11,
-                "step_gas_cost": 209
-            },
-            "secp256r1_mul": {
-                "memory_hole_gas_cost": 2,
-                "range_check": 13961,
-                "step_gas_cost": 125344
-            },
-            "secp256r1_new": {
-                "memory_hole_gas_cost": 40,
-                "range_check": 49,
-                "step_gas_cost": 580
-            },
-            "send_message_to_l1": {
-                "step_gas_cost": 141,
-                "range_check": 1
-            },
-            "storage_read": {
-                "step_gas_cost": 100,
-                "range_check": 1
-            },
-            "storage_write": {
-                "step_gas_cost": 100,
-                "range_check": 1
-            },
-            "get_class_hash_at": {
-                "step_gas_cost": 100,
-                "range_check": 1
-            }
-        }
+        "validated": "VALID"
     },
     "os_resources": {
         "execute_syscalls": {
@@ -319,13 +211,18 @@
                 "builtin_instance_counter": {},
                 "n_memory_holes": 0
             },
-            "Keccak": {
-                "n_steps": 381,
+            "KeccakRound": {
+                "n_steps": 281,
                 "builtin_instance_counter": {
                     "bitwise_builtin": 6,
                     "keccak_builtin": 1,
                     "range_check_builtin": 56
                 },
+                "n_memory_holes": 0
+            },
+            "Keccak": {
+                "n_steps": 100,
+                "builtin_instance_counter": {},
                 "n_memory_holes": 0
             },
             "LibraryCall": {
@@ -608,7 +505,7 @@
         }
     },
     "validate_max_n_steps": 1000000,
-    "min_sierra_version_for_sierra_gas": "1.6.0",
+    "min_sierra_version_for_sierra_gas": "1.7.0",
     "vm_resource_fee_cost": {
         "builtins": {
             "add_mod_builtin": [

--- a/crates/executor/src/class.rs
+++ b/crates/executor/src/class.rs
@@ -13,10 +13,14 @@ pub fn parse_deprecated_class_definition(
 
 pub fn parse_casm_definition(
     casm_definition: Vec<u8>,
+    sierra_version: starknet_api::contract_class::SierraVersion,
 ) -> anyhow::Result<starknet_api::contract_class::ContractClass> {
     let casm_definition = String::from_utf8(casm_definition)?;
 
     let class: CasmContractClass = serde_json::from_str(&casm_definition)?;
 
-    Ok(starknet_api::contract_class::ContractClass::V1(class))
+    Ok(starknet_api::contract_class::ContractClass::V1((
+        class,
+        sierra_version,
+    )))
 }

--- a/crates/executor/src/class.rs
+++ b/crates/executor/src/class.rs
@@ -1,26 +1,22 @@
+use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
+
 pub fn parse_deprecated_class_definition(
     definition: Vec<u8>,
-) -> anyhow::Result<blockifier::execution::contract_class::ContractClass> {
+) -> anyhow::Result<starknet_api::contract_class::ContractClass> {
     let definition = String::from_utf8(definition)?;
 
-    let class =
-        blockifier::execution::contract_class::ContractClassV0::try_from_json_string(&definition)?;
+    let class: starknet_api::deprecated_contract_class::ContractClass =
+        serde_json::from_str(&definition)?;
 
-    Ok(blockifier::execution::contract_class::ContractClass::V0(
-        class,
-    ))
+    Ok(starknet_api::contract_class::ContractClass::V0(class))
 }
 
 pub fn parse_casm_definition(
     casm_definition: Vec<u8>,
-) -> anyhow::Result<blockifier::execution::contract_class::ContractClass> {
+) -> anyhow::Result<starknet_api::contract_class::ContractClass> {
     let casm_definition = String::from_utf8(casm_definition)?;
 
-    let class = blockifier::execution::contract_class::ContractClassV1::try_from_json_string(
-        &casm_definition,
-    )?;
+    let class: CasmContractClass = serde_json::from_str(&casm_definition)?;
 
-    Ok(blockifier::execution::contract_class::ContractClass::V1(
-        class,
-    ))
+    Ok(starknet_api::contract_class::ContractClass::V1(class))
 }

--- a/crates/executor/src/error.rs
+++ b/crates/executor/src/error.rs
@@ -3,7 +3,7 @@ use blockifier::execution::errors::{
     EntryPointExecutionError as BlockifierEntryPointExecutionError,
     PreExecutionError,
 };
-use blockifier::execution::stack_trace::gen_transaction_execution_error_trace;
+use blockifier::execution::stack_trace::gen_tx_execution_error_trace;
 use blockifier::state::errors::StateError;
 use blockifier::transaction::errors::TransactionExecutionError as BlockifierTransactionExecutionError;
 
@@ -22,7 +22,7 @@ impl From<BlockifierTransactionExecutionError> for CallError {
     fn from(value: BlockifierTransactionExecutionError) -> Self {
         use BlockifierTransactionExecutionError::*;
 
-        let error_stack = gen_transaction_execution_error_trace(&value);
+        let error_stack = gen_tx_execution_error_trace(&value);
 
         match value {
             ContractConstructorExecutionFailed(
@@ -131,7 +131,7 @@ impl From<anyhow::Error> for TransactionExecutionError {
 
 impl TransactionExecutionError {
     pub fn new(transaction_index: usize, error: BlockifierTransactionExecutionError) -> Self {
-        let error_stack = gen_transaction_execution_error_trace(&error);
+        let error_stack = gen_tx_execution_error_trace(&error);
 
         Self::ExecutionError {
             transaction_index,

--- a/crates/executor/src/error_stack.rs
+++ b/crates/executor/src/error_stack.rs
@@ -4,6 +4,7 @@ use blockifier::execution::stack_trace::{
     ErrorStackSegment,
 };
 use blockifier::transaction::errors::TransactionExecutionError;
+use blockifier::transaction::objects::RevertError;
 use pathfinder_common::{ClassHash, ContractAddress, EntryPoint};
 
 use crate::IntoFelt;
@@ -21,6 +22,17 @@ impl From<TransactionExecutionError> for ErrorStack {
     fn from(value: TransactionExecutionError) -> Self {
         let error_stack = gen_tx_execution_error_trace(&value);
         error_stack.into()
+    }
+}
+
+impl From<RevertError> for ErrorStack {
+    fn from(value: RevertError) -> Self {
+        match value {
+            RevertError::Execution(error_stack) => error_stack.into(),
+            RevertError::PostExecution(fee_check_error) => {
+                Self(vec![Frame::StringFrame(fee_check_error.to_string())])
+            }
+        }
     }
 }
 

--- a/crates/executor/src/estimate.rs
+++ b/crates/executor/src/estimate.rs
@@ -42,8 +42,7 @@ pub fn estimate(
                     return Err(TransactionExecutionError::ExecutionError {
                         transaction_index: transaction_idx,
                         error: revert_string,
-                        // TODO: is ErrorStack available?
-                        error_stack: Default::default(),
+                        error_stack: revert_error.into(),
                     });
                 }
 

--- a/crates/executor/src/execution_state.rs
+++ b/crates/executor/src/execution_state.rs
@@ -56,7 +56,7 @@ mod versioned_constants {
 
     const STARKNET_VERSION_0_13_3: StarknetVersion = StarknetVersion::new(0, 13, 3, 0);
 
-    const STARKNET_VERSION_0_13_4: StarknetVersion = StarknetVersion::new(0, 13, 3, 0);
+    const STARKNET_VERSION_0_13_4: StarknetVersion = StarknetVersion::new(0, 13, 4, 0);
 
     pub static BLOCKIFIER_VERSIONED_CONSTANTS_0_13_0: LazyLock<VersionedConstants> =
         LazyLock::new(|| {

--- a/crates/executor/src/execution_state.rs
+++ b/crates/executor/src/execution_state.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::Context;
-use blockifier::blockifier::block::{pre_process_block, BlockInfo, BlockNumberHashPair};
+use blockifier::blockifier::block::pre_process_block;
 use blockifier::bouncer::BouncerConfig;
 use blockifier::context::{BlockContext, ChainInfo};
 use blockifier::state::cached_state::CachedState;
@@ -13,6 +13,7 @@ use pathfinder_common::{
     L1DataAvailabilityMode,
     StateUpdate,
 };
+use starknet_api::block::{BlockHashAndNumber, BlockInfo, GasPrice, NonzeroGasPrice};
 use starknet_api::core::PatriciaKey;
 
 use super::pending::PendingStateReader;
@@ -28,16 +29,22 @@ mod versioned_constants {
     use super::VersionedConstants;
 
     const BLOCKIFIER_VERSIONED_CONSTANTS_JSON_0_13_0: &[u8] =
-        include_bytes!("../resources/versioned_constants_13_0.json");
+        include_bytes!("../resources/versioned_constants_0_13_0.json");
 
     const BLOCKIFIER_VERSIONED_CONSTANTS_JSON_0_13_1: &[u8] =
-        include_bytes!("../resources/versioned_constants_13_1.json");
+        include_bytes!("../resources/versioned_constants_0_13_1.json");
 
     const BLOCKIFIER_VERSIONED_CONSTANTS_JSON_0_13_1_1: &[u8] =
-        include_bytes!("../resources/versioned_constants_13_1_1.json");
+        include_bytes!("../resources/versioned_constants_0_13_1_1.json");
 
     const BLOCKIFIER_VERSIONED_CONSTANTS_JSON_0_13_2: &[u8] =
-        include_bytes!("../resources/versioned_constants_13_2.json");
+        include_bytes!("../resources/versioned_constants_0_13_2.json");
+
+    const BLOCKIFIER_VERSIONED_CONSTANTS_JSON_0_13_2_1: &[u8] =
+        include_bytes!("../resources/versioned_constants_0_13_2_1.json");
+
+    const BLOCKIFIER_VERSIONED_CONSTANTS_JSON_0_13_3: &[u8] =
+        include_bytes!("../resources/versioned_constants_0_13_3.json");
 
     const STARKNET_VERSION_0_13_1: StarknetVersion = StarknetVersion::new(0, 13, 1, 0);
 
@@ -46,6 +53,10 @@ mod versioned_constants {
     const STARKNET_VERSION_0_13_2: StarknetVersion = StarknetVersion::new(0, 13, 2, 0);
 
     const STARKNET_VERSION_0_13_2_1: StarknetVersion = StarknetVersion::new(0, 13, 2, 1);
+
+    const STARKNET_VERSION_0_13_3: StarknetVersion = StarknetVersion::new(0, 13, 3, 0);
+
+    const STARKNET_VERSION_0_13_4: StarknetVersion = StarknetVersion::new(0, 13, 3, 0);
 
     pub static BLOCKIFIER_VERSIONED_CONSTANTS_0_13_0: LazyLock<VersionedConstants> =
         LazyLock::new(|| {
@@ -67,6 +78,16 @@ mod versioned_constants {
             serde_json::from_slice(BLOCKIFIER_VERSIONED_CONSTANTS_JSON_0_13_2).unwrap()
         });
 
+    pub static BLOCKIFIER_VERSIONED_CONSTANTS_0_13_2_1: LazyLock<VersionedConstants> =
+        LazyLock::new(|| {
+            serde_json::from_slice(BLOCKIFIER_VERSIONED_CONSTANTS_JSON_0_13_2_1).unwrap()
+        });
+
+    pub static BLOCKIFIER_VERSIONED_CONSTANTS_0_13_3: LazyLock<VersionedConstants> =
+        LazyLock::new(|| {
+            serde_json::from_slice(BLOCKIFIER_VERSIONED_CONSTANTS_JSON_0_13_3).unwrap()
+        });
+
     pub(super) fn for_version(
         version: &StarknetVersion,
         custom_versioned_constants: Option<VersionedConstants>,
@@ -80,6 +101,10 @@ mod versioned_constants {
             Cow::Borrowed(&BLOCKIFIER_VERSIONED_CONSTANTS_0_13_1_1)
         } else if version < &STARKNET_VERSION_0_13_2_1 {
             Cow::Borrowed(&BLOCKIFIER_VERSIONED_CONSTANTS_0_13_2)
+        } else if version < &STARKNET_VERSION_0_13_3 {
+            Cow::Borrowed(&BLOCKIFIER_VERSIONED_CONSTANTS_0_13_2_1)
+        } else if version < &STARKNET_VERSION_0_13_4 {
+            Cow::Borrowed(&BLOCKIFIER_VERSIONED_CONSTANTS_0_13_3)
         } else {
             custom_versioned_constants
                 .map(Cow::Owned)
@@ -136,7 +161,7 @@ impl<'tx> ExecutionState<'tx> {
 
             tracing::trace!(%block_number_whose_hash_becomes_available, %block_hash, "Setting historical block hash");
 
-            Some(BlockNumberHashPair {
+            Some(BlockHashAndNumber {
                 number: starknet_api::block::BlockNumber(
                     block_number_whose_hash_becomes_available.get(),
                 ),
@@ -155,6 +180,7 @@ impl<'tx> ExecutionState<'tx> {
             &mut cached_state,
             old_block_number_and_hash,
             block_info.block_number,
+            &versioned_constants.os_constants,
         )?;
 
         let block_context = BlockContext::new(
@@ -202,6 +228,55 @@ impl<'tx> ExecutionState<'tx> {
     }
 
     fn block_info(&self) -> anyhow::Result<BlockInfo> {
+        let eth_l1_gas_price =
+            NonzeroGasPrice::new(GasPrice(if self.header.eth_l1_gas_price.0 == 0 {
+                // Bad API design - the genesis block has 0 gas price, but
+                // blockifier doesn't allow for it. This isn't critical for
+                // consensus, so we just use 1.
+                1
+            } else {
+                self.header.eth_l1_gas_price.0
+            }))?;
+        let strk_l1_gas_price =
+            NonzeroGasPrice::new(GasPrice(if self.header.strk_l1_gas_price.0 == 0 {
+                // Bad API design - the genesis block has 0 gas price, but
+                // blockifier doesn't allow for it. This isn't critical for
+                // consensus, so we just use 1.
+                1
+            } else {
+                self.header.strk_l1_gas_price.0
+            }))?;
+        let eth_l1_data_gas_price =
+            NonzeroGasPrice::new(GasPrice(if self.header.eth_l1_data_gas_price.0 == 0 {
+                // Bad API design - pre-v0.13.1 blocks have 0 data gas price, but
+                // blockifier doesn't allow for it. This value is ignored for those
+                // transactions.
+                1
+            } else {
+                self.header.eth_l1_data_gas_price.0
+            }))?;
+        let strk_l1_data_gas_price =
+            NonzeroGasPrice::new(GasPrice(if self.header.strk_l1_data_gas_price.0 == 0 {
+                // Bad API design - pre-v0.13.1 blocks have 0 data gas price, but
+                // blockifier doesn't allow for it. This value is ignored for those
+                // transactions.
+                1
+            } else {
+                self.header.strk_l1_data_gas_price.0
+            }))?;
+        let eth_l2_gas_price =
+            NonzeroGasPrice::new(GasPrice(if self.header.eth_l2_gas_price.0 == 0 {
+                1
+            } else {
+                self.header.eth_l2_gas_price.0
+            }))?;
+        let strk_l2_gas_price =
+            NonzeroGasPrice::new(GasPrice(if self.header.strk_l2_gas_price.0 == 0 {
+                1
+            } else {
+                self.header.strk_l2_gas_price.0
+            }))?;
+
         Ok(BlockInfo {
             block_number: starknet_api::block::BlockNumber(self.header.number.get()),
             block_timestamp: starknet_api::block::BlockTimestamp(self.header.timestamp.get()),
@@ -209,38 +284,16 @@ impl<'tx> ExecutionState<'tx> {
                 PatriciaKey::try_from(self.header.sequencer_address.0.into_starkfelt())
                     .expect("Sequencer address overflow"),
             ),
-            gas_prices: blockifier::blockifier::block::GasPrices {
-                eth_l1_gas_price: if self.header.eth_l1_gas_price.0 == 0 {
-                    // Bad API design - the genesis block has 0 gas price, but
-                    // blockifier doesn't allow for it. This isn't critical for
-                    // consensus, so we just use 1.
-                    1.try_into().unwrap()
-                } else {
-                    self.header.eth_l1_gas_price.0.try_into().unwrap()
+            gas_prices: starknet_api::block::GasPrices {
+                eth_gas_prices: starknet_api::block::GasPriceVector {
+                    l1_gas_price: eth_l1_gas_price,
+                    l1_data_gas_price: eth_l1_data_gas_price,
+                    l2_gas_price: eth_l2_gas_price,
                 },
-                strk_l1_gas_price: if self.header.strk_l1_gas_price.0 == 0 {
-                    // Bad API design - the genesis block has 0 gas price, but
-                    // blockifier doesn't allow for it. This isn't critical for
-                    // consensus, so we just use 1.
-                    1.try_into().unwrap()
-                } else {
-                    self.header.strk_l1_gas_price.0.try_into().unwrap()
-                },
-                eth_l1_data_gas_price: if self.header.eth_l1_data_gas_price.0 == 0 {
-                    // Bad API design - pre-v0.13.1 blocks have 0 data gas price, but
-                    // blockifier doesn't allow for it. This value is ignored for those
-                    // transactions.
-                    1.try_into().unwrap()
-                } else {
-                    self.header.eth_l1_data_gas_price.0.try_into().unwrap()
-                },
-                strk_l1_data_gas_price: if self.header.strk_l1_data_gas_price.0 == 0 {
-                    // Bad API design - pre-v0.13.1 blocks have 0 data gas price, but
-                    // blockifier doesn't allow for it. This value is ignored for those
-                    // transactions.
-                    1.try_into().unwrap()
-                } else {
-                    self.header.strk_l1_data_gas_price.0.try_into().unwrap()
+                strk_gas_prices: starknet_api::block::GasPriceVector {
+                    l1_gas_price: strk_l1_gas_price,
+                    l1_data_gas_price: strk_l1_data_gas_price,
+                    l2_gas_price: strk_l2_gas_price,
                 },
             },
             use_kzg_da: self.allow_use_kzg_data

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -13,8 +13,10 @@ pub(crate) mod transaction;
 pub mod types;
 
 // re-export blockifier transaction type since it's exposed on our API
-pub use blockifier::execution::contract_class::ClassInfo;
-pub use blockifier::transaction::account_transaction::AccountTransaction;
+pub use blockifier::transaction::account_transaction::{
+    AccountTransaction,
+    ExecutionFlags as AccountTransactionExecutionFlags,
+};
 pub use blockifier::transaction::transaction_execution::Transaction;
 pub use blockifier::versioned_constants::VersionedConstants;
 pub use call::call;
@@ -25,4 +27,5 @@ pub use estimate::estimate;
 pub use execution_state::{ExecutionState, L1BlobDataAvailability};
 pub use felt::{IntoFelt, IntoStarkFelt};
 pub use simulate::{simulate, trace, TraceCache};
+pub use starknet_api::contract_class::ClassInfo;
 pub use transaction::transaction_hash;

--- a/crates/executor/src/lru_cache.rs
+++ b/crates/executor/src/lru_cache.rs
@@ -1,6 +1,6 @@
 use std::sync::{LazyLock, Mutex, MutexGuard};
 
-use blockifier::execution::contract_class::ContractClass;
+use blockifier::execution::contract_class::RunnableCompiledClass;
 use cached::{Cached, SizedCache};
 use pathfinder_common::BlockNumber;
 use starknet_api::core::ClassHash as StarknetClassHash;
@@ -9,7 +9,7 @@ pub static GLOBAL_CACHE: LazyLock<LruContractCache> = LazyLock::new(LruContractC
 
 #[derive(Clone)]
 pub struct Entry {
-    pub definition: ContractClass,
+    pub definition: RunnableCompiledClass,
     /// The height at which the class was declared
     pub height: BlockNumber,
 }
@@ -33,7 +33,7 @@ impl LruContractCache {
     pub fn set(
         &self,
         class_hash: StarknetClassHash,
-        contract_class: ContractClass,
+        contract_class: RunnableCompiledClass,
         block_number: BlockNumber,
     ) {
         self.locked_cache().cache_set(

--- a/crates/executor/src/pending.rs
+++ b/crates/executor/src/pending.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use blockifier::execution::contract_class::RunnableCompiledClass;
 use blockifier::state::errors::StateError;
 use blockifier::state::state_api::StateReader;
 use pathfinder_common::{StateUpdate, StorageAddress};
@@ -84,13 +85,11 @@ impl<S: StateReader> StateReader for PendingStateReader<S> {
             .unwrap_or_else(|| self.state.get_class_hash_at(contract_address))
     }
 
-    fn get_compiled_contract_class(
+    fn get_compiled_class(
         &self,
         class_hash: starknet_api::core::ClassHash,
-    ) -> blockifier::state::state_api::StateResult<
-        blockifier::execution::contract_class::ContractClass,
-    > {
-        self.state.get_compiled_contract_class(class_hash)
+    ) -> blockifier::state::state_api::StateResult<RunnableCompiledClass> {
+        self.state.get_compiled_class(class_hash)
     }
 
     fn get_compiled_class_hash(
@@ -103,6 +102,7 @@ impl<S: StateReader> StateReader for PendingStateReader<S> {
 
 #[cfg(test)]
 mod tests {
+    use blockifier::execution::contract_class::RunnableCompiledClass;
     use blockifier::state::state_api::StateReader;
     use pathfinder_common::{
         class_hash,
@@ -141,12 +141,10 @@ mod tests {
             Ok(starknet_api::core::ClassHash(CoreFelt::from(u32::MAX)))
         }
 
-        fn get_compiled_contract_class(
+        fn get_compiled_class(
             &self,
             _class_hash: starknet_api::core::ClassHash,
-        ) -> blockifier::state::state_api::StateResult<
-            blockifier::execution::contract_class::ContractClass,
-        > {
+        ) -> blockifier::state::state_api::StateResult<RunnableCompiledClass> {
             unimplemented!()
         }
 

--- a/crates/executor/src/simulate.rs
+++ b/crates/executor/src/simulate.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
 use anyhow::Context;
-use blockifier::state::cached_state::{CachedState, CommitmentStateDiff};
+use blockifier::state::cached_state::CachedState;
 use blockifier::state::errors::StateError;
 use blockifier::transaction::transaction_execution::Transaction;
 use blockifier::transaction::transactions::ExecutableTransaction;
@@ -18,6 +18,7 @@ use pathfinder_common::{
     StorageValue,
     TransactionHash,
 };
+use starknet_api::transaction::fields::GasVectorComputationMode;
 
 use super::error::TransactionExecutionError;
 use super::execution_state::ExecutionState;
@@ -79,8 +80,6 @@ impl Default for TraceCache {
 pub fn simulate(
     execution_state: ExecutionState<'_>,
     transactions: Vec<Transaction>,
-    skip_validate: bool,
-    skip_fee_charge: bool,
 ) -> Result<Vec<TransactionSimulation>, TransactionExecutionError> {
     let block_number = execution_state.header.number;
 
@@ -95,23 +94,18 @@ pub fn simulate(
             transaction_declared_deprecated_class(&transaction);
         let fee_type = super::transaction::fee_type(&transaction);
         let minimal_l1_gas_amount_vector = match &transaction {
-            Transaction::AccountTransaction(account_transaction) => Some(
-                blockifier::fee::gas_usage::estimate_minimal_gas_vector(
+            Transaction::Account(account_transaction) => {
+                Some(blockifier::fee::gas_usage::estimate_minimal_gas_vector(
                     &block_context,
                     account_transaction,
-                )
-                .map_err(|e| TransactionExecutionError::new(transaction_idx, e.into()))?,
-            ),
-            Transaction::L1HandlerTransaction(_) => None,
+                    &GasVectorComputationMode::All,
+                ))
+            }
+            Transaction::L1Handler(_) => None,
         };
 
         let mut tx_state = CachedState::<_>::create_transactional(&mut state);
-        let tx_info = transaction.execute(
-            &mut tx_state,
-            &block_context,
-            !skip_fee_charge,
-            !skip_validate,
-        );
+        let tx_info = transaction.execute(&mut tx_state, &block_context);
         let state_diff = to_state_diff(&mut tx_state, transaction_declared_deprecated_class_hash)?;
         tx_state.commit();
 
@@ -122,7 +116,7 @@ pub fn simulate(
                     tracing::trace!(revert_error=%revert_string, "Transaction reverted");
                 }
 
-                tracing::trace!(actual_fee=%tx_info.transaction_receipt.fee.0, actual_resources=?tx_info.transaction_receipt.resources, "Transaction simulation finished");
+                tracing::trace!(actual_fee=%tx_info.receipt.fee.0, actual_resources=?tx_info.receipt.resources, "Transaction simulation finished");
 
                 simulations.push(TransactionSimulation {
                     fee_estimation: FeeEstimate::from_tx_info_and_gas_price(
@@ -188,21 +182,19 @@ pub fn trace(
         let tx_declared_deprecated_class_hash = transaction_declared_deprecated_class(&tx);
 
         let mut tx_state = CachedState::<_>::create_transactional(&mut state);
-        let tx_info = tx
-            .execute(&mut tx_state, &block_context, true, true)
-            .map_err(|e| {
-                // Update the cache with the error. Lock the cache before sending to avoid
-                // race conditions between senders and receivers.
-                let err = ExecutionError {
-                    transaction_index: transaction_idx,
-                    error: e.to_string(),
-                    error_stack: e.into(),
-                };
-                let mut cache = cache.0.lock().unwrap();
-                let _ = sender.send(Err(err.clone()));
-                cache.cache_set(block_hash, CacheItem::CachedErr(err.clone()));
-                err
-            })?;
+        let tx_info = tx.execute(&mut tx_state, &block_context).map_err(|e| {
+            // Update the cache with the error. Lock the cache before sending to avoid
+            // race conditions between senders and receivers.
+            let err = ExecutionError {
+                transaction_index: transaction_idx,
+                error: e.to_string(),
+                error_stack: e.into(),
+            };
+            let mut cache = cache.0.lock().unwrap();
+            let _ = sender.send(Err(err.clone()));
+            cache.cache_set(block_hash, CacheItem::CachedErr(err.clone()));
+            err
+        })?;
         let state_diff = to_state_diff(&mut tx_state, tx_declared_deprecated_class_hash)
             .inspect_err(|_| {
                 // Remove the cache entry so it's no longer inflight.
@@ -232,32 +224,35 @@ enum TransactionType {
 
 fn transaction_type(transaction: &Transaction) -> TransactionType {
     match transaction {
-        Transaction::AccountTransaction(tx) => match tx {
-            blockifier::transaction::account_transaction::AccountTransaction::Declare(_) => {
+        Transaction::Account(tx) => match tx.tx {
+            starknet_api::executable_transaction::AccountTransaction::Declare(_) => {
                 TransactionType::Declare
             }
-            blockifier::transaction::account_transaction::AccountTransaction::DeployAccount(_) => {
+            starknet_api::executable_transaction::AccountTransaction::DeployAccount(_) => {
                 TransactionType::DeployAccount
             }
-            blockifier::transaction::account_transaction::AccountTransaction::Invoke(_) => {
+            starknet_api::executable_transaction::AccountTransaction::Invoke(_) => {
                 TransactionType::Invoke
             }
         },
-        Transaction::L1HandlerTransaction(_) => TransactionType::L1Handler,
+        Transaction::L1Handler(_) => TransactionType::L1Handler,
     }
 }
 
 fn transaction_declared_deprecated_class(transaction: &Transaction) -> Option<ClassHash> {
     match transaction {
-        Transaction::AccountTransaction(
-            blockifier::transaction::account_transaction::AccountTransaction::Declare(tx),
-        ) => match tx.tx() {
-            starknet_api::transaction::DeclareTransaction::V0(_)
-            | starknet_api::transaction::DeclareTransaction::V1(_) => {
-                Some(ClassHash(tx.class_hash().0.into_felt()))
+        Transaction::Account(outer) => match &outer.tx {
+            starknet_api::executable_transaction::AccountTransaction::Declare(inner) => {
+                match inner.tx {
+                    starknet_api::transaction::DeclareTransaction::V0(_)
+                    | starknet_api::transaction::DeclareTransaction::V1(_) => {
+                        Some(ClassHash(inner.class_hash().0.into_felt()))
+                    }
+                    starknet_api::transaction::DeclareTransaction::V2(_)
+                    | starknet_api::transaction::DeclareTransaction::V3(_) => None,
+                }
             }
-            starknet_api::transaction::DeclareTransaction::V2(_)
-            | starknet_api::transaction::DeclareTransaction::V3(_) => None,
+            _ => None,
         },
         _ => None,
     }
@@ -267,14 +262,14 @@ fn to_state_diff<S: blockifier::state::state_api::StateReader>(
     state: &mut blockifier::state::cached_state::CachedState<S>,
     old_declared_contract: Option<ClassHash>,
 ) -> Result<StateDiff, StateError> {
-    let state_diff = CommitmentStateDiff::from(state.to_state_diff()?);
+    let state_diff = state.to_state_diff()?;
 
     let mut deployed_contracts = Vec::new();
     let mut replaced_classes = Vec::new();
 
     // We need to check the previous class hash for a contract to decide if it's a
     // deployed contract or a replaced class.
-    for (address, class_hash) in state_diff.address_to_class_hash {
+    for (address, class_hash) in state_diff.state_maps.class_hashes {
         let previous_class_hash = state.state.get_class_hash_at(address)?;
 
         if previous_class_hash.0.into_felt().is_zero() {
@@ -290,35 +285,46 @@ fn to_state_diff<S: blockifier::state::state_api::StateReader>(
         }
     }
 
-    Ok(StateDiff {
-        storage_diffs: state_diff
-            .storage_updates
-            .into_iter()
-            .map(|(address, diffs)| {
-                // Output the storage updates in key order
-                let diffs: BTreeMap<StorageAddress, StorageValue> = diffs
-                    .into_iter()
-                    .map(|(key, value)| {
-                        (
-                            StorageAddress::new_or_panic(key.0.key().into_felt()),
-                            StorageValue(value.into_felt()),
-                        )
-                    })
-                    .collect();
-                (
-                    ContractAddress::new_or_panic(address.0.key().into_felt()),
-                    diffs
-                        .into_iter()
-                        .map(|(key, value)| StorageDiff { key, value })
-                        .collect(),
-                )
+    let mut storage_diffs: BTreeMap<_, _> = Default::default();
+    for ((address, key), value) in state_diff.state_maps.storage {
+        storage_diffs
+            .entry(ContractAddress::new_or_panic(address.0.key().into_felt()))
+            .and_modify(|map: &mut BTreeMap<StorageAddress, StorageValue>| {
+                map.insert(
+                    StorageAddress::new_or_panic(key.0.key().into_felt()),
+                    StorageValue(value.into_felt()),
+                );
             })
-            .collect(),
+            .or_insert_with(|| {
+                let mut map = BTreeMap::new();
+                map.insert(
+                    StorageAddress::new_or_panic(key.0.key().into_felt()),
+                    StorageValue(value.into_felt()),
+                );
+                map
+            });
+    }
+    let storage_diffs: BTreeMap<_, Vec<StorageDiff>> = storage_diffs
+        .into_iter()
+        .map(|(address, diffs)| {
+            (
+                address,
+                diffs
+                    .into_iter()
+                    .map(|(key, value)| StorageDiff { key, value })
+                    .collect(),
+            )
+        })
+        .collect();
+
+    Ok(StateDiff {
+        storage_diffs,
         deployed_contracts,
         // This info is not present in the state diff, so we need to pass it separately.
         deprecated_declared_classes: old_declared_contract.into_iter().collect(),
         declared_classes: state_diff
-            .class_hash_to_compiled_class_hash
+            .state_maps
+            .compiled_class_hashes
             .into_iter()
             .map(|(class_hash, compiled_class_hash)| DeclaredSierraClass {
                 class_hash: SierraHash(class_hash.0.into_felt()),
@@ -326,7 +332,8 @@ fn to_state_diff<S: blockifier::state::state_api::StateReader>(
             })
             .collect(),
         nonces: state_diff
-            .address_to_nonce
+            .state_maps
+            .nonces
             .into_iter()
             .map(|(address, nonce)| {
                 (
@@ -361,15 +368,15 @@ fn to_trace(
             .map(|i: &FunctionInvocation| i.computation_resources.clone())
             .unwrap_or_default();
     let data_availability = DataAvailabilityResources {
-        l1_gas: execution_info.transaction_receipt.da_gas.l1_gas,
-        l1_data_gas: execution_info.transaction_receipt.da_gas.l1_data_gas,
+        l1_gas: execution_info.receipt.da_gas.l1_gas.0.into(),
+        l1_data_gas: execution_info.receipt.da_gas.l1_data_gas.0.into(),
     };
     let execution_resources = ExecutionResources {
         computation_resources,
         data_availability,
-        l1_gas: execution_info.transaction_receipt.gas.l1_gas,
-        l1_data_gas: execution_info.transaction_receipt.da_gas.l1_data_gas,
-        l2_gas: 0,
+        l1_gas: execution_info.receipt.gas.l1_gas.0.into(),
+        l1_data_gas: execution_info.receipt.gas.l1_data_gas.0.into(),
+        l2_gas: execution_info.receipt.gas.l2_gas.0.into(),
     };
 
     match transaction_type {

--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -355,7 +355,7 @@ impl From<blockifier::execution::call_info::CallInfo> for FunctionInvocation {
             events,
             messages,
             result,
-            computation_resources: call_info.charged_resources.vm_resources.into(),
+            computation_resources: call_info.resources.into(),
             execution_resources: InnerCallExecutionResources {
                 l1_gas: call_info.execution.gas_consumed.into(),
                 // TODO: Use proper l2_gas value for Starknet 0.13.3

--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -1,8 +1,7 @@
 use std::collections::{BTreeMap, HashSet};
 
-use blockifier::blockifier::block::BlockInfo;
 use blockifier::execution::call_info::OrderedL2ToL1Message;
-use blockifier::transaction::objects::{FeeType, GasVector, TransactionExecutionInfo};
+use blockifier::transaction::objects::TransactionExecutionInfo;
 use pathfinder_common::{
     CasmHash,
     ClassHash,
@@ -13,6 +12,8 @@ use pathfinder_common::{
     StorageValue,
 };
 use pathfinder_crypto::Felt;
+use starknet_api::block::{BlockInfo, FeeType};
+use starknet_api::execution_resources::GasVector;
 
 use super::felt::IntoFelt;
 
@@ -36,28 +37,25 @@ impl FeeEstimate {
         fee_type: FeeType,
         minimal_l1_gas_amount_vector: &Option<GasVector>,
     ) -> FeeEstimate {
-        tracing::trace!(resources=?tx_info.transaction_receipt.resources, "Transaction resources");
-        let l1_gas_price = block_info
-            .gas_prices
-            .get_gas_price_by_fee_type(&fee_type)
-            .get();
-        let l1_data_gas_price = block_info
-            .gas_prices
-            .get_data_gas_price_by_fee_type(&fee_type)
-            .get();
+        tracing::trace!(resources=?tx_info.receipt.resources, "Transaction resources");
+        let gas_prices = block_info.gas_prices.gas_price_vector(&fee_type);
+        let l1_gas_price = gas_prices.l1_gas_price.get();
+        let l1_data_gas_price = gas_prices.l1_data_gas_price.get();
+        let l2_gas_price = gas_prices.l2_gas_price.get();
 
         let minimal_l1_gas_amount_vector = minimal_l1_gas_amount_vector.unwrap_or_default();
 
         let l1_gas_consumed = tx_info
-            .transaction_receipt
+            .receipt
             .gas
             .l1_gas
             .max(minimal_l1_gas_amount_vector.l1_gas);
         let l1_data_gas_consumed = tx_info
-            .transaction_receipt
+            .receipt
             .gas
             .l1_data_gas
             .max(minimal_l1_gas_amount_vector.l1_data_gas);
+        let l2_gas_consumed = tx_info.receipt.gas.l2_gas;
 
         // Blockifier does not put the actual fee into the receipt if `max_fee` in the
         // transaction was zero. In that case we have to compute the fee
@@ -67,18 +65,19 @@ impl FeeEstimate {
             GasVector {
                 l1_gas: l1_gas_consumed,
                 l1_data_gas: l1_data_gas_consumed,
+                l2_gas: l2_gas_consumed,
             },
             &fee_type,
         )
         .0;
 
         FeeEstimate {
-            l1_gas_consumed: l1_gas_consumed.into(),
-            l1_gas_price: l1_gas_price.into(),
-            l1_data_gas_consumed: l1_data_gas_consumed.into(),
-            l1_data_gas_price: l1_data_gas_price.into(),
-            l2_gas_consumed: 0.into(), // TODO: Fix when we have l2 gas price
-            l2_gas_price: 0.into(),    // TODO: Fix when we have l2 gas price
+            l1_gas_consumed: l1_gas_consumed.0.into(),
+            l1_gas_price: l1_gas_price.0.into(),
+            l1_data_gas_consumed: l1_data_gas_consumed.0.into(),
+            l1_data_gas_price: l1_data_gas_price.0.into(),
+            l2_gas_consumed: l2_gas_consumed.0.into(),
+            l2_gas_price: l2_gas_price.0.into(),
             overall_fee: overall_fee.into(),
             unit: fee_type.into(),
         }
@@ -356,7 +355,7 @@ impl From<blockifier::execution::call_info::CallInfo> for FunctionInvocation {
             events,
             messages,
             result,
-            computation_resources: call_info.resources.into(),
+            computation_resources: call_info.charged_resources.vm_resources.into(),
             execution_resources: InnerCallExecutionResources {
                 l1_gas: call_info.execution.gas_consumed.into(),
                 // TODO: Use proper l2_gas value for Starknet 0.13.3
@@ -376,9 +375,9 @@ impl From<blockifier::execution::entry_point::CallType> for CallType {
     }
 }
 
-impl From<starknet_api::deprecated_contract_class::EntryPointType> for EntryPointType {
-    fn from(value: starknet_api::deprecated_contract_class::EntryPointType) -> Self {
-        use starknet_api::deprecated_contract_class::EntryPointType::*;
+impl From<starknet_api::contract_class::EntryPointType> for EntryPointType {
+    fn from(value: starknet_api::contract_class::EntryPointType) -> Self {
+        use starknet_api::contract_class::EntryPointType::*;
         match value {
             External => EntryPointType::External,
             L1Handler => EntryPointType::L1Handler,

--- a/crates/pathfinder/examples/re_execute.rs
+++ b/crates/pathfinder/examples/re_execute.rs
@@ -181,38 +181,25 @@ fn execute(storage: &mut Storage, chain_id: ChainId, work: Work) {
 
                 let estimate = &simulation.fee_estimation;
 
-                let (gas_price, data_gas_price) = match estimate.unit {
-                    pathfinder_executor::types::PriceUnit::Wei => (
-                        work.header.eth_l1_gas_price.0,
-                        work.header.eth_l1_data_gas_price.0,
-                    ),
-                    pathfinder_executor::types::PriceUnit::Fri => (
-                        work.header.strk_l1_gas_price.0,
-                        work.header.strk_l1_data_gas_price.0,
-                    ),
-                };
-
                 let actual_data_gas_consumed =
                     receipt.execution_resources.data_availability.l1_data_gas;
-                let actual_gas_consumed =
-                    if receipt.execution_resources.total_gas_consumed.l1_gas == 0 {
-                        (actual_fee - actual_data_gas_consumed.saturating_mul(data_gas_price))
-                            / gas_price.max(1)
-                    } else {
-                        receipt.execution_resources.total_gas_consumed.l1_gas
-                    };
+                let actual_gas_consumed = receipt.execution_resources.total_gas_consumed.l1_gas;
+                let actual_l2_gas_consumed = receipt.execution_resources.l2_gas.0;
 
                 let estimated_gas_consumed = estimate.l1_gas_consumed.as_u128();
                 let estimated_data_gas_consumed = estimate.l1_data_gas_consumed.as_u128();
+                let estimated_l2_gas_consumed = estimate.l2_gas_consumed.as_u128();
 
                 let gas_diff = actual_gas_consumed.abs_diff(estimated_gas_consumed);
                 let data_gas_diff = actual_data_gas_consumed.abs_diff(estimated_data_gas_consumed);
+                let l2_gas_diff = actual_l2_gas_consumed.abs_diff(estimated_l2_gas_consumed);
                 let estimate_diff = estimate.overall_fee.abs_diff(actual_fee.into());
 
-                if gas_diff > 0 || data_gas_diff > 0 || estimate_diff > 0.into() {
-                    tracing::warn!(block_number=%work.header.number, transaction_hash=%receipt.transaction_hash, execution_status=?receipt.execution_status, transaction=?transaction.variant, %estimated_gas_consumed, %actual_gas_consumed, %estimated_data_gas_consumed, %actual_data_gas_consumed, estimated_fee=%estimate.overall_fee, %actual_fee, "Estimation mismatch");
+                if gas_diff > 0 || data_gas_diff > 0 || l2_gas_diff > 0 || estimate_diff > 0.into()
+                {
+                    tracing::warn!(block_number=%work.header.number, transaction_hash=%receipt.transaction_hash, execution_status=?receipt.execution_status, transaction=?transaction.variant, %estimated_gas_consumed, %actual_gas_consumed, %estimated_data_gas_consumed, %actual_data_gas_consumed, %estimated_l2_gas_consumed, %actual_l2_gas_consumed, estimated_fee=%estimate.overall_fee, %actual_fee, "Estimation mismatch");
                 } else {
-                    tracing::debug!(block_number=%work.header.number, transaction_hash=%receipt.transaction_hash, %estimated_gas_consumed, %actual_gas_consumed, %estimated_data_gas_consumed, %actual_data_gas_consumed, estimated_fee=%estimate.overall_fee, %actual_fee, "Estimation matches");
+                    tracing::debug!(block_number=%work.header.number, transaction_hash=%receipt.transaction_hash, %estimated_gas_consumed, %actual_gas_consumed, %estimated_data_gas_consumed, %actual_data_gas_consumed, %estimated_l2_gas_consumed, %actual_l2_gas_consumed, estimated_fee=%estimate.overall_fee, %actual_fee, "Estimation matches");
                 }
             }
         }

--- a/crates/pathfinder/examples/re_execute.rs
+++ b/crates/pathfinder/examples/re_execute.rs
@@ -157,7 +157,7 @@ fn execute(storage: &mut Storage, chain_id: ChainId, work: Work) {
         }
     };
 
-    match pathfinder_executor::simulate(execution_state, transactions, false, false) {
+    match pathfinder_executor::simulate(execution_state, transactions) {
         Ok(simulations) => {
             for (simulation, (receipt, transaction)) in simulations
                 .iter()

--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -1168,7 +1168,7 @@ mod tests {
     #[test]
     fn parse_versioned_constants_success() {
         super::parse_versioned_constants(
-            "../executor/resources/versioned_constants_13_1_1.json".into(),
+            "../executor/resources/versioned_constants_0_13_1_1.json".into(),
         )
         .unwrap();
     }

--- a/crates/rpc/src/executor.rs
+++ b/crates/rpc/src/executor.rs
@@ -86,15 +86,19 @@ pub(crate) fn map_broadcasted_transaction(
                     .context("Serializing Sierra class definition")?,
             )
             .context("Compiling Sierra class definition to CASM")?;
+            let sierra_version =
+                SierraVersion::extract_from_program(&tx.contract_class.sierra_program)?;
 
-            let casm_contract_definition =
-                pathfinder_executor::parse_casm_definition(casm_contract_definition)
-                    .context("Parsing CASM contract definition")?;
+            let casm_contract_definition = pathfinder_executor::parse_casm_definition(
+                casm_contract_definition,
+                sierra_version.clone(),
+            )
+            .context("Parsing CASM contract definition")?;
             Some(ClassInfo::new(
                 &casm_contract_definition,
                 tx.contract_class.sierra_program.len(),
                 tx.contract_class.abi.len(),
-                SierraVersion::extract_from_program(&tx.contract_class.sierra_program)?,
+                sierra_version,
             )?)
         }
         BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V3(tx)) => {
@@ -104,15 +108,19 @@ pub(crate) fn map_broadcasted_transaction(
                     .context("Serializing Sierra class definition")?,
             )
             .context("Compiling Sierra class definition to CASM")?;
+            let sierra_version =
+                SierraVersion::extract_from_program(&tx.contract_class.sierra_program)?;
 
-            let casm_contract_definition =
-                pathfinder_executor::parse_casm_definition(casm_contract_definition)
-                    .context("Parsing CASM contract definition")?;
+            let casm_contract_definition = pathfinder_executor::parse_casm_definition(
+                casm_contract_definition,
+                sierra_version.clone(),
+            )
+            .context("Parsing CASM contract definition")?;
             Some(ClassInfo::new(
                 &casm_contract_definition,
                 tx.contract_class.sierra_program.len(),
                 tx.contract_class.abi.len(),
-                SierraVersion::extract_from_program(&tx.contract_class.sierra_program)?,
+                sierra_version,
             )?)
         }
         BroadcastedTransaction::Invoke(_) | BroadcastedTransaction::DeployAccount(_) => None,
@@ -523,8 +531,11 @@ pub fn compose_executor_transaction(
             let class_definition: SierraContractClass =
                 serde_json::from_str(&String::from_utf8(class_definition)?)
                     .context("Deserializing class definition")?;
+            let sierra_version =
+                SierraVersion::extract_from_program(&class_definition.sierra_program)?;
 
-            let contract_class = pathfinder_executor::parse_casm_definition(casm_definition)?;
+            let contract_class =
+                pathfinder_executor::parse_casm_definition(casm_definition, sierra_version)?;
             Some(ClassInfo::new(
                 &contract_class,
                 class_definition.sierra_program.len(),
@@ -542,8 +553,11 @@ pub fn compose_executor_transaction(
             let class_definition: SierraContractClass =
                 serde_json::from_str(&String::from_utf8(class_definition)?)
                     .context("Deserializing class definition")?;
+            let sierra_version =
+                SierraVersion::extract_from_program(&class_definition.sierra_program)?;
 
-            let contract_class = pathfinder_executor::parse_casm_definition(casm_definition)?;
+            let contract_class =
+                pathfinder_executor::parse_casm_definition(casm_definition, sierra_version)?;
             Some(ClassInfo::new(
                 &contract_class,
                 class_definition.sierra_program.len(),

--- a/crates/rpc/src/executor.rs
+++ b/crates/rpc/src/executor.rs
@@ -2,7 +2,20 @@ use anyhow::Context;
 use pathfinder_common::transaction::TransactionVariant;
 use pathfinder_common::{ChainId, StarknetVersion};
 use pathfinder_executor::{ClassInfo, IntoStarkFelt};
+use starknet_api::block::GasPrice;
+use starknet_api::contract_class::SierraVersion;
 use starknet_api::core::PatriciaKey;
+use starknet_api::execution_resources::GasAmount;
+use starknet_api::transaction::fields::{
+    AccountDeploymentData,
+    Calldata,
+    ContractAddressSalt,
+    Fee,
+    PaymasterData,
+    Tip,
+    TransactionSignature,
+    ValidResourceBounds,
+};
 
 use crate::types::request::{
     BroadcastedDeployAccountTransaction,
@@ -28,6 +41,8 @@ pub const VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEW
 pub(crate) fn map_broadcasted_transaction(
     transaction: &BroadcastedTransaction,
     chain_id: ChainId,
+    skip_validate: bool,
+    skip_fee_charge: bool,
 ) -> anyhow::Result<pathfinder_executor::Transaction> {
     use crate::types::request::BroadcastedDeclareTransaction;
 
@@ -41,7 +56,12 @@ pub(crate) fn map_broadcasted_transaction(
             let contract_class =
                 pathfinder_executor::parse_deprecated_class_definition(contract_class_json)?;
 
-            Some(ClassInfo::new(&contract_class, 0, 0)?)
+            Some(ClassInfo::new(
+                &contract_class,
+                0,
+                0,
+                SierraVersion::DEPRECATED,
+            )?)
         }
         BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V1(tx)) => {
             let contract_class_json = tx
@@ -52,7 +72,12 @@ pub(crate) fn map_broadcasted_transaction(
             let contract_class =
                 pathfinder_executor::parse_deprecated_class_definition(contract_class_json)?;
 
-            Some(ClassInfo::new(&contract_class, 0, 0)?)
+            Some(ClassInfo::new(
+                &contract_class,
+                0,
+                0,
+                SierraVersion::DEPRECATED,
+            )?)
         }
         BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V2(tx)) => {
             let casm_contract_definition = pathfinder_compiler::compile_to_casm(
@@ -69,6 +94,7 @@ pub(crate) fn map_broadcasted_transaction(
                 &casm_contract_definition,
                 tx.contract_class.sierra_program.len(),
                 tx.contract_class.abi.len(),
+                SierraVersion::extract_from_program(&tx.contract_class.sierra_program)?,
             )?)
         }
         BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V3(tx)) => {
@@ -86,6 +112,7 @@ pub(crate) fn map_broadcasted_transaction(
                 &casm_contract_definition,
                 tx.contract_class.sierra_program.len(),
                 tx.contract_class.abi.len(),
+                SierraVersion::extract_from_program(&tx.contract_class.sierra_program)?,
             )?)
         }
         BroadcastedTransaction::Invoke(_) | BroadcastedTransaction::DeployAccount(_) => None,
@@ -137,6 +164,12 @@ pub(crate) fn map_broadcasted_transaction(
         }
     };
 
+    let execution_flags = pathfinder_executor::AccountTransactionExecutionFlags {
+        only_query: has_query_version,
+        validate: !skip_validate,
+        charge_fee: !skip_fee_charge,
+    };
+
     let transaction = transaction.clone().into_common(chain_id);
     let transaction_hash = transaction.hash;
     let transaction = map_transaction_variant(transaction.variant)?;
@@ -147,7 +180,7 @@ pub(crate) fn map_broadcasted_transaction(
         class_info,
         None,
         deployed_address,
-        has_query_version,
+        execution_flags,
     )?;
 
     Ok(tx)
@@ -159,10 +192,10 @@ fn map_transaction_variant(
     match variant {
         TransactionVariant::DeclareV0(tx) => {
             let tx = starknet_api::transaction::DeclareTransactionV0V1 {
-                max_fee: starknet_api::transaction::Fee(u128::from_be_bytes(
+                max_fee: Fee(u128::from_be_bytes(
                     tx.max_fee.0.to_be_bytes()[16..].try_into().unwrap(),
                 )),
-                signature: starknet_api::transaction::TransactionSignature(
+                signature: TransactionSignature(
                     tx.signature.iter().map(|s| s.0.into_starkfelt()).collect(),
                 ),
                 nonce: starknet_api::core::Nonce(tx.nonce.0.into_starkfelt()),
@@ -179,10 +212,10 @@ fn map_transaction_variant(
         }
         TransactionVariant::DeclareV1(tx) => {
             let tx = starknet_api::transaction::DeclareTransactionV0V1 {
-                max_fee: starknet_api::transaction::Fee(u128::from_be_bytes(
+                max_fee: Fee(u128::from_be_bytes(
                     tx.max_fee.0.to_be_bytes()[16..].try_into().unwrap(),
                 )),
-                signature: starknet_api::transaction::TransactionSignature(
+                signature: TransactionSignature(
                     tx.signature.iter().map(|s| s.0.into_starkfelt()).collect(),
                 ),
                 nonce: starknet_api::core::Nonce(tx.nonce.0.into_starkfelt()),
@@ -199,10 +232,10 @@ fn map_transaction_variant(
         }
         TransactionVariant::DeclareV2(tx) => {
             let tx = starknet_api::transaction::DeclareTransactionV2 {
-                max_fee: starknet_api::transaction::Fee(u128::from_be_bytes(
+                max_fee: Fee(u128::from_be_bytes(
                     tx.max_fee.0.to_be_bytes()[16..].try_into().unwrap(),
                 )),
-                signature: starknet_api::transaction::TransactionSignature(
+                signature: TransactionSignature(
                     tx.signature.iter().map(|s| s.0.into_starkfelt()).collect(),
                 ),
                 nonce: starknet_api::core::Nonce(tx.nonce.0.into_starkfelt()),
@@ -223,8 +256,8 @@ fn map_transaction_variant(
         TransactionVariant::DeclareV3(tx) => {
             let tx = starknet_api::transaction::DeclareTransactionV3 {
                 resource_bounds: map_resource_bounds(tx.resource_bounds)?,
-                tip: starknet_api::transaction::Tip(tx.tip.0),
-                signature: starknet_api::transaction::TransactionSignature(
+                tip: Tip(tx.tip.0),
+                signature: TransactionSignature(
                     tx.signature.iter().map(|s| s.0.into_starkfelt()).collect(),
                 ),
                 nonce: starknet_api::core::Nonce(tx.nonce.0.into_starkfelt()),
@@ -244,13 +277,13 @@ fn map_transaction_variant(
                     .fee_data_availability_mode
                     .into_starkfelt()
                     .try_into()?,
-                paymaster_data: starknet_api::transaction::PaymasterData(
+                paymaster_data: PaymasterData(
                     tx.paymaster_data
                         .iter()
                         .map(|p| p.0.into_starkfelt())
                         .collect(),
                 ),
-                account_deployment_data: starknet_api::transaction::AccountDeploymentData(
+                account_deployment_data: AccountDeploymentData(
                     tx.account_deployment_data
                         .iter()
                         .map(|a| a.0.into_starkfelt())
@@ -268,19 +301,19 @@ fn map_transaction_variant(
         TransactionVariant::DeployAccountV1(tx) => {
             let tx = starknet_api::transaction::DeployAccountTransaction::V1(
                 starknet_api::transaction::DeployAccountTransactionV1 {
-                    max_fee: starknet_api::transaction::Fee(u128::from_be_bytes(
+                    max_fee: Fee(u128::from_be_bytes(
                         tx.max_fee.0.to_be_bytes()[16..].try_into().unwrap(),
                     )),
-                    signature: starknet_api::transaction::TransactionSignature(
+                    signature: TransactionSignature(
                         tx.signature.iter().map(|s| s.0.into_starkfelt()).collect(),
                     ),
                     nonce: starknet_api::core::Nonce(tx.nonce.0.into_starkfelt()),
                     class_hash: starknet_api::core::ClassHash(tx.class_hash.0.into_starkfelt()),
 
-                    contract_address_salt: starknet_api::transaction::ContractAddressSalt(
+                    contract_address_salt: ContractAddressSalt(
                         tx.contract_address_salt.0.into_starkfelt(),
                     ),
-                    constructor_calldata: starknet_api::transaction::Calldata(std::sync::Arc::new(
+                    constructor_calldata: Calldata(std::sync::Arc::new(
                         tx.constructor_calldata
                             .iter()
                             .map(|c| c.0.into_starkfelt())
@@ -297,16 +330,16 @@ fn map_transaction_variant(
             let tx = starknet_api::transaction::DeployAccountTransaction::V3(
                 starknet_api::transaction::DeployAccountTransactionV3 {
                     resource_bounds,
-                    tip: starknet_api::transaction::Tip(tx.tip.0),
-                    signature: starknet_api::transaction::TransactionSignature(
+                    tip: Tip(tx.tip.0),
+                    signature: TransactionSignature(
                         tx.signature.iter().map(|s| s.0.into_starkfelt()).collect(),
                     ),
                     nonce: starknet_api::core::Nonce(tx.nonce.0.into_starkfelt()),
                     class_hash: starknet_api::core::ClassHash(tx.class_hash.0.into_starkfelt()),
-                    contract_address_salt: starknet_api::transaction::ContractAddressSalt(
+                    contract_address_salt: ContractAddressSalt(
                         tx.contract_address_salt.0.into_starkfelt(),
                     ),
-                    constructor_calldata: starknet_api::transaction::Calldata(std::sync::Arc::new(
+                    constructor_calldata: Calldata(std::sync::Arc::new(
                         tx.constructor_calldata
                             .iter()
                             .map(|c| c.0.into_starkfelt())
@@ -320,7 +353,7 @@ fn map_transaction_variant(
                         .fee_data_availability_mode
                         .into_starkfelt()
                         .try_into()?,
-                    paymaster_data: starknet_api::transaction::PaymasterData(
+                    paymaster_data: PaymasterData(
                         tx.paymaster_data
                             .iter()
                             .map(|p| p.0.into_starkfelt())
@@ -334,10 +367,10 @@ fn map_transaction_variant(
         TransactionVariant::InvokeV0(tx) => {
             let tx = starknet_api::transaction::InvokeTransactionV0 {
                 // TODO: maybe we should store tx.max_fee as u128 internally?
-                max_fee: starknet_api::transaction::Fee(u128::from_be_bytes(
+                max_fee: Fee(u128::from_be_bytes(
                     tx.max_fee.0.to_be_bytes()[16..].try_into().unwrap(),
                 )),
-                signature: starknet_api::transaction::TransactionSignature(
+                signature: TransactionSignature(
                     tx.signature.iter().map(|s| s.0.into_starkfelt()).collect(),
                 ),
                 contract_address: starknet_api::core::ContractAddress(
@@ -347,7 +380,7 @@ fn map_transaction_variant(
                 entry_point_selector: starknet_api::core::EntryPointSelector(
                     tx.entry_point_selector.0.into_starkfelt(),
                 ),
-                calldata: starknet_api::transaction::Calldata(std::sync::Arc::new(
+                calldata: Calldata(std::sync::Arc::new(
                     tx.calldata.iter().map(|c| c.0.into_starkfelt()).collect(),
                 )),
             };
@@ -359,10 +392,10 @@ fn map_transaction_variant(
         TransactionVariant::InvokeV1(tx) => {
             let tx = starknet_api::transaction::InvokeTransactionV1 {
                 // TODO: maybe we should store tx.max_fee as u128 internally?
-                max_fee: starknet_api::transaction::Fee(u128::from_be_bytes(
+                max_fee: Fee(u128::from_be_bytes(
                     tx.max_fee.0.to_be_bytes()[16..].try_into().unwrap(),
                 )),
-                signature: starknet_api::transaction::TransactionSignature(
+                signature: TransactionSignature(
                     tx.signature.iter().map(|s| s.0.into_starkfelt()).collect(),
                 ),
                 nonce: starknet_api::core::Nonce(tx.nonce.0.into_starkfelt()),
@@ -370,7 +403,7 @@ fn map_transaction_variant(
                     PatriciaKey::try_from(tx.sender_address.get().into_starkfelt())
                         .expect("No sender address overflow expected"),
                 ),
-                calldata: starknet_api::transaction::Calldata(std::sync::Arc::new(
+                calldata: Calldata(std::sync::Arc::new(
                     tx.calldata.iter().map(|c| c.0.into_starkfelt()).collect(),
                 )),
             };
@@ -384,8 +417,8 @@ fn map_transaction_variant(
 
             let tx = starknet_api::transaction::InvokeTransactionV3 {
                 resource_bounds,
-                tip: starknet_api::transaction::Tip(tx.tip.0),
-                signature: starknet_api::transaction::TransactionSignature(
+                tip: Tip(tx.tip.0),
+                signature: TransactionSignature(
                     tx.signature.iter().map(|s| s.0.into_starkfelt()).collect(),
                 ),
                 nonce: starknet_api::core::Nonce(tx.nonce.0.into_starkfelt()),
@@ -393,7 +426,7 @@ fn map_transaction_variant(
                     PatriciaKey::try_from(tx.sender_address.get().into_starkfelt())
                         .expect("No sender address overflow expected"),
                 ),
-                calldata: starknet_api::transaction::Calldata(std::sync::Arc::new(
+                calldata: Calldata(std::sync::Arc::new(
                     tx.calldata.iter().map(|c| c.0.into_starkfelt()).collect(),
                 )),
                 nonce_data_availability_mode: tx
@@ -404,13 +437,13 @@ fn map_transaction_variant(
                     .fee_data_availability_mode
                     .into_starkfelt()
                     .try_into()?,
-                paymaster_data: starknet_api::transaction::PaymasterData(
+                paymaster_data: PaymasterData(
                     tx.paymaster_data
                         .iter()
                         .map(|p| p.0.into_starkfelt())
                         .collect(),
                 ),
-                account_deployment_data: starknet_api::transaction::AccountDeploymentData(
+                account_deployment_data: AccountDeploymentData(
                     tx.account_deployment_data
                         .iter()
                         .map(|a| a.0.into_starkfelt())
@@ -433,7 +466,7 @@ fn map_transaction_variant(
                 entry_point_selector: starknet_api::core::EntryPointSelector(
                     tx.entry_point_selector.0.into_starkfelt(),
                 ),
-                calldata: starknet_api::transaction::Calldata(std::sync::Arc::new(
+                calldata: Calldata(std::sync::Arc::new(
                     tx.calldata.iter().map(|c| c.0.into_starkfelt()).collect(),
                 )),
             };
@@ -459,7 +492,12 @@ pub fn compose_executor_transaction(
 
             let contract_class =
                 pathfinder_executor::parse_deprecated_class_definition(class_definition)?;
-            Some(ClassInfo::new(&contract_class, 0, 0)?)
+            Some(ClassInfo::new(
+                &contract_class,
+                0,
+                0,
+                SierraVersion::DEPRECATED,
+            )?)
         }
         TransactionVariant::DeclareV1(tx) => {
             let class_definition = db_transaction
@@ -468,7 +506,12 @@ pub fn compose_executor_transaction(
 
             let contract_class =
                 pathfinder_executor::parse_deprecated_class_definition(class_definition)?;
-            Some(ClassInfo::new(&contract_class, 0, 0)?)
+            Some(ClassInfo::new(
+                &contract_class,
+                0,
+                0,
+                SierraVersion::DEPRECATED,
+            )?)
         }
         TransactionVariant::DeclareV2(tx) => {
             let casm_definition = db_transaction
@@ -486,6 +529,7 @@ pub fn compose_executor_transaction(
                 &contract_class,
                 class_definition.sierra_program.len(),
                 class_definition.abi.len(),
+                SierraVersion::extract_from_program(&class_definition.sierra_program)?,
             )?)
         }
         TransactionVariant::DeclareV3(tx) => {
@@ -504,6 +548,7 @@ pub fn compose_executor_transaction(
                 &contract_class,
                 class_definition.sierra_program.len(),
                 class_definition.abi.len(),
+                SierraVersion::extract_from_program(&class_definition.sierra_program)?,
             )?)
         }
         TransactionVariant::DeployV0(_)
@@ -546,7 +591,7 @@ pub fn compose_executor_transaction(
     };
 
     let paid_fee_on_l1 = match &transaction.variant {
-        TransactionVariant::L1Handler(_) => Some(starknet_api::transaction::Fee(1_000_000_000_000)),
+        TransactionVariant::L1Handler(_) => Some(Fee(1_000_000_000_000)),
         _ => None,
     };
 
@@ -560,7 +605,7 @@ pub fn compose_executor_transaction(
         class_info,
         paid_fee_on_l1,
         deployed_address,
-        false,
+        pathfinder_executor::AccountTransactionExecutionFlags::default(),
     )?;
 
     Ok(tx)
@@ -568,25 +613,12 @@ pub fn compose_executor_transaction(
 
 fn map_resource_bounds(
     r: pathfinder_common::transaction::ResourceBounds,
-) -> Result<starknet_api::transaction::ResourceBoundsMapping, starknet_api::StarknetApiError> {
-    use starknet_api::transaction::{Resource, ResourceBounds};
+) -> Result<ValidResourceBounds, starknet_api::StarknetApiError> {
+    use starknet_api::transaction::fields::ResourceBounds;
 
-    let bounds = vec![
-        (
-            Resource::L1Gas,
-            ResourceBounds {
-                max_amount: r.l1_gas.max_amount.0,
-                max_price_per_unit: r.l1_gas.max_price_per_unit.0,
-            },
-        ),
-        (
-            Resource::L2Gas,
-            ResourceBounds {
-                max_amount: r.l2_gas.max_amount.0,
-                max_price_per_unit: r.l2_gas.max_price_per_unit.0,
-            },
-        ),
-    ];
-
-    bounds.try_into()
+    // TODO: cannot be AllResources b/c we don't have L1 data gas here...
+    Ok(ValidResourceBounds::L1Gas(ResourceBounds {
+        max_amount: GasAmount(r.l1_gas.max_amount.0),
+        max_price_per_unit: GasPrice(r.l1_gas.max_price_per_unit.0),
+    }))
 }

--- a/crates/rpc/src/method/estimate_fee.rs
+++ b/crates/rpc/src/method/estimate_fee.rs
@@ -94,10 +94,17 @@ pub async fn estimate_fee(context: RpcContext, input: Input) -> Result<Output, E
         let transactions = input
             .request
             .into_iter()
-            .map(|tx| crate::executor::map_broadcasted_transaction(&tx, context.chain_id))
+            .map(|tx| {
+                crate::executor::map_broadcasted_transaction(
+                    &tx,
+                    context.chain_id,
+                    skip_validate,
+                    true,
+                )
+            })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let result = pathfinder_executor::estimate(state, transactions, skip_validate)?;
+        let result = pathfinder_executor::estimate(state, transactions)?;
 
         Ok::<_, EstimateFeeError>(result)
     })
@@ -378,18 +385,18 @@ mod tests {
             l1_data_gas_consumed: 192.into(),
             l1_data_gas_price: 2.into(),
             l2_gas_consumed: 0.into(),
-            l2_gas_price: 0.into(),
+            l2_gas_price: 1.into(),
             overall_fee: 24201.into(),
             unit: PriceUnit::Wei,
         };
         let deploy_expected = FeeEstimate {
-            l1_gas_consumed: 16.into(),
+            l1_gas_consumed: 15.into(),
             l1_gas_price: 1.into(),
             l1_data_gas_consumed: 224.into(),
             l1_data_gas_price: 2.into(),
             l2_gas_consumed: 0.into(),
-            l2_gas_price: 0.into(),
-            overall_fee: 464.into(),
+            l2_gas_price: 1.into(),
+            overall_fee: 463.into(),
             unit: PriceUnit::Wei,
         };
         let invoke_expected = FeeEstimate {
@@ -398,7 +405,7 @@ mod tests {
             l1_data_gas_consumed: 128.into(),
             l1_data_gas_price: 2.into(),
             l2_gas_consumed: 0.into(),
-            l2_gas_price: 0.into(),
+            l2_gas_price: 1.into(),
             overall_fee: 268.into(),
             unit: PriceUnit::Wei,
         };
@@ -408,7 +415,7 @@ mod tests {
             l1_data_gas_consumed: 128.into(),
             l1_data_gas_price: 2.into(),
             l2_gas_consumed: 0.into(),
-            l2_gas_price: 0.into(),
+            l2_gas_price: 1.into(),
             overall_fee: 266.into(),
             unit: PriceUnit::Wei,
         };
@@ -419,7 +426,7 @@ mod tests {
             l1_data_gas_consumed: 128.into(),
             l1_data_gas_price: 2.into(),
             l2_gas_consumed: 0.into(),
-            l2_gas_price: 0.into(),
+            l2_gas_price: 1.into(),
             overall_fee: 280.into(),
             unit: PriceUnit::Fri,
         };
@@ -473,7 +480,7 @@ mod tests {
             l1_data_gas_consumed: 192.into(),
             l1_data_gas_price: 2.into(),
             l2_gas_consumed: 0.into(),
-            l2_gas_price: 0.into(),
+            l2_gas_price: 1.into(),
             overall_fee: 1262.into(),
             unit: PriceUnit::Wei,
         };
@@ -483,7 +490,7 @@ mod tests {
             l1_data_gas_consumed: 224.into(),
             l1_data_gas_price: 2.into(),
             l2_gas_consumed: 0.into(),
-            l2_gas_price: 0.into(),
+            l2_gas_price: 1.into(),
             overall_fee: 464.into(),
             unit: PriceUnit::Wei,
         };
@@ -493,7 +500,7 @@ mod tests {
             l1_data_gas_consumed: 128.into(),
             l1_data_gas_price: 2.into(),
             l2_gas_consumed: 0.into(),
-            l2_gas_price: 0.into(),
+            l2_gas_price: 1.into(),
             overall_fee: 268.into(),
             unit: PriceUnit::Wei,
         };
@@ -503,7 +510,7 @@ mod tests {
             l1_data_gas_consumed: 128.into(),
             l1_data_gas_price: 2.into(),
             l2_gas_consumed: 0.into(),
-            l2_gas_price: 0.into(),
+            l2_gas_price: 1.into(),
             overall_fee: 266.into(),
             unit: PriceUnit::Wei,
         };
@@ -514,7 +521,7 @@ mod tests {
             l1_data_gas_consumed: 128.into(),
             l1_data_gas_price: 2.into(),
             l2_gas_consumed: 0.into(),
-            l2_gas_price: 0.into(),
+            l2_gas_price: 1.into(),
             overall_fee: 280.into(),
             unit: PriceUnit::Fri,
         };
@@ -568,7 +575,7 @@ mod tests {
             l1_data_gas_consumed: 192.into(),
             l1_data_gas_price: 2.into(),
             l2_gas_consumed: 0.into(),
-            l2_gas_price: 0.into(),
+            l2_gas_price: 1.into(),
             overall_fee: 24203.into(),
             unit: PriceUnit::Wei,
         };
@@ -578,7 +585,7 @@ mod tests {
             l1_data_gas_consumed: 224.into(),
             l1_data_gas_price: 2.into(),
             l2_gas_consumed: 0.into(),
-            l2_gas_price: 0.into(),
+            l2_gas_price: 1.into(),
             overall_fee: 467.into(),
             unit: PriceUnit::Wei,
         };
@@ -588,7 +595,7 @@ mod tests {
             l1_data_gas_consumed: 128.into(),
             l1_data_gas_price: 2.into(),
             l2_gas_consumed: 0.into(),
-            l2_gas_price: 0.into(),
+            l2_gas_price: 1.into(),
             overall_fee: 270.into(),
             unit: PriceUnit::Wei,
         };
@@ -598,7 +605,7 @@ mod tests {
             l1_data_gas_consumed: 128.into(),
             l1_data_gas_price: 2.into(),
             l2_gas_consumed: 0.into(),
-            l2_gas_price: 0.into(),
+            l2_gas_price: 1.into(),
             overall_fee: 267.into(),
             unit: PriceUnit::Wei,
         };
@@ -609,7 +616,7 @@ mod tests {
             l1_data_gas_consumed: 128.into(),
             l1_data_gas_price: 2.into(),
             l2_gas_consumed: 0.into(),
-            l2_gas_price: 0.into(),
+            l2_gas_price: 1.into(),
             overall_fee: 284.into(),
             unit: PriceUnit::Fri,
         };
@@ -663,7 +670,7 @@ mod tests {
             l1_data_gas_consumed: 192.into(),
             l1_data_gas_price: 2.into(),
             l2_gas_consumed: 0.into(),
-            l2_gas_price: 0.into(),
+            l2_gas_price: 1.into(),
             overall_fee: 1264.into(),
             unit: PriceUnit::Wei,
         };
@@ -673,7 +680,7 @@ mod tests {
             l1_data_gas_consumed: 224.into(),
             l1_data_gas_price: 2.into(),
             l2_gas_consumed: 0.into(),
-            l2_gas_price: 0.into(),
+            l2_gas_price: 1.into(),
             overall_fee: 467.into(),
             unit: PriceUnit::Wei,
         };
@@ -683,7 +690,7 @@ mod tests {
             l1_data_gas_consumed: 128.into(),
             l1_data_gas_price: 2.into(),
             l2_gas_consumed: 0.into(),
-            l2_gas_price: 0.into(),
+            l2_gas_price: 1.into(),
             overall_fee: 270.into(),
             unit: PriceUnit::Wei,
         };
@@ -693,7 +700,7 @@ mod tests {
             l1_data_gas_consumed: 128.into(),
             l1_data_gas_price: 2.into(),
             l2_gas_consumed: 0.into(),
-            l2_gas_price: 0.into(),
+            l2_gas_price: 1.into(),
             overall_fee: 267.into(),
             unit: PriceUnit::Wei,
         };
@@ -704,7 +711,7 @@ mod tests {
             l1_data_gas_consumed: 128.into(),
             l1_data_gas_price: 2.into(),
             l2_gas_consumed: 0.into(),
-            l2_gas_price: 0.into(),
+            l2_gas_price: 1.into(),
             overall_fee: 284.into(),
             unit: PriceUnit::Fri,
         };

--- a/crates/rpc/src/method/estimate_message_fee.rs
+++ b/crates/rpc/src/method/estimate_message_fee.rs
@@ -13,6 +13,7 @@ use pathfinder_common::{
 use pathfinder_crypto::Felt;
 use pathfinder_executor::{ExecutionState, IntoStarkFelt, L1BlobDataAvailability};
 use starknet_api::core::PatriciaKey;
+use starknet_api::transaction::fields::{Calldata, Fee};
 
 use crate::context::RpcContext;
 use crate::error::ApplicationError;
@@ -109,7 +110,7 @@ pub async fn estimate_message_fee(
 
         let transaction = create_executor_transaction(input, context.chain_id)?;
 
-        let result = pathfinder_executor::estimate(state, vec![transaction], false)?;
+        let result = pathfinder_executor::estimate(state, vec![transaction])?;
 
         Ok::<_, EstimateMessageFeeError>(result)
     })
@@ -164,7 +165,7 @@ fn create_executor_transaction(
         entry_point_selector: starknet_api::core::EntryPointSelector(
             input.message.entry_point_selector.0.into_starkfelt(),
         ),
-        calldata: starknet_api::transaction::Calldata(Arc::new(
+        calldata: Calldata(Arc::new(
             transaction
                 .calldata
                 .into_iter()
@@ -177,9 +178,9 @@ fn create_executor_transaction(
         starknet_api::transaction::Transaction::L1Handler(tx),
         starknet_api::transaction::TransactionHash(transaction_hash.0.into_starkfelt()),
         None,
-        Some(starknet_api::transaction::Fee(1)),
+        Some(Fee(1)),
         None,
-        false,
+        pathfinder_executor::AccountTransactionExecutionFlags::default(),
     )?;
     Ok(transaction)
 }
@@ -365,7 +366,7 @@ mod tests {
             l1_data_gas_consumed: 128.into(),
             l1_data_gas_price: 1.into(),
             l2_gas_consumed: 0.into(),
-            l2_gas_price: 0.into(),
+            l2_gas_price: 1.into(),
             overall_fee: 29422.into(),
             unit: pathfinder_executor::types::PriceUnit::Wei,
         });

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -935,8 +935,10 @@ pub(crate) mod tests {
                     messages: vec![],
                     result: vec![felt!("0x1")],
                     computation_resources: declare_fee_transfer_computation_resources(),
-                    execution_resources:
-                        pathfinder_executor::types::InnerCallExecutionResources::default(),
+                    execution_resources: pathfinder_executor::types::InnerCallExecutionResources {
+                        l1_gas: 4,
+                        l2_gas: 0,
+                    },
                 }
             }
 
@@ -956,8 +958,10 @@ pub(crate) mod tests {
                     messages: vec![],
                     result: vec![],
                     computation_resources: declare_validate_computation_resources(),
-                    execution_resources:
-                        pathfinder_executor::types::InnerCallExecutionResources::default(),
+                    execution_resources: pathfinder_executor::types::InnerCallExecutionResources {
+                        l1_gas: 1,
+                        l2_gas: 0,
+                    },
                 }
             }
 
@@ -1234,8 +1238,10 @@ pub(crate) mod tests {
                     messages: vec![],
                     result: vec![],
                     computation_resources: universal_deployer_validate_computation_resources(),
-                    execution_resources:
-                        pathfinder_executor::types::InnerCallExecutionResources::default(),
+                    execution_resources: pathfinder_executor::types::InnerCallExecutionResources {
+                        l1_gas: 1,
+                        l2_gas: 0,
+                    },
                 }
             }
 
@@ -1308,7 +1314,7 @@ pub(crate) mod tests {
                                 pedersen_builtin_applications: 7,
                                 ..Default::default()
                             },
-                            execution_resources: pathfinder_executor::types::InnerCallExecutionResources::default(),
+                            execution_resources: pathfinder_executor::types::InnerCallExecutionResources { l1_gas: 4, l2_gas: 0 },
                         }
                     ],
                     class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
@@ -1334,7 +1340,10 @@ pub(crate) mod tests {
                         *DEPLOYED_CONTRACT_ADDRESS.get(),
                     ],
                     computation_resources: universal_deployer_execute_computation_resources(),
-                    execution_resources: pathfinder_executor::types::InnerCallExecutionResources::default(),
+                    execution_resources: pathfinder_executor::types::InnerCallExecutionResources {
+                        l1_gas: 6,
+                        l2_gas: 0,
+                    },
                 }
             }
 
@@ -1371,8 +1380,10 @@ pub(crate) mod tests {
                     messages: vec![],
                     result: vec![felt!("0x1")],
                     computation_resources: universal_deployer_fee_transfer_computation_resources(),
-                    execution_resources:
-                        pathfinder_executor::types::InnerCallExecutionResources::default(),
+                    execution_resources: pathfinder_executor::types::InnerCallExecutionResources {
+                        l1_gas: 4,
+                        l2_gas: 0,
+                    },
                 }
             }
 
@@ -1622,8 +1633,10 @@ pub(crate) mod tests {
                     ],
                     messages: vec![],
                     result: vec![],
-                    execution_resources:
-                        pathfinder_executor::types::InnerCallExecutionResources::default(),
+                    execution_resources: pathfinder_executor::types::InnerCallExecutionResources {
+                        l1_gas: 1,
+                        l2_gas: 0,
+                    },
                     computation_resources: invoke_validate_computation_resources(),
                 }
             }
@@ -1654,8 +1667,8 @@ pub(crate) mod tests {
                         },
                         execution_resources:
                             pathfinder_executor::types::InnerCallExecutionResources {
-                                l1_gas: 12840,
-                                ..Default::default()
+                                l1_gas: 1,
+                                l2_gas: 0,
                             },
                     }],
                     class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
@@ -1672,8 +1685,10 @@ pub(crate) mod tests {
                     messages: vec![],
                     result: vec![test_storage_value.0],
                     computation_resources: invoke_execute_computation_resources(),
-                    execution_resources:
-                        pathfinder_executor::types::InnerCallExecutionResources::default(),
+                    execution_resources: pathfinder_executor::types::InnerCallExecutionResources {
+                        l1_gas: 3,
+                        l2_gas: 0,
+                    },
                 }
             }
 
@@ -1709,8 +1724,10 @@ pub(crate) mod tests {
                     messages: vec![],
                     result: vec![felt!("0x1")],
                     computation_resources: invoke_fee_transfer_computation_resources(),
-                    execution_resources:
-                        pathfinder_executor::types::InnerCallExecutionResources::default(),
+                    execution_resources: pathfinder_executor::types::InnerCallExecutionResources {
+                        l1_gas: 4,
+                        l2_gas: 0,
+                    },
                 }
             }
 

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -90,11 +90,17 @@ pub async fn simulate_transactions(
         let transactions = input
             .transactions
             .into_iter()
-            .map(|tx| crate::executor::map_broadcasted_transaction(&tx, context.chain_id))
+            .map(|tx| {
+                crate::executor::map_broadcasted_transaction(
+                    &tx,
+                    context.chain_id,
+                    skip_validate,
+                    skip_fee_charge,
+                )
+            })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let txs =
-            pathfinder_executor::simulate(state, transactions, skip_validate, skip_fee_charge)?;
+        let txs = pathfinder_executor::simulate(state, transactions)?;
         Ok(Output(txs))
     })
     .await
@@ -527,7 +533,7 @@ pub(crate) mod tests {
                     l1_data_gas_price: 2.into(),
                     l2_gas_consumed: 0.into(),
                     l2_gas_price: 0.into(),
-                    overall_fee: 15720.into(),
+                    overall_fee: OVERALL_FEE.into(),
                     unit: pathfinder_executor::types::PriceUnit::Wei,
                 }
             }

--- a/crates/rpc/src/v06/method/estimate_fee.rs
+++ b/crates/rpc/src/v06/method/estimate_fee.rs
@@ -477,7 +477,7 @@ pub(crate) mod tests {
                 l1_data_gas_consumed: None,
                 l1_data_gas_price: None,
                 l2_gas_consumed: 0.into(),
-                l2_gas_price: 0.into(),
+                l2_gas_price: 1.into(),
                 overall_fee: 2768.into(),
                 unit: PriceUnit::Wei,
             };
@@ -487,7 +487,7 @@ pub(crate) mod tests {
                 l1_data_gas_consumed: None,
                 l1_data_gas_price: None,
                 l2_gas_consumed: 0.into(),
-                l2_gas_price: 0.into(),
+                l2_gas_price: 1.into(),
                 overall_fee: 3020.into(),
                 unit: PriceUnit::Wei,
             };
@@ -497,18 +497,18 @@ pub(crate) mod tests {
                 l1_data_gas_consumed: None,
                 l1_data_gas_price: None,
                 l2_gas_consumed: 0.into(),
-                l2_gas_price: 0.into(),
+                l2_gas_price: 1.into(),
                 overall_fee: 1674.into(),
                 unit: PriceUnit::Wei,
             };
             let invoke_v0_expected = FeeEstimate {
-                l1_gas_consumed: 1669.into(),
+                l1_gas_consumed: 1652.into(),
                 l1_gas_price: 1.into(),
                 l1_data_gas_consumed: None,
                 l1_data_gas_price: None,
                 l2_gas_consumed: 0.into(),
-                l2_gas_price: 0.into(),
-                overall_fee: 1669.into(),
+                l2_gas_price: 1.into(),
+                overall_fee: 1652.into(),
                 unit: PriceUnit::Wei,
             };
             let invoke_v3_expected = FeeEstimate {
@@ -517,7 +517,7 @@ pub(crate) mod tests {
                 l1_data_gas_consumed: None,
                 l1_data_gas_price: None,
                 l2_gas_consumed: 0.into(),
-                l2_gas_price: 0.into(),
+                l2_gas_price: 1.into(),
                 overall_fee: 3348.into(),
                 unit: PriceUnit::Fri,
             };

--- a/crates/rpc/src/v06/method/estimate_message_fee.rs
+++ b/crates/rpc/src/v06/method/estimate_message_fee.rs
@@ -13,6 +13,7 @@ use pathfinder_common::{
 use pathfinder_crypto::Felt;
 use pathfinder_executor::{ExecutionState, IntoStarkFelt, L1BlobDataAvailability};
 use starknet_api::core::PatriciaKey;
+use starknet_api::transaction::fields::{Calldata, Fee};
 
 use crate::context::RpcContext;
 use crate::error::ApplicationError;
@@ -215,7 +216,7 @@ fn create_executor_transaction(
         entry_point_selector: starknet_api::core::EntryPointSelector(
             input.message.entry_point_selector.0.into_starkfelt(),
         ),
-        calldata: starknet_api::transaction::Calldata(Arc::new(
+        calldata: Calldata(Arc::new(
             transaction
                 .calldata
                 .into_iter()
@@ -228,7 +229,7 @@ fn create_executor_transaction(
         starknet_api::transaction::Transaction::L1Handler(tx),
         starknet_api::transaction::TransactionHash(transaction_hash.0.into_starkfelt()),
         None,
-        Some(starknet_api::transaction::Fee(1)),
+        Some(Fee(1)),
         None,
         false,
     )?;
@@ -411,7 +412,7 @@ mod tests {
             l1_data_gas_consumed: Some(0.into()),
             l1_data_gas_price: Some(1.into()),
             l2_gas_consumed: 0.into(),
-            l2_gas_price: 0.into(),
+            l2_gas_price: 1.into(),
             overall_fee: 16302.into(),
             unit: PriceUnit::Wei,
         };

--- a/crates/tagged/Cargo.toml
+++ b/crates/tagged/Cargo.toml
@@ -11,4 +11,5 @@ fake = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 pretty_assertions_sorted = { workspace = true }
+rand = { workspace = true }
 tagged-debug-derive = { path = "../tagged-debug-derive" }


### PR DESCRIPTION
This PR upgrades blockifier to a recent snapshot from the `main-v0.13.4` branch and implements the required API changes.

The Cairo compiler is also upgrades, so we can now compile Sierra 1.7.0 classes into CASM.