### PR TITLE
fix(executor): add versioned constants for 0.14.0

### DIFF
--- a/crates/executor/src/execution_state.rs
+++ b/crates/executor/src/execution_state.rs
@@ -36,6 +36,8 @@ mod versions {
     pub(super) const STARKNET_VERSION_0_13_4: StarknetVersion = StarknetVersion::new(0, 13, 4, 0);
 
     pub(super) const STARKNET_VERSION_0_13_5: StarknetVersion = StarknetVersion::new(0, 13, 5, 0);
+
+    pub(super) const STARKNET_VERSION_0_14_0: StarknetVersion = StarknetVersion::new(0, 14, 0, 0);
 }
 
 #[derive(Clone, Debug)]
@@ -103,6 +105,12 @@ impl VersionedConstantsMap {
             &STARKNET_VERSION_0_13_5,
             VersionedConstants::get(&starknet_api::block::StarknetVersion::V0_13_5)
                 .expect("Failed to get versioned constants for 0.13.5"),
+        );
+        Self::insert_default(
+            data,
+            &STARKNET_VERSION_0_14_0,
+            VersionedConstants::get(&starknet_api::block::StarknetVersion::V0_14_0)
+                .expect("Failed to get versioned constants for 0.14.0"),
         );
     }
 

--- a/crates/rpc/fixtures/0.6.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_13_4.json
+++ b/crates/rpc/fixtures/0.6.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_13_4.json
@@ -1,0 +1,356 @@
+[
+    {
+        "fee_estimation": {
+            "gas_consumed": "0x371",
+            "gas_price": "0x1",
+            "overall_fee": "0x4f1",
+            "unit": "WEI"
+        },
+        "transaction_trace": {
+            "fee_transfer_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x4f1",
+                    "0x0"
+                ],
+                "caller_address": "0xc01",
+                "calls": [],
+                "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "events": [
+                    {
+                        "data": [
+                            "0xc01",
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x4f1",
+                            "0x0"
+                        ],
+                        "keys": [
+                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                        ],
+                        "order": 0
+                    }
+                ],
+                "execution_resources": {
+                    "memory_holes": 59,
+                    "pedersen_builtin_applications": 4,
+                    "range_check_builtin_applications": 31,
+                    "steps": 1370
+                },
+                "messages": [],
+                "result": [
+                    "0x1"
+                ]
+            },
+            "type": "DECLARE",
+            "validate_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90"
+                ],
+                "caller_address": "0x0",
+                "calls": [],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "steps": 0
+                },
+                "messages": [],
+                "result": [
+                    "0x56414c4944"
+                ]
+            }
+        }
+    },
+    {
+        "fee_estimation": {
+            "gas_consumed": "0x17",
+            "gas_price": "0x1",
+            "overall_fee": "0x1d7",
+            "unit": "WEI"
+        },
+        "transaction_trace": {
+            "execute_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0xc02",
+                    "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                    "0x4",
+                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                    "0x0",
+                    "0x0",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [
+                            "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                            "0x0",
+                            "0x0",
+                            "0x0"
+                        ],
+                        "caller_address": "0xc01",
+                        "calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [],
+                                "caller_address": "0xc02",
+                                "calls": [],
+                                "class_hash": "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                                "contract_address": "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                                "entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+                                "entry_point_type": "CONSTRUCTOR",
+                                "events": [],
+                                "execution_resources": {
+                                    "steps": 0
+                                },
+                                "messages": [],
+                                "result": []
+                            }
+                        ],
+                        "class_hash": "0x6f38fb91ddbf325a0625533576bb6f6eafd9341868a9ec3faa4b01ce6c4f4dc",
+                        "contract_address": "0xc02",
+                        "entry_point_selector": "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                                    "0xc01",
+                                    "0x0",
+                                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                                    "0x0",
+                                    "0x0"
+                                ],
+                                "keys": [
+                                    "0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34d"
+                                ],
+                                "order": 0
+                            }
+                        ],
+                        "execution_resources": {
+                            "memory_holes": 2,
+                            "pedersen_builtin_applications": 7,
+                            "range_check_builtin_applications": 22,
+                            "steps": 1382
+                        },
+                        "messages": [],
+                        "result": [
+                            "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7"
+                        ]
+                    }
+                ],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "memory_holes": 2,
+                    "pedersen_builtin_applications": 7,
+                    "range_check_builtin_applications": 22,
+                    "steps": 1382
+                },
+                "messages": [],
+                "result": [
+                    "0x1",
+                    "0x1",
+                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7"
+                ]
+            },
+            "fee_transfer_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x1d7",
+                    "0x0"
+                ],
+                "caller_address": "0xc01",
+                "calls": [],
+                "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "events": [
+                    {
+                        "data": [
+                            "0xc01",
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x1d7",
+                            "0x0"
+                        ],
+                        "keys": [
+                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                        ],
+                        "order": 0
+                    }
+                ],
+                "execution_resources": {
+                    "memory_holes": 59,
+                    "pedersen_builtin_applications": 4,
+                    "range_check_builtin_applications": 31,
+                    "steps": 1370
+                },
+                "messages": [],
+                "result": [
+                    "0x1"
+                ]
+            },
+            "type": "INVOKE",
+            "validate_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0xc02",
+                    "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                    "0x4",
+                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                    "0x0",
+                    "0x0",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "steps": 0
+                },
+                "messages": [],
+                "result": [
+                    "0x56414c4944"
+                ]
+            }
+        }
+    },
+    {
+        "fee_estimation": {
+            "gas_consumed": "0x0",
+            "gas_price": "0x2",
+            "overall_fee": "0xba0f9",
+            "unit": "FRI"
+        },
+        "transaction_trace": {
+            "execute_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                    "0x3c8e49f80f188aa594216c470baf9428ed7dbef7af8f907328bee96696b878",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [],
+                        "caller_address": "0xc01",
+                        "calls": [],
+                        "class_hash": "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                        "contract_address": "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                        "entry_point_selector": "0x3c8e49f80f188aa594216c470baf9428ed7dbef7af8f907328bee96696b878",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [],
+                        "execution_resources": {
+                            "range_check_builtin_applications": 3,
+                            "steps": 165
+                        },
+                        "messages": [],
+                        "result": [
+                            "0x9"
+                        ]
+                    }
+                ],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "range_check_builtin_applications": 3,
+                    "steps": 165
+                },
+                "messages": [],
+                "result": [
+                    "0x1",
+                    "0x1",
+                    "0x9"
+                ]
+            },
+            "fee_transfer_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0xa926e",
+                    "0x0"
+                ],
+                "caller_address": "0xc01",
+                "calls": [],
+                "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
+                "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+                "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "events": [
+                    {
+                        "data": [
+                            "0xc01",
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0xa926e",
+                            "0x0"
+                        ],
+                        "keys": [
+                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                        ],
+                        "order": 0
+                    }
+                ],
+                "execution_resources": {
+                    "memory_holes": 59,
+                    "pedersen_builtin_applications": 4,
+                    "range_check_builtin_applications": 31,
+                    "steps": 1370
+                },
+                "messages": [],
+                "result": [
+                    "0x1"
+                ]
+            },
+            "type": "INVOKE",
+            "validate_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                    "0x3c8e49f80f188aa594216c470baf9428ed7dbef7af8f907328bee96696b878",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "steps": 0
+                },
+                "messages": [],
+                "result": [
+                    "0x56414c4944"
+                ]
+            }
+        }
+    }
+]

