### PR TITLE
chore(rpc): fix `test_multiple_transactions` for rpc `v08`

### DIFF
--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -741,7 +741,7 @@ pub(crate) mod tests {
                                         l1_gas: 0,
                                         l1_data_gas: 192,
                                     },
-                                l1_gas: 0,
+                                l1_gas: 878,
                                 l1_data_gas: 192,
                                 l2_gas: 0,
                             },
@@ -1004,7 +1004,7 @@ pub(crate) mod tests {
                                         l1_gas: 0,
                                         l1_data_gas: 224,
                                     },
-                                l1_gas: 0,
+                                l1_gas: 16,
                                 l1_data_gas: 224,
                                 l2_gas: 0,
                             },
@@ -1415,7 +1415,7 @@ pub(crate) mod tests {
                                         l1_gas: 0,
                                         l1_data_gas: 128,
                                     },
-                                l1_gas: 0,
+                                l1_gas: 12,
                                 l1_data_gas: 128,
                                 l2_gas: 0,
                             },
@@ -1645,7 +1645,10 @@ pub(crate) mod tests {
                             ..Default::default()
                         },
                         execution_resources:
-                            pathfinder_executor::types::InnerCallExecutionResources::default(),
+                            pathfinder_executor::types::InnerCallExecutionResources {
+                                l1_gas: 12840,
+                                ..Default::default()
+                            },
                     }],
                     class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
                     entry_point_type: pathfinder_executor::types::EntryPointType::External,

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -769,6 +769,7 @@ pub(crate) mod tests {
             include_state_diffs: true,
         };
 
+        // V07
         pretty_assertions_sorted::assert_eq!(
             output
                 .serialize(Serializer {
@@ -778,6 +779,20 @@ pub(crate) mod tests {
             expected
                 .serialize(Serializer {
                     version: RpcVersion::V07,
+                })
+                .unwrap(),
+        );
+
+        // V08
+        pretty_assertions_sorted::assert_eq!(
+            output
+                .serialize(Serializer {
+                    version: RpcVersion::V08,
+                })
+                .unwrap(),
+            expected
+                .serialize(Serializer {
+                    version: RpcVersion::V08,
                 })
                 .unwrap(),
         );


### PR DESCRIPTION
Fixes the test fixtures of `test_multiple_transactions` for RPC v08.

See also: #2457