### PR TITLE
flaky p2p sync test

### DIFF
--- a/crates/common/src/state_update.rs
+++ b/crates/common/src/state_update.rs
@@ -644,6 +644,14 @@ impl DeclaredClasses {
     }
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum StateUpdateError {
+    #[error("Contract class hash missing for contract {0}")]
+    ContractClassHashMissing(ContractAddress),
+    #[error(transparent)]
+    StorageError(#[from] anyhow::Error),
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/pathfinder/src/sync.rs
+++ b/crates/pathfinder/src/sync.rs
@@ -523,7 +523,7 @@ mod tests {
                 Ok(Err(error)) => {
                     let unexpected_fatal = error_setup.fatal_at.is_none();
                     if unexpected_fatal {
-                        tracing::debug!(?error, "Sync failed with an enexpected fatal error");
+                        tracing::debug!(?error, "Sync failed with an unexpected fatal error");
                     } else {
                         tracing::debug!(?error, "Sync failed with a fatal error");
                     }

--- a/crates/pathfinder/src/sync/error.rs
+++ b/crates/pathfinder/src/sync/error.rs
@@ -26,6 +26,8 @@ pub(super) enum SyncError {
     ClassDefinitionsDeclarationsMismatch(PeerId),
     #[error("Class hash computation failed")]
     ClassHashComputationError(PeerId),
+    #[error("Contract's class is missing")]
+    ContractClassMissing(PeerId),
     #[error("Discontinuity in header chain")]
     Discontinuity(PeerId),
     #[error("Event commitment mismatch")]

--- a/crates/pathfinder/src/sync/state_updates.rs
+++ b/crates/pathfinder/src/sync/state_updates.rs
@@ -285,7 +285,7 @@ pub async fn batch_update_starknet_state(
             tail,
             storage.clone(),
         )
-        .context("Updating Starknet state")?;
+        .with_context(|| format!("Updating Starknet state, tail {tail}"))?;
         let state_commitment = StateCommitment::calculate(storage_commitment, class_commitment);
         let expected_state_commitment = db
             .state_commitment(tail.into())

--- a/crates/pathfinder/src/sync/state_updates.rs
+++ b/crates/pathfinder/src/sync/state_updates.rs
@@ -10,6 +10,7 @@ use pathfinder_common::state_update::{
     ContractClassUpdate,
     ContractUpdate,
     StateUpdateData,
+    StateUpdateError,
     StateUpdateRef,
     SystemContractUpdate,
 };
@@ -285,7 +286,15 @@ pub async fn batch_update_starknet_state(
             tail,
             storage.clone(),
         )
-        .with_context(|| format!("Updating Starknet state, tail {tail}"))?;
+        .map_err(|error| match error {
+            StateUpdateError::ContractClassHashMissing(for_contract) => {
+                tracing::debug!(%for_contract, "Contract class hash is missing");
+                SyncError::ContractClassMissing(peer)
+            }
+            StateUpdateError::StorageError(error) => SyncError::Fatal(Arc::new(
+                error.context(format!("Updating Starknet state, tail {tail}")),
+            )),
+        })?;
         let state_commitment = StateCommitment::calculate(storage_commitment, class_commitment);
         let expected_state_commitment = db
             .state_commitment(tail.into())

--- a/crates/pathfinder/src/sync/track.rs
+++ b/crates/pathfinder/src/sync/track.rs
@@ -827,7 +827,7 @@ impl ProcessStage for StoreBlock {
             block_number,
             self.storage.clone(),
         )
-        .context("Updating Starknet state")?;
+        .with_context(|| format!("Updating Starknet state, block_number {block_number}"))?;
 
         // Ensure that roots match.
         let state_commitment = StateCommitment::calculate(storage_commitment, class_commitment);

--- a/crates/storage/src/fake.rs
+++ b/crates/storage/src/fake.rs
@@ -8,6 +8,7 @@ use pathfinder_common::receipt::Receipt;
 use pathfinder_common::state_update::{
     ContractClassUpdate,
     ContractUpdate,
+    StateUpdateError,
     StateUpdateRef,
     SystemContractUpdate,
 };
@@ -70,7 +71,7 @@ pub type UpdateTriesFn = Box<
         bool,
         BlockNumber,
         Storage,
-    ) -> anyhow::Result<(StorageCommitment, ClassCommitment)>,
+    ) -> Result<(StorageCommitment, ClassCommitment), StateUpdateError>,
 >;
 
 pub struct Config {


### PR DESCRIPTION
This PR fixes 2 things:
- syncing fake contract update which does not have a valid underlying class hash is a recoverable error, not a fatal one,
- removes flakiness from a related test, by improving how sync done watch works.