--- a/crates/rpc/fixtures/0.6.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_14_0.json
+++ b/crates/rpc/fixtures/0.6.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_14_0.json
@@ -1,0 +1,356 @@
+[
+    {
+        "fee_estimation": {
+            "gas_consumed": "0x372",
+            "gas_price": "0x1",
+            "overall_fee": "0x4f2",
+            "unit": "WEI"
+        },
+        "transaction_trace": {
+            "fee_transfer_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x4f2",
+                    "0x0"
+                ],
+                "caller_address": "0xc01",
+                "calls": [],
+                "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "events": [
+                    {
+                        "data": [
+                            "0xc01",
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x4f2",
+                            "0x0"
+                        ],
+                        "keys": [
+                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                        ],
+                        "order": 0
+                    }
+                ],
+                "execution_resources": {
+                    "memory_holes": 59,
+                    "pedersen_builtin_applications": 4,
+                    "range_check_builtin_applications": 32,
+                    "steps": 1455
+                },
+                "messages": [],
+                "result": [
+                    "0x1"
+                ]
+            },
+            "type": "DECLARE",
+            "validate_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90"
+                ],
+                "caller_address": "0x0",
+                "calls": [],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "steps": 0
+                },
+                "messages": [],
+                "result": [
+                    "0x56414c4944"
+                ]
+            }
+        }
+    },
+    {
+        "fee_estimation": {
+            "gas_consumed": "0x19",
+            "gas_price": "0x1",
+            "overall_fee": "0x1d9",
+            "unit": "WEI"
+        },
+        "transaction_trace": {
+            "execute_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0xc02",
+                    "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                    "0x4",
+                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                    "0x0",
+                    "0x0",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [
+                            "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                            "0x0",
+                            "0x0",
+                            "0x0"
+                        ],
+                        "caller_address": "0xc01",
+                        "calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [],
+                                "caller_address": "0xc02",
+                                "calls": [],
+                                "class_hash": "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                                "contract_address": "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                                "entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+                                "entry_point_type": "CONSTRUCTOR",
+                                "events": [],
+                                "execution_resources": {
+                                    "steps": 0
+                                },
+                                "messages": [],
+                                "result": []
+                            }
+                        ],
+                        "class_hash": "0x6f38fb91ddbf325a0625533576bb6f6eafd9341868a9ec3faa4b01ce6c4f4dc",
+                        "contract_address": "0xc02",
+                        "entry_point_selector": "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                                    "0xc01",
+                                    "0x0",
+                                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                                    "0x0",
+                                    "0x0"
+                                ],
+                                "keys": [
+                                    "0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34d"
+                                ],
+                                "order": 0
+                            }
+                        ],
+                        "execution_resources": {
+                            "memory_holes": 2,
+                            "pedersen_builtin_applications": 7,
+                            "range_check_builtin_applications": 26,
+                            "steps": 1484
+                        },
+                        "messages": [],
+                        "result": [
+                            "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7"
+                        ]
+                    }
+                ],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "memory_holes": 2,
+                    "pedersen_builtin_applications": 7,
+                    "range_check_builtin_applications": 26,
+                    "steps": 1484
+                },
+                "messages": [],
+                "result": [
+                    "0x1",
+                    "0x1",
+                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7"
+                ]
+            },
+            "fee_transfer_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x1d9",
+                    "0x0"
+                ],
+                "caller_address": "0xc01",
+                "calls": [],
+                "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "events": [
+                    {
+                        "data": [
+                            "0xc01",
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x1d9",
+                            "0x0"
+                        ],
+                        "keys": [
+                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                        ],
+                        "order": 0
+                    }
+                ],
+                "execution_resources": {
+                    "memory_holes": 59,
+                    "pedersen_builtin_applications": 4,
+                    "range_check_builtin_applications": 32,
+                    "steps": 1455
+                },
+                "messages": [],
+                "result": [
+                    "0x1"
+                ]
+            },
+            "type": "INVOKE",
+            "validate_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0xc02",
+                    "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                    "0x4",
+                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                    "0x0",
+                    "0x0",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "steps": 0
+                },
+                "messages": [],
+                "result": [
+                    "0x56414c4944"
+                ]
+            }
+        }
+    },
+    {
+        "fee_estimation": {
+            "gas_consumed": "0x0",
+            "gas_price": "0x2",
+            "overall_fee": "0xc7fae",
+            "unit": "FRI"
+        },
+        "transaction_trace": {
+            "execute_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                    "0x3c8e49f80f188aa594216c470baf9428ed7dbef7af8f907328bee96696b878",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [],
+                        "caller_address": "0xc01",
+                        "calls": [],
+                        "class_hash": "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                        "contract_address": "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                        "entry_point_selector": "0x3c8e49f80f188aa594216c470baf9428ed7dbef7af8f907328bee96696b878",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [],
+                        "execution_resources": {
+                            "range_check_builtin_applications": 3,
+                            "steps": 168
+                        },
+                        "messages": [],
+                        "result": [
+                            "0x9"
+                        ]
+                    }
+                ],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "range_check_builtin_applications": 3,
+                    "steps": 168
+                },
+                "messages": [],
+                "result": [
+                    "0x1",
+                    "0x1",
+                    "0x9"
+                ]
+            },
+            "fee_transfer_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0xb5ce4",
+                    "0x0"
+                ],
+                "caller_address": "0xc01",
+                "calls": [],
+                "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
+                "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+                "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "events": [
+                    {
+                        "data": [
+                            "0xc01",
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0xb5ce4",
+                            "0x0"
+                        ],
+                        "keys": [
+                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                        ],
+                        "order": 0
+                    }
+                ],
+                "execution_resources": {
+                    "memory_holes": 59,
+                    "pedersen_builtin_applications": 4,
+                    "range_check_builtin_applications": 32,
+                    "steps": 1455
+                },
+                "messages": [],
+                "result": [
+                    "0x1"
+                ]
+            },
+            "type": "INVOKE",
+            "validate_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                    "0x3c8e49f80f188aa594216c470baf9428ed7dbef7af8f907328bee96696b878",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "steps": 0
+                },
+                "messages": [],
+                "result": [
+                    "0x56414c4944"
+                ]
+            }
+        }
+    }
+]

