### PR TITLE
Initial consensus P2P `Behaviour` implementation

### DIFF
--- a/crates/p2p/src/consensus.rs
+++ b/crates/p2p/src/consensus.rs
@@ -1,17 +1,555 @@
 //! Consensus behaviour and other related utilities for the consensus p2p
 //! network.
 mod behaviour;
+mod height_and_round;
+mod stream;
+
+use std::collections::HashMap;
 
 pub use behaviour::Behaviour;
+use height_and_round::HeightAndRound;
+use p2p_proto::consensus::{ProposalPart, Vote};
+use pathfinder_common::ContractAddress;
+use stream::{StreamMessage, StreamMessageBody, StreamState};
+
+/// The topic for proposal messages in the consensus network.
+pub const TOPIC_PROPOSALS: &str = "consensus_proposals";
+/// The topic for vote messages in the consensus network.
+pub const TOPIC_VOTES: &str = "consensus_votes";
+
+/// The type of validator address in the consensus network.
+pub type ValidatorAddress = ContractAddress;
 
 /// Commands for the consensus behaviour.
-pub enum Command {}
+#[derive(Debug, Clone)]
+pub enum Command {
+    /// A proposal (part) for a new block.
+    Proposal(HeightAndRound, ProposalPart),
+    /// A vote for a proposal.
+    Vote(Vote),
+    /// Test command to create a proposal stream.
+    #[cfg(test)]
+    TestProposalStream(HeightAndRound, Vec<ProposalPart>, bool),
+}
 
 /// Events emitted by the consensus behaviour.
-pub enum Event {}
-
-/// State of the consensus behaviour.
-pub struct State {}
+#[derive(Debug, Clone, PartialEq)]
+pub enum Event {
+    /// A proposal (part) for a new block.
+    Proposal(HeightAndRound, ProposalPart),
+    /// A vote for a proposal.
+    Vote(Vote),
+}
 
 /// Configuration for the consensus P2P network.
+#[derive(Default)]
 pub struct Config {}
