### PR TITLE
feat(rpc/trace): add `is_reverted` flag to `FUNCTION_INVOCATION`

### DIFF
--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -207,6 +207,7 @@ pub struct FunctionInvocation {
     pub result: Vec<Felt>,
     pub computation_resources: ComputationResources,
     pub execution_resources: InnerCallExecutionResources,
+    pub is_reverted: bool,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -384,6 +385,7 @@ impl FunctionInvocation {
                 l1_gas: gas_vector.l1_gas.0.into(),
                 l2_gas: gas_vector.l2_gas.0.into(),
             },
+            is_reverted: call_info.execution.failed,
         }
     }
 }

--- a/crates/rpc/src/dto/simulation.rs
+++ b/crates/rpc/src/dto/simulation.rs
@@ -122,10 +122,13 @@ impl crate::dto::SerializeForVersion for &pathfinder_executor::types::FunctionIn
         serializer.serialize_iter("messages", self.messages.len(), &mut self.messages.iter())?;
         serializer.serialize_iter("result", self.result.len(), &mut self.result.iter())?;
         match serializer.version {
-            RpcVersion::V08 => serializer.serialize_field(
-                "execution_resources",
-                &InnerCallExecutionResources(&self.execution_resources),
-            )?,
+            RpcVersion::V08 => {
+                serializer.serialize_field(
+                    "execution_resources",
+                    &InnerCallExecutionResources(&self.execution_resources),
+                )?;
+                serializer.serialize_field("is_reverted", &self.is_reverted)?;
+            }
             _ => serializer.serialize_field(
                 "execution_resources",
                 &ComputationResources(&self.computation_resources),

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -320,6 +320,7 @@ pub(crate) mod tests {
                                 execution_resources: pathfinder_executor::types::InnerCallExecutionResources::default(),
                                 internal_calls: vec![],
                                 computation_resources: pathfinder_executor::types::ComputationResources::default(),
+                                is_reverted: false,
                             }),
                         validate_invocation: Some(
                             pathfinder_executor::types::FunctionInvocation {
@@ -344,7 +345,8 @@ pub(crate) mod tests {
                                 computation_resources: pathfinder_executor::types::ComputationResources{
                                     steps: 13,
                                     ..Default::default()
-                                }
+                                },
+                                is_reverted: false,
                             },
                         ),
                         fee_transfer_invocation: None,
@@ -446,6 +448,7 @@ pub(crate) mod tests {
                                 steps: 12,
                                 ..Default::default()
                             },
+                            is_reverted: false,
                         }
                     ),
                     fee_transfer_invocation: Some(
@@ -484,6 +487,7 @@ pub(crate) mod tests {
                                 pedersen_builtin_applications: 4,
                                 ..Default::default()
                             },
+                            is_reverted: false,
                         }
                     ),
                     state_diff: pathfinder_executor::types::StateDiff {
@@ -939,6 +943,7 @@ pub(crate) mod tests {
                         l1_gas: 4,
                         l2_gas: 0,
                     },
+                    is_reverted: false,
                 }
             }
 
@@ -962,6 +967,7 @@ pub(crate) mod tests {
                         l1_gas: 1,
                         l2_gas: 0,
                     },
+                    is_reverted: false,
                 }
             }
 
@@ -1242,6 +1248,7 @@ pub(crate) mod tests {
                         l1_gas: 1,
                         l2_gas: 0,
                     },
+                    is_reverted: false,
                 }
             }
 
@@ -1271,6 +1278,7 @@ pub(crate) mod tests {
                                     result: vec![],
                                     computation_resources: pathfinder_executor::types::ComputationResources::default(),
                                     execution_resources: pathfinder_executor::types::InnerCallExecutionResources::default(),
+                                    is_reverted: false,
                                 },
                             ],
                             class_hash: Some(UNIVERSAL_DEPLOYER_CLASS_HASH.0),
@@ -1315,6 +1323,7 @@ pub(crate) mod tests {
                                 ..Default::default()
                             },
                             execution_resources: pathfinder_executor::types::InnerCallExecutionResources { l1_gas: 4, l2_gas: 0 },
+                            is_reverted: false,
                         }
                     ],
                     class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
