### PR TITLE
fix(rpc/trace): don't fall back to fetching traces from feeder gateway for unsupported versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `starknet_simulateTransactions` returns an error instead of the trace of the reverted transaction if the L2 gas cap is insufficient.
+- `starknet_traceTransaction` and `starknet_traceBlockTransactions` returns an internal error with no details upon encountering a transaction execution error.
 
 ## [0.16.3] - 2025-04-03
 

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -128,9 +128,6 @@ pub async fn trace_block_transactions(
         );
         let traces = match pathfinder_executor::trace(state, cache, hash, executor_transactions) {
             Ok(traces) => traces,
-            Err(TransactionExecutionError::ExecutionError { .. }) => {
-                return Ok(LocalExecution::Unsupported(transactions))
-            }
             Err(e) => return Err(e.into()),
         };
 

--- a/crates/rpc/src/method/trace_transaction.rs
+++ b/crates/rpc/src/method/trace_transaction.rs
@@ -154,15 +154,6 @@ pub async fn trace_transaction(
                         })?;
                     Ok(LocalExecution::Success(trace))
                 }
-                Err(TransactionExecutionError::ExecutionError { .. }) => {
-                    Ok(LocalExecution::Unsupported(
-                        transactions
-                            .into_iter()
-                            .find(|tx| tx.hash == input.transaction_hash)
-                            .unwrap()
-                            .clone(),
-                    ))
-                }
                 Err(e) => Err(e.into()),
             }
         })


### PR DESCRIPTION
When doing transaction traces we have a check that checks if the Starknet version is supported. If it's less than the earliest version we support for execution, then we try and fall back to the feeder gateway before even trying execution.

We also had a check that if a `TransactionExecutionError` was returned during tracing, we would fall back to the feeder gateway. This is not needed and can be removed, since at that point we can be sure that the version is supported and the feeder gateway will just return an error (it doesn't actually have traces from 0.13.1.1, our earliest supported version).

This change removes this fallback, which in turn was masking the error message that was generated during execution: the feeder gateway error was transformed into an `InternalError` and no details were included in the JSON-RPC response.

Now we will return the error message from the execution, which is more useful for the end user.

