### PR TITLE
feat(pathfinder): duplicate p2p configs for sync and consensus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8039,6 +8039,7 @@ dependencies = [
  "mockall",
  "p2p",
  "p2p_proto",
+ "paste",
  "pathfinder-block-hashes",
  "pathfinder-class-hash",
  "pathfinder-common",

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -34,6 +34,7 @@ metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 p2p = { path = "../p2p" }
 p2p_proto = { path = "../p2p_proto" }
+paste = { workspace = true }
 pathfinder-block-hashes = { path = "../block-hashes" }
 pathfinder-class-hash = { path = "../class-hash" }
 pathfinder-common = { path = "../common" }

--- a/crates/pathfinder/src/bin/pathfinder/config/p2p.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config/p2p.rs
@@ -1,0 +1,29 @@
+#[cfg(feature = "p2p")]
+pub(super) mod cli;
+#[cfg(feature = "p2p")]
+mod config;
+
+#[cfg(feature = "p2p")]
+pub use config::{P2PConsensusConfig, P2PSyncConfig};
+
+#[cfg(not(feature = "p2p"))]
+#[derive(Clone)]
+pub struct P2PSyncConfig;
+
+#[cfg(not(feature = "p2p"))]
+#[derive(Clone)]
+pub struct P2PConsensusConfig;
+
+#[cfg(not(feature = "p2p"))]
+impl P2PSyncConfig {
+    pub(super) fn parse_or_exit(_: ()) -> Self {
+        Self
+    }
+}
+
+#[cfg(not(feature = "p2p"))]
+impl P2PConsensusConfig {
+    pub(super) fn parse_or_exit(_: ()) -> Self {
+        Self
+    }
+}

--- a/crates/pathfinder/src/bin/pathfinder/config/p2p/cli.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config/p2p/cli.rs
@@ -1,0 +1,190 @@
+use ipnet::IpNet;
+
+/// For a given `target`, this macro defines a `P2PTargetCoreCli` struct that
+/// contains all the core p2p CLI options, where each CLI option is prefixed
+/// with `p2p.target.` and each environment variable is prefixed with
+/// `PATHFINDER_P2P_TARGET_`. Moreover each struct member is also prefixed with
+/// `target_`, because this struct is ultimately flattened by clap, otherwise we
+/// would get "Command Pathfinder: Argument names must be unique, but
+/// 'field' is in use by more than one argument or group" error.
+macro_rules! define_p2p_core_cli {
+    ($target:literal) => {
+        paste::paste! {
+            #[derive(clap::Args)]
+            pub(super) struct [<P2P $target:camel CoreCli>] {
+                #[arg(
+                    long = "p2p." $target:lower ".identity-config-file",
+                    long_help = "Path to file containing the private key of the node. If not \
+                                provided, a new random key will be generated.",
+                    value_name = "PATH",
+                    env = "PATHFINDER_P2P_" $target:upper "_IDENTITY_CONFIG_FILE"
+                )]
+                pub [<$target:lower _identity_config_file>]: Option<std::path::PathBuf>,
+
+                #[arg(
+                    long = "p2p." $target:lower ".listen-on",
+                    long_help = "The list of multiaddresses on which to listen for incoming p2p connections. \
+                                If not provided, default route on randomly assigned port will be used.",
+                    value_name = "MULTIADDRESS_LIST",
+                    value_delimiter = ',',
+                    default_value = "/ip4/0.0.0.0/tcp/0",
+                    env = "PATHFINDER_P2P_" $target:upper "_LISTEN_ON"
+                )]
+                pub [<$target:lower _listen_on>]: Vec<String>,
+
+                #[arg(
+                    long = "p2p." $target:lower ".bootstrap-addresses",
+                    long_help = r#"Comma separated list of multiaddresses to use as bootstrap nodes. Each multiaddress must contain a peer ID.
+
+Example:
+    '/ip4/127.0.0.1/9001/p2p/12D3KooWBEkKyufuqCMoZLRhVzq4xdHxVWhhYeBpjw92GSyZ6xaN,/ip4/127.0.0.1/9002/p2p/12D3KooWBEkKyufuqCMoZLRhVzq4xdHxVWhhYeBpjw92GSyZ6xaN'"#,
+                    value_name = "MULTIADDRESS_LIST",
+                    value_delimiter = ',',
+                    env = "PATHFINDER_P2P_" $target:upper "_BOOTSTRAP_ADDRESSES"
+                )]
+                pub [<$target:lower _bootstrap_addresses>]: Vec<String>,
+
+                #[arg(
+                    long = "p2p." $target:lower ".predefined-peers",
+                    long_help = r#"Comma separated list of multiaddresses to use as peers apart from peers discovered via DHT discovery. Each multiaddress must contain a peer ID.
+
+Example:
+    '/ip4/127.0.0.1/9003/p2p/12D3KooWBEkKyufuqCMoZLRhVzq4xdHxVWhhYeBpjw92GSyZ6xaP,/ip4/127.0.0.1/9004/p2p/12D3KooWBEkKyufuqCMoZLRhVzq4xdHxVWhhYeBpjw92GSyZ6xaR'"#,
+                    value_name = "MULTIADDRESS_LIST",
+                    value_delimiter = ',',
+                    env = "PATHFINDER_P2P_" $target:upper "_PREDEFINED_PEERS"
+                )]
+                pub [<$target:lower _predefined_peers>]: Vec<String>,
+
+                #[arg(
+                    long = "p2p." $target:lower ".max-inbound-direct-connections",
+                    long_help = "The maximum number of inbound direct (non-relayed) connections.",
+                    value_name = "MAX_INBOUND_DIRECT_CONNECTIONS",
+                    env = "PATHFINDER_P2P_" $target:upper "_MAX_INBOUND_DIRECT_CONNECTIONS",
+                    default_value = "30"
+                )]
+                pub [<$target:lower _max_inbound_direct_connections>]: u32,
+
+                #[arg(
+                    long = "p2p." $target:lower ".max-inbound-relayed-connections",
+                    long_help = "The maximum number of inbound relayed connections.",
+                    value_name = "MAX_INBOUND_RELAYED_CONNECTIONS",
+                    env = "PATHFINDER_P2P_" $target:upper "_MAX_INBOUND_RELAYED_CONNECTIONS",
+                    default_value = "30"
+                )]
+                pub [<$target:lower _max_inbound_relayed_connections>]: u32,
+
+                #[arg(
+                    long = "p2p." $target:lower ".max-outbound-connections",
+                    long_help = "The maximum number of outbound connections.",
+                    value_name = "MAX_OUTBOUND_CONNECTIONS",
+                    env = "PATHFINDER_P2P_" $target:upper "_MAX_OUTBOUND_CONNECTIONS",
+                    default_value = "50"
+                )]
+                pub [<$target:lower _max_outbound_connections>]: u32,
+
+                #[arg(
+                    long = "p2p." $target:lower ".ip-whitelist",
+                    long_help = "Comma separated list of IP addresses or IP address ranges (in CIDR) to \
+                                whitelist for incoming connections. If not provided, all incoming \
+                                connections are allowed.",
+                    value_name = "LIST",
+                    default_value = "0.0.0.0/0,::/0",
+                    value_delimiter = ',',
+                    env = "PATHFINDER_P2P_" $target:upper "_IP_WHITELIST"
+                )]
+                pub [<$target:lower _ip_whitelist>]: Vec<IpNet>,
+
+                #[arg(
+                    long = "p2p." $target:lower ".experimental.kad-name",
+                    long_help = "Custom Kademlia protocol name.",
+                    value_name = "PROTOCOL_NAME",
+                    env = "PATHFINDER_P2P_" $target:upper "_EXPERIMENTAL_KAD_NAME"
+                )]
+                pub [<$target:lower _kad_name>]: Option<String>,
+
+                #[arg(
+                    long = "p2p." $target:lower ".experimental.direct-connection-timeout",
+                    long_help = "A direct (not relayed) peer can only connect once in this period.",
+                    value_name = "SECONDS",
+                    default_value = "30",
+                    env = "PATHFINDER_P2P_" $target:upper "_EXPERIMENTAL_DIRECT_CONNECTION_TIMEOUT"
+                )]
+                pub [<$target:lower _direct_connection_timeout>]: u32,
+
+                #[arg(
+                    long = "p2p." $target:lower ".experimental.eviction-timeout",
+                    long_help = "How long to prevent evicted peers from reconnecting.",
+                    value_name = "SECONDS",
+                    default_value = "900",
+                    env = "PATHFINDER_P2P_" $target:upper "_EXPERIMENTAL_EVICTION_TIMEOUT"
+                )]
+                pub [<$target:lower _eviction_timeout>]: u32,
+            }
+        }
+    };
+}
+
+define_p2p_core_cli! {"sync"}
+define_p2p_core_cli! {"consensus"}
+
+#[derive(clap::Args)]
+pub(crate) struct P2PSyncCli {
+    #[clap(flatten)]
+    pub(super) core: P2PSyncCoreCli,
+
+    #[arg(
+        long = "p2p.sync.proxy",
+        long_help = "Enable syncing from feeder gateway and proxy to p2p network. Otherwise sync from p2p network, which is the default.",
+        default_value = "false",
+        action = clap::ArgAction::Set,
+        env = "PATHFINDER_P2P_SYNC_PROXY"
+    )]
+    pub proxy: bool,
+
+    #[arg(
+        long = "p2p.sync.experimental.l1-checkpoint-override-json-path",
+        long_help = "Override L1 sync checkpoint retrieved from the Ethereum API. This option \
+                     points to a json encoded file containing an L1 checkpoint from which \
+                     pathfinder will sync backwards till genesis before switching to syncing \
+                     forward and following the head of the chain. Example contents: { \
+                     \"block_hash\": \"0x1\", \"block_number\": 2, \"state_root\": \"0x3\" }",
+        value_name = "JSON_FILE",
+        env = "PATHFINDER_P2P_EXPERIMENTAL_L1_CHECKPOINT_OVERRIDE"
+    )]
+    pub l1_checkpoint_override: Option<String>,
+
+    #[arg(
+        long = "p2p.sync.experimental.stream-timeout",
+        long_help = "Timeout of the entire stream in the request/response-stream protocol.",
+        value_name = "SECONDS",
+        default_value = "60",
+        env = "PATHFINDER_P2P_EXPERIMENTAL_STREAM_TIMEOUT"
+    )]
+    pub stream_timeout: u32,
+
+    #[arg(
+        long = "p2p.sync.experimental.response-timeout",
+        long_help = "Timeout of a single response in the request/response-stream protocol.",
+        value_name = "SECONDS",
+        default_value = "10",
+        env = "PATHFINDER_P2P_EXPERIMENTAL_RESPONSE_TIMEOUT"
+    )]
+    pub response_timeout: u32,
+
+    #[arg(
+        long = "p2p.sync.experimental.max-concurrent-streams",
+        long_help = "Maximum allowed number of concurrent streams per each \
+                     request/response-stream protocol per connection.",
+        value_name = "LIMIT",
+        default_value = "100",
+        env = "PATHFINDER_P2P_EXPERIMENTAL_MAX_CONCURRENT_STREAMS"
+    )]
+    pub max_concurrent_streams: usize,
+}
+
+#[derive(clap::Args)]
+pub(crate) struct P2PConsensusCli {
+    #[clap(flatten)]
+    pub(super) core: P2PConsensusCoreCli,
+}

