### PR TITLE
fix(cargo): bump MSRV to 1.83.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ opt-level = 3
 version = "0.15.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-rust-version = "1.81"
+rust-version = "1.83"
 authors = ["Equilibrium Labs <info@equilibrium.co>"]
 
 [workspace.dependencies]


### PR DESCRIPTION
The recent libp2p upgrade bumped the MSRV to 1.83.0, so we have to do the same.

Should fix the MSRV check CI job failure: https://github.com/eqlabs/pathfinder/actions/runs/13103900577