### PR TITLE
Consensus: Introduce WAL recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8571,6 +8571,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -21,9 +21,10 @@ pathfinder-crypto = { version = "0.17.0-beta.1", path = "../crypto" }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["time"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "test-util"] }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "test-util", "time"] }

--- a/crates/consensus/src/config.rs
+++ b/crates/consensus/src/config.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::time::Duration;
 
 use malachite_types::{ThresholdParams, TimeoutKind};
@@ -19,6 +20,8 @@ pub struct Config {
     pub timeout_values: TimeoutValues,
     /// The number of completed heights to keep in memory.
     pub history_depth: u64,
+    /// The directory to store the write-ahead log.
+    pub wal_dir: PathBuf,
 }
 
 impl Config {
@@ -28,6 +31,7 @@ impl Config {
         Self {
             address,
             history_depth: 10,
+            wal_dir: PathBuf::from("wal"),
             ..Default::default()
         }
     }
@@ -59,6 +63,12 @@ impl Config {
     /// Set the number of completed heights to keep in memory.
     pub fn with_history_depth(mut self, history_depth: u64) -> Self {
         self.history_depth = history_depth;
+        self
+    }
+
+    /// Set the WAL directory.
+    pub fn with_wal_dir(mut self, wal_dir: PathBuf) -> Self {
+        self.wal_dir = wal_dir;
         self
     }
 }

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
 
 use malachite_consensus::{Params, VoteSyncMode};
 pub use malachite_types::VoteType;
@@ -49,37 +50,107 @@ impl Consensus {
         }
     }
 
