### PR TITLE
feat: add ApplicationError::EntrypointNotFound

### DIFF
--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -21,6 +21,8 @@ pub enum ApplicationError {
     FailedToReceiveTxn,
     #[error("Contract not found")]
     ContractNotFound,
+    #[error("Requested entrypoint does not exist in the contract")]
+    EntrypointNotFound,
     #[error("Block not found")]
     BlockNotFound,
     #[error("Invalid transaction index in a block")]
@@ -125,6 +127,7 @@ impl ApplicationError {
             ApplicationError::FailedToReceiveTxn => 1,
             ApplicationError::NoTraceAvailable(_) => 10,
             ApplicationError::ContractNotFound => 20,
+            ApplicationError::EntrypointNotFound => 21,
             ApplicationError::BlockNotFound => 24,
             ApplicationError::InvalidTxnHash => 25,
             ApplicationError::InvalidBlockHash => 26,
@@ -187,6 +190,7 @@ impl ApplicationError {
         match self {
             ApplicationError::FailedToReceiveTxn => None,
             ApplicationError::ContractNotFound => None,
+            ApplicationError::EntrypointNotFound => None,
             ApplicationError::BlockNotFound => None,
             ApplicationError::InvalidTxnIndex => None,
             ApplicationError::InvalidTxnHash => None,

--- a/crates/rpc/src/method/call.rs
+++ b/crates/rpc/src/method/call.rs
@@ -11,6 +11,7 @@ pub enum CallError {
     Custom(anyhow::Error),
     BlockNotFound,
     ContractNotFound,
+    EntrypointNotFound,
     ContractError {
         revert_error: Option<String>,
         revert_error_stack: pathfinder_executor::ErrorStack,
@@ -28,7 +29,7 @@ impl From<pathfinder_executor::CallError> for CallError {
         use pathfinder_executor::CallError::*;
         match value {
             ContractNotFound => Self::ContractNotFound,
-            InvalidMessageSelector => Self::Custom(anyhow::anyhow!("Invalid message selector")),
+            InvalidMessageSelector => Self::EntrypointNotFound,
             ContractError(error, error_stack) => Self::ContractError {
                 revert_error: Some(format!("Execution error: {}", error)),
                 revert_error_stack: error_stack,
@@ -54,6 +55,7 @@ impl From<CallError> for ApplicationError {
         match value {
             CallError::BlockNotFound => ApplicationError::BlockNotFound,
             CallError::ContractNotFound => ApplicationError::ContractNotFound,
+            CallError::EntrypointNotFound => ApplicationError::EntrypointNotFound,
             CallError::ContractError {
                 revert_error,
                 revert_error_stack,
@@ -613,7 +615,7 @@ mod tests {
                 block_id: BLOCK_5,
             };
             let error = call(context, input).await;
-            assert_matches::assert_matches!(error, Err(CallError::Custom(_)));
+            assert_matches::assert_matches!(error, Err(CallError::EntrypointNotFound));
         }
 
         #[tokio::test]


### PR DESCRIPTION
Mapped from CallError::InvalidMessageSelector.

Fixes https://github.com/eqlabs/pathfinder/issues/2497 .