### PR TITLE
chore(rpc): update OpenRPC specification to 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - JSON-RPC 0.8 `subscription_id` is now a string.
+- Pathfinder now supports the JSON-RPC 0.8.1 specification. In this new version, the Websocket `subscription_id` type has been changed to `string`.
 
 ## [0.16.2] - 2025-03-12
 

--- a/crates/rpc/src/v08.rs
+++ b/crates/rpc/src/v08.rs
@@ -42,7 +42,7 @@ pub fn register_routes() -> RpcRouterBuilder {
         .register("starknet_subscribePendingTransactions",        SubscribePendingTransactions)
         .register("starknet_subscribeEvents",                     SubscribeEvents)
         .register("starknet_subscribeTransactionStatus",          SubscribeTransactionStatus)
-        .register("starknet_specVersion",                         || "0.8.0")
+        .register("starknet_specVersion",                         || "0.8.1")
         .register("starknet_syncing",                             crate::method::syncing)
         .register("starknet_traceBlockTransactions",              crate::method::trace_block_transactions)
         .register("starknet_traceTransaction",                    crate::method::trace_transaction)

--- a/docs/docs/interacting-with-pathfinder/json-rpc-api.md
+++ b/docs/docs/interacting-with-pathfinder/json-rpc-api.md
@@ -7,11 +7,11 @@ sidebar_position: 1
 The JSON-RPC interface allows you to query Starknet data, send transactions, and perform contract calls without going through a formal transaction on-chain. Pathfinder currently supports multiple API versions and a distinct set of custom extensions.
 
 ## Supported Versions
-- **Starknet v0.6.0**  
+- **JSON-RPC v0.6.0**  
   Accessible at the `/rpc/v0_6` endpoint.
-- **Starknet v0.7.0**  
+- **JSON-RPC v0.7.1**  
   Accessible at the `/rpc/v0_7` endpoint.
-- **Starknet v0.8.0**  
+- **JSON-RPC v0.8.1**  
   Accessible at the `/rpc/v0_8` endpoint.
 - **Pathfinder Extension**  
   Exposed via `/rpc/pathfinder/v0_1`.

--- a/docs/docs/interacting-with-pathfinder/websocket-api.md
+++ b/docs/docs/interacting-with-pathfinder/websocket-api.md
@@ -7,11 +7,11 @@ sidebar_position: 2
 The WebSocket interface serves the same API versions and extension endpoints as HTTP, but in a stateful, two-way communication channel. This can be especially useful for real-time notifications, subscription-based events, or building interactive dashboards.
  
 ## Supported Versions
-- **Starknet v0.6.0**  
+- **JSON-RPC v0.6.0**  
   Accessible at `/ws/rpc/v0_6`.
-- **Starknet v0.7.0**  
+- **JSON-RPC v0.7.1**  
   Accessible at `/ws/rpc/v0_7`.
-- **Starknet v0.8.0**  
+- **JSON-RPC v0.8.1**  
   Accessible at `/rpc/v0_8` and `/ws/rpc/v0_8`.
 - **Pathfinder Extension**  
   Exposed via `/ws/rpc/pathfinder/v0_1`

--- a/specs/rpc/v08/starknet_api_openrpc.json
+++ b/specs/rpc/v08/starknet_api_openrpc.json
@@ -3482,37 +3482,37 @@
           "l1_gas_consumed": {
             "title": "L1 gas consumed",
             "description": "The Ethereum gas consumption of the transaction, charged for L1->L2 messages and, depending on the block's DA_MODE, state diffs",
-            "$ref": "#/components/schemas/FELT"
+            "$ref": "#/components/schemas/u64"
           },
           "l1_gas_price": {
             "title": "L1 gas price",
             "description": "The gas price (in wei or fri, depending on the tx version) that was used in the cost estimation",
-            "$ref": "#/components/schemas/FELT"
+            "$ref": "#/components/schemas/u128"
           },
           "l2_gas_consumed": {
             "title": "L2 gas consumed",
             "description": "The L2 gas consumption of the transaction",
-            "$ref": "#/components/schemas/FELT"
+            "$ref": "#/components/schemas/u64"
           },
           "l2_gas_price": {
             "title": "L2 gas price",
             "description": "The L2 gas price (in wei or fri, depending on the tx version) that was used in the cost estimation",
-            "$ref": "#/components/schemas/FELT"
+            "$ref": "#/components/schemas/u128"
           },
           "l1_data_gas_consumed": {
             "title": "L1 data gas consumed",
             "description": "The Ethereum data gas consumption of the transaction",
-            "$ref": "#/components/schemas/FELT"
+            "$ref": "#/components/schemas/u64"
           },
           "l1_data_gas_price": {
             "title": "L1 data gas price",
             "description": "The data gas price (in wei or fri, depending on the tx version) that was used in the cost estimation",
-            "$ref": "#/components/schemas/FELT"
+            "$ref": "#/components/schemas/u128"
           },
           "overall_fee": {
             "title": "Overall fee",
-            "description": "The estimated fee for the transaction (in wei or fri, depending on the tx version), equals to gas_consumed*gas_price + data_gas_consumed*data_gas_price",
-            "$ref": "#/components/schemas/FELT"
+            "description": "The estimated fee for the transaction (in wei or fri, depending on the tx version), equals to l1_gas_consumed*l1_gas_price + l1_data_gas_consumed*l1_data_gas_price + l2_gas_consumed*l2_gas_price",
+            "$ref": "#/components/schemas/u128"
           },
           "unit": {
             "title": "Fee unit",

--- a/specs/rpc/v08/starknet_api_openrpc.json
+++ b/specs/rpc/v08/starknet_api_openrpc.json
@@ -249,50 +249,50 @@
       ]
     },
     {
-        "name": "starknet_getMessagesStatus",
-        "summary": "Given an l1 tx hash, returns the associated l1_handler tx hashes and statuses for all L1 -> L2 messages sent by the l1 transaction, ordered by the l1 tx sending order",
-        "paramStructure": "by-name",
-        "params": [
-            {
-            "name": "transaction_hash",
-            "summary": "The hash of the L1 transaction that sent L1->L2 messages",
-            "required": true,
-            "schema": {
-                "title": "Transaction hash",
-                "$ref": "#/components/schemas/L1_TXN_HASH"
-            }
-            }
-        ],
-        "result": {
-            "name": "result",
-            "schema": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "title": "status",
-                    "properties": {
-                    "transaction_hash": {
-                        "$ref": "#/components/schemas/TXN_HASH"
-                    },
-                    "finality_status": {
-                        "title": "finality status",
-                        "$ref": "#/components/schemas/TXN_STATUS"
-                    },
-                    "failure_reason": {
-                        "title": "failure reason",
-                        "description": "the failure reason, only appears if finality_status is REJECTED",
-                        "type": "string"
-                    }
-                    },
-                    "required": ["transaction_hash", "finality_status"]
-                }
-            }
-        },
-        "errors": [
-            {
-            "$ref": "#/components/errors/TXN_HASH_NOT_FOUND"
-            }
-        ]
+      "name": "starknet_getMessagesStatus",
+      "summary": "Given an l1 tx hash, returns the associated l1_handler tx hashes and statuses for all L1 -> L2 messages sent by the l1 transaction, ordered by the l1 tx sending order",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "transaction_hash",
+          "summary": "The hash of the L1 transaction that sent L1->L2 messages",
+          "required": true,
+          "schema": {
+            "title": "Transaction hash",
+            "$ref": "#/components/schemas/L1_TXN_HASH"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "status",
+            "properties": {
+              "transaction_hash": {
+                "$ref": "#/components/schemas/TXN_HASH"
+              },
+              "finality_status": {
+                "title": "finality status",
+                "$ref": "#/components/schemas/TXN_STATUS"
+              },
+              "failure_reason": {
+                "title": "failure reason",
+                "description": "the failure reason, only appears if finality_status is REJECTED",
+                "type": "string"
+              }
+            },
+            "required": ["transaction_hash", "finality_status"]
+          }
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/TXN_HASH_NOT_FOUND"
+        }
+      ]
     },
     {
       "name": "starknet_getTransactionByHash",
@@ -312,7 +312,7 @@
       "result": {
         "name": "result",
         "schema": {
-            "$ref": "#/components/schemas/TXN_WITH_HASH"
+          "$ref": "#/components/schemas/TXN_WITH_HASH"
         }
       },
       "errors": [
@@ -349,7 +349,7 @@
       "result": {
         "name": "transactionResult",
         "schema": {
-            "$ref": "#/components/schemas/TXN_WITH_HASH"
+          "$ref": "#/components/schemas/TXN_WITH_HASH"
         }
       },
       "errors": [
@@ -890,15 +890,15 @@
           "schema": {
             "title": "Block id",
             "allOf": [
-                {
-                    "$ref": "#/components/schemas/BLOCK_ID"
-                },
-                {
-                    "not": {
-                      "type": "string",
-                      "enum": ["pending"]
-                    }
+              {
+                "$ref": "#/components/schemas/BLOCK_ID"
+              },
+              {
+                "not": {
+                  "type": "string",
+                  "enum": ["pending"]
                 }
+              }
             ]
           }
         },
@@ -1008,10 +1008,19 @@
                   "$ref": "#/components/schemas/FELT"
                 }
               },
-              "required": ["contracts_tree_root", "classes_tree_root", "block_hash"]
+              "required": [
+                "contracts_tree_root",
+                "classes_tree_root",
+                "block_hash"
+              ]
             }
           },
