### PR TITLE
fix(rpc/v07): remove dto leftover type for `ResourceBounds`

### DIFF
--- a/crates/rpc/src/method/add_declare_transaction.rs
+++ b/crates/rpc/src/method/add_declare_transaction.rs
@@ -365,20 +365,9 @@ pub async fn add_declare_transaction(
                     add_transaction::Declare::V3(add_transaction::DeclareV3 {
                         signature: tx.signature,
                         nonce: tx.nonce,
-                        nonce_data_availability_mode:
-                            pathfinder_common::transaction::DataAvailabilityMode::from(
-                                tx.nonce_data_availability_mode,
-                            )
-                            .into(),
-                        fee_data_availability_mode:
-                            pathfinder_common::transaction::DataAvailabilityMode::from(
-                                tx.fee_data_availability_mode,
-                            )
-                            .into(),
-                        resource_bounds: pathfinder_common::transaction::ResourceBounds::from(
-                            tx.resource_bounds,
-                        )
-                        .into(),
+                        nonce_data_availability_mode: tx.nonce_data_availability_mode.into(),
+                        fee_data_availability_mode: tx.fee_data_availability_mode.into(),
+                        resource_bounds: tx.resource_bounds.into(),
                         tip: tx.tip,
                         paymaster_data: tx.paymaster_data,
                         contract_class: contract_definition,
@@ -415,6 +404,7 @@ mod tests {
     use std::sync::LazyLock;
 
     use pathfinder_common::macro_prelude::*;
+    use pathfinder_common::transaction::{DataAvailabilityMode, ResourceBound, ResourceBounds};
     use pathfinder_common::{
         CasmHash,
         ContractAddress,
@@ -438,14 +428,7 @@ mod tests {
         BroadcastedDeclareTransactionV2,
         BroadcastedDeclareTransactionV3,
     };
-    use crate::types::{
-        CairoContractClass,
-        ContractClass,
-        DataAvailabilityMode,
-        ResourceBound,
-        ResourceBounds,
-        SierraContractClass,
-    };
+    use crate::types::{CairoContractClass, ContractClass, SierraContractClass};
 
     pub static CONTRACT_CLASS: LazyLock<CairoContractClass> = LazyLock::new(|| {
         ContractClass::from_definition_bytes(CONTRACT_DEFINITION)

--- a/crates/rpc/src/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/method/add_deploy_account_transaction.rs
@@ -238,20 +238,9 @@ pub(crate) async fn add_deploy_account_transaction_impl(
                     add_transaction::DeployAccountV3 {
                         signature: tx.signature,
                         nonce: tx.nonce,
-                        nonce_data_availability_mode:
-                            pathfinder_common::transaction::DataAvailabilityMode::from(
-                                tx.nonce_data_availability_mode,
-                            )
-                            .into(),
-                        fee_data_availability_mode:
-                            pathfinder_common::transaction::DataAvailabilityMode::from(
-                                tx.fee_data_availability_mode,
-                            )
-                            .into(),
-                        resource_bounds: pathfinder_common::transaction::ResourceBounds::from(
-                            tx.resource_bounds,
-                        )
-                        .into(),
+                        nonce_data_availability_mode: tx.nonce_data_availability_mode.into(),
+                        fee_data_availability_mode: tx.fee_data_availability_mode.into(),
+                        resource_bounds: tx.resource_bounds.into(),
                         tip: tx.tip,
                         paymaster_data: tx.paymaster_data,
                         class_hash: tx.class_hash,
@@ -279,6 +268,7 @@ impl crate::dto::SerializeForVersion for Output {
 #[cfg(test)]
 mod tests {
     use pathfinder_common::macro_prelude::*;
+    use pathfinder_common::transaction::{DataAvailabilityMode, ResourceBound, ResourceBounds};
     use pathfinder_common::{
         ResourceAmount,
         ResourcePricePerUnit,
@@ -290,7 +280,6 @@ mod tests {
     use super::*;
     use crate::dto::{SerializeForVersion, Serializer};
     use crate::types::request::BroadcastedDeployAccountTransactionV3;
-    use crate::types::{DataAvailabilityMode, ResourceBound, ResourceBounds};
 
     const INPUT_JSON: &str = r#"{
         "max_fee": "0xbf391377813",

--- a/crates/rpc/src/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/method/add_invoke_transaction.rs
@@ -232,20 +232,9 @@ pub(crate) async fn add_invoke_transaction_impl(
                     add_transaction::InvokeFunctionV3 {
                         signature: tx.signature,
                         nonce: tx.nonce,
-                        nonce_data_availability_mode:
-                            pathfinder_common::transaction::DataAvailabilityMode::from(
-                                tx.nonce_data_availability_mode,
-                            )
-                            .into(),
-                        fee_data_availability_mode:
-                            pathfinder_common::transaction::DataAvailabilityMode::from(
-                                tx.fee_data_availability_mode,
-                            )
-                            .into(),
-                        resource_bounds: pathfinder_common::transaction::ResourceBounds::from(
-                            tx.resource_bounds,
-                        )
-                        .into(),
+                        nonce_data_availability_mode: tx.nonce_data_availability_mode.into(),
+                        fee_data_availability_mode: tx.fee_data_availability_mode.into(),
+                        resource_bounds: tx.resource_bounds.into(),
                         tip: tx.tip,
                         paymaster_data: tx.paymaster_data,
                         sender_address: tx.sender_address,
@@ -272,11 +261,11 @@ impl crate::dto::SerializeForVersion for Output {
 #[cfg(test)]
 mod tests {
     use pathfinder_common::macro_prelude::*;
+    use pathfinder_common::transaction::{DataAvailabilityMode, ResourceBound, ResourceBounds};
     use pathfinder_common::{ResourceAmount, ResourcePricePerUnit, Tip, TransactionVersion};
 
     use super::*;
     use crate::types::request::BroadcastedInvokeTransactionV1;
-    use crate::types::{DataAvailabilityMode, ResourceBound, ResourceBounds};
 
     fn test_invoke_txn() -> Transaction {
         Transaction::Invoke(BroadcastedInvokeTransaction::V1(

--- a/crates/rpc/src/method/estimate_fee.rs
+++ b/crates/rpc/src/method/estimate_fee.rs
@@ -193,6 +193,7 @@ impl crate::dto::SerializeForVersion for Output {
 mod tests {
     use pathfinder_common::macro_prelude::*;
     use pathfinder_common::prelude::*;
+    use pathfinder_common::transaction::{DataAvailabilityMode, ResourceBounds};
     use pathfinder_common::{felt, BlockId, Tip};
     use pathfinder_executor::types::{FeeEstimate, PriceUnit};
     use pretty_assertions_sorted::assert_eq;
@@ -207,7 +208,7 @@ mod tests {
         BroadcastedInvokeTransactionV3,
         BroadcastedTransaction,
     };
-    use crate::types::{ContractClass, DataAvailabilityMode, ResourceBounds, SierraContractClass};
+    use crate::types::{ContractClass, SierraContractClass};
 
     fn declare_transaction(account_contract_address: ContractAddress) -> BroadcastedTransaction {
         let sierra_definition = include_bytes!("../../fixtures/contracts/storage_access.json");

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -624,6 +624,11 @@ pub(crate) mod tests {
 
         // The input transactions are the same as in v04.
         pub mod input {
+            use pathfinder_common::transaction::{
+                DataAvailabilityMode,
+                ResourceBound,
+                ResourceBounds,
+            };
             use pathfinder_common::{
                 CallParam,
                 EntryPoint,
@@ -640,7 +645,6 @@ pub(crate) mod tests {
                 BroadcastedInvokeTransactionV3,
                 BroadcastedTransaction,
             };
-            use crate::types::{ResourceBound, ResourceBounds};
 
             pub fn declare(account_contract_address: ContractAddress) -> BroadcastedTransaction {
                 let contract_class =
@@ -741,8 +745,8 @@ pub(crate) mod tests {
                         tip: Tip(0),
                         paymaster_data: vec![],
                         account_deployment_data: vec![],
-                        nonce_data_availability_mode: crate::types::DataAvailabilityMode::L1,
-                        fee_data_availability_mode: crate::types::DataAvailabilityMode::L1,
+                        nonce_data_availability_mode: DataAvailabilityMode::L1,
+                        fee_data_availability_mode: DataAvailabilityMode::L1,
                         sender_address: account_contract_address,
                         calldata: vec![
                             // Number of calls
@@ -784,8 +788,8 @@ pub(crate) mod tests {
                         tip: Tip(0),
                         paymaster_data: vec![],
                         account_deployment_data: vec![],
-                        nonce_data_availability_mode: crate::types::DataAvailabilityMode::L1,
-                        fee_data_availability_mode: crate::types::DataAvailabilityMode::L1,
+                        nonce_data_availability_mode: DataAvailabilityMode::L1,
+                        fee_data_availability_mode: DataAvailabilityMode::L1,
                         sender_address: account_contract_address,
                         calldata: vec![
                             // Number of calls

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -6,155 +6,10 @@ pub mod syncing;
 pub(crate) mod transaction;
 
 pub use class::*;
-use pathfinder_common::{ResourceAmount, ResourcePricePerUnit};
-use serde::de::Error;
-
-use crate::dto::{U128Hex, U64Hex};
-use crate::RpcVersion;
-
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub struct ResourceBounds {
-    pub l1_gas: ResourceBound,
-    pub l2_gas: ResourceBound,
-    pub l1_data_gas: Option<ResourceBound>,
-}
-
-impl From<ResourceBounds> for pathfinder_common::transaction::ResourceBounds {
-    fn from(resource_bounds: ResourceBounds) -> Self {
-        Self {
-            l1_gas: resource_bounds.l1_gas.into(),
-            l2_gas: resource_bounds.l2_gas.into(),
-            l1_data_gas: resource_bounds.l1_data_gas.map(|g| g.into()),
-        }
-    }
-}
-
-impl crate::dto::SerializeForVersion for ResourceBounds {
-    fn serialize(
-        &self,
-        serializer: crate::dto::Serializer,
-    ) -> Result<crate::dto::Ok, crate::dto::Error> {
-        let mut serializer = serializer.serialize_struct()?;
-        serializer.serialize_field("l1_gas", &self.l1_gas)?;
-        serializer.serialize_field("l2_gas", &self.l2_gas)?;
-        if serializer.version >= RpcVersion::V08 {
-            // `l1_data_gas` is serialized as (0, 0) in v0.8+ even if it's not set
-            // See https://github.com/eqlabs/pathfinder/issues/2571
-            serializer.serialize_field("l1_data_gas", &self.l1_data_gas.unwrap_or_default())?;
-        }
-        serializer.end()
-    }
-}
-
-impl crate::dto::DeserializeForVersion for ResourceBounds {
-    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        let version = value.version;
-        value.deserialize_map(|value| {
-            Ok(Self {
-                l1_gas: value.deserialize("l1_gas")?,
-                l2_gas: value.deserialize("l2_gas")?,
-                l1_data_gas: if version >= RpcVersion::V08 {
-                    // `l1_data_gas` is *required* in v0.8+
-                    // See https://github.com/eqlabs/pathfinder/issues/2571
-                    Some(value.deserialize("l1_data_gas")?)
-                } else {
-                    None
-                },
-            })
-        })
-    }
-}
-
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub struct ResourceBound {
-    pub max_amount: ResourceAmount,
-    pub max_price_per_unit: ResourcePricePerUnit,
-}
-
-impl From<ResourceBound> for pathfinder_common::transaction::ResourceBound {
-    fn from(resource_bound: ResourceBound) -> Self {
-        Self {
-            max_amount: resource_bound.max_amount,
-            max_price_per_unit: resource_bound.max_price_per_unit,
-        }
-    }
-}
-
-impl crate::dto::SerializeForVersion for ResourceBound {
-    fn serialize(
-        &self,
-        serializer: crate::dto::Serializer,
-    ) -> Result<crate::dto::Ok, crate::dto::Error> {
-        let mut serializer = serializer.serialize_struct()?;
-        serializer.serialize_field("max_amount", &self.max_amount)?;
-        serializer.serialize_field("max_price_per_unit", &self.max_price_per_unit)?;
-        serializer.end()
-    }
-}
-
-impl crate::dto::DeserializeForVersion for ResourceBound {
-    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        value.deserialize_map(|value| {
-            Ok(Self {
-                max_amount: ResourceAmount(value.deserialize::<U64Hex>("max_amount")?.0),
-                max_price_per_unit: ResourcePricePerUnit(
-                    value.deserialize::<U128Hex>("max_price_per_unit")?.0,
-                ),
-            })
-        })
-    }
-}
-
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub enum DataAvailabilityMode {
-    #[default]
-    L1,
-    L2,
-}
-
-impl From<DataAvailabilityMode> for pathfinder_common::transaction::DataAvailabilityMode {
-    fn from(data_availability_mode: DataAvailabilityMode) -> Self {
-        match data_availability_mode {
-            DataAvailabilityMode::L1 => Self::L1,
-            DataAvailabilityMode::L2 => Self::L2,
-        }
-    }
-}
-
-impl From<DataAvailabilityMode> for starknet_api::data_availability::DataAvailabilityMode {
-    fn from(value: DataAvailabilityMode) -> Self {
-        match value {
-            DataAvailabilityMode::L1 => Self::L1,
-            DataAvailabilityMode::L2 => Self::L2,
-        }
-    }
-}
-
-impl crate::dto::SerializeForVersion for DataAvailabilityMode {
-    fn serialize(
-        &self,
-        serializer: crate::dto::Serializer,
-    ) -> Result<crate::dto::Ok, crate::dto::Error> {
-        serializer.serialize_str(match self {
-            DataAvailabilityMode::L1 => "L1",
-            DataAvailabilityMode::L2 => "L2",
-        })
-    }
-}
-
-impl crate::dto::DeserializeForVersion for DataAvailabilityMode {
-    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        let value: String = value.deserialize()?;
-        match value.as_str() {
-            "L1" => Ok(Self::L1),
-            "L2" => Ok(Self::L2),
-            _ => Err(serde_json::Error::custom("invalid data availability mode")),
-        }
-    }
-}
 
 /// Groups all strictly input types of the RPC API.
 pub mod request {
+    use pathfinder_common::transaction::{DataAvailabilityMode, ResourceBounds};
     use pathfinder_common::{
         AccountDeploymentDataElem,
         CallParam,
@@ -592,12 +447,12 @@ pub mod request {
         pub version: TransactionVersion,
         pub signature: Vec<TransactionSignatureElem>,
         pub nonce: TransactionNonce,
-        pub resource_bounds: super::ResourceBounds,
+        pub resource_bounds: ResourceBounds,
         pub tip: Tip,
         pub paymaster_data: Vec<PaymasterDataElem>,
         pub account_deployment_data: Vec<AccountDeploymentDataElem>,
-        pub nonce_data_availability_mode: super::DataAvailabilityMode,
-        pub fee_data_availability_mode: super::DataAvailabilityMode,
+        pub nonce_data_availability_mode: DataAvailabilityMode,
+        pub fee_data_availability_mode: DataAvailabilityMode,
 
         pub compiled_class_hash: CasmHash,
         pub contract_class: super::SierraContractClass,
@@ -856,11 +711,11 @@ pub mod request {
         pub version: TransactionVersion,
         pub signature: Vec<TransactionSignatureElem>,
         pub nonce: TransactionNonce,
-        pub resource_bounds: super::ResourceBounds,
+        pub resource_bounds: ResourceBounds,
         pub tip: Tip,
         pub paymaster_data: Vec<PaymasterDataElem>,
-        pub nonce_data_availability_mode: super::DataAvailabilityMode,
-        pub fee_data_availability_mode: super::DataAvailabilityMode,
+        pub nonce_data_availability_mode: DataAvailabilityMode,
+        pub fee_data_availability_mode: DataAvailabilityMode,
 
         pub contract_address_salt: ContractAddressSalt,
         pub constructor_calldata: Vec<CallParam>,
@@ -1189,12 +1044,12 @@ pub mod request {
         pub version: TransactionVersion,
         pub signature: Vec<TransactionSignatureElem>,
         pub nonce: TransactionNonce,
-        pub resource_bounds: super::ResourceBounds,
+        pub resource_bounds: ResourceBounds,
         pub tip: Tip,
         pub paymaster_data: Vec<PaymasterDataElem>,
         pub account_deployment_data: Vec<AccountDeploymentDataElem>,
-        pub nonce_data_availability_mode: super::DataAvailabilityMode,
-        pub fee_data_availability_mode: super::DataAvailabilityMode,
+        pub nonce_data_availability_mode: DataAvailabilityMode,
+        pub fee_data_availability_mode: DataAvailabilityMode,
 
         pub sender_address: ContractAddress,
         pub calldata: Vec<CallParam>,
@@ -1303,9 +1158,9 @@ pub mod request {
                         sender_address: declare.sender_address,
                         signature: declare.signature,
                         compiled_class_hash: declare.compiled_class_hash,
-                        nonce_data_availability_mode: declare.nonce_data_availability_mode.into(),
-                        fee_data_availability_mode: declare.fee_data_availability_mode.into(),
-                        resource_bounds: declare.resource_bounds.into(),
+                        nonce_data_availability_mode: declare.nonce_data_availability_mode,
+                        fee_data_availability_mode: declare.fee_data_availability_mode,
+                        resource_bounds: declare.resource_bounds,
                         tip: declare.tip,
                         paymaster_data: declare.paymaster_data,
                         account_deployment_data: declare.account_deployment_data,
@@ -1331,9 +1186,9 @@ pub mod request {
                     contract_address_salt: deploy.contract_address_salt,
                     constructor_calldata: deploy.constructor_calldata,
                     signature: deploy.signature,
-                    nonce_data_availability_mode: deploy.nonce_data_availability_mode.into(),
-                    fee_data_availability_mode: deploy.fee_data_availability_mode.into(),
-                    resource_bounds: deploy.resource_bounds.into(),
+                    nonce_data_availability_mode: deploy.nonce_data_availability_mode,
+                    fee_data_availability_mode: deploy.fee_data_availability_mode,
+                    resource_bounds: deploy.resource_bounds,
                     tip: deploy.tip,
                     paymaster_data: deploy.paymaster_data,
                 }),
@@ -1361,9 +1216,9 @@ pub mod request {
                         nonce: invoke.nonce,
                         sender_address: invoke.sender_address,
                         signature: invoke.signature,
-                        nonce_data_availability_mode: invoke.nonce_data_availability_mode.into(),
-                        fee_data_availability_mode: invoke.fee_data_availability_mode.into(),
-                        resource_bounds: invoke.resource_bounds.into(),
+                        nonce_data_availability_mode: invoke.nonce_data_availability_mode,
+                        fee_data_availability_mode: invoke.fee_data_availability_mode,
+                        resource_bounds: invoke.resource_bounds,
                         tip: invoke.tip,
                         paymaster_data: invoke.paymaster_data,
                         calldata: invoke.calldata,
@@ -1401,6 +1256,7 @@ pub mod request {
         ///   spec.
         mod serde {
             use pathfinder_common::macro_prelude::*;
+            use pathfinder_common::transaction::ResourceBound;
             use pathfinder_common::{felt, ResourceAmount, ResourcePricePerUnit};
             use pretty_assertions_sorted::assert_eq;
 
@@ -1409,9 +1265,6 @@ pub mod request {
             use crate::types::{
                 CairoContractClass,
                 ContractEntryPoints,
-                DataAvailabilityMode,
-                ResourceBound,
-                ResourceBounds,
                 SierraContractClass,
                 SierraEntryPoint,
                 SierraEntryPoints,
@@ -1687,12 +1540,13 @@ pub mod reply {
 
 #[cfg(test)]
 mod tests {
+    use pathfinder_common::transaction::{ResourceBound, ResourceBounds};
     use pathfinder_common::{ResourceAmount, ResourcePricePerUnit};
     use pretty_assertions_sorted::assert_eq;
     use serde_json::json;
 
-    use super::*;
     use crate::dto::{DeserializeForVersion, SerializeForVersion, Value};
+    use crate::RpcVersion;
 
     #[test]
     fn resource_bounds_serde() {


### PR DESCRIPTION
A legacy dto type for `ResourceBounds` was being used in our RPC implementation instead of the common type.

This PR removes that leftover type and adjusts our RPC implementation accordingly.

Thanks @xJonathanLEI 

Closes #2571 