### PR TITLE
feat(rpc/subscription): make `subscription_id` a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `starknet_subscribeEvents` subscriptions stop sending notifications.
 
+### Changed
+
+- JSON-RPC 0.8 `subscription_id` is now a string.
+
 ## [0.16.2] - 2025-03-12
 
 ### Added

--- a/crates/rpc/src/jsonrpc/router/subscription.rs
+++ b/crates/rpc/src/jsonrpc/router/subscription.rs
@@ -855,12 +855,12 @@ mod tests {
             .await
             .unwrap();
         let res = sender_rx.recv().await.unwrap().unwrap();
-        let subscription_id = match res {
+        let subscription_id: u64 = match res {
             Message::Text(json) => {
                 let json: serde_json::Value = serde_json::from_str(&json).unwrap();
                 assert_eq!(json["jsonrpc"], "2.0");
                 assert_eq!(json["id"], 1);
-                json["result"].as_u64().unwrap()
+                json["result"].as_str().unwrap().parse().unwrap()
             }
             _ => panic!("Expected text message"),
         };
@@ -876,7 +876,7 @@ mod tests {
                 "method": "pathfinder_subscriptionError",
                 "params": {
                     "result": { "code": -32603, "message": "Internal error" },
-                    "subscription_id": subscription_id
+                    "subscription_id": subscription_id.to_string()
                 }
             })
         )
@@ -932,12 +932,12 @@ mod tests {
             .await
             .unwrap();
         let res = sender_rx.recv().await.unwrap().unwrap();
-        let subscription_id = match res {
+        let subscription_id: u64 = match res {
             Message::Text(json) => {
                 let json: serde_json::Value = serde_json::from_str(&json).unwrap();
                 assert_eq!(json["jsonrpc"], "2.0");
                 assert_eq!(json["id"], 1);
-                json["result"].as_u64().unwrap()
+                json["result"].as_str().unwrap().parse().unwrap()
             }
             _ => panic!("Expected text message"),
         };
@@ -953,7 +953,7 @@ mod tests {
                 "method": "pathfinder_subscriptionError",
                 "params": {
                     "result": { "code": -32603, "message": "Internal error" },
-                    "subscription_id": subscription_id
+                    "subscription_id": subscription_id.to_string()
                 }
             })
         )

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -256,13 +256,19 @@ impl crate::dto::SerializeForVersion for SubscriptionId {
         &self,
         serializer: crate::dto::Serializer,
     ) -> Result<crate::dto::Ok, crate::dto::Error> {
-        serializer.serialize_u64(self.0 as u64)
+        serializer.serialize_str(self.0.to_string().as_str())
     }
 }
 
 impl crate::dto::DeserializeForVersion for SubscriptionId {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        let id: u32 = value.deserialize()?;
+        let id: String = value.deserialize()?;
+        let id: u32 = id.parse().map_err(|_| {
+            use serde::de::Error;
+            serde_json::Error::custom(format!(
+                "Failed to parse subscription id: {id:?}"
+            ))
+        })?;
         Ok(Self(id))
     }
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -265,9 +265,7 @@ impl crate::dto::DeserializeForVersion for SubscriptionId {
         let id: String = value.deserialize()?;
         let id: u32 = id.parse().map_err(|_| {
             use serde::de::Error;
-            serde_json::Error::custom(format!(
-                "Failed to parse subscription id: {id:?}"
-            ))
+            serde_json::Error::custom(format!("Failed to parse subscription id: {id:?}"))
         })?;
         Ok(Self(id))
     }

--- a/crates/rpc/src/method/subscribe_events.rs
+++ b/crates/rpc/src/method/subscribe_events.rs
@@ -359,7 +359,7 @@ mod tests {
                 let json: serde_json::Value = serde_json::from_str(&json).unwrap();
                 assert_eq!(json["jsonrpc"], "2.0");
                 assert_eq!(json["id"], 1);
-                json["result"].as_u64().unwrap()
+                json["result"].as_str().unwrap().parse().unwrap()
             }
             _ => panic!("Expected text message"),
         };
