### PR TITLE
chore(docs): publish Docusaurus-based new website

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -28,24 +28,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-      - name: Install mdBook
-        run: |
-          tag=$(curl 'https://api.github.com/repos/rust-lang/mdbook/releases/latest' | jq -r '.tag_name')
-          url="https://github.com/rust-lang/mdbook/releases/download/${tag}/mdbook-${tag}-x86_64-unknown-linux-gnu.tar.gz"
-          mkdir bin
-          curl -sSL $url | tar -xz --directory=bin
-          echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v3
-      - name: Build with mdBook
-        run: mdbook build ./website
+      - name: Install Docusaurus
+        run: yarn
+      - name: Build with Docusaurus
+        run: yarn build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: ./website/book
+          path: ./docs/build
 
   # Deployment job
   deploy:

--- a/docs/docs/database-snapshots.md
+++ b/docs/docs/database-snapshots.md
@@ -31,7 +31,7 @@ There are two main ways to download and use a snapshot with Pathfinder:
    ```
 3. Use `rclone` to copy the compressed SQLite file to your local directory:
    ```bash
-   rclone copy -P pathfinder-snapshots:pathfinder-snapshots/sepolia-testnet_0.14.0_209745_pruned.sqlite.zst .
+   rclone copy -P pathfinder-snapshots:pathfinder-snapshots/mainnet_0.15.0_1067473_pruned.sqlite.zst .
    ```
 
 :::tip 
@@ -43,7 +43,7 @@ Add `-P` to get a progress display that helps you track the download status.
 While HTTPS URLs are also provided, direct HTTPS downloads can sometimes be less reliable for very large files. If you must use HTTPS, verify you can resume downloads or maintain a stable connection. For example:
 
 ```bash
