### PR TITLE
fix: exclude from doctests example code that isn't meant to compile

### DIFF
--- a/crates/rpc/src/jsonrpc/router/method.rs
+++ b/crates/rpc/src/jsonrpc/router/method.rs
@@ -96,7 +96,7 @@ pub async fn handle_json_rpc_body(
     }
 }
 
-/// ```
+/// ```ignore
 /// async fn example(RpcContext, impl DeserializeForVersion, RpcVersion) -> Result<Output, Into<RpcError>>
 /// ```
 impl<F, Input, Output, Error, Fut>
@@ -145,7 +145,7 @@ where
     }
 }
 
-/// ```
+/// ```ignore
 /// async fn example(RpcContext, impl Deserialize) -> Result<Output, Into<RpcError>>
 /// ```
 impl<F, Input, Output, Error, Fut> IntoRpcEndpoint<((), Input), ((), Output), ((), RpcContext)>
@@ -194,7 +194,7 @@ where
     }
 }
 
-/// ```
+/// ```ignore
 /// async fn example(impl Deserialize) -> Result<Output, Into<RpcError>>
 /// ```
 #[async_trait]
@@ -243,7 +243,7 @@ where
     }
 }
 
-/// ```
+/// ```ignore
 /// async fn example(RpcContext) -> Result<Output, Into<RpcError>>
 /// ```
 #[async_trait]
@@ -294,7 +294,7 @@ where
     }
 }
 
-/// ```
+/// ```ignore
 /// async fn example() -> Result<Output, Into<RpcError>>
 /// ```
 #[async_trait]
@@ -345,7 +345,7 @@ where
     }
 }
 
-/// ```
+/// ```ignore
 /// fn example() -> &'static str
 /// ```
 #[async_trait]

--- a/crates/rpc/src/jsonrpc/websocket.rs
+++ b/crates/rpc/src/jsonrpc/websocket.rs
@@ -9,7 +9,7 @@
 //!
 //!
 //! Manual testing can be performed using `wscat`:
-//! ```
+//! ```ignore
 //! > pierre:~/pathfinder$ wscat -c ws://localhost:9545/ws
 //! Connected (press CTRL+C to quit)
 //! > {"jsonrpc":"2.0", "id": 1, "method": "pathfinder_subscribe", "params": ["newHeads"]}
@@ -19,7 +19,7 @@
 //!
 //! Subscriptions may lag behind because of a slow network or slow client and
 //! result in an error:
-//! ```
+//! ```ignore
 //! > pierre:~/pathfinder$ wscat -c ws://localhost:9545/ws
 //! Connected (press CTRL+C to quit)
 //! > {"jsonrpc":"2.0", "id": 1, "method": "pathfinder_subscribe", "params":


### PR DESCRIPTION
Prevents intermittent failures of `cargo test`.