### PR TITLE
fix(executor): fix DEPLOY_ACCOUNT transaction estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- `starknet_estimateFee` is failing for Braavos DEPLOY_ACCOUNT transactions involving a new Sierra 1.7.0 class.
+
 ## [0.17.0-beta.1] - 2025-05-13
 
 ### Added

--- a/crates/rpc/src/method/estimate_fee.rs
+++ b/crates/rpc/src/method/estimate_fee.rs
@@ -219,6 +219,7 @@ mod tests {
         BroadcastedDeclareTransaction,
         BroadcastedDeclareTransactionV2,
         BroadcastedDeclareTransactionV3,
+        BroadcastedDeployAccountTransactionV3,
         BroadcastedInvokeTransaction,
         BroadcastedInvokeTransactionV0,
         BroadcastedInvokeTransactionV1,
@@ -927,5 +928,126 @@ mod tests {
             result,
             Output(vec![declare_expected, deploy_expected, invoke_expected,])
         );
+    }
+
+    #[tokio::test]
+    async fn deploy_account_starknet_0_13_5() {
+        let starknet_version = StarknetVersion::new(0, 13, 5, 0);
+        let (context, last_block_header, _account_contract_address, _universal_deployer_address) =
+            crate::test_setup::test_context_with_starknet_version(starknet_version).await;
+
+        let deploy_account = crate::types::request::BroadcastedDeployAccountTransaction::V3(
+            BroadcastedDeployAccountTransactionV3 {
+                version: TransactionVersion::THREE,
+                signature: vec![],
+                nonce: transaction_nonce!("0x0"),
+                resource_bounds: ResourceBounds {
+                    l1_gas: ResourceBound {
+                        max_amount: ResourceAmount(0),
+                        max_price_per_unit: ResourcePricePerUnit(0),
+                    },
+                    l2_gas: ResourceBound {
+                        max_amount: ResourceAmount(0),
+                        max_price_per_unit: ResourcePricePerUnit(0),
+                    },
+                    l1_data_gas: Some(ResourceBound {
+                        max_amount: ResourceAmount(0),
+                        max_price_per_unit: ResourcePricePerUnit(0),
+                    }),
+                },
+                tip: Tip(0),
+                paymaster_data: vec![],
+                nonce_data_availability_mode: DataAvailabilityMode::L1,
+                fee_data_availability_mode: DataAvailabilityMode::L1,
+                contract_address_salt: contract_address_salt!("0x1"),
+                constructor_calldata: vec![call_param!("0xdeadbeef")],
+                class_hash: crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH,
+            },
+        );
+
+        let input = Input {
+            request: vec![BroadcastedTransaction::DeployAccount(deploy_account)],
+            simulation_flags: vec![],
+            block_id: BlockId::Number(last_block_header.number),
+        };
+        let result = super::estimate_fee(context, input).await.unwrap();
+
+        let output_json = result
+            .serialize(Serializer {
+                version: RpcVersion::V08,
+            })
+            .unwrap();
+        let expected_json = serde_json::json!([
+            {
+                "l1_data_gas_consumed": "0x1c0",
+                "l1_data_gas_price": "0x2",
+                "l1_gas_consumed": "0x0",
+                "l1_gas_price": "0x2",
+                "l2_gas_consumed": "0xb5842",
+                "l2_gas_price": "0x1",
+                "overall_fee": "0xb5bc2",
+                "unit": "FRI"
+            }
+        ]);
+        pretty_assertions_sorted::assert_eq!(expected_json, output_json);
+    }
+
+    #[tokio::test]
+    async fn deploy_account_starknet_0_13_1() {
+        let starknet_version = StarknetVersion::new(0, 13, 1, 0);
+        let (context, last_block_header, _account_contract_address, _universal_deployer_address) =
+            crate::test_setup::test_context_with_starknet_version(starknet_version).await;
+
+        let deploy_account = crate::types::request::BroadcastedDeployAccountTransaction::V3(
+            BroadcastedDeployAccountTransactionV3 {
+                version: TransactionVersion::THREE,
+                signature: vec![],
+                nonce: transaction_nonce!("0x0"),
+                resource_bounds: ResourceBounds {
+                    l1_gas: ResourceBound {
+                        max_amount: ResourceAmount(0),
+                        max_price_per_unit: ResourcePricePerUnit(0),
+                    },
+                    l2_gas: ResourceBound {
+                        max_amount: ResourceAmount(0),
+                        max_price_per_unit: ResourcePricePerUnit(0),
+                    },
+                    l1_data_gas: None,
+                },
+                tip: Tip(0),
+                paymaster_data: vec![],
+                nonce_data_availability_mode: DataAvailabilityMode::L1,
+                fee_data_availability_mode: DataAvailabilityMode::L1,
+                contract_address_salt: contract_address_salt!("0x1"),
+                constructor_calldata: vec![call_param!("0xdeadbeef")],
+                class_hash: crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH,
+            },
+        );
+
+        let input = Input {
+            request: vec![BroadcastedTransaction::DeployAccount(deploy_account)],
+            simulation_flags: vec![],
+            block_id: BlockId::Number(last_block_header.number),
+        };
+        let result = super::estimate_fee(context, input).await.unwrap();
+
+        let output_json = result
+            .serialize(Serializer {
+                version: RpcVersion::V08,
+            })
+            .unwrap();
+        let expected_json = serde_json::json!([
+            {
+                "l1_data_gas_consumed": "0x160",
+                "l1_data_gas_price": "0x2",
+                "l1_gas_consumed": "0xc",
+                "l1_gas_price": "0x2",
+                "l2_gas_consumed": "0x0",
+                "l2_gas_price": "0x1",
+                "overall_fee": "0x2d8",
+                "unit": "FRI"
+            }
+        ]);
+        pretty_assertions_sorted::assert_eq!(expected_json, output_json);
     }
 }


### PR DESCRIPTION
Turns out that we have two issues with DEPLOY_ACCOUNT estimation, both triggered by Braavos account deployments.

The first one is that `l2_gas_accounting_enabled()` does not work for all DEPLOY_ACCOUNT transactions. We were trying to fetch the class hash for the sender of the transaction, but for DEPLOY_ACCOUNT that is the address of the account that is being deployed, so no class hash is present yet. Because of this we were always running DEPLOY_ACCOUNT transactions with L2 gas accounting disabled.

Even if we had the class hash, we would still fail for Braavos accounts. The trick is that Braavos accounds are deployed in a special way: they are always using the same class hash, and the constructor immediately replaces the deployed class hash with a new one that is received as part of the "signature". This leads to the validate entry point actually being executed in a completely different class than the one that is present in the `class_hash` field of the transaction. This completely breaks our L2 gas accounting detection logic.

This commit changes the detection logic so that we always run DEPLOY_ACCOUNT with L2 gas accounting enabled. (This incurs a performance penalty though, because we now execute the transaction at least twice.)

The second issue is that when running the L2 gas accounting aware estimation logic, we derive the max L2 gas bound from the balance of the sender account. However, for account deployments it's perfectly possible that the account balance is still zero at the time of fee estimation.

This commit special cases DEPLOY_ACCOUNT transactions and just uses an upper limit for the L2 gas bound from versioned constants.

Closes #2734
