### PR TITLE
refactor(rpc): use per-connection subscription IDs

### DIFF
--- a/crates/rpc/src/jsonrpc/router/subscription.rs
+++ b/crates/rpc/src/jsonrpc/router/subscription.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 
 use axum::extract::ws::{Message, WebSocket};
@@ -27,9 +28,43 @@ pub(super) struct InvokeParams {
     router: RpcRouter,
     input: serde_json::Value,
     subscription_id: SubscriptionId,
-    subscriptions: Arc<DashMap<SubscriptionId, tokio::task::JoinHandle<()>>>,
+    subscriptions: Arc<Subscriptions>,
     ws_tx: mpsc::Sender<Result<Message, RpcResponse>>,
     lock: Arc<RwLock<()>>,
+}
+
+#[derive(Default, Debug)]
+pub struct Subscriptions {
+    subscriptions: DashMap<SubscriptionId, tokio::task::JoinHandle<()>>,
+    next_id: AtomicU32,
+}
+
+impl Subscriptions {
+    pub fn remove(
+        &self,
+        subscription_id: &SubscriptionId,
+    ) -> Option<(SubscriptionId, tokio::task::JoinHandle<()>)> {
+        self.subscriptions.remove(subscription_id)
+    }
+
+    pub fn contains_key(&self, subscription_id: &SubscriptionId) -> bool {
+        self.subscriptions.contains_key(subscription_id)
+    }
+
+    pub fn insert(
+        &self,
+        subscription_id: SubscriptionId,
+        handle: tokio::task::JoinHandle<()>,
+    ) -> Option<tokio::task::JoinHandle<()>> {
+        self.subscriptions.insert(subscription_id, handle)
+    }
+
+    pub fn next_id(&self) -> SubscriptionId {
+        let id = self
+            .next_id
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        SubscriptionId(id)
+    }
 }
 
 /// This trait is the main entry point for subscription endpoint
@@ -155,7 +190,7 @@ where
 
         let tx = SubscriptionSender {
             subscription_id,
-            subscriptions: subscriptions.clone(),
+            subscriptions: Arc::clone(&subscriptions),
             tx: ws_tx,
             version: router.version,
             _phantom: Default::default(),
@@ -317,7 +352,7 @@ where
 /// subscription task corresponding to that handle returns.
 struct SubscriptionsGuard {
     subscription_id: SubscriptionId,
-    subscriptions: Arc<DashMap<SubscriptionId, tokio::task::JoinHandle<()>>>,
+    subscriptions: Arc<Subscriptions>,
 }
 
 impl Drop for SubscriptionsGuard {
@@ -382,8 +417,7 @@ pub fn handle_json_rpc_socket(
     ws_tx: mpsc::Sender<Result<Message, RpcResponse>>,
     mut ws_rx: mpsc::Receiver<Result<Message, axum::Error>>,
 ) {
-    let subscriptions: Arc<DashMap<SubscriptionId, tokio::task::JoinHandle<()>>> =
-        Default::default();
+    let subscriptions = Arc::new(Subscriptions::default());
     // Read and handle messages from the websocket.
     util::task::spawn(async move {
         loop {
@@ -447,7 +481,7 @@ pub fn handle_json_rpc_socket(
                 match handle_request(
                     &state,
                     raw_value,
-                    subscriptions.clone(),
+                    Arc::clone(&subscriptions),
                     ws_tx.clone(),
                     lock.clone(),
                 )
@@ -565,7 +599,7 @@ pub fn handle_json_rpc_socket(
 async fn handle_request(
     state: &RpcRouter,
     raw_request: &RawValue,
-    subscriptions: Arc<DashMap<SubscriptionId, tokio::task::JoinHandle<()>>>,
+    subscriptions: Arc<Subscriptions>,
     ws_tx: mpsc::Sender<Result<Message, RpcResponse>>,
     lock: Arc<RwLock<()>>,
 ) -> Result<Option<RpcResponse>, RpcResponse> {
@@ -629,14 +663,14 @@ async fn handle_request(
 
     // Start the subscription.
     let router = state.clone();
-    let subscription_id = SubscriptionId::next();
+    let subscription_id = subscriptions.next_id();
     let ws_tx = ws_tx.clone();
     match endpoint
         .invoke(InvokeParams {
             router,
             input: params,
             subscription_id,
-            subscriptions: subscriptions.clone(),
+            subscriptions: Arc::clone(&subscriptions),
             ws_tx: ws_tx.clone(),
             lock,
         })
@@ -671,7 +705,7 @@ struct StarknetUnsubscribeParams {
 #[derive(Debug)]
 pub struct SubscriptionSender<T> {
     pub subscription_id: SubscriptionId,
-    pub subscriptions: Arc<DashMap<SubscriptionId, tokio::task::JoinHandle<()>>>,
+    pub subscriptions: Arc<Subscriptions>,
     pub tx: mpsc::Sender<Result<Message, RpcResponse>>,
     pub version: RpcVersion,
     pub _phantom: std::marker::PhantomData<T>,

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -18,7 +18,6 @@ pub mod v08;
 
 use std::net::SocketAddr;
 use std::result::Result;
-use std::sync::atomic::{AtomicU32, Ordering};
 
 use anyhow::Context;
 use axum::error_handling::HandleErrorLayer;
@@ -109,7 +108,7 @@ impl RpcServer {
             Err(e) => {
                 return Err(e).context(format!(
                     "RPC address {} is already in use.
-    
+
             Hint: This usually means you are already running another instance of pathfinder.
             Hint: If this happens when upgrading, make sure to shut down the first one first.
             Hint: If you are looking to run two instances of pathfinder, you must configure them \
@@ -243,13 +242,6 @@ impl Default for SyncState {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Deserialize)]
 pub(crate) struct SubscriptionId(pub u32);
-
-impl SubscriptionId {
-    pub fn next() -> Self {
-        static COUNTER: AtomicU32 = AtomicU32::new(0);
-        SubscriptionId(COUNTER.fetch_add(1, Ordering::Relaxed))
-    }
-}
 
 impl crate::dto::SerializeForVersion for SubscriptionId {
     fn serialize(
@@ -988,7 +980,7 @@ mod tests {
             "starknet_subscriptionReorg"
         ],
         Api::WebsocketOnly)]
-    
+
     #[case::v0_8_api_alternative_path("/ws/rpc/v0_8", "v08/starknet_api_openrpc.json", &[], Api::Both)]
     #[case::v0_8_executables_alternative_path("/ws/rpc/v0_8", "v08/starknet_executables.json", &[], Api::Both)]
     #[case::v0_8_trace_alternative_path("/ws/rpc/v0_8", "v08/starknet_trace_api_openrpc.json", &[], Api::Both)]


### PR DESCRIPTION
Instead of using a global subscription ID counter, we now use a per-connection counter to generate unique subscription IDs. This has the advantage of not leaking global state (like: total number of subscriptions so far) to individual clients.