@@ -1344,6 +1353,7 @@ pub(crate) mod tests {
                         l1_gas: 6,
                         l2_gas: 0,
                     },
+                    is_reverted: false,
                 }
             }
 
@@ -1384,6 +1394,7 @@ pub(crate) mod tests {
                         l1_gas: 4,
                         l2_gas: 0,
                     },
+                    is_reverted: false,
                 }
             }
 
@@ -1638,6 +1649,7 @@ pub(crate) mod tests {
                         l2_gas: 0,
                     },
                     computation_resources: invoke_validate_computation_resources(),
+                    is_reverted: false,
                 }
             }
 
@@ -1670,6 +1682,7 @@ pub(crate) mod tests {
                                 l1_gas: 1,
                                 l2_gas: 0,
                             },
+                        is_reverted: false,
                     }],
                     class_hash: Some(DUMMY_ACCOUNT_CLASS_HASH.0),
                     entry_point_type: pathfinder_executor::types::EntryPointType::External,
@@ -1689,6 +1702,7 @@ pub(crate) mod tests {
                         l1_gas: 3,
                         l2_gas: 0,
                     },
+                    is_reverted: false,
                 }
             }
 
@@ -1728,6 +1742,7 @@ pub(crate) mod tests {
                         l1_gas: 4,
                         l2_gas: 0,
                     },
+                    is_reverted: false,
                 }
             }
 
@@ -1916,6 +1931,7 @@ pub(crate) mod tests {
                     computation_resources: invoke_fee_transfer_computation_resources(),
                     execution_resources:
                         pathfinder_executor::types::InnerCallExecutionResources::default(),
+                    is_reverted: false,
                 }
             }
 

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -493,6 +493,9 @@ fn map_gateway_function_invocation(
             l1_gas: gas_consumed.l1_gas,
             l2_gas: gas_consumed.l2_gas.unwrap_or_default(),
         },
+        // Pre-0.13.4 failures in individual calls are not possible -- the whole TX is reverted in
+        // that case.
+        is_reverted: false,
     })
 }
 

--- a/doc/rpc/v08/starknet_api_openrpc.json
+++ b/doc/rpc/v08/starknet_api_openrpc.json
@@ -312,22 +312,7 @@
       "result": {
         "name": "result",
         "schema": {
-          "title": "Transaction",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/TXN"
-            },
-            {
-              "type": "object",
-              "properties": {
-                "transaction_hash": {
-                  "title": "transaction hash",
-                  "$ref": "#/components/schemas/TXN_HASH"
-                }
-              },
-              "required": ["transaction_hash"]
-            }
-          ]
+            "$ref": "#/components/schemas/TXN_WITH_HASH"
         }
       },
       "errors": [
@@ -364,22 +349,7 @@
       "result": {
         "name": "transactionResult",
         "schema": {
-          "title": "Transaction",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/TXN"
-            },
-            {
-              "type": "object",
-              "properties": {
-                "transaction_hash": {
-                  "title": "transaction hash",
-                  "$ref": "#/components/schemas/TXN_HASH"
-                }
-              },
-              "required": ["transaction_hash"]
-            }
-          ]
+            "$ref": "#/components/schemas/TXN_WITH_HASH"
         }
       },
       "errors": [
@@ -627,6 +597,9 @@
       "errors": [
         {
           "$ref": "#/components/errors/CONTRACT_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/ENTRYPOINT_NOT_FOUND"
         },
         {
           "$ref": "#/components/errors/CONTRACT_ERROR"
@@ -1293,7 +1266,7 @@
       "u128": {
         "type": "string",
         "title": "u128",
-        "description": "64 bit integers, represented by hex string of length at most 32",
+        "description": "128 bit integers, represented by hex string of length at most 32",
         "pattern": "^0x(0|[a-fA-F1-9]{1}[a-fA-F0-9]{0,31})$"
       },
       "CHAIN_ID": {
@@ -1514,24 +1487,9 @@
             "description": "The transactions in this block",
             "type": "array",
             "items": {
-              "title": "transactions in block",
-              "type": "object",
-              "allOf": [
-                {
-                  "title": "transaction",
-                  "$ref": "#/components/schemas/TXN"
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "transaction_hash": {
-                      "title": "transaction hash",
-                      "$ref": "#/components/schemas/TXN_HASH"
-                    }
-                  },
-                  "required": ["transaction_hash"]
-                }
-              ]
+              "schema": {
+                "$ref": "#/components/schemas/TXN_WITH_HASH"
+              }
             }
           }
         },
@@ -1893,6 +1851,26 @@
           }
         ]
       },
