### PR TITLE
fix(rpc/subscription): don't ignore notifications after skipped blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- `starknet_subscribeEvents` subscriptions stop sending notifications.
+
 ## [0.16.2] - 2025-03-12
 
 ### Added

--- a/crates/rpc/src/jsonrpc/router/subscription.rs
+++ b/crates/rpc/src/jsonrpc/router/subscription.rs
@@ -298,13 +298,7 @@ where
                 tracing::trace!(error=?e, "Error sending first subscription message, closing subscription");
                 return;
             }
-            let mut last_block = first_msg.block_number;
             while let Some(msg) = rx1.recv().await {
-                if msg.block_number.get() > last_block.get() + 1 {
-                    // One or more blocks have been skipped. This is likely due to a race
-                    // condition resulting from a reorg. This message should be ignored.
-                    continue;
-                }
                 tracing::trace!(block_number=%msg.block_number, notification=?msg.notification, "Sending subscription notification");
                 if let Err(e) = tx
                     .send(msg.notification, msg.subscription_name)
@@ -314,7 +308,6 @@ where
                     tracing::trace!(error=?e, "Error sending subscription message, closing subscription");
                     break;
                 }
-                last_block = msg.block_number;
             }
         }.instrument(tracing::debug_span!("subscription", subscription_id=%subscription_id.0))))
     }


### PR DESCRIPTION
Code sending Websocket notifications had a check that skipped notifications that were not sent for the next block number. This check might make sense for block header subscriptions, but definitely does not work for events and transaction status changes.

This PR removes that check.

Closes #2682
