### PR TITLE
fix(rpc/get_compiled_casm): don't wrap CASM class in a `casm` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `starknet_estimateFee` returns an internal error for v3 transactions with L2 gas `max_price_per_unit` set to zero.
+- `starknet_getCompiledCasm` returns CASM wrapped in a `casm` property.
 
 ## [0.16.1] - 2025-02-24
 


### PR DESCRIPTION
According to the JSON-RPC 0.8.0-rc3 specs the output CASM class should not be wrapped inside a `casm` property.

This PR removes that additional wrapping.

Closes #2635