+      "TXN_WITH_HASH": {
+        "schema": {
+          "title": "Transaction",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/TXN"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "transaction_hash": {
+                  "title": "transaction hash",
+                  "$ref": "#/components/schemas/TXN_HASH"
+                }
+              },
+              "required": ["transaction_hash"]
+            }
+          ]
+        }
+      },
       "SIGNATURE": {
         "title": "Signature",
         "description": "A transaction signature",
@@ -2185,135 +2163,15 @@
       },
       "BROADCASTED_INVOKE_TXN": {
         "title": "Broadcasted invoke transaction",
-        "$ref": "#/components/schemas/INVOKE_TXN"
+        "$ref": "#/components/schemas/INVOKE_TXN_V3"
       },
       "BROADCASTED_DEPLOY_ACCOUNT_TXN": {
         "title": "Broadcasted deploy account transaction",
-        "$ref": "#/components/schemas/DEPLOY_ACCOUNT_TXN"
+        "$ref": "#/components/schemas/DEPLOY_ACCOUNT_TXN_V3"
       },
       "BROADCASTED_DECLARE_TXN": {
         "title": "Broadcasted declare transaction",
-        "oneOf": [
-          {
-            "title": "Broadcasted declare transaction V1",
-            "$ref": "#/components/schemas/BROADCASTED_DECLARE_TXN_V1"
-          },
-          {
-            "title": "Broadcasted declare transaction V2",
-            "$ref": "#/components/schemas/BROADCASTED_DECLARE_TXN_V2"
-          },
-          {
-            "title": "Broadcasted declare transaction V3",
-            "$ref": "#/components/schemas/BROADCASTED_DECLARE_TXN_V3"
-          }
-        ]
-      },
-      "BROADCASTED_DECLARE_TXN_V1": {
-        "title": "Broadcasted declare contract transaction V1",
-        "allOf": [
-          {
-            "type": "object",
-            "title": "Declare txn v1",
-            "properties": {
-              "type": {
-                "title": "Declare",
-                "type": "string",
-                "enum": ["DECLARE"]
-              },
-              "sender_address": {
-                "title": "Sender address",
-                "description": "The address of the account contract sending the declaration transaction",
-                "$ref": "#/components/schemas/ADDRESS"
-              },
-              "max_fee": {
-                "title": "Max fee",
-                "$ref": "#/components/schemas/FELT",
-                "description": "The maximal fee that can be charged for including the transaction"
-              },
-              "version": {
-                "title": "Version",
-                "description": "Version of the transaction scheme",
-                "type": "string",
-                "enum": ["0x1", "0x100000000000000000000000000000001"]
-              },
-              "signature": {
-                "title": "Signature",
-                "$ref": "#/components/schemas/SIGNATURE"
-              },
-              "nonce": {
-                "title": "Nonce",
-                "$ref": "#/components/schemas/FELT"
-              },
-              "contract_class": {
-                "title": "Contract class",
-                "description": "The class to be declared",
-                "$ref": "#/components/schemas/DEPRECATED_CONTRACT_CLASS"
-              }
-            },
-            "required": ["type", "sender_address", "max_fee", "version", "signature", "nonce", "contract_class"]
-          }
-        ]
-      },
-      "BROADCASTED_DECLARE_TXN_V2": {
-        "title": "Broadcasted declare Transaction V2",
-        "description": "Broadcasted declare Contract Transaction V2",
-        "allOf": [
-          {
-            "type": "object",
-            "title": "Declare txn v2",
-            "properties": {
-              "type": {
-                "title": "Declare",
-                "type": "string",
-                "enum": ["DECLARE"]
-              },
-              "sender_address": {
-                "title": "Sender address",
-                "description": "The address of the account contract sending the declaration transaction",
-                "$ref": "#/components/schemas/ADDRESS"
-              },
-              "compiled_class_hash": {
-                "title": "Compiled class hash",
-                "description": "The hash of the Cairo assembly resulting from the Sierra compilation",
-                "$ref": "#/components/schemas/FELT"
-              },
-              "max_fee": {
-                "title": "Max fee",
-                "$ref": "#/components/schemas/FELT",
-                "description": "The maximal fee that can be charged for including the transaction"
-              },
-              "version": {
-                "title": "Version",
-                "description": "Version of the transaction scheme",
-                "type": "string",
-                "enum": ["0x2", "0x100000000000000000000000000000002"]
-              },
-              "signature": {
-                "title": "Signature",
-                "$ref": "#/components/schemas/SIGNATURE"
-              },
-              "nonce": {
-                "title": "Nonce",
-                "$ref": "#/components/schemas/FELT"
-              },
-              "contract_class": {
-                "title": "Contract class",
-                "description": "The class to be declared",
-                "$ref": "#/components/schemas/CONTRACT_CLASS"
-              }
-            },
-            "required": [
-              "type",
-              "sender_address",
-              "compiled_class_hash",
-              "max_fee",
-              "version",
-              "signature",
-              "nonce",
-              "contract_class"
-            ]
-          }
-        ]
+        "$ref": "#/components/schemas/BROADCASTED_DECLARE_TXN_V3"
       },
       "BROADCASTED_DECLARE_TXN_V3": {
         "title": "Broadcasted declare Transaction V3",
@@ -3342,7 +3200,7 @@
           "offset": {
             "title": "Offset",
             "description": "The offset of the entry point in the program",
-            "$ref": "#/components/schemas/NUM_AS_HEX"
+            "type": "integer"
           },
           "selector": {
             "title": "Selector",
@@ -3597,7 +3455,7 @@
             "$ref": "#/components/schemas/PRICE_UNIT"
           }
         },