--- a/crates/rpc/fixtures/0.7.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_13_4.json
+++ b/crates/rpc/fixtures/0.7.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_13_4.json
@@ -1,0 +1,392 @@
+[
+    {
+        "fee_estimation": {
+            "data_gas_consumed": "0xc0",
+            "data_gas_price": "0x2",
+            "gas_consumed": "0x371",
+            "gas_price": "0x1",
+            "overall_fee": "0x4f1",
+            "unit": "WEI"
+        },
+        "transaction_trace": {
+            "execution_resources": {
+                "data_availability": {
+                    "l1_data_gas": 192,
+                    "l1_gas": 0
+                },
+                "memory_holes": 59,
+                "pedersen_builtin_applications": 4,
+                "range_check_builtin_applications": 31,
+                "steps": 1370
+            },
+            "fee_transfer_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x4f1",
+                    "0x0"
+                ],
+                "caller_address": "0xc01",
+                "calls": [],
+                "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "events": [
+                    {
+                        "data": [
+                            "0xc01",
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x4f1",
+                            "0x0"
+                        ],
+                        "keys": [
+                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                        ],
+                        "order": 0
+                    }
+                ],
+                "execution_resources": {
+                    "memory_holes": 59,
+                    "pedersen_builtin_applications": 4,
+                    "range_check_builtin_applications": 31,
+                    "steps": 1370
+                },
+                "messages": [],
+                "result": [
+                    "0x1"
+                ]
+            },
+            "type": "DECLARE",
+            "validate_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90"
+                ],
+                "caller_address": "0x0",
+                "calls": [],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "steps": 0
+                },
+                "messages": [],
+                "result": [
+                    "0x56414c4944"
+                ]
+            }
+        }
+    },
+    {
+        "fee_estimation": {
+            "data_gas_consumed": "0xe0",
+            "data_gas_price": "0x2",
+            "gas_consumed": "0x17",
+            "gas_price": "0x1",
+            "overall_fee": "0x1d7",
+            "unit": "WEI"
+        },
+        "transaction_trace": {
+            "execute_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0xc02",
+                    "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                    "0x4",
+                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                    "0x0",
+                    "0x0",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [
+                            "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                            "0x0",
+                            "0x0",
+                            "0x0"
+                        ],
+                        "caller_address": "0xc01",
+                        "calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [],
+                                "caller_address": "0xc02",
+                                "calls": [],
+                                "class_hash": "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                                "contract_address": "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                                "entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+                                "entry_point_type": "CONSTRUCTOR",
+                                "events": [],
+                                "execution_resources": {
+                                    "steps": 0
+                                },
+                                "messages": [],
+                                "result": []
+                            }
+                        ],
+                        "class_hash": "0x6f38fb91ddbf325a0625533576bb6f6eafd9341868a9ec3faa4b01ce6c4f4dc",
+                        "contract_address": "0xc02",
+                        "entry_point_selector": "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                                    "0xc01",
+                                    "0x0",
+                                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                                    "0x0",
+                                    "0x0"
+                                ],
+                                "keys": [
+                                    "0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34d"
+                                ],
+                                "order": 0
+                            }
+                        ],
+                        "execution_resources": {
+                            "memory_holes": 2,
+                            "pedersen_builtin_applications": 7,
+                            "range_check_builtin_applications": 22,
+                            "steps": 1382
+                        },
+                        "messages": [],
+                        "result": [
+                            "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7"
+                        ]
+                    }
+                ],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "memory_holes": 2,
+                    "pedersen_builtin_applications": 7,
+                    "range_check_builtin_applications": 22,
+                    "steps": 1382
+                },
+                "messages": [],
+                "result": [
+                    "0x1",
+                    "0x1",
+                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7"
+                ]
+            },
+            "execution_resources": {
+                "data_availability": {
+                    "l1_data_gas": 224,
+                    "l1_gas": 0
+                },
+                "memory_holes": 61,
+                "pedersen_builtin_applications": 11,
+                "range_check_builtin_applications": 53,
+                "steps": 2752
+            },
+            "fee_transfer_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x1d7",
+                    "0x0"
+                ],
+                "caller_address": "0xc01",
+                "calls": [],
+                "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "events": [
+                    {
+                        "data": [
+                            "0xc01",
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x1d7",
+                            "0x0"
+                        ],
+                        "keys": [
+                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                        ],
+                        "order": 0
+                    }
+                ],
+                "execution_resources": {
+                    "memory_holes": 59,
+                    "pedersen_builtin_applications": 4,
+                    "range_check_builtin_applications": 31,
+                    "steps": 1370
+                },
+                "messages": [],
+                "result": [
+                    "0x1"
+                ]
+            },
+            "type": "INVOKE",
+            "validate_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0xc02",
+                    "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                    "0x4",
+                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                    "0x0",
+                    "0x0",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "steps": 0
+                },
+                "messages": [],
+                "result": [
+                    "0x56414c4944"
+                ]
+            }
+        }
+    },
+    {
+        "fee_estimation": {
+            "data_gas_consumed": "0x80",
+            "data_gas_price": "0x2",
+            "gas_consumed": "0x0",
+            "gas_price": "0x2",
+            "overall_fee": "0xba0f9",
+            "unit": "FRI"
+        },
+        "transaction_trace": {
+            "execute_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                    "0x3c8e49f80f188aa594216c470baf9428ed7dbef7af8f907328bee96696b878",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [],
+                        "caller_address": "0xc01",
+                        "calls": [],
+                        "class_hash": "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                        "contract_address": "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                        "entry_point_selector": "0x3c8e49f80f188aa594216c470baf9428ed7dbef7af8f907328bee96696b878",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [],
+                        "execution_resources": {
+                            "range_check_builtin_applications": 3,
+                            "steps": 165
+                        },
+                        "messages": [],
+                        "result": [
+                            "0x9"
+                        ]
+                    }
+                ],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "range_check_builtin_applications": 3,
+                    "steps": 165
+                },
+                "messages": [],
+                "result": [
+                    "0x1",
+                    "0x1",
+                    "0x9"
+                ]
+            },
+            "execution_resources": {
+                "data_availability": {
+                    "l1_data_gas": 128,
+                    "l1_gas": 0
+                },
+                "memory_holes": 59,
+                "pedersen_builtin_applications": 4,
+                "range_check_builtin_applications": 34,
+                "steps": 1535
+            },
+            "fee_transfer_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0xa926e",
+                    "0x0"
+                ],
+                "caller_address": "0xc01",
+                "calls": [],
+                "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
+                "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+                "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "events": [
+                    {
+                        "data": [
+                            "0xc01",
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0xa926e",
+                            "0x0"
+                        ],
+                        "keys": [
+                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                        ],
+                        "order": 0
+                    }
+                ],
+                "execution_resources": {
+                    "memory_holes": 59,
+                    "pedersen_builtin_applications": 4,
+                    "range_check_builtin_applications": 31,
+                    "steps": 1370
+                },
+                "messages": [],
+                "result": [
+                    "0x1"
+                ]
+            },
+            "type": "INVOKE",
+            "validate_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                    "0x3c8e49f80f188aa594216c470baf9428ed7dbef7af8f907328bee96696b878",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "steps": 0
+                },
+                "messages": [],
+                "result": [
+                    "0x56414c4944"
+                ]
+            }
+        }
+    }
+]

