### PR TITLE
fix: aggregate bloom filter migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `starknet_subscribeEvents` subscriptions stop sending notifications.
+- Broken aggregate bloom filter migration has been updated to work properly. If you migrated from a database running in
+archived mode, please [re-download our latest snapshot](https://eqlabs.github.io/pathfinder/database-snapshots) and re-run the migrations.
 
 ## [0.16.2] - 2025-03-12
 

--- a/crates/storage/src/schema/revision_0066.rs
+++ b/crates/storage/src/schema/revision_0066.rs
@@ -2,9 +2,10 @@ use std::time::Instant;
 
 use anyhow::Context;
 use pathfinder_common::BlockNumber;
+use rusqlite::OptionalExtension;
 
 use crate::bloom::{AggregateBloom, BloomFilter};
-use crate::params::params;
+use crate::prelude::{params, RowExt};
 
 pub(crate) fn migrate(tx: &rusqlite::Transaction<'_>) -> anyhow::Result<()> {
     tracing::info!("Creating event_filters table and migrating event Bloom filters");
@@ -36,19 +37,25 @@ pub(crate) fn migrate(tx: &rusqlite::Transaction<'_>) -> anyhow::Result<()> {
 /// [crate::StorageManager] as the
 /// [RunningEventFilter](crate::connection::event::RunningEventFilter).
 fn migrate_event_filters(tx: &rusqlite::Transaction<'_>) -> anyhow::Result<()> {
-    let bloom_filter_count = tx
-        .query_row("SELECT COUNT(*) FROM starknet_events_filters", [], |row| {
-            row.get::<_, u64>(0)
-        })
-        .context("Counting existing event Bloom filters")?;
+    let Some(latest_block) = tx
+        .query_row(
+            "SELECT number FROM canonical_blocks ORDER BY number DESC LIMIT 1",
+            [],
+            |row| {
+                let number = row.get_block_number(0)?.get();
 
-    if bloom_filter_count == 0 {
+                Ok(number)
+            },
+        )
+        .optional()
+        .context("Counting existing blocks")?
+    else {
         // No event Bloom filters to migrate.
         return Ok(());
-    }
+    };
 
     let mut fetch_bloom_stmt =
-        tx.prepare("SELECT bloom FROM starknet_events_filters ORDER BY block_number")?;
+        tx.prepare("SELECT bloom FROM starknet_events_filters WHERE block_number = ?")?;
 
     let mut insert_aggregate_stmt = tx.prepare_cached(
         r"
@@ -57,27 +64,27 @@ fn migrate_event_filters(tx: &rusqlite::Transaction<'_>) -> anyhow::Result<()> {
         ",
     )?;
 
-    let mut bloom_filters = fetch_bloom_stmt
-        .query_map([], |row| {
-            let bloom: Vec<u8> = row.get(0)?;
-            Ok(BloomFilter::from_compressed_bytes(&bloom))
-        })
-        .context("Querying old Bloom filters")?;
-
+    let total_blocks = latest_block + 1;
     let mut aggregate = AggregateBloom::new(BlockNumber::GENESIS);
-    let mut migrated_count: u64 = 0;
     let mut last_progress_report = Instant::now();
 
-    tracing::info!(
-        "Migrating event Bloom filters: 0.00% (0/{})",
-        bloom_filter_count
-    );
-    while let Some(bloom_filter) = bloom_filters.next().transpose()? {
-        let current_block = BlockNumber::new_or_panic(migrated_count);
+    tracing::info!("Migrating event Bloom filters: 0.00% (0/{})", total_blocks);
+    for block in 0..=latest_block {
+        let block_number = BlockNumber::new_or_panic(block);
+        let bloom_filter = fetch_bloom_stmt
+            .query_row(params![&block_number], |row| {
+                let bloom: Vec<u8> = row.get(0)?;
+                Ok(BloomFilter::from_compressed_bytes(&bloom))
+            })
+            .optional()
+            .context(format!("Querying old Bloom filter for block {block}"))?
+            // It might be possible for a block to not have an associated entry in the
+            // `starknet_events_filters` table.
+            .unwrap_or(BloomFilter::new());
 
-        aggregate.insert(&bloom_filter, current_block);
+        aggregate.insert(&bloom_filter, block_number);
 
-        if current_block == aggregate.to_block {
+        if block_number == aggregate.to_block {
             insert_aggregate_stmt
                 .execute(params![
                     &aggregate.from_block,
@@ -86,24 +93,22 @@ fn migrate_event_filters(tx: &rusqlite::Transaction<'_>) -> anyhow::Result<()> {
                 ])
                 .context("Inserting aggregate bloom filter")?;
 
-            aggregate = AggregateBloom::new(current_block + 1);
+            aggregate = AggregateBloom::new(block_number + 1);
         }
-
-        migrated_count += 1;
 
         if last_progress_report.elapsed().as_secs() >= 10 {
             tracing::info!(
                 "Migrating event Bloom filters: {:.2}% ({}/{})",
-                migrated_count as f64 / bloom_filter_count as f64 * 100.0,
-                migrated_count,
-                bloom_filter_count
+                block as f64 / total_blocks as f64 * 100.0,
+                block,
+                total_blocks
             );
             last_progress_report = Instant::now();
         }
     }
     tracing::info!(
         "Migrating event Bloom filters: 100.00% ({count}/{count})",
-        count = bloom_filter_count,
+        count = total_blocks,
     );
 
     Ok(())


### PR DESCRIPTION
Fixes the aggregate bloom filter migration. It now accounts for the possibility that a block might not have an associated entry in the `starknet_events_filters` table.

Closes https://github.com/eqlabs/pathfinder/issues/2691.