-        "required": ["gas_consumed", "gas_price", "data_gas_consumed", "data_gas_price", "overall_fee", "unit"]
+        "required": ["l1_gas_consumed", "l1_gas_price", "l2_gas_consumed", "l2_gas_price","l1_data_gas_consumed", "l1_data_gas_price", "overall_fee", "unit"]
       },
       "FEE_PAYMENT": {
         "title": "Fee Payment",
@@ -3804,6 +3662,10 @@
       "CONTRACT_NOT_FOUND": {
         "code": 20,
         "message": "Contract not found"
+      },
+      "ENTRYPOINT_NOT_FOUND": {
+        "code": 21,
+        "message": "Requested entrypoint does not exist in the contract"
       },
       "BLOCK_NOT_FOUND": {
         "code": 24,

--- a/doc/rpc/v08/starknet_executables.json
+++ b/doc/rpc/v08/starknet_executables.json
@@ -138,10 +138,12 @@
                             "properties": {
                                 "builtins": {
                                     "type": "array",
-                                    "items": "string"
+                                    "items": {
+                                        "type": "string"
+                                    }
                                 }
                             },
-                            "required": "builtins"
+                            "required": ["builtins"]
                         }
                     ]
                 }
@@ -893,7 +895,7 @@
                             "InitSquashData": {
                                 "type": "object",
                                 "properties": {
-                                    "dict_access": {
+                                    "dict_accesses": {
                                         "$ref": "#/components/schemas/ResOperand"
                                     },
                                     "ptr_diff": {

--- a/doc/rpc/v08/starknet_trace_api_openrpc.json
+++ b/doc/rpc/v08/starknet_trace_api_openrpc.json
@@ -356,6 +356,11 @@
                 "title": "Execution resources",
                 "description": "Resources consumed by the internal call",
                 "$ref": "#/components/schemas/INNER_CALL_EXECUTION_RESOURCES"
+              },
+              "is_reverted": {
+                "title": "Is Reverted",
+                "description": "true if this inner call panicked",
+                "type": "boolean"
               }
             },
             "required": [
@@ -367,7 +372,8 @@
               "calls",
               "events",
               "messages",
-              "execution_resources"
+              "execution_resources",
+              "is_reverted"
             ]
           }
         ]

