### PR TITLE
fix(executor/estimate): fee estimation should fail for reverts

### DIFF
--- a/crates/executor/src/error_stack.rs
+++ b/crates/executor/src/error_stack.rs
@@ -11,7 +11,7 @@ use pathfinder_common::{ClassHash, ContractAddress, EntryPoint};
 
 use crate::IntoFelt;
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct ErrorStack(pub Vec<Frame>);
 
 impl From<BlockifierErrorStack> for ErrorStack {
@@ -53,7 +53,7 @@ impl From<Cairo1RevertSummary> for ErrorStack {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Frame {
     CallFrame(CallFrame),
     StringFrame(String),
@@ -87,7 +87,7 @@ impl From<Cairo1RevertFrame> for Frame {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct CallFrame {
     pub storage_address: ContractAddress,
     pub class_hash: ClassHash,

--- a/crates/executor/src/estimate.rs
+++ b/crates/executor/src/estimate.rs
@@ -1,16 +1,17 @@
 use blockifier::transaction::objects::TransactionExecutionInfo;
 use blockifier::transaction::transaction_execution::Transaction;
+use pathfinder_common::TransactionHash;
 use starknet_api::transaction::fields::GasVectorComputationMode;
 
 use super::error::TransactionExecutionError;
 use super::execution_state::ExecutionState;
-use super::transaction::transaction_hash;
 use super::types::FeeEstimate;
 use crate::transaction::{
     execute_transaction,
     find_l2_gas_limit_and_execute_transaction,
     l2_gas_accounting_enabled,
 };
+use crate::IntoFelt;
 
 pub fn estimate(
     execution_state: ExecutionState<'_>,
@@ -27,7 +28,7 @@ pub fn estimate(
             let _span = tracing::debug_span!(
                 "estimate",
                 block_number = %block_number,
-                transaction_hash = %transaction_hash(&tx),
+                transaction_hash = %TransactionHash(Transaction::tx_hash(&tx).0.into_felt()),
                 transaction_index = %tx_index
             )
             .entered();

--- a/crates/executor/src/estimate.rs
+++ b/crates/executor/src/estimate.rs
@@ -1,6 +1,7 @@
-use blockifier::transaction::objects::TransactionExecutionInfo;
+use blockifier::transaction::objects::{HasRelatedFeeType, TransactionExecutionInfo};
 use blockifier::transaction::transaction_execution::Transaction;
 use pathfinder_common::TransactionHash;
+use starknet_api::block::FeeType;
 use starknet_api::transaction::fields::GasVectorComputationMode;
 
 use super::error::TransactionExecutionError;
@@ -84,7 +85,7 @@ impl FeeEstimate {
         gas_vector_computation_mode: &GasVectorComputationMode,
         block_context: &blockifier::context::BlockContext,
     ) -> Self {
-        let fee_type = super::transaction::fee_type(transaction);
+        let fee_type = fee_type(transaction);
         let minimal_gas_vector = match transaction {
             Transaction::Account(account_transaction) => {
                 Some(blockifier::fee::gas_usage::estimate_minimal_gas_vector(
@@ -102,5 +103,12 @@ impl FeeEstimate {
             fee_type,
             &minimal_gas_vector,
         )
+    }
+}
+
+pub fn fee_type(transaction: &Transaction) -> FeeType {
+    match transaction {
+        Transaction::Account(tx) => tx.fee_type(),
+        Transaction::L1Handler(tx) => tx.fee_type(),
     }
 }

--- a/crates/executor/src/estimate.rs
+++ b/crates/executor/src/estimate.rs
@@ -55,12 +55,23 @@ pub fn estimate(
                 "Transaction estimation finished"
             );
 
-            Ok(FeeEstimate::from_tx_and_tx_info(
-                &tx,
-                &tx_info,
-                &gas_vector_computation_mode,
-                &block_context,
-            ))
+            if let Some(revert_error) = tx_info.revert_error {
+                let revert_string = revert_error.to_string();
+                tracing::debug!(revert_error=%revert_string, "Transaction reverted");
+
+                Err(TransactionExecutionError::ExecutionError {
+                    transaction_index: tx_index,
+                    error: revert_string,
+                    error_stack: revert_error.into(),
+                })
+            } else {
+                Ok(FeeEstimate::from_tx_and_tx_info(
+                    &tx,
+                    &tx_info,
+                    &gas_vector_computation_mode,
+                    &block_context,
+                ))
+            }
         })
         .collect()
 }

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -28,4 +28,3 @@ pub use execution_state::{ExecutionState, L1BlobDataAvailability};
 pub use felt::{IntoFelt, IntoStarkFelt};
 pub use simulate::{simulate, trace, TraceCache};
 pub use starknet_api::contract_class::ClassInfo;
-pub use transaction::transaction_hash;

--- a/crates/executor/src/simulate.rs
+++ b/crates/executor/src/simulate.rs
@@ -29,6 +29,7 @@ use crate::transaction::{
     execute_transaction,
     find_l2_gas_limit_and_execute_transaction,
     l2_gas_accounting_enabled,
+    ExecutionBehaviorOnRevert,
 };
 use crate::types::{
     DataAvailabilityResources,
@@ -115,9 +116,10 @@ pub fn simulate(
                     tx_index,
                     &mut tx_state,
                     &block_context,
+                    ExecutionBehaviorOnRevert::Continue,
                 )?
             } else {
-                execute_transaction(&tx, tx_index, &mut tx_state, &block_context)?
+                execute_transaction(&tx, tx_index, &mut tx_state, &block_context, &ExecutionBehaviorOnRevert::Continue)?
             };
             let state_diff = to_state_diff(&mut tx_state, transaction_declared_deprecated_class(&tx))?;
             tx_state.commit();

--- a/crates/executor/src/simulate.rs
+++ b/crates/executor/src/simulate.rs
@@ -29,7 +29,6 @@ use crate::transaction::{
     execute_transaction,
     find_l2_gas_limit_and_execute_transaction,
     l2_gas_accounting_enabled,
-    transaction_hash,
 };
 use crate::types::{
     DataAvailabilityResources,
@@ -98,7 +97,7 @@ pub fn simulate(
             let _span = tracing::debug_span!(
                 "simulate",
                 block_number = %block_number,
-                transaction_hash = %transaction_hash(&tx),
+                transaction_hash = %TransactionHash(Transaction::tx_hash(&tx).0.into_felt()),
                 transaction_index = %tx_index
             )
             .entered();
@@ -183,7 +182,7 @@ pub fn trace(
 
     let mut traces = Vec::with_capacity(transactions.len());
     for (transaction_idx, tx) in transactions.into_iter().enumerate() {
-        let hash = transaction_hash(&tx);
+        let hash = TransactionHash(Transaction::tx_hash(&tx).0.into_felt());
         let _span =
             tracing::debug_span!("trace", transaction_hash=%hash, %transaction_idx).entered();
 

--- a/crates/executor/src/transaction.rs
+++ b/crates/executor/src/transaction.rs
@@ -4,39 +4,14 @@ use blockifier::state::state_api::UpdatableState;
 use blockifier::transaction::objects::{HasRelatedFeeType, TransactionExecutionInfo};
 use blockifier::transaction::transaction_execution::Transaction;
 use blockifier::transaction::transactions::ExecutableTransaction;
-use pathfinder_common::TransactionHash;
 use starknet_api::block::FeeType;
 use starknet_api::core::ClassHash;
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::transaction::fields::GasVectorComputationMode;
 
-use super::felt::IntoFelt;
 use crate::TransactionExecutionError;
 
-// This workaround will not be necessary after the PR:
-// https://github.com/starkware-libs/blockifier/pull/927
-pub fn transaction_hash(transaction: &Transaction) -> TransactionHash {
-    TransactionHash(
-        match transaction {
-            Transaction::Account(outer) => match &outer.tx {
-                starknet_api::executable_transaction::AccountTransaction::Declare(inner) => {
-                    inner.tx_hash
-                }
-                starknet_api::executable_transaction::AccountTransaction::DeployAccount(inner) => {
-                    inner.tx_hash()
-                }
-                starknet_api::executable_transaction::AccountTransaction::Invoke(inner) => {
-                    inner.tx_hash()
-                }
-            },
-            Transaction::L1Handler(outer) => outer.tx_hash,
-        }
-        .0
-        .into_felt(),
-    )
-}
-
-pub fn fee_type(transaction: &Transaction) -> FeeType {
+pub(crate) fn fee_type(transaction: &Transaction) -> FeeType {
     match transaction {
         Transaction::Account(tx) => tx.fee_type(),
         Transaction::L1Handler(tx) => tx.fee_type(),

--- a/crates/executor/src/transaction.rs
+++ b/crates/executor/src/transaction.rs
@@ -1,22 +1,14 @@
 use blockifier::execution::contract_class::TrackedResource;
 use blockifier::state::cached_state::{CachedState, MutRefState};
 use blockifier::state::state_api::UpdatableState;
-use blockifier::transaction::objects::{HasRelatedFeeType, TransactionExecutionInfo};
+use blockifier::transaction::objects::TransactionExecutionInfo;
 use blockifier::transaction::transaction_execution::Transaction;
 use blockifier::transaction::transactions::ExecutableTransaction;
-use starknet_api::block::FeeType;
 use starknet_api::core::ClassHash;
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::transaction::fields::GasVectorComputationMode;
 
 use crate::TransactionExecutionError;
-
-pub(crate) fn fee_type(transaction: &Transaction) -> FeeType {
-    match transaction {
-        Transaction::Account(tx) => tx.fee_type(),
-        Transaction::L1Handler(tx) => tx.fee_type(),
-    }
-}
 
 pub fn gas_vector_computation_mode(transaction: &Transaction) -> GasVectorComputationMode {
     match &transaction {


### PR DESCRIPTION
This change aligns the behavior of `starknet_estimateFee` with `starknet_simulateTransactions`, ensuring that fee estimation fails for reverted transactions, while simulation continues to provide estimates and traces with revert reasons.

In the expected output for the test we can also see that our handling of `Cairo1RevertSummary` within an error stack is suboptimal: instead of having the string representation in there we should properly convert the summary into multiple frames. I've created https://github.com/eqlabs/pathfinder/issues/2596 for that problem.