### PR TITLE
fix(github/deploy_website): run build commands in the right directory

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -26,9 +26,13 @@ jobs:
         id: pages
         uses: actions/configure-pages@v5
       - name: Install Docusaurus
-        run: yarn
+        run: |
+          cd docs
+          yarn
       - name: Build with Docusaurus
-        run: yarn build
+        run: |
+          cd docs
+          yarn build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Another dumb issue fixed. This time it's actually [building fine](https://github.com/eqlabs/pathfinder/actions/runs/13196848488/job/36839941462).
