### PR TITLE
fix(executor): simulate should return reverted transaction if L2 cap is too low

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- `starknet_simulateTransactions` returns an error instead of the trace of the reverted transaction if the L2 gas cap is insufficient.
+
 ## [0.16.3] - 2025-04-03
 
 ### Added

--- a/crates/executor/src/estimate.rs
+++ b/crates/executor/src/estimate.rs
@@ -39,7 +39,7 @@ pub fn estimate(
             .entered();
 
             let gas_vector_computation_mode = super::transaction::gas_vector_computation_mode(&tx);
-            let tx_info = if l2_gas_accounting_enabled(
+            let (tx_info, gas_limit) = if l2_gas_accounting_enabled(
                 &tx,
                 &state,
                 &block_context,
@@ -71,7 +71,7 @@ pub fn estimate(
 
             Ok(FeeEstimate::from_tx_and_gas_vector(
                 &tx,
-                &tx_info.receipt.gas,
+                &gas_limit,
                 &gas_vector_computation_mode,
                 &block_context,
             ))

--- a/crates/executor/src/estimate.rs
+++ b/crates/executor/src/estimate.rs
@@ -1,7 +1,8 @@
-use blockifier::transaction::objects::{HasRelatedFeeType, TransactionExecutionInfo};
+use blockifier::transaction::objects::HasRelatedFeeType;
 use blockifier::transaction::transaction_execution::Transaction;
 use pathfinder_common::TransactionHash;
 use starknet_api::block::FeeType;
+use starknet_api::execution_resources::GasVector;
 use starknet_api::transaction::fields::GasVectorComputationMode;
 use util::percentage::Percentage;
 
@@ -68,9 +69,9 @@ pub fn estimate(
                 "Transaction estimation finished"
             );
 
-            Ok(FeeEstimate::from_tx_and_tx_info(
+            Ok(FeeEstimate::from_tx_and_gas_vector(
                 &tx,
-                &tx_info,
+                &tx_info.receipt.gas,
                 &gas_vector_computation_mode,
                 &block_context,
             ))
@@ -79,9 +80,9 @@ pub fn estimate(
 }
 
 impl FeeEstimate {
-    pub(crate) fn from_tx_and_tx_info(
+    pub(crate) fn from_tx_and_gas_vector(
         transaction: &Transaction,
-        tx_info: &TransactionExecutionInfo,
+        gas_vector: &GasVector,
         gas_vector_computation_mode: &GasVectorComputationMode,
         block_context: &blockifier::context::BlockContext,
     ) -> Self {
@@ -97,8 +98,8 @@ impl FeeEstimate {
             Transaction::L1Handler(_) => None,
         };
 
-        FeeEstimate::from_tx_info_and_gas_price(
-            tx_info,
+        FeeEstimate::from_gas_vector_and_gas_price(
+            gas_vector,
             block_context.block_info(),
             fee_type,
             &minimal_gas_vector,

--- a/crates/executor/src/simulate.rs
+++ b/crates/executor/src/simulate.rs
@@ -120,9 +120,9 @@ pub fn simulate(
             tracing::trace!(actual_fee=%tx_info.receipt.fee.0, actual_resources=?tx_info.receipt.resources, "Transaction simulation finished");
 
             Ok(TransactionSimulation {
-                fee_estimation: FeeEstimate::from_tx_and_tx_info(
+                fee_estimation: FeeEstimate::from_tx_and_gas_vector(
                     &tx,
-                    &tx_info,
+                    &tx_info.receipt.gas,
                     &gas_vector_computation_mode,
                     &block_context,
                 ),

--- a/crates/executor/src/simulate.rs
+++ b/crates/executor/src/simulate.rs
@@ -97,7 +97,7 @@ pub fn simulate(
 
             let gas_vector_computation_mode = super::transaction::gas_vector_computation_mode(&tx);
             let mut tx_state = CachedState::<_>::create_transactional(&mut state);
-            let tx_info = if l2_gas_accounting_enabled(
+            let (tx_info, gas_limit) = if l2_gas_accounting_enabled(
                 &tx,
                 &tx_state,
                 &block_context,
@@ -122,7 +122,7 @@ pub fn simulate(
             Ok(TransactionSimulation {
                 fee_estimation: FeeEstimate::from_tx_and_gas_vector(
                     &tx,
-                    &tx_info.receipt.gas,
+                    &gas_limit,
                     &gas_vector_computation_mode,
                     &block_context,
                 ),

--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -1,7 +1,6 @@
 use std::collections::{BTreeMap, HashSet};
 
 use blockifier::execution::call_info::OrderedL2ToL1Message;
-use blockifier::transaction::objects::TransactionExecutionInfo;
 use pathfinder_common::prelude::*;
 use pathfinder_crypto::Felt;
 use starknet_api::block::{BlockInfo, FeeType};
@@ -23,13 +22,13 @@ pub struct FeeEstimate {
 
 impl FeeEstimate {
     /// Computes fee estimate from the transaction execution information.
-    pub(crate) fn from_tx_info_and_gas_price(
-        tx_info: &TransactionExecutionInfo,
+    pub(crate) fn from_gas_vector_and_gas_price(
+        gas_vector: &GasVector,
         block_info: &BlockInfo,
         fee_type: FeeType,
         minimal_gas_vector: &Option<GasVector>,
     ) -> FeeEstimate {
-        tracing::trace!(resources=?tx_info.receipt.resources, "Transaction resources");
+        tracing::trace!(?gas_vector, "Transaction resources");
         let gas_prices = block_info.gas_prices.gas_price_vector(&fee_type);
         let l1_gas_price = gas_prices.l1_gas_price.get();
         let l1_data_gas_price = gas_prices.l1_data_gas_price.get();
@@ -37,13 +36,9 @@ impl FeeEstimate {
 
         let minimal_gas_vector = minimal_gas_vector.unwrap_or_default();
 
-        let l1_gas_consumed = tx_info.receipt.gas.l1_gas.max(minimal_gas_vector.l1_gas);
-        let l1_data_gas_consumed = tx_info
-            .receipt
-            .gas
-            .l1_data_gas
-            .max(minimal_gas_vector.l1_data_gas);
-        let l2_gas_consumed = tx_info.receipt.gas.l2_gas.max(minimal_gas_vector.l2_gas);
+        let l1_gas_consumed = gas_vector.l1_gas.max(minimal_gas_vector.l1_gas);
+        let l1_data_gas_consumed = gas_vector.l1_data_gas.max(minimal_gas_vector.l1_data_gas);
+        let l2_gas_consumed = gas_vector.l2_gas.max(minimal_gas_vector.l2_gas);
 
         // Blockifier does not put the actual fee into the receipt if `max_fee` in the
         // transaction was zero. In that case we have to compute the fee

--- a/crates/rpc/fixtures/0.8.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_13_4.json
+++ b/crates/rpc/fixtures/0.8.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_13_4.json
@@ -318,7 +318,7 @@
       "execution_resources": {
         "l1_data_gas": 128,
         "l1_gas": 0,
-        "l2_gas": 761849
+        "l2_gas": 692590
       },
       "fee_transfer_invocation": {
         "call_type": "CALL",


### PR DESCRIPTION
During fee estimation, after finding the minimum L2 gas, we are re-running the transaction in case the initial L2 gas value in the transaction is too low. This is done so that simulate can return the proper error / reverted transaction.

There were two issues with our code:

1. We were always executing using `ExecutionBehaviorOnRevert::Fail`, which means that we were not able to return the reverted transaction (but return an error instead).
2. We were using an L2 gas vale of zero instead of the initial L2 gas during execution, which potentially lead to a different error.

This change addresses these issues and also fixes an imprecision. We have been using the transaction receipt in `TransactionExecutionInfo` to return the proper minimun L2 gas value to the caller in find_l2_gas_limit_and_execute_transaction(). However, that receipt is also used to produce the `execution_resources` field in the transaction trace, which in turn should contain the _actual_ L2 gas consumption.

find_l2_gas_limit_and_execute_transaction() now returns both: the transaction execution info should contain the _actual_ resource usage, and we return the gas vector that should be used to compute the fee estimate (using the minimum L2 gas) explicitly.

Closes: #2706