### PR TITLE
fix(executor): fix L2 gas computation and inner-call gas estimation 

### DIFF
--- a/crates/executor/src/estimate.rs
+++ b/crates/executor/src/estimate.rs
@@ -1,6 +1,5 @@
 use blockifier::transaction::transaction_execution::Transaction;
 use blockifier::transaction::transactions::ExecutableTransaction;
-use starknet_api::transaction::fields::GasVectorComputationMode;
 
 use super::error::TransactionExecutionError;
 use super::execution_state::ExecutionState;
@@ -19,12 +18,14 @@ pub fn estimate(
         let _span = tracing::debug_span!("estimate", transaction_hash=%super::transaction::transaction_hash(&transaction), %block_number, %transaction_idx).entered();
 
         let fee_type = super::transaction::fee_type(&transaction);
+        let gas_vector_computation_mode =
+            super::transaction::gas_vector_computation_mode(&transaction);
         let minimal_l1_gas_amount_vector = match &transaction {
             Transaction::Account(account_transaction) => {
                 Some(blockifier::fee::gas_usage::estimate_minimal_gas_vector(
                     &block_context,
                     account_transaction,
-                    &GasVectorComputationMode::All,
+                    &gas_vector_computation_mode,
                 ))
             }
             Transaction::L1Handler(_) => None,

--- a/crates/executor/src/simulate.rs
+++ b/crates/executor/src/simulate.rs
@@ -135,6 +135,7 @@ pub fn simulate(
                         state_diff,
                         block_context.versioned_constants(),
                         &gas_vector_computation_mode,
+                        block_context.block_info().use_kzg_da,
                     ),
                 });
             }
@@ -222,6 +223,7 @@ pub fn trace(
             state_diff,
             block_context.versioned_constants(),
             &gas_vector_computation_mode,
+            block_context.block_info().use_kzg_da,
         );
         traces.push((hash, trace));
     }