+    /// Recover all heights from the write-ahead log.
+    pub fn recover<P: ValidatorSetProvider + 'static>(
+        config: Config,
+        validator_sets: Arc<P>,
+    ) -> Self {
+        use crate::wal::recovery;
+
+        tracing::info!(
+            validator = %config.address,
+            wal_dir = %config.wal_dir.display(),
+            "Starting consensus recovery from WAL"
+        );
+
+        // Read the write-ahead log and recover all incomplete heights.
+        let incomplete_heights = match recovery::recover_incomplete_heights(&config.wal_dir) {
+            Ok(heights) => {
+                tracing::info!(
+                    validator = %config.address,
+                    incomplete_heights = heights.len(),
+                    "Found incomplete heights to recover"
+                );
+                heights
+            }
+            Err(e) => {
+                tracing::error!(
+                    validator = %config.address,
+                    wal_dir = %config.wal_dir.display(),
+                    error = %e,
+                    "Failed to recover incomplete heights from WAL"
+                );
+                Vec::new()
+            }
+        };
+
+        // Create a new consensus engine.
+        let mut consensus = Self::new(config);
+
+        // Manually recover all incomplete heights.
+        for (height, entries) in incomplete_heights {
+            tracing::info!(
+                validator = %consensus.config.address,
+                height = %height,
+                entry_count = entries.len(),
+                "Recovering height from WAL"
+            );
+
+            let validator_set = validator_sets.get_validator_set(&height);
+            let mut internal_consensus = consensus.create_consensus(height, &validator_set);
+            internal_consensus.handle_command(ConsensusCommand::StartHeight(height, validator_set));
+            internal_consensus.recover_from_wal(entries);
+            consensus.internal.insert(height, internal_consensus);
+        }
+
+        tracing::info!(
+            validator = %consensus.config.address,
+            recovered_heights = consensus.internal.len(),
+            "Completed consensus recovery"
+        );
+
+        consensus
+    }
+
+    fn create_consensus(
+        &mut self,
+        height: Height,
+        validator_set: &ValidatorSet,
+    ) -> InternalConsensus {
+        let params = Params {
+            initial_height: height,
+            initial_validator_set: validator_set.clone(),
+            address: self.config.address,
+            threshold_params: self.config.threshold_params,
+            value_payload: ValuePayload::ProposalOnly,
+            vote_sync_mode: self.config.vote_sync_mode,
+        };
+
+        // Create a WAL for the height. If we fail, use a NoopWal.
+        let wal = match FileWalSink::new(&self.config.address, &height, &self.config.wal_dir) {
+            Ok(wal) => Box::new(wal) as Box<dyn WalSink>,
+            Err(e) => {
+                tracing::error!(
+                    validator = %self.config.address,
+                    height = %height,
+                    error = %e,
+                    "Failed to create wal for height"
+                );
+                Box::new(NoopWal)
+            }
+        };
+
+        // A new consensus is created for every new height.
+        InternalConsensus::new(params, self.config.timeout_values.clone(), wal)
+    }
+
     /// Feed a command into the consensus engine.
     pub fn handle_command(&mut self, cmd: ConsensusCommand) {
         match cmd {
             // Start a new height.
             ConsensusCommand::StartHeight(height, validator_set) => {
-                let params = Params {
-                    initial_height: height,
-                    initial_validator_set: validator_set.clone(),
-                    address: self.config.address,
-                    threshold_params: self.config.threshold_params,
-                    value_payload: ValuePayload::ProposalOnly,
-                    vote_sync_mode: self.config.vote_sync_mode,
-                };
-
-                // Create a WAL for the height. If we fail, use a NoopWal.
-                let wal = match FileWalSink::new(&self.config.address, &height) {
-                    Ok(wal) => Box::new(wal) as Box<dyn WalSink>,
-                    Err(e) => {
-                        tracing::error!(
-                            validator = %self.config.address,
-                            height = %height,
-                            error = %e,
-                            "Failed to create wal for height"
-                        );
-                        Box::new(NoopWal)
-                    }
-                };
-
                 // A new consensus is created for every new height.
-                let mut consensus =
-                    InternalConsensus::new(params, self.config.timeout_values.clone(), wal);
+                let mut consensus = self.create_consensus(height, &validator_set);
                 consensus.handle_command(ConsensusCommand::StartHeight(height, validator_set));
                 self.internal.insert(height, consensus);
                 tracing::debug!(
@@ -155,9 +226,21 @@ impl Consensus {
         }
     }
 
-    #[cfg(test)]
-    pub fn drain_events(&mut self) -> Vec<ConsensusEvent> {
-        std::mem::take(&mut self.event_queue).into()
+    /// Check if a specific height has been finalized (i.e., a decision has been
+    /// reached)
+    pub fn is_height_finalized(&self, height: &Height) -> bool {
+        if let Some(engine) = self.internal.get(height) {
+            engine.is_finalized()
+        } else {
+            // If the height is not in our internal map, it might have been pruned
+            // after being finalized, so we assume it's finalized
+            if let Some(min_height) = self.min_kept_height {
+                if *height < min_height {
+                    return true;
+                }
+            }
+            false
+        }
     }
 }
 
@@ -225,4 +308,26 @@ pub enum ConsensusEvent {
     Decision { height: Height, hash: Hash },
     /// An internal error occurred in consensus.
     Error(anyhow::Error),
+}
+
+/// A trait for types that can provide a validator set for a given height.
+pub trait ValidatorSetProvider: Send + Sync {
+    fn get_validator_set(&self, height: &Height) -> ValidatorSet;
+}
+
+/// A validator set provider that always returns the same validator set.
+pub struct StaticValidatorSetProvider {
+    validator_set: ValidatorSet,
+}
+
+impl StaticValidatorSetProvider {
+    pub fn new(validator_set: ValidatorSet) -> Self {
+        Self { validator_set }
+    }
+}
+
+impl ValidatorSetProvider for StaticValidatorSetProvider {
+    fn get_validator_set(&self, _height: &Height) -> ValidatorSet {
+        self.validator_set.clone()
+    }
 }

--- a/crates/consensus/src/wal.rs
+++ b/crates/consensus/src/wal.rs
@@ -1,18 +1,35 @@
 use std::fs;
 use std::fs::OpenOptions;
-use std::io::Write;
-use std::path::PathBuf;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
 
-use malachite_consensus::SignedConsensusMsg;
+use malachite_consensus::{Input, ProposedValue, SignedConsensusMsg};
 use malachite_types::{Timeout, Value};
 use serde::{Deserialize, Serialize};
 
 use crate::malachite::MalachiteContext;
-use crate::{Height, Round, SignedProposal, SignedVote, ValidatorAddress, ValueId};
+use crate::{ConsensusValue, Height, Round, SignedProposal, SignedVote, ValidatorAddress, ValueId};
+
+/// The prefix of the write-ahead log file.
+pub(crate) const WAL_FILE_PREFIX: &str = "wal-";
+
+/// The extension of the write-ahead log file.
+pub(crate) const WAL_FILE_EXTENSION: &str = "json";
+
+/// The filename of the write-ahead log for a given validator and height.
+pub(crate) fn filename(address: &ValidatorAddress, height: &Height) -> String {
+    format!("{WAL_FILE_PREFIX}{address}-{height}.{WAL_FILE_EXTENSION}")
+}
 
 /// A trait for types that can append to a write-ahead log.
 pub(crate) trait WalSink: Send {
+    /// Append an entry to the write-ahead log.
     fn append(&mut self, entry: WalEntry);
+
+    /// Check if this WAL has been finalized (a decision has been reached)
+    fn is_finalized(&self) -> bool {
+        false // Default impl. for WALs that don't track finalization
+    }
 }
 
 /// A write-ahead log entry.
@@ -33,6 +50,8 @@ pub(crate) enum WalEntry {
         value: ValueId,
         validity: bool,
     },
+    /// A decision was reached.
+    Decision { height: Height, value: ValueId },
 }
 
 // This is necessary because unfortunately the malachite types are not
@@ -104,32 +123,139 @@ impl From<Timeout> for WalEntry {
     }
 }
 
+/// Convert a WAL entry to the corresponding malachite Input.
+pub(crate) fn convert_wal_entry_to_input(entry: WalEntry) -> Input<MalachiteContext> {
+    match entry {
+        WalEntry::SignedProposal(proposal) => {
+            tracing::debug!(
+                value_id = ?proposal.proposal.value_id,
+                from = %proposal.proposal.proposer,
+                height = %proposal.proposal.height,
+                round = %proposal.proposal.round,
+                "Recovering proposal from WAL"
+            );
+            let signed_msg =
+                malachite_types::SignedProposal::new(proposal.proposal, proposal.signature);
+            Input::Proposal(signed_msg)
+        }
+        WalEntry::SignedVote(vote) => {
+            tracing::debug!(
+                vote_type = ?vote.vote.r#type,
+                from = %vote.vote.validator_address,
+                height = %vote.vote.height,
+                round = %vote.vote.round,
+                "Recovering vote from WAL"
+            );
+            let signed_vote = malachite_types::SignedVote::new(vote.vote, vote.signature);
+            Input::Vote(signed_vote)
+        }
+        WalEntry::Timeout { kind, round } => {
+            let timeout_kind = match kind.as_str() {
+                "propose" => malachite_types::TimeoutKind::Propose,
+                "prevote" => malachite_types::TimeoutKind::Prevote,
+                "prevote-time-limit" => malachite_types::TimeoutKind::PrevoteTimeLimit,
+                "precommit" => malachite_types::TimeoutKind::Precommit,
+                "precommit-time-limit" => malachite_types::TimeoutKind::PrecommitTimeLimit,
+                "prevote-rebroadcast" => malachite_types::TimeoutKind::PrevoteRebroadcast,
+                "precommit-rebroadcast" => malachite_types::TimeoutKind::PrecommitRebroadcast,
+                _ => unreachable!(),
+            };
+            let timeout = Timeout::new(round.into_inner(), timeout_kind);
+            tracing::debug!(
+                timeout = ?timeout,
+                "Recovering timeout from WAL"
+            );
+            Input::TimeoutElapsed(timeout)
+        }
+        WalEntry::ProposedValue {
+            height,
+            round,
+            valid_round,
+            proposer,
+            value,
+            validity,
+        } => {
+            tracing::debug!(
+                height = %height,
+                round = %round,
+                value = ?value,
+                "Recovering proposed value from WAL"
+            );
+            let proposed_value = ProposedValue {
+                height,
+                round: round.into_inner(),
+                valid_round: valid_round.into_inner(),
+                proposer,
+                value: ConsensusValue::new(value),
+                validity: if validity {
+                    malachite_types::Validity::Valid
+                } else {
+                    malachite_types::Validity::Invalid
+                },
+            };
+            Input::ProposedValue(proposed_value, malachite_types::ValueOrigin::Sync)
+        }
+        _ => unreachable!(),
+    }
+}
+
 /// A write-ahead log that writes to a file.
 pub struct FileWalSink {
     file: std::fs::File,
     path: PathBuf,
+    has_decision: bool,
 }
 
 impl FileWalSink {
-    pub fn new(address: &ValidatorAddress, height: &Height) -> std::io::Result<Self> {
-        let path = PathBuf::from(format!("wal-{address}-{height}.json"));
+    pub fn new(
+        address: &ValidatorAddress,
+        height: &Height,
+        wal_dir: &Path,
+    ) -> std::io::Result<Self> {
+        // Create the WAL directory if it doesn't exist
+        std::fs::create_dir_all(wal_dir)?;
+
+        let filename = filename(address, height);
+        let path = wal_dir.join(filename);
         let file = OpenOptions::new().create(true).append(true).open(&path)?;
-        Ok(Self { file, path })
+        Ok(Self {
+            file,
+            path,
+            has_decision: false,
+        })
     }
 }
 
 impl Drop for FileWalSink {
     fn drop(&mut self) {
-        if let Err(e) = fs::remove_file(&self.path) {
+        // Ensure all data is flushed to disk before we potentially delete the file
+        if let Err(e) = self.file.flush() {
             tracing::error!(
                 path = %self.path.display(),
                 error = %e,
-                "Failed to delete WAL file"
+                "Failed to flush WAL file before drop"
             );
+        }
+
+        if self.has_decision {
+            // Only delete the WAL file if we've reached a decision
+            if let Err(e) = fs::remove_file(&self.path) {
+                tracing::error!(
+                    path = %self.path.display(),
+                    error = %e,
+                    "Failed to delete WAL file after decision"
+                );
+            } else {
+                tracing::debug!(
+                    path = %self.path.display(),
+                    "Successfully deleted WAL file after decision"
+                );
+            }
         } else {
+            // Keep the WAL file if no decision was reached
             tracing::debug!(
                 path = %self.path.display(),
-                "Successfully deleted WAL file"
+                "Keeping WAL file as no decision was reached"
             );
         }
     }
@@ -137,8 +263,21 @@ impl Drop for FileWalSink {
 
 impl WalSink for FileWalSink {
     fn append(&mut self, entry: WalEntry) {
+        // Check if this entry is a decision
+        if matches!(entry, WalEntry::Decision { .. }) {
+            self.has_decision = true;
+            tracing::debug!(
+                path = %self.path.display(),
+                "Marking WAL as finalized - decision reached"
+            );
+        }
+
         let line = serde_json::to_string(&entry).expect("WAL serialization failed");
         writeln!(self.file, "{line}").expect("WAL write failed");
+    }
+
+    fn is_finalized(&self) -> bool {
+        self.has_decision
     }
 }
 
@@ -148,5 +287,133 @@ pub(crate) struct NoopWal;
 impl WalSink for NoopWal {
     fn append(&mut self, entry: WalEntry) {
         tracing::debug!("NoopWal: Appending entry: {:?}", entry);
+    }
+
+    fn is_finalized(&self) -> bool {
+        false // NoopWal is never finalized
+    }
+}
+
+/// Recovery utilities for the write-ahead log.
+pub(crate) mod recovery {
+
+    use super::*;
+
+    /// Extract the height from the filename of the write-ahead log file.
+    pub(crate) fn extract_height_from_filename(path: &Path) -> Height {
+        let filename = path.file_name().unwrap_or_default().to_string_lossy();
+        let height = filename.split('-').nth(1).unwrap_or_default();
+        let height = height.parse::<u64>().unwrap_or_else(|_| {
+            tracing::warn!(
+                filename = %filename,
+                path = %path.display(),
+                "Failed to parse height from filename, using 0"
+            );
+            0
+        });
+        Height::new(height)
+    }
+
+    /// Collect all the write-ahead log files in the given directory. The result
+    /// is sorted by height.
+    pub(crate) fn collect_wal_files(
+        wal_dir: &Path,
+    ) -> Result<Vec<(Height, PathBuf)>, std::io::Error> {
+        let mut files = Vec::new();
+        let dir = fs::read_dir(wal_dir).map_err(|e| {
+            std::io::Error::other(format!(
+                "Failed to read WAL directory {}: {}",
+                wal_dir.display(),
+                e
+            ))
+        })?;
+        for entry in dir {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_file()
+                && path.extension().unwrap_or_default() == WAL_FILE_EXTENSION
+                && path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .starts_with(WAL_FILE_PREFIX)
+            {
+                let height = extract_height_from_filename(&path);
+                files.push((height, path));
+            }
+        }
+        files.sort_by_key(|(height, _)| *height);
+        Ok(files)
+    }
+
+    /// Read the entries from the write-ahead log file.
+    pub(crate) fn read_entries(path: &Path) -> Result<Vec<WalEntry>, std::io::Error> {
+        let file = fs::File::open(path)?;
+        let reader = BufReader::new(file);
+        let mut entries = Vec::new();
+
+        for (line_num, line) in reader.lines().enumerate() {
+            let line = line?;
+            if !line.trim().is_empty() {
+                let entry: WalEntry = serde_json::from_str(&line).map_err(|e| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!(
+                            "Failed to parse WAL entry at line {} in {}: {}",
+                            line_num + 1,
+                            path.display(),
+                            e
+                        ),
+                    )
+                })?;
+                entries.push(entry);
+            }
+        }
+        Ok(entries)
+    }
+
+    /// Recover all incomplete heights from the write-ahead log.
+    pub(crate) fn recover_incomplete_heights(
+        wal_dir: &Path,
+    ) -> Result<Vec<(Height, Vec<WalEntry>)>, std::io::Error> {
+        // Check if the WAL directory exists
+        if !wal_dir.exists() {
+            tracing::info!(
+                wal_dir = %wal_dir.display(),
+                "WAL directory does not exist, no recovery needed"
+            );
+            return Ok(Vec::new());
+        }
+
+        let files = collect_wal_files(wal_dir)?;
+        tracing::info!(
+            files = ?files,
+            "Recovering incomplete heights from WAL",
+        );
+        let mut result = Vec::new();
+        // For each file, read the entries and add them to the result if the height is
+        // not finalized.
+        for (height, path) in files {
+            let entries = read_entries(&path)?;
+            let is_finalized = entries
+                .iter()
+                .any(|e| matches!(e, WalEntry::Decision { .. }));
+            if is_finalized {
+                tracing::debug!(
+                    height = %height,
+                    path = %path.display(),
+                    "Skipping finalized height"
+                );
+                continue;
+            }
+            tracing::debug!(
+                height = %height,
+                path = %path.display(),
+                entry_count = entries.len(),
+                "Recovering incomplete height"
+            );
+            result.push((height, entries));
+        }
+        Ok(result)
     }
 }

--- a/crates/consensus/tests/common.rs
+++ b/crates/consensus/tests/common.rs
@@ -1,0 +1,26 @@
+use std::time::Duration;
+
+use pathfinder_consensus::{Consensus, ConsensusEvent};
+use tokio::time::advance;
+
+/// Advances simulated time and polls `Consensus` until a matching event is seen
+/// or max attempts are hit. Returns the matching event if found.
+pub async fn drive_until<F>(
+    consensus: &mut Consensus,
+    tick: Duration,
+    max_attempts: usize,
+    mut match_fn: F,
+) -> Option<ConsensusEvent>
+where
+    F: FnMut(&ConsensusEvent) -> bool,
+{
+    for _ in 0..max_attempts {
+        advance(tick).await;
+        if let Some(event) = consensus.next_event().await {
+            if match_fn(&event) {
+                return Some(event);
+            }
+        }
+    }
+    None
+}

--- a/crates/consensus/tests/timeouts.rs
+++ b/crates/consensus/tests/timeouts.rs
@@ -23,8 +23,11 @@ use pathfinder_consensus::{
     Vote,
 };
 use pathfinder_crypto::Felt;
-use tokio::time::{advance, pause};
+use tokio::time::pause;
 use tracing_subscriber::EnvFilter;
+
+mod common;
+use common::drive_until;
 
 #[allow(dead_code)]
 fn setup_tracing_full() {
@@ -36,28 +39,6 @@ fn setup_tracing_full() {
         .with_target(true)
         .without_time()
         .try_init();
-}
-
-/// Advances simulated time and polls `Consensus` until a matching event is seen
-/// or max attempts are hit. Returns the matching event if found.
-async fn drive_until<F>(
-    consensus: &mut Consensus,
-    tick: Duration,
-    max_attempts: usize,
-    mut match_fn: F,
-) -> Option<ConsensusEvent>
-where
-    F: FnMut(&ConsensusEvent) -> bool,
-{
-    for _ in 0..max_attempts {
-        advance(tick).await;
-        if let Some(event) = consensus.next_event().await {
-            if match_fn(&event) {
-                return Some(event);
-            }
-        }
-    }
-    None
 }
 
 #[tokio::test]


### PR DESCRIPTION
This PR implements recovery from the write-ahead log (WAL), allowing the consensus engine to resume from previously incomplete heights on startup. The engine now scans persisted WAL files, identifies which heights were not finalized, and replays their entries into the consensus logic to continue where it left off.

It is up to the host application to start a fresh Consensus engine with `Consensus::new(config)` or, if we're recovering from a crash, use `Consensus::recover(config, validator_set_provider)` instead.

Includes a test to verify recovery flows correctly from persisted state.