-wget --continue https://pub-1fac64c3c0334cda85b45bcc02635c32.r2.dev/mainnet_0.14.0_751397_pruned.sqlite.zst
+wget --continue https://pub-1fac64c3c0334cda85b45bcc02635c32.r2.dev/mainnet_0.15.0_1067473_pruned.sqlite.zst
 ```
 
 ## Extracting Snapshots and Checksums
@@ -79,5 +79,5 @@ The table below lists currently available snapshots, their block heights, and co
 | Sepolia testnet | 451735  | >= 0.15.0                   | archive | `sepolia-testnet_0.15.0_451735_archive.sqlite.zst` | [Download](https://pub-1fac64c3c0334cda85b45bcc02635c32.r2.dev/sepolia-testnet_0.15.0_451735_archive.sqlite.zst) | 32.21 GB        | `b143779c172eb55ee449f6d686c626c1df67c3b3c66545c869af8bf73e846c38` |
 
 :::info
-**Pruned** mode retains limited historical state tries, reducing storage size but limiting storage-proof queries. **Archive** mode is fully historic, storing all state tries since genesis.
+**Pruned** mode retains limited historical state tries, reducing storage size but limiting storage-proof queries. (All queries other than storage proofs are unaffected.) **Archive** mode is fully historic, storing all state tries since genesis.
 :::

--- a/docs/docs/incidents/2023-06-17_mainnet_incident.md
+++ b/docs/docs/incidents/2023-06-17_mainnet_incident.md
@@ -1,0 +1,84 @@
+# 2023-06-17 Mainnet Outage Post-mortem
+
+On Saturday, 17 June 2023, 18h05 UTC, Pathfinder nodes stopped syncing on mainnet causing an ecosystem wide outage. The cause was a disagreement between Pathfinder and the sequencer about a class hash. A fix was published the following morning at 08h30 UTC.
+
+## Synopsis
+
+The issue was first reported an hour after it occurred by Francesco (Apibara). As it involved a hash it made identifying the cause difficult. This was compounded by the timing - late Saturday night made it more complicated to get the right people involved. In addition, given that this was our first major incident, we didn't have a well-established protocol on how to handle the situation. This caused the issue to be under-communicated and delayed our response time.
+
+Nine hours after the incident started, Jonathan Lei (starknet-rs) correctly identified the cause. A fix was submitted and merged three hours later, followed by a Pathfinder release two hours later. Two hours after that most of the ecosystem was upgraded and back in sync.
+
+## Root cause of the issue
+
+Pathfinder failed to sync block `84 448` on mainnet, with the following error:
+
+```
+WARN L2 sync process terminated with: Handling newly declared classes for block BlockNumber(84448)
+
+Caused by:
+    0: Downloading class 0x00801AD5DC7C995ADDF7FBCE1C4C74413586ACB44F9FF44BA903A08A6153FA80
+    1: Class hash mismatch, 0x05294AB04A4BDFAEBBAE72688888D465AA4C5FD232D979A61AF1217215E1455A instead of 0x00801AD5DC7C995ADDF7FBCE1C4C74413586ACB44F9FF44BA903A08A6153FA80
+```
+
+Interpretation: a class with hash `0x00801AD5DC7C995ADDF7FBCE1C4C74413586ACB44F9FF44BA903A08A6153FA80` was declared but hash verification failed, causing the node to reject the block.
+
+This is a Cairo 0 class, which made this incident all the more confusing. The code in question had been running untouched and problem free for over a year.
+
+The culprit turned out to be JSON's flexibility with string encoding. A Cairo 0 class hash depends on its JSON artifact and JSON supports a variety of different string encoding formats. JSON libraries are therefore free to choose any of these formats when encoding an object. Unfortunately, the libraries used by Pathfinder and the sequencer use different encodings.
+
+But then how did this ever work? It turns out most string encodings produce identical results for pure ASCII strings. The failing class was simply the first Cairo 0 class to include non-ASCII characters - in this case as part of the text for an error message. This caused the final encoded bytes to differ, resulting in a different hash.
+
+## Resolution
+
+The [fix PR](https://github.com/eqlabs/pathfinder/pull/1142) takes any non-ASCII characters and re-encodes them to match the formatting used by the sequencer. 
+
+The PR was merged and Pathfinder v0.6.1 was released. The fix was also backported to create v0.5.7 for users who had not yet upgraded to v0.6.
+
+## What went wrong
+
+Bugs are a part of software and while we can follow best practices to reduce the number and severity of bugs, we can never fully eliminate them. In light of this, one should also have procedures in place to minimize the impact of bugs that do slip through. Our procedure was lacking - we could, and should have, done much better here.
+
+We need much better system monitoring. Ideally an alert should have warned us 10 minutes in; instead we got lucky that an attentive user notified us only one hour later.
+
+We also need better communication procedures. We managed to reach a Starkware engineer but clearly failed to communicate the severity of the issue. This meant people that could have helped were unaware of the issue until the next morning. Communication with the rest of the ecosystem was also limited due to the lack of properly defined communication channels and responsibilities.
+
+It also highlights the lack of node diversity currently within Starknet. Having multiple node implementations divides the risk as different implementations are unlikely to share the same bug. Fortunately Starknet has a growing list of strong node implementations with Juno and Papyrus which will reduce this weakness in the future.
+
+## Improvements
+
+Mistakes are opportunities to learn and here are some of the lessons we have taken.
+
+Improve our monitoring, especially around mainnet. This includes automatically notifying the relevant people.
+
+Have a clear line of communication for emergency situations and have a response team on stand-by 24/7. Combined, these enable us to rapidly gather the people required to resolve the situation asap.
+
+Establish a playbook for those providing support - these are stressful situations and it can be difficult to make decisions in the moment. We should know our roles and responsibilities. The more we can plan in advance the less we have to distract us during the crisis.
+
+Know who is responsible for communicating with the ecosystem. This ties into the above point, but we want to emphasize that we are aware that this was a problem and are taking steps to address it.
+
+Reduce the time taken from fix to release. Collectively, the release build time and time to regain sync took ~4 hours. This was compounded by the fact that two releases were required. Pathfinder will take steps to reduce its release build times. The sync times will be dramatically reduced once p2p support lands.
+
+## Timeline
+
+All times given are in UTC.
+
+```
+2023-06-17 18:05 Block `84 448` is created, Pathfinder nodes start failing
+2023-06-17 19:10 Issue reported by Francesco via Telegram DM
+2023-06-17 19:20 Test case replicating the failure created
+2023-06-17 19:22 Issue raised with Starkware, at this point severity still unclear
+2023-06-17 20:10 Reach out to others in the ecosystem for help, notably Jonathan Lei
+2023-06-17 20:30 Follow potential leads given by Starkware engineers, unfortunately without success
+2023-06-18 03:00 Jonathan Lei determines the root cause
+2023-06-18 05:23 Jonathan Lei PR submitted with fix
+2023-06-18 06:00 PR merged
+2023-06-18 06:05 Pathfinder release build v0.5.7 initiated 
+2023-06-18 06:55 Pathfinder release build v0.5.7 completed 
+2023-06-18 07:00 Pathfinder release build v0.6.1 initiated 
+2023-06-18 08:30 Pathfinder release build v0.6.1 completed 
+2023-06-18 08:30 API services start upgrading
+2023-06-18 10:30 API services upgraded
+2023-06-18 11:30 API services back in sync and online
+2023-06-18 11:30 incident over
+`
+

--- a/docs/docs/incidents/_category_.json
+++ b/docs/docs/incidents/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Incidents",
+    position: 8
+}

--- a/docs/docs/interacting-with-pathfinder/websocket-api.md
+++ b/docs/docs/interacting-with-pathfinder/websocket-api.md
@@ -12,7 +12,7 @@ The WebSocket interface serves the same API versions and extension endpoints as 
 - **Starknet v0.7.0**  
   Accessible at `/ws/rpc/v0_7`.
 - **Starknet v0.8.0-rc1**  
-  Accessible at `/ws/rpc/v0_8`.
+  Accessible at `/rpc/v0_8`.
 - **Pathfinder Extension**  
   Exposed via `/ws/rpc/pathfinder/v0_1`
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -9,19 +9,19 @@ import { themes as prismThemes } from 'prism-react-renderer';
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Pathfinder',
-  tagline: 'Dinosaurs are cool',
+  tagline: 'Giving you a safe view into Starknet.',
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
-  url: 'https://your-docusaurus-site.example.com',
+  url: 'https://eqlabs.github.io/',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/',
+  baseUrl: '/pathfinder/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'facebook', // Usually your GitHub org/user name.
-  projectName: 'docusaurus', // Usually your repo name.
+  organizationName: 'eqlabs', // Usually your GitHub org/user name.
+  projectName: 'pathfinder', // Usually your repo name.
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
@@ -104,12 +104,12 @@ const config = {
             ],
           },
         ],
-        copyright: `Pathfinder © ${new Date().getFullYear()}`,
+        copyright: `Equilibrium Labs © ${new Date().getFullYear()}`,
       },
       prism: {
         theme: prismThemes.github,
         darkTheme: prismThemes.dracula,
-        additionalLanguages: ['bash', 'json', 'go', 'rust'],
+        additionalLanguages: ['bash', 'json', 'rust'],
       },
     }),
 };


### PR DESCRIPTION
This PR fixes some issues in the new website contents / configuration, adds the single incident page the old website had and changes our deployment workflow to deploy the new site to https://eqlabs.github.io/pathfinder.

Removal of the old website and redundant parts of the README will be done in a follow-up PR once the deployment has been done.