### PR TITLE
feat(rpc/subscribe_events): send matching events from the pending block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `starknet_getCompiledCasm` returns CASM wrapped in a `casm` property.
 - `starknet_traceBlockTransactions` fails on Starknet 0.13.4 when a fallback to fetching from the feeder gateway is required.
 - Websocket subscriptions to the `latest` block do not send notifications for the current latest block.
+- `starknet_subscribeEvents` subscriptions send matching events only from the `latest` block, not as soon as those show up in `pending`.
 
 ## [0.16.1] - 2025-02-24
 

--- a/crates/rpc/src/method/subscribe_events.rs
+++ b/crates/rpc/src/method/subscribe_events.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use axum::async_trait;
@@ -20,6 +21,31 @@ pub struct Params {
     from_address: Option<ContractAddress>,
     keys: Option<Vec<Vec<EventKey>>>,
     block_id: Option<SubscriptionBlockId>,
+}
+
+impl Params {
+    fn matches(&self, event: &pathfinder_common::event::Event) -> bool {
+        if let Some(from_address) = self.from_address {
+            if event.from_address != from_address {
+                return false;
+            }
+        }
+        if let Some(keys) = &self.keys {
+            if keys.is_empty() {
+                return true;
+            }
+            if event.keys.len() < keys.len() {
+                return false;
+            }
+            event
+                .keys
+                .iter()
+                .zip(keys.iter())
+                .all(|(key, filter)| filter.is_empty() || filter.contains(key))
+        } else {
+            true
+        }
+    }
 }
 
 impl crate::dto::DeserializeForVersion for Option<Params> {
@@ -139,9 +165,11 @@ impl RpcSubscriptionFlow for SubscribeEvents {
     ) -> Result<(), RpcError> {
         let mut blocks = state.notifications.l2_blocks.subscribe();
         let mut reorgs = state.notifications.reorgs.subscribe();
+        let mut pending_data = state.pending_data.0.clone();
         let params = params.unwrap_or_default();
-        let keys = params.keys.unwrap_or_default();
-        let key_filter_is_empty = keys.iter().flatten().count() == 0;
+
+        let mut sent_txs = HashSet::new();
+        let mut current_block = BlockNumber::GENESIS;
         loop {
             tokio::select! {
                 reorg = reorgs.recv() => {
@@ -171,28 +199,21 @@ impl RpcSubscriptionFlow for SubscribeEvents {
                         Ok(block) => {
                             let block_number = block.block_number;
                             let block_hash = block.block_hash;
+
+                            if block_number != current_block {
+                                sent_txs.clear();
+                                current_block = block_number;
+                            }
                             for (receipt, events) in block.transaction_receipts.iter() {
+                                if sent_txs.contains(&receipt.transaction_hash) {
+                                    continue;
+                                }
                                 for event in events {
                                     // Check if the event matches the filter.
-                                    if let Some(from_address) = params.from_address {
-                                        if event.from_address != from_address {
-                                            continue;
-                                        }
-                                    }
-                                    let matches_keys = if key_filter_is_empty {
-                                        true
-                                    } else if event.keys.len() < keys.len() {
-                                        false
-                                    } else {
-                                        event
-                                            .keys
-                                            .iter()
-                                            .zip(keys.iter())
-                                            .all(|(key, filter)| filter.is_empty() || filter.contains(key))
-                                    };
-                                    if !matches_keys {
+                                    if !params.matches(event) {
                                         continue;
                                     }
+                                    sent_txs.insert(receipt.transaction_hash);
                                     if tx.send(SubscriptionMessage {
                                         notification: Notification::EmittedEvent(EmittedEvent {
                                             data: event.data.clone(),
@@ -220,6 +241,44 @@ impl RpcSubscriptionFlow for SubscribeEvents {
                         }
                     }
                 }
+                pending_changed = pending_data.changed() => {
+                    if let Err(e) = pending_changed {
+                        tracing::debug!(error=%e, "Pending data channel closed, stopping subscription");
+                        break;
+                    }
+                    let pending = pending_data.borrow_and_update().clone();
+                    let block_number = pending.number;
+                    if block_number != current_block {
+                        sent_txs.clear();
+                        current_block = block_number;
+                    }
+                    for (receipt, events) in pending.block.transaction_receipts.iter() {
+                        if sent_txs.contains(&receipt.transaction_hash) {
+                            continue;
+                        }
+                        for event in events {
+                            // Check if the event matches the filter.
+                            if !params.matches(event) {
+                                continue;
+                            }
+                            sent_txs.insert(receipt.transaction_hash);
+                            if tx.send(SubscriptionMessage {
+                                notification: Notification::EmittedEvent(EmittedEvent {
+                                    data: event.data.clone(),
+                                    keys: event.keys.clone(),
+                                    from_address: event.from_address,
+                                    block_hash: None,
+                                    block_number: Some(block_number),
+                                    transaction_hash: receipt.transaction_hash,
+                                }),
+                                block_number,
+                                subscription_name: SUBSCRIPTION_NAME,
+                            }).await.is_err() {
+                                break;
+                            }
+                        }
+                    }
+                }
             }
         }
         Ok(())
@@ -228,6 +287,7 @@ impl RpcSubscriptionFlow for SubscribeEvents {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
     use std::time::Duration;
 
     use axum::extract::ws::Message;
@@ -250,7 +310,7 @@ mod tests {
     use pathfinder_ethereum::EthereumClient;
     use pathfinder_storage::StorageBuilder;
     use starknet_gateway_client::Client;
-    use starknet_gateway_types::reply::Block;
+    use starknet_gateway_types::reply::{Block, PendingBlock};
     use tokio::sync::mpsc;
 
     use crate::context::{EthContractAddresses, RpcConfig, RpcContext};
@@ -263,7 +323,7 @@ mod tests {
     #[tokio::test]
     async fn no_filtering() {
         let num_blocks = SubscribeEvents::CATCH_UP_BATCH_SIZE + 10;
-        let router = setup(num_blocks).await;
+        let (router, _pending_data_tx) = setup(num_blocks).await;
         let (sender_tx, mut sender_rx) = mpsc::channel(1024);
         let (receiver_tx, receiver_rx) = mpsc::channel(1024);
         handle_json_rpc_socket(router.clone(), sender_tx, receiver_rx);
@@ -324,7 +384,7 @@ mod tests {
 
     #[tokio::test]
     async fn filter_from_address() {
-        let router = setup(SubscribeEvents::CATCH_UP_BATCH_SIZE + 10).await;
+        let (router, _pending_data_tx) = setup(SubscribeEvents::CATCH_UP_BATCH_SIZE + 10).await;
         let (sender_tx, mut sender_rx) = mpsc::channel(1024);
         let (receiver_tx, receiver_rx) = mpsc::channel(1024);
         handle_json_rpc_socket(router.clone(), sender_tx, receiver_rx);
@@ -390,7 +450,7 @@ mod tests {
 
     #[tokio::test]
     async fn filter_keys() {
-        let router = setup(SubscribeEvents::CATCH_UP_BATCH_SIZE + 10).await;
+        let (router, _pending_data_tx) = setup(SubscribeEvents::CATCH_UP_BATCH_SIZE + 10).await;
         let (sender_tx, mut sender_rx) = mpsc::channel(1024);
         let (receiver_tx, receiver_rx) = mpsc::channel(1024);
         handle_json_rpc_socket(router.clone(), sender_tx, receiver_rx);
@@ -456,7 +516,7 @@ mod tests {
 
     #[tokio::test]
     async fn filter_from_address_and_keys() {
-        let router = setup(SubscribeEvents::CATCH_UP_BATCH_SIZE + 10).await;
+        let (router, _pending_data_tx) = setup(SubscribeEvents::CATCH_UP_BATCH_SIZE + 10).await;
         let (sender_tx, mut sender_rx) = mpsc::channel(1024);
         let (receiver_tx, receiver_rx) = mpsc::channel(1024);
         handle_json_rpc_socket(router.clone(), sender_tx, receiver_rx);
@@ -521,9 +581,97 @@ mod tests {
         assert!(sender_rx.is_empty());
     }
 
+    #[test_log::test(tokio::test)]
+    async fn filter_keys_pending() {
+        let num_blocks = SubscribeEvents::CATCH_UP_BATCH_SIZE + 10;
+        let (router, pending_data_tx) = setup(num_blocks).await;
+        let (sender_tx, mut sender_rx) = mpsc::channel(1024);
+        let (receiver_tx, receiver_rx) = mpsc::channel(1024);
+        handle_json_rpc_socket(router.clone(), sender_tx, receiver_rx);
+        let params = serde_json::json!(
+            {
+                "block_id": {"block_number": 0},
+                "keys": [["0x46", format!("{:x}", num_blocks), format!("{:x}", num_blocks + 1)]],
+            }
+        );
+        receiver_tx
+            .send(Ok(Message::Text(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "starknet_subscribeEvents",
+                    "params": params
+                })
+                .to_string(),
+            )))
+            .await
+            .unwrap();
+        let res = sender_rx.recv().await.unwrap().unwrap();
+        let subscription_id = match res {
+            Message::Text(json) => {
+                let json: serde_json::Value = serde_json::from_str(&json).unwrap();
+                assert_eq!(json["jsonrpc"], "2.0");
+                assert_eq!(json["id"], 1);
+                json["result"].as_u64().unwrap()
+            }
+            _ => panic!("Expected text message"),
+        };
+
+        let expected = sample_event_message(0x46, subscription_id);
+        let event = sender_rx.recv().await.unwrap().unwrap();
+        let json: serde_json::Value = match event {
+            Message::Text(json) => serde_json::from_str(&json).unwrap(),
+            _ => panic!("Expected text message"),
+        };
+        assert_eq!(json, expected);
+
+        let next_block_number = SubscribeEvents::CATCH_UP_BATCH_SIZE + 10;
+        pending_data_tx
+            .send(crate::PendingData {
+                block: Arc::new(sample_pending_block(next_block_number)),
+                state_update: Arc::new(Default::default()),
+                number: BlockNumber::new_or_panic(next_block_number),
+            })
+            .unwrap();
+        let expected = sample_event_message_without_block_hash(next_block_number, subscription_id);
+        let event = sender_rx.recv().await.unwrap().unwrap();
+        let json: serde_json::Value = match event {
+            Message::Text(json) => serde_json::from_str(&json).unwrap(),
+            _ => panic!("Expected text message"),
+        };
+        assert_eq!(json, expected);
+
+        router
+            .context
+            .notifications
+            .l2_blocks
+            .send(sample_block(next_block_number).into())
+            .unwrap();
+
+        let next_block_number = next_block_number + 1;
+        assert_eq!(
+            router
+                .context
+                .notifications
+                .l2_blocks
+                .send(sample_block(next_block_number).into())
+                .unwrap(),
+            1
+        );
+
+        let expected = sample_event_message(next_block_number, subscription_id);
+        let event = sender_rx.recv().await.unwrap().unwrap();
+        let json: serde_json::Value = match event {
+            Message::Text(json) => serde_json::from_str(&json).unwrap(),
+            _ => panic!("Expected text message"),
+        };
+        assert_eq!(json, expected);
+        assert!(sender_rx.is_empty());
+    }
+
     #[tokio::test]
     async fn too_many_keys_filter() {
-        let router = setup(SubscribeEvents::CATCH_UP_BATCH_SIZE + 10).await;
+        let (router, _pending_data_tx) = setup(SubscribeEvents::CATCH_UP_BATCH_SIZE + 10).await;
         let (sender_tx, mut sender_rx) = mpsc::channel(1024);
         let (receiver_tx, receiver_rx) = mpsc::channel(1024);
         handle_json_rpc_socket(router.clone(), sender_tx, receiver_rx);
@@ -585,9 +733,9 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn reorg() {
-        let router = setup(1).await;
+        let (router, _pending_data_tx) = setup(1).await;
         let (sender_tx, mut sender_rx) = mpsc::channel(1024);
         let (receiver_tx, receiver_rx) = mpsc::channel(1024);
         handle_json_rpc_socket(router.clone(), sender_tx, receiver_rx);
@@ -677,7 +825,7 @@ mod tests {
 
     #[tokio::test]
     async fn subscribe_with_pending_block() {
-        let router = setup(1).await;
+        let (router, _pending_data_tx) = setup(1).await;
         let (sender_tx, mut sender_rx) = mpsc::channel(1024);
         let (receiver_tx, receiver_rx) = mpsc::channel(1024);
         handle_json_rpc_socket(router.clone(), sender_tx, receiver_rx);
@@ -719,7 +867,7 @@ mod tests {
         );
     }
 
-    async fn setup(num_blocks: u64) -> RpcRouter {
+    async fn setup(num_blocks: u64) -> (RpcRouter, tokio::sync::watch::Sender<crate::PendingData>) {
         assert!(num_blocks > 0);
 
         let storage = StorageBuilder::in_memory().unwrap();
@@ -742,16 +890,17 @@ mod tests {
                     .unwrap();
                 }
                 db.commit().unwrap();
+                tracing::debug!("Inserted {} blocks", num_blocks);
             }
         })
         .await
         .unwrap();
-        let (_, pending_data) = tokio::sync::watch::channel(Default::default());
+        let (pending_data_tx, pending_data) = tokio::sync::watch::channel(Default::default());
         let notifications = Notifications::default();
         let ctx = RpcContext {
             cache: Default::default(),
-            storage,
-            execution_storage: StorageBuilder::in_memory().unwrap(),
+            storage: storage.clone(),
+            execution_storage: storage,
             pending_data: PendingWatcher::new(pending_data),
             sync_status: SyncState {
                 status: Syncing::False.into(),
@@ -774,7 +923,7 @@ mod tests {
                 versioned_constants_map: Default::default(),
             },
         };
-        v08::register_routes().build(ctx)
+        (v08::register_routes().build(ctx), pending_data_tx)
     }
 
     fn sample_header(block_number: u64) -> BlockHeader {
@@ -829,6 +978,17 @@ mod tests {
         }
     }
 
+    fn sample_pending_block(block_number: u64) -> PendingBlock {
+        PendingBlock {
+            transaction_receipts: vec![(
+                sample_receipt(block_number),
+                vec![sample_event(block_number)],
+            )],
+            transactions: vec![sample_transaction(block_number)],
+            ..Default::default()
+        }
+    }
+
     fn sample_event_message(block_number: u64, subscription_id: u64) -> serde_json::Value {
         serde_json::json!({
             "jsonrpc":"2.0",
@@ -853,6 +1013,18 @@ mod tests {
                 "subscription_id": subscription_id
             }
         })
+    }
+
+    fn sample_event_message_without_block_hash(
+        block_number: u64,
+        subscription_id: u64,
+    ) -> serde_json::Value {
+        let mut message = sample_event_message(block_number, subscription_id);
+        message["params"]["result"]
+            .as_object_mut()
+            .unwrap()
+            .remove("block_hash");
+        message
     }
 
     // Retry to let other tasks make progress.


### PR DESCRIPTION
This PR adds the ability to send events matching the filter from the pending block to the client right as they are included in the pending block. This minimizes the latency it takes for users to receive relevant updates.

One side effect is that since the pending block has no block hash, we send out emitted events without the block hash as a context. Since almost all events show up first in the pending block, in practice this means that we are no longer sending block hashes for the emitted events...

Closes #2640