### PR TITLE
Consensus: add write-ahead log (WAL) support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6513,8 +6513,10 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98c6c3a026c52ad8c84bc9b4e80cd504728ea85caa61dce46f9a9fdda5e4cf0a"
 dependencies = [
+ "base64 0.22.1",
  "ed25519-consensus",
  "informalsystems-malachitebft-core-types",
+ "serde",
  "signature",
 ]
 
@@ -8276,6 +8278,7 @@ dependencies = [
  "prost-build",
  "prost-types 0.13.3",
  "rand 0.8.5",
+ "serde",
  "serde_json",
 ]
 
@@ -8556,6 +8559,7 @@ name = "pathfinder-consensus"
 version = "0.17.0-beta.2"
 dependencies = [
  "anyhow",
+ "base64 0.13.1",
  "ed25519-consensus",
  "informalsystems-malachitebft-core-consensus",
  "informalsystems-malachitebft-core-types",
@@ -8565,6 +8569,8 @@ dependencies = [
  "pathfinder-common",
  "pathfinder-crypto",
  "rand 0.8.5",
+ "serde",
+ "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -9,15 +9,18 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+base64 = { workspace = true }
 ed25519-consensus = "2.1.0"
 malachite-consensus = { package = "informalsystems-malachitebft-core-consensus", version = "0.2" }
 malachite-metrics = { package = "informalsystems-malachitebft-metrics", version = "0.2" }
-malachite-signing-ed25519 = { package = "informalsystems-malachitebft-signing-ed25519", version = "0.2" }
+malachite-signing-ed25519 = { package = "informalsystems-malachitebft-signing-ed25519", version = "0.2", features = ["serde"] }
 malachite-types = { package = "informalsystems-malachitebft-core-types", version = "0.2" }
 p2p_proto = { path = "../p2p_proto" }
 pathfinder-common = { version = "0.17.0-beta.1", path = "../common" }
 pathfinder-crypto = { version = "0.17.0-beta.1", path = "../crypto" }
 rand = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/crates/consensus/src/config.rs
+++ b/crates/consensus/src/config.rs
@@ -17,6 +17,8 @@ pub struct Config {
     pub vote_sync_mode: VoteSyncMode,
     /// The timeout configuration.
     pub timeout_values: TimeoutValues,
+    /// The number of completed heights to keep in memory.
+    pub history_depth: u64,
 }
 
 impl Config {
@@ -25,6 +27,7 @@ impl Config {
     pub fn new(address: ValidatorAddress) -> Self {
         Self {
             address,
+            history_depth: 10,
             ..Default::default()
         }
     }
@@ -50,6 +53,12 @@ impl Config {
     /// Set the timeout values.
     pub fn with_timeout_values(mut self, timeout_values: TimeoutValues) -> Self {
         self.timeout_values = timeout_values;
+        self
+    }
+
+    /// Set the number of completed heights to keep in memory.
+    pub fn with_history_depth(mut self, history_depth: u64) -> Self {
+        self.history_depth = history_depth;
         self
     }
 }

--- a/crates/consensus/src/malachite/address.rs
+++ b/crates/consensus/src/malachite/address.rs
@@ -1,9 +1,11 @@
+use serde::{Deserialize, Serialize};
+
 /// A validator address for the malachite context.
 ///
 /// This is a wrapper around the `ContractAddress` type from the
 /// `pathfinder_common` crate which implements the `Address` trait for the
 /// malachite context.
-#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Copy, Default, Hash)]
+#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Copy, Default, Hash, Serialize, Deserialize)]
 pub struct ValidatorAddress(pathfinder_common::ContractAddress);
 
 impl From<p2p_proto::common::Address> for ValidatorAddress {

--- a/crates/consensus/src/malachite/context.rs
+++ b/crates/consensus/src/malachite/context.rs
@@ -74,10 +74,10 @@ impl malachite_types::Context for MalachiteContext {
         );
         Proposal {
             height,
-            round,
+            round: round.into(),
             value_id: value,
             proposer: address,
-            pol_round,
+            pol_round: pol_round.into(),
         }
     }
 
@@ -98,7 +98,7 @@ impl malachite_types::Context for MalachiteContext {
         Vote {
             r#type: VoteType::Prevote,
             height,
-            round,
+            round: round.into(),
             validator_address: address,
             value: value_id,
             extension: None,
@@ -122,7 +122,7 @@ impl malachite_types::Context for MalachiteContext {
         Vote {
             r#type: VoteType::Precommit,
             height,
-            round,
+            round: round.into(),
             validator_address: address,
             value: value_id,
             extension: None,

--- a/crates/consensus/src/malachite/height.rs
+++ b/crates/consensus/src/malachite/height.rs
@@ -1,8 +1,12 @@
+use serde::{Deserialize, Serialize};
+
 /// A block number for the malachite context.
 ///
 /// This is a wrapper around the `BlockNumber` type from the `pathfinder_common`
 /// crate which implements the `Height` trait for the malachite context.
-#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Copy, Debug, Default, Hash)]
+#[derive(
+    Ord, PartialOrd, Eq, PartialEq, Clone, Copy, Debug, Default, Hash, Serialize, Deserialize,
+)]
 pub struct Height(pathfinder_common::BlockNumber);
 
 impl Height {

--- a/crates/consensus/src/malachite/proposal.rs
+++ b/crates/consensus/src/malachite/proposal.rs
@@ -1,7 +1,9 @@
+use serde::{Deserialize, Serialize};
+
 use super::{ConsensusValue, Height, MalachiteContext, Round, ValidatorAddress};
 
 /// A proposal for a value in a round
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Proposal {
     pub height: Height,
     pub round: Round,
@@ -15,8 +17,8 @@ impl malachite_types::Proposal<MalachiteContext> for Proposal {
         self.height
     }
 
-    fn round(&self) -> Round {
-        self.round
+    fn round(&self) -> malachite_types::Round {
+        self.round.inner()
     }
 
     fn value(&self) -> &ConsensusValue {
@@ -27,8 +29,8 @@ impl malachite_types::Proposal<MalachiteContext> for Proposal {
         self.value_id
     }
 
-    fn pol_round(&self) -> Round {
-        self.pol_round
+    fn pol_round(&self) -> malachite_types::Round {
+        self.pol_round.inner()
     }
 
     fn validator_address(&self) -> &ValidatorAddress {

--- a/crates/consensus/src/malachite/round.rs
+++ b/crates/consensus/src/malachite/round.rs
@@ -1,2 +1,64 @@
 /// A round for the malachite context.
-pub type Round = malachite_types::Round;
+#[derive(Clone, Copy, PartialOrd, Ord, Debug, PartialEq, Eq)]
+pub struct Round(malachite_types::Round);
+
+impl Round {
+    pub fn new(round: malachite_types::Round) -> Self {
+        Self(round)
+    }
+
+    pub fn as_u32(&self) -> Option<u32> {
+        self.0.as_u32()
+    }
+
+    pub fn inner(&self) -> malachite_types::Round {
+        self.0
+    }
+
+    pub fn into_inner(self) -> malachite_types::Round {
+        self.0
+    }
+}
+
+impl From<malachite_types::Round> for Round {
+    fn from(round: malachite_types::Round) -> Self {
+        Self(round)
+    }
+}
+
+impl From<u32> for Round {
+    fn from(round: u32) -> Self {
+        Self(malachite_types::Round::from(round))
+    }
+}
+
+impl serde::Serialize for Round {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.0.as_u32() {
+            Some(value) => serializer.serialize_u32(value),
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Round {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let round_opt = Option::<u32>::deserialize(deserializer)?;
+        match round_opt {
+            Some(value) => Ok(Self(malachite_types::Round::from(value))),
+            None => Ok(Self(malachite_types::Round::Nil)),
+        }
+    }
+}
+
+impl std::fmt::Display for Round {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/crates/consensus/src/malachite/value.rs
+++ b/crates/consensus/src/malachite/value.rs
@@ -1,5 +1,7 @@
+use serde::{Deserialize, Serialize};
+
 /// A value id for the malachite context.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct ValueId(p2p_proto::common::Hash);
 
 impl From<p2p_proto::common::Hash> for ValueId {
@@ -38,7 +40,7 @@ fn short_val(val: &p2p_proto::common::Hash) -> String {
 }
 
 /// The actual value being agreed upon.
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct ConsensusValue(ValueId);
 
 impl ConsensusValue {

--- a/crates/consensus/src/malachite/vote.rs
+++ b/crates/consensus/src/malachite/vote.rs
@@ -1,6 +1,12 @@
 pub use malachite_types::VoteType;
-use malachite_types::{Height as MalachiteHeight, NilOrVal, SignedExtension};
+use malachite_types::{
+    Height as MalachiteHeight,
+    NilOrVal,
+    Round as MalachiteRound,
+    SignedExtension,
+};
 use p2p_proto::consensus as p2p_proto;
+use serde::{Deserialize, Serialize};
 
 use super::{Height, MalachiteContext, Round, ValidatorAddress, ValueId};
 
@@ -18,6 +24,133 @@ pub struct Vote {
     pub extension: Option<SignedExtension<MalachiteContext>>,
 }
 
+impl serde::Serialize for Vote {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // Create a simple struct for serialization
+        #[derive(Serialize)]
+        struct VoteHelper<'a> {
+            #[serde(rename = "type")]
+            vote_type: &'static str,
+            height: &'a Height,
+            round: &'a Round,
+            value: Option<&'a ValueId>,
+            validator_address: &'a ValidatorAddress,
+            extension: Option<ExtensionHelper>,
+        }
+
+        #[derive(Serialize)]
+        struct ExtensionHelper {
+            message: String,
+            signature: String,
+        }
+
+        let vote_type = match self.r#type {
+            VoteType::Prevote => "prevote",
+            VoteType::Precommit => "precommit",
+        };
+
+        let value = match &self.value {
+            NilOrVal::Nil => None,
+            NilOrVal::Val(val) => Some(val),
+        };
+
+        let extension = self.extension.as_ref().map(|ext| ExtensionHelper {
+            message: base64::encode(&ext.message),
+            signature: base64::encode(ext.signature.to_bytes()),
+        });
+
+        let helper = VoteHelper {
+            vote_type,
+            height: &self.height,
+            round: &self.round,
+            value,
+            validator_address: &self.validator_address,
+            extension,
+        };
+
+        helper.serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Vote {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Helper struct for deserialization
+        #[derive(Deserialize)]
+        struct VoteHelper {
+            #[serde(rename = "type")]
+            vote_type: String,
+            height: Height,
+            round: Round,
+            value: Option<ValueId>,
+            validator_address: ValidatorAddress,
+            extension: Option<ExtensionHelper>,
+        }
+
+        #[derive(Deserialize)]
+        struct ExtensionHelper {
+            message: String,
+            signature: String,
+        }
+
+        let helper = VoteHelper::deserialize(deserializer)?;
+
+        let vote_type = match helper.vote_type.as_str() {
+            "prevote" => VoteType::Prevote,
+            "precommit" => VoteType::Precommit,
+            _ => {
+                return Err(serde::de::Error::invalid_value(
+                    serde::de::Unexpected::Str(&helper.vote_type),
+                    &"prevote or precommit",
+                ))
+            }
+        };
+
+        let value = match helper.value {
+            None => NilOrVal::Nil,
+            Some(val) => NilOrVal::Val(val),
+        };
+
+        let extension = helper
+            .extension
+            .map(|ext_helper| {
+                let message = base64::decode(&ext_helper.message).map_err(|e| {
+                    serde::de::Error::custom(format!("Invalid base64 message: {}", e))
+                })?;
+                let signature_bytes = base64::decode(&ext_helper.signature).map_err(|e| {
+                    serde::de::Error::custom(format!("Invalid base64 signature: {}", e))
+                })?;
+
+                if signature_bytes.len() != 64 {
+                    return Err(serde::de::Error::custom("Signature must be 64 bytes"));
+                }
+
+                let mut signature_array = [0u8; 64];
+                signature_array.copy_from_slice(&signature_bytes);
+
+                Ok(SignedExtension {
+                    message,
+                    signature: malachite_signing_ed25519::Signature::from_bytes(signature_array),
+                })
+            })
+            .transpose()?;
+
+        Ok(Vote {
+            r#type: vote_type,
+            height: helper.height,
+            round: helper.round,
+            value,
+            validator_address: helper.validator_address,
+            extension,
+        })
+    }
+}
+
 impl From<p2p_proto::Vote> for Vote {
     fn from(vote: p2p_proto::Vote) -> Self {
         Self {
@@ -26,7 +159,7 @@ impl From<p2p_proto::Vote> for Vote {
                 p2p_proto::VoteType::Precommit => VoteType::Precommit,
             },
             height: Height::new(vote.height),
-            round: Round::new(vote.round),
+            round: Round::from(vote.round),
             value: match vote.block_hash {
                 Some(v) => NilOrVal::Val(ValueId::from(v)),
                 None => NilOrVal::Nil,
@@ -61,8 +194,8 @@ impl malachite_types::Vote<MalachiteContext> for Vote {
         self.height
     }
 
-    fn round(&self) -> Round {
-        self.round
+    fn round(&self) -> MalachiteRound {
+        self.round.inner()
     }
 
     fn value(&self) -> &NilOrVal<ValueId> {
@@ -94,5 +227,95 @@ impl malachite_types::Vote<MalachiteContext> for Vote {
             extension: Some(extension),
             ..self
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ::p2p_proto::common::{Address, Hash};
+    use pathfinder_crypto::Felt;
+
+    use super::*;
+
+    #[test]
+    fn test_vote_serialization_roundtrip() {
+        // Create a test vote
+        let vote = Vote {
+            r#type: VoteType::Prevote,
+            height: Height::new(100),
+            round: Round::from(5),
+            value: NilOrVal::Val(ValueId::new(Hash(
+                Felt::from_hex_str("0x123456789").unwrap(),
+            ))),
+            validator_address: ValidatorAddress::from(Address(
+                Felt::from_hex_str("0xabcdef").unwrap(),
+            )),
+            extension: Some(SignedExtension {
+                message: vec![1, 2, 3, 4, 5],
+                signature: malachite_signing_ed25519::Signature::from_bytes([
+                    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+                    23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42,
+                    43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62,
+                    63, 64,
+                ]),
+            }),
+        };
+
+        // Serialize to JSON
+        let json = serde_json::to_string(&vote).expect("Failed to serialize vote");
+        println!("Serialized vote: {}", json);
+
+        // Deserialize from JSON
+        let deserialized_vote: Vote =
+            serde_json::from_str(&json).expect("Failed to deserialize vote");
+
+        // Verify the roundtrip
+        assert_eq!(vote.r#type, deserialized_vote.r#type);
+        assert_eq!(vote.height, deserialized_vote.height);
+        assert_eq!(vote.round, deserialized_vote.round);
+        assert_eq!(vote.value, deserialized_vote.value);
+        assert_eq!(vote.validator_address, deserialized_vote.validator_address);
+        assert_eq!(
+            vote.extension.as_ref().map(|e| &e.message),
+            deserialized_vote.extension.as_ref().map(|e| &e.message)
+        );
+        assert_eq!(
+            vote.extension.as_ref().map(|e| e.signature.to_bytes()),
+            deserialized_vote
+                .extension
+                .as_ref()
+                .map(|e| e.signature.to_bytes())
+        );
+    }
+
+    #[test]
+    fn test_vote_serialization_with_nil_value() {
+        // Create a test vote with Nil value
+        let vote = Vote {
+            r#type: VoteType::Precommit,
+            height: Height::new(101),
+            round: Round::from(6),
+            value: NilOrVal::Nil,
+            validator_address: ValidatorAddress::from(Address(
+                Felt::from_hex_str("0xdef").unwrap(),
+            )),
+            extension: None,
+        };
+
+        // Serialize to JSON
+        let json = serde_json::to_string(&vote).expect("Failed to serialize vote");
+        println!("Serialized vote with nil value: {}", json);
+
+        // Deserialize from JSON
+        let deserialized_vote: Vote =
+            serde_json::from_str(&json).expect("Failed to deserialize vote");
+
+        // Verify the roundtrip
+        assert_eq!(vote.r#type, deserialized_vote.r#type);
+        assert_eq!(vote.height, deserialized_vote.height);
+        assert_eq!(vote.round, deserialized_vote.round);
+        assert_eq!(vote.value, deserialized_vote.value);
+        assert_eq!(vote.validator_address, deserialized_vote.validator_address);
+        assert_eq!(vote.extension, deserialized_vote.extension);
     }
 }

--- a/crates/consensus/src/wal.rs
+++ b/crates/consensus/src/wal.rs
@@ -1,0 +1,152 @@
+use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+
+use malachite_consensus::SignedConsensusMsg;
+use malachite_types::{Timeout, Value};
+use serde::{Deserialize, Serialize};
+
+use crate::malachite::MalachiteContext;
+use crate::{Height, Round, SignedProposal, SignedVote, ValidatorAddress, ValueId};
+
+/// A trait for types that can append to a write-ahead log.
+pub(crate) trait WalSink: Send {
+    fn append(&mut self, entry: WalEntry);
+}
+
+/// A write-ahead log entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) enum WalEntry {
+    /// A signed proposal.
+    SignedProposal(SignedProposal),
+    /// A signed vote.
+    SignedVote(SignedVote),
+    /// A timeout.
+    Timeout { kind: String, round: Round },
+    /// A proposed value.
+    ProposedValue {
+        height: Height,
+        round: Round,
+        valid_round: Round,
+        proposer: ValidatorAddress,
+        value: ValueId,
+        validity: bool,
+    },
+}
+
+// This is necessary because unfortunately the malachite types are not
+// serializable.
+impl From<malachite_consensus::WalEntry<MalachiteContext>> for WalEntry {
+    fn from(entry: malachite_consensus::WalEntry<MalachiteContext>) -> Self {
+        use malachite_consensus::WalEntry as MalachiteWalEntry;
+        match entry {
+            MalachiteWalEntry::ConsensusMsg(msg) => {
+                let signature = *msg.signature();
+                match msg {
+                    SignedConsensusMsg::Proposal(proposal) => {
+                        let proposal = proposal.message;
+                        WalEntry::SignedProposal(SignedProposal {
+                            proposal,
+                            signature,
+                        })
+                    }
+                    SignedConsensusMsg::Vote(vote) => {
+                        let vote = vote.message;
+                        WalEntry::SignedVote(SignedVote { vote, signature })
+                    }
+                }
+            }
+            MalachiteWalEntry::Timeout(timeout) => {
+                use malachite_types::TimeoutKind as Kind;
+                WalEntry::Timeout {
+                    kind: match timeout.kind {
+                        Kind::Propose => "propose",
+                        Kind::Prevote => "prevote",
+                        Kind::PrevoteTimeLimit => "prevote-time-limit",
+                        Kind::Precommit => "precommit",
+                        Kind::PrecommitTimeLimit => "precommit-time-limit",
+                        Kind::PrevoteRebroadcast => "prevote-rebroadcast",
+                        Kind::PrecommitRebroadcast => "precommit-rebroadcast",
+                    }
+                    .to_string(),
+                    round: timeout.round.into(),
+                }
+            }
+            MalachiteWalEntry::ProposedValue(proposed_value) => WalEntry::ProposedValue {
+                height: proposed_value.height,
+                round: proposed_value.round.into(),
+                valid_round: proposed_value.valid_round.into(),
+                proposer: proposed_value.proposer,
+                value: proposed_value.value.id(),
+                validity: proposed_value.validity.is_valid(),
+            },
+        }
+    }
+}
+
+impl From<Timeout> for WalEntry {
+    fn from(timeout: Timeout) -> Self {
+        use malachite_types::TimeoutKind as Kind;
+        WalEntry::Timeout {
+            kind: match timeout.kind {
+                Kind::Propose => "propose",
+                Kind::Prevote => "prevote",
+                Kind::PrevoteTimeLimit => "prevote-time-limit",
+                Kind::Precommit => "precommit",
+                Kind::PrecommitTimeLimit => "precommit-time-limit",
+                Kind::PrevoteRebroadcast => "prevote-rebroadcast",
+                Kind::PrecommitRebroadcast => "precommit-rebroadcast",
+            }
+            .to_string(),
+            round: timeout.round.into(),
+        }
+    }
+}
+
+/// A write-ahead log that writes to a file.
+pub struct FileWalSink {
+    file: std::fs::File,
+    path: PathBuf,
+}
+
+impl FileWalSink {
+    pub fn new(address: &ValidatorAddress, height: &Height) -> std::io::Result<Self> {
+        let path = PathBuf::from(format!("wal-{address}-{height}.json"));
+        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+        Ok(Self { file, path })
+    }
+}
+
+impl Drop for FileWalSink {
+    fn drop(&mut self) {
+        if let Err(e) = fs::remove_file(&self.path) {
+            tracing::error!(
+                path = %self.path.display(),
+                error = %e,
+                "Failed to delete WAL file"
+            );
+        } else {
+            tracing::debug!(
+                path = %self.path.display(),
+                "Successfully deleted WAL file"
+            );
+        }
+    }
+}
+
+impl WalSink for FileWalSink {
+    fn append(&mut self, entry: WalEntry) {
+        let line = serde_json::to_string(&entry).expect("WAL serialization failed");
+        writeln!(self.file, "{line}").expect("WAL write failed");
+    }
+}
+
+/// A write-ahead log that does nothing.
+pub(crate) struct NoopWal;
+
+impl WalSink for NoopWal {
+    fn append(&mut self, entry: WalEntry) {
+        tracing::debug!("NoopWal: Appending entry: {:?}", entry);
+    }
+}

--- a/crates/consensus/tests/consensus_sim.rs
+++ b/crates/consensus/tests/consensus_sim.rs
@@ -105,7 +105,7 @@ async fn consensus_simulation() {
                                     height: h,
                                     round: r,
                                     proposer: addr,
-                                    pol_round: Round::new(0),
+                                    pol_round: Round::from(0),
                                     value_id: consensus_value.clone(),
                                 };
 

--- a/crates/consensus/tests/timeouts.rs
+++ b/crates/consensus/tests/timeouts.rs
@@ -92,7 +92,7 @@ async fn single_node_propose_timeout_advances_round() {
             ..
         }) => {
             assert_eq!(h, height);
-            assert_eq!(r, Round::new(0));
+            assert_eq!(r, Round::from(0));
         }
         other => panic!("Expected RequestProposal for round 0, got: {:?}", other),
     }
@@ -102,7 +102,7 @@ async fn single_node_propose_timeout_advances_round() {
         &mut consensus,
         Duration::from_secs(5),
         10,
-        |evt| matches!(evt, ConsensusEvent::RequestProposal { round, .. } if *round == Round::new(1)),
+        |evt| matches!(evt, ConsensusEvent::RequestProposal { round, .. } if *round == Round::from(1)),
     ).await;
 
     assert!(result.is_some(), "Timeout did not trigger expected round 1");
@@ -136,16 +136,16 @@ async fn single_node_prevote_timeout_advances_round() {
         &mut consensus,
         Duration::from_secs(1),
         5,
-        |evt| matches!(evt, ConsensusEvent::RequestProposal { round, .. } if *round == Round::new(0)),
+        |evt| matches!(evt, ConsensusEvent::RequestProposal { round, .. } if *round == Round::from(0)),
     ).await;
 
     // Send a proposal (to enter prevote step)
     let value_id = ValueId::new(Hash(Felt::from_hex_str("0x123456789").unwrap()));
     let proposal = Proposal {
         height,
-        round: Round::new(0),
+        round: Round::from(0),
         value_id: ConsensusValue::new(value_id),
-        pol_round: Round::ZERO,
+        pol_round: Round::from(0),
         proposer: addr,
     };
     let signature: Signature = Signature::from_bytes([0; 64]);
@@ -160,7 +160,7 @@ async fn single_node_prevote_timeout_advances_round() {
         &mut consensus,
         Duration::from_secs(5),
         10,
-        |evt| matches!(evt, ConsensusEvent::RequestProposal { round, .. } if *round == Round::new(1)),
+        |evt| matches!(evt, ConsensusEvent::RequestProposal { round, .. } if *round == Round::from(1)),
     ).await;
 
     assert!(
@@ -197,7 +197,7 @@ async fn single_node_precommit_timeout_advances_round() {
         &mut consensus,
         Duration::from_secs(1),
         5,
-        |evt| matches!(evt, ConsensusEvent::RequestProposal { round, .. } if *round == Round::new(0)),
+        |evt| matches!(evt, ConsensusEvent::RequestProposal { round, .. } if *round == Round::from(0)),
     )
     .await;
 
@@ -205,9 +205,9 @@ async fn single_node_precommit_timeout_advances_round() {
     let value_id = ValueId::new(Hash(Felt::from_hex_str("0x123456789").unwrap()));
     let proposal = Proposal {
         height,
-        round: Round::new(0),
+        round: Round::from(0),
         value_id: ConsensusValue::new(value_id.clone()),
-        pol_round: Round::ZERO,
+        pol_round: Round::from(0),
         proposer: addr,
     };
     let signature: Signature = Signature::from_bytes([0; 64]);
@@ -221,7 +221,7 @@ async fn single_node_precommit_timeout_advances_round() {
     let vote = Vote {
         r#type: VoteType::Prevote,
         height,
-        round: Round::new(0),
+        round: Round::from(0),
         validator_address: addr,
         value: NilOrVal::Val(value_id),
         extension: None,
@@ -239,7 +239,7 @@ async fn single_node_precommit_timeout_advances_round() {
         &mut consensus,
         Duration::from_secs(5),
         10,
-        |evt| matches!(evt, ConsensusEvent::RequestProposal { round, .. } if *round == Round::new(1)),
+        |evt| matches!(evt, ConsensusEvent::RequestProposal { round, .. } if *round == Round::from(1)),
     )
     .await;
 

--- a/crates/consensus/tests/wal.rs
+++ b/crates/consensus/tests/wal.rs
@@ -1,0 +1,178 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use ed25519_consensus::SigningKey;
+use malachite_signing_ed25519::PublicKey;
+use p2p_proto::common::{Address, Hash};
+use pathfinder_consensus::*;
+use pathfinder_crypto::Felt;
+use tokio::sync::mpsc;
+use tokio::time::{sleep, Duration};
+use tracing::{error, info};
+use tracing_subscriber::EnvFilter;
+
+#[allow(dead_code)]
+fn setup_tracing_full() {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("trace"));
+
+    let _ = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::TRACE)
+        .with_env_filter(filter)
+        .with_target(true)
+        .without_time()
+        .try_init();
+}
+
+#[tokio::test]
+async fn wal_concurrent_heights_retention_test() {
+    //setup_tracing_full();
+
+    const NUM_VALIDATORS: usize = 2;
+    const NUM_HEIGHTS: u64 = 15; // More than config.history_depth
+
+    let value_hash = Hash(Felt::from_hex_str("0xabcdef").unwrap());
+    let value_id = ValueId::new(value_hash);
+    let consensus_value = ConsensusValue::new(value_id.clone());
+
+    // Create validators and channels
+    let mut validators = vec![];
+    let mut validator_set = vec![];
+    let mut senders = HashMap::new();
+    let mut receivers = HashMap::new();
+
+    for i in 1..=NUM_VALIDATORS {
+        let sk = SigningKey::new(rand::rngs::OsRng);
+        let pk = sk.verification_key();
+        let addr = ValidatorAddress::from(Address(Felt::from_hex_str(&format!("0x{i}")).unwrap()));
+        let pubkey = PublicKey::from_bytes(pk.to_bytes());
+
+        validator_set.push(Validator {
+            address: addr,
+            public_key: pubkey,
+            voting_power: 1,
+        });
+
+        let (tx, rx) = mpsc::unbounded_channel();
+        senders.insert(addr, tx);
+        receivers.insert(addr, rx);
+
+        validators.push((addr, sk));
+    }
+
+    // Create validator set
+    let validator_set = ValidatorSet::new(validator_set);
+
+    // Track decisions for each height
+    let decisions = Arc::new(Mutex::new(HashMap::new()));
+
+    // Spawn each validator in its own task
+    let mut handles = vec![];
+    for (addr, _) in validators {
+        let mut rx = receivers.remove(&addr).unwrap();
+        let peers = senders.clone();
+        let validator_set = validator_set.clone();
+        let decisions = Arc::clone(&decisions);
+        let consensus_value = consensus_value.clone();
+
+        let handle = tokio::spawn(async move {
+            let mut consensus = Consensus::new(Config::new(addr));
+            // Start all heights up front
+            for current_height in 1..=NUM_HEIGHTS {
+                let height = Height::new(current_height);
+                consensus
+                    .handle_command(ConsensusCommand::StartHeight(height, validator_set.clone()));
+            }
+
+            sleep(Duration::from_millis(100)).await;
+
+            // Now process events for all heights
+            loop {
+                while let Some(event) = consensus.next_event().await {
+                    match event {
+                        ConsensusEvent::RequestProposal {
+                            height: h,
+                            round: r,
+                            ..
+                        } => {
+                            info!(
+                                "🔍 {} is proposing at height {h}, round {r:?}",
+                                pretty_addr(&addr)
+                            );
+
+                            let proposal = Proposal {
+                                height: h,
+                                round: r,
+                                proposer: addr,
+                                pol_round: Round::from(0),
+                                value_id: consensus_value.clone(),
+                            };
+
+                            consensus.handle_command(ConsensusCommand::Propose(proposal));
+                        }
+
+                        ConsensusEvent::Gossip(msg) => {
+                            for (peer, chan) in peers.iter() {
+                                if peer != &addr {
+                                    info!("🔍 {} sending to {peer}", pretty_addr(&addr));
+                                    let _ = chan.send(msg.clone());
+                                }
+                            }
+                        }
+
+                        ConsensusEvent::Decision { height: h, hash } => {
+                            info!(
+                                "✅ {} decided on {hash:?} at height {h}",
+                                pretty_addr(&addr)
+                            );
+                            let mut decisions = decisions.lock().unwrap();
+                            decisions.insert((addr, h), hash);
+                        }
+
+                        ConsensusEvent::Error(error) => {
+                            error!("❌ {} error: {error:?}", pretty_addr(&addr));
+                            break;
+                        }
+                    }
+                }
+                while let Ok(msg) = rx.try_recv() {
+                    info!(
+                        "💌 Validator {} received command: {msg:?}",
+                        pretty_addr(&addr)
+                    );
+                    let cmd = match msg {
+                        NetworkMessage::Proposal(p) => ConsensusCommand::Proposal(p),
+                        NetworkMessage::Vote(v) => ConsensusCommand::Vote(v),
+                    };
+                    consensus.handle_command(cmd);
+                }
+                // Break if all heights are decided
+                if decisions.lock().unwrap().len() == (NUM_HEIGHTS as usize * NUM_VALIDATORS) {
+                    break;
+                }
+                sleep(Duration::from_millis(5)).await;
+            }
+        });
+
+        handles.push(handle);
+    }
+
+    // Instead of waiting for all to finish, just sleep for a while
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Check that at least config.history_depth WAL files exist
+    let files = std::fs::read_dir(".")
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().starts_with("wal-"))
+        .collect::<Vec<_>>();
+    assert!(
+        files.len() >= 10, // 10 is the default config.history_depth
+        "Expected at least 10 WAL files, found {}",
+        files.len()
+    );
+}
+
+fn pretty_addr(addr: &ValidatorAddress) -> String {
+    let addr_str = addr.to_string();
+    addr_str.chars().skip(addr_str.len() - 4).collect()
+}

--- a/crates/p2p_proto/Cargo.toml
+++ b/crates/p2p_proto/Cargo.toml
@@ -18,6 +18,7 @@ primitive-types = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 rand = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
 
 [build-dependencies]

--- a/crates/p2p_proto/src/common.rs
+++ b/crates/p2p_proto/src/common.rs
@@ -6,10 +6,24 @@ use libp2p_identity::PeerId;
 use pathfinder_crypto::Felt;
 use primitive_types::H256;
 use rand::Rng;
+use serde::{Deserialize, Serialize};
 
 use crate::{proto, ToProtobuf, TryFromProtobuf};
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Dummy, std::hash::Hash, Default)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Dummy,
+    std::hash::Hash,
+    Default,
+    Serialize,
+    Deserialize,
+)]
 pub struct Hash(pub Felt);
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, std::hash::Hash, Default)]


### PR DESCRIPTION
This PR adds write-ahead log (WAL) support to the consensus engine to enable crash recovery. The WAL ensures that consensus state can be reconstructed after a node restart by persisting all consensus messages and state transitions to disk.

### Changes
- **Added WAL infrastructure** - `WalSink` trait with `FileWalSink` and `NoopWal` implementations
- **Added height history management** - Configurable `history_depth` parameter (default: 10) to control memory usage
- **Added WAL file retention** - Files are kept for the same duration as in-memory consensus engines
- **Added concurrent height test** - Verifies WAL retention works with multiple active heights

### Coming up
This PR implements only the "saving" part of WAL functionality. The recovery/replay logic will be implemented in a follow-up PR to keep changes focused and reviewable.