+
+/// The state of the consensus P2P network.
+#[derive(Default)]
+pub struct State {
+    /// The active streams of the consensus P2P network.
+    active_streams: HashMap<HeightAndRound, StreamState<ProposalPart>>,
+    // TODO: Implement cleanup of inactive streams
+}
+
+impl State {
+    pub fn new() -> Self {
+        Self {
+            active_streams: HashMap::new(),
+        }
+    }
+}
+
+/// Create a new outgoing proposal stream message.
+pub fn create_outgoing_proposal_message(
+    state: &mut State,
+    height_and_round: HeightAndRound,
+    proposal: ProposalPart,
+) -> Vec<StreamMessage<ProposalPart>> {
+    let mut messages = Vec::with_capacity(2);
+
+    // Get or create stream state
+    let stream_state = state
+        .active_streams
+        .entry(height_and_round)
+        .or_insert_with(StreamState::new_outgoing);
+
+    if let StreamState::Outgoing(state) = stream_state {
+        let message_id = state.last_sent_message_id.map_or(0, |id| id + 1);
+
+        // Track the sent message
+        state.sent_messages.insert(message_id, proposal.clone());
+        state.last_sent_message_id = Some(message_id);
+
+        messages.push(StreamMessage {
+            message: StreamMessageBody::Content(proposal.clone()),
+            stream_id: height_and_round,
+            message_id,
+        });
+
+        // If this is the last message, send the Fin signal
+        if matches!(proposal, ProposalPart::ProposalFin(_)) {
+            let message_id = state.last_sent_message_id.unwrap();
+
+            // Track the Fin message
+            state.fin_sent = true;
+
+            messages.push(StreamMessage {
+                message: StreamMessageBody::Fin,
+                stream_id: height_and_round,
+                message_id,
+            });
+        }
+    } else {
+        panic!("Expected Outgoing stream state")
+    }
+
+    messages
+}
+
+/// Handle an incoming proposal message.
+pub fn handle_incoming_proposal_message(
+    state: &mut State,
+    message: StreamMessage<ProposalPart>,
+) -> Vec<Event> {
+    let stream_id = message.stream_id;
+
+    // Get or create stream state for this (height, round)
+    let stream_state = state
+        .active_streams
+        .entry(stream_id)
+        .or_insert_with(StreamState::new_incoming);
+
+    if let StreamState::Incoming(state) = stream_state {
+        // Handle "Fin" message
+        if let StreamMessageBody::Fin = message.message {
+            state.fin_message_id = Some(message.message_id);
+            // TODO: Do we need to do anything here?
+            return vec![];
+        }
+
+        // Buffer out of order messages
+        if message.message_id != state.next_message_id {
+            state.received_messages.insert(message.message_id, message);
+            return vec![];
+        }
+
+        // Process this message (it's in order)
+        let mut events = Vec::new();
+        if let StreamMessageBody::Content(content) = message.message {
+            events.push(Event::Proposal(stream_id, content));
+            state.next_message_id += 1;
+        }
+
+        // Process any buffered messages that are now in order
+        while let Some(next_message) = state.received_messages.remove(&state.next_message_id) {
+            if let StreamMessageBody::Content(content) = next_message.message {
+                events.push(Event::Proposal(stream_id, content));
+                state.next_message_id += 1;
+            }
+        }
+
+        events
+    } else {
+        panic!("Expected Incoming stream state")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+    use std::time::Duration;
+
+    use libp2p::identity::Keypair;
+    use p2p_proto::common::{Address, Hash, L1DataAvailabilityMode};
+    use p2p_proto::consensus::{
+        BlockInfo,
+        ProposalFin,
+        ProposalInit,
+        ProposalPart,
+        Transaction,
+        TransactionVariant,
+        VoteType,
+    };
+    use p2p_proto::transaction::L1HandlerV0;
+    use pathfinder_common::ChainId;
+    use pathfinder_crypto::Felt;
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::consensus::{Command, Event};
+    use crate::core::{self, Config};
+    use crate::libp2p::Multiaddr;
+    use crate::{consensus, main_loop, new_consensus};
+
+    /// Tests creating an outgoing proposal message and updating the state.
+    #[test]
+    fn test_create_outgoing_proposal_message_updates_state() {
+        let mut state = State::new();
+        let height_and_round: HeightAndRound = (1, 2).into();
+
+        // Create a sample proposal
+        let block_info = BlockInfo {
+            height: 100,
+            timestamp: 1234567890,
+            builder: Address(Felt::from_hex_str("0x456").unwrap()),
+            l1_da_mode: L1DataAvailabilityMode::Calldata,
+            l2_gas_price_fri: 1000,
+            l1_gas_price_wei: 2000,
+            l1_data_gas_price_wei: 3000,
+            eth_to_fri_rate: 4000,
+        };
+        let proposal = ProposalPart::BlockInfo(block_info);
+
+        // Create messages
+        let messages =
+            create_outgoing_proposal_message(&mut state, height_and_round, proposal.clone());
+
+        // Verify state was updated
+        let stream_state = state.active_streams.get(&height_and_round).unwrap();
+        if let StreamState::Outgoing(outgoing_state) = stream_state {
+            assert_eq!(outgoing_state.last_sent_message_id, Some(0));
+            assert_eq!(outgoing_state.sent_messages.len(), 1);
+            assert_eq!(outgoing_state.sent_messages.get(&0).unwrap(), &proposal);
+            assert!(!outgoing_state.fin_sent);
+        } else {
+            panic!("Expected Outgoing stream state");
+        }
+
+        // Verify messages
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].message_id, 0);
+        assert_eq!(messages[0].stream_id, height_and_round);
+    }
+
+    /// Tests handling an incoming proposal message and updating the state.
+    #[test]
+    fn test_handle_incoming_proposal_message_updates_state() {
+        let mut state = State::new();
+        let height_and_round: HeightAndRound = (1, 2).into();
+
+        // Create a sample proposal
+        let block_info = BlockInfo {
+            height: 100,
+            timestamp: 1234567890,
+            builder: Address(Felt::from_hex_str("0x456").unwrap()),
+            l1_da_mode: L1DataAvailabilityMode::Calldata,
+            l2_gas_price_fri: 1000,
+            l1_gas_price_wei: 2000,
+            l1_data_gas_price_wei: 3000,
+            eth_to_fri_rate: 4000,
+        };
+        let proposal = ProposalPart::BlockInfo(block_info);
+
+        // Create a message
+        let message = StreamMessage {
+            stream_id: height_and_round,
+            message_id: 0,
+            message: StreamMessageBody::Content(proposal.clone()),
+        };
+
+        // Handle the message
+        let events = handle_incoming_proposal_message(&mut state, message);
+
+        // Verify state was updated
+        let stream_state = state.active_streams.get(&height_and_round).unwrap();
+        if let StreamState::Incoming(incoming_state) = stream_state {
+            println!("Next message id: {}", incoming_state.next_message_id);
+            assert_eq!(incoming_state.next_message_id, 1);
+            assert!(incoming_state.received_messages.is_empty());
+            assert_eq!(incoming_state.fin_message_id, None);
+        } else {
+            panic!("Expected Incoming stream state");
+        }
+
+        // Verify events
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0], Event::Proposal(height_and_round, proposal));
+    }
+
+    /// Tests sending proposal streams between two nodes with message shuffling.
+    ///
+    /// This test creates two nodes, connects them, and sends multiple proposal
+    /// streams from one node to another. The messages in each stream are
+    /// shuffled before sending, simulating out-of-order network delivery.
+    /// The test verifies that the receiving node correctly reassembles the
+    /// streams and receives all proposals in the proper order.
+    #[tokio::test]
+    async fn test_proposal_stream() {
+        // Create two nodes with different identities
+        let (node1_client, _, node1_loop) = create_test_node().await;
+        let (node2_client, mut node2_events, node2_loop) = create_test_node().await;
+
+        // Start the main loops
+        tokio::spawn(node1_loop.run());
+        tokio::spawn(node2_loop.run());
+
+        // Start listening on node1
+        let node1_addr = "/ip4/127.0.0.1/tcp/50003".parse::<Multiaddr>().unwrap();
+        node1_client
+            .start_listening(node1_addr.clone())
+            .await
+            .unwrap();
+        tracing::info!(%node1_addr, "Node 1 listening");
+
+        // Start listening on node2
+        let node2_addr = "/ip4/127.0.0.1/tcp/50004".parse::<Multiaddr>().unwrap();
+        node2_client
+            .start_listening(node2_addr.clone())
+            .await
+            .unwrap();
+        tracing::info!(%node2_addr, "Node 2 listening");
+
+        // Dial node1 from node2
+        node2_client
+            .dial(*node1_client.peer_id(), node1_addr.clone())
+            .await
+            .unwrap();
+        tracing::info!(%node1_addr, "Node 2 dialing Node 1");
+
+        // Wait for the nodes to connect
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        // Create a sequence of complete proposal streams
+        let proposals = vec![
+            create_proposal_stream(1, 1, 100),
+            create_proposal_stream(1, 2, 101),
+            create_proposal_stream(2, 1, 102),
+        ];
+
+        // Send proposals
+        for (height_round, proposal_stream) in &proposals {
+            tracing::info!(?height_round, "Node 1 sending proposal stream");
+
+            // Send the entire proposal stream with shuffle flag
+            node1_client
+                .send(Command::TestProposalStream(
+                    (*height_round).into(),
+                    proposal_stream.clone(),
+                    true, // shuffle enabled
+                ))
+                .await
+                .unwrap();
+        }
+
+        // Node 2 should receive all proposal streams
+        let mut received_proposals = HashMap::new();
+        let mut completed_proposals = HashSet::new();
+
+        while completed_proposals.len() < proposals.len() {
+            if let Some(Event::Proposal(height_and_round, received_proposal)) =
+                node2_events.recv().await
+            {
+                tracing::info!(
+                    ?height_and_round,
+                    ?received_proposal,
+                    "Node 2 received proposal part"
+                );
+
+                // Get or create the vector for this height/round
+                let proposal_parts = received_proposals
+                    .entry(height_and_round)
+                    .or_insert_with(Vec::new);
+
+                proposal_parts.push(received_proposal.clone());
+
+                // If we received a Fin message, verify the complete proposal
+                if let ProposalPart::ProposalFin(_) = received_proposal {
+                    // Find the matching proposal by height/round
+                    let (_, expected_stream) = proposals
+                        .iter()
+                        .find(|((h, r), _)| {
+                            *h == height_and_round.height() && *r == height_and_round.round()
+                        })
+                        .expect("Received unknown proposal stream");
+
+                    // Verify we have all parts and they match in order
+                    assert_eq!(
+                        proposal_parts.len(),
+                        expected_stream.len(),
+                        "Received wrong number of proposal parts"
+                    );
+
+                    for (received, expected) in proposal_parts.iter().zip(expected_stream.iter()) {
+                        assert_eq!(
+                            received, expected,
+                            "Proposal part content or order doesn't match"
+                        );
+                    }
+
+                    tracing::info!(?height_and_round, "Proposal stream verified successfully");
+                    completed_proposals.insert(height_and_round);
+                }
+            }
+        }
+    }
+
+    /// Tests sending vote messages between two nodes.
+    ///
+    /// This test creates two nodes, connects them, and sends multiple vote
+    /// messages from one node to another. The test verifies that the receiving
+    /// node correctly receives all vote messages.
+    #[tokio::test]
+    async fn test_vote_messages() {
+        // Create two nodes with different identities
+        let (node1_client, _, node1_loop) = create_test_node().await;
+        let (node2_client, mut node2_events, node2_loop) = create_test_node().await;
+
+        // Start the main loops
+        tokio::spawn(node1_loop.run());
+        tokio::spawn(node2_loop.run());
+
+        // Start listening on node1
+        let node1_addr = "/ip4/127.0.0.1/tcp/50005".parse::<Multiaddr>().unwrap();
+        node1_client
+            .start_listening(node1_addr.clone())
+            .await
+            .unwrap();
+        tracing::info!(%node1_addr, "Node 1 listening");
+
+        // Start listening on node2
+        let node2_addr = "/ip4/127.0.0.1/tcp/50006".parse::<Multiaddr>().unwrap();
+        node2_client
+            .start_listening(node2_addr.clone())
+            .await
+            .unwrap();
+        tracing::info!(%node2_addr, "Node 2 listening");
+
+        // Dial node1 from node2
+        node2_client
+            .dial(*node1_client.peer_id(), node1_addr.clone())
+            .await
+            .unwrap();
+        tracing::info!(%node1_addr, "Node 2 dialing Node 1");
+
+        // Wait for the nodes to connect
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        // Create a sequence of votes to send
+        let votes = vec![
+            Vote {
+                vote_type: VoteType::Prevote,
+                height: 100,
+                round: 1,
+                block_hash: Some(Hash(Felt::from_hex_str("0x123").unwrap())),
+                voter: Address(Felt::from_hex_str("0x456").unwrap()),
+            },
+            Vote {
+                vote_type: VoteType::Precommit,
+                height: 100,
+                round: 1,
+                block_hash: Some(Hash(Felt::from_hex_str("0x789").unwrap())),
+                voter: Address(Felt::from_hex_str("0xabc").unwrap()),
+            },
+            Vote {
+                vote_type: VoteType::Prevote,
+                height: 101,
+                round: 2,
+                block_hash: None, // NIL vote
+                voter: Address(Felt::from_hex_str("0xdef").unwrap()),
+            },
+        ];
+
+        // Send votes from node1
+        for vote in &votes {
+            tracing::info!(?vote, "Node 1 sending vote");
+            node1_client
+                .send(Command::Vote(vote.clone()))
+                .await
+                .unwrap();
+        }
+
+        // Node 2 should receive all votes
+        let mut received_votes = Vec::new();
+        let mut expected_votes = votes.clone();
+
+        while !expected_votes.is_empty() {
+            if let Some(Event::Vote(received_vote)) = node2_events.recv().await {
+                tracing::info!(?received_vote, "Node 2 received vote");
+                received_votes.push(received_vote.clone());
+
+                // Find and remove the matching expected vote
+                if let Some(pos) = expected_votes.iter().position(|v| v == &received_vote) {
+                    expected_votes.remove(pos);
+                }
+            }
+        }
+
+        // Verify we received all votes
+        assert_eq!(
+            received_votes.len(),
+            votes.len(),
+            "Did not receive all votes"
+        );
+        assert!(
+            expected_votes.is_empty(),
+            "Some expected votes were not received"
+        );
+    }
+
+    async fn create_test_node() -> (
+        core::Client<consensus::Command>,
+        mpsc::Receiver<consensus::Event>,
+        main_loop::MainLoop<consensus::Behaviour>,
+    ) {
+        let keypair = Keypair::generate_ed25519();
+        let core_config = Config::for_test();
+        let consensus_config = consensus::Config::default();
+        let chain_id = ChainId::MAINNET;
+
+        new_consensus(keypair, core_config, consensus_config, chain_id)
+    }
+
+    fn create_proposal_stream(
+        height: u64,
+        round: u32,
+        base: u64,
+    ) -> ((u64, u32), Vec<ProposalPart>) {
+        let mut stream = Vec::new();
+
+        // ProposalInit
+        stream.push(ProposalPart::ProposalInit(ProposalInit {
+            height,
+            round,
+            proposer: p2p_proto::common::Address(Felt::from_hex_str("0x123").unwrap()),
+            valid_round: None,
+        }));
+
+        // BlockInfo
+        stream.push(ProposalPart::BlockInfo(BlockInfo {
+            height,
+            timestamp: 1234567890 + base,
+            builder: p2p_proto::common::Address(Felt::from_hex_str("0x456").unwrap()),
+            l1_da_mode: p2p_proto::common::L1DataAvailabilityMode::Calldata,
+            l2_gas_price_fri: 1000 + base as u128,
+            l1_gas_price_wei: 2000 + base as u128,
+            l1_data_gas_price_wei: 3000 + base as u128,
+            eth_to_fri_rate: 4000 + base as u128,
+        }));
+
+        // TransactionBatch (send a few)
+        for i in 0..3 {
+            stream.push(ProposalPart::TransactionBatch(vec![Transaction {
+                transaction_hash: p2p_proto::common::Hash(
+                    Felt::from_hex_str(&format!("0x123abc{}", i)).unwrap(),
+                ),
+                txn: TransactionVariant::L1HandlerV0(L1HandlerV0 {
+                    nonce: Felt::from_hex_str(&format!("0x{}", i + 1)).unwrap(),
+                    address: p2p_proto::common::Address(
+                        Felt::from_hex_str(&format!("0x789{}", i)).unwrap(),
+                    ),
+                    entry_point_selector: Felt::from_hex_str(&format!("0x{}", i + 1)).unwrap(),
+                    calldata: vec![Felt::from_hex_str(&format!("0x{}", i + 1)).unwrap()],
+                }),
+            }]));
+        }
+
+        // ProposalFin
+        stream.push(ProposalPart::ProposalFin(ProposalFin {
+            proposal_commitment: p2p_proto::common::Hash(Felt::from_hex_str("0x69420abc").unwrap()),
+        }));
+
+        ((height, round), stream)
+    }
+}

