### PR TITLE
feat(rpc): add `/ws/rpc/v0_8` route for the JSON-RPC 0.8.0 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- The JSON-RPC 0.8.0 API can now be accessed under `/ws/rpc/v0_8` as well if Websockets are enabled. This is equivalent to the `/rpc/v0_8` path and is provided only as a convenience feature.
+
 ### Fixed
 
 - `starknet_subscribeEvents` subscriptions stop sending notifications.

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -187,7 +187,6 @@ impl RpcServer {
             .with_state(v06_routes.clone())
             .route("/rpc/v0_7", post(rpc_handler))
             .with_state(v07_routes.clone())
-            // TODO Uncomment once RPC 0.8 is ready.
             .route("/rpc/v0_8", post(rpc_handler).get(rpc_handler))
             .with_state(v08_routes.clone())
             .route("/rpc/pathfinder/v0.1", post(rpc_handler))
@@ -202,6 +201,8 @@ impl RpcServer {
                 .with_state(v06_routes)
                 .route("/ws/rpc/v0_7", get(websocket_handler))
                 .with_state(v07_routes)
+                .route("/ws/rpc/v0_8", post(rpc_handler).get(rpc_handler))
+                .with_state(v08_routes)
                 .route("/ws/rpc/pathfinder/v0_1", get(websocket_handler))
                 .with_state(pathfinder_routes)
         } else {
@@ -973,6 +974,23 @@ mod tests {
     #[case::v0_8_write("/rpc/v0_8", "v08/starknet_write_api.json", &[], Api::Both)]
     #[case::v0_8_websocket(
         "/rpc/v0_8",
+        "v08/starknet_ws_api.json",
+        // "starknet_subscription*" methods are in fact notifications
+        &[
+            "starknet_subscriptionNewHeads",
+            "starknet_subscriptionPendingTransactions",
+            "starknet_subscriptionTransactionStatus",
+            "starknet_subscriptionEvents",
+            "starknet_subscriptionReorg"
+        ],
+        Api::WebsocketOnly)]
+    
+    #[case::v0_8_api_alternative_path("/ws/rpc/v0_8", "v08/starknet_api_openrpc.json", &[], Api::Both)]
+    #[case::v0_8_executables_alternative_path("/ws/rpc/v0_8", "v08/starknet_executables.json", &[], Api::Both)]
+    #[case::v0_8_trace_alternative_path("/ws/rpc/v0_8", "v08/starknet_trace_api_openrpc.json", &[], Api::Both)]
+    #[case::v0_8_write_alternative_path("/ws/rpc/v0_8", "v08/starknet_write_api.json", &[], Api::Both)]
+    #[case::v0_8_websocket_alternative_path(
+        "/ws/rpc/v0_8",
         "v08/starknet_ws_api.json",
         // "starknet_subscription*" methods are in fact notifications
         &[

--- a/docs/docs/interacting-with-pathfinder/json-rpc-api.md
+++ b/docs/docs/interacting-with-pathfinder/json-rpc-api.md
@@ -11,7 +11,7 @@ The JSON-RPC interface allows you to query Starknet data, send transactions, and
   Accessible at the `/rpc/v0_6` endpoint.
 - **Starknet v0.7.0**  
   Accessible at the `/rpc/v0_7` endpoint.
-- **Starknet v0.8.0-rc3**  
+- **Starknet v0.8.0**  
   Accessible at the `/rpc/v0_8` endpoint.
 - **Pathfinder Extension**  
   Exposed via `/rpc/pathfinder/v0_1`.

--- a/docs/docs/interacting-with-pathfinder/websocket-api.md
+++ b/docs/docs/interacting-with-pathfinder/websocket-api.md
@@ -11,8 +11,8 @@ The WebSocket interface serves the same API versions and extension endpoints as 
   Accessible at `/ws/rpc/v0_6`.
 - **Starknet v0.7.0**  
   Accessible at `/ws/rpc/v0_7`.
-- **Starknet v0.8.0-rc1**  
-  Accessible at `/rpc/v0_8`.
+- **Starknet v0.8.0**  
+  Accessible at `/rpc/v0_8` and `/ws/rpc/v0_8`.
 - **Pathfinder Extension**  
   Exposed via `/ws/rpc/pathfinder/v0_1`
 


### PR DESCRIPTION
To make it easier for users to route Websocket connections to our API for all supported JSON-RPC versions, this PR adds the `/ws/rpc/v0_8` route as an alias for `/rpc/v0_8` if the (legacy) Websocket APIs are enabled (that serve JSON-RPC 0.6 and 0.7).

Closes #2688 