### PR TITLE
feat(rpc): parse "pre_confirmed" block ID in JSON-RPC 0.9

### DIFF
--- a/crates/rpc/src/dto/block.rs
+++ b/crates/rpc/src/dto/block.rs
@@ -6,11 +6,13 @@ use crate::{Reorg, RpcVersion};
 
 impl crate::dto::DeserializeForVersion for pathfinder_common::BlockId {
     fn deserialize(value: super::Value) -> Result<Self, serde_json::Error> {
+        let rpc_version = value.version;
         if value.is_string() {
             let value: String = value.deserialize()?;
             match value.as_str() {
                 "latest" => Ok(Self::Latest),
-                "pending" => Ok(Self::Pending),
+                "pending" if rpc_version < RpcVersion::V09 => Ok(Self::Pending),
+                "pre_confirmed" if rpc_version >= RpcVersion::V09 => Ok(Self::Pending),
                 _ => Err(serde_json::Error::custom("Invalid block id")),
             }
         } else {


### PR DESCRIPTION
We treat it as a synonym for "pending" right now: the internal representation is BlockId::Pending, because that's what our code handles.

Semantic differences between "pre_confirmed" and "pending" are already handled based on the actual type of the pending data we have.

Closes: #2793 