--- a/crates/p2p/src/consensus/behaviour.rs
+++ b/crates/p2p/src/consensus/behaviour.rs
@@ -1,7 +1,21 @@
-use libp2p::gossipsub;
+use libp2p::gossipsub::{self, IdentTopic};
 use libp2p::swarm::NetworkBehaviour;
+use libp2p::{identity, PeerId};
+use p2p_proto::consensus::Vote;
+use p2p_proto::ProtobufSerializable;
+#[cfg(test)]
+use rand::seq::SliceRandom;
 use tokio::sync::mpsc;
+use tracing::error;
 
+use crate::consensus::stream::StreamMessage;
+use crate::consensus::{
+    create_outgoing_proposal_message,
+    handle_incoming_proposal_message,
+    Event,
+    TOPIC_PROPOSALS,
+    TOPIC_VOTES,
+};
 use crate::{consensus, ApplicationBehaviour};
 
 /// The consensus P2P network behaviour.
@@ -15,16 +29,111 @@ impl ApplicationBehaviour for Behaviour {
     type Event = consensus::Event;
     type State = consensus::State;
 
-    async fn handle_command(&mut self, _command: Self::Command, _state: &mut Self::State) {
-        todo!()
+    async fn handle_command(&mut self, command: Self::Command, state: &mut Self::State) {
+        use consensus::Command as ConsensusCommand;
+        match command {
+            ConsensusCommand::Proposal(height_and_round, proposal_part) => {
+                let stream_msgs =
+                    create_outgoing_proposal_message(state, height_and_round, proposal_part);
+                for msg in stream_msgs {
+                    let topic = IdentTopic::new(TOPIC_PROPOSALS);
+                    if let Err(e) = self.gossipsub.publish(topic, msg.to_protobuf_bytes()) {
+                        error!("Failed to publish proposal message: {}", e);
+                    }
+                }
+            }
+            ConsensusCommand::Vote(vote) => {
+                let data = vote.to_protobuf_bytes();
+                let topic = IdentTopic::new(TOPIC_VOTES);
+                if let Err(e) = self.gossipsub.publish(topic, data) {
+                    error!("Failed to publish vote message: {}", e);
+                }
+            }
+            #[cfg(test)]
+            ConsensusCommand::TestProposalStream(height_and_round, proposal_stream, shuffle) => {
+                // This command is used to test out-of-order delivery of proposal streams.
+                // The `message_id` must be assigned sequentially within
+                // `create_outgoing_proposal_message`, so this test command
+                // needs to live in the network layer rather than the application layer.
+                let mut stream_msgs = Vec::new();
+                for part in proposal_stream {
+                    let msgs = create_outgoing_proposal_message(state, height_and_round, part);
+                    stream_msgs.extend(msgs);
+                }
+                if shuffle {
+                    stream_msgs.shuffle(&mut rand::thread_rng());
+                }
+                for msg in stream_msgs {
+                    let topic = IdentTopic::new(TOPIC_PROPOSALS);
+                    if let Err(e) = self.gossipsub.publish(topic, msg.to_protobuf_bytes()) {
+                        error!("Failed to publish proposal message: {}", e);
+                    }
+                }
+            }
+        }
     }
 
     async fn handle_event(
         &mut self,
-        _event: <Self as NetworkBehaviour>::ToSwarm,
-        _state: &mut Self::State,
-        _event_sender: mpsc::Sender<Self::Event>,
+        event: BehaviourEvent,
+        state: &mut Self::State,
+        event_sender: mpsc::Sender<Self::Event>,
     ) {
-        todo!()
+        use gossipsub::Event::*;
+        let BehaviourEvent::Gossipsub(e) = event;
+        match e {
+            Message {
+                propagation_source: _,
+                message_id,
+                message,
+            } => match message.topic.as_str() {
+                TOPIC_PROPOSALS => {
+                    if let Ok(stream_msg) = StreamMessage::from_protobuf_bytes(&message.data) {
+                        let events = handle_incoming_proposal_message(state, stream_msg);
+                        for event in events {
+                            let _ = event_sender.send(event).await;
+                        }
+                    } else {
+                        error!("Failed to parse proposal message with id: {}", message_id);
+                    }
+                }
+                TOPIC_VOTES => {
+                    if let Ok(vote) = Vote::from_protobuf_bytes(&message.data) {
+                        let _ = event_sender.send(Event::Vote(vote)).await;
+                    } else {
+                        error!("Failed to parse vote message with id: {}", message_id);
+                    }
+                }
+                _ => {}
+            },
+            _ => {
+                // TODO: Do we care about any other Gossipsub events?
+            }
+        }
+    }
+}
+
+impl Behaviour {
+    /// Create a new consensus behaviour.
+    pub fn new(keypair: identity::Keypair) -> Self {
+        let peer_id = PeerId::from(keypair.public());
+
+        let gossipsub_config = gossipsub::Config::default();
+        let mut gossipsub = gossipsub::Behaviour::new(
+            gossipsub::MessageAuthenticity::Signed(keypair),
+            gossipsub_config,
+        )
+        .unwrap();
+
+        let proposals_topic = IdentTopic::new(TOPIC_PROPOSALS);
+        let votes_topic = IdentTopic::new(TOPIC_VOTES);
+
+        gossipsub.subscribe(&proposals_topic).unwrap();
+        gossipsub.subscribe(&votes_topic).unwrap();
+
+        tracing::info!("Consensus node started with peer ID: {}", peer_id);
+        tracing::info!("Subscribed to topics: {}, {}", proposals_topic, votes_topic);
+
+        Behaviour { gossipsub }
     }
 }

--- a/crates/p2p/src/consensus/height_and_round.rs
+++ b/crates/p2p/src/consensus/height_and_round.rs
@@ -1,0 +1,65 @@
+use libp2p::bytes::{Buf, BufMut};
+
+/// Height and round of the proposal.
+///
+/// This serves as the `stream_id` when sending messages via Gossip.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct HeightAndRound {
+    height: u64,
+    round: u32,
+}
+
+impl HeightAndRound {
+    pub fn new(height: u64, round: u32) -> Self {
+        Self { height, round }
+    }
+
+    pub fn height(&self) -> u64 {
+        self.height
+    }
+
+    pub fn round(&self) -> u32 {
+        self.round
+    }
+}
+
+impl From<(u64, u32)> for HeightAndRound {
+    fn from(value: (u64, u32)) -> Self {
+        Self {
+            height: value.0,
+            round: value.1,
+        }
+    }
+}
+
+impl From<HeightAndRound> for Vec<u8> {
+    fn from(value: HeightAndRound) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(12);
+        bytes.put_u64(value.height);
+        bytes.put_u32(value.round);
+        bytes
+    }
+}
+
+impl TryFrom<Vec<u8>> for HeightAndRound {
+    type Error = std::io::Error;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        if value.len() != 12 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Invalid length",
+            ));
+        }
+        let mut bytes = value.as_slice();
+        let height = bytes.get_u64();
+        let round = bytes.get_u32();
+        Ok(HeightAndRound { height, round })
+    }
+}
+
+impl std::fmt::Display for HeightAndRound {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "({}:{})", self.height, self.round)
+    }
+}

