### PR TITLE
chore(ci): temporarily disable arm64 docker builds in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,7 +63,6 @@ jobs:
           context: .
           platforms: |
             linux/amd64
-            linux/arm64
           file: ./Dockerfile
           build-args: |
             PATHFINDER_FORCE_VERSION=${{ steps.generate_version.outputs.pathfinder_version }}


### PR DESCRIPTION
One of the new build dependencies of `blockifier`, `starknet-sierra-compile` has a build script that does not work in our cross-compile setup due to directly invoking `cargo install` without the `--target` flag properly set. This causes the build to fail on arm64.
