### PR TITLE
Streamline our release process

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,57 @@
+name: Publish Crates
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (without v prefix)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish-crates:
+    name: Publish crates to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      
+      - name: Login to crates.io
+        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
+
+      # Publish crates in dependency order with retries
+      - name: Publish crates
+        run: |
+          publish_with_retry() {
+            local package=$1
+            local max_attempts=3
+            local attempt=1
+            
+            while [ $attempt -le $max_attempts ]; do
+              echo "Attempting to publish $package (attempt $attempt/$max_attempts)"
+              if cargo publish -p $package; then
+                return 0
+              fi
+              attempt=$((attempt + 1))
+              [ $attempt -le $max_attempts ] && sleep 30
+            done
+            return 1
+          }
+
+          # First publish crypto as it has no internal dependencies
+          publish_with_retry pathfinder-crypto
+          sleep 30
+          
+          # Publish common which depends on crypto
+          publish_with_retry pathfinder-common
+          sleep 30
+          
+          # Publish serde which depends on common and crypto
+          publish_with_retry pathfinder-serde
+          sleep 30
+          
+          # Finally publish class-hash which depends on common, crypto and serde
+          publish_with_retry pathfinder-class-hash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,21 @@ on:
       - v[0-9]+.*
 
 jobs:
+    verify-crates:
+        name: Verify crates can be published
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v4
+          - uses: dtolnay/rust-toolchain@stable
+
+          # Verify each crate can be published
+          - name: Verify crates
+            run: |
+              for crate in crypto common serde class-hash; do
+                echo "Verifying pathfinder-$crate..."
+                cargo publish --dry-run -p pathfinder-$crate
+              done
+
     create-draft-release:
         runs-on: ubuntu-latest
         steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7639,7 +7639,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha3",
- "thiserror",
+ "thiserror 1.0.69",
  "vergen",
 ]
 
