### PR TITLE
fix(p2p,rpc): limit Cairo 0 class definition size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Use aggregate Bloom filters for `starknet_getEvents` to improve performance.
+- Cairo 0 class definition size is now capped at 4 MiB.
 
 ## [0.15.2] - 2024-12-04
 

--- a/crates/common/src/class_definition.rs
+++ b/crates/common/src/class_definition.rs
@@ -10,6 +10,8 @@ use serde_with::serde_as;
 
 use crate::{ByteCodeOffset, EntryPoint};
 
+pub const CLASS_DEFINITION_MAX_ALLOWED_SIZE: u64 = 4 * 1024 * 1024;
+
 #[derive(Debug, Deserialize, Dummy)]
 pub enum ClassDefinition<'a> {
     Sierra(Sierra<'a>),

--- a/crates/p2p/src/client/conv.rs
+++ b/crates/p2p/src/client/conv.rs
@@ -909,10 +909,10 @@ impl TryFromDto<p2p_proto::class::Cairo0Class> for CairoDefinition {
         let abi = dto.abi;
 
         let compressed_program = base64::decode(dto.program)?;
-        let mut gzip_decoder =
-            flate2::read::GzDecoder::new(std::io::Cursor::new(compressed_program));
+        let gzip_decoder = flate2::read::GzDecoder::new(std::io::Cursor::new(compressed_program));
         let mut program = Vec::new();
         gzip_decoder
+            .take(pathfinder_common::class_definition::CLASS_DEFINITION_MAX_ALLOWED_SIZE)
             .read_to_end(&mut program)
             .context("Decompressing program JSON")?;
 

--- a/crates/rpc/src/types/class.rs
+++ b/crates/rpc/src/types/class.rs
@@ -223,10 +223,11 @@ impl CairoContractClass {
 
     pub fn serialize_to_json(&self) -> anyhow::Result<Vec<u8>> {
         // decode program
-        let mut decompressor =
+        let decompressor =
             flate2::read::GzDecoder::new(Cursor::new(base64::decode(&self.program).unwrap()));
         let mut program = Vec::new();
         decompressor
+            .take(pathfinder_common::class_definition::CLASS_DEFINITION_MAX_ALLOWED_SIZE)
             .read_to_end(&mut program)
             .context("Decompressing program")?;
 


### PR DESCRIPTION
Make sure the uncompressed size of Cairo 0 class definitions does not exceed our limit of 4 MiB.

Closes #2471

