### PR TITLE
Publish crates on release published trigger

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -2,11 +2,8 @@ name: Publish Crates
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to publish (without v prefix)'
-        required: true
-        type: string
+  release:
+    types: [published]
 
 permissions:
   contents: read


### PR DESCRIPTION
The crate publishing job should now run as soon as we publish a new release!