### PR TITLE
chore: bump version to 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,43 +7,7 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.17.0-beta.3] - 2025-06-26
-
-### Fixed
-
-- JSON-RPC v0.8.1 `starknet_estimateFee` method call fails if the account balance is zero.
-
-### Changed
-
-- The default value of the `--sync.poll-interval` configuration parameter has been changed to 1 seconds. Pathfinder is now polling both the latest block information and the pending/pre-confirmed block every second by default.
-
-### Removed
-
-- `pathfinder_getProof`, `pathfinder_getClassProof` and `pathfinder_getTransactionStatus` (obsoleted by standardized `starknet_*` APIs).
-
-## [0.17.0-beta.2] - 2025-06-04
-
-### Added
-
-- Pathfinder now allows the users to configure the number of historical messages to be streamed via the [webscoket API](https://eqlabs.github.io/pathfinder/interacting-with-pathfinder/websocket-api). This can be done using the `--rpc.websocket.max-history` CLI option.
-
-  - Accepted values are:
-
-    - "unlimited" - All historical messages will be streamed.
-    - "N" - An integer specifying the number of historical messages to be streamed.
-
-  - This option defaults to N = 1024 if not specified.
-
-### Fixed
-
-- `starknet_estimateFee` is failing for Braavos DEPLOY_ACCOUNT transactions involving a new Sierra 1.7.0 class.
-- `starknet_traceBlockTransactions` fails for blocks <= 2687.
-
-### Changed
-
-- `blockifier` has been upgraded to version 0.15.0-rc.1, adding initial support for Starknet 0.14.0 execution.
-
-## [0.17.0-beta.1] - 2025-05-13
+## [0.17.0] - 2025-06-29
 
 ### Added
 
@@ -84,14 +48,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     b. The latest L2 block if it is behind the latest L1 checkpoint or no L1 checkpoints have been received by the node (practically unreachable)
 
 - `starknet_getTransactionStatus` now returns RECEIVED even when the gateway cannot find the transaction, provided the transaction was successfully sent by the responding node within the last 5 minutes.
+- Pathfinder now allows the users to configure the number of historical messages to be streamed via the [webscoket API](https://eqlabs.github.io/pathfinder/interacting-with-pathfinder/websocket-api). This can be done using the `--rpc.websocket.max-history` CLI option.
+
+  - Accepted values are:
+
+    - "unlimited" - All historical messages will be streamed.
+    - "N" - An integer specifying the number of historical messages to be streamed.
+
+  - This option defaults to N = 1024 if not specified.
 
 ### Fixed
 
 - `starknet_unsubscribe` does not accept subscription IDs as strings.
+- `starknet_estimateFee` is failing for Braavos DEPLOY_ACCOUNT transactions involving a new Sierra 1.7.0 class.
+- `starknet_traceBlockTransactions` fails for blocks <= 2687.
+- JSON-RPC v0.8.1 `starknet_estimateFee` method call fails if the account balance is zero.
 
 ### Changed
 
 - `--rpc.get-events-max-uncached-event-filters-to-load` CLI option has been replaced with `rpc.get-events-event-filter-block-range-limit`. The new option serves the same purpose of preventing queries from taking too long, but it should be clearer in its intent.
+- `blockifier` has been upgraded to version 0.15.0-rc.1, adding initial support for Starknet 0.14.0 execution.
+- The default value of the `--sync.poll-interval` configuration parameter has been changed to 1 seconds. Pathfinder is now polling both the latest block information and the pending/pre-confirmed block every second by default.
+
+### Removed
+
+- `pathfinder_getProof`, `pathfinder_getClassProof` and `pathfinder_getTransactionStatus` (obsoleted by standardized `starknet_*` APIs).
 
 ## [0.16.5] - 2025-05-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5428,7 +5428,7 @@ checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
 name = "gateway-test-utils"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "reqwest",
  "serde_json",
@@ -8229,7 +8229,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p2p"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8265,7 +8265,7 @@ dependencies = [
 
 [[package]]
 name = "p2p_proto"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "fake",
  "libp2p-identity",
@@ -8284,7 +8284,7 @@ dependencies = [
 
 [[package]]
 name = "p2p_proto_derive"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8293,7 +8293,7 @@ dependencies = [
 
 [[package]]
 name = "p2p_stream"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8413,7 +8413,7 @@ checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
 name = "pathfinder"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -8484,7 +8484,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-block-hashes"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "pathfinder-common",
  "pathfinder-crypto",
@@ -8492,7 +8492,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-class-hash"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "fake",
@@ -8511,7 +8511,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-common"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -8536,7 +8536,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-compiler"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "cairo-lang-starknet 1.0.0-alpha.6",
@@ -8556,7 +8556,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-consensus"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -8578,7 +8578,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-crypto"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "ark-ff 0.5.0",
  "assert_matches",
@@ -8595,7 +8595,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-ethereum"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -8615,7 +8615,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-executor"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "blockifier",
@@ -8639,7 +8639,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-merkle-tree"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -8655,7 +8655,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-retry"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "tokio",
  "tokio-retry",
@@ -8663,7 +8663,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-rpc"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -8722,7 +8722,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-serde"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "num-bigint 0.4.6",
@@ -8737,7 +8737,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-storage"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -8798,7 +8798,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-version"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "vergen",
 ]
@@ -10758,7 +10758,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-gateway-client"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -10792,7 +10792,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-gateway-test-fixtures"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "pathfinder-common",
  "pathfinder-crypto",
@@ -10800,7 +10800,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-gateway-types"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "fake",
@@ -11943,7 +11943,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "util"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ lto = true
 opt-level = 3
 
 [workspace.package]
-version = "0.17.0-beta.3"
+version = "0.17.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.83"

--- a/crates/class-hash/Cargo.toml
+++ b/crates/class-hash/Cargo.toml
@@ -17,8 +17,8 @@ categories = [
 
 [dependencies]
 anyhow = { workspace = true }
-pathfinder-common = { version = "0.17.0-beta.3", path = "../common" }
-pathfinder-crypto = { version = "0.17.0-beta.3", path = "../crypto" }
+pathfinder-common = { version = "0.17.0", path = "../common" }
+pathfinder-crypto = { version = "0.17.0", path = "../crypto" }
 primitive-types = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = [

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -21,7 +21,7 @@ metrics = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = "0.2"
 paste = { workspace = true }
-pathfinder-crypto = { version = "0.17.0-beta.3", path = "../crypto" }
+pathfinder-crypto = { version = "0.17.0", path = "../crypto" }
 pathfinder-tagged = { version = "0.1.0", path = "../tagged" }
 pathfinder-tagged-debug-derive = { version = "0.1.0", path = "../tagged-debug-derive" }
 primitive-types = { workspace = true, features = ["serde"] }

--- a/crates/load-test/Cargo.lock
+++ b/crates/load-test/Cargo.lock
@@ -1002,7 +1002,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "pathfinder-crypto"
-version = "0.17.0-beta.3"
+version = "0.17.0"
 dependencies = [
  "bitvec",
  "fake",

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -34,7 +34,7 @@ libp2p = { workspace = true, features = [
 ] }
 p2p_proto = { path = "../p2p_proto" }
 p2p_stream = { path = "../p2p_stream" }
-pathfinder-common = { version = "0.17.0-beta.3", path = "../common" }
+pathfinder-common = { version = "0.17.0", path = "../common" }
 pathfinder-crypto = { path = "../crypto" }
 pathfinder-tagged = { path = "../tagged" }
 pathfinder-tagged-debug-derive = { path = "../tagged-debug-derive" }

--- a/crates/serde/Cargo.toml
+++ b/crates/serde/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["encoding", "cryptography::cryptocurrencies", "development-tools",
 [dependencies]
 anyhow = { workspace = true }
 num-bigint = { workspace = true }
-pathfinder-common = { version = "0.17.0-beta.3", path = "../common" }
-pathfinder-crypto = { version = "0.17.0-beta.3", path = "../crypto" }
+pathfinder-common = { version = "0.17.0", path = "../common" }
+pathfinder-crypto = { version = "0.17.0", path = "../crypto" }
 primitive-types = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }


### PR DESCRIPTION
I've aggregated all `0.17.0-beta.X` changes into a single v0.17.0 `CHANGELOG.md` entry.

If anyone believes this is not the way to go, feel free to speak up.