### PR TITLE
chore(scripts/upgrade): update release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -59,6 +59,7 @@ done
 # Update Cargo.lock and verify everything still builds
 cargo check --workspace --all-targets
 cargo check --workspace --all-targets --all-features
+# The `load-test` crate is excluded from the workspace but has a dependency on `pathfinder-common`.
 pushd crates/load-test
 cargo check
 popd

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -59,12 +59,15 @@ done
 # Update Cargo.lock and verify everything still builds
 cargo check --workspace --all-targets
 cargo check --workspace --all-targets --all-features
+pushd crates/load-test
+cargo check
+popd
 
 # Create and checkout new release branch
 git checkout -b release/v${VERSION}
 
 # Create git commit and tag
-git add Cargo.toml Cargo.lock crates/*/Cargo.toml CHANGELOG.md
+git add Cargo.toml Cargo.lock **/Cargo.toml **/Cargo.lock CHANGELOG.md
 git commit -m "chore: bump version to ${VERSION}"
 git tag -a "v${VERSION}" -m "Pathfinder v${VERSION}"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -69,7 +69,6 @@ git checkout -b release/v${VERSION}
 # Create git commit and tag
 git add Cargo.toml Cargo.lock **/Cargo.toml **/Cargo.lock CHANGELOG.md
 git commit -m "chore: bump version to ${VERSION}"
-git tag -a "v${VERSION}" -m "Pathfinder v${VERSION}"
 
 # Quik recap of what was done
 echo -e "\nChanges made:"
@@ -81,7 +80,7 @@ for crate in "${CRATES[@]}"; do
 done
 
 # Confirmation before pushing
-echo -e "\nPush these changes to \`release/v${VERSION}\` and create a tag \`v${VERSION}\`? (Y/n)"
+echo -e "\nPush these changes to \`release/v${VERSION}\`? (Y/n)"
 read -r answer
 if [[ "$answer" == "n" ]] || [[ "$answer" == "N" ]]; then
     echo "Aborting push. Changes are committed locally."
@@ -89,4 +88,4 @@ if [[ "$answer" == "n" ]] || [[ "$answer" == "N" ]]; then
 fi
 
 # Push changes
-git push --set-upstream origin release/v${VERSION} && git push origin "v${VERSION}"
+git push --set-upstream origin release/v${VERSION}


### PR DESCRIPTION
This PR makes some adjustments to the release script:

- The script now updates and commits `crates/load-test/Cargo.lock` as well.
- The script does not create and push the version tag. We usually release from `main`, so the workflow is the following: 
    - We create a release branch, do the version bump and push it to GitHub.
    - We open a PR with the change which will be merged to `main`.
    - We tag the merge commit on `main` and push the tag to GitHub.
    - Pushing the tag triggers the release workflow, which creates draft release notes and binary builds.