### PR TITLE
fix(executor): derive max L2 fee from balance

### DIFF
--- a/crates/pathfinder/examples/re_execute.rs
+++ b/crates/pathfinder/examples/re_execute.rs
@@ -158,7 +158,7 @@ fn execute(storage: &mut Storage, chain_id: ChainId, work: Work) {
         }
     };
 
-    match pathfinder_executor::simulate(execution_state, transactions, Percentage::new(10)) {
+    match pathfinder_executor::simulate(execution_state, transactions, Percentage::new(0)) {
         Ok(simulations) => {
             for (simulation, (receipt, transaction)) in simulations
                 .iter()
@@ -183,7 +183,7 @@ fn execute(storage: &mut Storage, chain_id: ChainId, work: Work) {
                 let estimate = &simulation.fee_estimation;
 
                 let actual_data_gas_consumed =
-                    receipt.execution_resources.data_availability.l1_data_gas;
+                    receipt.execution_resources.total_gas_consumed.l1_data_gas;
                 let actual_gas_consumed = receipt.execution_resources.total_gas_consumed.l1_gas;
                 let actual_l2_gas_consumed = receipt.execution_resources.l2_gas.0;
 


### PR DESCRIPTION
Blockifier has a pre-check for `AccountTransaction` that checks that the account has sufficient balance to cover all committed resource bounds.

Because of this `starknet_simulateTransaction` fails with "insufficient balance" when we're initially running the transaction with L2 gas max amount set to u64::MAX.

We should derive the max L2 gas amount so that the balance of the account still covers all the resource bounds.

This PR fixes another small issue: when we're re-executing the transaction with an L2 gas limit of zero so that we get a detailed error, we now explicitly request execution to fail in case of a reverted transaction.
