### PR TITLE
fix(pathfinder/config): increase default request timeout to 10 seconds

### DIFF
--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -251,7 +251,7 @@ This should only be enabled for debugging purposes as it adds substantial proces
         value_name = "Seconds",
         long_help = "Timeout duration for all gateway and feeder-gateway requests",
         env = "PATHFINDER_GATEWAY_REQUEST_TIMEOUT",
-        default_value = "5"
+        default_value = "10"
     )]
     gateway_timeout: std::num::NonZeroU64,
 


### PR DESCRIPTION
After the Starknet mainnet upgrade to 0.13.5 there were a few blocks (like 1256131) for which state updates cannot be reliably fetched within five seconds.

This change increases the default request timeout to 10 seconds.

Closes #2673