--- a/crates/p2p/src/consensus/stream.rs
+++ b/crates/p2p/src/consensus/stream.rs
@@ -1,0 +1,180 @@
+use std::collections::HashMap;
+
+use p2p_proto::{ProtobufSerializable, ToProtobuf};
+use prost::Message;
+
+use crate::consensus::height_and_round::HeightAndRound;
+
+/// The type of the stream id.
+pub type StreamId = HeightAndRound;
+
+/// A message sent as part of a stream.
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct StreamMessage<T> {
+    /// The stream this message belongs to.
+    pub stream_id: StreamId,
+    /// The id of the message in the stream.
+    pub message_id: u64,
+    /// The body of the message.
+    pub message: StreamMessageBody<T>,
+}
+
+impl<T: ProtobufSerializable> ProtobufSerializable for StreamMessage<T> {
+    /// Convert the stream message to a byte vector that can be sent over the
+    /// network.
+    fn to_protobuf_bytes(&self) -> Vec<u8> {
+        let proto_message = p2p_proto::consensus::StreamMessage {
+            stream_id: self.stream_id.into(),
+            message_id: self.message_id,
+            message: match &self.message {
+                StreamMessageBody::Content(content) => {
+                    p2p_proto::consensus::StreamMessageVariant::Content(content.to_protobuf_bytes())
+                }
+                StreamMessageBody::Fin => p2p_proto::consensus::StreamMessageVariant::Fin,
+            },
+        };
+        proto_message.to_protobuf().encode_to_vec()
+    }
+
+    /// Convert a byte vector to a stream message.
+    fn from_protobuf_bytes(bytes: &[u8]) -> Result<Self, std::io::Error> {
+        let proto_message = p2p_proto::proto::consensus::StreamMessage::decode(bytes)?;
+        let message = match proto_message.message {
+            Some(p2p_proto::proto::consensus::stream_message::Message::Content(content)) => {
+                StreamMessageBody::Content(T::from_protobuf_bytes(&content)?)
+            }
+            Some(p2p_proto::proto::consensus::stream_message::Message::Fin(_)) => {
+                StreamMessageBody::Fin
+            }
+            None => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "missing message",
+                ))
+            }
+        };
+
+        Ok(StreamMessage {
+            stream_id: proto_message.stream_id.try_into()?,
+            message_id: proto_message.message_id,
+            message,
+        })
+    }
+}
+
+/// Body of the message in the stream.
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub enum StreamMessageBody<T> {
+    /// A message with content.
+    Content(T),
+    /// A message indicating the end of the stream.
+    Fin,
+}
+
+/// State of an ongoing stream.
+///
+/// This is used to track the state of a stream and the messages
+/// that have been sent and received.
+#[derive(Debug)]
+pub enum StreamState<T> {
+    /// A stream that is receiving messages.
+    Incoming(IncomingStreamState<T>),
+    /// A stream that is sending messages.
+    Outgoing(OutgoingStreamState<T>),
+}
+
+impl<T> StreamState<T> {
+    /// Create a new incoming stream state.
+    pub fn new_incoming() -> Self {
+        Self::Incoming(IncomingStreamState::new())
+    }
+
+    /// Create a new outgoing stream state.
+    pub fn new_outgoing() -> Self {
+        Self::Outgoing(OutgoingStreamState::new())
+    }
+}
+
+/// State of a stream that is receiving messages.
+#[derive(Debug)]
+pub struct IncomingStreamState<T> {
+    /// The next message id that is expected.
+    pub next_message_id: u64,
+    /// The messages that have been received.
+    pub received_messages: HashMap<u64, StreamMessage<T>>,
+    /// The id of the message that indicates the end of the stream.
+    pub fin_message_id: Option<u64>,
+}
+
+impl<T> IncomingStreamState<T> {
+    fn new() -> Self {
+        Self {
+            next_message_id: 0,
+            received_messages: HashMap::new(),
+            fin_message_id: None,
+        }
+    }
+}
+
+/// State of a stream that is sending messages.
+#[derive(Debug)]
+pub struct OutgoingStreamState<T> {
+    /// The id of the last message that was sent, if any.
+    pub last_sent_message_id: Option<u64>,
+    /// The messages that have been sent.
+    pub sent_messages: HashMap<u64, T>,
+    /// Whether the Fin message has been sent.
+    pub fin_sent: bool,
+}
+
+impl<T> OutgoingStreamState<T> {
+    fn new() -> Self {
+        Self {
+            last_sent_message_id: None,
+            sent_messages: HashMap::new(),
+            fin_sent: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use p2p_proto::common::{Address, L1DataAvailabilityMode};
+    use pathfinder_crypto::Felt;
+
+    use super::*;
+
+    #[test]
+    fn test_encode_decode() {
+        // Create a sample ProposalPart
+        let block_info = p2p_proto::consensus::BlockInfo {
+            height: 100,
+            timestamp: 1234567890,
+            builder: Address(Felt::from_hex_str("0x456").unwrap()),
+            l1_da_mode: L1DataAvailabilityMode::Calldata,
+            l2_gas_price_fri: 1000,
+            l1_gas_price_wei: 2000,
+            l1_data_gas_price_wei: 3000,
+            eth_to_fri_rate: 4000,
+        };
+        let proposal = p2p_proto::consensus::ProposalPart::BlockInfo(block_info);
+
+        // Create a StreamMessage with the ProposalPart
+        let stream_message = StreamMessage {
+            stream_id: (1, 2).into(), // HeightAndRound
+            message_id: 42,
+            message: StreamMessageBody::Content(proposal.clone()),
+        };
+
+        // Encode to bytes
+        let bytes = stream_message.clone().to_protobuf_bytes();
+
+        // Decode back
+        let decoded =
+            StreamMessage::<p2p_proto::consensus::ProposalPart>::from_protobuf_bytes(&bytes)
+                .unwrap();
+
+        // Verify the round trip
+        assert_eq!(stream_message, decoded);
+    }
+}

--- a/crates/p2p/src/core/client.rs
+++ b/crates/p2p/src/core/client.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use anyhow::Context;
 use libp2p::{Multiaddr, PeerId};
+use tokio::sync::mpsc::error::SendError;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::core::Command;
@@ -18,6 +19,10 @@ pub struct Client<C> {
 impl<C> Client<C> {
     pub(crate) fn new(sender: mpsc::Sender<Command<C>>, peer_id: PeerId) -> Self {
         Self { sender, peer_id }
+    }
+
+    pub async fn send(&self, command: C) -> Result<(), SendError<Command<C>>> {
+        self.sender.send(Command::Application(command)).await
     }
 
     pub fn peer_id(&self) -> &PeerId {

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -22,7 +22,7 @@ mod secret;
 mod test_utils;
 mod transport;
 
-pub use builder::Builder;
+use builder::Builder;
 pub use libp2p;
 pub use peer_data::PeerData;
 
@@ -49,14 +49,12 @@ pub fn new_consensus(
     _consensus_config: consensus::Config,
     chain_id: ChainId,
 ) -> (
-    core::Client<sync::Command>,
-    mpsc::Receiver<sync::Event>,
-    main_loop::MainLoop<sync::Behaviour>,
+    core::Client<consensus::Command>,
+    mpsc::Receiver<consensus::Event>,
+    main_loop::MainLoop<consensus::Behaviour>,
 ) {
-    // TODO remove allow when behaviour is built properly
-    #[allow(unreachable_code)]
-    Builder::new(keypair, core_config, chain_id)
-        .app_behaviour(todo!())
+    Builder::new(keypair.clone(), core_config, chain_id)
+        .app_behaviour(consensus::Behaviour::new(keypair))
         .build()
 }
 

--- a/crates/p2p_proto/build.rs
+++ b/crates/p2p_proto/build.rs
@@ -10,6 +10,7 @@ fn main() -> Result<()> {
             "proto/receipt.proto",
             "proto/state.proto",
             "proto/transaction.proto",
+            "proto/consensus.proto",
         ],
         &["proto"],
     )?;

--- a/crates/p2p_proto/proto/consensus.proto
+++ b/crates/p2p_proto/proto/consensus.proto
@@ -1,0 +1,83 @@
+syntax = "proto3";
+import "common.proto";
+import "transaction.proto";
+
+package starknet.consensus;
+
+// Contains all variants of mempool and an L1Handler variant to cover all transactions that can be
+// in a new block.
+message ConsensusTransaction {
+    oneof txn {
+        starknet.transaction.DeclareV3WithClass             declare_v3 = 1;
+        starknet.transaction.Transaction.DeployAccountV3    deploy_account_v3 = 2;
+        starknet.transaction.Transaction.InvokeV3           invoke_v3 = 3;
+        starknet.transaction.Transaction.L1HandlerV0        l1_handler = 4;
+    }
+    starknet.common.Hash transaction_hash = 5;
+}
+
+message Vote {
+    enum  VoteType {
+        Prevote   = 0;
+        Precommit = 1;
+    };
+
+    // We use a type field to distinguish between prevotes and precommits instead of different
+    // messages, to make sure the data, and therefore the signatures, are unambiguous between
+    // Prevote and Precommit.
+    VoteType      vote_type  = 2;
+    uint64        height     = 3;
+    uint32        round      = 4;
+    // This is optional since a vote can be NIL.
+    optional starknet.common.Hash block_hash = 5;
+    starknet.common.Address       voter      = 6;
+}
+
+message StreamMessage {
+    oneof message {
+        bytes content = 1;
+        starknet.common.Fin fin = 2;
+    }
+    bytes stream_id = 3;
+    uint64 message_id = 4;
+}
+
+message ProposalInit {
+    uint64 height = 1;
+    uint32 round = 2;
+    optional uint32 valid_round = 3;
+    starknet.common.Address proposer = 4;
+}
+
+message BlockInfo {
+    uint64 height = 1;
+    uint64 timestamp = 2;
+    starknet.common.Address                 builder = 3;
+    starknet.common.L1DataAvailabilityMode  l1_da_mode = 4;
+    starknet.common.Uint128                 l2_gas_price_fri = 5;
+    starknet.common.Uint128                 l1_gas_price_wei = 6;
+    starknet.common.Uint128                 l1_data_gas_price_wei = 7;
+    starknet.common.Uint128                 eth_to_fri_rate = 8;
+}
+
+message TransactionBatch {
+    repeated ConsensusTransaction transactions = 1;
+}
+
+message ProposalFin {
+    // Identifies a Starknet block based on the content streamed in the proposal.
+    starknet.common.Hash proposal_commitment = 1;
+}
+
+// Network format:
+// 1. First message is ProposalInit
+// 2. Last message is ProposalFin
+// 3. In between can be any number of other messages.
+message ProposalPart {
+    oneof message {
+        ProposalInit init = 1;
+        ProposalFin fin = 2;
+        BlockInfo block_info = 3;
+        TransactionBatch transactions = 4;
+    }
+}

--- a/crates/p2p_proto/proto/transaction.proto
+++ b/crates/p2p_proto/proto/transaction.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 import "common.proto";
+import "class.proto";
 import "receipt.proto";
 
 package starknet.transaction;
@@ -51,6 +52,8 @@ message Transaction
     message DeclareV3 {
         starknet.common.Address          sender                       = 1;
         AccountSignature                 signature                    = 2;
+        // In consensus the hash is missing because Cairo1Class already contains it
+        // https://github.com/starknet-io/starknet-p2p-specs/blob/a75602f7986ccad0b3b700f34b4d6921454d20ba/p2p/proto/transaction.proto#L33 
         starknet.common.Hash             class_hash                   = 3;
         starknet.common.Felt252          nonce                        = 4;
         starknet.common.Hash             compiled_class_hash          = 5;
@@ -163,4 +166,10 @@ message TransactionsResponse {
         TransactionWithReceipt transaction_with_receipt = 1;
         starknet.common.Fin    fin                      = 2; // Fin is sent after the peer sent all the data or when it encountered a block that it doesn't have its transactions.
     }
+}
+
+// Specific to consensus: https://github.com/starknet-io/starknet-p2p-specs/blob/a75602f7986ccad0b3b700f34b4d6921454d20ba/p2p/proto/transaction.proto#L44
+message DeclareV3WithClass {
+    Transaction.DeclareV3 common = 1;
+    starknet.class.Cairo1Class class = 2;
 }

--- a/crates/p2p_proto/src/common.rs
+++ b/crates/p2p_proto/src/common.rs
@@ -67,6 +67,36 @@ pub enum L1DataAvailabilityMode {
     Blob,
 }
 
+impl ToProtobuf<i32> for L1DataAvailabilityMode {
+    fn to_protobuf(self) -> i32 {
+        use proto::common::L1DataAvailabilityMode::{Blob, Calldata};
+        match self {
+            L1DataAvailabilityMode::Calldata => Calldata as i32,
+            L1DataAvailabilityMode::Blob => Blob as i32,
+        }
+    }
+}
+
+impl TryFromProtobuf<i32> for L1DataAvailabilityMode {
+    fn try_from_protobuf(input: i32, field_name: &'static str) -> Result<Self, std::io::Error> {
+        use proto::common::L1DataAvailabilityMode::{Blob, Calldata};
+        Ok(
+            match TryFrom::try_from(input).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "Invalid L1 data availability mode field element {field_name} enum value: \
+                         {e}"
+                    ),
+                )
+            })? {
+                Calldata => L1DataAvailabilityMode::Calldata,
+                Blob => L1DataAvailabilityMode::Blob,
+            },
+        )
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Dummy)]
 pub enum VolitionDomain {
     L1,
@@ -204,36 +234,6 @@ impl TryFromProtobuf<proto::common::Address> for Address {
 impl Display for BlockId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "({},{})", self.number, self.hash.0)
-    }
-}
-
-impl ToProtobuf<i32> for L1DataAvailabilityMode {
-    fn to_protobuf(self) -> i32 {
-        use proto::common::L1DataAvailabilityMode::{Blob, Calldata};
-        match self {
-            L1DataAvailabilityMode::Calldata => Calldata as i32,
-            L1DataAvailabilityMode::Blob => Blob as i32,
-        }
-    }
-}
-
-impl TryFromProtobuf<i32> for L1DataAvailabilityMode {
-    fn try_from_protobuf(input: i32, field_name: &'static str) -> Result<Self, std::io::Error> {
-        use proto::common::L1DataAvailabilityMode::{Blob, Calldata};
-        Ok(
-            match TryFrom::try_from(input).map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!(
-                        "Invalid L1 data availability mode field element {field_name} enum value: \
-                         {e}"
-                    ),
-                )
-            })? {
-                Calldata => L1DataAvailabilityMode::Calldata,
-                Blob => L1DataAvailabilityMode::Blob,
-            },
-        )
     }
 }
 