@@ -371,12 +373,14 @@ fn to_trace(
     state_diff: StateDiff,
     versioned_constants: &VersionedConstants,
     gas_vector_computation_mode: &GasVectorComputationMode,
+    use_kzg_da: bool,
 ) -> TransactionTrace {
     let validate_invocation = execution_info.validate_call_info.map(|call_info| {
         FunctionInvocation::from_call_info(
             call_info,
             versioned_constants,
             gas_vector_computation_mode,
+            use_kzg_da,
         )
     });
     let maybe_function_invocation = execution_info.execute_call_info.map(|call_info| {
@@ -384,6 +388,7 @@ fn to_trace(
             call_info,
             versioned_constants,
             gas_vector_computation_mode,
+            use_kzg_da,
         )
     });
     let fee_transfer_invocation = execution_info.fee_transfer_call_info.map(|call_info| {
@@ -391,6 +396,7 @@ fn to_trace(
             call_info,
             versioned_constants,
             gas_vector_computation_mode,
+            use_kzg_da,
         )
     });
 

--- a/crates/executor/src/simulate.rs
+++ b/crates/executor/src/simulate.rs
@@ -182,7 +182,7 @@ pub fn trace(
     let mut traces = Vec::with_capacity(transactions.len());
     for (transaction_idx, tx) in transactions.into_iter().enumerate() {
         let hash = transaction_hash(&tx);
-        let _span = tracing::debug_span!("simulate", transaction_hash=%super::transaction::transaction_hash(&tx), %transaction_idx).entered();
+        let _span = tracing::debug_span!("trace", transaction_hash=%super::transaction::transaction_hash(&tx), %transaction_idx).entered();
 
         let tx_type = transaction_type(&tx);
         let tx_declared_deprecated_class_hash = transaction_declared_deprecated_class(&tx);
@@ -208,6 +208,8 @@ pub fn trace(
                 cache.cache_remove(&block_hash);
             })?;
         tx_state.commit();
+
+        tracing::trace!("Transaction tracing finished");
 
         let trace = to_trace(
             tx_type,

--- a/crates/executor/src/transaction.rs
+++ b/crates/executor/src/transaction.rs
@@ -2,6 +2,7 @@ use blockifier::transaction::objects::HasRelatedFeeType;
 use blockifier::transaction::transaction_execution::Transaction;
 use pathfinder_common::TransactionHash;
 use starknet_api::block::FeeType;
+use starknet_api::transaction::fields::GasVectorComputationMode;
 
 use super::felt::IntoFelt;
 
@@ -32,5 +33,43 @@ pub fn fee_type(transaction: &Transaction) -> FeeType {
     match transaction {
         Transaction::Account(tx) => tx.fee_type(),
         Transaction::L1Handler(tx) => tx.fee_type(),
+    }
+}
+
+pub fn gas_vector_computation_mode(transaction: &Transaction) -> GasVectorComputationMode {
+    match &transaction {
+        Transaction::Account(account_transaction) => {
+            use starknet_api::executable_transaction::AccountTransaction;
+            match &account_transaction.tx {
+                AccountTransaction::Declare(tx) => {
+                    use starknet_api::transaction::DeclareTransaction;
+                    match &tx.tx {
+                        DeclareTransaction::V3(tx) => {
+                            tx.resource_bounds.get_gas_vector_computation_mode()
+                        }
+                        _ => GasVectorComputationMode::NoL2Gas,
+                    }
+                }
+                AccountTransaction::DeployAccount(tx) => {
+                    use starknet_api::transaction::DeployAccountTransaction;
+                    match &tx.tx {
+                        DeployAccountTransaction::V3(tx) => {
+                            tx.resource_bounds.get_gas_vector_computation_mode()
+                        }
+                        _ => GasVectorComputationMode::NoL2Gas,
+                    }
+                }
+                AccountTransaction::Invoke(tx) => {
+                    use starknet_api::transaction::InvokeTransaction;
+                    match &tx.tx {
+                        InvokeTransaction::V3(tx) => {
+                            tx.resource_bounds.get_gas_vector_computation_mode()
+                        }
+                        _ => GasVectorComputationMode::NoL2Gas,
+                    }
+                }
+            }
+        }
+        Transaction::L1Handler(_) => GasVectorComputationMode::NoL2Gas,
     }
 }

--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashSet};
 
 use blockifier::execution::call_info::OrderedL2ToL1Message;
+use blockifier::fee::resources::{StarknetResources, TransactionResources};
 use blockifier::transaction::objects::TransactionExecutionInfo;
 use pathfinder_common::{
     CasmHash,
@@ -14,7 +15,6 @@ use pathfinder_common::{
 use pathfinder_crypto::Felt;
 use starknet_api::block::{BlockInfo, FeeType};
 use starknet_api::execution_resources::GasVector;
-use starknet_api::transaction::fields::GasVectorComputationMode;
 
 use super::felt::IntoFelt;
 
@@ -313,133 +313,56 @@ pub struct DataAvailabilityResources {
     pub l1_data_gas: u128,
 }
 
-// Non-recursive variant of `CallInfo::summarize()`
-fn summarize_call_info(
-    call_info: &blockifier::execution::call_info::CallInfo,
-) -> blockifier::execution::call_info::ExecutionSummary {
-    let class_hash = call_info
-        .call
-        .class_hash
-        .expect("Class hash must be set after execution.");
-    let executed_class_hashes: HashSet<starknet_api::core::ClassHash> =
-        std::iter::once(class_hash).collect();
-
-    // Storage entries.
-    let visited_storage_entries = call_info
-        .accessed_storage_keys
-        .iter()
-        .map(|storage_key| (call_info.call.storage_address, *storage_key))
-        .collect();
-
-    // Messages.
-    let l2_to_l1_payload_lengths = call_info
-        .execution
-        .l2_to_l1_messages
-        .iter()
-        .map(|message| message.message.payload.0.len())
-        .collect();
-
-    let event_summary = specific_event_summary(call_info);
-
-    let inner_call_execution_resources = call_info.inner_calls.iter().fold(
-        cairo_vm::vm::runners::cairo_runner::ExecutionResources::default(),
-        |acc, call_info| &acc + &call_info.resources,
-    );
-    let non_recursive_vm_resources = &call_info.resources - &inner_call_execution_resources;
-
-    blockifier::execution::call_info::ExecutionSummary {
-        charged_resources: blockifier::execution::call_info::ChargedResources {
-            vm_resources: non_recursive_vm_resources,
-            gas_consumed: starknet_api::execution_resources::GasAmount(
-                call_info.execution.gas_consumed,
-            ),
-        },
-        executed_class_hashes,
-        visited_storage_entries,
-        l2_to_l1_payload_lengths,
-        event_summary,
-    }
-}
-
-// Copy of `CallInfo::specific_event_summary()` because that is private
-fn specific_event_summary(
-    call_info: &blockifier::execution::call_info::CallInfo,
-) -> blockifier::execution::call_info::EventSummary {
-    let mut event_summary = blockifier::execution::call_info::EventSummary {
-        n_events: call_info.execution.events.len(),
-        ..Default::default()
-    };
-    for blockifier::execution::call_info::OrderedEvent { event, .. } in
-        call_info.execution.events.iter()
-    {
-        let data_len: u64 = event
-            .data
-            .0
-            .len()
-            .try_into()
-            .expect("Conversion from usize to u64 should not fail.");
-        event_summary.total_event_data_size += data_len;
-        let key_len: u64 = event
-            .keys
-            .len()
-            .try_into()
-            .expect("Conversion from usize to u64 should not fail.");
-        event_summary.total_event_keys += key_len;
-    }
-    event_summary
-}
-
 impl FunctionInvocation {
+    // This estimation purposefully ignores some of the gas costs since we don't
+    // have all the necessary defails to compute them and those will be taken
+    // into account only when computing the transaction receipt.
+    // Ignored costs include state change costs, code size related costs for
+    // DECLARE, L1 handler payload size and Starknet OS overhead.
+    fn estimate_gas_consumed(
+        call_info: &blockifier::execution::call_info::CallInfo,
+        versioned_constants: &blockifier::versioned_constants::VersionedConstants,
+        gas_vector_computation_mode: &starknet_api::transaction::fields::GasVectorComputationMode,
+        use_kzg_da: bool,
+    ) -> GasVector {
+        let execution_summary = call_info.summarize(versioned_constants);
+        let sierra_gas = execution_summary.charged_resources.gas_consumed;
+        let vm_resources = execution_summary
+            .charged_resources
+            .vm_resources
+            .filter_unused_builtins();
+        let state_changes = blockifier::state::cached_state::StateChanges::default();
+        let state_resources = blockifier::fee::resources::StateResources::new(
+            &state_changes,
+            None,
+            Default::default(),
+        );
+        let starknet_resources =
+            StarknetResources::new(0, 0, 0, state_resources, None, execution_summary);
+        let tx_resources = TransactionResources {
+            starknet_resources,
+            computation: blockifier::fee::resources::ComputationResources {
+                vm_resources,
+                n_reverted_steps: 0,
+                sierra_gas,
+                reverted_sierra_gas: 0u64.into(),
+            },
+        };
+        tx_resources.to_gas_vector(versioned_constants, use_kzg_da, gas_vector_computation_mode)
+    }
+
     pub fn from_call_info(
         call_info: blockifier::execution::call_info::CallInfo,
         versioned_constants: &blockifier::versioned_constants::VersionedConstants,
         gas_vector_computation_mode: &starknet_api::transaction::fields::GasVectorComputationMode,
+        use_kzg_da: bool,
     ) -> Self {
-        let execution_summary = summarize_call_info(&call_info);
-
-        // Message costs
-        let message_resources = blockifier::fee::resources::MessageResources::new(
-            execution_summary.l2_to_l1_payload_lengths,
-            None,
+        let gas_consumed = Self::estimate_gas_consumed(
+            &call_info,
+            versioned_constants,
+            gas_vector_computation_mode,
+            use_kzg_da,
         );
-        let message_gas_cost = message_resources.to_gas_vector();
-
-        // Event costs
-        let archival_gas_costs = match gas_vector_computation_mode {
-            GasVectorComputationMode::All => &versioned_constants.archival_data_gas_costs,
-            GasVectorComputationMode::NoL2Gas => {
-                &versioned_constants.deprecated_l2_resource_gas_costs
-            }
-        };
-        let event_gas_amount = (archival_gas_costs.gas_per_data_felt
-            * (archival_gas_costs.event_key_factor
-                * execution_summary.event_summary.total_event_keys
-                + execution_summary.event_summary.total_event_data_size))
-            .to_integer()
-            .into();
-        let event_gas_cost = match gas_vector_computation_mode {
-            GasVectorComputationMode::All => GasVector::from_l2_gas(event_gas_amount),
-            GasVectorComputationMode::NoL2Gas => GasVector::from_l1_gas(event_gas_amount),
-        };
-
-        // Computation costs
-        let computation_resources = blockifier::fee::resources::ComputationResources {
-            vm_resources: execution_summary
-                .charged_resources
-                .vm_resources
-                .filter_unused_builtins(),
-            n_reverted_steps: 0,
-            sierra_gas: execution_summary.charged_resources.gas_consumed,
-            reverted_sierra_gas: 0u64.into(),
-        };
-        let computation_gas_cost =
-            computation_resources.to_gas_vector(versioned_constants, gas_vector_computation_mode);
-
-        let gas_vector = computation_gas_cost
-            .checked_add(event_gas_cost)
-            .unwrap_or_else(|| panic!("resource overflow while adding event costs"))
-            .checked_add(message_gas_cost)
-            .unwrap_or_else(|| panic!("resource overflow while adding message costs"));
 
         let messages = ordered_l2_to_l1_messages(&call_info);
 
@@ -447,7 +370,12 @@ impl FunctionInvocation {
             .inner_calls
             .into_iter()
             .map(|call_info| {
-                Self::from_call_info(call_info, versioned_constants, gas_vector_computation_mode)
+                Self::from_call_info(
+                    call_info,
+                    versioned_constants,
+                    gas_vector_computation_mode,
+                    use_kzg_da,
+                )
             })
             .collect();
 
@@ -491,8 +419,8 @@ impl FunctionInvocation {
             result,
             computation_resources: call_info.resources.into(),
             execution_resources: InnerCallExecutionResources {
-                l1_gas: gas_vector.l1_gas.0.into(),
-                l2_gas: gas_vector.l2_gas.0.into(),
+                l1_gas: gas_consumed.l1_gas.0.into(),
+                l2_gas: gas_consumed.l2_gas.0.into(),
             },
             is_reverted: call_info.execution.failed,
         }

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -1350,7 +1350,7 @@ pub(crate) mod tests {
                     ],
                     computation_resources: universal_deployer_execute_computation_resources(),
                     execution_resources: pathfinder_executor::types::InnerCallExecutionResources {
-                        l1_gas: 2,
+                        l1_gas: 7,
                         l2_gas: 0,
                     },
                     is_reverted: false,
@@ -1699,7 +1699,7 @@ pub(crate) mod tests {
                     result: vec![test_storage_value.0],
                     computation_resources: invoke_execute_computation_resources(),
                     execution_resources: pathfinder_executor::types::InnerCallExecutionResources {
-                        l1_gas: 2,
+                        l1_gas: 3,
                         l2_gas: 0,
                     },
                     is_reverted: false,

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -1322,7 +1322,7 @@ pub(crate) mod tests {
                                 pedersen_builtin_applications: 7,
                                 ..Default::default()
                             },
-                            execution_resources: pathfinder_executor::types::InnerCallExecutionResources { l1_gas: 4, l2_gas: 0 },
+                            execution_resources: pathfinder_executor::types::InnerCallExecutionResources { l1_gas: 5, l2_gas: 0 },
                             is_reverted: false,
                         }
                     ],
@@ -1350,7 +1350,7 @@ pub(crate) mod tests {
                     ],
                     computation_resources: universal_deployer_execute_computation_resources(),
                     execution_resources: pathfinder_executor::types::InnerCallExecutionResources {
-                        l1_gas: 6,
+                        l1_gas: 2,
                         l2_gas: 0,
                     },
                     is_reverted: false,
@@ -1699,7 +1699,7 @@ pub(crate) mod tests {
                     result: vec![test_storage_value.0],
                     computation_resources: invoke_execute_computation_resources(),
                     execution_resources: pathfinder_executor::types::InnerCallExecutionResources {
-                        l1_gas: 3,
+                        l1_gas: 2,
                         l2_gas: 0,
                     },
                     is_reverted: false,


### PR DESCRIPTION
This PR fixes inner-call gas usage estimation for transaction traces. On the JSON-RPC 0.8 interface we now return `l1_gas` and `l2_gas` cost estimation for inner calls instead of the raw VM resources (which are not available anyway when running with L2 gas).

We now determine the gas vector computation mode (whether to use L2 gas) from the resource bounds in the transaction and then consistently use that when computing costs.