### PR TITLE
fix(rpc/pending): use pre-confirmed block only for JSON-RPC 0.9 and up

### DIFF
--- a/crates/rpc/src/context.rs
+++ b/crates/rpc/src/context.rs
@@ -256,4 +256,18 @@ impl RpcContext {
 
         context.with_pending_data(rx)
     }
+
+    #[cfg(test)]
+    pub async fn for_tests_with_pre_confirmed() -> Self {
+        // This is a bit silly with the arc in and out, but since its for tests the
+        // ergonomics of having Arc also constructed is nice.
+        let context = Self::for_tests();
+        let pending_data =
+            super::test_utils::create_pre_confirmed_data(context.storage.clone()).await;
+
+        let (tx, rx) = tokio_watch::channel(Default::default());
+        tx.send(pending_data).unwrap();
+
+        context.with_pending_data(rx)
+    }
 }

--- a/crates/rpc/src/method/get_messages_status.rs
+++ b/crates/rpc/src/method/get_messages_status.rs
@@ -4,6 +4,7 @@ use pathfinder_ethereum::EthereumApi;
 
 use crate::context::RpcContext;
 use crate::method::get_transaction_status;
+use crate::RpcVersion;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Input {
@@ -70,7 +71,11 @@ pub struct Output(Vec<L1HandlerTransactionStatus>);
 
 crate::error::generate_rpc_error_subset!(Error: TxnHashNotFound);
 
-pub async fn get_messages_status(context: RpcContext, input: Input) -> Result<Output, Error> {
+pub async fn get_messages_status(
+    context: RpcContext,
+    input: Input,
+    rpc_version: RpcVersion,
+) -> Result<Output, Error> {
     let span = tracing::Span::current();
 
     let _g = span.enter();
@@ -92,7 +97,7 @@ pub async fn get_messages_status(context: RpcContext, input: Input) -> Result<Ou
         let tx_hash = tx.calculate_hash(context.chain_id);
 
         let input = get_transaction_status::Input::new(tx_hash);
-        let status = get_transaction_status(context.clone(), input)
+        let status = get_transaction_status(context.clone(), input, rpc_version)
             .await
             .map_err(|_| Error::TxnHashNotFound)?;
 

--- a/crates/rpc/src/method/get_storage_at.rs
+++ b/crates/rpc/src/method/get_storage_at.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use pathfinder_common::{BlockId, ContractAddress, StorageAddress, StorageValue};
 
 use crate::context::RpcContext;
+use crate::RpcVersion;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Input {
@@ -28,7 +29,11 @@ pub struct Output(StorageValue);
 crate::error::generate_rpc_error_subset!(Error: ContractNotFound, BlockNotFound);
 
 /// Get the value of the storage at the given address and key.
-pub async fn get_storage_at(context: RpcContext, input: Input) -> Result<Output, Error> {
+pub async fn get_storage_at(
+    context: RpcContext,
+    input: Input,
+    rpc_version: RpcVersion,
+) -> Result<Output, Error> {
     let span = tracing::Span::current();
     let jh = util::task::spawn_blocking(move |_| {
         let _g = span.enter();
@@ -42,7 +47,7 @@ pub async fn get_storage_at(context: RpcContext, input: Input) -> Result<Output,
         if input.block_id.is_pending() {
             if let Some(value) = context
                 .pending_data
-                .get(&tx)
+                .get(&tx, rpc_version)
                 .context("Querying pending data")?
                 .state_update()
                 .storage_value(input.contract_address, input.key)
@@ -120,6 +125,8 @@ mod tests {
         assert_eq!(input, expected);
     }
 
+    const RPC_VERSION: RpcVersion = RpcVersion::V09;
+
     #[tokio::test]
     async fn pending() {
         let ctx = RpcContext::for_tests_with_pending().await;
@@ -134,6 +141,7 @@ mod tests {
                 key,
                 block_id,
             },
+            RPC_VERSION,
         )
         .await
         .unwrap();
@@ -155,6 +163,7 @@ mod tests {
                 key,
                 block_id,
             },
+            RPC_VERSION,
         )
         .await
         .unwrap();
@@ -177,6 +186,7 @@ mod tests {
                 key,
                 block_id,
             },
+            RPC_VERSION,
         )
         .await
         .unwrap();
@@ -198,6 +208,7 @@ mod tests {
                 key,
                 block_id,
             },
+            RPC_VERSION,
         )
         .await
         .unwrap();
@@ -219,6 +230,7 @@ mod tests {
                 key,
                 block_id,
             },
+            RPC_VERSION,
         )
         .await
         .unwrap();
@@ -240,6 +252,7 @@ mod tests {
                 key,
                 block_id,
             },
+            RPC_VERSION,
         )
         .await
         .unwrap();
@@ -261,6 +274,7 @@ mod tests {
                 key,
                 block_id,
             },
+            RPC_VERSION,
         )
         .await
         .unwrap();
@@ -282,6 +296,7 @@ mod tests {
                 key,
                 block_id,
             },
+            RPC_VERSION,
         )
         .await;
 
@@ -302,6 +317,7 @@ mod tests {
                 key,
                 block_id,
             },
+            RPC_VERSION,
         )
         .await;
 
@@ -322,6 +338,7 @@ mod tests {
                 key,
                 block_id,
             },
+            RPC_VERSION,
         )
         .await;
 
