### PR TITLE
Consensus: Add `ResetTimeouts` effect handling

### DIFF
--- a/crates/consensus/src/internal.rs
+++ b/crates/consensus/src/internal.rs
@@ -320,6 +320,10 @@ fn handle_effect(
             timeout_manager.cancel_all_timeouts();
             Ok(resume.resume_with(()))
         }
+        Effect::ResetTimeouts(resume) => {
+            timeout_manager.reset_timeouts();
+            Ok(resume.resume_with(()))
+        }
         Effect::WalAppend(msg, resume) => {
             wal.append(msg.into());
             Ok(resume.resume_with(()))
@@ -421,7 +425,7 @@ impl TimeoutManager {
         self.timeouts = self
             .timeouts
             .drain()
-            .filter(|st| st.timeout == timeout)
+            .filter(|st| st.timeout != timeout)
             .collect();
 
         tracing::debug!(
@@ -435,5 +439,268 @@ impl TimeoutManager {
         self.timeouts.clear();
 
         tracing::debug!("Cancelled all timeouts");
+    }
+
+    /// Reset all timeouts.
+    pub fn reset_timeouts(&mut self) {
+        let now = Instant::now();
+        let mut reset = BinaryHeap::new();
+
+        // Drain all timeouts and update their due times
+        for mut scheduled_timeout in self.timeouts.drain() {
+            scheduled_timeout.due = now + self.timeout_values.get(scheduled_timeout.timeout.kind);
+            reset.push(scheduled_timeout);
+        }
+
+        self.timeouts = reset;
+
+        tracing::debug!("Reset all timeouts");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use malachite_types::{Round, Timeout, TimeoutKind};
+
+    use crate::config::TimeoutValues;
+    use crate::internal::TimeoutManager;
+
+    /// Tests basic timeout scheduling and firing behavior.
+    /// Verifies that timeouts are scheduled correctly and the shortest timeout
+    /// fires first.
+    #[tokio::test]
+    async fn test_timeout_manager_scheduling() {
+        let timeout_values = TimeoutValues {
+            propose: Duration::from_millis(100),
+            prevote: Duration::from_millis(200),
+            precommit: Duration::from_millis(300),
+            prevote_time_limit: Duration::from_millis(400),
+            precommit_time_limit: Duration::from_millis(500),
+            prevote_rebroadcast: Duration::from_millis(600),
+            precommit_rebroadcast: Duration::from_millis(700),
+        };
+
+        let mut manager = TimeoutManager {
+            timeouts: std::collections::BinaryHeap::new(),
+            timeout_values,
+        };
+
+        // Schedule timeouts with different durations
+        let timeout1 = Timeout::new(Round::Some(1), TimeoutKind::Propose);
+        let timeout2 = Timeout::new(Round::Some(2), TimeoutKind::Prevote);
+        let timeout3 = Timeout::new(Round::Some(3), TimeoutKind::Precommit);
+
+        manager.schedule_timeout(timeout1);
+        manager.schedule_timeout(timeout2);
+        manager.schedule_timeout(timeout3);
+
+        // Verify all timeouts are scheduled
+        assert_eq!(manager.timeouts.len(), 3);
+
+        // Wait for the shortest timeout to fire
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        // Check that the propose timeout (shortest) has fired
+        let now = tokio::time::Instant::now();
+        if let Some(next) = manager.timeouts.peek() {
+            if now >= next.due {
+                let scheduled_timeout = manager.timeouts.pop().expect("No timeout to pop");
+                assert_eq!(scheduled_timeout.timeout.kind, TimeoutKind::Propose);
+                assert_eq!(scheduled_timeout.timeout.round, Round::Some(1));
+            }
+        }
+
+        // Verify remaining timeouts
+        assert_eq!(manager.timeouts.len(), 2);
+    }
+
+    /// Tests timeout cancellation functionality.
+    /// Verifies that specific timeouts can be cancelled and all timeouts can be
+    /// cleared.
+    #[tokio::test]
+    async fn test_timeout_manager_cancellation() {
+        let timeout_values = TimeoutValues::default();
+        let mut manager = TimeoutManager {
+            timeouts: std::collections::BinaryHeap::new(),
+            timeout_values,
+        };
+
+        let timeout1 = Timeout::new(Round::Some(1), TimeoutKind::Propose);
+        let timeout2 = Timeout::new(Round::Some(2), TimeoutKind::Prevote);
+        let timeout3 = Timeout::new(Round::Some(3), TimeoutKind::Precommit);
+
+        // Schedule timeouts
+        manager.schedule_timeout(timeout1);
+        manager.schedule_timeout(timeout2);
+        manager.schedule_timeout(timeout3);
+
+        assert_eq!(manager.timeouts.len(), 3);
+
+        // Cancel a specific timeout
+        manager.cancel_timeout(timeout2);
+        assert_eq!(manager.timeouts.len(), 2);
+
+        // Verify the cancelled timeout is not present
+        for scheduled_timeout in manager.timeouts.iter() {
+            assert_ne!(scheduled_timeout.timeout, timeout2);
+        }
+
+        // Cancel all timeouts
+        manager.cancel_all_timeouts();
+        assert_eq!(manager.timeouts.len(), 0);
+    }
+
+    /// Tests timeout reset functionality.
+    /// Verifies that all timeouts can be reset with new due times while
+    /// preserving their count.
+    #[tokio::test]
+    async fn test_timeout_manager_reset() {
+        let timeout_values = TimeoutValues {
+            propose: Duration::from_millis(100),
+            prevote: Duration::from_millis(200),
+            precommit: Duration::from_millis(300),
+            prevote_time_limit: Duration::from_millis(400),
+            precommit_time_limit: Duration::from_millis(500),
+            prevote_rebroadcast: Duration::from_millis(600),
+            precommit_rebroadcast: Duration::from_millis(700),
+        };
+
+        let mut manager = TimeoutManager {
+            timeouts: std::collections::BinaryHeap::new(),
+            timeout_values,
+        };
+
+        let timeout1 = Timeout::new(Round::Some(1), TimeoutKind::Propose);
+        let timeout2 = Timeout::new(Round::Some(2), TimeoutKind::Prevote);
+
+        // Schedule timeouts
+        manager.schedule_timeout(timeout1);
+        manager.schedule_timeout(timeout2);
+
+        assert_eq!(manager.timeouts.len(), 2);
+
+        // Wait a bit to ensure time has passed
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Reset timeouts
+        manager.reset_timeouts();
+
+        // Verify timeouts are still present but with updated due times
+        assert_eq!(manager.timeouts.len(), 2);
+
+        // Verify the due times are in the future
+        let now = tokio::time::Instant::now();
+        for scheduled_timeout in manager.timeouts.iter() {
+            assert!(scheduled_timeout.due > now);
+        }
+    }
+
+    /// Tests timeout ordering and firing sequence.
+    /// Verifies that timeouts fire in the correct order (shortest duration
+    /// first) regardless of scheduling order.
+    #[tokio::test]
+    async fn test_timeout_manager_ordering() {
+        let timeout_values = TimeoutValues {
+            propose: Duration::from_millis(300),   // Longest
+            prevote: Duration::from_millis(100),   // Shortest
+            precommit: Duration::from_millis(200), // Medium
+            prevote_time_limit: Duration::from_millis(400),
+            precommit_time_limit: Duration::from_millis(500),
+            prevote_rebroadcast: Duration::from_millis(600),
+            precommit_rebroadcast: Duration::from_millis(700),
+        };
+
+        let mut manager = TimeoutManager {
+            timeouts: std::collections::BinaryHeap::new(),
+            timeout_values,
+        };
+
+        // Schedule timeouts in reverse order
+        let timeout1 = Timeout::new(Round::Some(1), TimeoutKind::Propose); // 300ms
+        let timeout2 = Timeout::new(Round::Some(2), TimeoutKind::Prevote); // 100ms
+        let timeout3 = Timeout::new(Round::Some(3), TimeoutKind::Precommit); // 200ms
+
+        manager.schedule_timeout(timeout1);
+        manager.schedule_timeout(timeout2);
+        manager.schedule_timeout(timeout3);
+
+        // First should be prevote (100ms)
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        if let Some(scheduled_timeout) = manager.timeouts.pop() {
+            assert_eq!(scheduled_timeout.timeout.kind, TimeoutKind::Prevote);
+            assert_eq!(scheduled_timeout.timeout.round, Round::Some(2));
+        }
+
+        // Second should be precommit (200ms)
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        if let Some(scheduled_timeout) = manager.timeouts.pop() {
+            assert_eq!(scheduled_timeout.timeout.kind, TimeoutKind::Precommit);
+            assert_eq!(scheduled_timeout.timeout.round, Round::Some(3));
+        }
+
+        // Third should be propose (300ms)
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        if let Some(scheduled_timeout) = manager.timeouts.pop() {
+            assert_eq!(scheduled_timeout.timeout.kind, TimeoutKind::Propose);
+            assert_eq!(scheduled_timeout.timeout.round, Round::Some(1));
+        }
+
+        assert_eq!(manager.timeouts.len(), 0);
+    }
+
+    /// Tests edge cases and error conditions.
+    /// Verifies behavior with non-existent timeouts, empty states, and
+    /// duplicate timeouts.
+    #[tokio::test]
+    async fn test_timeout_manager_edge_cases() {
+        let timeout_values = TimeoutValues::default();
+        let mut manager = TimeoutManager {
+            timeouts: std::collections::BinaryHeap::new(),
+            timeout_values,
+        };
+
+        // Test cancelling non-existent timeout
+        let non_existent_timeout = Timeout::new(Round::Some(999), TimeoutKind::Propose);
+        manager.cancel_timeout(non_existent_timeout);
+        assert_eq!(manager.timeouts.len(), 0);
+
+        // Test cancelling all timeouts when empty
+        manager.cancel_all_timeouts();
+        assert_eq!(manager.timeouts.len(), 0);
+
+        // Test resetting timeouts when empty
+        manager.reset_timeouts();
+        assert_eq!(manager.timeouts.len(), 0);
+
+        // Test scheduling same timeout multiple times
+        let timeout = Timeout::new(Round::Some(1), TimeoutKind::Propose);
+        manager.schedule_timeout(timeout);
+        manager.schedule_timeout(timeout);
+        manager.schedule_timeout(timeout);
+
+        assert_eq!(manager.timeouts.len(), 3);
+
+        // Cancel all instances of this timeout (correct behavior)
+        manager.cancel_timeout(timeout);
+        assert_eq!(manager.timeouts.len(), 0);
+
+        // Test scheduling different timeouts and cancelling one
+        let timeout1 = Timeout::new(Round::Some(1), TimeoutKind::Propose);
+        let timeout2 = Timeout::new(Round::Some(2), TimeoutKind::Prevote);
+
+        manager.schedule_timeout(timeout1);
+        manager.schedule_timeout(timeout2);
+
+        assert_eq!(manager.timeouts.len(), 2);
+
+        // Cancel one specific timeout
+        manager.cancel_timeout(timeout1);
+        assert_eq!(manager.timeouts.len(), 1);
+
+        // Verify the remaining timeout is the correct one
+        let remaining = manager.timeouts.peek().unwrap();
+        assert_eq!(remaining.timeout, timeout2);
     }
 }


### PR DESCRIPTION
Noticed that I hadn't implemented Malachite's `Effect::ResetTimeouts` effect, so this this PR adds support for it and includes comprehensive unit tests for the timeout manager, which uncovered  a bug in the cancellation logic which has now been fixed.
