### PR TITLE
fix: optional token addresses in feeder gateway's get_contract_addresses

### DIFF
--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -16,8 +16,7 @@ use pathfinder_common::{
     StateDiffCommitment,
     TransactionCommitment,
 };
-use pathfinder_serde::{EthereumAddressAsHexStr, GasPriceAsHexStr, H256AsNoLeadingZerosHexStr};
-use primitive_types::H256;
+use pathfinder_serde::{EthereumAddressAsHexStr, GasPriceAsHexStr};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 pub use transaction::DataAvailabilityMode;
@@ -2185,11 +2184,9 @@ pub struct EthContractAddresses {
     #[serde_as(as = "EthereumAddressAsHexStr")]
     pub starknet: EthereumAddress,
 
-    #[serde_as(as = "Option<H256AsNoLeadingZerosHexStr>")]
-    pub strk_l2_token_address: Option<H256>,
+    pub strk_l2_token_address: Option<ContractAddress>,
 
-    #[serde_as(as = "Option<H256AsNoLeadingZerosHexStr>")]
-    pub eth_l2_token_address: Option<H256>,
+    pub eth_l2_token_address: Option<ContractAddress>,
 }
 
 pub mod add_transaction {

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -2185,11 +2185,11 @@ pub struct EthContractAddresses {
     #[serde_as(as = "EthereumAddressAsHexStr")]
     pub starknet: EthereumAddress,
 
-    #[serde_as(as = "H256AsNoLeadingZerosHexStr")]
-    pub strk_l2_token_address: H256,
+    #[serde_as(as = "Option<H256AsNoLeadingZerosHexStr>")]
+    pub strk_l2_token_address: Option<H256>,
 
-    #[serde_as(as = "H256AsNoLeadingZerosHexStr")]
-    pub eth_l2_token_address: H256,
+    #[serde_as(as = "Option<H256AsNoLeadingZerosHexStr>")]
+    pub eth_l2_token_address: Option<H256>,
 }
 
 pub mod add_transaction {

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -886,7 +886,7 @@ mod pathfinder_context {
                 l1_core_address,
                 reply_contract_addresses.eth_l2_token_address,
                 reply_contract_addresses.strk_l2_token_address,
-            )?;
+            );
 
             // Check for proxies by comparing the core address against those of the known
             // networks.


### PR DESCRIPTION
Make token addresses in get_contract_addresses optional, when they aren't returned use defaults.

Fixes #2621.