--- a/crates/rpc/fixtures/0.7.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_14_0.json
+++ b/crates/rpc/fixtures/0.7.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_14_0.json
@@ -1,0 +1,392 @@
+[
+    {
+        "fee_estimation": {
+            "data_gas_consumed": "0xc0",
+            "data_gas_price": "0x2",
+            "gas_consumed": "0x372",
+            "gas_price": "0x1",
+            "overall_fee": "0x4f2",
+            "unit": "WEI"
+        },
+        "transaction_trace": {
+            "execution_resources": {
+                "data_availability": {
+                    "l1_data_gas": 192,
+                    "l1_gas": 0
+                },
+                "memory_holes": 59,
+                "pedersen_builtin_applications": 4,
+                "range_check_builtin_applications": 32,
+                "steps": 1455
+            },
+            "fee_transfer_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x4f2",
+                    "0x0"
+                ],
+                "caller_address": "0xc01",
+                "calls": [],
+                "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "events": [
+                    {
+                        "data": [
+                            "0xc01",
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x4f2",
+                            "0x0"
+                        ],
+                        "keys": [
+                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                        ],
+                        "order": 0
+                    }
+                ],
+                "execution_resources": {
+                    "memory_holes": 59,
+                    "pedersen_builtin_applications": 4,
+                    "range_check_builtin_applications": 32,
+                    "steps": 1455
+                },
+                "messages": [],
+                "result": [
+                    "0x1"
+                ]
+            },
+            "type": "DECLARE",
+            "validate_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90"
+                ],
+                "caller_address": "0x0",
+                "calls": [],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "steps": 0
+                },
+                "messages": [],
+                "result": [
+                    "0x56414c4944"
+                ]
+            }
+        }
+    },
+    {
+        "fee_estimation": {
+            "data_gas_consumed": "0xe0",
+            "data_gas_price": "0x2",
+            "gas_consumed": "0x19",
+            "gas_price": "0x1",
+            "overall_fee": "0x1d9",
+            "unit": "WEI"
+        },
+        "transaction_trace": {
+            "execute_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0xc02",
+                    "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                    "0x4",
+                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                    "0x0",
+                    "0x0",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [
+                            "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                            "0x0",
+                            "0x0",
+                            "0x0"
+                        ],
+                        "caller_address": "0xc01",
+                        "calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [],
+                                "caller_address": "0xc02",
+                                "calls": [],
+                                "class_hash": "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                                "contract_address": "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                                "entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+                                "entry_point_type": "CONSTRUCTOR",
+                                "events": [],
+                                "execution_resources": {
+                                    "steps": 0
+                                },
+                                "messages": [],
+                                "result": []
+                            }
+                        ],
+                        "class_hash": "0x6f38fb91ddbf325a0625533576bb6f6eafd9341868a9ec3faa4b01ce6c4f4dc",
+                        "contract_address": "0xc02",
+                        "entry_point_selector": "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                                    "0xc01",
+                                    "0x0",
+                                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                                    "0x0",
+                                    "0x0"
+                                ],
+                                "keys": [
+                                    "0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34d"
+                                ],
+                                "order": 0
+                            }
+                        ],
+                        "execution_resources": {
+                            "memory_holes": 2,
+                            "pedersen_builtin_applications": 7,
+                            "range_check_builtin_applications": 26,
+                            "steps": 1484
+                        },
+                        "messages": [],
+                        "result": [
+                            "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7"
+                        ]
+                    }
+                ],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "memory_holes": 2,
+                    "pedersen_builtin_applications": 7,
+                    "range_check_builtin_applications": 26,
+                    "steps": 1484
+                },
+                "messages": [],
+                "result": [
+                    "0x1",
+                    "0x1",
+                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7"
+                ]
+            },
+            "execution_resources": {
+                "data_availability": {
+                    "l1_data_gas": 224,
+                    "l1_gas": 0
+                },
+                "memory_holes": 61,
+                "pedersen_builtin_applications": 11,
+                "range_check_builtin_applications": 58,
+                "steps": 2939
+            },
+            "fee_transfer_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x1d9",
+                    "0x0"
+                ],
+                "caller_address": "0xc01",
+                "calls": [],
+                "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "events": [
+                    {
+                        "data": [
+                            "0xc01",
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x1d9",
+                            "0x0"
+                        ],
+                        "keys": [
+                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                        ],
+                        "order": 0
+                    }
+                ],
+                "execution_resources": {
+                    "memory_holes": 59,
+                    "pedersen_builtin_applications": 4,
+                    "range_check_builtin_applications": 32,
+                    "steps": 1455
+                },
+                "messages": [],
+                "result": [
+                    "0x1"
+                ]
+            },
+            "type": "INVOKE",
+            "validate_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0xc02",
+                    "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                    "0x4",
+                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                    "0x0",
+                    "0x0",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "steps": 0
+                },
+                "messages": [],
+                "result": [
+                    "0x56414c4944"
+                ]
+            }
+        }
+    },
+    {
+        "fee_estimation": {
+            "data_gas_consumed": "0x80",
+            "data_gas_price": "0x2",
+            "gas_consumed": "0x0",
+            "gas_price": "0x2",
+            "overall_fee": "0xc7fae",
+            "unit": "FRI"
+        },
+        "transaction_trace": {
+            "execute_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                    "0x3c8e49f80f188aa594216c470baf9428ed7dbef7af8f907328bee96696b878",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [],
+                        "caller_address": "0xc01",
+                        "calls": [],
+                        "class_hash": "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                        "contract_address": "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                        "entry_point_selector": "0x3c8e49f80f188aa594216c470baf9428ed7dbef7af8f907328bee96696b878",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [],
+                        "execution_resources": {
+                            "range_check_builtin_applications": 3,
+                            "steps": 168
+                        },
+                        "messages": [],
+                        "result": [
+                            "0x9"
+                        ]
+                    }
+                ],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "range_check_builtin_applications": 3,
+                    "steps": 168
+                },
+                "messages": [],
+                "result": [
+                    "0x1",
+                    "0x1",
+                    "0x9"
+                ]
+            },
+            "execution_resources": {
+                "data_availability": {
+                    "l1_data_gas": 128,
+                    "l1_gas": 0
+                },
+                "memory_holes": 59,
+                "pedersen_builtin_applications": 4,
+                "range_check_builtin_applications": 35,
+                "steps": 1623
+            },
+            "fee_transfer_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0xb5ce4",
+                    "0x0"
+                ],
+                "caller_address": "0xc01",
+                "calls": [],
+                "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
+                "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+                "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "events": [
+                    {
+                        "data": [
+                            "0xc01",
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0xb5ce4",
+                            "0x0"
+                        ],
+                        "keys": [
+                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                        ],
+                        "order": 0
+                    }
+                ],
+                "execution_resources": {
+                    "memory_holes": 59,
+                    "pedersen_builtin_applications": 4,
+                    "range_check_builtin_applications": 32,
+                    "steps": 1455
+                },
+                "messages": [],
+                "result": [
+                    "0x1"
+                ]
+            },
+            "type": "INVOKE",
+            "validate_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                    "0x3c8e49f80f188aa594216c470baf9428ed7dbef7af8f907328bee96696b878",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "steps": 0
+                },
+                "messages": [],
+                "result": [
+                    "0x56414c4944"
+                ]
+            }
+        }
+    }
+]

