### PR TITLE
fix(rpc/estimate_message_fee): fix test failure after blockifier upgrade

### DIFF
--- a/crates/rpc/fixtures/0.9.0/fee_estimates/full.json
+++ b/crates/rpc/fixtures/0.9.0/fee_estimates/full.json
@@ -1,10 +1,10 @@
 {
   "l1_data_gas_consumed": "0x80",
   "l1_data_gas_price": "0x1",
-  "l1_gas_consumed": "0x3937",
+  "l1_gas_consumed": "0x3938",
   "l1_gas_price": "0x2",
   "l2_gas_consumed": "0x0",
   "l2_gas_price": "0x1",
-  "overall_fee": "0x72ee",
+  "overall_fee": "0x72f0",
   "unit": "WEI"
 }


### PR DESCRIPTION
There was a conflict between adding JSON-RPC `v09` support and the blockifier upgrade. The `estimate_message_fee` test fixture for `v09` has to be updated to match the new blockifier behavior.

