### PR TITLE
chore: improve platform detection for macOS

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -28,7 +28,7 @@ fi
 do_sed() {
     local file=$1
     local pattern=$2
-    if [[ "$(uname)" == "Darwin" ]]; then
+    if [[ "$(uname -s)" == "Darwin" ]]; then
         sed -i '.bak' "$pattern" "$file"
         rm "${file}.bak"
     else


### PR DESCRIPTION
I updated the platform detection logic in the `do_sed` function.
The original check used `$(uname)`, which works fine in most cases, but I replaced it with `$(uname -s)` to make sure we get a more precise result, especially in cases with unusual system configurations.