### PR TITLE
chore(cargo): bump MSRV to Rust 1.81.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ opt-level = 3
 version = "0.15.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-rust-version = "1.80"
+rust-version = "1.81"
 authors = ["Equilibrium Labs <info@equilibrium.co>"]
 
 [workspace.dependencies]


### PR DESCRIPTION
The Cairo compiler no longer compiles using Rust 1.80.

