### PR TITLE
feat(rpc/v06): re-add block getters

### DIFF
--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -966,8 +966,6 @@ mod tests {
         "/rpc/v0_6",
         "v06/starknet_api_openrpc.json",
         &[
-            "starknet_getBlockWithTxHashes",
-            "starknet_getBlockWithTxs",
             "starknet_getStateUpdate",
             "starknet_getTransactionReceipt",
             "starknet_getTransactionStatus",

--- a/crates/rpc/src/v06.rs
+++ b/crates/rpc/src/v06.rs
@@ -7,6 +7,8 @@ pub fn register_routes() -> RpcRouterBuilder {
         .register("starknet_blockHashAndNumber",                  crate::method::block_hash_and_number)
         .register("starknet_chainId",                             crate::method::chain_id)
         .register("starknet_getBlockTransactionCount",            crate::method::get_block_transaction_count)
+        .register("starknet_getBlockWithTxHashes",                crate::method::get_block_with_tx_hashes)
+        .register("starknet_getBlockWithTxs",                     crate::method::get_block_with_txs)
         .register("starknet_getClassHashAt",                      crate::method::get_class_hash_at)
         .register("starknet_getNonce",                            crate::method::get_nonce)
         .register("starknet_getStorageAt",                        crate::method::get_storage_at)


### PR DESCRIPTION
For `starknet_getBlockWithTxHashes` and `starknet_getBlockWithTxs` the only difference compared to v07 is that the block header and pending block header types are missing L1 data gas and L1 DA mode fields.

This change also adds some rudimentary tests for testing the serialization of the block header for all the different JSON-RPC versions we're supporting.

Closes: #2554
