### PR TITLE
fix(rpc): handle missing call_type field in feeder gateway block trace responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `starknet_estimateFee` is failing for Braavos DEPLOY_ACCOUNT transactions involving a new Sierra 1.7.0 class.
+- `starknet_traceBlockTransactions` fails for blocks <= 2687.
 
 ## [0.17.0-beta.1] - 2025-05-13
 

--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -178,12 +178,12 @@ pub struct Event {
 pub struct FunctionInvocation {
     pub calldata: Vec<Felt>,
     pub contract_address: ContractAddress,
-    pub selector: Felt,
-    pub call_type: CallType,
+    pub selector: Option<Felt>,
+    pub call_type: Option<CallType>,
     pub caller_address: Felt,
     pub internal_calls: Vec<FunctionInvocation>,
     pub class_hash: Option<Felt>,
-    pub entry_point_type: EntryPointType,
+    pub entry_point_type: Option<EntryPointType>,
     pub events: Vec<Event>,
     pub messages: Vec<MsgToL1>,
     pub result: Vec<Felt>,
@@ -341,15 +341,15 @@ impl FunctionInvocation {
             contract_address: ContractAddress::new_or_panic(
                 call_info.call.storage_address.0.key().into_felt(),
             ),
-            selector: call_info.call.entry_point_selector.0.into_felt(),
-            call_type: call_info.call.call_type.into(),
+            selector: Some(call_info.call.entry_point_selector.0.into_felt()),
+            call_type: Some(call_info.call.call_type.into()),
             caller_address: call_info.call.caller_address.0.key().into_felt(),
             internal_calls,
             class_hash: call_info
                 .call
                 .class_hash
                 .map(|class_hash| class_hash.0.into_felt()),
-            entry_point_type: call_info.call.entry_point_type.into(),
+            entry_point_type: Some(call_info.call.entry_point_type.into()),
             events,
             messages,
             result,

--- a/crates/rpc/fixtures/mainnet-200.json
+++ b/crates/rpc/fixtures/mainnet-200.json
@@ -1,0 +1,505 @@
+{
+    "block_hash": "0x4e9d705d6b47d8e4ddbb401216b2755f1e6983e241d9968f91084e0a4a02854",
+    "parent_block_hash": "0x5977880363d522779418c1790fd23d51e093a005f24e80b7ecfc4ff985ab9cd",
+    "block_number": 200,
+    "state_root": "0xb6ff22c51cceaf3955af3e0d82efa994de5af66b9baf8b0ca27991f1396e87",
+    "transaction_commitment": "0x0",
+    "event_commitment": "0x0",
+    "status": "ACCEPTED_ON_L1",
+    "l1_da_mode": "CALLDATA",
+    "l1_gas_price": {
+        "price_in_wei": "0x0",
+        "price_in_fri": "0x0"
+    },
+    "l1_data_gas_price": {
+        "price_in_wei": "0x1",
+        "price_in_fri": "0x1"
+    },
+    "l2_gas_price": {
+        "price_in_wei": "0x1",
+        "price_in_fri": "0x1"
+    },
+    "transactions": [
+        {
+            "transaction_hash": "0x149513f8ce216aa4c674b150369281b786b7766deea4cbaf931771dc985cb2",
+            "version": "0x0",
+            "max_fee": "0x0",
+            "signature": [],
+            "entry_point_selector": "0x12ead94ae9d3f9d2bdb6b847cf255f1f398193a1f88884a0ae8e18f24a037b6",
+            "calldata": [
+                "0x6adee7fb2b504ce9acc4f4ccc6e4232db5d30e7d"
+            ],
+            "contract_address": "0x7d3ef9de2e5a3d306db37dab9e968a376e0c3017b0eed8985090e48f57115c0",
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "transaction_hash": "0x6ec9ddd7acaeb34fccf3d59502c3c501ca8829dcbb9306577b5ba4e82d73017",
+            "version": "0x0",
+            "max_fee": "0x0",
+            "signature": [],
+            "entry_point_selector": "0x12ead94ae9d3f9d2bdb6b847cf255f1f398193a1f88884a0ae8e18f24a037b6",
+            "calldata": [
+                "0x7dfd8d5931cd60b9363d6f62d4ebd57bef6626f2"
+            ],
+            "contract_address": "0x6a203775cb9add394cb458c978080eb16dc03e09a358c973ff6094ad8b024ff",
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "transaction_hash": "0x47a4390fdfa1189840a10332eb4deb4600696d20c782a790a22692f7bf65368",
+            "version": "0x0",
+            "max_fee": "0x0",
+            "signature": [],
+            "entry_point_selector": "0x19a35a6e95cb7a3318dbb244f20975a1cd8587cc6b5259f15f61d7beb7ee43b",
+            "calldata": [
+                "0x45c7d372754e2687b0bbc0bc6df577d24bb23da6cc4cf04889f317374c7fe29",
+                "0x5f07dba883bf8ff58591294a7264ddfbe8ebb5acbf4879af92608dbcf09fc8"
+            ],
+            "contract_address": "0x64806831499bb4130752dc798d87e95d120c5b8968516d0a3432aecbfff69e4",
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "transaction_hash": "0x56873723e90a364a1d783709506d9306a1b9c36b4849be6e18a3e215d4f4d2a",
+            "version": "0x0",
+            "max_fee": "0x0",
+            "signature": [],
+            "entry_point_selector": "0x27c3334165536f239cfd400ed956eabff55fc60de4fb56728b6a4f6b87db01c",
+            "calldata": [
+                "0x180e185bcf26b51a6545d5bcf3980335b617adb020276bd92dc4d4ce3bcf133",
+                "0x218f305395474a84a39307fa5297be118fe17bf65e27ac5e2de6617baa44c64",
+                "0x2",
+                "0x3f372e56b0632c4f9e8e57f64f99dc41d9050d73cf7ad769e6ab6581b0bbaa0",
+                "0x0"
+            ],
+            "contract_address": "0x2e4ff7cab441fd49d6c9f728a621895283af2ecadb29d7baed6637bc0b3e5a3",
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "transaction_hash": "0x323d5a267929f18ba6b0d6bdbfac5e43db81df23079166ea36dea34c595cd4f",
+            "version": "0x0",
+            "max_fee": "0x0",
+            "signature": [],
+            "entry_point_selector": "0x12ead94ae9d3f9d2bdb6b847cf255f1f398193a1f88884a0ae8e18f24a037b6",
+            "calldata": [
+                "0x52a6ed4dbffc70bbaeeff7f662aa1bb41ce8f691"
+            ],
+            "contract_address": "0x13a7778053c853f14a319b8fa733835b948451e77ea464aa592d8f3bcefabce",
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "transaction_hash": "0x2d8a5f48341b95bb6ae3e644794e83328e35cf0e80e4107560d66858fac3dc7",
+            "version": "0x0",
+            "max_fee": "0x0",
+            "signature": [],
+            "entry_point_selector": "0x3d7905601c217734671143d457f0db37f7f8883112abd34b92c4abfeafde0c3",
+            "calldata": [
+                "0x3e6d642b7a67b346548ac1bbf45da13f8f638a97a37168c30720edac2bf75ad",
+                "0x75c14b8154afb76263ac0ad5c3734edd706ba00468cabc0160081866cb80097"
+            ],
+            "contract_address": "0x150399d7b867df0e4c48e7f4f8353ffe950a23de7c260fa57c9575cebe99465",
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "transaction_hash": "0x5534b234f3098fd5db3ea5fc44f09ee3a4c9ce9aa8b4873426237885e44665",
+            "version": "0x0",
+            "max_fee": "0x0",
+            "signature": [],
+            "entry_point_selector": "0x218f305395474a84a39307fa5297be118fe17bf65e27ac5e2de6617baa44c64",
+            "calldata": [
+                "0x6906f30f7caaa106dfc5f4d3e5bfbc947dc209c34f7d5ef93fe1bd1f748db94",
+                "0x1"
+            ],
+            "contract_address": "0x45417d9d8af80b7c2d57b8b23f6d2ec7fe004895c3bd6b44c31c257fa5c27be",
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "transaction_hash": "0x3ef3811bf823e5298ff1b0774c273e08ac255e007785b45b201b10c5d5a6fe2",
+            "version": "0x0",
+            "max_fee": "0x0",
+            "signature": [],
+            "entry_point_selector": "0x19a35a6e95cb7a3318dbb244f20975a1cd8587cc6b5259f15f61d7beb7ee43b",
+            "calldata": [
+                "0x591a1df27057ad8477fcd33d33f03466403f289c47b046a120febd02454cf22",
+                "0x2f8905acbcd6b3bfa6847759dec1910efdd9ff48104267e95fd42d4a3e0e68b"
+            ],
+            "contract_address": "0x13366c36b0ce9363f399ea635ec16b1ab56b3b32892d3ffce69a56f67a94cf0",
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "transaction_hash": "0x5e7e257b328845317343407b4999358ac33c9ad429fe58de1a51a2d69b81153",
+            "version": "0x0",
+            "max_fee": "0x0",
+            "signature": [],
+            "entry_point_selector": "0x19a35a6e95cb7a3318dbb244f20975a1cd8587cc6b5259f15f61d7beb7ee43b",
+            "calldata": [
+                "0x535e52d266d5ef4c7c62b8de1fa964e5cc31ebf3c6091184f75f3156a8b0139",
+                "0x4b40d35c577ff023971aafb2eae9aa83c855e42e39275a9c84235ae6fa4402c"
+            ],
+            "contract_address": "0x32082b82384b9dd09bfd03278f5e1133df7fba5a496b47e7a8224bc29563e4d",
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "transaction_hash": "0x6636acb05fe7fee0d2af3268dad54406ddac6c4268e2ba71444efa2791561a3",
+            "version": "0x0",
+            "max_fee": "0x0",
+            "signature": [],
+            "entry_point_selector": "0x12ead94ae9d3f9d2bdb6b847cf255f1f398193a1f88884a0ae8e18f24a037b6",
+            "calldata": [
+                "0xefebbff1e7e615bacb00032ae5c50bfd00b57395"
+            ],
+            "contract_address": "0x23c8171674e2da64a3e0e6c0981e6198f87c7a937b1cbb2af1a6722325fd19c",
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "transaction_hash": "0x5d5b9e6a445ce14bf8bebe21fbe40443211621fa33b57bf10c6f1fedeae141e",
+            "version": "0x0",
+            "max_fee": "0x0",
+            "signature": [],
+            "entry_point_selector": "0x317eb442b72a9fae758d4fb26830ed0d9f31c8e7da4dbff4e8c59ea6a158e7f",
+            "calldata": [
+                "0x2da48495889cece9b7bc2c44f669f28cee6a83a06de741ef626ea0cd7a53d3d",
+                "0x2",
+                "0x50d0daf42895537d5084d25fcc8df7a56c3d98d51b25029bd67286701ee409f",
+                "0x547eb14b584271c3c1b98c8965a4eb88e029a116493369eaeb93536aaab12b1"
+            ],
+            "contract_address": "0x77991a6b3ea372786afb7b39d992b5fe41e689312979984cf2a94bf7d7c2ee2",
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "transaction_hash": "0x205537fc4f051c33be2f8972c99cd19fd3743d5afab256d29e5ba8a66121591",
+            "version": "0x0",
+            "max_fee": "0x0",
+            "signature": [],
+            "entry_point_selector": "0x218f305395474a84a39307fa5297be118fe17bf65e27ac5e2de6617baa44c64",
+            "calldata": [
+                "0x4c58cec25abf2a9c4c740e5e01f7180f0dcc835ad5008ee02f531734fe82727",
+                "0x0"
+            ],
+            "contract_address": "0x45be9002756cf3b198721874cb7565bba55dd19eac527a2fe56e51034e540a9",
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "transaction_hash": "0x1c99865310e573bddacae8df24f3ab2ce3be786684d5768caabd0ec3d5f1e2f",
+            "version": "0x0",
+            "max_fee": "0x0",
+            "signature": [
+                "0x39bf1ec40f175ed7511d1fd75e33e9fcce0bbb28e82a5a978c608dfb1a69c0d",
+                "0x25f507c45d20ffbbf7f0f60d77bc05e5d9b908e9df926e630ca71a9f693777d"
+            ],
+            "entry_point_selector": "0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320",
+            "calldata": [
+                "0xe136645195ae75cb8079430425472549f7bb9ece56652a5d24ff0e41b0d934",
+                "0x1"
+            ],
+            "contract_address": "0x72c5c2dedc514a7d05a0d4f64b6caaef987ba7c056693cb0dbf8bc73bc11122",
+            "type": "INVOKE_FUNCTION"
+        }
+    ],
+    "timestamp": 1638498601,
+    "transaction_receipts": [
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 0,
+            "transaction_hash": "0x149513f8ce216aa4c674b150369281b786b7766deea4cbaf931771dc985cb2",
+            "l2_to_l1_messages": [
+                {
+                    "from_address": "0x7d3ef9de2e5a3d306db37dab9e968a376e0c3017b0eed8985090e48f57115c0",
+                    "to_address": "0x6AdEe7fb2B504cE9ACc4F4cCC6e4232dB5D30E7d",
+                    "payload": [
+                        "0xc",
+                        "0x22"
+                    ]
+                }
+            ],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 31,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 0,
+                    "range_check_builtin": 0,
+                    "bitwise_builtin": 0,
+                    "output_builtin": 0,
+                    "ecdsa_builtin": 0,
+                    "ec_op_builtin": 0
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x0"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 1,
+            "transaction_hash": "0x6ec9ddd7acaeb34fccf3d59502c3c501ca8829dcbb9306577b5ba4e82d73017",
+            "l2_to_l1_messages": [
+                {
+                    "from_address": "0x6a203775cb9add394cb458c978080eb16dc03e09a358c973ff6094ad8b024ff",
+                    "to_address": "0x7dfD8d5931Cd60B9363d6f62d4EBd57Bef6626F2",
+                    "payload": [
+                        "0xc",
+                        "0x22"
+                    ]
+                }
+            ],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 31,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 0,
+                    "range_check_builtin": 0,
+                    "bitwise_builtin": 0,
+                    "output_builtin": 0,
+                    "ecdsa_builtin": 0,
+                    "ec_op_builtin": 0
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x0"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 2,
+            "transaction_hash": "0x47a4390fdfa1189840a10332eb4deb4600696d20c782a790a22692f7bf65368",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 178,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 0,
+                    "range_check_builtin": 0,
+                    "bitwise_builtin": 0,
+                    "output_builtin": 0,
+                    "ecdsa_builtin": 0,
+                    "ec_op_builtin": 0
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x0"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 3,
+            "transaction_hash": "0x56873723e90a364a1d783709506d9306a1b9c36b4849be6e18a3e215d4f4d2a",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 278,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 0,
+                    "range_check_builtin": 1,
+                    "bitwise_builtin": 0,
+                    "output_builtin": 0,
+                    "ecdsa_builtin": 0,
+                    "ec_op_builtin": 0
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x0"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 4,
+            "transaction_hash": "0x323d5a267929f18ba6b0d6bdbfac5e43db81df23079166ea36dea34c595cd4f",
+            "l2_to_l1_messages": [
+                {
+                    "from_address": "0x13a7778053c853f14a319b8fa733835b948451e77ea464aa592d8f3bcefabce",
+                    "to_address": "0x52a6ED4dbffC70BbAEeFF7f662AA1BB41CE8F691",
+                    "payload": [
+                        "0xc",
+                        "0x22"
+                    ]
+                }
+            ],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 31,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 0,
+                    "range_check_builtin": 0,
+                    "bitwise_builtin": 0,
+                    "output_builtin": 0,
+                    "ecdsa_builtin": 0,
+                    "ec_op_builtin": 0
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x0"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 5,
+            "transaction_hash": "0x2d8a5f48341b95bb6ae3e644794e83328e35cf0e80e4107560d66858fac3dc7",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 25,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 0,
+                    "range_check_builtin": 0,
+                    "bitwise_builtin": 0,
+                    "output_builtin": 0,
+                    "ecdsa_builtin": 0,
+                    "ec_op_builtin": 0
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x0"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 6,
+            "transaction_hash": "0x5534b234f3098fd5db3ea5fc44f09ee3a4c9ce9aa8b4873426237885e44665",
+            "l2_to_l1_messages": [
+                {
+                    "from_address": "0x45417d9d8af80b7c2d57b8b23f6d2ec7fe004895c3bd6b44c31c257fa5c27be",
+                    "to_address": "0x0000000000000000000000000000000000000001",
+                    "payload": [
+                        "0xc",
+                        "0x22"
+                    ]
+                }
+            ],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 332,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 0,
+                    "range_check_builtin": 0,
+                    "bitwise_builtin": 0,
+                    "output_builtin": 0,
+                    "ecdsa_builtin": 0,
+                    "ec_op_builtin": 0
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x0"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 7,
+            "transaction_hash": "0x3ef3811bf823e5298ff1b0774c273e08ac255e007785b45b201b10c5d5a6fe2",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 178,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 0,
+                    "range_check_builtin": 0,
+                    "bitwise_builtin": 0,
+                    "output_builtin": 0,
+                    "ecdsa_builtin": 0,
+                    "ec_op_builtin": 0
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x0"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 8,
+            "transaction_hash": "0x5e7e257b328845317343407b4999358ac33c9ad429fe58de1a51a2d69b81153",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 178,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 0,
+                    "range_check_builtin": 0,
+                    "bitwise_builtin": 0,
+                    "output_builtin": 0,
+                    "ecdsa_builtin": 0,
+                    "ec_op_builtin": 0
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x0"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 9,
+            "transaction_hash": "0x6636acb05fe7fee0d2af3268dad54406ddac6c4268e2ba71444efa2791561a3",
+            "l2_to_l1_messages": [
+                {
+                    "from_address": "0x23c8171674e2da64a3e0e6c0981e6198f87c7a937b1cbb2af1a6722325fd19c",
+                    "to_address": "0xEfEBbFf1e7E615BACB00032ae5C50BFd00b57395",
+                    "payload": [
+                        "0xc",
+                        "0x22"
+                    ]
+                }
+            ],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 31,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 0,
+                    "range_check_builtin": 0,
+                    "bitwise_builtin": 0,
+                    "output_builtin": 0,
+                    "ecdsa_builtin": 0,
+                    "ec_op_builtin": 0
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x0"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 10,
+            "transaction_hash": "0x5d5b9e6a445ce14bf8bebe21fbe40443211621fa33b57bf10c6f1fedeae141e",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 169,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 2,
+                    "range_check_builtin": 7,
+                    "bitwise_builtin": 0,
+                    "output_builtin": 0,
+                    "ecdsa_builtin": 0,
+                    "ec_op_builtin": 0
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x0"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 11,
+            "transaction_hash": "0x205537fc4f051c33be2f8972c99cd19fd3743d5afab256d29e5ba8a66121591",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 238,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 0,
+                    "range_check_builtin": 0,
+                    "bitwise_builtin": 0,
+                    "output_builtin": 0,
+                    "ecdsa_builtin": 0,
+                    "ec_op_builtin": 0
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x0"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 12,
+            "transaction_hash": "0x1c99865310e573bddacae8df24f3ab2ce3be786684d5768caabd0ec3d5f1e2f",
+            "l2_to_l1_messages": [],
+            "events": [],
+            "execution_resources": {
+                "n_steps": 169,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 3,
+                    "range_check_builtin": 6,
+                    "bitwise_builtin": 0,
+                    "output_builtin": 0,
+                    "ecdsa_builtin": 1,
+                    "ec_op_builtin": 0
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x0"
+        }
+    ]
+}

--- a/crates/rpc/src/dto/simulation.rs
+++ b/crates/rpc/src/dto/simulation.rs
@@ -103,12 +103,12 @@ impl crate::dto::SerializeForVersion for &pathfinder_executor::types::FunctionIn
         serializer: crate::dto::Serializer,
     ) -> Result<crate::dto::Ok, crate::dto::Error> {
         let mut serializer = serializer.serialize_struct()?;
-        serializer.serialize_field(
+        serializer.serialize_optional(
             "call_type",
-            &match self.call_type {
+            self.call_type.as_ref().map(|call_type| match call_type {
                 pathfinder_executor::types::CallType::Call => "CALL",
                 pathfinder_executor::types::CallType::Delegate => "DELEGATE",
-            },
+            }),
         )?;
         serializer.serialize_field("caller_address", &self.caller_address)?;
         serializer.serialize_iter(
@@ -119,17 +119,19 @@ impl crate::dto::SerializeForVersion for &pathfinder_executor::types::FunctionIn
         if let Some(class_hash) = &self.class_hash {
             serializer.serialize_field("class_hash", &class_hash)?;
         }
-        serializer.serialize_field(
+        serializer.serialize_optional(
             "entry_point_type",
-            &match self.entry_point_type {
-                pathfinder_executor::types::EntryPointType::Constructor => "CONSTRUCTOR",
-                pathfinder_executor::types::EntryPointType::External => "EXTERNAL",
-                pathfinder_executor::types::EntryPointType::L1Handler => "L1_HANDLER",
-            },
+            self.entry_point_type
+                .as_ref()
+                .map(|entry_point_type| match entry_point_type {
+                    pathfinder_executor::types::EntryPointType::Constructor => "CONSTRUCTOR",
+                    pathfinder_executor::types::EntryPointType::External => "EXTERNAL",
+                    pathfinder_executor::types::EntryPointType::L1Handler => "L1_HANDLER",
+                }),
         )?;
         serializer.serialize_iter("events", self.events.len(), &mut self.events.iter())?;
         serializer.serialize_field("contract_address", &self.contract_address)?;
-        serializer.serialize_field("entry_point_selector", &self.selector)?;
+        serializer.serialize_optional("entry_point_selector", self.selector.as_ref())?;
         serializer.serialize_iter("calldata", self.calldata.len(), &mut self.calldata.iter())?;
         serializer.serialize_iter("messages", self.messages.len(), &mut self.messages.iter())?;
         serializer.serialize_iter("result", self.result.len(), &mut self.result.iter())?;

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -304,10 +304,10 @@ pub(crate) mod tests {
                 trace: pathfinder_executor::types::TransactionTrace::DeployAccount(
                     pathfinder_executor::types::DeployAccountTransactionTrace {
                         constructor_invocation: Some(pathfinder_executor::types::FunctionInvocation {
-                                call_type: pathfinder_executor::types::CallType::Call,
+                                call_type: Some(pathfinder_executor::types::CallType::Call),
                                 caller_address: felt!("0x0"),
                                 class_hash: Some(crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH.0),
-                                entry_point_type: pathfinder_executor::types::EntryPointType::Constructor,
+                                entry_point_type: Some(pathfinder_executor::types::EntryPointType::Constructor),
                                 events: vec![pathfinder_executor::types::Event {
                                     order: 0,
                                     data: vec![],
@@ -318,7 +318,7 @@ pub(crate) mod tests {
                                 }],
                                 calldata: vec![felt!("0x1")],
                                 contract_address: DEPLOYED_CONTRACT_ADDRESS,
-                                selector: entry_point!("0x028FFE4FF0F226A9107253E17A904099AA4F63A02A5621DE0576E5AA71BC5194").0,
+                                selector: Some(entry_point!("0x028FFE4FF0F226A9107253E17A904099AA4F63A02A5621DE0576E5AA71BC5194").0),
                                 messages: vec![],
                                 result: vec![],
                                 execution_resources: pathfinder_executor::types::InnerCallExecutionResources::default(),
@@ -333,10 +333,10 @@ pub(crate) mod tests {
                             }),
                         validate_invocation: Some(
                             pathfinder_executor::types::FunctionInvocation {
-                                call_type: pathfinder_executor::types::CallType::Call,
+                                call_type: Some(pathfinder_executor::types::CallType::Call),
                                 caller_address: felt!("0x0"),
                                 class_hash: Some(crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH.0),
-                                entry_point_type: pathfinder_executor::types::EntryPointType::External,
+                                entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
                                 events: vec![],
                                 calldata: vec![
                                     crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH.0,
@@ -344,7 +344,7 @@ pub(crate) mod tests {
                                     call_param!("0x1").0,
                                 ],
                                 contract_address: DEPLOYED_CONTRACT_ADDRESS,
-                                selector: entry_point!("0x036FCBF06CD96843058359E1A75928BEACFAC10727DAB22A3972F0AF8AA92895").0,
+                                selector: Some(entry_point!("0x036FCBF06CD96843058359E1A75928BEACFAC10727DAB22A3972F0AF8AA92895").0),
                                 messages: vec![],
                                 result: vec![
                                     felt!("0x56414c4944")
@@ -473,13 +473,13 @@ pub(crate) mod tests {
                 trace: pathfinder_executor::types::TransactionTrace::Declare(pathfinder_executor::types::DeclareTransactionTrace {
                     validate_invocation: Some(
                         pathfinder_executor::types::FunctionInvocation {
-                            call_type: pathfinder_executor::types::CallType::Call,
+                            call_type: Some(pathfinder_executor::types::CallType::Call),
                             caller_address: felt!("0x0"),
                             class_hash: Some(crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH.0),
-                            entry_point_type: pathfinder_executor::types::EntryPointType::External,
+                            entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
                             events: vec![],
                             contract_address: account_contract_address,
-                            selector: EntryPoint::hashed(b"__validate_declare__").0,
+                            selector: Some(EntryPoint::hashed(b"__validate_declare__").0),
                             calldata: vec![CAIRO0_HASH.0],
                             messages: vec![],
                             result: vec![felt!("0x56414c4944")],
@@ -496,10 +496,10 @@ pub(crate) mod tests {
                     ),
                     fee_transfer_invocation: Some(
                         pathfinder_executor::types::FunctionInvocation {
-                            call_type: pathfinder_executor::types::CallType::Call,
+                            call_type: Some(pathfinder_executor::types::CallType::Call),
                             caller_address: *account_contract_address.get(),
                             class_hash: Some(ERC20_CONTRACT_DEFINITION_CLASS_HASH.0),
-                            entry_point_type: pathfinder_executor::types::EntryPointType::External,
+                            entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
                             events: vec![pathfinder_executor::types::Event {
                                 order: 0,
                                 data: vec![
@@ -518,7 +518,7 @@ pub(crate) mod tests {
                                 call_param!("0x0").0,
                             ],
                             contract_address: ETH_FEE_TOKEN_ADDRESS,
-                            selector: EntryPoint::hashed(b"transfer").0,
+                            selector: Some(EntryPoint::hashed(b"transfer").0),
                             messages: vec![],
                             result: vec![felt!("0x1")],
                             execution_resources: pathfinder_executor::types::InnerCallExecutionResources::default(),
@@ -927,10 +927,10 @@ pub(crate) mod tests {
                 last_block_header: &BlockHeader,
             ) -> pathfinder_executor::types::FunctionInvocation {
                 pathfinder_executor::types::FunctionInvocation {
-                    call_type: pathfinder_executor::types::CallType::Call,
+                    call_type: Some(pathfinder_executor::types::CallType::Call),
                     caller_address: *account_contract_address.get(),
                     class_hash: Some(ERC20_CONTRACT_DEFINITION_CLASS_HASH.0),
-                    entry_point_type: pathfinder_executor::types::EntryPointType::External,
+                    entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
                     events: vec![pathfinder_executor::types::Event {
                         order: 0,
                         data: vec![
@@ -949,7 +949,7 @@ pub(crate) mod tests {
                         felt!("0x0"),
                     ],
                     contract_address: ETH_FEE_TOKEN_ADDRESS,
-                    selector: EntryPoint::hashed(b"transfer").0,
+                    selector: Some(EntryPoint::hashed(b"transfer").0),
                     internal_calls: vec![],
                     messages: vec![],
                     result: vec![felt!("0x1")],
@@ -966,13 +966,13 @@ pub(crate) mod tests {
                 account_contract_address: ContractAddress,
             ) -> pathfinder_executor::types::FunctionInvocation {
                 pathfinder_executor::types::FunctionInvocation {
-                    call_type: pathfinder_executor::types::CallType::Call,
+                    call_type: Some(pathfinder_executor::types::CallType::Call),
                     caller_address: felt!("0x0"),
                     class_hash: Some(crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH.0),
-                    entry_point_type: pathfinder_executor::types::EntryPointType::External,
+                    entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
                     events: vec![],
                     contract_address: account_contract_address,
-                    selector: EntryPoint::hashed(b"__validate_declare__").0,
+                    selector: Some(EntryPoint::hashed(b"__validate_declare__").0),
                     calldata: vec![SIERRA_HASH.0],
                     internal_calls: vec![],
                     messages: vec![],
@@ -1135,14 +1135,14 @@ pub(crate) mod tests {
                 universal_deployer_address: ContractAddress,
             ) -> pathfinder_executor::types::FunctionInvocation {
                 pathfinder_executor::types::FunctionInvocation {
-                    call_type: pathfinder_executor::types::CallType::Call,
+                    call_type: Some(pathfinder_executor::types::CallType::Call),
                     caller_address: felt!("0x0"),
                     class_hash: Some(crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH.0),
-                    entry_point_type: pathfinder_executor::types::EntryPointType::External,
+                    entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
                     internal_calls: vec![],
                     events: vec![],
                     contract_address: account_contract_address,
-                    selector: EntryPoint::hashed(b"__validate__").0,
+                    selector: Some(EntryPoint::hashed(b"__validate__").0),
                     calldata: vec![
                         call_param!("0x1").0,
                         universal_deployer_address.0,
@@ -1174,22 +1174,22 @@ pub(crate) mod tests {
                 universal_deployer_address: ContractAddress,
             ) -> pathfinder_executor::types::FunctionInvocation {
                 pathfinder_executor::types::FunctionInvocation {
-                    call_type: pathfinder_executor::types::CallType::Call,
+                    call_type: Some(pathfinder_executor::types::CallType::Call),
                     caller_address: felt!("0x0"),
                     internal_calls: vec![
                         pathfinder_executor::types::FunctionInvocation {
-                            call_type: pathfinder_executor::types::CallType::Call,
+                            call_type: Some(pathfinder_executor::types::CallType::Call),
                             caller_address: *account_contract_address.get(),
                             internal_calls: vec![
                                 pathfinder_executor::types::FunctionInvocation {
-                                    call_type: pathfinder_executor::types::CallType::Call,
+                                    call_type: Some(pathfinder_executor::types::CallType::Call),
                                     caller_address: *universal_deployer_address.get(),
                                     internal_calls: vec![],
                                     class_hash: Some(SIERRA_HASH.0),
-                                    entry_point_type: pathfinder_executor::types::EntryPointType::Constructor,
+                                    entry_point_type: Some(pathfinder_executor::types::EntryPointType::Constructor),
                                     events: vec![],
                                     contract_address: DEPLOYED_CONTRACT_ADDRESS,
-                                    selector: EntryPoint::hashed(b"constructor").0,
+                                    selector: Some(EntryPoint::hashed(b"constructor").0),
                                     calldata: vec![],
                                     messages: vec![],
                                     result: vec![],
@@ -1199,7 +1199,7 @@ pub(crate) mod tests {
                                 },
                             ],
                             class_hash: Some(UNIVERSAL_DEPLOYER_CLASS_HASH.0),
-                            entry_point_type: pathfinder_executor::types::EntryPointType::External,
+                            entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
                             events: vec![
                                 pathfinder_executor::types::Event {
                                     order: 0,
@@ -1217,7 +1217,7 @@ pub(crate) mod tests {
                                 },
                             ],
                             contract_address: universal_deployer_address,
-                            selector: EntryPoint::hashed(b"deployContract").0,
+                            selector: Some(EntryPoint::hashed(b"deployContract").0),
                             calldata: vec![
                                 // classHash
                                 SIERRA_HASH.0,
@@ -1244,10 +1244,10 @@ pub(crate) mod tests {
                         }
                     ],
                     class_hash: Some(crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH.0),
-                    entry_point_type: pathfinder_executor::types::EntryPointType::External,
+                    entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
                     events: vec![],
                     contract_address: account_contract_address,
-                    selector: EntryPoint::hashed(b"__execute__").0,
+                    selector: Some(EntryPoint::hashed(b"__execute__").0),
                     calldata: vec![
                         call_param!("0x1").0,
                         universal_deployer_address.0,
@@ -1283,11 +1283,11 @@ pub(crate) mod tests {
                 overall_fee_correction: u64,
             ) -> pathfinder_executor::types::FunctionInvocation {
                 pathfinder_executor::types::FunctionInvocation {
-                    call_type: pathfinder_executor::types::CallType::Call,
+                    call_type: Some(pathfinder_executor::types::CallType::Call),
                     caller_address: *account_contract_address.get(),
                     internal_calls: vec![],
                     class_hash: Some(ERC20_CONTRACT_DEFINITION_CLASS_HASH.0),
-                    entry_point_type: pathfinder_executor::types::EntryPointType::External,
+                    entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
                     events: vec![pathfinder_executor::types::Event {
                         order: 0,
                         data: vec![
@@ -1307,7 +1307,7 @@ pub(crate) mod tests {
                         call_param!("0x0").0,
                     ],
                     contract_address: ETH_FEE_TOKEN_ADDRESS,
-                    selector: EntryPoint::hashed(b"transfer").0,
+                    selector: Some(EntryPoint::hashed(b"transfer").0),
                     messages: vec![],
                     result: vec![felt!("0x1")],
                     computation_resources: universal_deployer_fee_transfer_computation_resources(),
@@ -1457,14 +1457,14 @@ pub(crate) mod tests {
                 account_contract_address: ContractAddress,
             ) -> pathfinder_executor::types::FunctionInvocation {
                 pathfinder_executor::types::FunctionInvocation {
-                    call_type: pathfinder_executor::types::CallType::Call,
+                    call_type: Some(pathfinder_executor::types::CallType::Call),
                     caller_address: felt!("0x0"),
                     class_hash: Some(crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH.0),
-                    entry_point_type: pathfinder_executor::types::EntryPointType::External,
+                    entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
                     internal_calls: vec![],
                     events: vec![],
                     contract_address: account_contract_address,
-                    selector: EntryPoint::hashed(b"__validate__").0,
+                    selector: Some(EntryPoint::hashed(b"__validate__").0),
                     calldata: vec![
                         call_param!("0x1").0,
                         DEPLOYED_CONTRACT_ADDRESS.0,
@@ -1488,17 +1488,19 @@ pub(crate) mod tests {
                 test_storage_value: StorageValue,
             ) -> pathfinder_executor::types::FunctionInvocation {
                 pathfinder_executor::types::FunctionInvocation {
-                    call_type: pathfinder_executor::types::CallType::Call,
+                    call_type: Some(pathfinder_executor::types::CallType::Call),
                     caller_address: felt!("0x0"),
                     internal_calls: vec![pathfinder_executor::types::FunctionInvocation {
-                        call_type: pathfinder_executor::types::CallType::Call,
+                        call_type: Some(pathfinder_executor::types::CallType::Call),
                         caller_address: *account_contract_address.get(),
                         class_hash: Some(SIERRA_HASH.0),
-                        entry_point_type: pathfinder_executor::types::EntryPointType::External,
+                        entry_point_type: Some(
+                            pathfinder_executor::types::EntryPointType::External,
+                        ),
                         events: vec![],
                         internal_calls: vec![],
                         contract_address: DEPLOYED_CONTRACT_ADDRESS,
-                        selector: EntryPoint::hashed(b"get_data").0,
+                        selector: Some(EntryPoint::hashed(b"get_data").0),
                         calldata: vec![],
                         messages: vec![],
                         result: vec![test_storage_value.0],
@@ -1515,10 +1517,10 @@ pub(crate) mod tests {
                         is_reverted: false,
                     }],
                     class_hash: Some(crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH.0),
-                    entry_point_type: pathfinder_executor::types::EntryPointType::External,
+                    entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
                     events: vec![],
                     contract_address: account_contract_address,
-                    selector: EntryPoint::hashed(b"__execute__").0,
+                    selector: Some(EntryPoint::hashed(b"__execute__").0),
                     calldata: vec![
                         call_param!("0x1").0,
                         DEPLOYED_CONTRACT_ADDRESS.0,
@@ -1543,10 +1545,10 @@ pub(crate) mod tests {
                 overall_fee_correction: u64,
             ) -> pathfinder_executor::types::FunctionInvocation {
                 pathfinder_executor::types::FunctionInvocation {
-                    call_type: pathfinder_executor::types::CallType::Call,
+                    call_type: Some(pathfinder_executor::types::CallType::Call),
                     caller_address: *account_contract_address.get(),
                     class_hash: Some(ERC20_CONTRACT_DEFINITION_CLASS_HASH.0),
-                    entry_point_type: pathfinder_executor::types::EntryPointType::External,
+                    entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
                     internal_calls: vec![],
                     events: vec![pathfinder_executor::types::Event {
                         order: 0,
@@ -1566,7 +1568,7 @@ pub(crate) mod tests {
                         call_param!("0x0").0,
                     ],
                     contract_address: ETH_FEE_TOKEN_ADDRESS,
-                    selector: EntryPoint::hashed(b"transfer").0,
+                    selector: Some(EntryPoint::hashed(b"transfer").0),
                     messages: vec![],
                     result: vec![felt!("0x1")],
                     computation_resources: invoke_fee_transfer_computation_resources(),

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -431,20 +431,15 @@ fn map_gateway_function_invocation(
     Ok(pathfinder_executor::types::FunctionInvocation {
         calldata: invocation.calldata,
         contract_address: invocation.contract_address,
-        selector: invocation
-            .selector
-            .ok_or_else(|| anyhow::anyhow!("selector is missing from trace response"))?,
-        call_type: match invocation
-            .call_type
-            .ok_or_else(|| anyhow::anyhow!("call_type is missing from trace response"))?
-        {
+        selector: invocation.selector,
+        call_type: invocation.call_type.map(|call_type| match call_type {
             starknet_gateway_types::trace::CallType::Call => {
                 pathfinder_executor::types::CallType::Call
             }
             starknet_gateway_types::trace::CallType::Delegate => {
                 pathfinder_executor::types::CallType::Delegate
             }
-        },
+        }),
         caller_address: invocation.caller_address,
         internal_calls: invocation
             .internal_calls
@@ -452,20 +447,19 @@ fn map_gateway_function_invocation(
             .map(map_gateway_function_invocation)
             .collect::<Result<_, _>>()?,
         class_hash: invocation.class_hash,
-        entry_point_type: match invocation
-            .entry_point_type
-            .ok_or_else(|| anyhow::anyhow!("entry_point_type is missing from trace response"))?
-        {
-            starknet_gateway_types::trace::EntryPointType::Constructor => {
-                pathfinder_executor::types::EntryPointType::Constructor
-            }
-            starknet_gateway_types::trace::EntryPointType::External => {
-                pathfinder_executor::types::EntryPointType::External
-            }
-            starknet_gateway_types::trace::EntryPointType::L1Handler => {
-                pathfinder_executor::types::EntryPointType::L1Handler
-            }
-        },
+        entry_point_type: invocation.entry_point_type.map(
+            |entry_point_type| match entry_point_type {
+                starknet_gateway_types::trace::EntryPointType::External => {
+                    pathfinder_executor::types::EntryPointType::External
+                }
+                starknet_gateway_types::trace::EntryPointType::Constructor => {
+                    pathfinder_executor::types::EntryPointType::Constructor
+                }
+                starknet_gateway_types::trace::EntryPointType::L1Handler => {
+                    pathfinder_executor::types::EntryPointType::L1Handler
+                }
+            },
+        ),
         events: invocation
             .events
             .into_iter()


### PR DESCRIPTION
For pre-0.9 Starknet blocks the feeder gateway returns a block trace response that is missing the call_type field for all function invocations.

Turns out it's not just `call_type` that might be missing, but -- based on our `starknet_gateway_types::trace::FunctionInvocation` type `selector` and `entry_point_type` might also be  missing.

According to Starkware we cannot simply default `call_type` to any value, since these pre-0.9 calls are neither CALL nor DELEGATE, so we would be inaccurate if we were to return those values.

This doesn't leave too much choice but to break the JSON-RPC spec by not including these properties in function invocation responses if they are missing from the feeder gateway response.

Closes #2728 