@@ -10056,6 +10056,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7352,6 +7352,8 @@ dependencies = [
  "p2p_stream",
  "pathfinder-common",
  "pathfinder-crypto",
+ "pathfinder-tagged",
+ "pathfinder-tagged-debug-derive",
  "pretty_assertions_sorted",
  "primitive-types",
  "prost 0.13.3",
@@ -7362,8 +7364,6 @@ dependencies = [
  "serde_json",
  "sha2",
  "sha3",
- "tagged",
- "tagged-debug-derive",
  "test-log",
  "tokio",
  "tokio-stream",
@@ -7385,6 +7385,8 @@ dependencies = [
  "p2p_proto_derive",
  "pathfinder-common",
  "pathfinder-crypto",
+ "pathfinder-tagged",
+ "pathfinder-tagged-debug-derive",
  "pretty_assertions_sorted",
  "primitive-types",
  "prost 0.13.3",
@@ -7392,8 +7394,6 @@ dependencies = [
  "prost-types 0.13.3",
  "rand",
  "serde_json",
- "tagged",
- "tagged-debug-derive",
 ]
 
 [[package]]
@@ -7662,6 +7662,8 @@ dependencies = [
  "num-traits",
  "paste",
  "pathfinder-crypto",
+ "pathfinder-tagged",
+ "pathfinder-tagged-debug-derive",
  "primitive-types",
  "rand",
  "rstest",
@@ -7669,8 +7671,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha3",
- "tagged",
- "tagged-debug-derive",
  "thiserror",
  "vergen",
 ]
@@ -7893,6 +7893,25 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "zstd 0.13.2",
+]
+
+[[package]]
+name = "pathfinder-tagged"
+version = "0.15.3"
+dependencies = [
+ "fake",
+ "pathfinder-tagged-debug-derive",
+ "pretty_assertions_sorted",
+ "rand",
+]
+
+[[package]]
+name = "pathfinder-tagged-debug-derive"
+version = "0.15.3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -10059,25 +10078,6 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
-]
-
-[[package]]
-name = "tagged"
-version = "0.15.3"
-dependencies = [
- "fake",
- "pretty_assertions_sorted",
- "rand",
- "tagged-debug-derive",
-]
-
-[[package]]
-name = "tagged-debug-derive"
-version = "0.15.3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7897,7 +7897,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-tagged"
-version = "0.15.3"
+version = "0.1.0"
 dependencies = [
  "fake",
  "pathfinder-tagged-debug-derive",
@@ -7907,7 +7907,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-tagged-debug-derive"
-version = "0.15.3"
+version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/class-hash/Cargo.toml
+++ b/crates/class-hash/Cargo.toml
@@ -8,9 +8,9 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-pathfinder-common = { path = "../common" }
-pathfinder-crypto = { path = "../crypto" }
-pathfinder-serde = { path = "../serde" }
+pathfinder-common = { version = "0.15.3", path = "../common" }
+pathfinder-crypto = { version = "0.15.3", path = "../crypto" }
+pathfinder-serde = { version = "0.15.3", path = "../serde" }
 primitive-types = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = [

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -18,6 +18,8 @@ num-bigint = { workspace = true }
 num-traits = "0.2"
 paste = { workspace = true }
 pathfinder-crypto = { version = "0.15.3", path = "../crypto" }
+pathfinder-tagged = { version = "0.1.0", path = "../tagged" }
+pathfinder-tagged-debug-derive = { version = "0.1.0", path = "../tagged-debug-derive" }
 primitive-types = { workspace = true, features = ["serde"] }
 rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
@@ -27,8 +29,6 @@ serde_json = { workspace = true, features = [
 ] }
 serde_with = { workspace = true }
 sha3 = { workspace = true }
-pathfinder-tagged = { version = "0.1.0", path = "../tagged" }
-pathfinder-tagged-debug-derive = { version = "0.1.0", path = "../tagged-debug-derive" }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -27,8 +27,8 @@ serde_json = { workspace = true, features = [
 ] }
 serde_with = { workspace = true }
 sha3 = { workspace = true }
-pathfinder-tagged = { path = "../tagged" }
-pathfinder-tagged-debug-derive = { path = "../tagged-debug-derive" }
+pathfinder-tagged = { version = "0.0.1", path = "../tagged" }
+pathfinder-tagged-debug-derive = { version = "0.0.1", path = "../tagged-debug-derive" }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -27,8 +27,8 @@ serde_json = { workspace = true, features = [
 ] }
 serde_with = { workspace = true }
 sha3 = { workspace = true }
-tagged = { path = "../tagged" }
-tagged-debug-derive = { path = "../tagged-debug-derive" }
+pathfinder-tagged = { path = "../tagged" }
+pathfinder-tagged-debug-derive = { path = "../tagged-debug-derive" }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -27,8 +27,8 @@ serde_json = { workspace = true, features = [
 ] }
 serde_with = { workspace = true }
 sha3 = { workspace = true }
-pathfinder-tagged = { version = "0.0.1", path = "../tagged" }
-pathfinder-tagged-debug-derive = { version = "0.0.1", path = "../tagged-debug-derive" }
+pathfinder-tagged = { version = "0.1.0", path = "../tagged" }
+pathfinder-tagged-debug-derive = { version = "0.1.0", path = "../tagged-debug-derive" }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -17,7 +17,7 @@ metrics = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = "0.2"
 paste = { workspace = true }
-pathfinder-crypto = { path = "../crypto" }
+pathfinder-crypto = { version = "0.15.3", path = "../crypto" }
 primitive-types = { workspace = true, features = ["serde"] }
 rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/common/src/event.rs
+++ b/crates/common/src/event.rs
@@ -4,8 +4,8 @@ use fake::Dummy;
 use num_bigint::BigUint;
 use pathfinder_crypto::Felt;
 use serde_with::serde_conv;
-use tagged::Tagged;
-use tagged_debug_derive::TaggedDebug;
+use pathfinder_tagged::Tagged;
+use pathfinder_tagged_debug_derive::TaggedDebug;
 
 use crate::{ContractAddress, EventData, EventKey};
 

--- a/crates/common/src/event.rs
+++ b/crates/common/src/event.rs
@@ -3,9 +3,9 @@ use std::str::FromStr;
 use fake::Dummy;
 use num_bigint::BigUint;
 use pathfinder_crypto::Felt;
-use serde_with::serde_conv;
 use pathfinder_tagged::Tagged;
 use pathfinder_tagged_debug_derive::TaggedDebug;
+use serde_with::serde_conv;
 
 use crate::{ContractAddress, EventData, EventKey};
 

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -46,8 +46,8 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 sha3 = { workspace = true }
-tagged = { path = "../tagged" }
-tagged-debug-derive = { path = "../tagged-debug-derive" }
+pathfinder-tagged = { path = "../tagged" }
+pathfinder-tagged-debug-derive = { path = "../tagged-debug-derive" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
 tokio-stream = { workspace = true }
 tracing = { workspace = true }
@@ -62,8 +62,8 @@ clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
 hex = { workspace = true }
 rand = { workspace = true }
 rstest = { workspace = true }
-tagged = { path = "../tagged" }
-tagged-debug-derive = { path = "../tagged-debug-derive" }
+pathfinder-tagged = { path = "../tagged" }
+pathfinder-tagged-debug-derive = { path = "../tagged-debug-derive" }
 test-log = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -37,6 +37,8 @@ p2p_proto = { path = "../p2p_proto" }
 p2p_stream = { path = "../p2p_stream" }
 pathfinder-common = { path = "../common" }
 pathfinder-crypto = { path = "../crypto" }
+pathfinder-tagged = { path = "../tagged" }
+pathfinder-tagged-debug-derive = { path = "../tagged-debug-derive" }
 pretty_assertions_sorted = { workspace = true }
 primitive-types = { workspace = true }
 prost = { workspace = true }
@@ -46,8 +48,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 sha3 = { workspace = true }
-pathfinder-tagged = { path = "../tagged" }
-pathfinder-tagged-debug-derive = { path = "../tagged-debug-derive" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
 tokio-stream = { workspace = true }
 tracing = { workspace = true }
@@ -60,10 +60,10 @@ zeroize = { workspace = true }
 [dev-dependencies]
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
 hex = { workspace = true }
-rand = { workspace = true }
-rstest = { workspace = true }
 pathfinder-tagged = { path = "../tagged" }
 pathfinder-tagged-debug-derive = { path = "../tagged-debug-derive" }
+rand = { workspace = true }
+rstest = { workspace = true }
 test-log = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/crates/p2p/src/client/peer_agnostic/fixtures.rs
+++ b/crates/p2p/src/client/peer_agnostic/fixtures.rs
@@ -32,9 +32,9 @@ use pathfinder_common::{
     TransactionHash,
     TransactionIndex,
 };
-use rand::seq::SliceRandom;
 use pathfinder_tagged::Tagged;
 use pathfinder_tagged_debug_derive::TaggedDebug;
+use rand::seq::SliceRandom;
 use tokio::sync::Mutex;
 
 use super::ClassDefinition;

--- a/crates/p2p/src/client/peer_agnostic/fixtures.rs
+++ b/crates/p2p/src/client/peer_agnostic/fixtures.rs
@@ -33,8 +33,8 @@ use pathfinder_common::{
     TransactionIndex,
 };
 use rand::seq::SliceRandom;
-use tagged::Tagged;
-use tagged_debug_derive::TaggedDebug;
+use pathfinder_tagged::Tagged;
+use pathfinder_tagged_debug_derive::TaggedDebug;
 use tokio::sync::Mutex;
 
 use super::ClassDefinition;
@@ -95,7 +95,7 @@ impl TestTxn {
 }
 
 pub fn peer(tag: i32) -> TestPeer {
-    tagged::init();
+    pathfinder_tagged::init();
     Tagged::<TestPeer>::get(format!("peer {tag}"), || TestPeer(PeerId::random()))
         .unwrap()
         .data

--- a/crates/p2p/src/client/types.rs
+++ b/crates/p2p/src/client/types.rs
@@ -25,8 +25,8 @@ use pathfinder_common::{
     TransactionHash,
     TransactionIndex,
 };
-use tagged::Tagged;
-use tagged_debug_derive::TaggedDebug;
+use pathfinder_tagged::Tagged;
+use pathfinder_tagged_debug_derive::TaggedDebug;
 
 use crate::client::conv::TryFromDto;
 

--- a/crates/p2p_proto/Cargo.toml
+++ b/crates/p2p_proto/Cargo.toml
@@ -14,13 +14,13 @@ libp2p-identity = { workspace = true, features = ["peerid"] }
 p2p_proto_derive = { path = "../p2p_proto_derive" }
 pathfinder-common = { path = "../common" }
 pathfinder-crypto = { path = "../crypto" }
+pathfinder-tagged = { path = "../tagged" }
+pathfinder-tagged-debug-derive = { path = "../tagged-debug-derive" }
 primitive-types = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 rand = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
-pathfinder-tagged = { path = "../tagged" }
-pathfinder-tagged-debug-derive = { path = "../tagged-debug-derive" }
 
 [dev-dependencies]
 pretty_assertions_sorted = { workspace = true }

--- a/crates/p2p_proto/Cargo.toml
+++ b/crates/p2p_proto/Cargo.toml
@@ -19,8 +19,8 @@ prost = { workspace = true }
 prost-types = { workspace = true }
 rand = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
-tagged = { path = "../tagged" }
-tagged-debug-derive = { path = "../tagged-debug-derive" }
+pathfinder-tagged = { path = "../tagged" }
+pathfinder-tagged-debug-derive = { path = "../tagged-debug-derive" }
 
 [dev-dependencies]
 pretty_assertions_sorted = { workspace = true }

--- a/crates/p2p_proto/src/class.rs
+++ b/crates/p2p_proto/src/class.rs
@@ -2,8 +2,8 @@ use std::fmt::Debug;
 
 use fake::{Dummy, Fake, Faker};
 use pathfinder_crypto::Felt;
-use tagged::Tagged;
-use tagged_debug_derive::TaggedDebug;
+use pathfinder_tagged::Tagged;
+use pathfinder_tagged_debug_derive::TaggedDebug;
 
 use crate::common::{Hash, Iteration};
 use crate::{proto, proto_field, ToProtobuf, TryFromProtobuf};

--- a/crates/p2p_proto/src/event.rs
+++ b/crates/p2p_proto/src/event.rs
@@ -1,7 +1,7 @@
 use fake::Dummy;
 use pathfinder_crypto::Felt;
-use tagged::Tagged;
-use tagged_debug_derive::TaggedDebug;
+use pathfinder_tagged::Tagged;
+use pathfinder_tagged_debug_derive::TaggedDebug;
 
 use crate::common::{Hash, Iteration};
 use crate::{proto, proto_field, ToProtobuf, TryFromProtobuf};

--- a/crates/p2p_proto/src/header.rs
+++ b/crates/p2p_proto/src/header.rs
@@ -1,8 +1,8 @@
 use std::time::SystemTime;
 
 use fake::{Dummy, Fake, Faker};
-use tagged::Tagged;
-use tagged_debug_derive::TaggedDebug;
+use pathfinder_tagged::Tagged;
+use pathfinder_tagged_debug_derive::TaggedDebug;
 
 use crate::common::{
     Address,

--- a/crates/p2p_proto/src/state.rs
+++ b/crates/p2p_proto/src/state.rs
@@ -2,8 +2,8 @@ use std::fmt::Debug;
 
 use fake::Dummy;
 use pathfinder_crypto::Felt;
-use tagged::Tagged;
-use tagged_debug_derive::TaggedDebug;
+use pathfinder_tagged::Tagged;
+use pathfinder_tagged_debug_derive::TaggedDebug;
 
 use crate::common::{Address, Hash, Iteration, VolitionDomain};
 use crate::{proto, proto_field, ToProtobuf, TryFromProtobuf};

--- a/crates/serde/Cargo.toml
+++ b/crates/serde/Cargo.toml
@@ -9,8 +9,8 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 num-bigint = { workspace = true }
-pathfinder-common = { path = "../common" }
-pathfinder-crypto = { path = "../crypto" }
+pathfinder-common = { version = "0.15.3", path = "../common" }
+pathfinder-crypto = { version = "0.15.3", path = "../crypto" }
 primitive-types = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/tagged-debug-derive/Cargo.toml
+++ b/crates/tagged-debug-derive/Cargo.toml
@@ -5,6 +5,10 @@ authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
 rust-version = { workspace = true }
+description = "Debug trait derive macro for pathfinder-tagged types"
+repository = "https://github.com/eqlabs/pathfinder"
+keywords = ["starknet", "derive", "debug", "proc-macro"]
+categories = ["development-tools::procedural-macro-helpers"]
 
 [lib]
 proc-macro = true

--- a/crates/tagged-debug-derive/Cargo.toml
+++ b/crates/tagged-debug-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pathfinder-tagged-debug-derive"
-version = { workspace = true }
+version = "0.1.0"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/crates/tagged-debug-derive/Cargo.toml
+++ b/crates/tagged-debug-derive/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tagged-debug-derive"
+name = "pathfinder-tagged-debug-derive"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/tagged/Cargo.toml
+++ b/crates/tagged/Cargo.toml
@@ -14,6 +14,6 @@ categories = ["development-tools"]
 fake = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
+pathfinder-tagged-debug-derive = { path = "../tagged-debug-derive" }
 pretty_assertions_sorted = { workspace = true }
 rand = { workspace = true }
-pathfinder-tagged-debug-derive = { path = "../tagged-debug-derive" }

--- a/crates/tagged/Cargo.toml
+++ b/crates/tagged/Cargo.toml
@@ -5,6 +5,10 @@ authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
 rust-version = { workspace = true }
+description = "Type tagging utilities for the Pathfinder Starknet node implementation"
+repository = "https://github.com/eqlabs/pathfinder"
+keywords = ["starknet", "ethereum", "web3", "type-safety"]
+categories = ["development-tools"]
 
 [dependencies]
 fake = { workspace = true, features = ["derive"] }

--- a/crates/tagged/Cargo.toml
+++ b/crates/tagged/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tagged"
+name = "pathfinder-tagged"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
@@ -12,4 +12,4 @@ fake = { workspace = true, features = ["derive"] }
 [dev-dependencies]
 pretty_assertions_sorted = { workspace = true }
 rand = { workspace = true }
-tagged-debug-derive = { path = "../tagged-debug-derive" }
+pathfinder-tagged-debug-derive = { path = "../tagged-debug-derive" }

--- a/crates/tagged/Cargo.toml
+++ b/crates/tagged/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pathfinder-tagged"
-version = { workspace = true }
+version = "0.1.0"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/crates/tagged/src/lib.rs
+++ b/crates/tagged/src/lib.rs
@@ -145,7 +145,7 @@ impl<T: Clone + PartialEq + 'static> Tagged<T> {
 mod tests {
     use fake::Dummy;
     use pretty_assertions_sorted::assert_eq;
-    use tagged_debug_derive::TaggedDebug;
+    use pathfinder_tagged_debug_derive::TaggedDebug;
 
     use super::*;
 

--- a/crates/tagged/src/lib.rs
+++ b/crates/tagged/src/lib.rs
@@ -144,8 +144,8 @@ impl<T: Clone + PartialEq + 'static> Tagged<T> {
 #[cfg(test)]
 mod tests {
     use fake::Dummy;
-    use pretty_assertions_sorted::assert_eq;
     use pathfinder_tagged_debug_derive::TaggedDebug;
+    use pretty_assertions_sorted::assert_eq;
 
     use super::*;
 

--- a/justfile
+++ b/justfile
@@ -29,7 +29,12 @@ dep-sort:
 doc:
     cargo doc --no-deps --document-private-items
 
+release version:
+    chmod +x scripts/release.sh
+    scripts/release.sh {{version}}
+
 alias b := build 
 alias t := test 
 alias c := check 
 alias f := fmt 
+alias r := release

--- a/justfile
+++ b/justfile
@@ -30,7 +30,6 @@ doc:
     cargo doc --no-deps --document-private-items
 
 release version:
-    chmod +x scripts/release.sh
     scripts/release.sh {{version}}
 
 alias b := build 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+set -e
+
+VERSION=$1
+
+# Check if tag already exists
+if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
+    echo "Error: Tag v${VERSION} already exists!"
+    echo "Please remove the tag running 'git tag -d v${VERSION}' and try again."
+    exit 1
+fi
+
+# Check if branch already exists
+if git show-ref --verify --quiet "refs/heads/release/v${VERSION}" || \
+   git show-ref --verify --quiet "refs/remotes/origin/release/v${VERSION}"; then
+    echo "Error: Branch release/v${VERSION} already exists locally or remotely!"
+    echo "Please remove the branch running 'git branch -D release/v${VERSION}' and try again."
+    exit 1
+fi
+
+# Verify version format
+if ! echo "$VERSION" | grep -E "^[0-9]+\.[0-9]+\.[0-9]+$" > /dev/null; then
+    echo "Version must be in format X.Y.Z"
+    exit 1
+fi
+
+# Cross-platform sed command (macOS and Linux)
+do_sed() {
+    local file=$1
+    local pattern=$2
+    if [[ "$(uname)" == "Darwin" ]]; then
+        sed -i '.bak' "$pattern" "$file"
+        rm "${file}.bak"
+    else
+        sed -i "$pattern" "$file"
+    fi
+}
+
+# Update CHANGELOG.md - replace "## Unreleased" with version and date
+CURRENT_DATE=$(date +%Y-%m-%d)
+do_sed "CHANGELOG.md" "s/## Unreleased/## [${VERSION}] - ${CURRENT_DATE}/"
+
+# Update workspace version
+do_sed "Cargo.toml" "s/^version = \".*\"/version = \"${VERSION}\"/"
+
+# List of crates to be published to crates.io
+# These require explicit version dependencies for publishing
+CRATES=("common" "crypto" "serde" "class-hash")
+
+# Update versions in crate Cargo.toml files
+for crate in "${CRATES[@]}"; do
+    file="crates/${crate}/Cargo.toml"
+    echo "Updating dependencies for $file..."
+    do_sed "$file" "s/pathfinder-common = { version = \"[^\"]*\"/pathfinder-common = { version = \"${VERSION}\"/"
+    do_sed "$file" "s/pathfinder-crypto = { version = \"[^\"]*\"/pathfinder-crypto = { version = \"${VERSION}\"/"
+    do_sed "$file" "s/pathfinder-serde = { version = \"[^\"]*\"/pathfinder-serde = { version = \"${VERSION}\"/"
+done
+
+# Update Cargo.lock
+cargo_update_args=()
+for crate in "${CRATES[@]}"; do
+    cargo_update_args+=(-p "pathfinder-${crate}")
+done
+cargo update "${cargo_update_args[@]}"
+
+# Verify everything still builds
+cargo check --workspace
+
+# Create and checkout new release branch
+git checkout -b release/v${VERSION}
+
+# Create git commit and tag
+git add Cargo.toml Cargo.lock crates/*/Cargo.toml CHANGELOG.md
+git commit -m "chore: bump version to ${VERSION}"
+git tag -a "v${VERSION}" -m "Pathfinder v${VERSION}"
+
+# Quik recap of what was done
+echo -e "\nChanges made:"
+echo "- Updated workspace version to ${VERSION}"
+echo "- Updated CHANGELOG.md with version ${VERSION} and date ${CURRENT_DATE}"
+echo "- Updated dependency versions in public crates:"
+for crate in "${CRATES[@]}"; do
+    echo "  - crates/${crate}/Cargo.toml"
+done
+
+# Confirmation before pushing
+echo -e "\nPush these changes to \`release/v${VERSION}\` and create a tag \`v${VERSION}\`? (Y/n)"
+read -r answer
+if [[ "$answer" == "n" ]] || [[ "$answer" == "N" ]]; then
+    echo "Aborting push. Changes are committed locally."
+    exit 1
+fi
+
+# Push changes
+git push --set-upstream origin release/v${VERSION} && git push origin "v${VERSION}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -56,15 +56,9 @@ for crate in "${CRATES[@]}"; do
     do_sed "$file" "s/pathfinder-serde = { version = \"[^\"]*\"/pathfinder-serde = { version = \"${VERSION}\"/"
 done
 
-# Update Cargo.lock
-cargo_update_args=()
-for crate in "${CRATES[@]}"; do
-    cargo_update_args+=(-p "pathfinder-${crate}")
-done
-cargo update "${cargo_update_args[@]}"
-
-# Verify everything still builds
-cargo check --workspace
+# Update Cargo.lock and verify everything still builds
+cargo check --workspace --all-targets
+cargo check --workspace --all-targets --all-features
 
 # Create and checkout new release branch
 git checkout -b release/v${VERSION}


### PR DESCRIPTION
This PR adds automation for our release process and crates.io publishing workflow.

### Just Command
Added a simple `release` command that automates all tedious release prep:
- Version format validation
- CHANGELOG updates
- Workspace version updates
- Dependency version updates for publishable crates
- Git branch, release commit and tag creation
- User confirmation before pushing changes

Usage: `just release X.Y.Z` 

### CI pipeline updates
1. Dry run `cargo publish` before creating draft release.
2. Introduce `publish-crates` CI job to be linked to manual release publication.

Closes #2509 