@@ -423,7 +423,7 @@ mod tests {
                 let json: serde_json::Value = serde_json::from_str(&json).unwrap();
                 assert_eq!(json["jsonrpc"], "2.0");
                 assert_eq!(json["id"], 1);
-                json["result"].as_u64().unwrap()
+                json["result"].as_str().unwrap().parse().unwrap()
             }
             _ => panic!("Expected text message"),
         };
@@ -489,7 +489,7 @@ mod tests {
                 let json: serde_json::Value = serde_json::from_str(&json).unwrap();
                 assert_eq!(json["jsonrpc"], "2.0");
                 assert_eq!(json["id"], 1);
-                json["result"].as_u64().unwrap()
+                json["result"].as_str().unwrap().parse().unwrap()
             }
             _ => panic!("Expected text message"),
         };
@@ -556,7 +556,7 @@ mod tests {
                 let json: serde_json::Value = serde_json::from_str(&json).unwrap();
                 assert_eq!(json["jsonrpc"], "2.0");
                 assert_eq!(json["id"], 1);
-                json["result"].as_u64().unwrap()
+                json["result"].as_str().unwrap().parse().unwrap()
             }
             _ => panic!("Expected text message"),
         };
@@ -623,7 +623,7 @@ mod tests {
                 let json: serde_json::Value = serde_json::from_str(&json).unwrap();
                 assert_eq!(json["jsonrpc"], "2.0");
                 assert_eq!(json["id"], 1);
-                json["result"].as_u64().unwrap()
+                json["result"].as_str().unwrap().parse().unwrap()
             }
             _ => panic!("Expected text message"),
         };
@@ -763,12 +763,12 @@ mod tests {
             .await
             .unwrap();
         let res = sender_rx.recv().await.unwrap().unwrap();
-        let subscription_id = match res {
+        let subscription_id: u64 = match res {
             Message::Text(json) => {
                 let json: serde_json::Value = serde_json::from_str(&json).unwrap();
                 assert_eq!(json["jsonrpc"], "2.0");
                 assert_eq!(json["id"], 1);
-                json["result"].as_u64().unwrap()
+                json["result"].as_str().unwrap().parse().unwrap()
             }
             _ => panic!("Expected text message"),
         };
@@ -793,7 +793,7 @@ mod tests {
                         "keys": ["0x0", "0x1", "0x2"],
                         "transaction_hash": "0x0"
                     },
-                    "subscription_id": subscription_id
+                    "subscription_id": subscription_id.to_string()
                 }
             })
         );
@@ -828,7 +828,7 @@ mod tests {
                         "last_block_hash": "0x2",
                         "last_block_number": 2
                     },
-                    "subscription_id": subscription_id
+                    "subscription_id": subscription_id.to_string()
                 }
             })
         );
@@ -999,7 +999,7 @@ mod tests {
                     "block_hash": Felt::from_u64(block_number),
                     "transaction_hash": Felt::from_u64(block_number),
                 },
-                "subscription_id": subscription_id
+                "subscription_id": subscription_id.to_string()
             }
         })
     }

--- a/crates/rpc/src/method/subscribe_new_heads.rs
+++ b/crates/rpc/src/method/subscribe_new_heads.rs
@@ -220,7 +220,7 @@ mod tests {
                         "last_block_hash": "0x2",
                         "last_block_number": 2
                     },
-                    "subscription_id": subscription_id.0
+                    "subscription_id": subscription_id.0.to_string()
                 }
             })
         );
@@ -251,7 +251,7 @@ mod tests {
                 let json: serde_json::Value = serde_json::from_str(&json).unwrap();
                 assert_eq!(json["jsonrpc"], "2.0");
                 assert_eq!(json["id"], 1);
-                json["result"].as_u64().unwrap()
+                json["result"].as_str().unwrap().parse().unwrap()
             }
             _ => panic!("Expected text message"),
         };
