### PR TITLE
fix(executor): improve error stack for Cairo reverts

### DIFF
--- a/crates/executor/src/error_stack.rs
+++ b/crates/executor/src/error_stack.rs
@@ -16,7 +16,13 @@ pub struct ErrorStack(pub Vec<Frame>);
 
 impl From<BlockifierErrorStack> for ErrorStack {
     fn from(value: BlockifierErrorStack) -> Self {
-        Self(value.stack.into_iter().map(Into::into).collect())
+        Self(
+            value
+                .stack
+                .into_iter()
+                .flat_map(|v| Frames::from(v).0)
+                .collect(),
+        )
     }
 }
 
@@ -40,16 +46,7 @@ impl From<RevertError> for ErrorStack {
 
 impl From<Cairo1RevertSummary> for ErrorStack {
     fn from(value: Cairo1RevertSummary) -> Self {
-        let failure_reason =
-            starknet_api::execution_utils::format_panic_data(&value.last_retdata.0);
-        Self(
-            value
-                .stack
-                .into_iter()
-                .map(Into::into)
-                .chain(std::iter::once(Frame::StringFrame(failure_reason)))
-                .collect(),
-        )
+        Self(Frames::from(value).0)
     }
 }
 
@@ -59,21 +56,11 @@ pub enum Frame {
     StringFrame(String),
 }
 
-impl From<ErrorStackSegment> for Frame {
-    fn from(value: ErrorStackSegment) -> Self {
-        match value {
-            ErrorStackSegment::EntryPoint(entry_point) => Frame::CallFrame(CallFrame {
-                storage_address: ContractAddress(entry_point.storage_address.0.into_felt()),
-                class_hash: ClassHash(entry_point.class_hash.0.into_felt()),
-                selector: entry_point.selector.map(|s| EntryPoint(s.0.into_felt())),
-            }),
-            ErrorStackSegment::Cairo1RevertSummary(revert_summary) => {
-                Frame::StringFrame(format!("{:?}", revert_summary))
-            }
-            ErrorStackSegment::Vm(vm_exception) => Frame::StringFrame(String::from(&vm_exception)),
-            ErrorStackSegment::StringFrame(string_frame) => Frame::StringFrame(string_frame),
-        }
-    }
+#[derive(Clone, Debug, PartialEq)]
+pub struct CallFrame {
+    pub storage_address: ContractAddress,
+    pub class_hash: ClassHash,
+    pub selector: Option<EntryPoint>,
 }
 
 impl From<Cairo1RevertFrame> for Frame {
@@ -87,9 +74,38 @@ impl From<Cairo1RevertFrame> for Frame {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
-pub struct CallFrame {
-    pub storage_address: ContractAddress,
-    pub class_hash: ClassHash,
-    pub selector: Option<EntryPoint>,
+struct Frames(pub Vec<Frame>);
+
+impl From<ErrorStackSegment> for Frames {
+    fn from(value: ErrorStackSegment) -> Self {
+        match value {
+            ErrorStackSegment::EntryPoint(entry_point) => Self(vec![Frame::CallFrame(CallFrame {
+                storage_address: ContractAddress(entry_point.storage_address.0.into_felt()),
+                class_hash: ClassHash(entry_point.class_hash.0.into_felt()),
+                selector: entry_point.selector.map(|s| EntryPoint(s.0.into_felt())),
+            })]),
+            ErrorStackSegment::Cairo1RevertSummary(revert_summary) => revert_summary.into(),
+            ErrorStackSegment::Vm(vm_exception) => {
+                Self(vec![Frame::StringFrame(String::from(&vm_exception))])
+            }
+            ErrorStackSegment::StringFrame(string_frame) => {
+                Self(vec![Frame::StringFrame(string_frame)])
+            }
+        }
+    }
+}
+
+impl From<Cairo1RevertSummary> for Frames {
+    fn from(value: Cairo1RevertSummary) -> Self {
+        let failure_reason =
+            starknet_api::execution_utils::format_panic_data(&value.last_retdata.0);
+        Self(
+            value
+                .stack
+                .into_iter()
+                .map(Into::into)
+                .chain(std::iter::once(Frame::StringFrame(failure_reason)))
+                .collect(),
+        )
+    }
 }

--- a/crates/rpc/src/method/estimate_fee.rs
+++ b/crates/rpc/src/method/estimate_fee.rs
@@ -1029,19 +1029,18 @@ mod tests {
                     class_hash: crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH,
                     selector: Some(EntryPoint::hashed(b"__execute__")),
                 }),
+                pathfinder_executor::Frame::CallFrame(pathfinder_executor::CallFrame {
+                    storage_address: account_contract_address,
+                    class_hash: crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH,
+                    selector: Some(EntryPoint::hashed(b"__execute__")),
+                }),
+                pathfinder_executor::Frame::CallFrame(pathfinder_executor::CallFrame {
+                    storage_address: contract_address!("0x17c54b787c2eccfb057cf6aa2f941d612249549fff74140adc20bb949eab74b"),
+                    class_hash: class_hash!("0x01A48FD3F75D0A7C2288AC23FB6ABA26CD375607BA63E4A3B3ED47FC8E99DC21"),
+                    selector: Some(EntryPoint::hashed(b"bogus")),
+                }),
                 pathfinder_executor::Frame::StringFrame(
-                    "Cairo1RevertSummary { header: Execution, stack: \
-                    [Cairo1RevertFrame { \
-                      contract_address: ContractAddress(PatriciaKey(0xc01)), \
-                      class_hash: Some(ClassHash(0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978)), \
-                      selector: EntryPointSelector(0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad) \
-                      }, \
-                    Cairo1RevertFrame { \
-                      contract_address: ContractAddress(PatriciaKey(0x17c54b787c2eccfb057cf6aa2f941d612249549fff74140adc20bb949eab74b)), \
-                      class_hash: Some(ClassHash(0x1a48fd3f75d0a7c2288ac23fb6aba26cd375607ba63e4a3b3ed47fc8e99dc21)), \
-                      selector: EntryPointSelector(0x2a1f595e2db7bf53e1a4bc9834eef6b86d3cd66ec9c8b3588c09253d0affc51) \
-                    }], \
-                    last_retdata: Retdata([0x454e545259504f494e545f4e4f545f464f554e44]) }".to_owned()
+                    "0x454e545259504f494e545f4e4f545f464f554e44 ('ENTRYPOINT_NOT_FOUND')".to_owned()
                 )
             ]));
         });


### PR DESCRIPTION
Currently, `Cairo1RevertSummary`` is converted into a string representation in our error stack. However, this type is an error stack on its own, containing multiple call frames followed by more information on the actual revert.

To provide better structured information on JSON-RPC 0.8, we now properly convert Cairo1RevertSummary into a series of call fames followed by a single string describing the cause of the revert.

Closes #2596