### PR TITLE
fix(rpc/subscription): send notifications for `latest` block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- supporting custom versioned constants for multiple Starknet versions.
+- Support for custom versioned constants for multiple Starknet versions.
 
 ### Fixed
 
 - `starknet_estimateFee` returns an internal error for v3 transactions with L2 gas `max_price_per_unit` set to zero.
 - `starknet_getCompiledCasm` returns CASM wrapped in a `casm` property.
 - `starknet_traceBlockTransactions` fails on Starknet 0.13.4 when a fallback to fetching from the feeder gateway is required.
+- Websocket subscriptions to the `latest` block do not send notifications for the current latest block.
 
 ## [0.16.1] - 2025-02-24
 

--- a/crates/rpc/src/method/subscribe_new_heads.rs
+++ b/crates/rpc/src/method/subscribe_new_heads.rs
@@ -191,13 +191,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn happy_path_with_no_historic_blocks() {
-        happy_path_test(0).await;
-    }
-
-    #[tokio::test]
     async fn reorg() {
-        let (_, mut rx, subscription_id, router) = happy_path_test(0).await;
+        let (_, mut rx, subscription_id, router) = happy_path_test(1).await;
         router
             .context
             .notifications
@@ -327,7 +322,7 @@ mod tests {
 
     #[tokio::test]
     async fn subscribe_no_params() {
-        let router = setup(0).await;
+        let router = setup(1).await;
         let (sender_tx, mut sender_rx) = mpsc::channel(1024);
         let (receiver_tx, receiver_rx) = mpsc::channel(1024);
         handle_json_rpc_socket(router.clone(), sender_tx, receiver_rx);
@@ -352,6 +347,16 @@ mod tests {
             }
             _ => panic!("Expected text message"),
         };
+
+        // receive latest header
+        let header = sender_rx.recv().await.unwrap().unwrap();
+        let json: serde_json::Value = match header {
+            Message::Text(json) => serde_json::from_str(&json).unwrap(),
+            _ => panic!("Expected text message"),
+        };
+        let expected = sample_new_heads_message(0, subscription_id);
+        assert_eq!(json, expected);
+
         for i in 0..10 {
             retry(|| {
                 router
@@ -375,7 +380,7 @@ mod tests {
 
     #[tokio::test]
     async fn subscribe_empty_params() {
-        let router = setup(0).await;
+        let router = setup(1).await;
         let (sender_tx, mut sender_rx) = mpsc::channel(1024);
         let (receiver_tx, receiver_rx) = mpsc::channel(1024);
         handle_json_rpc_socket(router.clone(), sender_tx, receiver_rx);
@@ -401,6 +406,16 @@ mod tests {
             }
             _ => panic!("Expected text message"),
         };
+
+        // receive latest header
+        let header = sender_rx.recv().await.unwrap().unwrap();
+        let json: serde_json::Value = match header {
+            Message::Text(json) => serde_json::from_str(&json).unwrap(),
+            _ => panic!("Expected text message"),
+        };
+        let expected = sample_new_heads_message(0, subscription_id);
+        assert_eq!(json, expected);
+
         for i in 0..10 {
             retry(|| {
                 router
@@ -424,7 +439,7 @@ mod tests {
 
     #[tokio::test]
     async fn unsubscribe() {
-        let (tx, mut rx, subscription_id, router) = happy_path_test(0).await;
+        let (tx, mut rx, subscription_id, router) = happy_path_test(1).await;
         tx.send(Ok(Message::Text(
             serde_json::json!({
                 "jsonrpc": "2.0",
@@ -462,7 +477,7 @@ mod tests {
 
     #[tokio::test]
     async fn subscribe_with_pending_block() {
-        let router = setup(0).await;
+        let router = setup(1).await;
         let (sender_tx, mut sender_rx) = mpsc::channel(1024);
         let (receiver_tx, receiver_rx) = mpsc::channel(1024);
         handle_json_rpc_socket(router.clone(), sender_tx, receiver_rx);
@@ -505,6 +520,7 @@ mod tests {
     }
 
     async fn setup(num_blocks: u64) -> RpcRouter {
+        assert!(num_blocks > 0);
         let storage = StorageBuilder::in_memory().unwrap();
         tokio::task::spawn_blocking({
             let storage = storage.clone();

--- a/crates/rpc/src/method/subscribe_pending_transactions.rs
+++ b/crates/rpc/src/method/subscribe_pending_transactions.rs
@@ -143,11 +143,14 @@ mod tests {
     use pathfinder_common::{
         contract_address,
         transaction_hash,
+        BlockHash,
+        BlockHeader,
         BlockNumber,
         ChainId,
         ContractAddress,
         TransactionHash,
     };
+    use pathfinder_crypto::Felt;
     use pathfinder_ethereum::EthereumClient;
     use pathfinder_storage::StorageBuilder;
     use starknet_gateway_client::Client;
@@ -468,8 +471,23 @@ mod tests {
         })
     }
 
+    fn sample_header(block_number: u64) -> BlockHeader {
+        BlockHeader {
+            hash: BlockHash(Felt::from_u64(block_number)),
+            number: BlockNumber::new_or_panic(block_number),
+            parent_hash: BlockHash::ZERO,
+            ..Default::default()
+        }
+    }
+
     fn setup() -> Setup {
         let storage = StorageBuilder::in_memory().unwrap();
+        {
+            let mut conn = storage.connection().unwrap();
+            let db = conn.transaction().unwrap();
+            db.insert_block_header(&sample_header(0)).unwrap();
+            db.commit().unwrap();
+        }
         let (pending_data_tx, pending_data) = tokio::sync::watch::channel(Default::default());
         let notifications = Notifications::default();
         let ctx = RpcContext {


### PR DESCRIPTION
When subscribing with the `latest` block, we still have to do catch-up. The JSON-RPC specification says that the starting point for the subscription should be the block specified by `block_id` in the subscription request. This means that we have to send a notification for the `latest` block, irrespective if it was requested explicitly or implicitly and if we used the `latest` label or its specific block number or hash.

Closes #2642
