### PR TITLE
fix(p2p_stream): fix propagation of read response timeout

### DIFF
--- a/crates/p2p_stream/src/handler.rs
+++ b/crates/p2p_stream/src/handler.rs
@@ -249,6 +249,12 @@ where
                             )))
                             .await
                             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                        return Err(io::Error::new(
+                            io::ErrorKind::TimedOut,
+                            format!(
+                                "Timeout reading response from stream for request id {request_id}"
+                            ),
+                        ));
                     }
                     Ok(Ok(response)) => {
                         rs_send

--- a/crates/p2p_stream/tests/error_reporting.rs
+++ b/crates/p2p_stream/tests/error_reporting.rs
@@ -195,7 +195,7 @@ async fn report_outbound_timeout_on_read_response_timeout() {
         let (peer, req_id_done, error) = wait_inbound_failure(&mut swarm1).await.unwrap();
         assert_eq!(peer, peer2_id);
         assert_eq!(req_id_done, req_id);
-        assert!(matches!(error, InboundFailure::Timeout));
+        assert!(matches!(error, InboundFailure::ConnectionClosed));
     };
 
     let client_task = async move {


### PR DESCRIPTION
Codec read response timeout was not properly propagated to the connection handler, causing the swarm not being notified about the timeout.

This has also caused test flakyness in the respective  test (`report_outbound_timeout_on_read_response_timeout`) which wasn't really testing read response timeout, but was timing out because of the stream timeout.
