### PR TITLE
feat/p2p: remove consensus-related functionality ahead of network split

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6366,7 +6366,6 @@ dependencies = [
  "futures",
  "libp2p-core",
  "libp2p-dcutr",
- "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-kad",

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -20,7 +20,6 @@ libp2p = { workspace = true, features = [
     "autonat",
     "dcutr",
     "dns",
-    "gossipsub",
     "identify",
     "kad",
     "macros",

--- a/crates/p2p/src/client/peer_agnostic.rs
+++ b/crates/p2p/src/client/peer_agnostic.rs
@@ -70,34 +70,15 @@ use crate::peer_data::PeerData;
 #[derive(Clone, Debug)]
 pub struct Client {
     inner: peer_aware::Client,
-    block_propagation_topic: Arc<String>,
     peers: Arc<RwLock<Decaying<HashSet<PeerId>>>>,
 }
 
 impl Client {
-    pub fn new(inner: peer_aware::Client, block_propagation_topic: String) -> Self {
+    pub fn new(inner: peer_aware::Client) -> Self {
         Self {
             inner,
-            block_propagation_topic: Arc::new(block_propagation_topic),
             peers: Default::default(),
         }
-    }
-
-    // Propagate new L2 head head
-    pub async fn propagate_new_head(
-        &self,
-        block_id: p2p_proto::common::BlockId,
-    ) -> anyhow::Result<()> {
-        tracing::debug!(number=%block_id.number, hash=%block_id.hash.0, topic=%self.block_propagation_topic,
-            "Propagating head"
-        );
-
-        self.inner
-            .publish(
-                &self.block_propagation_topic,
-                p2p_proto::header::NewBlock::Id(block_id),
-            )
-            .await
     }
 
     async fn get_random_peers(&self) -> Vec<PeerId> {

--- a/crates/p2p/src/test_utils/main_loop.rs
+++ b/crates/p2p/src/test_utils/main_loop.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 
-use libp2p::gossipsub;
 use libp2p::kad::{QueryId, QueryResult};
 use libp2p::swarm::SwarmEvent;
 use tokio::sync::mpsc;
@@ -8,24 +7,8 @@ use tokio::sync::mpsc;
 use crate::{behaviour, Event, TestCommand, TestEvent};
 
 pub async fn handle_event(event_sender: &mpsc::Sender<Event>, event: SwarmEvent<behaviour::Event>) {
-    match event {
-        SwarmEvent::NewListenAddr { address, .. } => {
-            send_event(event_sender, TestEvent::NewListenAddress(address)).await;
-        }
-        SwarmEvent::Behaviour(behaviour::Event::Gossipsub(gossipsub::Event::Subscribed {
-            peer_id,
-            topic,
-        })) => {
-            send_event(
-                event_sender,
-                TestEvent::Subscribed {
-                    remote: peer_id,
-                    topic: topic.into_string(),
-                },
-            )
-            .await;
-        }
-        _ => {}
+    if let SwarmEvent::NewListenAddr { address, .. } = event {
+        send_event(event_sender, TestEvent::NewListenAddress(address)).await;
     }
 }
 

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -1,4 +1,4 @@
 pub mod block_hash;
 mod sync;
 
-pub use sync::{l1, l2, revert, sync, Gossiper, SyncContext, RESET_DELAY_ON_FAILURE};
+pub use sync::{l1, l2, revert, sync, SyncContext, RESET_DELAY_ON_FAILURE};


### PR DESCRIPTION
We're moving towards a two-network approach:
1. **Sync:** How nodes sync with each other.
2. **Consensus:** Handling real-time chain updates (etc.)

This PR trims out all code that was related to `2` from our current P2P implementation, leaving just everything related to `1`. as we start moving towards this new two-network approach.