### PR TITLE
fix(rpc): fix subscription id parsing for `starknet_unsubscribe`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - With pruning enabled, affected JSON-RPC method requests will only succeed if the requested block is within the last N + 1 blocks.
   - The choice between `archive` and `pruned` mode is made once, when creating the database. Once chosen, it cannot be changed without creating a new database.
   - It is possible to change the number of blocks stored in pruned mode between runs, using the same CLI option with a different value for N.
+  
+
+### Fixed
+
+- `starknet_unsubscribe` does not accept subscription IDs as strings.
 
 ### Changed
 

--- a/crates/rpc/src/dto.rs
+++ b/crates/rpc/src/dto.rs
@@ -216,6 +216,11 @@ impl Value {
         }
     }
 
+    pub fn from_str(data: &str, version: RpcVersion) -> Result<Self, serde_json::Error> {
+        let data = serde_json::from_str(data)?;
+        Ok(Self::new(data, version))
+    }
+
     pub fn is_string(&self) -> bool {
         self.data.is_string()
     }

--- a/crates/rpc/src/jsonrpc/request.rs
+++ b/crates/rpc/src/jsonrpc/request.rs
@@ -58,10 +58,9 @@ impl<'a> RawParams<'a> {
         version: RpcVersion,
     ) -> Result<T, RpcError> {
         let s = self.0.map(|x| x.get()).unwrap_or_default();
-        let value: serde_json::Value =
-            serde_json::from_str(s).map_err(|e| RpcError::InvalidParams(e.to_string()))?;
-        T::deserialize(Value::new(value, version))
-            .map_err(|e| RpcError::InvalidParams(e.to_string()))
+        let value =
+            Value::from_str(s, version).map_err(|e| RpcError::InvalidParams(e.to_string()))?;
+        T::deserialize(value).map_err(|e| RpcError::InvalidParams(e.to_string()))
     }
 }
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -890,11 +890,9 @@ mod tests {
         ];
 
         for (line, input, expected) in examples {
-            let parsed = Syncing::deserialize(crate::dto::Value::new(
-                serde_json::from_str(input).unwrap(),
-                RpcVersion::V07,
-            ))
-            .unwrap();
+            let parsed =
+                Syncing::deserialize(crate::dto::Value::from_str(input, RpcVersion::V07).unwrap())
+                    .unwrap();
             assert_eq!(parsed, expected, "example from line {line}");
         }
     }

--- a/crates/rpc/src/method/subscribe_new_heads.rs
+++ b/crates/rpc/src/method/subscribe_new_heads.rs
@@ -441,7 +441,7 @@ mod tests {
                 "jsonrpc": "2.0",
                 "id": 100,
                 "method": "starknet_unsubscribe",
-                "params": {"subscription_id": subscription_id.0}
+                "params": {"subscription_id": subscription_id.0.to_string()}
             })
             .to_string(),
         )))


### PR DESCRIPTION
`starknet_unsubscribe` was not parsing the subscription id correctly. Instead of using the `DeserializeForVersion` implementation for the subscription id, it was simply using `serde::Deserialize` which was defaulting to parsing the subscription id as an integer.

Closes: #2720 