--- a/crates/pathfinder/src/bin/pathfinder/config/p2p/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config/p2p/config.rs
@@ -1,0 +1,187 @@
+use std::time::Duration;
+
+use clap::CommandFactory;
+use ipnet::IpNet;
+use p2p::libp2p::Multiaddr;
+
+use super::cli::{P2PConsensusCli, P2PConsensusCoreCli, P2PSyncCli, P2PSyncCoreCli};
+use crate::config::Cli;
+
+#[derive(Clone)]
+pub struct P2PCoreConfig {
+    pub identity_config_file: Option<std::path::PathBuf>,
+    pub listen_on: Vec<Multiaddr>,
+    pub bootstrap_addresses: Vec<Multiaddr>,
+    pub predefined_peers: Vec<Multiaddr>,
+    pub max_inbound_direct_connections: usize,
+    pub max_inbound_relayed_connections: usize,
+    pub max_outbound_connections: usize,
+    pub ip_whitelist: Vec<IpNet>,
+    pub kad_name: Option<String>,
+    pub direct_connection_timeout: Duration,
+    pub eviction_timeout: Duration,
+}
+
+#[derive(Clone)]
+pub struct P2PSyncConfig {
+    pub core: P2PCoreConfig,
+    pub proxy: bool,
+    pub l1_checkpoint_override: Option<pathfinder_ethereum::EthereumStateUpdate>,
+    pub stream_timeout: Duration,
+    pub response_timeout: Duration,
+    pub max_concurrent_streams: usize,
+}
+
+#[derive(Clone)]
+pub struct P2PConsensusConfig {
+    pub _core: P2PCoreConfig,
+}
+
+/// Generates an `impl From` implementation for a given `target` that converts
+/// a `P2PTargetCoreCli` struct into a `P2PCoreConfig` struct.
+macro_rules! impl_from_p2p_cli {
+    ($target:literal) => {
+        paste::paste! {
+            impl From<[<P2P $target:camel CoreCli>]> for P2PCoreConfig {
+                fn from(cli: [<P2P $target:camel CoreCli>]) -> Self {
+                    use std::str::FromStr;
+
+                    use clap::error::ErrorKind;
+                    use p2p::libp2p::multiaddr::Result;
+
+                    let parse_multiaddr_vec = |field: &str, multiaddrs: Vec<String>| -> Vec<Multiaddr> {
+                        multiaddrs
+                            .into_iter()
+                            .map(|addr| Multiaddr::from_str(&addr))
+                            .collect::<Result<Vec<_>>>()
+                            .unwrap_or_else(|error| {
+                                Cli::command()
+                                    .error(ErrorKind::ValueValidation, format!("{field}: {error}"))
+                                    .exit()
+                            })
+                    };
+
+                    if (1..25).contains(&cli.[<$target:lower _max_inbound_direct_connections>]) {
+                        Cli::command()
+                            .error(
+                                ErrorKind::ValueValidation,
+                                concat!("p2p.", stringify!($target:lower), ".max-inbound-direct-connections must be zero or at least 25"),
+                            )
+                            .exit()
+                    }
+
+                    if (1..25).contains(&cli.[<$target:lower _max_inbound_relayed_connections>]) {
+                        Cli::command()
+                            .error(
+                                ErrorKind::ValueValidation,
+                                concat!("p2p.", stringify!($target:lower), ".max-inbound-relayed-connections must be zero or at least 25"),
+                            )
+                            .exit()
+                    }
+
+                    // The low watermark is defined in `bootstrap_on_low_peers`
+                    // https://github.com/libp2p/rust-libp2p/blob/d7beb55f672dce54017fa4b30f67ecb8d66b9810/protocols/kad/src/behaviour.rs#L1401).
+                    // as the K value of 20
+                    // https://github.com/libp2p/rust-libp2p/blob/d7beb55f672dce54017fa4b30f67ecb8d66b9810/protocols/kad/src/lib.rs#L93
+                    if cli.[<$target:lower _max_outbound_connections>] <= 20 {
+                        Cli::command()
+                            .error(
+                                ErrorKind::ValueValidation,
+                                concat!("p2p.", stringify!($target:lower), ".max-outbound-connections must be at least 21"),
+                            )
+                            .exit()
+                    }
+
+                    if cli.[<$target:lower _kad_name>].iter().any(|x| !x.starts_with('/')) {
+                        Cli::command()
+                            .error(
+                                ErrorKind::ValueValidation,
+                                concat!("each item in p2p.", stringify!($target:lower), ".experimental.kad-names must start with '/'"),
+                            )
+                            .exit()
+                    }
+
+                    Self {
+                        identity_config_file: cli.[< $target:lower _identity_config_file>],
+                        listen_on: parse_multiaddr_vec(concat!("p2p.", stringify!($target:lower), ".listen-on"), cli.[<$target:lower _listen_on>]),
+                        bootstrap_addresses: parse_multiaddr_vec(
+                            concat!("p2p.", stringify!($target:lower), ".bootstrap-addresses"),
+                            cli.[<$target:lower _bootstrap_addresses>],
+                        ),
+                        predefined_peers: parse_multiaddr_vec(
+                            concat!("p2p.", stringify!($target:lower), ".predefined-peers"),
+                            cli.[<$target:lower _predefined_peers>],
+                        ),
+                        max_inbound_direct_connections: cli.[<$target:lower _max_inbound_direct_connections>] as usize,
+                        max_inbound_relayed_connections: cli.[<$target:lower _max_inbound_relayed_connections>] as usize,
+                        max_outbound_connections: cli.[<$target:lower _max_outbound_connections>] as usize,
+                        ip_whitelist: cli.[<$target:lower _ip_whitelist>],
+                        kad_name: cli.[<$target:lower _kad_name>],
+                        direct_connection_timeout: Duration::from_secs(cli.[<$target:lower _direct_connection_timeout>].into()),
+                        eviction_timeout: Duration::from_secs(cli.[<$target:lower _eviction_timeout>].into()),
+                    }
+                }
+            }
+        }
+    };
+}
+
+impl_from_p2p_cli! {"sync"}
+impl_from_p2p_cli!("consensus");
+
+impl P2PSyncConfig {
+    pub(crate) fn parse_or_exit(args: P2PSyncCli) -> Self {
+        Self {
+            // SAFETY: core conversion is safe because we exit the process on error
+            core: args.core.into(),
+            proxy: args.proxy,
+            l1_checkpoint_override: parse_l1_checkpoint_or_exit(args.l1_checkpoint_override),
+            stream_timeout: Duration::from_secs(args.stream_timeout.into()),
+            response_timeout: Duration::from_secs(args.response_timeout.into()),
+            max_concurrent_streams: args.max_concurrent_streams,
+        }
+    }
+}
+
+fn parse_l1_checkpoint_or_exit(
+    l1_checkpoint_override: Option<String>,
+) -> Option<pathfinder_ethereum::EthereumStateUpdate> {
+    use clap::error::ErrorKind;
+    use pathfinder_common::{BlockHash, BlockNumber, StateCommitment};
+
+    #[derive(serde::Deserialize)]
+    struct Dto {
+        state_root: StateCommitment,
+        block_number: BlockNumber,
+        block_hash: BlockHash,
+    }
+
+    fn exit_now(e: impl std::fmt::Display) {
+        Cli::command()
+            .error(
+                ErrorKind::ValueValidation,
+                format!("p2p.experimental.l1-checkpoint-override: {e}"),
+            )
+            .exit()
+    }
+
+    l1_checkpoint_override.map(|f| {
+        // SAFETY: unwraps are safe because we exit the process on error
+        let f = std::fs::File::open(f).map_err(exit_now).unwrap();
+        let dto: Dto = serde_json::from_reader(f).map_err(exit_now).unwrap();
+        pathfinder_ethereum::EthereumStateUpdate {
+            state_root: dto.state_root,
+            block_number: dto.block_number,
+            block_hash: dto.block_hash,
+        }
+    })
+}
+
+impl P2PConsensusConfig {
+    pub(crate) fn parse_or_exit(args: P2PConsensusCli) -> Self {
+        Self {
+            // SAFETY: core conversion is safe because we exit the process on error
+            _core: args.core.into(),
+        }
+    }
+}

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -463,7 +463,7 @@ fn permission_check(base: &std::path::Path) -> Result<(), anyhow::Error> {
 async fn start_p2p(
     chain_id: ChainId,
     storage: Storage,
-    config: config::P2PConfig,
+    config: config::p2p::P2PSyncConfig,
 ) -> anyhow::Result<(
     tokio::task::JoinHandle<anyhow::Result<()>>,
     Option<p2p::client::peer_agnostic::Client>,
@@ -493,7 +493,7 @@ async fn start_p2p(
         }
     }
 
-    let keypair = match config.identity_config_file {
+    let keypair = match config.core.identity_config_file {
         Some(path) => {
             let config = Zeroizing::new(IdentityConfig::from_file(path.as_path())?);
             let private_key = Zeroizing::new(base64::decode(config.private_key.as_bytes())?);
@@ -507,19 +507,19 @@ async fn start_p2p(
 
     let context = P2PContext {
         cfg: p2p::Config {
-            direct_connection_timeout: config.direct_connection_timeout,
+            direct_connection_timeout: config.core.direct_connection_timeout,
             relay_connection_timeout: Duration::from_secs(10),
-            max_inbound_direct_peers: config.max_inbound_direct_connections,
-            max_inbound_relayed_peers: config.max_inbound_relayed_connections,
-            max_outbound_peers: config.max_outbound_connections,
-            ip_whitelist: config.ip_whitelist,
+            max_inbound_direct_peers: config.core.max_inbound_direct_connections,
+            max_inbound_relayed_peers: config.core.max_inbound_relayed_connections,
+            max_outbound_peers: config.core.max_outbound_connections,
+            ip_whitelist: config.core.ip_whitelist,
             bootstrap_period: Some(Duration::from_secs(2 * 60)),
-            eviction_timeout: config.eviction_timeout,
+            eviction_timeout: config.core.eviction_timeout,
             inbound_connections_rate_limit: p2p::RateLimit {
                 max: 10,
                 interval: Duration::from_secs(1),
             },
-            kad_name: config.kad_name,
+            kad_name: config.core.kad_name,
             stream_timeout: config.stream_timeout,
             response_timeout: config.response_timeout,
             max_concurrent_streams: config.max_concurrent_streams,
@@ -527,9 +527,9 @@ async fn start_p2p(
         chain_id,
         storage,
         keypair,
-        listen_on: config.listen_on,
-        bootstrap_addresses: config.bootstrap_addresses,
-        predefined_peers: config.predefined_peers,
+        listen_on: config.core.listen_on,
+        bootstrap_addresses: config.core.bootstrap_addresses,
+        predefined_peers: config.core.predefined_peers,
     };
 
     let (p2p_client, p2p_handle) = pathfinder_lib::p2p_network::start(context).await?;
@@ -541,7 +541,7 @@ async fn start_p2p(
 async fn start_p2p(
     _: ChainId,
     _: Storage,
-    _: config::P2PConfig,
+    _: config::p2p::P2PSyncConfig,
 ) -> anyhow::Result<(
     tokio::task::JoinHandle<anyhow::Result<()>>,
     Option<p2p::client::peer_agnostic::Client>,


### PR DESCRIPTION
Initially I thought that the top-down split into 2 p2p networks (config, p2p context, initialization, etc.) would be done in more or less a single PR but there's just too many changes.

This PR duplicates and splits p2p config into 2 realms: `p2p.sync.(...)` and `p2p.consensus.(...)`. The latter one is also integrated into `main` but left unused so far.

Running `--help` will yield the following p2p related options:
```
      --p2p.sync.identity-config-file <PATH>
      --p2p.sync.listen-on <MULTIADDRESS_LIST>
      --p2p.sync.bootstrap-addresses <MULTIADDRESS_LIST>
      --p2p.sync.predefined-peers <MULTIADDRESS_LIST>
      --p2p.sync.max-inbound-direct-connections <MAX_INBOUND_DIRECT_CONNECTIONS>
      --p2p.sync.max-inbound-relayed-connections <MAX_INBOUND_RELAYED_CONNECTIONS>
      --p2p.sync.max-outbound-connections <MAX_OUTBOUND_CONNECTIONS>
      --p2p.sync.ip-whitelist <LIST>
      --p2p.sync.experimental.kad-name <PROTOCOL_NAME>
      --p2p.sync.experimental.direct-connection-timeout <SECONDS>
      --p2p.sync.experimental.eviction-timeout <SECONDS>
      --p2p.sync.proxy <PROXY>
      --p2p.sync.experimental.l1-checkpoint-override-json-path <JSON_FILE>
      --p2p.sync.experimental.stream-timeout <SECONDS>
      --p2p.sync.experimental.response-timeout <SECONDS>
      --p2p.sync.experimental.max-concurrent-streams <LIMIT>
      --p2p.consensus.identity-config-file <PATH>
      --p2p.consensus.listen-on <MULTIADDRESS_LIST>
      --p2p.consensus.bootstrap-addresses <MULTIADDRESS_LIST>
      --p2p.consensus.predefined-peers <MULTIADDRESS_LIST>
      --p2p.consensus.max-inbound-direct-connections <MAX_INBOUND_DIRECT_CONNECTIONS>
      --p2p.consensus.max-inbound-relayed-connections <MAX_INBOUND_RELAYED_CONNECTIONS>
      --p2p.consensus.max-outbound-connections <MAX_OUTBOUND_CONNECTIONS>
      --p2p.consensus.ip-whitelist <LIST>
      --p2p.consensus.experimental.kad-name <PROTOCOL_NAME>
      --p2p.consensus.experimental.direct-connection-timeout <SECONDS>
      --p2p.consensus.experimental.eviction-timeout <SECONDS>
```
As you can see these ones are specific to the core behaviour, while others are application (sync-/consensus-) specific:
```
      --p2p.*.identity-config-file <PATH>
      --p2p.*.listen-on <MULTIADDRESS_LIST>
      --p2p.*.bootstrap-addresses <MULTIADDRESS_LIST>
      --p2p.*.predefined-peers <MULTIADDRESS_LIST>
      --p2p.*.max-inbound-direct-connections <MAX_INBOUND_DIRECT_CONNECTIONS>
      --p2p.*.max-inbound-relayed-connections <MAX_INBOUND_RELAYED_CONNECTIONS>
      --p2p.*.max-outbound-connections <MAX_OUTBOUND_CONNECTIONS>
      --p2p.*.ip-whitelist <LIST>
      --p2p.*.experimental.kad-name <PROTOCOL_NAME>
      --p2p.*.experimental.direct-connection-timeout <SECONDS>
      --p2p.*.experimental.eviction-timeout <SECONDS>
```

I wanted to avoid copy-paste duplication at all cost so some macros imo were inevitable. Submodules are structured in a way that hides implementation details so you don't have to stumble across that code every now and then (unless you have a really good reason to).