-          "required": ["classes_proof", "contracts_proof", "contracts_storage_proofs", "global_roots"]
+          "required": [
+            "classes_proof",
+            "contracts_proof",
+            "contracts_storage_proofs",
+            "global_roots"
+          ]
         }
       },
       "errors": [
@@ -1949,7 +1958,14 @@
                 "$ref": "#/components/schemas/FELT"
               }
             },
-            "required": ["type", "sender_address", "max_fee", "version", "signature", "class_hash"]
+            "required": [
+              "type",
+              "sender_address",
+              "max_fee",
+              "version",
+              "signature",
+              "class_hash"
+            ]
           }
         ]
       },
@@ -1996,7 +2012,15 @@
                 "$ref": "#/components/schemas/FELT"
               }
             },
-            "required": ["type", "sender_address", "max_fee", "version", "signature", "nonce", "class_hash"]
+            "required": [
+              "type",
+              "sender_address",
+              "max_fee",
+              "version",
+              "signature",
+              "nonce",
+              "class_hash"
+            ]
           }
         ]
       },
@@ -2476,7 +2500,13 @@
                 "$ref": "#/components/schemas/FELT"
               }
             },
-            "required": ["version", "type", "constructor_calldata", "contract_address_salt", "class_hash"]
+            "required": [
+              "version",
+              "type",
+              "constructor_calldata",
+              "contract_address_salt",
+              "class_hash"
+            ]
           }
         ]
       },
@@ -2522,7 +2552,15 @@
             }
           }
         },
-        "required": ["type", "contract_address", "entry_point_selector", "calldata", "max_fee", "version", "signature"]
+        "required": [
+          "type",
+          "contract_address",
+          "entry_point_selector",
+          "calldata",
+          "max_fee",
+          "version",
+          "signature"
+        ]
       },
       "INVOKE_TXN_V1": {
         "title": "Invoke transaction V1",
@@ -2568,7 +2606,15 @@
                 "$ref": "#/components/schemas/FELT"
               }
             },
-            "required": ["type", "sender_address", "calldata", "max_fee", "version", "signature", "nonce"]
+            "required": [
+              "type",
+              "sender_address",
+              "calldata",
+              "max_fee",
+              "version",
+              "signature",
+              "nonce"
+            ]
           }
         ]
       },
@@ -3028,7 +3074,12 @@
             }
           }
         },
-        "required": ["from_address", "to_address", "payload", "entry_point_selector"]
+        "required": [
+          "from_address",
+          "to_address",
+          "payload",
+          "entry_point_selector"
+        ]
       },
       "TXN_STATUS_RESULT": {
         "title": "Transaction status result",
@@ -3156,7 +3207,11 @@
             "description": "The class ABI, as supplied by the user declaring the class"
           }
         },
-        "required": ["sierra_program", "contract_class_version", "entry_points_by_type"]
+        "required": [
+          "sierra_program",
+          "contract_class_version",
+          "entry_points_by_type"
+        ]
       },
       "DEPRECATED_CONTRACT_CLASS": {
         "title": "Deprecated contract class",
@@ -3465,7 +3520,16 @@
             "$ref": "#/components/schemas/PRICE_UNIT"
           }
         },
