### PR TITLE
chore(rpc): improve RPC and subscriptions tracing

### DIFF
--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -125,7 +125,9 @@ impl RpcRouter {
 
         metrics::increment_counter!("rpc_method_calls_total", "method" => method_name, "version" => self.version.to_str());
 
-        let method = method.invoke(self.context.clone(), request.params, self.version).instrument(tracing::debug_span!("rpc_call", method=%method_name));
+        let method = method
+            .invoke(self.context.clone(), request.params, self.version)
+            .instrument(tracing::debug_span!("rpc_call", method=%method_name));
         let result = std::panic::AssertUnwindSafe(method).catch_unwind().await;
 
         let output = match result {

--- a/crates/rpc/src/jsonrpc/router/subscription.rs
+++ b/crates/rpc/src/jsonrpc/router/subscription.rs
@@ -244,7 +244,7 @@ where
                         tx.send_err(e).await.ok();
                     }
                 }
-            });
+            }.in_current_span());
             let first_msg = match rx1.recv().await {
                 Some(msg) => msg,
                 None => {
@@ -313,7 +313,7 @@ where
                 }
                 last_block = msg.block_number;
             }
-        }))
+        }.instrument(tracing::debug_span!("subscription", subscription_id=%subscription_id.0))))
     }
 }
 
@@ -558,7 +558,7 @@ pub fn handle_json_rpc_socket(
                 }
             }
         }
-    });
+    }.in_current_span());
 }
 
 /// Handle a single request. Returns `Result` for convenience, so that the `?`

--- a/crates/rpc/src/middleware/tracing.rs
+++ b/crates/rpc/src/middleware/tracing.rs
@@ -1,5 +1,11 @@
 use tower_http::classify::{ServerErrorsAsFailures, SharedClassifier};
-use tower_http::trace::{DefaultOnEos, DefaultOnRequest, DefaultOnResponse, TraceLayer};
+use tower_http::trace::{
+    DefaultOnEos,
+    DefaultOnFailure,
+    DefaultOnRequest,
+    DefaultOnResponse,
+    TraceLayer,
+};
 use tracing::Level;
 
 pub(crate) fn trace_layer(
@@ -7,6 +13,7 @@ pub(crate) fn trace_layer(
     tower_http::trace::TraceLayer::new_for_http()
         // Records request ID header value in the span.
         .make_span_with(RequestHeaderSpan)
+        .on_failure(DefaultOnFailure::default().level(Level::DEBUG))
         .on_request(DefaultOnRequest::default().level(Level::TRACE))
         .on_response(DefaultOnResponse::default().level(Level::TRACE))
         .on_eos(DefaultOnEos::default().level(Level::TRACE))


### PR DESCRIPTION
This PR adds some more tracing spans and events in the JSON-RPC code, especially for subscriptions. Now per-call and per-subscription spans are created that capture the request and subscription ID for the whole duration of the processing code.