--- a/doc/rpc/v08/starknet_write_api.json
+++ b/doc/rpc/v08/starknet_write_api.json
@@ -183,7 +183,7 @@
           "$ref": "#/components/errors/NON_ACCOUNT"
         },
         {
-          "$ref": "#/components/errors/CLASS_HASH_NOT_FOUND"
+          "$ref": "./api/starknet_api_openrpc.json#/components/errors/CLASS_HASH_NOT_FOUND"
         },
         {
           "$ref": "#/components/errors/DUPLICATE_TX"
@@ -201,9 +201,7 @@
     "contentDescriptors": {},
     "schemas": {
       "NUM_AS_HEX": {
-        "title": "An integer number in hex format (0x...)",
-        "type": "string",
-        "pattern": "^0x[a-fA-F0-9]+$"
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/NUM_AS_HEX"
       },
       "SIGNATURE": {
         "$ref": "./api/starknet_api_openrpc.json#/components/schemas/SIGNATURE"
@@ -228,10 +226,6 @@
       }
     },
     "errors": {
-      "CLASS_HASH_NOT_FOUND": {
-        "code": 28,
-        "message": "Class hash not found"
-      },
       "CLASS_ALREADY_DECLARED": {
         "code": 51,
         "message": "Class already declared"
@@ -255,7 +249,8 @@
       },
       "COMPILATION_FAILED": {
         "code": 56,
-        "message": "Compilation failed"
+        "message": "Compilation failed",
+        "data": "string"
       },
       "CONTRACT_CLASS_SIZE_IS_TOO_LARGE": {
         "code": 57,

--- a/doc/rpc/v08/starknet_ws_api.json
+++ b/doc/rpc/v08/starknet_ws_api.json
@@ -133,7 +133,7 @@
     {
       "name": "starknet_subscribeTransactionStatus",
       "summary": "Transaction Status subscription",
-      "description": "Creates a WebSocket stream which will fire events when a transaction status is updated",
+      "description": "Creates a WebSocket stream which at first fires an event with the current known transaction status, followed by events for every transaction status update",
       "params": [
         {
           "name": "transaction_hash",
@@ -141,14 +141,6 @@
           "required": true,
           "schema": {
             "$ref": "#/components/schemas/FELT"
-          }
-        },
-        {
-          "name": "block_id",
-          "summary": "The block to get notifications from, default is latest, limited to 1024 blocks back",
-          "required": false,
-          "schema": {
-            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_ID"
           }
         }
       ],
@@ -159,12 +151,6 @@
         }
       },
       "errors": [
-        {
-          "$ref": "#/components/errors/TOO_MANY_BLOCKS_BACK"
-        },
-        {
-          "$ref": "./api/starknet_api_openrpc.json#/components/errors/BLOCK_NOT_FOUND"
-        }
       ]
     },
     {
@@ -244,7 +230,7 @@
                 "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN_HASH"
               },
               {
-                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN"
+                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN_WITH_HASH"
               }
             ]
           }
@@ -316,9 +302,7 @@
             "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN_HASH"
           },
           "status": {
-            "schema": {
-              "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN_STATUS_RESULT"
-            }
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN_STATUS_RESULT"
           }
         }
       },
@@ -336,9 +320,7 @@
           "starting_block_hash": {
             "title": "Starting Block Hash",
             "description": "Hash of the first known block of the orphaned chain",
-            "schema": {
-              "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_HASH"
-            }
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_HASH"
           },
           "starting_block_number": {
             "title": "Starting Block Number",
@@ -348,9 +330,7 @@
           "ending_block_hash": {
             "title": "Ending Block",
             "description": "The last known block of the orphaned chain",
-            "schema": {
-              "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_HASH"
-            }
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_HASH"
           },
           "ending_block_number": {
             "title": "Ending Block Number",


### PR DESCRIPTION
Starting from Starknet 0.13.4 panics in calls can be caught and handled by callers, so failure in an individual call does not cause the transaction to fail (and revert) immediately.

To be able to find out which calls have failed an update to the 0.8 OpenRPC spec now requires the `is_reverted` flag for function invocations.

Closes: #2496