### PR TITLE
docs: Fix broken license badge link

### DIFF
--- a/crates/class-hash/README.md
+++ b/crates/class-hash/README.md
@@ -2,7 +2,7 @@
 
 [![Documentation](https://docs.rs/pathfinder-class-hash/badge.svg)](https://docs.rs/pathfinder-class-hash)
 [![Crates.io](https://img.shields.io/crates/v/pathfinder-class-hash)](https://crates.io/crates/pathfinder-class-hash)
-[![License](https://img.shields.io/crates/l/pathfinder-class-hash)](https://github.com/eqlabs/pathfinder/blob/main/crates/class-hash/LICENSE)
+[![License](https://img.shields.io/crates/l/pathfinder-class-hash)](https://github.com/eqlabs/pathfinder/blob/main/LICENSE-MIT)
 
 
 This crate provides functionality to compute class hashes for both Cairo 0.x and Sierra (Cairo 1.x+) contracts in the Starknet ecosystem. It implements the official Starknet class hash computation algorithm, handling special cases for different Cairo versions and maintaining compatibility with the network's expectations.


### PR DESCRIPTION
## Summary

This PR fixes the broken license badge link in the README.  
The badge previously pointed to a non-existent `LICENSE` file, resulting in a 404 error. It now correctly links to `LICENSE-MIT`.

## Notes

- This is a documentation-only change.
- No code or behavior is affected.
