### PR TITLE
fix(rpc/call): properly handle failed Sierra 1.7 calls

### DIFF
--- a/crates/executor/src/call.rs
+++ b/crates/executor/src/call.rs
@@ -9,7 +9,7 @@ use blockifier::execution::entry_point::{
 use blockifier::state::state_api::StateReader;
 use blockifier::transaction::objects::{DeprecatedTransactionInfo, TransactionInfo};
 use blockifier::versioned_constants::VersionedConstants;
-use pathfinder_common::{CallParam, CallResultValue, ContractAddress, EntryPoint};
+use pathfinder_common::{felt, CallParam, CallResultValue, ContractAddress, EntryPoint};
 use starknet_api::contract_class::EntryPointType;
 use starknet_api::core::PatriciaKey;
 
@@ -25,16 +25,16 @@ pub fn call(
 ) -> Result<Vec<CallResultValue>, CallError> {
     let (mut state, block_context) = execution_state.starknet_state()?;
 
-    let contract_address = starknet_api::core::ContractAddress(PatriciaKey::try_from(
+    let starknet_api_contract_address = starknet_api::core::ContractAddress(PatriciaKey::try_from(
         contract_address.0.into_starkfelt(),
     )?);
-    let entry_point_selector =
+    let starknet_api_entry_point_selector =
         starknet_api::core::EntryPointSelector(entry_point_selector.0.into_starkfelt());
     let calldata = calldata
         .into_iter()
         .map(|param| param.0.into_starkfelt())
         .collect();
-    let class_hash = state.get_class_hash_at(contract_address)?;
+    let class_hash = state.get_class_hash_at(starknet_api_contract_address)?;
 
     let initial_gas = VersionedConstants::latest_constants()
         .os_constants
@@ -43,9 +43,9 @@ pub fn call(
         .default_initial_gas_cost;
 
     let call_entry_point = CallEntryPoint {
-        storage_address: contract_address,
+        storage_address: starknet_api_contract_address,
         entry_point_type: EntryPointType::External,
-        entry_point_selector,
+        entry_point_selector: starknet_api_entry_point_selector,
         calldata: starknet_api::transaction::fields::Calldata(Arc::new(calldata)),
         initial_gas,
         call_type: blockifier::execution::entry_point::CallType::Call,
@@ -67,11 +67,59 @@ pub fn call(
         .map_err(|e| {
             CallError::from_entry_point_execution_error(
                 e,
-                &contract_address,
+                &starknet_api_contract_address,
                 &class_hash,
-                &entry_point_selector,
+                &starknet_api_entry_point_selector,
             )
         })?;
+
+    let error_stack_call_frame = crate::Frame::CallFrame(crate::CallFrame {
+        storage_address: contract_address,
+        class_hash: pathfinder_common::ClassHash(class_hash.0.into_felt()),
+        selector: Some(entry_point_selector),
+    });
+
+    // Sierra 1.7 classes can return a failure without reverting.
+    if call_info.execution.failed {
+        match call_info.execution.retdata.0.as_slice() {
+            [error_code]
+                if error_code.into_felt()
+                    == felt!(
+                        blockifier::execution::syscalls::hint_processor::ENTRYPOINT_NOT_FOUND_ERROR
+                    ) =>
+            {
+                return Err(CallError::InvalidMessageSelector);
+            }
+            [error_code]
+                if error_code.into_felt()
+                    == felt!(blockifier::execution::syscalls::hint_processor::OUT_OF_GAS_ERROR) =>
+            {
+                let error_message = "Out of gas";
+                let error_stack = crate::ErrorStack(vec![
+                    error_stack_call_frame,
+                    crate::Frame::StringFrame(error_message.to_owned()),
+                ]);
+
+                return Err(CallError::ContractError(
+                    anyhow::anyhow!(error_message),
+                    error_stack,
+                ));
+            }
+            _ => {
+                let error_message =
+                    format!("Failed with retdata: {:?}", call_info.execution.retdata);
+                let error_stack = crate::ErrorStack(vec![
+                    error_stack_call_frame,
+                    crate::Frame::StringFrame(error_message.clone()),
+                ]);
+
+                return Err(CallError::ContractError(
+                    anyhow::Error::msg(error_message),
+                    error_stack,
+                ));
+            }
+        }
+    }
 
     let result = call_info
         .execution

--- a/crates/executor/src/error.rs
+++ b/crates/executor/src/error.rs
@@ -29,7 +29,8 @@ impl From<BlockifierTransactionExecutionError> for CallError {
                 ConstructorEntryPointExecutionError::ExecutionError { error, .. },
             ) => match error {
                 BlockifierEntryPointExecutionError::PreExecutionError(
-                    PreExecutionError::EntryPointNotFound(_),
+                    PreExecutionError::EntryPointNotFound(_)
+                    | PreExecutionError::NoEntryPointOfTypeFound(_),
                 ) => Self::InvalidMessageSelector,
                 BlockifierEntryPointExecutionError::PreExecutionError(
                     PreExecutionError::UninitializedStorageAddress(_),
@@ -38,7 +39,8 @@ impl From<BlockifierTransactionExecutionError> for CallError {
             },
             ExecutionError { error, .. } => match error {
                 BlockifierEntryPointExecutionError::PreExecutionError(
-                    PreExecutionError::EntryPointNotFound(_),
+                    PreExecutionError::EntryPointNotFound(_)
+                    | PreExecutionError::NoEntryPointOfTypeFound(_),
                 ) => Self::InvalidMessageSelector,
                 BlockifierEntryPointExecutionError::PreExecutionError(
                     PreExecutionError::UninitializedStorageAddress(_),
@@ -47,7 +49,8 @@ impl From<BlockifierTransactionExecutionError> for CallError {
             },
             ValidateTransactionError { error, .. } => match error {
                 BlockifierEntryPointExecutionError::PreExecutionError(
-                    PreExecutionError::EntryPointNotFound(_),
+                    PreExecutionError::EntryPointNotFound(_)
+                    | PreExecutionError::NoEntryPointOfTypeFound(_),
                 ) => Self::InvalidMessageSelector,
                 BlockifierEntryPointExecutionError::PreExecutionError(
                     PreExecutionError::UninitializedStorageAddress(_),


### PR DESCRIPTION
In Starknet 0.13.4 calls can fail without reverting the whole execution. This means that any call can now just fail without throwing an error and we have to use the retdata to find out what was the cause of failure.

Blockifier seems to have special cases for OUT_OF_GAS and ENTRYPOINT_NOT_FOUND errors, so we handle these two cases separately.

The rest of failures gets converted into a ContractError with the actual retdata part of the error message.