### PR TITLE
Fix broken link to Pathfinder JSON Extensions section in WebSocket API docs

### DIFF
--- a/docs/docs/interacting-with-pathfinder/websocket-api.md
+++ b/docs/docs/interacting-with-pathfinder/websocket-api.md
@@ -41,7 +41,7 @@ ws.onmessage = (event) => {
 
 ## Pathfinder WebSocket Extensions
 
-As with the [JSON extensions](json-rpc-api#pathfinder-json-extensions), Pathfinder provides Websocket equivalents of their custom endpoints. They are served under:
+As with the [JSON extensions](json-rpc-api.md#pathfinder-json-extensions), Pathfinder provides Websocket equivalents of their custom endpoints. They are served under:
 ```
 /ws/rpc/pathfinder/v0_1
 ```


### PR DESCRIPTION
This commit updates the reference to the "Pathfinder JSON Extensions" section in the websocket-api.md documentation. The link now correctly points to the anchor in json-rpc-api.md, ensuring users are directed to the intended section without encountering a broken link.