### PR TITLE
feat(rpc): revertible L1HandlerTransactionExecutionInfo

### DIFF
--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -1053,7 +1053,7 @@ pub(crate) mod tests {
                                     universal_deployer_address,
                                 )),
                                 execute_invocation:
-                                    pathfinder_executor::types::ExecuteInvocation::FunctionInvocation(Some(
+                                    pathfinder_executor::types::RevertibleFunctionInvocation::FunctionInvocation(Some(
                                         universal_deployer_execute(
                                             account_contract_address,
                                             universal_deployer_address,
@@ -1382,7 +1382,7 @@ pub(crate) mod tests {
                             execution_info: pathfinder_executor::types::InvokeTransactionExecutionInfo {
                                 validate_invocation: Some(invoke_validate(account_contract_address)),
                                 execute_invocation:
-                                    pathfinder_executor::types::ExecuteInvocation::FunctionInvocation(Some(
+                                    pathfinder_executor::types::RevertibleFunctionInvocation::FunctionInvocation(Some(
                                         invoke_execute(account_contract_address, test_storage_value),
                                     )),
                                 fee_transfer_invocation: Some(invoke_fee_transfer(

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -391,9 +391,11 @@ pub(crate) fn map_gateway_trace(
             pathfinder_executor::types::InvokeTransactionTrace {
                 execution_info: pathfinder_executor::types::InvokeTransactionExecutionInfo {
                     execute_invocation: if let Some(revert_reason) = trace.revert_error {
-                        pathfinder_executor::types::ExecuteInvocation::RevertedReason(revert_reason)
+                        pathfinder_executor::types::RevertibleFunctionInvocation::RevertedReason(
+                            revert_reason,
+                        )
                     } else {
-                        pathfinder_executor::types::ExecuteInvocation::FunctionInvocation(
+                        pathfinder_executor::types::RevertibleFunctionInvocation::FunctionInvocation(
                             trace
                                 .function_invocation
                                 .map(map_gateway_function_invocation)
@@ -417,10 +419,18 @@ pub(crate) fn map_gateway_trace(
             pathfinder_executor::types::TransactionTrace::L1Handler(
                 pathfinder_executor::types::L1HandlerTransactionTrace {
                     execution_info: pathfinder_executor::types::L1HandlerTransactionExecutionInfo {
-                        function_invocation: trace
-                            .function_invocation
-                            .map(map_gateway_function_invocation)
-                            .transpose()?,
+                        function_invocation: if let Some(revert_reason) = trace.revert_error {
+                            pathfinder_executor::types::RevertibleFunctionInvocation::RevertedReason(
+                                revert_reason,
+                            )
+                        } else {
+                            pathfinder_executor::types::RevertibleFunctionInvocation::FunctionInvocation(
+                                trace
+                                    .function_invocation
+                                    .map(map_gateway_function_invocation)
+                                    .transpose()?,
+                            )
+                        },
                         execution_resources,
                     },
                     state_diff: Default::default(),


### PR DESCRIPTION
Rename `ExecuteInvocation` DTO to `RevertibleFunctionInvocation`, use it for `L1HandlerTransactionExecutionInfo::function_invocation`.

Fixes https://github.com/eqlabs/pathfinder/issues/2798 .