--- a/crates/rpc/fixtures/0.8.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_14_0.json
+++ b/crates/rpc/fixtures/0.8.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_14_0.json
@@ -1,0 +1,388 @@
+[
+    {
+        "fee_estimation": {
+            "l1_data_gas_consumed": "0xc0",
+            "l1_data_gas_price": "0x2",
+            "l1_gas_consumed": "0x372",
+            "l1_gas_price": "0x1",
+            "l2_gas_consumed": "0x0",
+            "l2_gas_price": "0x1",
+            "overall_fee": "0x4f2",
+            "unit": "WEI"
+        },
+        "transaction_trace": {
+            "execution_resources": {
+                "l1_data_gas": 192,
+                "l1_gas": 882,
+                "l2_gas": 0
+            },
+            "fee_transfer_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x4f2",
+                    "0x0"
+                ],
+                "caller_address": "0xc01",
+                "calls": [],
+                "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "events": [
+                    {
+                        "data": [
+                            "0xc01",
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x4f2",
+                            "0x0"
+                        ],
+                        "keys": [
+                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                        ],
+                        "order": 0
+                    }
+                ],
+                "execution_resources": {
+                    "l1_gas": 4,
+                    "l2_gas": 0
+                },
+                "is_reverted": false,
+                "messages": [],
+                "result": [
+                    "0x1"
+                ]
+            },
+            "type": "DECLARE",
+            "validate_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90"
+                ],
+                "caller_address": "0x0",
+                "calls": [],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "l1_gas": 1,
+                    "l2_gas": 0
+                },
+                "is_reverted": false,
+                "messages": [],
+                "result": [
+                    "0x56414c4944"
+                ]
+            }
+        }
+    },
+    {
+        "fee_estimation": {
+            "l1_data_gas_consumed": "0xe0",
+            "l1_data_gas_price": "0x2",
+            "l1_gas_consumed": "0x19",
+            "l1_gas_price": "0x1",
+            "l2_gas_consumed": "0x0",
+            "l2_gas_price": "0x1",
+            "overall_fee": "0x1d9",
+            "unit": "WEI"
+        },
+        "transaction_trace": {
+            "execute_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0xc02",
+                    "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                    "0x4",
+                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                    "0x0",
+                    "0x0",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [
+                            "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                            "0x0",
+                            "0x0",
+                            "0x0"
+                        ],
+                        "caller_address": "0xc01",
+                        "calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [],
+                                "caller_address": "0xc02",
+                                "calls": [],
+                                "class_hash": "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                                "contract_address": "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                                "entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+                                "entry_point_type": "CONSTRUCTOR",
+                                "events": [],
+                                "execution_resources": {
+                                    "l1_gas": 0,
+                                    "l2_gas": 0
+                                },
+                                "is_reverted": false,
+                                "messages": [],
+                                "result": []
+                            }
+                        ],
+                        "class_hash": "0x6f38fb91ddbf325a0625533576bb6f6eafd9341868a9ec3faa4b01ce6c4f4dc",
+                        "contract_address": "0xc02",
+                        "entry_point_selector": "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                                    "0xc01",
+                                    "0x0",
+                                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                                    "0x0",
+                                    "0x0"
+                                ],
+                                "keys": [
+                                    "0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34d"
+                                ],
+                                "order": 0
+                            }
+                        ],
+                        "execution_resources": {
+                            "l1_gas": 5,
+                            "l2_gas": 0
+                        },
+                        "is_reverted": false,
+                        "messages": [],
+                        "result": [
+                            "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7"
+                        ]
+                    }
+                ],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "l1_gas": 10,
+                    "l2_gas": 0
+                },
+                "is_reverted": false,
+                "messages": [],
+                "result": [
+                    "0x1",
+                    "0x1",
+                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7"
+                ]
+            },
+            "execution_resources": {
+                "l1_data_gas": 224,
+                "l1_gas": 25,
+                "l2_gas": 0
+            },
+            "fee_transfer_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x1d9",
+                    "0x0"
+                ],
+                "caller_address": "0xc01",
+                "calls": [],
+                "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "events": [
+                    {
+                        "data": [
+                            "0xc01",
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x1d9",
+                            "0x0"
+                        ],
+                        "keys": [
+                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                        ],
+                        "order": 0
+                    }
+                ],
+                "execution_resources": {
+                    "l1_gas": 4,
+                    "l2_gas": 0
+                },
+                "is_reverted": false,
+                "messages": [],
+                "result": [
+                    "0x1"
+                ]
+            },
+            "type": "INVOKE",
+            "validate_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0xc02",
+                    "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                    "0x4",
+                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                    "0x0",
+                    "0x0",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "l1_gas": 2,
+                    "l2_gas": 0
+                },
+                "is_reverted": false,
+                "messages": [],
+                "result": [
+                    "0x56414c4944"
+                ]
+            }
+        }
+    },
+    {
+        "fee_estimation": {
+            "l1_data_gas_consumed": "0x80",
+            "l1_data_gas_price": "0x2",
+            "l1_gas_consumed": "0x0",
+            "l1_gas_price": "0x2",
+            "l2_gas_consumed": "0xc7eae",
+            "l2_gas_price": "0x1",
+            "overall_fee": "0xc7fae",
+            "unit": "FRI"
+        },
+        "transaction_trace": {
+            "execute_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                    "0x3c8e49f80f188aa594216c470baf9428ed7dbef7af8f907328bee96696b878",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [],
+                        "caller_address": "0xc01",
+                        "calls": [],
+                        "class_hash": "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                        "contract_address": "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                        "entry_point_selector": "0x3c8e49f80f188aa594216c470baf9428ed7dbef7af8f907328bee96696b878",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [],
+                        "execution_resources": {
+                            "l1_gas": 0,
+                            "l2_gas": 40000
+                        },
+                        "is_reverted": false,
+                        "messages": [],
+                        "result": [
+                            "0x9"
+                        ]
+                    }
+                ],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "l1_gas": 0,
+                    "l2_gas": 201160
+                },
+                "is_reverted": false,
+                "messages": [],
+                "result": [
+                    "0x1",
+                    "0x1",
+                    "0x9"
+                ]
+            },
+            "execution_resources": {
+                "l1_data_gas": 128,
+                "l1_gas": 0,
+                "l2_gas": 744420
+            },
+            "fee_transfer_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0xb5ce4",
+                    "0x0"
+                ],
+                "caller_address": "0xc01",
+                "calls": [],
+                "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
+                "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+                "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "events": [
+                    {
+                        "data": [
+                            "0xc01",
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0xb5ce4",
+                            "0x0"
+                        ],
+                        "keys": [
+                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                        ],
+                        "order": 0
+                    }
+                ],
+                "execution_resources": {
+                    "l1_gas": 0,
+                    "l2_gas": 190720
+                },
+                "is_reverted": false,
+                "messages": [],
+                "result": [
+                    "0x1"
+                ]
+            },
+            "type": "INVOKE",
+            "validate_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                    "0x3c8e49f80f188aa594216c470baf9428ed7dbef7af8f907328bee96696b878",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "l1_gas": 0,
+                    "l2_gas": 42780
+                },
+                "is_reverted": false,
+                "messages": [],
+                "result": [
+                    "0x56414c4944"
+                ]
+            }
+        }
+    }
+]

