### PR TITLE
Expose class hashing functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7575,6 +7575,7 @@ dependencies = [
  "p2p",
  "p2p_proto",
  "pathfinder-block-hashes",
+ "pathfinder-class-hash",
  "pathfinder-common",
  "pathfinder-compiler",
  "pathfinder-crypto",
@@ -7623,6 +7624,28 @@ version = "0.15.3"
 dependencies = [
  "pathfinder-common",
  "pathfinder-crypto",
+]
+
+[[package]]
+name = "pathfinder-class-hash"
+version = "0.15.3"
+dependencies = [
+ "anyhow",
+ "assert_matches",
+ "fake",
+ "pathfinder-common",
+ "pathfinder-crypto",
+ "pathfinder-serde",
+ "primitive-types",
+ "rand",
+ "rstest",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha3",
+ "starknet-gateway-test-fixtures",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -7777,6 +7800,7 @@ dependencies = [
  "hyper 1.5.0",
  "metrics",
  "mime",
+ "pathfinder-class-hash",
  "pathfinder-common",
  "pathfinder-compiler",
  "pathfinder-crypto",
@@ -7843,6 +7867,7 @@ dependencies = [
  "hex",
  "metrics",
  "paste",
+ "pathfinder-class-hash",
  "pathfinder-common",
  "pathfinder-crypto",
  "pathfinder-ethereum",
@@ -9784,6 +9809,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "fake",
+ "pathfinder-class-hash",
  "pathfinder-common",
  "pathfinder-crypto",
  "pathfinder-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/block-hashes",
+    "crates/class-hash",
     "crates/common",
     "crates/compiler",
     "crates/crypto",

--- a/crates/class-hash/Cargo.toml
+++ b/crates/class-hash/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "starknet-gateway-types"
+name = "pathfinder-class-hash"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
@@ -8,15 +8,10 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-fake = { workspace = true, features = ["serde_json"] }
-pathfinder-class-hash = { path = "../class-hash" }
 pathfinder-common = { path = "../common" }
 pathfinder-crypto = { path = "../crypto" }
 pathfinder-serde = { path = "../serde" }
 primitive-types = { workspace = true }
-rand = { workspace = true }
-reqwest = { workspace = true }
-rstest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = [
     "arbitrary_precision",
@@ -29,5 +24,8 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+fake = { workspace = true, features = ["serde_json"] }
+rand = { workspace = true }
+rstest = { workspace = true }
 starknet-gateway-test-fixtures = { path = "../gateway-test-fixtures" }
 tokio = { workspace = true, features = ["macros", "test-util"] }

--- a/crates/gateway-types/src/lib.rs
+++ b/crates/gateway-types/src/lib.rs
@@ -1,4 +1,3 @@
-pub mod class_hash;
 pub mod error;
 pub mod reply;
 pub mod request;

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -34,6 +34,7 @@ metrics-exporter-prometheus = { workspace = true }
 p2p = { path = "../p2p" }
 p2p_proto = { path = "../p2p_proto" }
 pathfinder-block-hashes = { path = "../block-hashes" }
+pathfinder-class-hash = { path = "../class-hash" }
 pathfinder-common = { path = "../common" }
 pathfinder-compiler = { path = "../compiler" }
 pathfinder-crypto = { path = "../crypto" }

--- a/crates/pathfinder/examples/compute_class_hash.rs
+++ b/crates/pathfinder/examples/compute_class_hash.rs
@@ -11,9 +11,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut s = Vec::new();
     std::io::stdin().read_to_end(&mut s).unwrap();
     let s = s;
-    let class_hash = match starknet_gateway_types::class_hash::compute_class_hash(&s)? {
-        starknet_gateway_types::class_hash::ComputedClassHash::Cairo(h) => h.0,
-        starknet_gateway_types::class_hash::ComputedClassHash::Sierra(h) => h.0,
+    let class_hash = match pathfinder_class_hash::compute_class_hash(&s)? {
+        pathfinder_class_hash::ComputedClassHash::Cairo(h) => h.0,
+        pathfinder_class_hash::ComputedClassHash::Sierra(h) => h.0,
     };
     println!("{class_hash:x}");
     Ok(())

--- a/crates/pathfinder/src/state/sync/class.rs
+++ b/crates/pathfinder/src/state/sync/class.rs
@@ -19,7 +19,7 @@ pub async fn download_class<SequencerClient: GatewayApi>(
     class_hash: ClassHash,
     fetch_casm_from_fgw: bool,
 ) -> Result<DownloadedClass, anyhow::Error> {
-    use starknet_gateway_types::class_hash::compute_class_hash;
+    use pathfinder_class_hash::compute_class_hash;
 
     let definition = sequencer
         .pending_class_by_hash(class_hash)
@@ -35,7 +35,7 @@ pub async fn download_class<SequencerClient: GatewayApi>(
     let (hash, definition) = rx.await.context("Panic on rayon thread")?;
     let hash = hash?;
 
-    use starknet_gateway_types::class_hash::ComputedClassHash;
+    use pathfinder_class_hash::ComputedClassHash;
     match hash {
         ComputedClassHash::Cairo(hash) => {
             if class_hash != hash {
@@ -44,7 +44,7 @@ pub async fn download_class<SequencerClient: GatewayApi>(
 
             Ok(DownloadedClass::Cairo { definition, hash })
         }
-        starknet_gateway_types::class_hash::ComputedClassHash::Sierra(hash) => {
+        ComputedClassHash::Sierra(hash) => {
             anyhow::ensure!(
                 class_hash == hash,
                 "Class hash mismatch, {} instead of {}",

--- a/crates/pathfinder/src/sync/class_definitions.rs
+++ b/crates/pathfinder/src/sync/class_definitions.rs
@@ -9,6 +9,7 @@ use p2p::client::types::ClassDefinition as P2PClassDefinition;
 use p2p::libp2p::PeerId;
 use p2p::PeerData;
 use p2p_proto::transaction;
+use pathfinder_class_hash::from_parts::{compute_cairo_class_hash, compute_sierra_class_hash};
 use pathfinder_common::class_definition::{Cairo, ClassDefinition as GwClassDefinition, Sierra};
 use pathfinder_common::state_update::DeclaredClasses;
 use pathfinder_common::{BlockNumber, CasmHash, ClassHash, SierraHash};
@@ -16,10 +17,6 @@ use pathfinder_storage::{Storage, Transaction};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde_json::de;
 use starknet_gateway_client::GatewayApi;
-use starknet_gateway_types::class_hash::from_parts::{
-    compute_cairo_class_hash,
-    compute_sierra_class_hash,
-};
 use starknet_gateway_types::error::SequencerError;
 use starknet_gateway_types::reply::call;
 use tokio::sync::mpsc::{self, Receiver};

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -19,6 +19,7 @@ http-body = { workspace = true }
 hyper = { workspace = true }
 metrics = { workspace = true }
 mime = { workspace = true }
+pathfinder-class-hash = { path = "../class-hash" }
 pathfinder-common = { path = "../common" }
 pathfinder-compiler = { path = "../compiler" }
 pathfinder-crypto = { path = "../crypto" }

--- a/crates/rpc/src/types/class.rs
+++ b/crates/rpc/src/types/class.rs
@@ -1,10 +1,10 @@
 use std::io::{Cursor, Read};
 
 use anyhow::Context;
+use pathfinder_class_hash::{compute_class_hash, ComputedClassHash};
 use pathfinder_crypto::Felt;
 use pathfinder_serde::U64AsHexStr;
 use serde::{Deserialize, Serialize};
-use starknet_gateway_types::class_hash::{compute_class_hash, ComputedClassHash};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ContractClass {
@@ -531,11 +531,11 @@ mod tests {
     }
 
     mod declare_class_hash {
+        use pathfinder_class_hash::compute_class_hash;
         use starknet_gateway_test_fixtures::class_definitions::{
             CAIRO_0_11_SIERRA,
             CONTRACT_DEFINITION,
         };
-        use starknet_gateway_types::class_hash::compute_class_hash;
 
         use super::super::ContractClass;
 

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -21,6 +21,7 @@ flume = { version = "0.11.0", default-features = false, features = [
 hex = { workspace = true }
 metrics = { workspace = true }
 paste = { workspace = true }
+pathfinder-class-hash = { path = "../class-hash" }
 pathfinder-common = { path = "../common" }
 pathfinder-crypto = { path = "../crypto" }
 pathfinder-ethereum = { path = "../ethereum" }

--- a/crates/storage/src/fake.rs
+++ b/crates/storage/src/fake.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 use std::ops::RangeInclusive;
 
 use fake::{Fake, Faker};
+use pathfinder_class_hash::compute_class_hash;
 use pathfinder_common::event::Event;
 use pathfinder_common::receipt::Receipt;
 use pathfinder_common::state_update::{
@@ -38,7 +39,6 @@ use pathfinder_crypto::signature::SignatureError;
 use pathfinder_crypto::Felt;
 use rand::seq::IteratorRandom;
 use rand::Rng;
-use starknet_gateway_types::class_hash::compute_class_hash;
 
 use crate::{Storage, StorageBuilder};
 


### PR DESCRIPTION
This PR exposes the [requested](https://github.com/eqlabs/pathfinder/pull/2465) class hash functionality in the simplest way possible *

- Moves the class hashing functionality from `starknet-gateway-types` to a publicly accessible crate.
- Adds a CI job to publish dependent crates (`crypto`, `common`, `serde`) and the new class hash crate itself `class-hash` to crates.io on every pathfinder release.

Closes #2466 


\* Ideally our `common` crate should be refactored to expose a more organized API/types with cleaner docs. I attempted this a couple times but our macros make it hard to organize types based on their domain/concerns. It's still a WIP, but didn't want to drag this further, so I'll continue some other time.