@@ -342,6 +359,7 @@ mod tests {
                 key,
                 block_id,
             },
+            RPC_VERSION,
         )
         .await;
 

--- a/crates/rpc/src/method/get_transaction_by_block_id_and_index.rs
+++ b/crates/rpc/src/method/get_transaction_by_block_id_and_index.rs
@@ -3,6 +3,7 @@ use pathfinder_common::transaction::Transaction;
 use pathfinder_common::{BlockId, TransactionIndex};
 
 use crate::context::RpcContext;
+use crate::RpcVersion;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Input {
@@ -32,6 +33,7 @@ crate::error::generate_rpc_error_subset!(
 pub async fn get_transaction_by_block_id_and_index(
     context: RpcContext,
     input: Input,
+    rpc_version: RpcVersion,
 ) -> Result<Output, GetTransactionByBlockIdAndIndexError> {
     let index: usize = input
         .index
@@ -53,7 +55,7 @@ pub async fn get_transaction_by_block_id_and_index(
             BlockId::Pending => {
                 let result = context
                     .pending_data
-                    .get(&db_tx)
+                    .get(&db_tx, rpc_version)
                     .context("Querying pending dat")?
                     .transactions()
                     .get(index)

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -4,12 +4,12 @@ use pathfinder_executor::types::InnerCallExecutionResources;
 use pathfinder_executor::TransactionExecutionError;
 use starknet_gateway_client::GatewayApi;
 
-use crate::compose_executor_transaction;
 use crate::context::RpcContext;
 use crate::executor::{
     ExecutionStateError,
     VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEWAY,
 };
+use crate::{compose_executor_transaction, RpcVersion};
 
 #[derive(Debug, Clone)]
 pub struct TraceBlockTransactionsInput {
@@ -37,6 +37,7 @@ pub struct TraceBlockTransactionsOutput {
 pub async fn trace_block_transactions(
     context: RpcContext,
     input: TraceBlockTransactionsInput,
+    rpc_version: RpcVersion,
 ) -> Result<TraceBlockTransactionsOutput, TraceBlockTransactionsError> {
     enum LocalExecution {
         Success(TraceBlockTransactionsOutput),
@@ -56,7 +57,7 @@ pub async fn trace_block_transactions(
             BlockId::Pending => {
                 let pending = context
                     .pending_data
-                    .get(&db_tx)
+                    .get(&db_tx, rpc_version)
                     .context("Querying pending data")?;
 
                 let header = pending.header();
@@ -775,7 +776,7 @@ pub(crate) mod tests {
         let input = TraceBlockTransactionsInput {
             block_id: next_block_header.hash.into(),
         };
-        let output = trace_block_transactions(context, input)
+        let output = trace_block_transactions(context, input, version)
             .await
             .unwrap()
             .serialize(Serializer { version })
@@ -785,6 +786,8 @@ pub(crate) mod tests {
 
         Ok(())
     }
+
+    const RPC_VERSION: RpcVersion = RpcVersion::V09;
 
     /// Test that multiple requests for the same block return correctly. This
     /// checks that the trace request coalescing doesn't do anything
@@ -802,7 +805,11 @@ pub(crate) mod tests {
         for _ in 0..NUM_REQUESTS {
             let input = input.clone();
             let context = context.clone();
-            joins.spawn(async move { trace_block_transactions(context, input).await.unwrap() });
+            joins.spawn(async move {
+                trace_block_transactions(context, input, RPC_VERSION)
+                    .await
+                    .unwrap()
+            });
         }
         let mut outputs = Vec::new();
         while let Some(output) = joins.join_next().await {
@@ -967,7 +974,7 @@ pub(crate) mod tests {
             block_id: next_block_header.hash.into(),
         };
 
-        let output = trace_block_transactions(context, input)
+        let output = trace_block_transactions(context, input, RPC_VERSION)
             .await
             .unwrap()
             .serialize(Serializer { version })
@@ -1063,6 +1070,7 @@ pub(crate) mod tests {
             TraceBlockTransactionsInput {
                 block_id: BlockId::Number(block.block_number),
             },
+            RPC_VERSION,
         )
         .await
         .unwrap();
@@ -1153,6 +1161,7 @@ pub(crate) mod tests {
             TraceBlockTransactionsInput {
                 block_id: BlockId::Number(block.block_number),
             },
+            RPC_VERSION,
         )
         .await
         .unwrap();


### PR DESCRIPTION
`PendingWatcher::get()` now uses the JSON-RPC API version number to decide whether to return the pre-committed block data.

For JSON-RPC 0.9 and up, the data is returned as is.

For older JSON-RPC versions we return an empty pre-committed block instead.

Closes: #2801 