### PR TITLE
revert: dynamically switch to the new feeder URL for 0.14.0

### DIFF
--- a/crates/gateway-client/tests/metrics.rs
+++ b/crates/gateway-client/tests/metrics.rs
@@ -7,7 +7,7 @@
 use std::future::Future;
 
 use futures::stream::StreamExt;
-use gateway_test_utils::{response_from, setup_with_varied_responses, GATEWAY_TIMEOUT};
+use gateway_test_utils::{response_from, setup_with_varied_responses};
 use pathfinder_common::{BlockId, BlockNumber};
 use pretty_assertions_sorted::assert_eq;
 use starknet_gateway_client::{Client, GatewayApi};
@@ -70,9 +70,7 @@ where
             responses,
         ),
     ]);
-    let client = Client::with_base_url(url, GATEWAY_TIMEOUT)
-        .unwrap()
-        .disable_retry_for_tests();
+    let client = Client::for_test(url).unwrap().disable_retry_for_tests();
 
     [BlockId::Number(BlockNumber::new_or_panic(123)); 7]
         .into_iter()

--- a/crates/gateway-test-utils/src/lib.rs
+++ b/crates/gateway-test-utils/src/lib.rs
@@ -1,8 +1,5 @@
-use std::time::Duration;
-
 use starknet_gateway_types::error::KnownStarknetErrorCode;
 
-pub const GATEWAY_TIMEOUT: Duration = Duration::from_secs(5);
 /// Helper function which allows for easy creation of a response tuple
 /// that contains a
 /// [StarknetError](starknet_gateway_types::error::StarknetError) for a

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -758,10 +758,9 @@ mod pathfinder_context {
             use pathfinder_crypto::Felt;
             use starknet_gateway_client::GatewayApi;
 
-            let gateway =
-                GatewayClient::with_urls(gateway, feeder.clone(), feeder, gateway_timeout)
-                    .context("Creating gateway client")?
-                    .with_api_key(api_key);
+            let gateway = GatewayClient::with_urls(gateway, feeder, gateway_timeout)
+                .context("Creating gateway client")?
+                .with_api_key(api_key);
 
             let network_id =
                 ChainId(Felt::from_be_slice(chain_id.as_bytes()).context("Parsing chain ID")?);

--- a/crates/rpc/src/context.rs
+++ b/crates/rpc/src/context.rs
@@ -186,25 +186,28 @@ impl RpcContext {
         chain: pathfinder_common::Chain,
         trie_prune_mode: pathfinder_storage::TriePruneMode,
     ) -> Self {
-        use gateway_test_utils::GATEWAY_TIMEOUT;
+        use std::time::Duration;
+
         use pathfinder_common::Chain;
         use pathfinder_ethereum::core_addr;
+
+        const TIMEOUT: Duration = Duration::from_secs(5);
 
         let (chain_id, core_contract_address, sequencer) = match chain {
             Chain::Mainnet => (
                 ChainId::MAINNET,
                 core_addr::MAINNET,
-                SequencerClient::mainnet(GATEWAY_TIMEOUT),
+                SequencerClient::mainnet(TIMEOUT),
             ),
             Chain::SepoliaTestnet => (
                 ChainId::SEPOLIA_TESTNET,
                 core_addr::SEPOLIA_TESTNET,
-                SequencerClient::sepolia_testnet(GATEWAY_TIMEOUT),
+                SequencerClient::sepolia_testnet(TIMEOUT),
             ),
             Chain::SepoliaIntegration => (
                 ChainId::SEPOLIA_INTEGRATION,
                 core_addr::SEPOLIA_INTEGRATION,
-                SequencerClient::sepolia_integration(GATEWAY_TIMEOUT),
+                SequencerClient::sepolia_integration(TIMEOUT),
             ),
             Chain::Custom => unreachable!("Should not be testing with custom chain"),
         };


### PR DESCRIPTION
Also:
- use new URLs (`feeder.[alpha-sepolia|alpha-mainnet|integration-sepolia].starknet.io`) for all non-custom networks

Tested on: integration, sepolia, mainnet.

Fixes: https://github.com/eqlabs/pathfinder/issues/2745

