### PR TITLE
feat(rpc/v06): re-add trivial and unchanged methods

### DIFF
--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -964,19 +964,15 @@ mod tests {
         "/rpc/v0_6",
         "v06/starknet_api_openrpc.json",
         &[
-            "starknet_specVersion",
             "starknet_getBlockWithTxHashes",
             "starknet_getBlockWithTxs",
             "starknet_getStateUpdate",
             "starknet_getTransactionReceipt",
             "starknet_getTransactionStatus",
             "starknet_getClass",
-            "starknet_getClassHashAt",
             "starknet_getClassAt",
             "starknet_estimateFee",
             "starknet_estimateMessageFee",
-            "starknet_blockHashAndNumber",
-            "starknet_syncing",
             "starknet_getEvents",
             "starknet_call",
         ],
@@ -1003,7 +999,7 @@ mod tests {
         Api::HttpOnly)]
     // #[case::v0_6_write_websocket("/ws/rpc/v0_6", "v06/starknet_write_api.json", &[], Api::WebsocketOnly)]
     // get_transaction_status is now part of the official spec, so we are phasing it out.
-    #[case::v0_6_pathfinder("/rpc/v0_6", "pathfinder_rpc_api.json", &["pathfinder_version", "pathfinder_getProof", "pathfinder_getTransactionStatus"], Api::HttpOnly)]
+    #[case::v0_6_pathfinder("/rpc/v0_6", "pathfinder_rpc_api.json", &["pathfinder_version", "pathfinder_getTransactionStatus"], Api::HttpOnly)]
     // #[case::v0_6_pathfinder_websocket("/ws/rpc/v0_6", "pathfinder_rpc_api.json", &["pathfinder_version", "pathfinder_getTransactionStatus"], Api::WebsocketOnly)]
 
     #[case::pathfinder("/rpc/pathfinder/v0.1", "pathfinder_rpc_api.json", &[], Api::HttpOnly)]

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -198,6 +198,8 @@ impl RpcServer {
             router
                 .route("/ws", get(websocket_handler))
                 .with_state(default_router)
+                .route("/ws/rpc/v0_6", get(websocket_handler))
+                .with_state(v06_routes)
                 .route("/ws/rpc/v0_7", get(websocket_handler))
                 .with_state(v07_routes)
                 .route("/ws/rpc/pathfinder/v0_1", get(websocket_handler))
@@ -1000,7 +1002,7 @@ mod tests {
     // #[case::v0_6_write_websocket("/ws/rpc/v0_6", "v06/starknet_write_api.json", &[], Api::WebsocketOnly)]
     // get_transaction_status is now part of the official spec, so we are phasing it out.
     #[case::v0_6_pathfinder("/rpc/v0_6", "pathfinder_rpc_api.json", &["pathfinder_version", "pathfinder_getTransactionStatus"], Api::HttpOnly)]
-    // #[case::v0_6_pathfinder_websocket("/ws/rpc/v0_6", "pathfinder_rpc_api.json", &["pathfinder_version", "pathfinder_getTransactionStatus"], Api::WebsocketOnly)]
+    #[case::v0_6_pathfinder_websocket("/ws/rpc/v0_6", "pathfinder_rpc_api.json", &["pathfinder_version", "pathfinder_getTransactionStatus"], Api::WebsocketOnly)]
 
     #[case::pathfinder("/rpc/pathfinder/v0.1", "pathfinder_rpc_api.json", &[], Api::HttpOnly)]
     #[case::pathfinder("/ws/rpc/pathfinder/v0_1", "pathfinder_rpc_api.json", &[], Api::WebsocketOnly)]

--- a/crates/rpc/src/v06.rs
+++ b/crates/rpc/src/v06.rs
@@ -4,10 +4,15 @@ use crate::jsonrpc::{RpcRouter, RpcRouterBuilder};
 pub fn register_routes() -> RpcRouterBuilder {
     RpcRouter::builder(crate::RpcVersion::V06)
         .register("starknet_blockNumber",                         crate::method::block_number)
+        .register("starknet_blockHashAndNumber",                  crate::method::block_hash_and_number)
         .register("starknet_chainId",                             crate::method::chain_id)
         .register("starknet_getBlockTransactionCount",            crate::method::get_block_transaction_count)
+        .register("starknet_getClassHashAt",                      crate::method::get_class_hash_at)
         .register("starknet_getNonce",                            crate::method::get_nonce)
         .register("starknet_getStorageAt",                        crate::method::get_storage_at)
         .register("starknet_getTransactionByHash",                crate::method::get_transaction_by_hash)
         .register("starknet_getTransactionByBlockIdAndIndex",     crate::method::get_transaction_by_block_id_and_index)
+        .register("starknet_specVersion",                         || "0.6.0")
+        .register("starknet_syncing",                             crate::method::syncing)
+        .register("pathfinder_getProof",                          crate::pathfinder::methods::get_proof)
 }


### PR DESCRIPTION
These methods are trivial and the specs are the same in all JSON-RPC versions, so we can just re-add these to v06.

While adding `pathfinder_getProof` I also figured out that we were missing the registration for the v06-specific Websocket route, so I've re-added that.