--- a/crates/p2p_proto/src/consensus.rs
+++ b/crates/p2p_proto/src/consensus.rs
@@ -1,0 +1,221 @@
+use fake::Dummy;
+
+use crate::common::{Address, Hash, L1DataAvailabilityMode};
+use crate::proto::consensus::ConsensusTransaction;
+use crate::transaction::{DeclareV3WithClass, DeployAccountV3, InvokeV3, L1HandlerV0};
+use crate::{proto, proto_field, ToProtobuf, TryFromProtobuf};
+
+#[derive(Debug, Clone, PartialEq, Eq, Dummy)]
+pub enum TransactionVariant {
+    DeclareV3(DeclareV3WithClass),
+    DeployAccountV3(DeployAccountV3),
+    InvokeV3(InvokeV3),
+    L1HandlerV0(L1HandlerV0),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, ToProtobuf, TryFromProtobuf, Dummy)]
+#[protobuf(name = "crate::proto::consensus::ConsensusTransaction")]
+pub struct Transaction {
+    pub txn: TransactionVariant,
+    pub transaction_hash: Hash,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Dummy)]
+pub enum VoteType {
+    Prevote,
+    Precommit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, ToProtobuf, TryFromProtobuf, Dummy)]
+#[protobuf(name = "crate::proto::consensus::StreamMessage")]
+pub struct StreamMessage {
+    pub message: StreamMessageVariant,
+    pub stream_id: Vec<u8>,
+    pub message_id: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Dummy)]
+pub enum StreamMessageVariant {
+    Content(Vec<u8>),
+    Fin,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, ToProtobuf, TryFromProtobuf, Dummy)]
+#[protobuf(name = "crate::proto::consensus::ProposalInit")]
+pub struct ProposalInit {
+    pub height: u64,
+    pub round: u32,
+    #[optional]
+    pub valid_round: Option<u32>,
+    pub proposer: Address,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, ToProtobuf, TryFromProtobuf, Dummy)]
+#[protobuf(name = "crate::proto::consensus::BlockInfo")]
+pub struct BlockInfo {
+    pub height: u64,
+    pub timestamp: u64,
+    pub builder: Address,
+    pub l1_da_mode: L1DataAvailabilityMode,
+    pub l2_gas_price_fri: u128,
+    pub l1_gas_price_wei: u128,
+    pub l1_data_gas_price_wei: u128,
+    pub eth_to_fri_rate: u128,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, ToProtobuf, TryFromProtobuf, Dummy)]
+#[protobuf(name = "crate::proto::consensus::ProposalFin")]
+pub struct ProposalFin {
+    pub proposal_commitment: Hash,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Dummy)]
+pub enum ProposalPart {
+    ProposalInit(ProposalInit),
+    BlockInfo(BlockInfo),
+    TransactionBatch(Vec<Transaction>),
+    ProposalFin(ProposalFin),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TransactionBatch {
+    /// The transactions in the batch.
+    pub transactions: Vec<ConsensusTransaction>,
+}
+
+impl ToProtobuf<proto::consensus::consensus_transaction::Txn> for TransactionVariant {
+    fn to_protobuf(self) -> proto::consensus::consensus_transaction::Txn {
+        use proto::consensus::consensus_transaction::Txn::{
+            DeclareV3,
+            DeployAccountV3,
+            InvokeV3,
+            L1Handler,
+        };
+        match self {
+            Self::DeclareV3(txn) => DeclareV3(txn.to_protobuf()),
+            Self::DeployAccountV3(txn) => DeployAccountV3(txn.to_protobuf()),
+            Self::InvokeV3(txn) => InvokeV3(txn.to_protobuf()),
+            Self::L1HandlerV0(txn) => L1Handler(txn.to_protobuf()),
+        }
+    }
+}
+
+impl TryFromProtobuf<proto::consensus::consensus_transaction::Txn> for TransactionVariant {
+    fn try_from_protobuf(
+        input: proto::consensus::consensus_transaction::Txn,
+        field_name: &'static str,
+    ) -> Result<Self, std::io::Error> {
+        use proto::consensus::consensus_transaction::Txn::{
+            DeclareV3,
+            DeployAccountV3,
+            InvokeV3,
+            L1Handler,
+        };
+        match input {
+            DeclareV3(t) => TryFromProtobuf::try_from_protobuf(t, field_name).map(Self::DeclareV3),
+            DeployAccountV3(t) => {
+                TryFromProtobuf::try_from_protobuf(t, field_name).map(Self::DeployAccountV3)
+            }
+            InvokeV3(t) => TryFromProtobuf::try_from_protobuf(t, field_name).map(Self::InvokeV3),
+            L1Handler(t) => {
+                TryFromProtobuf::try_from_protobuf(t, field_name).map(Self::L1HandlerV0)
+            }
+        }
+    }
+}
+
+impl ToProtobuf<i32> for VoteType {
+    fn to_protobuf(self) -> i32 {
+        use proto::consensus::vote::VoteType::{Precommit, Prevote};
+        match self {
+            VoteType::Prevote => Prevote as i32,
+            VoteType::Precommit => Precommit as i32,
+        }
+    }
+}
+
+impl TryFromProtobuf<i32> for VoteType {
+    fn try_from_protobuf(input: i32, field_name: &'static str) -> Result<Self, std::io::Error> {
+        use proto::consensus::vote::VoteType::{Precommit, Prevote};
+        Ok(
+            match TryFrom::try_from(input).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("Invalid vote type field element {field_name} enum value: {e}"),
+                )
+            })? {
+                Prevote => VoteType::Prevote,
+                Precommit => VoteType::Precommit,
+            },
+        )
+    }
+}
+
+impl ToProtobuf<proto::consensus::stream_message::Message> for StreamMessageVariant {
+    fn to_protobuf(self) -> proto::consensus::stream_message::Message {
+        use proto::consensus::stream_message::Message::{Content, Fin};
+        match self {
+            Self::Content(message) => Content(message),
+            Self::Fin => Fin(proto::common::Fin {}),
+        }
+    }
+}
+
+impl TryFromProtobuf<proto::consensus::stream_message::Message> for StreamMessageVariant {
+    fn try_from_protobuf(
+        input: proto::consensus::stream_message::Message,
+        field_name: &'static str,
+    ) -> Result<Self, std::io::Error> {
+        use proto::consensus::stream_message::Message::{Content, Fin};
+        match input {
+            Content(message) => {
+                TryFromProtobuf::try_from_protobuf(message, field_name).map(Self::Content)
+            }
+            Fin(_) => Ok(Self::Fin),
+        }
+    }
+}
+
+impl ToProtobuf<proto::consensus::ProposalPart> for ProposalPart {
+    fn to_protobuf(self) -> proto::consensus::ProposalPart {
+        use proto::consensus::proposal_part::Message::{BlockInfo, Fin, Init, Transactions};
+        use proto::consensus::TransactionBatch;
+        proto::consensus::ProposalPart {
+            message: Some(match self {
+                Self::ProposalInit(init) => Init(init.to_protobuf()),
+                Self::BlockInfo(bi) => BlockInfo(bi.to_protobuf()),
+                Self::TransactionBatch(transactions) => Transactions(TransactionBatch {
+                    transactions: transactions
+                        .into_iter()
+                        .map(|txn| txn.to_protobuf())
+                        .collect(),
+                }),
+                Self::ProposalFin(fin) => Fin(fin.to_protobuf()),
+            }),
+        }
+    }
+}
+
+impl TryFromProtobuf<proto::consensus::ProposalPart> for ProposalPart {
+    fn try_from_protobuf(
+        input: proto::consensus::ProposalPart,
+        field_name: &'static str,
+    ) -> Result<Self, std::io::Error> {
+        use proto::consensus::proposal_part::Message::{BlockInfo, Fin, Init, Transactions};
+        match proto_field(input.message, field_name)? {
+            Init(init) => {
+                TryFromProtobuf::try_from_protobuf(init, field_name).map(Self::ProposalInit)
+            }
+            BlockInfo(bi) => {
+                TryFromProtobuf::try_from_protobuf(bi, field_name).map(Self::BlockInfo)
+            }
+            Transactions(transactions) => transactions
+                .transactions
+                .into_iter()
+                .map(|txn| TryFromProtobuf::try_from_protobuf(txn, field_name))
+                .collect::<Result<Vec<_>, _>>()
+                .map(Self::TransactionBatch),
+            Fin(fin) => TryFromProtobuf::try_from_protobuf(fin, field_name).map(Self::ProposalFin),
+        }
+    }
+}

