### PR TITLE
feat(rpc/v06): re-add class getter methods

### DIFF
--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -969,8 +969,6 @@ mod tests {
             "starknet_getStateUpdate",
             "starknet_getTransactionReceipt",
             "starknet_getTransactionStatus",
-            "starknet_getClass",
-            "starknet_getClassAt",
             "starknet_estimateFee",
             "starknet_estimateMessageFee",
             "starknet_getEvents",

--- a/crates/rpc/src/v06.rs
+++ b/crates/rpc/src/v06.rs
@@ -9,6 +9,8 @@ pub fn register_routes() -> RpcRouterBuilder {
         .register("starknet_blockNumber",                         crate::method::block_number)
         .register("starknet_blockHashAndNumber",                  crate::method::block_hash_and_number)
         .register("starknet_chainId",                             crate::method::chain_id)
+        .register("starknet_getClass",                            crate::method::get_class)
+        .register("starknet_getClassAt",                          crate::method::get_class_at)
         .register("starknet_getBlockTransactionCount",            crate::method::get_block_transaction_count)
         .register("starknet_getBlockWithTxHashes",                crate::method::get_block_with_tx_hashes)
         .register("starknet_getBlockWithTxs",                     crate::method::get_block_with_txs)


### PR DESCRIPTION
The serialization format of classes has not changed between JSON-RPC versions. Since the input is the same in all versions, we can safely re-add JSON-RPC 0.6 `starknet_getClass` and `starknet_getClassAt` methods.

Closes #2556