-        "required": ["l1_gas_consumed", "l1_gas_price", "l2_gas_consumed", "l2_gas_price","l1_data_gas_consumed", "l1_data_gas_price", "overall_fee", "unit"]
+        "required": [
+          "l1_gas_consumed",
+          "l1_gas_price",
+          "l2_gas_consumed",
+          "l2_gas_price",
+          "l1_data_gas_consumed",
+          "l1_data_gas_price",
+          "overall_fee",
+          "unit"
+        ]
       },
       "FEE_PAYMENT": {
         "title": "Fee Payment",

--- a/specs/rpc/v08/starknet_executables.json
+++ b/specs/rpc/v08/starknet_executables.json
@@ -1,1370 +1,1178 @@
 {
-    "openrpc": "1.0.0",
-    "info": {
-        "version": "0.8.0",
-        "title": "API for getting Starknet executables from nodes that store compiled artifacts",
-        "license": {}
-    },
-    "servers": [],
-    "methods": [
+  "openrpc": "1.0.0",
+  "info": {
+    "version": "0.8.0",
+    "title": "API for getting Starknet executables from nodes that store compiled artifacts",
+    "license": {}
+  },
+  "servers": [],
+  "methods": [
+    {
+      "name": "starknet_getCompiledCasm",
+      "summary": "Get the CASM code resulting from compiling a given class",
+      "params": [
         {
-            "name": "starknet_getCompiledCasm",
-            "summary": "Get the CASM code resulting from compiling a given class",
-            "params": [
-                {
-                    "name": "class_hash",
-                    "description": "The hash of the contract class whose CASM will be returned",
-                    "required": true,
-                    "schema": {
-                        "title": "Field element",
-                        "$ref": "#/components/schemas/FELT"
-                    }
-                }
-            ],
-            "result": {
-                "name": "result",
-                "description": "The compiled contract class",
-                "schema": {
-                    "title": "Starknet get compiled CASM result",
-                    "$ref": "#/components/schemas/CASM_COMPILED_CONTRACT_CLASS"
-                }
-            },
-            "errors": [
-                {
-                    "$ref": "#/components/errors/COMPILATION_ERROR"
-                },
-                {
-                    "$ref": "./api/starknet_api_openrpc.json#/components/errors/CLASS_HASH_NOT_FOUND"
-                }
-            ]
+          "name": "class_hash",
+          "description": "The hash of the contract class whose CASM will be returned",
+          "required": true,
+          "schema": {
+            "title": "Field element",
+            "$ref": "#/components/schemas/FELT"
+          }
         }
-    ],
-    "components": {
-        "contentDescriptors": {},
-        "schemas": {
-            "CASM_COMPILED_CONTRACT_CLASS": {
-                "type": "object",
-                "properties": {
-                    "entry_points_by_type": {
-                        "title": "Entry points by type",
-                        "type": "object",
-                        "properties": {
-                            "CONSTRUCTOR": {
-                                "type": "array",
-                                "title": "Constructor",
-                                "items": {
-                                    "$ref": "#/components/schemas/CASM_ENTRY_POINT"
-                                }
-                            },
-                            "EXTERNAL": {
-                                "title": "External",
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CASM_ENTRY_POINT"
-                                }
-                            },
-                            "L1_HANDLER": {
-                                "title": "L1 handler",
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CASM_ENTRY_POINT"
-                                }
-                            }
-                        },
-                        "required": [
-                            "CONSTRUCTOR",
-                            "EXTERNAL",
-                            "L1_HANDLER"
-                        ]
-                    },
-                    "bytecode": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/FELT"
-                        }
-                    },
-                    "prime": {
-                        "$ref": "#/components/schemas/NUM_AS_HEX"
-                    },
-                    "compiler_version": {
-                        "type": "string"
-                    },
-                    "hints": {
-                        "type": "array",
-                        "items": {
-                            "type": "array",
-                            "description": "2-tuple of pc value and an array of hints to execute",
-                            "items": {
-                                "oneOf": [
-                                    {
-                                        "type": "integer"
-                                    },
-                                    {
-                                        "type": "array",
-                                        "items": {
-                                            "$ref": "#/components/schemas/HINT"
-                                        }
-                                    }
-                                ]
-                            },
-                            "minItems": 2,
-                            "maxItems": 2
-                        }
-                    },
-                    "bytecode_segment_lengths": {
-                        "type": "array",
-                        "description": "a list of sizes of segments in the bytecode, each segment is hashed individually when computing the bytecode hash",
-                        "items": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "required": [
-                    "prime",
-                    "compiler_version",
-                    "entry_points_by_type",
-                    "bytecode",
-                    "hints"
-                ]
-            },
-            "CASM_ENTRY_POINT": {
-                "type": "object",
-                "properties": {
-                    "offset": {
-                        "title": "Offset",
-                        "description": "The offset of the entry point in the program",
-                        "type": "integer"
-                    },
-                    "selector": {
-                        "title": "Selector",
-                        "description": "A unique identifier of the entry point (function) in the program",
-                        "$ref": "#/components/schemas/FELT"
-                    },
-                    "builtins": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "required": ["offset", "selector", "builtins"]
-            },
-            "CellRef": {
-                "title": "CellRef",
-                "type": "object",
-                "properties": {
-                    "register": {
-                        "type": "string",
-                        "enum": [
-                            "AP",
-                            "FP"
-                        ]
-                    },
-                    "offset": {
-                        "type": "integer"
-                    }
-                },
-                "required": [
-                    "register",
-                    "offset"
-                ]
-            },
-            "Deref": {
-                "type": "object",
-                "properties": {
-                    "Deref": {
-                        "$ref": "#/components/schemas/CellRef"
-                    }
-                },
-                "required": [
-                    "Deref"
-                ]
-            },
-            "DoubleDeref": {
-                "title": "DoubleDeref",
-                "type": "object",
-                "properties": {
-                    "DoubleDeref": {
-                        "title": "DoubleDeref",
-                        "description": "A (CellRef, offset) tuple",
-                        "type": "array",
-                        "items": {
-                            "oneOf": [
-                                {
-                                    "$ref": "#/components/schemas/CellRef"
-                                },
-                                {
-                                    "type": "integer"
-                                }
-                            ]
-                        },
-                        "minItems": 2,
-                        "maxItems": 2
-                    }
-                },
-                "required": [
-                    "DoubleDeref"
-                ]
-            },
-            "Immediate": {
-                "title": "Immediate",
-                "type": "object",
-                "properties": {
-                    "Immediate": {
-                        "$ref": "#/components/schemas/NUM_AS_HEX"
-                    }
-                },
-                "required": [
-                    "Immediate"
-                ]
-            },
-            "BinOp":{
-                "title": "BinOperand",
-                "type": "object",
-                "properties":{
-                    "BinOp": {
-                        "type": "object",
-                        "properties": {
-                        "op": {
-                            "type": "string",
-                            "enum": [
-                                "Add",
-                                "Mul"
-                            ]
-                        },
-                        "a": {
-                            "$ref": "#/components/schemas/CellRef"
-                        },
-                        "b": {
-                            "oneOf": [
-                                {
-                                    "$ref": "#/components/schemas/Deref"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/Immediate"
-                                }
-                            ]
-                        }
-                        },
-                        "required":[
-                            "op",
-                            "a",
-                            "b"
-                        ]
-                    }
-                },
-                "required":[
-                    "BinOp"
-                ]
-            },
-            "ResOperand": {
-                "oneOf": [
-                    {
-                        "$ref": "#/components/schemas/Deref"
-                    },
-                    {
-                        "$ref": "#/components/schemas/DoubleDeref"
-                    },
-                    {
-                        "$ref": "#/components/schemas/Immediate"
-                    },
-                    {
-                        "$ref": "#/components/schemas/BinOp"
-                    }
-                ]
-            },
-            "HINT": {
-                "oneOf": [
-                    {
-                        "$ref": "#/components/schemas/DEPRECATED_HINT"
-                    },
-                    {
-                        "$ref": "#/components/schemas/CORE_HINT"
-                    },
-                    {
-                        "$ref": "#/components/schemas/STARKNET_HINT"
-                    }
-                ]
-            },
-            "DEPRECATED_HINT": {
-                "oneOf": [
-                    {
-                        "type": "string",
-                        "title": "AssertCurrentAccessIndicesIsEmpty",
-                        "enum": [
-                            "AssertCurrentAccessIndicesIsEmpty"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "AssertAllAccessesUsed",
-                        "properties": {
-                            "AssertAllAccessesUsed": {
-                                "type": "object",
-                                "properties": {
-                                    "n_used_accesses": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "n_used_accesses"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "AssertAllAccessesUsed"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "title": "AssertAllKeysUsed",
-                        "enum": [
-                            "AssertAllKeysUsed"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "title": "AssertLeAssertThirdArcExcluded",
-                        "enum": [
-                            "AssertLeAssertThirdArcExcluded"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "AssertLtAssertValidInput",
-                        "properties": {
-                            "AssertLtAssertValidInput": {
-                                "type": "object",
-                                "properties": {
-                                    "a": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "b": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    }
-                                },
-                                "required": [
-                                    "a",
-                                    "b"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "AssertLtAssertValidInput"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "Felt252DictRead",
-                        "properties": {
-                            "Felt252DictRead": {
-                                "type": "object",
-                                "properties": {
-                                    "dict_ptr": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "key": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "value_dst": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "dict_ptr",
-                                    "key",
-                                    "value_dst"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "Felt252DictRead"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "Felt252DictWrite",
-                        "properties": {
-                            "Felt252DictWrite": {
-                                "type": "object",
-                                "properties": {
-                                    "dict_ptr": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "key": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "value": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    }
-                                },
-                                "required": [
-                                    "dict_ptr",
-                                    "key",
-                                    "value"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "Felt252DictWrite"
-                        ]
-                    }
-                ]
-            },
-            "CORE_HINT": {
-                "oneOf": [
-                    {
-                        "type": "object",
-                        "title": "AllocSegment",
-                        "properties": {
-                            "AllocSegment": {
-                                "type": "object",
-                                "properties": {
-                                    "dst": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "dst"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "AllocSegment"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "TestLessThan",
-                        "properties": {
-                            "TestLessThan": {
-                                "type": "object",
-                                "properties": {
-                                    "lhs": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "rhs": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "dst": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "lhs",
-                                    "rhs",
-                                    "dst"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "TestLessThan"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "TestLessThanOrEqual",
-                        "properties": {
-                            "TestLessThanOrEqual": {
-                                "type": "object",
-                                "properties": {
-                                    "lhs": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "rhs": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "dst": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "lhs",
-                                    "rhs",
-                                    "dst"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "TestLessThanOrEqual"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "TestLessThanOrEqualAddress",
-                        "properties": {
-                            "TestLessThanOrEqualAddress": {
-                                "type": "object",
-                                "properties": {
-                                    "lhs": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "rhs": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "dst": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "lhs",
-                                    "rhs",
-                                    "dst"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "TestLessThanOrEqualAddress"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "WideMul128",
-                        "properties": {
-                            "WideMul128": {
-                                "type": "object",
-                                "properties": {
-                                    "lhs": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "rhs": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "high": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "low": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "lhs",
-                                    "rhs",
-                                    "high",
-                                    "low"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "WideMul128"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "DivMod",
-                        "properties": {
-                            "DivMod": {
-                                "type": "object",
-                                "properties": {
-                                    "lhs": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "rhs": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "quotient": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "remainder": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "lhs",
-                                    "rhs",
-                                    "quotient",
-                                    "remainder"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "DivMod"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "Uint256DivMod",
-                        "properties": {
-                            "Uint256DivMod": {
-                                "type": "object",
-                                "properties": {
-                                    "dividend0": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "dividend1": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "divisor0": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "divisor1": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "quotient0": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "quotient1": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "remainder0": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "remainder1": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "dividend0",
-                                    "dividend1",
-                                    "divisor0",
-                                    "divisor1",
-                                    "quotient0",
-                                    "quotient1",
-                                    "remainder0",
-                                    "remainder1"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "Uint256DivMod"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "Uint512DivModByUint256",
-                        "properties": {
-                            "Uint512DivModByUint256": {
-                                "type": "object",
-                                "properties": {
-                                    "dividend0": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "dividend1": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "dividend2": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "dividend3": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "divisor0": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "divisor1": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "quotient0": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "quotient1": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "quotient2": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "quotient3": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "remainder0": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "remainder1": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "dividend0",
-                                    "dividend1",
-                                    "dividend2",
-                                    "dividend3",
-                                    "divisor0",
-                                    "divisor1",
-                                    "quotient0",
-                                    "quotient1",
-                                    "quotient2",
-                                    "quotient3",
-                                    "remainder0",
-                                    "remainder1"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "Uint512DivModByUint256"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "SquareRoot",
-                        "properties": {
-                            "SquareRoot": {
-                                "type": "object",
-                                "properties": {
-                                    "value": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "dst": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "value",
-                                    "dst"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "SquareRoot"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "Uint256SquareRoot",
-                        "properties": {
-                            "Uint256SquareRoot": {
-                                "type": "object",
-                                "properties": {
-                                    "value_low": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "value_high": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "sqrt0": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "sqrt1": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "remainder_low": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "remainder_high": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "sqrt_mul_2_minus_remainder_ge_u128": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "value_low",
-                                    "value_high",
-                                    "sqrt0",
-                                    "sqrt1",
-                                    "remainder_low",
-                                    "remainder_high",
-                                    "sqrt_mul_2_minus_remainder_ge_u128"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "Uint256SquareRoot"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "LinearSplit",
-                        "properties": {
-                            "LinearSplit": {
-                                "type": "object",
-                                "properties": {
-                                    "value": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "scalar": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "max_x": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "x": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "y": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "value",
-                                    "scalar",
-                                    "max_x",
-                                    "x",
-                                    "y"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "LinearSplit"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "AllocFelt252Dict",
-                        "properties": {
-                            "AllocFelt252Dict": {
-                                "type": "object",
-                                "properties": {
-                                    "segment_arena_ptr": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    }
-                                },
-                                "required": [
-                                    "segment_arena_ptr"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "AllocFelt252Dict"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "Felt252DictEntryInit",
-                        "properties": {
-                            "Felt252DictEntryInit": {
-                                "type": "object",
-                                "properties": {
-                                    "dict_ptr": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "key": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    }
-                                },
-                                "required": [
-                                    "dict_ptr",
-                                    "key"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "Felt252DictEntryInit"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "Felt252DictEntryUpdate",
-                        "properties": {
-                            "Felt252DictEntryUpdate": {
-                                "type": "object",
-                                "properties": {
-                                    "dict_ptr": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "value": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    }
-                                },
-                                "required": [
-                                    "dict_ptr",
-                                    "value"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "Felt252DictEntryUpdate"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "GetSegmentArenaIndex",
-                        "properties": {
-                            "GetSegmentArenaIndex": {
-                                "type": "object",
-                                "properties": {
-                                    "dict_end_ptr": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "dict_index": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "dict_end_ptr",
-                                    "dict_index"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "GetSegmentArenaIndex"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "InitSquashData",
-                        "properties": {
-                            "InitSquashData": {
-                                "type": "object",
-                                "properties": {
-                                    "dict_accesses": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "ptr_diff": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "n_accesses": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "big_keys": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "first_key": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "dict_accesses",
-                                    "ptr_diff",
-                                    "n_accesses",
-                                    "big_keys",
-                                    "first_key"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "InitSquashData"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "GetCurrentAccessIndex",
-                        "properties": {
-                            "GetCurrentAccessIndex": {
-                                "type": "object",
-                                "properties": {
-                                    "range_check_ptr": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    }
-                                },
-                                "required": [
-                                    "range_check_ptr"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "GetCurrentAccessIndex"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "ShouldSkipSquashLoop",
-                        "properties": {
-                            "ShouldSkipSquashLoop": {
-                                "type": "object",
-                                "properties": {
-                                    "should_skip_loop": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "should_skip_loop"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "ShouldSkipSquashLoop"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "GetCurrentAccessDelta",
-                        "properties": {
-                            "GetCurrentAccessDelta": {
-                                "type": "object",
-                                "properties": {
-                                    "index_delta_minus1": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "index_delta_minus1"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "GetCurrentAccessDelta"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "ShouldContinueSquashLoop",
-                        "properties": {
-                            "ShouldContinueSquashLoop": {
-                                "type": "object",
-                                "properties": {
-                                    "should_continue": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "should_continue"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "ShouldContinueSquashLoop"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "GetNextDictKey",
-                        "properties": {
-                            "GetNextDictKey": {
-                                "type": "object",
-                                "properties": {
-                                    "next_key": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "next_key"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "GetNextDictKey"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "AssertLeFindSmallArcs",
-                        "properties": {
-                            "AssertLeFindSmallArcs": {
-                                "type": "object",
-                                "properties": {
-                                    "range_check_ptr": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "a": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "b": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    }
-                                },
-                                "required": [
-                                    "range_check_ptr",
-                                    "a",
-                                    "b"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "AssertLeFindSmallArcs"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "AssertLeIsFirstArcExcluded",
-                        "properties": {
-                            "AssertLeIsFirstArcExcluded": {
-                                "type": "object",
-                                "properties": {
-                                    "skip_exclude_a_flag": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "skip_exclude_a_flag"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "AssertLeIsFirstArcExcluded"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "AssertLeIsSecondArcExcluded",
-                        "properties": {
-                            "AssertLeIsSecondArcExcluded": {
-                                "type": "object",
-                                "properties": {
-                                    "skip_exclude_b_minus_a": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "skip_exclude_b_minus_a"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "AssertLeIsSecondArcExcluded"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "RandomEcPoint",
-                        "properties": {
-                            "RandomEcPoint": {
-                                "type": "object",
-                                "properties": {
-                                    "x": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "y": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "x",
-                                    "y"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "RandomEcPoint"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "FieldSqrt",
-                        "properties": {
-                            "FieldSqrt": {
-                                "type": "object",
-                                "properties": {
-                                    "val": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "sqrt": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "val",
-                                    "sqrt"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "FieldSqrt"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "DebugPrint",
-                        "properties": {
-                            "DebugPrint": {
-                                "type": "object",
-                                "properties": {
-                                    "start": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "end": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    }
-                                },
-                                "required": [
-                                    "start",
-                                    "end"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "DebugPrint"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "AllocConstantSize",
-                        "properties": {
-                            "AllocConstantSize": {
-                                "type": "object",
-                                "properties": {
-                                    "size": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "dst": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "size",
-                                    "dst"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "AllocConstantSize"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "U256InvModN",
-                        "properties": {
-                            "U256InvModN": {
-                                "type": "object",
-                                "properties": {
-                                    "b0": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "b1": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "n0": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "n1": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "g0_or_no_inv": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "g1_option": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "s_or_r0": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "s_or_r1": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "t_or_k0": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "t_or_k1": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "b0",
-                                    "b1",
-                                    "n0",
-                                    "n1",
-                                    "g0_or_no_inv",
-                                    "g1_option",
-                                    "s_or_r0",
-                                    "s_or_r1",
-                                    "t_or_k0",
-                                    "t_or_k1"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "U256InvModN"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "EvalCircuit",
-                        "properties": {
-                            "EvalCircuit": {
-                                "type": "object",
-                                "properties": {
-                                    "n_add_mods": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "add_mod_builtin": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "n_mul_mods": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "mul_mod_builtin": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    }
-                                },
-                                "required": [
-                                    "n_add_mods",
-                                    "add_mod_builtin",
-                                    "n_mul_mods",
-                                    "mul_mod_builtin"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "EvalCircuit"
-                        ]
-                    }
-                ]
-            },
-            "STARKNET_HINT": {
-                "oneOf": [
-                    {
-                        "type": "object",
-                        "title": "SystemCall",
-                        "properties": {
-                            "SystemCall": {
-                                "type": "object",
-                                "properties": {
-                                    "system": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    }
-                                },
-                                "required": [
-                                    "system"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "SystemCall"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "Cheatcode",
-                        "properties": {
-                            "Cheatcode": {
-                                "type": "object",
-                                "properties": {
-                                    "selector": {
-                                        "$ref": "#/components/schemas/NUM_AS_HEX"
-                                    },
-                                    "input_start": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "input_end": {
-                                        "$ref": "#/components/schemas/ResOperand"
-                                    },
-                                    "output_start": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    },
-                                    "output_end": {
-                                        "$ref": "#/components/schemas/CellRef"
-                                    }
-                                },
-                                "required": [
-                                    "selector",
-                                    "input_start",
-                                    "input_end",
-                                    "output_start",
-                                    "output_end"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "Cheatcode"
-                        ]
-                    }
-                ]
-            },
-            "FELT": {
-                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/FELT"
-            },
-            "NUM_AS_HEX": {
-                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/NUM_AS_HEX"
-            },
-            "DEPRECATED_CAIRO_ENTRY_POINT": {
-                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/DEPRECATED_CAIRO_ENTRY_POINT"
-            }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The compiled contract class",
+        "schema": {
+          "title": "Starknet get compiled CASM result",
+          "$ref": "#/components/schemas/CASM_COMPILED_CONTRACT_CLASS"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/COMPILATION_ERROR"
         },
-        "errors": {
-            "COMPILATION_ERROR": {
-                "code": 100,
-                "message": "Failed to compile the contract",
-                "data": {
-                    "type": "object",
-                    "description": "More data about the compilation failure",
-                    "properties": {
-                        "compilation_error": {
-                            "title": "compilation error",
-                            "type": "string"
-                        }
-                    },
-                    "required": "compilation_error"
-                }
-            }
+        {
+          "$ref": "./api/starknet_api_openrpc.json#/components/errors/CLASS_HASH_NOT_FOUND"
         }
+      ]
     }
+  ],
+  "components": {
+    "contentDescriptors": {},
+    "schemas": {
+      "CASM_COMPILED_CONTRACT_CLASS": {
+        "type": "object",
+        "properties": {
+          "entry_points_by_type": {
+            "title": "Entry points by type",
+            "type": "object",
+            "properties": {
+              "CONSTRUCTOR": {
+                "type": "array",
+                "title": "Constructor",
+                "items": {
+                  "$ref": "#/components/schemas/CASM_ENTRY_POINT"
+                }
+              },
+              "EXTERNAL": {
+                "title": "External",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/CASM_ENTRY_POINT"
+                }
+              },
+              "L1_HANDLER": {
+                "title": "L1 handler",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/CASM_ENTRY_POINT"
+                }
+              }
+            },
+            "required": ["CONSTRUCTOR", "EXTERNAL", "L1_HANDLER"]
+          },
+          "bytecode": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            }
+          },
+          "prime": {
+            "$ref": "#/components/schemas/NUM_AS_HEX"
+          },
+          "compiler_version": {
+            "type": "string"
+          },
+          "hints": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "description": "2-tuple of pc value and an array of hints to execute",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/HINT"
+                    }
+                  }
+                ]
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "bytecode_segment_lengths": {
+            "type": "array",
+            "description": "a list of sizes of segments in the bytecode, each segment is hashed individually when computing the bytecode hash",
+            "items": {
+              "type": "integer"
+            }
+          }
+        },
+        "required": [
+          "prime",
+          "compiler_version",
+          "entry_points_by_type",
+          "bytecode",
+          "hints"
+        ]
+      },
+      "CASM_ENTRY_POINT": {
+        "type": "object",
+        "properties": {
+          "offset": {
+            "title": "Offset",
+            "description": "The offset of the entry point in the program",
+            "type": "integer"
+          },
+          "selector": {
+            "title": "Selector",
+            "description": "A unique identifier of the entry point (function) in the program",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "builtins": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["offset", "selector", "builtins"]
+      },
+      "CellRef": {
+        "title": "CellRef",
+        "type": "object",
+        "properties": {
+          "register": {
+            "type": "string",
+            "enum": ["AP", "FP"]
+          },
+          "offset": {
+            "type": "integer"
+          }
+        },
+        "required": ["register", "offset"]
+      },
+      "Deref": {
+        "type": "object",
+        "properties": {
+          "Deref": {
+            "$ref": "#/components/schemas/CellRef"
+          }
+        },
+        "required": ["Deref"]
+      },
+      "DoubleDeref": {
+        "title": "DoubleDeref",
+        "type": "object",
+        "properties": {
+          "DoubleDeref": {
+            "title": "DoubleDeref",
+            "description": "A (CellRef, offset) tuple",
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/CellRef"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "minItems": 2,
+            "maxItems": 2
+          }
+        },
+        "required": ["DoubleDeref"]
+      },
+      "Immediate": {
+        "title": "Immediate",
+        "type": "object",
+        "properties": {
+          "Immediate": {
+            "$ref": "#/components/schemas/NUM_AS_HEX"
+          }
+        },
+        "required": ["Immediate"]
+      },
+      "BinOp": {
+        "title": "BinOperand",
+        "type": "object",
+        "properties": {
+          "BinOp": {
+            "type": "object",
+            "properties": {
+              "op": {
+                "type": "string",
+                "enum": ["Add", "Mul"]
+              },
+              "a": {
+                "$ref": "#/components/schemas/CellRef"
+              },
+              "b": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/Deref"
+                  },
+                  {
+                    "$ref": "#/components/schemas/Immediate"
+                  }
+                ]
+              }
+            },
+            "required": ["op", "a", "b"]
+          }
+        },
+        "required": ["BinOp"]
+      },
+      "ResOperand": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/Deref"
+          },
+          {
+            "$ref": "#/components/schemas/DoubleDeref"
+          },
+          {
+            "$ref": "#/components/schemas/Immediate"
+          },
+          {
+            "$ref": "#/components/schemas/BinOp"
+          }
+        ]
+      },
+      "HINT": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/DEPRECATED_HINT"
+          },
+          {
+            "$ref": "#/components/schemas/CORE_HINT"
+          },
+          {
+            "$ref": "#/components/schemas/STARKNET_HINT"
+          }
+        ]
+      },
+      "DEPRECATED_HINT": {
+        "oneOf": [
+          {
+            "type": "string",
+            "title": "AssertCurrentAccessIndicesIsEmpty",
+            "enum": ["AssertCurrentAccessIndicesIsEmpty"]
+          },
+          {
+            "type": "object",
+            "title": "AssertAllAccessesUsed",
+            "properties": {
+              "AssertAllAccessesUsed": {
+                "type": "object",
+                "properties": {
+                  "n_used_accesses": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["n_used_accesses"]
+              }
+            },
+            "required": ["AssertAllAccessesUsed"]
+          },
+          {
+            "type": "string",
+            "title": "AssertAllKeysUsed",
+            "enum": ["AssertAllKeysUsed"]
+          },
+          {
+            "type": "string",
+            "title": "AssertLeAssertThirdArcExcluded",
+            "enum": ["AssertLeAssertThirdArcExcluded"]
+          },
+          {
+            "type": "object",
+            "title": "AssertLtAssertValidInput",
+            "properties": {
+              "AssertLtAssertValidInput": {
+                "type": "object",
+                "properties": {
+                  "a": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "b": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  }
+                },
+                "required": ["a", "b"]
+              }
+            },
+            "required": ["AssertLtAssertValidInput"]
+          },
+          {
+            "type": "object",
+            "title": "Felt252DictRead",
+            "properties": {
+              "Felt252DictRead": {
+                "type": "object",
+                "properties": {
+                  "dict_ptr": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "key": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "value_dst": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["dict_ptr", "key", "value_dst"]
+              }
+            },
+            "required": ["Felt252DictRead"]
+          },
+          {
+            "type": "object",
+            "title": "Felt252DictWrite",
+            "properties": {
+              "Felt252DictWrite": {
+                "type": "object",
+                "properties": {
+                  "dict_ptr": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "key": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "value": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  }
+                },
+                "required": ["dict_ptr", "key", "value"]
+              }
+            },
+            "required": ["Felt252DictWrite"]
+          }
+        ]
+      },
+      "CORE_HINT": {
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "AllocSegment",
+            "properties": {
+              "AllocSegment": {
+                "type": "object",
+                "properties": {
+                  "dst": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["dst"]
+              }
+            },
+            "required": ["AllocSegment"]
+          },
+          {
+            "type": "object",
+            "title": "TestLessThan",
+            "properties": {
+              "TestLessThan": {
+                "type": "object",
+                "properties": {
+                  "lhs": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "rhs": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "dst": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["lhs", "rhs", "dst"]
+              }
+            },
+            "required": ["TestLessThan"]
+          },
+          {
+            "type": "object",
+            "title": "TestLessThanOrEqual",
+            "properties": {
+              "TestLessThanOrEqual": {
+                "type": "object",
+                "properties": {
+                  "lhs": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "rhs": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "dst": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["lhs", "rhs", "dst"]
+              }
+            },
+            "required": ["TestLessThanOrEqual"]
+          },
+          {
+            "type": "object",
+            "title": "TestLessThanOrEqualAddress",
+            "properties": {
+              "TestLessThanOrEqualAddress": {
+                "type": "object",
+                "properties": {
+                  "lhs": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "rhs": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "dst": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["lhs", "rhs", "dst"]
+              }
+            },
+            "required": ["TestLessThanOrEqualAddress"]
+          },
+          {
+            "type": "object",
+            "title": "WideMul128",
+            "properties": {
+              "WideMul128": {
+                "type": "object",
+                "properties": {
+                  "lhs": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "rhs": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "high": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "low": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["lhs", "rhs", "high", "low"]
+              }
+            },
+            "required": ["WideMul128"]
+          },
+          {
+            "type": "object",
+            "title": "DivMod",
+            "properties": {
+              "DivMod": {
+                "type": "object",
+                "properties": {
+                  "lhs": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "rhs": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "quotient": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "remainder": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["lhs", "rhs", "quotient", "remainder"]
+              }
+            },
+            "required": ["DivMod"]
+          },
+          {
+            "type": "object",
+            "title": "Uint256DivMod",
+            "properties": {
+              "Uint256DivMod": {
+                "type": "object",
+                "properties": {
+                  "dividend0": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "dividend1": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "divisor0": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "divisor1": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "quotient0": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "quotient1": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "remainder0": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "remainder1": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": [
+                  "dividend0",
+                  "dividend1",
+                  "divisor0",
+                  "divisor1",
+                  "quotient0",
+                  "quotient1",
+                  "remainder0",
+                  "remainder1"
+                ]
+              }
+            },
+            "required": ["Uint256DivMod"]
+          },
+          {
+            "type": "object",
+            "title": "Uint512DivModByUint256",
+            "properties": {
+              "Uint512DivModByUint256": {
+                "type": "object",
+                "properties": {
+                  "dividend0": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "dividend1": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "dividend2": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "dividend3": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "divisor0": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "divisor1": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "quotient0": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "quotient1": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "quotient2": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "quotient3": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "remainder0": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "remainder1": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": [
+                  "dividend0",
+                  "dividend1",
+                  "dividend2",
+                  "dividend3",
+                  "divisor0",
+                  "divisor1",
+                  "quotient0",
+                  "quotient1",
+                  "quotient2",
+                  "quotient3",
+                  "remainder0",
+                  "remainder1"
+                ]
+              }
+            },
+            "required": ["Uint512DivModByUint256"]
+          },
+          {
+            "type": "object",
+            "title": "SquareRoot",
+            "properties": {
+              "SquareRoot": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "dst": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["value", "dst"]
+              }
+            },
+            "required": ["SquareRoot"]
+          },
+          {
+            "type": "object",
+            "title": "Uint256SquareRoot",
+            "properties": {
+              "Uint256SquareRoot": {
+                "type": "object",
+                "properties": {
+                  "value_low": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "value_high": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "sqrt0": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "sqrt1": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "remainder_low": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "remainder_high": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "sqrt_mul_2_minus_remainder_ge_u128": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": [
+                  "value_low",
+                  "value_high",
+                  "sqrt0",
+                  "sqrt1",
+                  "remainder_low",
+                  "remainder_high",
+                  "sqrt_mul_2_minus_remainder_ge_u128"
+                ]
+              }
+            },
+            "required": ["Uint256SquareRoot"]
+          },
+          {
+            "type": "object",
+            "title": "LinearSplit",
+            "properties": {
+              "LinearSplit": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "scalar": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "max_x": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "x": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "y": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["value", "scalar", "max_x", "x", "y"]
+              }
+            },
+            "required": ["LinearSplit"]
+          },
+          {
+            "type": "object",
+            "title": "AllocFelt252Dict",
+            "properties": {
+              "AllocFelt252Dict": {
+                "type": "object",
+                "properties": {
+                  "segment_arena_ptr": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  }
+                },
+                "required": ["segment_arena_ptr"]
+              }
+            },
+            "required": ["AllocFelt252Dict"]
+          },
+          {
+            "type": "object",
+            "title": "Felt252DictEntryInit",
+            "properties": {
+              "Felt252DictEntryInit": {
+                "type": "object",
+                "properties": {
+                  "dict_ptr": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "key": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  }
+                },
+                "required": ["dict_ptr", "key"]
+              }
+            },
+            "required": ["Felt252DictEntryInit"]
+          },
+          {
+            "type": "object",
+            "title": "Felt252DictEntryUpdate",
+            "properties": {
+              "Felt252DictEntryUpdate": {
+                "type": "object",
+                "properties": {
+                  "dict_ptr": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "value": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  }
+                },
+                "required": ["dict_ptr", "value"]
+              }
+            },
+            "required": ["Felt252DictEntryUpdate"]
+          },
+          {
+            "type": "object",
+            "title": "GetSegmentArenaIndex",
+            "properties": {
+              "GetSegmentArenaIndex": {
+                "type": "object",
+                "properties": {
+                  "dict_end_ptr": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "dict_index": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["dict_end_ptr", "dict_index"]
+              }
+            },
+            "required": ["GetSegmentArenaIndex"]
+          },
+          {
+            "type": "object",
+            "title": "InitSquashData",
+            "properties": {
+              "InitSquashData": {
+                "type": "object",
+                "properties": {
+                  "dict_accesses": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "ptr_diff": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "n_accesses": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "big_keys": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "first_key": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": [
+                  "dict_accesses",
+                  "ptr_diff",
+                  "n_accesses",
+                  "big_keys",
+                  "first_key"
+                ]
+              }
+            },
+            "required": ["InitSquashData"]
+          },
+          {
+            "type": "object",
+            "title": "GetCurrentAccessIndex",
+            "properties": {
+              "GetCurrentAccessIndex": {
+                "type": "object",
+                "properties": {
+                  "range_check_ptr": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  }
+                },
+                "required": ["range_check_ptr"]
+              }
+            },
+            "required": ["GetCurrentAccessIndex"]
+          },
+          {
+            "type": "object",
+            "title": "ShouldSkipSquashLoop",
+            "properties": {
+              "ShouldSkipSquashLoop": {
+                "type": "object",
+                "properties": {
+                  "should_skip_loop": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["should_skip_loop"]
+              }
+            },
+            "required": ["ShouldSkipSquashLoop"]
+          },
+          {
+            "type": "object",
+            "title": "GetCurrentAccessDelta",
+            "properties": {
+              "GetCurrentAccessDelta": {
+                "type": "object",
+                "properties": {
+                  "index_delta_minus1": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["index_delta_minus1"]
+              }
+            },
+            "required": ["GetCurrentAccessDelta"]
+          },
+          {
+            "type": "object",
+            "title": "ShouldContinueSquashLoop",
+            "properties": {
+              "ShouldContinueSquashLoop": {
+                "type": "object",
+                "properties": {
+                  "should_continue": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["should_continue"]
+              }
+            },
+            "required": ["ShouldContinueSquashLoop"]
+          },
+          {
+            "type": "object",
+            "title": "GetNextDictKey",
+            "properties": {
+              "GetNextDictKey": {
+                "type": "object",
+                "properties": {
+                  "next_key": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["next_key"]
+              }
+            },
+            "required": ["GetNextDictKey"]
+          },
+          {
+            "type": "object",
+            "title": "AssertLeFindSmallArcs",
+            "properties": {
+              "AssertLeFindSmallArcs": {
+                "type": "object",
+                "properties": {
+                  "range_check_ptr": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "a": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "b": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  }
+                },
+                "required": ["range_check_ptr", "a", "b"]
+              }
+            },
+            "required": ["AssertLeFindSmallArcs"]
+          },
+          {
+            "type": "object",
+            "title": "AssertLeIsFirstArcExcluded",
+            "properties": {
+              "AssertLeIsFirstArcExcluded": {
+                "type": "object",
+                "properties": {
+                  "skip_exclude_a_flag": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["skip_exclude_a_flag"]
+              }
+            },
+            "required": ["AssertLeIsFirstArcExcluded"]
+          },
+          {
+            "type": "object",
+            "title": "AssertLeIsSecondArcExcluded",
+            "properties": {
+              "AssertLeIsSecondArcExcluded": {
+                "type": "object",
+                "properties": {
+                  "skip_exclude_b_minus_a": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["skip_exclude_b_minus_a"]
+              }
+            },
+            "required": ["AssertLeIsSecondArcExcluded"]
+          },
+          {
+            "type": "object",
+            "title": "RandomEcPoint",
+            "properties": {
+              "RandomEcPoint": {
+                "type": "object",
+                "properties": {
+                  "x": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "y": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["x", "y"]
+              }
+            },
+            "required": ["RandomEcPoint"]
+          },
+          {
+            "type": "object",
+            "title": "FieldSqrt",
+            "properties": {
+              "FieldSqrt": {
+                "type": "object",
+                "properties": {
+                  "val": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "sqrt": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["val", "sqrt"]
+              }
+            },
+            "required": ["FieldSqrt"]
+          },
+          {
+            "type": "object",
+            "title": "DebugPrint",
+            "properties": {
+              "DebugPrint": {
+                "type": "object",
+                "properties": {
+                  "start": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "end": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  }
+                },
+                "required": ["start", "end"]
+              }
+            },
+            "required": ["DebugPrint"]
+          },
+          {
+            "type": "object",
+            "title": "AllocConstantSize",
+            "properties": {
+              "AllocConstantSize": {
+                "type": "object",
+                "properties": {
+                  "size": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "dst": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["size", "dst"]
+              }
+            },
+            "required": ["AllocConstantSize"]
+          },
+          {
+            "type": "object",
+            "title": "U256InvModN",
+            "properties": {
+              "U256InvModN": {
+                "type": "object",
+                "properties": {
+                  "b0": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "b1": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "n0": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "n1": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "g0_or_no_inv": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "g1_option": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "s_or_r0": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "s_or_r1": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "t_or_k0": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "t_or_k1": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": [
+                  "b0",
+                  "b1",
+                  "n0",
+                  "n1",
+                  "g0_or_no_inv",
+                  "g1_option",
+                  "s_or_r0",
+                  "s_or_r1",
+                  "t_or_k0",
+                  "t_or_k1"
+                ]
+              }
+            },
+            "required": ["U256InvModN"]
+          },
+          {
+            "type": "object",
+            "title": "EvalCircuit",
+            "properties": {
+              "EvalCircuit": {
+                "type": "object",
+                "properties": {
+                  "n_add_mods": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "add_mod_builtin": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "n_mul_mods": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "mul_mod_builtin": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  }
+                },
+                "required": [
+                  "n_add_mods",
+                  "add_mod_builtin",
+                  "n_mul_mods",
+                  "mul_mod_builtin"
+                ]
+              }
+            },
+            "required": ["EvalCircuit"]
+          }
+        ]
+      },
+      "STARKNET_HINT": {
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "SystemCall",
+            "properties": {
+              "SystemCall": {
+                "type": "object",
+                "properties": {
+                  "system": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  }
+                },
+                "required": ["system"]
+              }
+            },
+            "required": ["SystemCall"]
+          },
+          {
+            "type": "object",
+            "title": "Cheatcode",
+            "properties": {
+              "Cheatcode": {
+                "type": "object",
+                "properties": {
+                  "selector": {
+                    "$ref": "#/components/schemas/NUM_AS_HEX"
+                  },
+                  "input_start": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "input_end": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "output_start": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "output_end": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": [
+                  "selector",
+                  "input_start",
+                  "input_end",
+                  "output_start",
+                  "output_end"
+                ]
+              }
+            },
+            "required": ["Cheatcode"]
+          }
+        ]
+      },
+      "FELT": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/FELT"
+      },
+      "NUM_AS_HEX": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/NUM_AS_HEX"
+      },
+      "DEPRECATED_CAIRO_ENTRY_POINT": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/DEPRECATED_CAIRO_ENTRY_POINT"
+      }
+    },
+    "errors": {
+      "COMPILATION_ERROR": {
+        "code": 100,
+        "message": "Failed to compile the contract",
+        "data": {
+          "type": "object",
+          "description": "More data about the compilation failure",
+          "properties": {
+            "compilation_error": {
+              "title": "compilation error",
+              "type": "string"
+            }
+          },
+          "required": "compilation_error"
+        }
+      }
+    }
+  }
 }

--- a/specs/rpc/v08/starknet_trace_api_openrpc.json
+++ b/specs/rpc/v08/starknet_trace_api_openrpc.json
@@ -257,7 +257,11 @@
                 "enum": ["DEPLOY_ACCOUNT"]
               }
             },
-            "required": ["type", "execution_resources", "constructor_invocation"]
+            "required": [
+              "type",
+              "execution_resources",
+              "constructor_invocation"
+            ]
           },
           {
             "name": "L1_HANDLER_TXN_TRACE",

--- a/specs/rpc/v08/starknet_ws_api.json
+++ b/specs/rpc/v08/starknet_ws_api.json
@@ -144,8 +144,7 @@
           "$ref": "#/components/schemas/SUBSCRIPTION_ID"
         }
       },
-      "errors": [
-      ]
+      "errors": []
     },
     {
       "name": "starknet_subscriptionTransactionStatus",
@@ -370,7 +369,12 @@
             "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_NUMBER"
           }
         },
-        "required": ["starting_block_hash", "starting_block_number", "ending_block_hash", "ending_block_number"]
+        "required": [
+          "starting_block_hash",
+          "starting_block_number",
+          "ending_block_hash",
+          "ending_block_number"
+        ]
       }
     },
     "errors": {

--- a/specs/rpc/v08/starknet_ws_api.json
+++ b/specs/rpc/v08/starknet_ws_api.json
@@ -303,7 +303,7 @@
         "name": "subscription id",
         "description": "An identifier for this subscription stream used to associate events with this subscription.",
         "schema": {
-          "type": "integer"
+          "type": "string"
         }
       },
       "SUBSCRIPTION_BLOCK_ID": {


### PR DESCRIPTION
This PR:

- Updates the OpenRPC specifications in our repo.
- Changes the value returned by `starknet_specVersion` to `0.8.1`.
- Adds a changelog entry.

Please note that upstream OpenRPC files have been reformatted (using Prettier), so please check this PR commit-by-commit to get the _real_ diff to the spec.

Closes: #2693
