### PR TITLE
fix(rpc/v08): remove `CALL_ON_PENDING` error and introduce `SUBSCRIPTION_BLOCK_ID`

### DIFF
--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -105,8 +105,6 @@ pub enum ApplicationError {
     InvalidSubscriptionID,
     #[error("Too many addresses in filter sender_address filter")]
     TooManyAddressesInFilter,
-    #[error("This method does not support being called on the pending block")]
-    CallOnPending,
     /// Internal errors are errors whose details we don't want to show to the
     /// end user. These are logged, and a simple "internal error" message is
     /// shown to the end user.
@@ -169,7 +167,6 @@ impl ApplicationError {
             // doc/rpc/starknet_ws_api.json
             ApplicationError::InvalidSubscriptionID => 66,
             ApplicationError::TooManyAddressesInFilter => 67,
-            ApplicationError::CallOnPending => 69,
             // https://www.jsonrpc.org/specification#error_object
             ApplicationError::GatewayError(_)
             | ApplicationError::Internal(_)
@@ -232,7 +229,6 @@ impl ApplicationError {
             ApplicationError::UnsupportedContractClassVersion => None,
             ApplicationError::InvalidSubscriptionID => None,
             ApplicationError::TooManyAddressesInFilter => None,
-            ApplicationError::CallOnPending => None,
             ApplicationError::GatewayError(error) => Some(json!({
                 "error": error,
             })),


### PR DESCRIPTION
A change in the JSON-RPC 0.8.0-rc.3 specification made it explicit that the pending block is not allowed as the starting block for any subscription.

The `block_id` parameter in a subscription request should now be of type `SUBSCRIPTION_BLOCK_ID` and the `CALL_ON_PENDING` error has been removed.

Closes #2583 