--- a/crates/rpc/fixtures/0.9.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_14_0.json
+++ b/crates/rpc/fixtures/0.9.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_14_0.json
@@ -1,0 +1,388 @@
+[
+    {
+        "fee_estimation": {
+            "l1_data_gas_consumed": "0xc0",
+            "l1_data_gas_price": "0x2",
+            "l1_gas_consumed": "0x372",
+            "l1_gas_price": "0x1",
+            "l2_gas_consumed": "0x0",
+            "l2_gas_price": "0x1",
+            "overall_fee": "0x4f2",
+            "unit": "WEI"
+        },
+        "transaction_trace": {
+            "execution_resources": {
+                "l1_data_gas": 192,
+                "l1_gas": 882,
+                "l2_gas": 0
+            },
+            "fee_transfer_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x4f2",
+                    "0x0"
+                ],
+                "caller_address": "0xc01",
+                "calls": [],
+                "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "events": [
+                    {
+                        "data": [
+                            "0xc01",
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x4f2",
+                            "0x0"
+                        ],
+                        "keys": [
+                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                        ],
+                        "order": 0
+                    }
+                ],
+                "execution_resources": {
+                    "l1_gas": 4,
+                    "l2_gas": 0
+                },
+                "is_reverted": false,
+                "messages": [],
+                "result": [
+                    "0x1"
+                ]
+            },
+            "type": "DECLARE",
+            "validate_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90"
+                ],
+                "caller_address": "0x0",
+                "calls": [],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "l1_gas": 1,
+                    "l2_gas": 0
+                },
+                "is_reverted": false,
+                "messages": [],
+                "result": [
+                    "0x56414c4944"
+                ]
+            }
+        }
+    },
+    {
+        "fee_estimation": {
+            "l1_data_gas_consumed": "0xe0",
+            "l1_data_gas_price": "0x2",
+            "l1_gas_consumed": "0x19",
+            "l1_gas_price": "0x1",
+            "l2_gas_consumed": "0x0",
+            "l2_gas_price": "0x1",
+            "overall_fee": "0x1d9",
+            "unit": "WEI"
+        },
+        "transaction_trace": {
+            "execute_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0xc02",
+                    "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                    "0x4",
+                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                    "0x0",
+                    "0x0",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [
+                            "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                            "0x0",
+                            "0x0",
+                            "0x0"
+                        ],
+                        "caller_address": "0xc01",
+                        "calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [],
+                                "caller_address": "0xc02",
+                                "calls": [],
+                                "class_hash": "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                                "contract_address": "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                                "entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+                                "entry_point_type": "CONSTRUCTOR",
+                                "events": [],
+                                "execution_resources": {
+                                    "l1_gas": 0,
+                                    "l2_gas": 0
+                                },
+                                "is_reverted": false,
+                                "messages": [],
+                                "result": []
+                            }
+                        ],
+                        "class_hash": "0x6f38fb91ddbf325a0625533576bb6f6eafd9341868a9ec3faa4b01ce6c4f4dc",
+                        "contract_address": "0xc02",
+                        "entry_point_selector": "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                                    "0xc01",
+                                    "0x0",
+                                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                                    "0x0",
+                                    "0x0"
+                                ],
+                                "keys": [
+                                    "0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34d"
+                                ],
+                                "order": 0
+                            }
+                        ],
+                        "execution_resources": {
+                            "l1_gas": 5,
+                            "l2_gas": 0
+                        },
+                        "is_reverted": false,
+                        "messages": [],
+                        "result": [
+                            "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7"
+                        ]
+                    }
+                ],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "l1_gas": 10,
+                    "l2_gas": 0
+                },
+                "is_reverted": false,
+                "messages": [],
+                "result": [
+                    "0x1",
+                    "0x1",
+                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7"
+                ]
+            },
+            "execution_resources": {
+                "l1_data_gas": 224,
+                "l1_gas": 25,
+                "l2_gas": 0
+            },
+            "fee_transfer_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x1d9",
+                    "0x0"
+                ],
+                "caller_address": "0xc01",
+                "calls": [],
+                "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "events": [
+                    {
+                        "data": [
+                            "0xc01",
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x1d9",
+                            "0x0"
+                        ],
+                        "keys": [
+                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                        ],
+                        "order": 0
+                    }
+                ],
+                "execution_resources": {
+                    "l1_gas": 4,
+                    "l2_gas": 0
+                },
+                "is_reverted": false,
+                "messages": [],
+                "result": [
+                    "0x1"
+                ]
+            },
+            "type": "INVOKE",
+            "validate_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0xc02",
+                    "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                    "0x4",
+                    "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                    "0x0",
+                    "0x0",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "l1_gas": 2,
+                    "l2_gas": 0
+                },
+                "is_reverted": false,
+                "messages": [],
+                "result": [
+                    "0x56414c4944"
+                ]
+            }
+        }
+    },
+    {
+        "fee_estimation": {
+            "l1_data_gas_consumed": "0x80",
+            "l1_data_gas_price": "0x2",
+            "l1_gas_consumed": "0x0",
+            "l1_gas_price": "0x2",
+            "l2_gas_consumed": "0xc7eae",
+            "l2_gas_price": "0x1",
+            "overall_fee": "0xc7fae",
+            "unit": "FRI"
+        },
+        "transaction_trace": {
+            "execute_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                    "0x3c8e49f80f188aa594216c470baf9428ed7dbef7af8f907328bee96696b878",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [],
+                        "caller_address": "0xc01",
+                        "calls": [],
+                        "class_hash": "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+                        "contract_address": "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                        "entry_point_selector": "0x3c8e49f80f188aa594216c470baf9428ed7dbef7af8f907328bee96696b878",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [],
+                        "execution_resources": {
+                            "l1_gas": 0,
+                            "l2_gas": 40000
+                        },
+                        "is_reverted": false,
+                        "messages": [],
+                        "result": [
+                            "0x9"
+                        ]
+                    }
+                ],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "l1_gas": 0,
+                    "l2_gas": 201160
+                },
+                "is_reverted": false,
+                "messages": [],
+                "result": [
+                    "0x1",
+                    "0x1",
+                    "0x9"
+                ]
+            },
+            "execution_resources": {
+                "l1_data_gas": 128,
+                "l1_gas": 0,
+                "l2_gas": 744420
+            },
+            "fee_transfer_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0xb5ce4",
+                    "0x0"
+                ],
+                "caller_address": "0xc01",
+                "calls": [],
+                "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
+                "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+                "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "events": [
+                    {
+                        "data": [
+                            "0xc01",
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0xb5ce4",
+                            "0x0"
+                        ],
+                        "keys": [
+                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                        ],
+                        "order": 0
+                    }
+                ],
+                "execution_resources": {
+                    "l1_gas": 0,
+                    "l2_gas": 190720
+                },
+                "is_reverted": false,
+                "messages": [],
+                "result": [
+                    "0x1"
+                ]
+            },
+            "type": "INVOKE",
+            "validate_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+                    "0x3c8e49f80f188aa594216c470baf9428ed7dbef7af8f907328bee96696b878",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "calls": [],
+                "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+                "contract_address": "0xc01",
+                "entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "l1_gas": 0,
+                    "l2_gas": 42780
+                },
+                "is_reverted": false,
+                "messages": [],
+                "result": [
+                    "0x56414c4944"
+                ]
+            }
+        }
+    }
+]


### PR DESCRIPTION
This PR fixes an oversight we've made when adding Starknet 0.14.0 support: we have to explicitly add the new versioned constants, otherwise execution on 0.14.0  will _still_ use 0.13.5 constants.

