### PR TITLE
fix(github/workflows/release): build aarch64 release binary on proper OS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
                 - target: x86_64-unknown-linux-gnu
                   os: ubuntu-22.04
                 - target: aarch64-unknown-linux-gnu
-                  os: ubuntu-22.04
+                  os: ubuntu-22.04-arm
                 - target: x86_64-apple-darwin
                   os: macos-latest
                 - target: aarch64-apple-darwin


### PR DESCRIPTION
To avoid cross-compiling (and related issues) we need to build the aarch64 release binary on an aarch64 machine. On GitHub Actions hosted runners this means that the `os` must be set to `ubuntu-22.04-arm`.
