### PR TITLE
feat(rpc/v06): re-add write API

### DIFF
--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -988,16 +988,8 @@ mod tests {
         ],
         Api::HttpOnly)]
     // #[case::v0_6_trace_websocket("/ws/rpc/v0_6", "v06/starknet_trace_api_openrpc.json", &[], Api::WebsocketOnly)]
-    #[case::v0_6_write(
-        "/rpc/v0_6",
-        "v06/starknet_write_api.json",
-        &[
-            "starknet_addInvokeTransaction",
-            "starknet_addDeclareTransaction",
-            "starknet_addDeployAccountTransaction",
-        ],
-        Api::HttpOnly)]
-    // #[case::v0_6_write_websocket("/ws/rpc/v0_6", "v06/starknet_write_api.json", &[], Api::WebsocketOnly)]
+    #[case::v0_6_write("/rpc/v0_6", "v06/starknet_write_api.json", &[], Api::HttpOnly)]
+    #[case::v0_6_write_websocket("/ws/rpc/v0_6", "v06/starknet_write_api.json", &[], Api::WebsocketOnly)]
     // get_transaction_status is now part of the official spec, so we are phasing it out.
     #[case::v0_6_pathfinder("/rpc/v0_6", "pathfinder_rpc_api.json", &["pathfinder_version", "pathfinder_getTransactionStatus"], Api::HttpOnly)]
     #[case::v0_6_pathfinder_websocket("/ws/rpc/v0_6", "pathfinder_rpc_api.json", &["pathfinder_version", "pathfinder_getTransactionStatus"], Api::WebsocketOnly)]

--- a/crates/rpc/src/v06.rs
+++ b/crates/rpc/src/v06.rs
@@ -3,6 +3,9 @@ use crate::jsonrpc::{RpcRouter, RpcRouterBuilder};
 #[rustfmt::skip]
 pub fn register_routes() -> RpcRouterBuilder {
     RpcRouter::builder(crate::RpcVersion::V06)
+        .register("starknet_addDeclareTransaction",               crate::method::add_declare_transaction)
+        .register("starknet_addDeployAccountTransaction",         crate::method::add_deploy_account_transaction)
+        .register("starknet_addInvokeTransaction",                crate::method::add_invoke_transaction)
         .register("starknet_blockNumber",                         crate::method::block_number)
         .register("starknet_blockHashAndNumber",                  crate::method::block_hash_and_number)
         .register("starknet_chainId",                             crate::method::chain_id)


### PR DESCRIPTION
The BROADCASTED_TRANSACTION schema is unchanged between the 0.6.0 and 0.7.1 OpenRPC specification and the write API methods are the same, too.

We can just re-enable `starknet_add*Transaction` methods with our current implementation.

Closes #2553
