### PR TITLE
replace 404 reference transaction.rs

### DIFF
--- a/crates/merkle-tree/src/transaction.rs
+++ b/crates/merkle-tree/src/transaction.rs
@@ -13,7 +13,7 @@ use crate::tree::MerkleTree;
 /// single starknet block i.e. each block a new event / transaction
 /// tree is formed from an empty one.
 ///
-/// More information about these commitments can be found in the Starknet [documentation](https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/header/).
+/// More information about these commitments can be found in the Starknet [documentation](https://docs.starknet.io/architecture-and-concepts/network-architecture/block-structure/#block_header_fields).
 pub struct TransactionOrEventTree<H: FeltHash> {
     tree: MerkleTree<H, 64>,
 }


### PR DESCRIPTION
Hi, I fixed 404 reference in the documentation and replaced with working ones.

https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/header/ - old link
https://docs.starknet.io/architecture-and-concepts/network-architecture/block-structure/#block_header_fields