--- a/crates/p2p_proto/src/lib.rs
+++ b/crates/p2p_proto/src/lib.rs
@@ -25,6 +25,10 @@ pub mod proto {
     pub mod transaction {
         include!(concat!(env!("OUT_DIR"), "/starknet.transaction.rs"));
     }
+    #[allow(clippy::large_enum_variant)]
+    pub mod consensus {
+        include!(concat!(env!("OUT_DIR"), "/starknet.consensus.rs"));
+    }
 }
 
 pub trait ToProtobuf<Output>
@@ -167,6 +171,7 @@ fn proto_field<T>(input: Option<T>, field_name: &'static str) -> Result<T, std::
 use p2p_proto_derive::*;
 pub mod class;
 pub mod common;
+pub mod consensus;
 pub mod event;
 pub mod header;
 pub mod receipt;

--- a/crates/p2p_proto/src/lib.rs
+++ b/crates/p2p_proto/src/lib.rs
@@ -168,6 +168,12 @@ fn proto_field<T>(input: Option<T>, field_name: &'static str) -> Result<T, std::
     })
 }
 
+/// Handles the conversion between domain types and protobuf messages.
+pub trait ProtobufSerializable: Sized {
+    fn to_protobuf_bytes(&self) -> Vec<u8>;
+    fn from_protobuf_bytes(bytes: &[u8]) -> Result<Self, std::io::Error>;
+}
+
 use p2p_proto_derive::*;
 pub mod class;
 pub mod common;

