### PR TITLE
refactor: remove unused BlockId-related implementations and types

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -256,16 +256,10 @@ impl TransactionVersion {
 
 /// A way of identifying a specific block.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(any(test, feature = "full-serde"), derive(Serialize))]
-#[serde(deny_unknown_fields)]
 pub enum BlockId {
-    #[serde(rename = "block_number")]
     Number(BlockNumber),
-    #[serde(rename = "block_hash")]
     Hash(BlockHash),
-    #[serde(rename = "latest")]
     Latest,
-    #[serde(rename = "pending")]
     Pending,
 }
 

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -255,7 +255,7 @@ impl TransactionVersion {
 }
 
 /// A way of identifying a specific block.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "full-serde"), derive(Serialize))]
 #[serde(deny_unknown_fields)]
 pub enum BlockId {
@@ -797,38 +797,6 @@ mod tests {
             assert!(StarknetVersion::from_str("1.2").is_err());
             assert!(StarknetVersion::from_str("1").is_err());
             assert!(StarknetVersion::from_str("1.2.a").is_err());
-        }
-    }
-
-    mod block_id_serde {
-        use super::super::BlockId;
-
-        #[test]
-        fn latest() {
-            let result = serde_json::from_str::<BlockId>(r#""latest""#).unwrap();
-            assert_eq!(result, BlockId::Latest);
-        }
-
-        #[test]
-        fn pending() {
-            let result = serde_json::from_str::<BlockId>(r#""pending""#).unwrap();
-            assert_eq!(result, BlockId::Pending);
-        }
-
-        #[test]
-        fn number() {
-            use crate::BlockNumber;
-            let result = serde_json::from_str::<BlockId>(r#"{"block_number": 123456}"#).unwrap();
-            assert_eq!(result, BlockId::Number(BlockNumber(123456)));
-        }
-
-        #[test]
-        fn hash() {
-            use crate::macro_prelude::block_hash;
-
-            let result =
-                serde_json::from_str::<BlockId>(r#"{"block_hash": "0xdeadbeef"}"#).unwrap();
-            assert_eq!(result, BlockId::Hash(block_hash!("0xdeadbeef")));
         }
     }
 

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -318,15 +318,10 @@ impl BlockId {
 /// A way of identifying a specific block that has been finalized.
 ///
 /// Useful in contexts that do not work with pending blocks.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
-#[cfg_attr(any(test, feature = "full-serde"), derive(Serialize))]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum FinalizedBlockId {
-    #[serde(rename = "block_number")]
     Number(BlockNumber),
-    #[serde(rename = "block_hash")]
     Hash(BlockHash),
-    #[serde(rename = "latest")]
     Latest,
 }
 

--- a/crates/gateway-types/src/request.rs
+++ b/crates/gateway-types/src/request.rs
@@ -1,117 +1,4 @@
 //! Structures used for serializing requests to Starkware's sequencer REST API.
-use pathfinder_common::prelude::*;
-use serde::{Deserialize, Serialize};
-
-/// Special tag used when specifying the `latest` or `pending` block.
-#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub enum Tag {
-    /// The most recent fully constructed block
-    ///
-    /// Represented as the JSON string `"latest"` when passed as an RPC method
-    /// argument, for example:
-    /// `{"jsonrpc":"2.0","id":"0","method":"starknet_getBlockWithTxsByHash","
-    /// params":["latest"]}`
-    #[serde(rename = "latest")]
-    Latest,
-    /// Currently constructed block
-    ///
-    /// Represented as the JSON string `"pending"` when passed as an RPC method
-    /// argument, for example:
-    /// `{"jsonrpc":"2.0","id":"0","method":"starknet_getBlockWithTxsByHash","
-    /// params":["pending"]}`
-    #[serde(rename = "pending")]
-    Pending,
-}
-
-impl std::fmt::Display for Tag {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Tag::Latest => f.write_str("latest"),
-            Tag::Pending => f.write_str("pending"),
-        }
-    }
-}
-
-/// A wrapper that contains either a [Hash](self::BlockHashOrTag::Hash) or a
-/// [Tag](self::BlockHashOrTag::Tag).
-#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(untagged)]
-#[serde(deny_unknown_fields)]
-pub enum BlockHashOrTag {
-    /// Hash of a block
-    ///
-    /// Represented as a `0x`-prefixed hex JSON string of length from 1 up to 64
-    /// characters when passed as an RPC method argument, for example:
-    /// `{"jsonrpc":"2.0","id":"0","method":"starknet_getBlockWithTxsByHash","params":["0x7d328a71faf48c5c3857e99f20a77b18522480956d1cd5bff1ff2df3c8b427b"]}`
-    Hash(BlockHash),
-    /// Special [`Tag`] describing a block
-    Tag(Tag),
-}
-
-impl std::fmt::Display for BlockHashOrTag {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Hash(BlockHash(h)) => f.write_str(&h.to_hex_str()),
-            Self::Tag(t) => std::fmt::Display::fmt(t, f),
-        }
-    }
-}
-
-impl From<BlockHash> for BlockHashOrTag {
-    fn from(hash: BlockHash) -> Self {
-        Self::Hash(hash)
-    }
-}
-
-impl From<BlockHashOrTag> for pathfinder_common::BlockId {
-    fn from(x: BlockHashOrTag) -> Self {
-        match x {
-            BlockHashOrTag::Hash(h) => Self::Hash(h),
-            BlockHashOrTag::Tag(Tag::Latest) => Self::Latest,
-            BlockHashOrTag::Tag(Tag::Pending) => Self::Pending,
-        }
-    }
-}
-
-/// A wrapper that contains either a block
-/// [Number](self::BlockNumberOrTag::Number) or a
-/// [Tag](self::BlockNumberOrTag::Tag).
-#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(untagged)]
-#[serde(deny_unknown_fields)]
-pub enum BlockNumberOrTag {
-    /// Number (height) of a block
-    Number(BlockNumber),
-    /// Special [`Tag`] describing a block
-    Tag(Tag),
-}
-
-impl std::fmt::Display for BlockNumberOrTag {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Number(n) => std::fmt::Display::fmt(n, f),
-            Self::Tag(t) => std::fmt::Display::fmt(t, f),
-        }
-    }
-}
-
-impl From<BlockNumber> for BlockNumberOrTag {
-    fn from(number: BlockNumber) -> Self {
-        Self::Number(number)
-    }
-}
-
-impl From<BlockNumberOrTag> for pathfinder_common::BlockId {
-    fn from(x: BlockNumberOrTag) -> Self {
-        match x {
-            BlockNumberOrTag::Number(n) => Self::Number(n),
-            BlockNumberOrTag::Tag(Tag::Latest) => Self::Latest,
-            BlockNumberOrTag::Tag(Tag::Pending) => Self::Pending,
-        }
-    }
-}
-
 pub mod add_transaction {
     use std::collections::HashMap;
 
@@ -121,10 +8,10 @@ pub mod add_transaction {
         SelectorAndOffset,
     };
     use pathfinder_common::prelude::*;
+    use pathfinder_common::{CallParam, ContractAddress, Fee, TransactionSignatureElem};
     use pathfinder_serde::{CallParamAsDecimalStr, TransactionSignatureElemAsDecimalStr};
     use serde_with::serde_as;
 
-    use super::{CallParam, ContractAddress, Fee, TransactionSignatureElem};
     use crate::reply::transaction::{DataAvailabilityMode, ResourceBounds};
 
     /// Both variants are somewhat different compared to the contract definition


### PR DESCRIPTION
Turns out we were not using the serde serialization implementations, and some of the related types in the gateway types crate.
