### PR TITLE
chore(github): build aarch64 Linux release binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
               include:
                 - target: x86_64-unknown-linux-gnu
                   os: ubuntu-22.04
+                - target: aarch64-unknown-linux-gnu
+                  os: ubuntu-22.04
                 - target: x86_64-apple-darwin
                   os: macos-latest
                 - target: aarch64-apple-darwin


### PR DESCRIPTION
This PR adds a new release binary for `aarch64-unknown-linux-gnu`.

Closes #2742