--- a/crates/p2p_proto/src/transaction.rs
+++ b/crates/p2p_proto/src/transaction.rs
@@ -1,6 +1,7 @@
 use fake::Dummy;
 use pathfinder_crypto::Felt;
 
+use crate::class::Cairo1Class;
 use crate::common::{Address, Hash, Iteration, VolitionDomain};
 use crate::receipt::Receipt;
 use crate::{proto, proto_field, ToProtobuf, TryFromProtobuf};
@@ -71,6 +72,13 @@ pub struct DeclareV3 {
     pub account_deployment_data: Vec<Felt>,
     pub nonce_data_availability_mode: VolitionDomain,
     pub fee_data_availability_mode: VolitionDomain,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, ToProtobuf, TryFromProtobuf, Dummy)]
+#[protobuf(name = "crate::proto::transaction::DeclareV3WithClass")]
+pub struct DeclareV3WithClass {
+    pub common: DeclareV3,
+    pub class: Cairo1Class,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ToProtobuf, TryFromProtobuf, Dummy)]


### PR DESCRIPTION
First take at implementing the consensus P2P layer. This is (are) the first necessary building block(s) for node-to-node communication in our consensus network, _hopefully_ compatible with the Starknet Apollo sequencer et al.

- GossipSub integration for message propagation
- Protobuf message types for proposals, votes, and stream messages
- Full serialization/deserialization support with tests
- Stream logic for reliable message delivery

The protobuf messages include everything we need for proposals (init, block info, transactions, fin) and voting (prevote/precommit). We've also got stream message handling with proper ID tracking and message ordering.

All the serialization code is tested thoroughly - both the direct protobuf path and the binary format. I believe we've got good coverage of all the message variants and their interactions.

This should now give us a solid foundation to build on. 

### Notes:
- Pathfinder hasn't been wired (yet) to support this new P2P network. Coming next.
- Yes, there's a few `TODO`s left that need attention, will tackle them as we go.
- This is still a bit of a WIP, but should not affect Pathfinder runtime in any way.