### PR TITLE
feat: remove `get_events_max_blocks_to_scan` CLI param

### DIFF
--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -305,15 +305,6 @@ This should only be enabled for debugging purposes as it adds substantial proces
     submission_tracker_size_limit: std::num::NonZeroUsize,
 
     #[arg(
-        long = "rpc.get-events-max-blocks-to-scan",
-        long_help = "The number of blocks to scan when querying for events. This limit is used to \
-                     prevent queries from taking too long.",
-        env = "PATHFINDER_RPC_GET_EVENTS_MAX_BLOCKS_TO_SCAN",
-        default_value = "500"
-    )]
-    get_events_max_blocks_to_scan: std::num::NonZeroUsize,
-
-    #[arg(
         long = "rpc.get-events-event-filter-block-range-limit",
         long_help = format!(
             "The maximum number of blocks to be covered by aggregate Bloom filters when querying for events. Each filter covers a {} block range. 
@@ -736,7 +727,6 @@ pub struct Config {
     pub gateway_api_key: Option<String>,
     pub gateway_timeout: Duration,
     pub event_filter_cache_size: NonZeroUsize,
-    pub get_events_max_blocks_to_scan: NonZeroUsize,
     pub get_events_event_filter_block_range_limit: NonZeroUsize,
     pub blockchain_history: Option<BlockchainHistory>,
     pub state_tries: Option<StateTries>,
@@ -923,7 +913,6 @@ impl Config {
             is_rpc_enabled: cli.is_rpc_enabled,
             gateway_api_key: cli.gateway_api_key,
             event_filter_cache_size: cli.event_filter_cache_size,
-            get_events_max_blocks_to_scan: cli.get_events_max_blocks_to_scan,
             get_events_event_filter_block_range_limit: cli
                 .get_events_event_filter_block_range_limit,
             gateway_timeout: Duration::from_secs(cli.gateway_timeout.get()),

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -221,7 +221,6 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
 
     let rpc_config = pathfinder_rpc::context::RpcConfig {
         batch_concurrency_limit: config.rpc_batch_concurrency_limit,
-        get_events_max_blocks_to_scan: config.get_events_max_blocks_to_scan,
         get_events_event_filter_block_range_limit: config.get_events_event_filter_block_range_limit,
         fee_estimation_epsilon: config.fee_estimation_epsilon,
         versioned_constants_map: config.versioned_constants_map.clone(),

--- a/crates/rpc/src/context.rs
+++ b/crates/rpc/src/context.rs
@@ -66,7 +66,6 @@ impl EthContractAddresses {
 #[derive(Clone)]
 pub struct RpcConfig {
     pub batch_concurrency_limit: NonZeroUsize,
-    pub get_events_max_blocks_to_scan: NonZeroUsize,
     pub get_events_event_filter_block_range_limit: NonZeroUsize,
     pub fee_estimation_epsilon: Percentage,
     pub versioned_constants_map: VersionedConstantsMap,
@@ -216,7 +215,6 @@ impl RpcContext {
 
         let config = RpcConfig {
             batch_concurrency_limit: NonZeroUsize::new(8).unwrap(),
-            get_events_max_blocks_to_scan: NonZeroUsize::new(1000).unwrap(),
             get_events_event_filter_block_range_limit: NonZeroUsize::new(1000).unwrap(),
             fee_estimation_epsilon: Percentage::new(10),
             versioned_constants_map: Default::default(),

--- a/crates/rpc/src/method/get_events.rs
+++ b/crates/rpc/src/method/get_events.rs
@@ -222,7 +222,6 @@ pub async fn get_events(
         let page = transaction
             .events(
                 &constraints,
-                context.config.get_events_max_blocks_to_scan,
                 context.config.get_events_event_filter_block_range_limit,
             )
             .map_err(|e| match e {

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -742,8 +742,6 @@ mod tests {
     use test_utils::*;
 
     use super::*;
-    static MAX_BLOCKS_TO_SCAN: LazyLock<NonZeroUsize> =
-        LazyLock::new(|| NonZeroUsize::new(100).unwrap());
     static EVENT_FILTERS_BLOCK_RANGE_LIMIT: LazyLock<NonZeroUsize> =
         LazyLock::new(|| NonZeroUsize::new(100).unwrap());
 
@@ -919,11 +917,7 @@ mod tests {
         };
 
         let events_before = tx
-            .events(
-                &constraints,
-                *MAX_BLOCKS_TO_SCAN,
-                *EVENT_FILTERS_BLOCK_RANGE_LIMIT,
-            )
+            .events(&constraints, *EVENT_FILTERS_BLOCK_RANGE_LIMIT)
             .unwrap()
             .events;
 
@@ -949,11 +943,7 @@ mod tests {
         }
 
         let events_after = tx
-            .events(
-                &constraints,
-                *MAX_BLOCKS_TO_SCAN,
-                *EVENT_FILTERS_BLOCK_RANGE_LIMIT,
-            )
+            .events(&constraints, *EVENT_FILTERS_BLOCK_RANGE_LIMIT)
             .unwrap()
             .events;
 
@@ -1055,11 +1045,7 @@ mod tests {
         };
 
         let events = tx
-            .events(
-                &constraints,
-                *MAX_BLOCKS_TO_SCAN,
-                *EVENT_FILTERS_BLOCK_RANGE_LIMIT,
-            )
+            .events(&constraints, *EVENT_FILTERS_BLOCK_RANGE_LIMIT)
             .unwrap()
             .events;
 


### PR DESCRIPTION
This CLI parameter was introduced to allow limiting the time `starknet_getEvents` requests take. However, there is another, similar, CLI parameter that serves the same purpose - `get_events_event_filter_block_range_limit`. In order to simplify the logic in that area of the code (and potentially avoid bugs), we can remove one of these parameters.