### PR TITLE
feat: switch to the new feeder URL once Starknet is upgraded to 0.14.0

### DIFF
--- a/crates/gateway-client/src/builder.rs
+++ b/crates/gateway-client/src/builder.rs
@@ -13,16 +13,19 @@
 //!   4. [Final](stage::Final) where you select the REST operation type, which
 //!      is then executed.
 use pathfinder_common::{BlockId, ClassHash, TransactionHash};
+use reqwest::StatusCode;
 use starknet_gateway_types::error::SequencerError;
 
 use crate::metrics::{with_metrics, BlockTag, RequestMetadata};
+use crate::IS_PRE_0_14_0;
 
 const X_THROTTLING_BYPASS: &str = "X-Throttling-Bypass";
 
 /// A Sequencer Request builder.
 pub struct Request<'a, S: RequestState> {
     state: S,
-    url: reqwest::Url,
+    primary_url: reqwest::Url,
+    secondary_url: reqwest::Url,
     api_key: Option<String>,
     client: &'a reqwest::Client,
 }
@@ -77,11 +80,13 @@ impl<'a> Request<'a, stage::Init> {
     /// Initialize a [Request] builder.
     pub fn builder(
         client: &'a reqwest::Client,
-        url: reqwest::Url,
+        primary_url: reqwest::Url,
+        secondary_url: reqwest::Url,
         api_key: Option<String>,
     ) -> Request<'a, stage::Method> {
         Request {
-            url,
+            primary_url,
+            secondary_url,
             client,
             api_key,
             state: stage::Method,
@@ -153,13 +158,19 @@ impl<'a> Request<'a, stage::Method> {
 
     /// Appends the given method to the request url.
     fn method(mut self, method: &'static str) -> Request<'a, stage::Params> {
-        self.url
+        self.primary_url
             .path_segments_mut()
-            .expect("Base URL is valid")
+            .expect("Primary URL is valid")
+            .push(method);
+
+        self.secondary_url
+            .path_segments_mut()
+            .expect("Secondary URL is valid")
             .push(method);
 
         Request {
-            url: self.url,
+            primary_url: self.primary_url,
+            secondary_url: self.secondary_url,
             client: self.client,
             api_key: self.api_key,
             state: stage::Params {
@@ -205,7 +216,7 @@ impl<'a> Request<'a, stage::Params> {
     }
 
     pub fn param(mut self, name: &str, value: &str) -> Self {
-        self.url.query_pairs_mut().append_pair(name, value);
+        self.primary_url.query_pairs_mut().append_pair(name, value);
         self
     }
 
@@ -217,7 +228,8 @@ impl<'a> Request<'a, stage::Params> {
     /// Sets the request retry behavior.
     pub fn retry(self, retry: bool) -> Request<'a, stage::Final> {
         Request {
-            url: self.url,
+            primary_url: self.primary_url,
+            secondary_url: self.secondary_url,
             client: self.client,
             api_key: self.api_key,
             state: stage::Final {
@@ -235,6 +247,36 @@ impl Request<'_, stage::Final> {
     where
         T: serde::de::DeserializeOwned,
     {
+        // TODO remove this workaround once mainnet is on 0.14.0
+        async fn send_request_and_probe_0_14_0<T: serde::de::DeserializeOwned>(
+            primary_url: reqwest::Url,
+            secondary_url: reqwest::Url,
+            api_key: Option<String>,
+            client: &reqwest::Client,
+            meta: RequestMetadata,
+        ) -> Result<T, SequencerError> {
+            // The flag could in theory be set multiple times, but as it's only ever
+            // set to false the multiple stores don't cause any problems.
+            let is_pre_0_14_0 = IS_PRE_0_14_0.load(std::sync::atomic::Ordering::Relaxed);
+            match send_request(primary_url, api_key.clone(), client, meta).await {
+                Err(SequencerError::ReqwestError(e))
+                    if e.status() == Some(StatusCode::NOT_FOUND) && is_pre_0_14_0 =>
+                {
+                    let result = send_request(secondary_url, api_key, client, meta).await;
+                    if result.is_ok() {
+                        // The old URL was not found, and we got a successful reply from the new
+                        // one, which gives us enough confidence to start using the new URL
+                        // for the next requests.
+                        IS_PRE_0_14_0.store(false, std::sync::atomic::Ordering::Relaxed);
+                        tracing::info!("Feeder gateway URL updated to Starknet 0.14.0");
+                    }
+
+                    result
+                }
+                r => r,
+            }
+        }
+
         async fn send_request<T: serde::de::DeserializeOwned>(
             url: reqwest::Url,
             api_key: Option<String>,
@@ -255,13 +297,30 @@ impl Request<'_, stage::Final> {
         }
 
         match self.state.retry {
-            false => send_request(self.url, self.api_key, self.client, self.state.meta).await,
+            false => {
+                send_request_and_probe_0_14_0(
+                    self.primary_url,
+                    self.secondary_url,
+                    self.api_key,
+                    self.client,
+                    self.state.meta,
+                )
+                .await
+            }
             true => {
                 retry0(
                     || async {
-                        let url = self.url.clone();
+                        let primary_url = self.primary_url.clone();
+                        let secondary_url = self.secondary_url.clone();
                         let api_key = self.api_key.clone();
-                        send_request(url, api_key, self.client, self.state.meta).await
+                        send_request_and_probe_0_14_0(
+                            primary_url,
+                            secondary_url,
+                            api_key,
+                            self.client,
+                            self.state.meta,
+                        )
+                        .await
                     },
                     retry_condition,
                 )
@@ -273,6 +332,36 @@ impl Request<'_, stage::Final> {
     /// Sends the Sequencer request as a REST `GET` operation and returns the
     /// response's bytes.
     pub async fn get_as_bytes(self) -> Result<bytes::Bytes, SequencerError> {
+        // TODO remove this workaround once mainnet is on 0.14.0
+        async fn get_as_bytes_inner_and_probe_0_14_0(
+            primary_url: reqwest::Url,
+            secondary_url: reqwest::Url,
+            api_key: Option<String>,
+            client: &reqwest::Client,
+            meta: RequestMetadata,
+        ) -> Result<bytes::Bytes, SequencerError> {
+            // The flag could in theory be set multiple times, but as it's only ever
+            // set to false the multiple stores don't cause any problems.
+            let is_pre_0_14_0 = IS_PRE_0_14_0.load(std::sync::atomic::Ordering::Relaxed);
+            match get_as_bytes_inner(primary_url, api_key.clone(), client, meta).await {
+                Err(SequencerError::ReqwestError(e))
+                    if e.status() == Some(StatusCode::NOT_FOUND) && is_pre_0_14_0 =>
+                {
+                    let result = get_as_bytes_inner(secondary_url, api_key, client, meta).await;
+                    if result.is_ok() {
+                        // The old URL was not found, and we got a successful reply from the new
+                        // one, which gives us enough confidence to start using the new URL
+                        // for the next requests.
+                        IS_PRE_0_14_0.store(false, std::sync::atomic::Ordering::Relaxed);
+                        tracing::info!("Feeder gateway URL updated to Starknet 0.14.0");
+                    }
+
+                    result
+                }
+                r => r,
+            }
+        }
+
         async fn get_as_bytes_inner(
             url: reqwest::Url,
             api_key: Option<String>,
@@ -295,13 +384,30 @@ impl Request<'_, stage::Final> {
         }
 
         match self.state.retry {
-            false => get_as_bytes_inner(self.url, self.api_key, self.client, self.state.meta).await,
+            false => {
+                get_as_bytes_inner_and_probe_0_14_0(
+                    self.primary_url,
+                    self.secondary_url,
+                    self.api_key,
+                    self.client,
+                    self.state.meta,
+                )
+                .await
+            }
             true => {
                 retry0(
                     || async {
-                        let url = self.url.clone();
+                        let primary_url = self.primary_url.clone();
+                        let secondary_url = self.secondary_url.clone();
                         let api_key = self.api_key.clone();
-                        get_as_bytes_inner(url, api_key, self.client, self.state.meta).await
+                        get_as_bytes_inner_and_probe_0_14_0(
+                            primary_url,
+                            secondary_url,
+                            api_key,
+                            self.client,
+                            self.state.meta,
+                        )
+                        .await
                     },
                     retry_condition,
                 )
@@ -355,7 +461,7 @@ impl Request<'_, stage::Final> {
         match self.state.retry {
             false => {
                 post_with_json_inner(
-                    self.url,
+                    self.primary_url,
                     self.api_key,
                     self.client,
                     self.state.meta,
@@ -367,8 +473,8 @@ impl Request<'_, stage::Final> {
             true => {
                 retry0(
                     || async {
-                        tracing::trace!(url=%self.url, "Posting data to gateway");
-                        let url = self.url.clone();
+                        tracing::trace!(url=%self.primary_url, "Posting data to gateway");
+                        let url = self.primary_url.clone();
                         let api_key = self.api_key.clone();
                         post_with_json_inner(
                             url,

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -756,9 +756,10 @@ mod pathfinder_context {
             use pathfinder_crypto::Felt;
             use starknet_gateway_client::GatewayApi;
 
-            let gateway = GatewayClient::with_urls(gateway, feeder, gateway_timeout)
-                .context("Creating gateway client")?
-                .with_api_key(api_key);
+            let gateway =
+                GatewayClient::with_urls(gateway, feeder.clone(), feeder, gateway_timeout)
+                    .context("Creating gateway client")?
+                    .with_api_key(api_key);
 
             let network_id =
                 ChainId(Felt::from_be_slice(chain_id.as_bytes()).context("Parsing chain ID")?);


### PR DESCRIPTION
Add support for new feeder URL.

---------------------------

Mechanism:
- primary and secondary URL
- upon a 404 from the primary a request is tried to the secondary,
- if it succeeds a flag is set and from then on only secondary is used.

The code changes are a bit hacky but my aim was to:
- add simple code that is easy to remove given the builder APIs that we use,
- maintain backward compatibility and allow seamless entry into 0.14.0 without the need to restart the process,
- avoid doubling the number of requests before/after the upgrade (as in a simple try first or second URL strategy), maybe excluding a small window of time when a couple of requests can all bounce off the old URL due to race conditions (which are absolutely harmless btw).

The hacky logic should ofc be removed once mainnet moves to 0.14.0.

Tested on integration.