### PR TITLE
fix(storage): fix blockchain pruning check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The default value of L2 gas price for historical blocks has been changed from 0 to 1 (for both WEI and FRI), to agree with the feeder gateway default.
+- Trying to enable blockchain pruning on an archive database does indeed enable pruning in the database despite printing an error that pruning cannot be enabled.
 
 ## [0.17.0] - 2025-06-29
 


### PR DESCRIPTION
The blockchain pruning flag was updated _before_ the actual validation was performed, leading to a situation where on the next run the blockchain pruning mode was already enabled for a database that was _not_ created with pruning enabled.

Closes: #2839 