### PR TITLE
chore: upgrade Rust to 1.87.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # Note that we're explicitly using the Debian bookworm image to make sure we're
 # compatible with the Debian container we'll be copying the pathfinder
 # executable to.
-FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:0.1.71-rust-1.85.1-slim-bookworm AS cargo-chef
+FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:0.1.71-rust-1.87.0-slim-bookworm AS cargo-chef
 WORKDIR /usr/src/pathfinder
 
 FROM --platform=$BUILDPLATFORM cargo-chef AS rust-planner

--- a/crates/class-hash/src/lib.rs
+++ b/crates/class-hash/src/lib.rs
@@ -698,7 +698,8 @@ pub mod json {
         SelectorAndFunctionIndex,
         SelectorAndOffset,
     };
-
+    
+    #[allow(clippy::large_enum_variant)]
     pub enum ContractDefinition<'a> {
         Cairo(CairoContractDefinition<'a>),
         Sierra(SierraContractDefinition<'a>),

--- a/crates/executor/src/transaction.rs
+++ b/crates/executor/src/transaction.rs
@@ -348,6 +348,7 @@ fn search_done(lower_bound: GasAmount, upper_bound: GasAmount, search_margin: Ga
 /// the function returns the saved initial state to the caller to decide whether
 /// to commit the state update (by doing nothing) or revert it (by assigning it
 /// back into the executor).
+#[allow(clippy::result_large_err)]
 fn simulate_transaction<'tx>(
     tx: &Transaction,
     tx_index: usize,
@@ -391,6 +392,7 @@ fn simulate_transaction<'tx>(
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 enum TransactionSimulationError<'tx> {
     OutOfGas(PathfinderExecutionState<'tx>),
     ExecutionError(TransactionExecutionError),

--- a/crates/p2p/src/sync/tests.rs
+++ b/crates/p2p/src/sync/tests.rs
@@ -195,10 +195,7 @@ mod propagate_codec_errors_to_caller {
         Box::new(|| {
             Box::new(|_| {
                 async {
-                    Err(std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        "stream error",
-                    ))
+                    Err(std::io::Error::other("stream error"))
                 }
                 .boxed()
             })

--- a/crates/p2p_stream/src/handler.rs
+++ b/crates/p2p_stream/src/handler.rs
@@ -248,7 +248,7 @@ where
                                 ),
                             )))
                             .await
-                            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                            .map_err(std::io::Error::other)?;
                         return Err(io::Error::new(
                             io::ErrorKind::TimedOut,
                             format!(
@@ -260,7 +260,7 @@ where
                         rs_send
                             .send(Ok(response))
                             .await
-                            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                            .map_err(std::io::Error::other)?;
                     }
                     // The stream is closed, there's nothing more to receive
                     Ok(Err(error)) if error.kind() == io::ErrorKind::UnexpectedEof => break,
@@ -270,7 +270,7 @@ where
                         rs_send
                             .send(Err(error_clone))
                             .await
-                            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                            .map_err(std::io::Error::other)?;
                         return Err(error);
                     }
                 }

--- a/crates/p2p_stream/tests/utils/mod.rs
+++ b/crates/p2p_stream/tests/utils/mod.rs
@@ -65,7 +65,7 @@ impl TryFrom<u32> for Action {
             7 => Ok(Action::SanityResponse((value & 0xFFFFFF00) >> 8)),
             8 => Ok(Action::TimeoutOnWriteRequest),
             9 => Ok(Action::TimeoutOnReadRequest),
-            _ => Err(io::Error::new(io::ErrorKind::Other, "invalid action")),
+            _ => Err(io::Error::other( "invalid action")),
         }
     }
 }
@@ -90,7 +90,7 @@ impl Codec for TestCodec {
 
         match u32::from_be_bytes(buf).try_into()? {
             Action::FailOnReadRequest => {
-                Err(io::Error::new(io::ErrorKind::Other, "FailOnReadRequest"))
+                Err(io::Error::other("FailOnReadRequest"))
             }
             Action::TimeoutOnReadRequest => loop {
                 tokio::time::sleep(Duration::MAX).await;
@@ -113,7 +113,7 @@ impl Codec for TestCodec {
 
         match u32::from_be_bytes(buf).try_into()? {
             Action::FailOnReadResponse => {
-                Err(io::Error::new(io::ErrorKind::Other, "FailOnReadResponse"))
+                Err(io::Error::other("FailOnReadResponse"))
             }
             Action::TimeoutOnReadResponse => loop {
                 tokio::time::sleep(Duration::MAX).await;
@@ -133,7 +133,7 @@ impl Codec for TestCodec {
     {
         match req {
             Action::FailOnWriteRequest => {
-                Err(io::Error::new(io::ErrorKind::Other, "FailOnWriteRequest"))
+                Err(io::Error::other("FailOnWriteRequest"))
             }
             Action::TimeoutOnWriteRequest => loop {
                 tokio::time::sleep(Duration::MAX).await;
@@ -157,7 +157,7 @@ impl Codec for TestCodec {
     {
         match res {
             Action::FailOnWriteResponse => {
-                Err(io::Error::new(io::ErrorKind::Other, "FailOnWriteResponse"))
+                Err(io::Error::other("FailOnWriteResponse"))
             }
             Action::TimeoutOnWriteResponse => loop {
                 tokio::time::sleep(Duration::MAX).await;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.87.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.85.1"
+channel = "1.86.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
The new Cairo compiler version required for Starknet 0.14.0 _requires_ at least Rust 1.86.0, so we'd better upgrade to the latest stable version.