### PR TITLE
refactor(executor): use blockifier's inner call gas vector calculation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ axum = "0.7.5"
 base64 = "0.13.1"
 bincode = "2.0.0-rc.3"
 bitvec = "1.0.1"
-blockifier = "0.14.0-rc.1"
+blockifier = { version = "0.14.0-rc.1", features = ["node_api"] }
 bloomfilter = "1.0.12"
 bytes = "1.4.0"
 cached = "0.44.0"

--- a/crates/executor/src/simulate.rs
+++ b/crates/executor/src/simulate.rs
@@ -138,7 +138,6 @@ pub fn simulate(
                     state_diff,
                     block_context.versioned_constants(),
                     &gas_vector_computation_mode,
-                    block_context.block_info().use_kzg_da,
                 ),
             })
         })
@@ -221,7 +220,6 @@ pub fn trace(
             state_diff,
             block_context.versioned_constants(),
             &gas_vector_computation_mode,
-            block_context.block_info().use_kzg_da,
         );
         traces.push((hash, trace));
     }
@@ -371,14 +369,12 @@ fn to_trace(
     state_diff: StateDiff,
     versioned_constants: &VersionedConstants,
     gas_vector_computation_mode: &GasVectorComputationMode,
-    use_kzg_da: bool,
 ) -> TransactionTrace {
     let validate_invocation = execution_info.validate_call_info.map(|call_info| {
         FunctionInvocation::from_call_info(
             call_info,
             versioned_constants,
             gas_vector_computation_mode,
-            use_kzg_da,
         )
     });
     let maybe_function_invocation = execution_info.execute_call_info.map(|call_info| {
@@ -386,7 +382,6 @@ fn to_trace(
             call_info,
             versioned_constants,
             gas_vector_computation_mode,
-            use_kzg_da,
         )
     });
     let fee_transfer_invocation = execution_info.fee_transfer_call_info.map(|call_info| {
@@ -394,7 +389,6 @@ fn to_trace(
             call_info,
             versioned_constants,
             gas_vector_computation_mode,
-            use_kzg_da,
         )
     });
 


### PR DESCRIPTION
After having upgraded blockifier to 0.14.0-rc.1 we can now use the built-in inner call gas vector calculation we have contributed.
