### PR TITLE
fix(storage/events): don't return non-contiguous aggregate filters in `load_event_filter_range()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `starknet_simulateTransactions` returns an error instead of the trace of the reverted transaction if the L2 gas cap is insufficient.
 - `starknet_traceTransaction` and `starknet_traceBlockTransactions` returns an internal error with no details upon encountering a transaction execution error.
+- `starknet_getEvents` returns an incomplete set of events for some queries over a block range larger than 106k blocks.
 
 ## [0.16.3] - 2025-04-03
 

--- a/crates/storage/src/connection/event.rs
+++ b/crates/storage/src/connection/event.rs
@@ -487,6 +487,13 @@ impl Transaction<'_> {
         self.event_filter_cache.set_many(&event_filters);
         event_filters.extend(cached_filters);
         event_filters.sort_by_key(|filter| filter.from_block);
+        let num_cont = event_filters
+            .windows(2)
+            .take_while(|filters| filters[0].to_block + 1 == filters[1].from_block)
+            .count()
+            // need to add 1 to include the last filter in the range
+            + 1;
+        event_filters.truncate(num_cont);
 
         let total_loaded_filters = total_event_filters - cache_hits;
         let load_limit_reached = total_loaded_filters > max_event_filters_to_load;


### PR DESCRIPTION
There's a bug in the processing logic when we combine `max_event_filters_to_load` in the SQLite query and cached filters that are within the block range.

Due to simply appending the cached aggregate filters to the set of filters returned it's possible that there's a hole in the block range covered by the filters. In case there are more than `max_event_filters_to_load` filters in the database, we stop loading filters when we reach the limit. However, the cached filters that are appended to the result set may not be contiguous with the last filter in the result set.

This breaks the assumption that the filters returned by `load_event_filter_range()` are contiguous, which causes `events()` to just skip evaluating ranges of blocks that are not covered by the filters.

Closes #2709

