### PR TITLE
fix(docker): fix and re-enable aarch64 Docker image builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,6 +63,7 @@ jobs:
           context: .
           platforms: |
             linux/amd64
+            linux/arm64
           file: ./Dockerfile
           build-args: |
             PATHFINDER_FORCE_VERSION=${{ steps.generate_version.outputs.pathfinder_version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # Note that we're explicitly using the Debian bookworm image to make sure we're
 # compatible with the Debian container we'll be copying the pathfinder
 # executable to.
-FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:0.1.70-rust-1.84-slim-bookworm AS cargo-chef
+FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:0.1.71-rust-1.84.1-slim-bookworm AS cargo-chef
 WORKDIR /usr/src/pathfinder
 
 FROM --platform=$BUILDPLATFORM cargo-chef AS rust-planner

--- a/build/cargo-build.sh
+++ b/build/cargo-build.sh
@@ -1,10 +1,13 @@
 #!/bin/bash -e
 if [[ "${TARGETARCH}" == "amd64" ]]; then
-    CARGO_INCREMENTAL=0 cargo build --target x86_64-unknown-linux-gnu $*
+    CARGO_INCREMENTAL=0 \
+    CARGO_BUILD_TARGET=x86_64-unknown-linux-gnu \
+    cargo build $*
 elif [[ "${TARGETARCH}" == "arm64" ]]; then
     PKG_CONFIG_ALLOW_CROSS=1 \
     RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -L/usr/aarch64-linux-gnu/lib -L/build/sysroot/usr/lib/aarch64-linux-gnu" \
     C_INCLUDE_PATH=/build/sysroot/usr/include \
     JEMALLOC_SYS_WITH_LG_PAGE=16 \
-    cargo build --target aarch64-unknown-linux-gnu $*
+    CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu \
+    cargo build $*
 fi

--- a/build/cargo-chef-cook.sh
+++ b/build/cargo-chef-cook.sh
@@ -1,10 +1,12 @@
 #!/bin/bash -e
 if [[ "${TARGETARCH}" == "amd64" ]]; then
-    cargo chef cook --target x86_64-unknown-linux-gnu $*
+    CARGO_BUILD_TARGET=x86_64-unknown-linux-gnu \
+    cargo chef cook $*
 elif [[ "${TARGETARCH}" == "arm64" ]]; then
     PKG_CONFIG_ALLOW_CROSS=1 \
     RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -L/usr/aarch64-linux-gnu/lib -L/build/sysroot/usr/lib/aarch64-linux-gnu" \
     C_INCLUDE_PATH=/build/sysroot/usr/include \
     JEMALLOC_SYS_WITH_LG_PAGE=16 \
-    cargo chef cook --target aarch64-unknown-linux-gnu $*
+    CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu \
+    cargo chef cook $*
 fi


### PR DESCRIPTION
We have previously disabled our aarch64 Docker image builds because a build script in on of the dependencies of blockifier was not working when we were cross-compiling Pathfinder.

It turned out that there's an easy workaround: instead of specifying `--target XXX` to our `cargo build` invocation we should just use the CARGO_BUILD_TARGET environment variable. That gets properly inherited by the `cargo install` command ran by the build script and the binary is properly compiled for our target architecture.