### PR TITLE
feat(rpc/v06): re-add transaction getter methods

### DIFF
--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -968,8 +968,6 @@ mod tests {
             "starknet_getBlockWithTxHashes",
             "starknet_getBlockWithTxs",
             "starknet_getStateUpdate",
-            "starknet_getTransactionByHash",
-            "starknet_getTransactionByBlockIdAndIndex",
             "starknet_getTransactionReceipt",
             "starknet_getTransactionStatus",
             "starknet_getClass",

--- a/crates/rpc/src/v06.rs
+++ b/crates/rpc/src/v06.rs
@@ -8,4 +8,6 @@ pub fn register_routes() -> RpcRouterBuilder {
         .register("starknet_getBlockTransactionCount",            crate::method::get_block_transaction_count)
         .register("starknet_getNonce",                            crate::method::get_nonce)
         .register("starknet_getStorageAt",                        crate::method::get_storage_at)
+        .register("starknet_getTransactionByHash",                crate::method::get_transaction_by_hash)
+        .register("starknet_getTransactionByBlockIdAndIndex",     crate::method::get_transaction_by_block_id_and_index)
 }


### PR DESCRIPTION
The `TXN` type is the same as we have in JSON-RPC 0.7, so the input and output of these methods already matches the JSON-RPC 0.6 spec.

Closes #2552 