### PR TITLE
fix(rpc): fix response for `starknet_getBlockWithTxns`

### DIFF
--- a/crates/rpc/src/method/get_block_with_txs.rs
+++ b/crates/rpc/src/method/get_block_with_txs.rs
@@ -105,7 +105,7 @@ impl crate::dto::SerializeForVersion for Output {
                 serializer.serialize_iter(
                     "transactions",
                     transactions.len(),
-                    &mut transactions.iter(),
+                    &mut transactions.iter().map(crate::dto::TransactionWithHash),
                 )?;
                 serializer.end()
             }
@@ -119,7 +119,7 @@ impl crate::dto::SerializeForVersion for Output {
                 serializer.serialize_iter(
                     "transactions",
                     transactions.len(),
-                    &mut transactions.iter(),
+                    &mut transactions.iter().map(crate::dto::TransactionWithHash),
                 )?;
                 serializer.serialize_field(
                     "status",


### PR DESCRIPTION
Transactions in the response were serialized without the transaction hash, which is required by the specification for all RPC versions.

Closes #2623
