### PR TITLE
chore(justfile): explicitly enable p2p feature only

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,12 +2,12 @@ default:
     just --summary --unsorted
 
 test $RUST_BACKTRACE="1" *args="":
-    cargo nextest run --no-fail-fast --all-targets --all-features --workspace --locked \
+    cargo nextest run --no-fail-fast --all-targets --features p2p --workspace --locked \
     -E 'not test(/^p2p_network::sync_handlers::tests::prop/)' \
     {{args}}
 
 proptest $RUST_BACKTRACE="1" *args="":
-    cargo nextest run --no-fail-fast --all-targets --all-features --workspace --locked \
+    cargo nextest run --no-fail-fast --all-targets --features p2p --workspace --locked \
     -E 'test(/^p2p_network::sync_handlers::tests::prop/)' \
     {{args}}
 
@@ -21,7 +21,7 @@ fmt:
     cargo +nightly fmt --all
 
 clippy *args="":
-    cargo clippy --workspace --all-targets --all-features --locked {{args}} -- -D warnings -D rust_2018_idioms
+    cargo clippy --workspace --all-targets --features p2p --locked {{args}} -- -D warnings -D rust_2018_idioms
 
 dep-sort:
     cargo sort --check --workspace


### PR DESCRIPTION
"cairo-native" requires an extensive setup of dependencies, so this change modifies justfile to enable all features _except_ "cairo-native". Currently that is "p2p" only.