### PR TITLE
fix(executor): correct max L2 limit in L2 gas estimation logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- JSON-RPC v0.8.1 `starknet_estimateFee` method call fails if the account balance is zero.
+
 ### Changed
 
 - The default value of the `--sync.poll-interval` configuration parameter has been changed to 1 seconds. Pathfinder is now polling both the latest block information and the pending/pre-confirmed block every second by default.

--- a/crates/rpc/src/method/estimate_fee.rs
+++ b/crates/rpc/src/method/estimate_fee.rs
@@ -935,9 +935,9 @@ mod tests {
             l1_gas_price: 2.into(),
             l1_data_gas_consumed: 128.into(),
             l1_data_gas_price: 2.into(),
-            l2_gas_consumed: 15596094.into(),
+            l2_gas_consumed: 15624585.into(),
             l2_gas_price: 1.into(),
-            overall_fee: 15596350.into(),
+            overall_fee: 15624841.into(),
             unit: PriceUnit::Fri,
         };
         self::assert_eq!(


### PR DESCRIPTION
Previously, we have introduced a change that sets the maximum L2 gas limit for the initial transaction run to the maximal value that the account balance allows. This is done because blockifier _does_ check that the committed resources are covered by the account balance.

However, that check is done only if the `charge_fee` flag is set (which is the case for `starknet_simulateTransactions` only, unless `SKIP_FEE_CHARGE` is set).

This means that for `starknet_estimateFee` we cannot estimate transactions for accounts that are not yet funded properly, even though blockifier would allow it.

This commit changes the logic to use the balance-dependent limit only when the `charge_fee` flag is set, and uses blockifier's default limit for per-transaction L2 gas otherwise.

Closes: #2807 