@@ -339,7 +339,7 @@ mod tests {
                 let json: serde_json::Value = serde_json::from_str(&json).unwrap();
                 assert_eq!(json["jsonrpc"], "2.0");
                 assert_eq!(json["id"], 1);
-                json["result"].as_u64().unwrap()
+                json["result"].as_str().unwrap().parse().unwrap()
             }
             _ => panic!("Expected text message"),
         };
@@ -398,7 +398,7 @@ mod tests {
                 let json: serde_json::Value = serde_json::from_str(&json).unwrap();
                 assert_eq!(json["jsonrpc"], "2.0");
                 assert_eq!(json["id"], 1);
-                json["result"].as_u64().unwrap()
+                json["result"].as_str().unwrap().parse().unwrap()
             }
             _ => panic!("Expected text message"),
         };
@@ -580,7 +580,7 @@ mod tests {
                 let json: serde_json::Value = serde_json::from_str(&json).unwrap();
                 assert_eq!(json["jsonrpc"], "2.0");
                 assert_eq!(json["id"], 1);
-                json["result"].as_u64().unwrap()
+                json["result"].as_str().unwrap().parse().unwrap()
             }
             _ => panic!("Expected text message"),
         };
@@ -648,7 +648,7 @@ mod tests {
                     "starknet_version": "",
                     "timestamp": 0
                 },
-                "subscription_id": subscription_id
+                "subscription_id": subscription_id.to_string()
             }
         })
     }

--- a/crates/rpc/src/method/subscribe_pending_transactions.rs
+++ b/crates/rpc/src/method/subscribe_pending_transactions.rs
@@ -172,7 +172,7 @@ mod tests {
                 let json: serde_json::Value = serde_json::from_str(&json).unwrap();
                 assert_eq!(json["jsonrpc"], "2.0");
                 assert_eq!(json["id"], 1);
-                json["result"].as_u64().unwrap()
+                json["result"].as_str().unwrap().parse().unwrap()
             }
             _ => {
                 panic!("Expected text message");
@@ -261,7 +261,7 @@ mod tests {
                 let json: serde_json::Value = serde_json::from_str(&json).unwrap();
                 assert_eq!(json["jsonrpc"], "2.0");
                 assert_eq!(json["id"], 1);
-                json["result"].as_u64().unwrap()
+                json["result"].as_str().unwrap().parse().unwrap()
             }
             _ => {
                 panic!("Expected text message");
@@ -314,7 +314,7 @@ mod tests {
                 let json: serde_json::Value = serde_json::from_str(&json).unwrap();
                 assert_eq!(json["jsonrpc"], "2.0");
                 assert_eq!(json["id"], 1);
-                json["result"].as_u64().unwrap()
+                json["result"].as_str().unwrap().parse().unwrap()
             }
             _ => {
                 panic!("Expected text message");
@@ -363,7 +363,7 @@ mod tests {
                 let json: serde_json::Value = serde_json::from_str(&json).unwrap();
                 assert_eq!(json["jsonrpc"], "2.0");
                 assert_eq!(json["id"], 1);
-                json["result"].as_u64().unwrap()
+                json["result"].as_str().unwrap().parse().unwrap()
             }
             _ => {
                 panic!("Expected text message");
@@ -429,7 +429,7 @@ mod tests {
             "method":"starknet_subscriptionPendingTransactions",
             "params": {
                 "result": hash,
-                "subscription_id": subscription_id
+                "subscription_id": subscription_id.to_string()
             }
         })
     }
@@ -452,7 +452,7 @@ mod tests {
                     "type": "DECLARE",
                     "version": "0x0"
                 },
-                "subscription_id": subscription_id
+                "subscription_id": subscription_id.to_string()
             }
         })
     }


### PR DESCRIPTION
To follow up a change in the JSON-RPC 0.8.1 specification, subscription_id is now a string instead of an integer.

Closes #2692
