### PR TITLE
feat(rpc): add support for "l1_accepted" block tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `pathfinder_lastL1AcceptedBlockHashAndNumber`, a pathfinder extension analogous to `starknet_blockHashAndNumber`
+- As an extension to the Starknet JSON-RPC specification, Pathfinder now accepts the `l1_accepted` `BLOCK_TAG`. This can be used to reference the latest L1 accepted block known by the node.
 
 ### Fixed
 

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -258,13 +258,13 @@ impl TransactionVersion {
 ///
 /// Useful in contexts that do not work with pending blocks.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum FinalizedBlockId {
+pub enum BlockId {
     Number(BlockNumber),
     Hash(BlockHash),
     Latest,
 }
 
-impl FinalizedBlockId {
+impl BlockId {
     pub fn is_latest(&self) -> bool {
         self == &Self::Latest
     }
@@ -390,13 +390,13 @@ impl TryFrom<Felt> for GasPrice {
     }
 }
 
-impl From<BlockNumber> for FinalizedBlockId {
+impl From<BlockNumber> for BlockId {
     fn from(number: BlockNumber) -> Self {
         Self::Number(number)
     }
 }
 
-impl From<BlockHash> for FinalizedBlockId {
+impl From<BlockHash> for BlockId {
     fn from(hash: BlockHash) -> Self {
         Self::Hash(hash)
     }

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -254,67 +254,6 @@ impl TransactionVersion {
     pub const THREE_WITH_QUERY_VERSION: Self = Self::THREE.with_query_version();
 }
 
-/// A way of identifying a specific block.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum BlockId {
-    Number(BlockNumber),
-    Hash(BlockHash),
-    Latest,
-    Pending,
-}
-
-impl BlockId {
-    pub fn is_pending(&self) -> bool {
-        self == &BlockId::Pending
-    }
-
-    pub fn is_latest(&self) -> bool {
-        self == &BlockId::Latest
-    }
-
-    /// Converts this [BlockId] to a [FinalizedBlockId].
-    ///
-    /// # Panics
-    ///
-    /// If this [BlockId] is [`BlockId::Pending`].
-    pub fn to_finalized_or_panic(self) -> FinalizedBlockId {
-        match self {
-            BlockId::Number(number) => FinalizedBlockId::Number(number),
-            BlockId::Hash(hash) => FinalizedBlockId::Hash(hash),
-            BlockId::Latest => FinalizedBlockId::Latest,
-            BlockId::Pending => panic!("Cannot convert BlockId::Pending to FinalizedBlockId"),
-        }
-    }
-
-    /// Converts this [BlockId] to a [FinalizedBlockId].
-    ///
-    /// # Returns
-    ///
-    /// - [anyhow::Error] if the [BlockId] is [`BlockId::Pending`].
-    /// - [FinalizedBlockId] with the corresponding variant otherwise.
-    pub fn try_to_finalized(self) -> anyhow::Result<FinalizedBlockId> {
-        match self {
-            BlockId::Number(number) => Ok(FinalizedBlockId::Number(number)),
-            BlockId::Hash(hash) => Ok(FinalizedBlockId::Hash(hash)),
-            BlockId::Latest => Ok(FinalizedBlockId::Latest),
-            BlockId::Pending => {
-                anyhow::bail!("Cannot convert BlockId::Pending to FinalizedBlockId")
-            }
-        }
-    }
-
-    /// Converts this [BlockId] to a [FinalizedBlockId].
-    ///
-    /// Coerces [`BlockId::Pending`] to [`FinalizedBlockId::Latest`].
-    pub fn to_finalized_coerced(self) -> FinalizedBlockId {
-        match self {
-            BlockId::Number(number) => FinalizedBlockId::Number(number),
-            BlockId::Hash(hash) => FinalizedBlockId::Hash(hash),
-            BlockId::Latest | BlockId::Pending => FinalizedBlockId::Latest,
-        }
-    }
-}
-
 /// A way of identifying a specific block that has been finalized.
 ///
 /// Useful in contexts that do not work with pending blocks.
@@ -328,16 +267,6 @@ pub enum FinalizedBlockId {
 impl FinalizedBlockId {
     pub fn is_latest(&self) -> bool {
         self == &Self::Latest
-    }
-}
-
-impl From<FinalizedBlockId> for BlockId {
-    fn from(value: FinalizedBlockId) -> Self {
-        match value {
-            FinalizedBlockId::Number(number) => BlockId::Number(number),
-            FinalizedBlockId::Hash(hash) => BlockId::Hash(hash),
-            FinalizedBlockId::Latest => BlockId::Latest,
-        }
     }
 }
 
@@ -458,18 +387,6 @@ impl TryFrom<Felt> for GasPrice {
         let mut bytes = [0u8; 16];
         bytes.copy_from_slice(&src.as_be_bytes()[16..]);
         Ok(Self(u128::from_be_bytes(bytes)))
-    }
-}
-
-impl From<BlockNumber> for BlockId {
-    fn from(number: BlockNumber) -> Self {
-        Self::Number(number)
-    }
-}
-
-impl From<BlockHash> for BlockId {
-    fn from(hash: BlockHash) -> Self {
-        Self::Hash(hash)
     }
 }
 

--- a/crates/executor/src/state_reader.rs
+++ b/crates/executor/src/state_reader.rs
@@ -58,7 +58,7 @@ impl<S: StorageAdapter> PathfinderStateReader<S> {
         }
     }
 
-    fn state_block_id(&self) -> Option<pathfinder_common::FinalizedBlockId> {
+    fn state_block_id(&self) -> Option<pathfinder_common::BlockId> {
         self.block_number.map(Into::into)
     }
 

--- a/crates/executor/src/state_reader/storage_adapter.rs
+++ b/crates/executor/src/state_reader/storage_adapter.rs
@@ -2,12 +2,12 @@ use blockifier::blockifier::config::TransactionExecutorConfig;
 use blockifier::state::errors::StateError;
 use pathfinder_common::{
     BlockHash,
+    BlockId,
     BlockNumber,
     CasmHash,
     ClassHash,
     ContractAddress,
     ContractNonce,
-    FinalizedBlockId,
     StorageAddress,
     StorageValue,
 };
@@ -22,7 +22,7 @@ type ClassDefinitionWithBlockNumber = Option<(Option<BlockNumber>, Vec<u8>)>;
 pub trait StorageAdapter {
     fn transaction_executor_config(&self) -> TransactionExecutorConfig;
 
-    fn block_hash(&self, block: FinalizedBlockId) -> anyhow::Result<Option<BlockHash>>;
+    fn block_hash(&self, block: BlockId) -> anyhow::Result<Option<BlockHash>>;
 
     fn casm_definition(&self, class_hash: ClassHash) -> Result<Option<Vec<u8>>, StateError>;
 
@@ -33,19 +33,19 @@ pub trait StorageAdapter {
 
     fn casm_definition_at(
         &self,
-        block_id: FinalizedBlockId,
+        block_id: BlockId,
         class_hash: ClassHash,
     ) -> Result<Option<Vec<u8>>, StateError>;
 
     fn class_definition_at_with_block_number(
         &self,
-        block_id: FinalizedBlockId,
+        block_id: BlockId,
         class_hash: ClassHash,
     ) -> Result<Option<(BlockNumber, Vec<u8>)>, StateError>;
 
     fn storage_value(
         &self,
-        block_id: FinalizedBlockId,
+        block_id: BlockId,
         contract_address: ContractAddress,
         storage_address: StorageAddress,
     ) -> Result<Option<StorageValue>, StateError>;
@@ -53,12 +53,12 @@ pub trait StorageAdapter {
     fn contract_nonce(
         &self,
         contract_address: ContractAddress,
-        block_id: FinalizedBlockId,
+        block_id: BlockId,
     ) -> Result<Option<ContractNonce>, StateError>;
 
     fn contract_class_hash(
         &self,
-        block_id: FinalizedBlockId,
+        block_id: BlockId,
         contract_address: ContractAddress,
     ) -> Result<Option<ClassHash>, StateError>;
 
@@ -66,7 +66,7 @@ pub trait StorageAdapter {
 
     fn casm_hash_at(
         &self,
-        block_id: FinalizedBlockId,
+        block_id: BlockId,
         class_hash: ClassHash,
     ) -> Result<Option<CasmHash>, StateError>;
 }

--- a/crates/executor/src/state_reader/storage_adapter/concurrent.rs
+++ b/crates/executor/src/state_reader/storage_adapter/concurrent.rs
@@ -4,12 +4,12 @@ use blockifier::blockifier::config::{ConcurrencyConfig, TransactionExecutorConfi
 use blockifier::state::errors::StateError;
 use pathfinder_common::{
     BlockHash,
+    BlockId,
     BlockNumber,
     CasmHash,
     ClassHash,
     ContractAddress,
     ContractNonce,
-    FinalizedBlockId,
     StorageAddress,
     StorageValue,
 };
@@ -29,44 +29,41 @@ pub struct ConcurrentStorageAdapter {
 }
 
 enum Command {
-    BlockHash(
-        FinalizedBlockId,
-        SyncSender<anyhow::Result<Option<BlockHash>>>,
-    ),
+    BlockHash(BlockId, SyncSender<anyhow::Result<Option<BlockHash>>>),
     CasmDefinition(ClassHash, SyncSender<Result<Option<Vec<u8>>, StateError>>),
     ClassDefinitionWithBlockNumber(
         ClassHash,
         SyncSender<Result<ClassDefinitionWithBlockNumber, StateError>>,
     ),
     CasmDefinitionAt(
-        FinalizedBlockId,
+        BlockId,
         ClassHash,
         SyncSender<Result<Option<Vec<u8>>, StateError>>,
     ),
     ClassDefinitionAtWithBlockNumber(
-        FinalizedBlockId,
+        BlockId,
         ClassHash,
         SyncSender<Result<ClassDefinitionAtWithBlockNumber, StateError>>,
     ),
     StorageValue(
-        FinalizedBlockId,
+        BlockId,
         ContractAddress,
         StorageAddress,
         SyncSender<Result<Option<StorageValue>, StateError>>,
     ),
     ContractNonce(
         ContractAddress,
-        FinalizedBlockId,
+        BlockId,
         SyncSender<Result<Option<ContractNonce>, StateError>>,
     ),
     ContractClassHash(
-        FinalizedBlockId,
+        BlockId,
         ContractAddress,
         SyncSender<Result<Option<ClassHash>, StateError>>,
     ),
     CasmHash(ClassHash, SyncSender<Result<Option<CasmHash>, StateError>>),
     CasmHashAt(
-        FinalizedBlockId,
+        BlockId,
         ClassHash,
         SyncSender<Result<Option<CasmHash>, StateError>>,
     ),
@@ -118,7 +115,7 @@ impl StorageAdapter for ConcurrentStorageAdapter {
         }
     }
 
-    fn block_hash(&self, block: FinalizedBlockId) -> anyhow::Result<Option<BlockHash>> {
+    fn block_hash(&self, block: BlockId) -> anyhow::Result<Option<BlockHash>> {
         let (tx, rx) = mpsc::sync_channel(1);
         self.tx
             .send(Command::BlockHash(block, tx))
@@ -147,7 +144,7 @@ impl StorageAdapter for ConcurrentStorageAdapter {
 
     fn casm_definition_at(
         &self,
-        block_id: FinalizedBlockId,
+        block_id: BlockId,
         class_hash: ClassHash,
     ) -> Result<Option<Vec<u8>>, StateError> {
         let (tx, rx) = mpsc::sync_channel(1);
@@ -159,7 +156,7 @@ impl StorageAdapter for ConcurrentStorageAdapter {
 
     fn class_definition_at_with_block_number(
         &self,
-        block_id: FinalizedBlockId,
+        block_id: BlockId,
         class_hash: ClassHash,
     ) -> Result<Option<(BlockNumber, Vec<u8>)>, StateError> {
         let (tx, rx) = mpsc::sync_channel(1);
@@ -173,7 +170,7 @@ impl StorageAdapter for ConcurrentStorageAdapter {
 
     fn storage_value(
         &self,
-        block_id: FinalizedBlockId,
+        block_id: BlockId,
         contract_address: ContractAddress,
         storage_address: StorageAddress,
     ) -> Result<Option<StorageValue>, StateError> {
@@ -192,7 +189,7 @@ impl StorageAdapter for ConcurrentStorageAdapter {
     fn contract_nonce(
         &self,
         contract_address: ContractAddress,
-        block_id: FinalizedBlockId,
+        block_id: BlockId,
     ) -> Result<Option<ContractNonce>, StateError> {
         let (tx, rx) = mpsc::sync_channel(1);
         self.tx
@@ -203,7 +200,7 @@ impl StorageAdapter for ConcurrentStorageAdapter {
 
     fn contract_class_hash(
         &self,
-        block_id: FinalizedBlockId,
+        block_id: BlockId,
         contract_address: ContractAddress,
     ) -> Result<Option<ClassHash>, StateError> {
         let (tx, rx) = mpsc::sync_channel(1);
@@ -223,7 +220,7 @@ impl StorageAdapter for ConcurrentStorageAdapter {
 
     fn casm_hash_at(
         &self,
-        block_id: FinalizedBlockId,
+        block_id: BlockId,
         class_hash: ClassHash,
     ) -> Result<Option<CasmHash>, StateError> {
         let (tx, rx) = mpsc::sync_channel(1);

--- a/crates/executor/src/state_reader/storage_adapter/rc.rs
+++ b/crates/executor/src/state_reader/storage_adapter/rc.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use blockifier::blockifier::config::TransactionExecutorConfig;
 use blockifier::state::errors::StateError;
-use pathfinder_common::{BlockHash, FinalizedBlockId};
+use pathfinder_common::{BlockHash, BlockId};
 use pathfinder_storage::Transaction;
 
 use crate::state_reader::storage_adapter::{map_anyhow_to_state_err, StorageAdapter};
@@ -25,7 +25,7 @@ impl<'tx> StorageAdapter for RcStorageAdapter<'tx> {
         TransactionExecutorConfig::default()
     }
 
-    fn block_hash(&self, block: FinalizedBlockId) -> anyhow::Result<Option<BlockHash>> {
+    fn block_hash(&self, block: BlockId) -> anyhow::Result<Option<BlockHash>> {
         self.db_tx.block_hash(block)
     }
 
@@ -49,7 +49,7 @@ impl<'tx> StorageAdapter for RcStorageAdapter<'tx> {
 
     fn casm_definition_at(
         &self,
-        block_id: FinalizedBlockId,
+        block_id: BlockId,
         class_hash: pathfinder_common::ClassHash,
     ) -> Result<Option<Vec<u8>>, StateError> {
         self.db_tx
@@ -59,7 +59,7 @@ impl<'tx> StorageAdapter for RcStorageAdapter<'tx> {
 
     fn class_definition_at_with_block_number(
         &self,
-        block_id: FinalizedBlockId,
+        block_id: BlockId,
         class_hash: pathfinder_common::ClassHash,
     ) -> Result<Option<(pathfinder_common::BlockNumber, Vec<u8>)>, StateError> {
         self.db_tx
@@ -69,7 +69,7 @@ impl<'tx> StorageAdapter for RcStorageAdapter<'tx> {
 
     fn storage_value(
         &self,
-        block_id: FinalizedBlockId,
+        block_id: BlockId,
         contract_address: pathfinder_common::ContractAddress,
         storage_address: pathfinder_common::StorageAddress,
     ) -> Result<Option<pathfinder_common::StorageValue>, StateError> {
@@ -81,7 +81,7 @@ impl<'tx> StorageAdapter for RcStorageAdapter<'tx> {
     fn contract_nonce(
         &self,
         contract_address: pathfinder_common::ContractAddress,
-        block_id: FinalizedBlockId,
+        block_id: BlockId,
     ) -> Result<Option<pathfinder_common::ContractNonce>, StateError> {
         self.db_tx
             .contract_nonce(contract_address, block_id)
@@ -90,7 +90,7 @@ impl<'tx> StorageAdapter for RcStorageAdapter<'tx> {
 
     fn contract_class_hash(
         &self,
-        block_id: FinalizedBlockId,
+        block_id: BlockId,
         contract_address: pathfinder_common::ContractAddress,
     ) -> Result<Option<pathfinder_common::ClassHash>, StateError> {
         self.db_tx
@@ -109,7 +109,7 @@ impl<'tx> StorageAdapter for RcStorageAdapter<'tx> {
 
     fn casm_hash_at(
         &self,
-        block_id: FinalizedBlockId,
+        block_id: BlockId,
         class_hash: pathfinder_common::ClassHash,
     ) -> Result<Option<pathfinder_common::CasmHash>, StateError> {
         self.db_tx

--- a/crates/gateway-client/src/builder.rs
+++ b/crates/gateway-client/src/builder.rs
@@ -12,10 +12,11 @@
 //!   3. [Params](stage::Params) where you select the retry behavior.
 //!   4. [Final](stage::Final) where you select the REST operation type, which
 //!      is then executed.
-use pathfinder_common::{BlockId, ClassHash, TransactionHash};
+use pathfinder_common::{ClassHash, TransactionHash};
 use starknet_gateway_types::error::SequencerError;
 
 use crate::metrics::{with_metrics, BlockTag, RequestMetadata};
+use crate::BlockId;
 
 const X_THROTTLING_BYPASS: &str = "X-Throttling-Bypass";
 
@@ -659,7 +660,7 @@ mod tests {
         use warp::http::response::Builder;
         use warp::Filter;
 
-        use crate::{Client, GatewayApi};
+        use crate::{BlockId, Client, GatewayApi};
 
         fn server() -> (tokio::task::JoinHandle<()>, std::net::SocketAddr) {
             let any = warp::any().then(|| async { Builder::new().status(500).body("whatever") });
@@ -674,10 +675,7 @@ mod tests {
             let mut url = reqwest::Url::parse("http://localhost/").unwrap();
             url.set_port(Some(addr.port())).unwrap();
             let client = Client::for_test(url).unwrap().disable_retry_for_tests();
-            let error = client
-                .block_header(pathfinder_common::BlockId::Latest)
-                .await
-                .unwrap_err();
+            let error = client.block_header(BlockId::Latest).await.unwrap_err();
             assert_eq!(
                 error.to_string(),
                 "error decoding response body: invalid error variant"

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -22,17 +22,6 @@ pub enum BlockId {
     Pending,
 }
 
-impl From<pathfinder_common::BlockId> for BlockId {
-    fn from(block_id: pathfinder_common::BlockId) -> Self {
-        match block_id {
-            pathfinder_common::BlockId::Number(number) => BlockId::Number(number),
-            pathfinder_common::BlockId::Hash(hash) => BlockId::Hash(hash),
-            pathfinder_common::BlockId::Latest => BlockId::Latest,
-            pathfinder_common::BlockId::Pending => BlockId::Pending,
-        }
-    }
-}
-
 impl From<BlockNumber> for BlockId {
     fn from(block_number: BlockNumber) -> Self {
         BlockId::Number(block_number)

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -34,6 +34,16 @@ impl From<BlockHash> for BlockId {
     }
 }
 
+impl From<pathfinder_common::BlockId> for BlockId {
+    fn from(block_id: pathfinder_common::BlockId) -> Self {
+        match block_id {
+            pathfinder_common::BlockId::Number(block_number) => BlockId::Number(block_number),
+            pathfinder_common::BlockId::Hash(block_hash) => BlockId::Hash(block_hash),
+            pathfinder_common::BlockId::Latest => BlockId::Latest,
+        }
+    }
+}
+
 #[allow(unused_variables)]
 #[mockall::automock]
 #[async_trait::async_trait]

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -4,7 +4,6 @@ use std::result::Result;
 use std::time::Duration;
 
 use pathfinder_common::prelude::*;
-use pathfinder_common::BlockId;
 use reqwest::Url;
 use starknet_gateway_types::error::SequencerError;
 use starknet_gateway_types::reply::{PendingBlock, PreConfirmedBlock};
@@ -13,6 +12,38 @@ use starknet_gateway_types::{reply, request};
 
 mod builder;
 mod metrics;
+
+/// A way of identifying a specific block.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum BlockId {
+    Number(BlockNumber),
+    Hash(BlockHash),
+    Latest,
+    Pending,
+}
+
+impl From<pathfinder_common::BlockId> for BlockId {
+    fn from(block_id: pathfinder_common::BlockId) -> Self {
+        match block_id {
+            pathfinder_common::BlockId::Number(number) => BlockId::Number(number),
+            pathfinder_common::BlockId::Hash(hash) => BlockId::Hash(hash),
+            pathfinder_common::BlockId::Latest => BlockId::Latest,
+            pathfinder_common::BlockId::Pending => BlockId::Pending,
+        }
+    }
+}
+
+impl From<BlockNumber> for BlockId {
+    fn from(block_number: BlockNumber) -> Self {
+        BlockId::Number(block_number)
+    }
+}
+
+impl From<BlockHash> for BlockId {
+    fn from(block_hash: BlockHash) -> Self {
+        BlockId::Hash(block_hash)
+    }
+}
 
 #[allow(unused_variables)]
 #[mockall::automock]

--- a/crates/gateway-client/src/metrics.rs
+++ b/crates/gateway-client/src/metrics.rs
@@ -1,10 +1,9 @@
 //! Metrics related utilities
 use futures::Future;
-use pathfinder_common::BlockId;
 
 use super::builder::stage::Method;
 use super::builder::Request;
-use super::SequencerError;
+use super::{BlockId, SequencerError};
 
 const METRIC_REQUESTS: &str = "gateway_requests_total";
 const METRIC_FAILED_REQUESTS: &str = "gateway_requests_failed_total";

--- a/crates/gateway-client/tests/metrics.rs
+++ b/crates/gateway-client/tests/metrics.rs
@@ -8,9 +8,9 @@ use std::future::Future;
 
 use futures::stream::StreamExt;
 use gateway_test_utils::{response_from, setup_with_varied_responses};
-use pathfinder_common::{BlockId, BlockNumber};
+use pathfinder_common::BlockNumber;
 use pretty_assertions_sorted::assert_eq;
-use starknet_gateway_client::{Client, GatewayApi};
+use starknet_gateway_client::{BlockId, Client, GatewayApi};
 use starknet_gateway_types::error::KnownStarknetErrorCode;
 
 #[tokio::test]

--- a/crates/pathfinder/examples/compute_pre0132_hashes.rs
+++ b/crates/pathfinder/examples/compute_pre0132_hashes.rs
@@ -33,7 +33,7 @@ fn main() -> anyhow::Result<()> {
     // Get latest block number
     let latest_block_number = {
         let tx = db.transaction().unwrap();
-        tx.block_id(pathfinder_common::FinalizedBlockId::Latest)
+        tx.block_id(pathfinder_common::BlockId::Latest)
             .context("Fetching latest block number")?
             .context("No latest block number")?
             .0
@@ -49,7 +49,7 @@ fn main() -> anyhow::Result<()> {
 
         let tx = db.transaction().unwrap();
         let block_number = BlockNumber::new_or_panic(block_number);
-        let block_id = pathfinder_common::FinalizedBlockId::Number(block_number);
+        let block_id = pathfinder_common::BlockId::Number(block_number);
 
         // Load block header
         let mut header = tx

--- a/crates/pathfinder/examples/find_validator_compatible.rs
+++ b/crates/pathfinder/examples/find_validator_compatible.rs
@@ -5,7 +5,7 @@ use std::num::NonZeroU32;
 
 use anyhow::Context;
 use pathfinder_common::transaction::TransactionVariant;
-use pathfinder_common::{BlockNumber, FinalizedBlockId};
+use pathfinder_common::{BlockId, BlockNumber};
 use pathfinder_storage::StorageBuilder;
 
 fn main() -> anyhow::Result<()> {
@@ -35,7 +35,7 @@ fn main() -> anyhow::Result<()> {
 /// Create a valid sequence of proposal parts for the given block.
 fn find_compatible_blocks(db_txn: &pathfinder_storage::Transaction<'_>) -> anyhow::Result<()> {
     let latest = db_txn
-        .block_number(FinalizedBlockId::Latest)
+        .block_number(BlockId::Latest)
         .context("Getting latest block number")?
         .context("No blocks found")?
         .get();

--- a/crates/pathfinder/examples/re_execute.rs
+++ b/crates/pathfinder/examples/re_execute.rs
@@ -3,7 +3,7 @@ use std::num::{NonZeroU32, NonZeroUsize};
 use anyhow::Context;
 use pathfinder_common::receipt::Receipt;
 use pathfinder_common::transaction::Transaction;
-use pathfinder_common::{BlockHeader, BlockNumber, ChainId, FinalizedBlockId};
+use pathfinder_common::{BlockHeader, BlockId, BlockNumber, ChainId};
 use pathfinder_executor::{ExecutionState, NativeClassCache};
 use pathfinder_rpc::context::{ETH_FEE_TOKEN_ADDRESS, STRK_FEE_TOKEN_ADDRESS};
 use pathfinder_storage::Storage;
@@ -46,7 +46,7 @@ fn main() -> anyhow::Result<()> {
 
     let (latest_block, chain_id) = {
         let tx = db.transaction().unwrap();
-        let (latest_block, _) = tx.block_id(FinalizedBlockId::Latest)?.unwrap();
+        let (latest_block, _) = tx.block_id(BlockId::Latest)?.unwrap();
         let latest_block = latest_block.get();
         let chain_id = get_chain_id(&tx).unwrap();
         (latest_block, chain_id)
@@ -67,7 +67,7 @@ fn main() -> anyhow::Result<()> {
     (first_block..=last_block)
         .map(|block_number| {
             let transaction = db.transaction().unwrap();
-            let block_id = FinalizedBlockId::Number(BlockNumber::new_or_panic(block_number));
+            let block_id = BlockId::Number(BlockNumber::new_or_panic(block_number));
             let block_header = transaction.block_header(block_id).unwrap().unwrap();
             let transactions_and_receipts = transaction
                 .transaction_data_for_block(block_id)

--- a/crates/pathfinder/examples/recompute_state_diff_length.rs
+++ b/crates/pathfinder/examples/recompute_state_diff_length.rs
@@ -16,7 +16,7 @@ fn main() -> anyhow::Result<()> {
 
     let latest_block_number = {
         let tx = db.transaction().unwrap();
-        tx.block_id(pathfinder_common::FinalizedBlockId::Latest)
+        tx.block_id(pathfinder_common::BlockId::Latest)
             .context("Fetching latest block number")?
             .context("No latest block number")?
             .0
@@ -26,7 +26,7 @@ fn main() -> anyhow::Result<()> {
 
     for block_number in 0..latest_block_number.get() {
         let block_number = BlockNumber::new_or_panic(block_number);
-        let block_id = pathfinder_common::FinalizedBlockId::Number(block_number);
+        let block_id = pathfinder_common::BlockId::Number(block_number);
         let state_update = tx
             .state_update(block_id)?
             .context("Fetching state update")?;

--- a/crates/pathfinder/examples/test_state_rollback.rs
+++ b/crates/pathfinder/examples/test_state_rollback.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU32;
 use std::time::Instant;
 
 use anyhow::Context;
-use pathfinder_common::{BlockNumber, FinalizedBlockId};
+use pathfinder_common::{BlockId, BlockNumber};
 use pathfinder_storage::StorageBuilder;
 
 fn main() -> anyhow::Result<()> {
@@ -21,7 +21,7 @@ fn main() -> anyhow::Result<()> {
 
     let latest_block = {
         let tx = db.transaction().unwrap();
-        let (latest_block, _) = tx.block_id(FinalizedBlockId::Latest)?.unwrap();
+        let (latest_block, _) = tx.block_id(BlockId::Latest)?.unwrap();
         latest_block.get()
     };
     let from: u64 = std::env::args()

--- a/crates/pathfinder/examples/verify_block_hashes.rs
+++ b/crates/pathfinder/examples/verify_block_hashes.rs
@@ -36,7 +36,7 @@ fn main() -> anyhow::Result<()> {
 
     let latest_block_number = {
         let tx = db.transaction().unwrap();
-        tx.block_id(pathfinder_common::FinalizedBlockId::Latest)
+        tx.block_id(pathfinder_common::BlockId::Latest)
             .context("Fetching latest block number")?
             .context("No latest block number")?
             .0
@@ -45,7 +45,7 @@ fn main() -> anyhow::Result<()> {
     for block_number in 0..latest_block_number.get() {
         let tx = db.transaction().unwrap();
         let block_number = BlockNumber::new_or_panic(block_number);
-        let block_id = pathfinder_common::FinalizedBlockId::Number(block_number);
+        let block_id = pathfinder_common::BlockId::Number(block_number);
         let mut header = tx
             .block_header(block_id)
             .context("Fetching block header")?

--- a/crates/pathfinder/examples/verify_transaction_commitment.rs
+++ b/crates/pathfinder/examples/verify_transaction_commitment.rs
@@ -29,7 +29,7 @@ fn main() -> anyhow::Result<()> {
 
     let latest_block_number = {
         let tx = db.transaction().unwrap();
-        tx.block_id(pathfinder_common::FinalizedBlockId::Latest)
+        tx.block_id(pathfinder_common::BlockId::Latest)
             .context("Fetching latest block number")?
             .context("Latest block number does not exist")?
             .0
@@ -43,8 +43,7 @@ fn main() -> anyhow::Result<()> {
         }
 
         let tx = db.transaction().unwrap();
-        let block_id =
-            pathfinder_common::FinalizedBlockId::Number(BlockNumber::new_or_panic(block_number));
+        let block_id = pathfinder_common::BlockId::Number(BlockNumber::new_or_panic(block_number));
         let header = tx
             .block_header(block_id)
             .context("Fetching block header")?

--- a/crates/pathfinder/examples/verify_transaction_hashes.rs
+++ b/crates/pathfinder/examples/verify_transaction_hashes.rs
@@ -39,7 +39,7 @@ fn main() -> anyhow::Result<()> {
 
     let latest_block_number = {
         let tx = db.transaction().unwrap();
-        tx.block_id(pathfinder_common::FinalizedBlockId::Latest)
+        tx.block_id(pathfinder_common::BlockId::Latest)
             .context("Fetching latest block number")?
             .context("Latest block number does not exist")?
             .0
@@ -53,8 +53,7 @@ fn main() -> anyhow::Result<()> {
         }
 
         let tx = db.transaction().unwrap();
-        let block_id =
-            pathfinder_common::FinalizedBlockId::Number(BlockNumber::new_or_panic(block_number));
+        let block_id = pathfinder_common::BlockId::Number(BlockNumber::new_or_panic(block_number));
         let transactions = tx
             .transaction_data_for_block(block_id)?
             .context("Transaction data missing")?;

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use anyhow::Context;
 use pathfinder_common::prelude::*;
-use pathfinder_common::{Chain, FinalizedBlockId};
+use pathfinder_common::{BlockId, Chain};
 use pathfinder_crypto::Felt;
 use pathfinder_ethereum::{EthereumApi, EthereumStateUpdate};
 use pathfinder_merkle_tree::starknet_state::update_starknet_state;
@@ -180,7 +180,7 @@ where
     let l2_head = tokio::task::block_in_place(|| -> anyhow::Result<_> {
         let tx = db_conn.transaction()?;
         let l2_head = tx
-            .block_header(FinalizedBlockId::Latest)
+            .block_header(BlockId::Latest)
             .context("Fetching latest block header from database")?
             .map(|header| (header.number, header.hash, header.state_commitment));
 
@@ -319,7 +319,7 @@ where
 
                 let l2_head = tokio::task::block_in_place(|| {
                     let tx = db_conn.transaction()?;
-                    tx.block_header(FinalizedBlockId::Latest)
+                    tx.block_header(BlockId::Latest)
                 })
                 .context("Query L2 head from database")?
                 .map(|block| (block.number, block.hash, block.state_commitment));
@@ -445,7 +445,7 @@ async fn consumer(
             .transaction()
             .context("Creating database transaction")?;
         let latest = tx
-            .block_header(FinalizedBlockId::Latest)
+            .block_header(BlockId::Latest)
             .context("Fetching latest block header")?
             .map(|b| (b.timestamp, b.number + 1))
             .unwrap_or_default();
@@ -632,7 +632,7 @@ async fn consumer(
                 Pending((pending_block, pending_state_update)) => {
                     tracing::trace!("Updating pending data");
                     let (number, hash) = tx
-                        .block_id(FinalizedBlockId::Latest)
+                        .block_id(BlockId::Latest)
                         .context("Fetching latest block hash")?
                         .unwrap_or_default();
 
@@ -709,7 +709,7 @@ fn perform_blockchain_pruning(
     let (pruning_point_block, pruning_point_suffix) = match pruning_event {
         PruningEvent::L1Checkpoint(l1_checkpoint) => {
             let Some(l2_head) = tx
-                .block_number(FinalizedBlockId::Latest)
+                .block_number(BlockId::Latest)
                 .context("Querying latest block number")?
             else {
                 // Empty database.
@@ -783,7 +783,7 @@ async fn latest_n_blocks(
             .transaction()
             .context("Creating database transaction")?;
 
-        let mut current = FinalizedBlockId::Latest;
+        let mut current = BlockId::Latest;
         let mut blocks = Vec::new();
 
         for _ in 0..n {
@@ -1069,7 +1069,7 @@ fn l2_reorg(
     notifications: &mut Notifications,
 ) -> anyhow::Result<()> {
     let mut head = transaction
-        .block_id(FinalizedBlockId::Latest)
+        .block_id(BlockId::Latest)
         .context("Querying latest block number")?
         .context("Latest block number is none during reorg")?
         .0;
@@ -1958,7 +1958,7 @@ mod tests {
     }
 
     mod blockchain_pruning {
-        use pathfinder_common::FinalizedBlockId;
+        use pathfinder_common::BlockId;
         use pathfinder_ethereum::EthereumStateUpdate;
 
         use super::*;
@@ -2120,14 +2120,14 @@ mod tests {
 
             let tx = conn.transaction().unwrap();
             for block in 0..(num_blocks - 1) {
-                let block_id: FinalizedBlockId = BlockNumber::new_or_panic(block).into();
+                let block_id: BlockId = BlockNumber::new_or_panic(block).into();
                 // Transaction data has been pruned (as well as block so query returns None).
                 assert!(tx.transactions_for_block(block_id).unwrap().is_none());
                 assert!(tx.transaction_hashes_for_block(block_id).unwrap().is_none());
                 // Block data has been pruned.
                 assert!(!tx.block_exists(block_id).unwrap());
             }
-            let latest = tx.block_number(FinalizedBlockId::Latest).unwrap().unwrap();
+            let latest = tx.block_number(BlockId::Latest).unwrap().unwrap();
             assert_eq!(latest, BlockNumber::new_or_panic(4));
             let transactions = tx.transactions_for_block(latest.into()).unwrap().unwrap();
             let transaction_hashes = tx
@@ -2178,7 +2178,7 @@ mod tests {
             let tx = conn.transaction().unwrap();
 
             for block in 0..(num_blocks - 1) {
-                let block_id: FinalizedBlockId = BlockNumber::new_or_panic(block).into();
+                let block_id: BlockId = BlockNumber::new_or_panic(block).into();
                 // Transaction data has been pruned (as well as block so query returns None).
                 assert!(tx.transactions_for_block(block_id).unwrap().is_none());
                 assert!(tx.transaction_hashes_for_block(block_id).unwrap().is_none());
@@ -2189,7 +2189,7 @@ mod tests {
             // Check that non-obsolete state update data has not been pruned.
             assert_eq!(
                 tx.contract_class_hash(
-                    FinalizedBlockId::Number(BlockNumber::new_or_panic(2)),
+                    BlockId::Number(BlockNumber::new_or_panic(2)),
                     contract_address_bytes!(b"contract 2"),
                 )
                 .unwrap()
@@ -2198,7 +2198,7 @@ mod tests {
             );
             assert_eq!(
                 tx.contract_class_hash(
-                    FinalizedBlockId::Number(BlockNumber::new_or_panic(3)),
+                    BlockId::Number(BlockNumber::new_or_panic(3)),
                     contract_address_bytes!(b"contract 1"),
                 )
                 .unwrap()
@@ -2207,7 +2207,7 @@ mod tests {
             );
             assert_eq!(
                 tx.storage_value(
-                    FinalizedBlockId::Number(BlockNumber::new_or_panic(4)),
+                    BlockId::Number(BlockNumber::new_or_panic(4)),
                     contract_address_bytes!(b"contract 1"),
                     storage_address_bytes!(b"storage address 1"),
                 )
@@ -2218,14 +2218,14 @@ mod tests {
             assert_eq!(
                 tx.contract_nonce(
                     contract_address_bytes!(b"contract 1"),
-                    FinalizedBlockId::Number(BlockNumber::new_or_panic(5)),
+                    BlockId::Number(BlockNumber::new_or_panic(5)),
                 )
                 .unwrap()
                 .unwrap(),
                 contract_nonce!("0x2"),
             );
 
-            let latest = tx.block_number(FinalizedBlockId::Latest).unwrap().unwrap();
+            let latest = tx.block_number(BlockId::Latest).unwrap().unwrap();
             assert_eq!(latest, BlockNumber::new_or_panic(num_blocks - 1));
             let transactions = tx.transactions_for_block(latest.into()).unwrap().unwrap();
             let transaction_hashes = tx
@@ -2400,12 +2400,12 @@ Blockchain history must include the reorg tail and its parent block to perform a
             consumer(event_rx, context, tx).await.unwrap();
 
             let tx = conn.transaction().unwrap();
-            let latest = tx.block_number(FinalizedBlockId::Latest).unwrap().unwrap();
+            let latest = tx.block_number(BlockId::Latest).unwrap().unwrap();
             assert_eq!(latest, BlockNumber::GENESIS + block_count as u64 - 3);
 
             let prunable_blocks = vec![0, 1];
             for block in prunable_blocks {
-                let block_id: FinalizedBlockId = BlockNumber::new_or_panic(block).into();
+                let block_id: BlockId = BlockNumber::new_or_panic(block).into();
                 // Transaction data has been pruned (as well as block so query returns None).
                 assert!(tx.transactions_for_block(block_id).unwrap().is_none());
                 assert!(tx.transaction_hashes_for_block(block_id).unwrap().is_none());
@@ -2459,7 +2459,7 @@ Blockchain history must include the reorg tail and its parent block to perform a
             let pruned_blocks = [0, 1];
 
             for block in pruned_blocks {
-                let block_id: FinalizedBlockId = BlockNumber::new_or_panic(block).into();
+                let block_id: BlockId = BlockNumber::new_or_panic(block).into();
                 // Transaction data has been pruned (as well as block so query returns None).
                 assert!(tx.transactions_for_block(block_id).unwrap().is_none());
                 assert!(tx.transaction_hashes_for_block(block_id).unwrap().is_none());
@@ -2487,7 +2487,7 @@ Blockchain history must include the reorg tail and its parent block to perform a
                     class_hash_bytes!(b"class 2"),
                 );
             let result = tx
-                .state_update(FinalizedBlockId::Number(BlockNumber::new_or_panic(3)))
+                .state_update(BlockId::Number(BlockNumber::new_or_panic(3)))
                 .unwrap()
                 .unwrap();
             assert_eq!(result, state_update);
@@ -2510,7 +2510,7 @@ Blockchain history must include the reorg tail and its parent block to perform a
                 );
 
             let result = tx
-                .state_update(FinalizedBlockId::Number(BlockNumber::new_or_panic(4)))
+                .state_update(BlockId::Number(BlockNumber::new_or_panic(4)))
                 .unwrap()
                 .unwrap();
             assert_eq!(result, state_update);
@@ -2577,7 +2577,7 @@ Blockchain history must include the reorg tail and its parent block to perform a
             let non_prunable_blocks = vec![1, 2, 3, 4];
 
             for block in prunable_blocks {
-                let block_id: FinalizedBlockId = BlockNumber::new_or_panic(block).into();
+                let block_id: BlockId = BlockNumber::new_or_panic(block).into();
                 // Transaction data has been pruned (as well as block so query returns None).
                 assert!(tx.transactions_for_block(block_id).unwrap().is_none());
                 assert!(tx.transaction_hashes_for_block(block_id).unwrap().is_none());
@@ -2586,7 +2586,7 @@ Blockchain history must include the reorg tail and its parent block to perform a
             }
 
             for block in non_prunable_blocks {
-                let block_id: FinalizedBlockId = BlockNumber::new_or_panic(block).into();
+                let block_id: BlockId = BlockNumber::new_or_panic(block).into();
                 // Transaction and block data has not been pruned.
                 let transactions = tx.transactions_for_block(block_id).unwrap().unwrap();
                 let transaction_hashes =

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -584,7 +584,7 @@ async fn download_block(
                     let tx = conn
                         .transaction()
                         .context("Creating database transaction")?;
-                    tx.block_hash(pathfinder_common::FinalizedBlockId::Number(seq_head_number))
+                    tx.block_hash(pathfinder_common::BlockId::Number(seq_head_number))
                         .context("Query block hash")?
                 };
                 match our_block_hash {

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -344,7 +344,7 @@ pub async fn poll_latest(
         interval.tick().await;
 
         let Ok(latest) = gateway
-            .block_header(pathfinder_common::BlockId::Latest)
+            .block_header(starknet_gateway_client::BlockId::Latest)
             .await
             .inspect_err(|e| tracing::debug!(error=%e, "Error requesting latest block ID"))
         else {
@@ -1193,10 +1193,10 @@ mod tests {
         use assert_matches::assert_matches;
         use pathfinder_common::macro_prelude::*;
         use pathfinder_common::prelude::*;
-        use pathfinder_common::{BlockId, Chain};
+        use pathfinder_common::Chain;
         use pathfinder_crypto::Felt;
         use pathfinder_storage::StorageBuilder;
-        use starknet_gateway_client::MockGatewayApi;
+        use starknet_gateway_client::{BlockId, MockGatewayApi};
         use starknet_gateway_types::error::{
             KnownStarknetErrorCode,
             SequencerError,

--- a/crates/pathfinder/src/sync.rs
+++ b/crates/pathfinder/src/sync.rs
@@ -254,7 +254,7 @@ impl LatestStream {
                 interval.tick().await;
 
                 let Ok(latest) = fgw
-                    .block_header(pathfinder_common::BlockId::Latest)
+                    .block_header(starknet_gateway_client::BlockId::Latest)
                     .await
                     .inspect_err(|e| tracing::debug!(error=%e, "Error requesting latest block ID"))
                 else {
@@ -312,7 +312,6 @@ mod tests {
     use pathfinder_common::receipt::Receipt;
     use pathfinder_common::state_update::{self, StateUpdateData};
     use pathfinder_common::transaction::Transaction;
-    use pathfinder_common::BlockId;
     use pathfinder_crypto::signature::ecdsa_sign;
     use pathfinder_crypto::Felt;
     use pathfinder_ethereum::EthereumClient;
@@ -323,6 +322,7 @@ mod tests {
     use rayon::iter::Rev;
     use rstest::rstest;
     use sha3::digest::consts::U6;
+    use starknet_gateway_client::BlockId;
     use starknet_gateway_types::error::SequencerError;
 
     use super::*;

--- a/crates/pathfinder/src/sync/checkpoint.rs
+++ b/crates/pathfinder/src/sync/checkpoint.rs
@@ -604,7 +604,7 @@ impl LocalState {
             let db = db.transaction().context("Creating database transaction")?;
 
             let latest_header = db
-                .block_id(pathfinder_common::FinalizedBlockId::Latest)
+                .block_id(pathfinder_common::BlockId::Latest)
                 .context("Querying latest header")?;
 
             let checkpoint = db

--- a/crates/rpc/fixtures/0.6.0/transactions/receipt_l1_accepted.json
+++ b/crates/rpc/fixtures/0.6.0/transactions/receipt_l1_accepted.json
@@ -3,8 +3,8 @@
     "amount": "0x0",
     "unit": "WEI"
   },
-  "block_hash": "0x6c6174657374",
-  "block_number": 2,
+  "block_hash": "0x626c6f636b2031",
+  "block_number": 1,
   "events": [],
   "execution_resources": {
     "memory_holes": 5,
@@ -12,8 +12,8 @@
     "steps": 10
   },
   "execution_status": "SUCCEEDED",
-  "finality_status": "ACCEPTED_ON_L2",
+  "finality_status": "ACCEPTED_ON_L1",
   "messages_sent": [],
-  "transaction_hash": "0x74786e2033",
+  "transaction_hash": "0x74786e2031",
   "type": "INVOKE"
 }

--- a/crates/rpc/fixtures/0.7.0/transactions/receipt_l1_accepted.json
+++ b/crates/rpc/fixtures/0.7.0/transactions/receipt_l1_accepted.json
@@ -3,17 +3,21 @@
     "amount": "0x0",
     "unit": "WEI"
   },
-  "block_hash": "0x6c6174657374",
-  "block_number": 2,
+  "block_hash": "0x626c6f636b2031",
+  "block_number": 1,
   "events": [],
   "execution_resources": {
+    "data_availability": {
+      "l1_data_gas": 0,
+      "l1_gas": 0
+    },
     "memory_holes": 5,
     "pedersen_builtin_applications": 32,
     "steps": 10
   },
   "execution_status": "SUCCEEDED",
-  "finality_status": "ACCEPTED_ON_L2",
+  "finality_status": "ACCEPTED_ON_L1",
   "messages_sent": [],
-  "transaction_hash": "0x74786e2033",
+  "transaction_hash": "0x74786e2031",
   "type": "INVOKE"
 }

--- a/crates/rpc/fixtures/0.7.0/transactions/receipt_l2_accepted.json
+++ b/crates/rpc/fixtures/0.7.0/transactions/receipt_l2_accepted.json
@@ -3,8 +3,8 @@
     "amount": "0x0",
     "unit": "WEI"
   },
-  "block_hash": "0x626c6f636b2031",
-  "block_number": 1,
+  "block_hash": "0x6c6174657374",
+  "block_number": 2,
   "events": [],
   "execution_resources": {
     "data_availability": {
@@ -18,6 +18,6 @@
   "execution_status": "SUCCEEDED",
   "finality_status": "ACCEPTED_ON_L2",
   "messages_sent": [],
-  "transaction_hash": "0x74786e2031",
+  "transaction_hash": "0x74786e2033",
   "type": "INVOKE"
 }

--- a/crates/rpc/fixtures/0.8.0/transactions/receipt_l1_accepted.json
+++ b/crates/rpc/fixtures/0.8.0/transactions/receipt_l1_accepted.json
@@ -3,8 +3,8 @@
     "amount": "0x0",
     "unit": "WEI"
   },
-  "block_hash": "0x6c6174657374",
-  "block_number": 2,
+  "block_hash": "0x626c6f636b2031",
+  "block_number": 1,
   "events": [],
   "execution_resources": {
     "l1_data_gas": 0,
@@ -12,8 +12,8 @@
     "l2_gas": 0
   },
   "execution_status": "SUCCEEDED",
-  "finality_status": "ACCEPTED_ON_L2",
+  "finality_status": "ACCEPTED_ON_L1",
   "messages_sent": [],
-  "transaction_hash": "0x74786e2033",
+  "transaction_hash": "0x74786e2031",
   "type": "INVOKE"
 }

--- a/crates/rpc/fixtures/0.9.0/transactions/receipt_l1_accepted.json
+++ b/crates/rpc/fixtures/0.9.0/transactions/receipt_l1_accepted.json
@@ -3,8 +3,8 @@
     "amount": "0x0",
     "unit": "WEI"
   },
-  "block_hash": "0x6c6174657374",
-  "block_number": 2,
+  "block_hash": "0x626c6f636b2031",
+  "block_number": 1,
   "events": [],
   "execution_resources": {
     "l1_data_gas": 0,
@@ -12,8 +12,8 @@
     "l2_gas": 0
   },
   "execution_status": "SUCCEEDED",
-  "finality_status": "ACCEPTED_ON_L2",
+  "finality_status": "ACCEPTED_ON_L1",
   "messages_sent": [],
-  "transaction_hash": "0x74786e2033",
+  "transaction_hash": "0x74786e2031",
   "type": "INVOKE"
 }

--- a/crates/rpc/fixtures/0.9.0/transactions/receipt_l2_accepted.json
+++ b/crates/rpc/fixtures/0.9.0/transactions/receipt_l2_accepted.json
@@ -3,8 +3,8 @@
     "amount": "0x0",
     "unit": "WEI"
   },
-  "block_hash": "0x626c6f636b2031",
-  "block_number": 1,
+  "block_hash": "0x6c6174657374",
+  "block_number": 2,
   "events": [],
   "execution_resources": {
     "l1_data_gas": 0,
@@ -14,6 +14,6 @@
   "execution_status": "SUCCEEDED",
   "finality_status": "ACCEPTED_ON_L2",
   "messages_sent": [],
-  "transaction_hash": "0x74786e2031",
+  "transaction_hash": "0x74786e2033",
   "type": "INVOKE"
 }

--- a/crates/rpc/src/dto/block.rs
+++ b/crates/rpc/src/dto/block.rs
@@ -11,6 +11,7 @@ impl crate::dto::DeserializeForVersion for crate::types::request::BlockId {
             let value: String = value.deserialize()?;
             match value.as_str() {
                 "latest" => Ok(Self::Latest),
+                "l1_accepted" => Ok(Self::L1Accepted),
                 "pending" if rpc_version < RpcVersion::V09 => Ok(Self::Pending),
                 "pre_confirmed" if rpc_version >= RpcVersion::V09 => Ok(Self::Pending),
                 _ => Err(serde_json::Error::custom("Invalid block id")),

--- a/crates/rpc/src/dto/block.rs
+++ b/crates/rpc/src/dto/block.rs
@@ -4,7 +4,7 @@ use serde::de::Error;
 use crate::dto::SerializeStruct;
 use crate::{Reorg, RpcVersion};
 
-impl crate::dto::DeserializeForVersion for pathfinder_common::BlockId {
+impl crate::dto::DeserializeForVersion for crate::types::request::BlockId {
     fn deserialize(value: super::Value) -> Result<Self, serde_json::Error> {
         let rpc_version = value.version;
         if value.is_string() {

--- a/crates/rpc/src/jsonrpc/router/subscription.rs
+++ b/crates/rpc/src/jsonrpc/router/subscription.rs
@@ -225,7 +225,7 @@ where
                 }
                 _ => starting_block,
             };
-            let starting_block = pathfinder_common::FinalizedBlockId::from(starting_block);
+            let starting_block = pathfinder_common::BlockId::from(starting_block);
 
             db.block_number(starting_block)
                 .map_err(RpcError::InternalError)?
@@ -233,7 +233,7 @@ where
                     match max_history {
                         WebsocketHistory::Limited(limit) => {
                             let latest = db
-                                .block_number(pathfinder_common::FinalizedBlockId::Latest)
+                                .block_number(pathfinder_common::BlockId::Latest)
                                 .map_err(RpcError::InternalError)?
                                 .unwrap_or(BlockNumber::GENESIS);
                             // + 1 because `starting_block` also counts as one block.

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -288,7 +288,7 @@ pub mod test_utils {
         Receipt,
     };
     use pathfinder_common::transaction::*;
-    use pathfinder_common::FinalizedBlockId;
+    use pathfinder_common::BlockId;
     use pathfinder_merkle_tree::{ClassCommitmentTree, StorageCommitmentTree};
     use pathfinder_storage::{Storage, StorageBuilder};
     use starknet_gateway_types::reply::GasPrices;
@@ -702,7 +702,7 @@ pub mod test_utils {
             let mut db = storage2.connection().unwrap();
             let tx = db.transaction().unwrap();
 
-            tx.block_header(FinalizedBlockId::Latest)
+            tx.block_header(BlockId::Latest)
                 .unwrap()
                 .expect("Storage should contain a latest block")
         })
@@ -884,7 +884,7 @@ pub mod test_utils {
             let mut db = storage2.connection().unwrap();
             let tx = db.transaction().unwrap();
 
-            tx.block_header(FinalizedBlockId::Latest)
+            tx.block_header(BlockId::Latest)
                 .unwrap()
                 .expect("Storage should contain a latest block")
         })

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -685,8 +685,8 @@ pub mod test_utils {
             .insert_transaction_data(header2.number, &transactions2, Some(&events2))
             .unwrap();
 
-        // Mark block 0 as L1 accepted.
-        db_txn.update_l1_l2_pointer(Some(header0.number)).unwrap();
+        // Mark block 1 as L1 accepted.
+        db_txn.update_l1_l2_pointer(Some(header1.number)).unwrap();
 
         db_txn.commit().unwrap();
         storage

--- a/crates/rpc/src/method/block_hash_and_number.rs
+++ b/crates/rpc/src/method/block_hash_and_number.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use pathfinder_common::FinalizedBlockId;
+use pathfinder_common::BlockId;
 
 use crate::context::RpcContext;
 
@@ -21,7 +21,7 @@ pub async fn block_hash_and_number(context: RpcContext) -> Result<Output, Error>
             .context("Opening database connection")?;
         let tx = db.transaction().context("Opening database transaction")?;
 
-        tx.block_id(FinalizedBlockId::Latest)
+        tx.block_id(BlockId::Latest)
             .context("Reading latest block number and hash from database")?
             .map(|(number, hash)| Output { number, hash })
             .ok_or(Error::NoBlocks)

--- a/crates/rpc/src/method/block_number.rs
+++ b/crates/rpc/src/method/block_number.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use pathfinder_common::FinalizedBlockId;
+use pathfinder_common::BlockId;
 
 use crate::context::RpcContext;
 
@@ -18,7 +18,7 @@ pub async fn block_number(context: RpcContext) -> Result<Output, Error> {
             .context("Opening database connection")?;
         let tx = db.transaction().context("Opening database transaction")?;
 
-        tx.block_id(FinalizedBlockId::Latest)
+        tx.block_id(BlockId::Latest)
             .context("Reading latest block number from database")?
             .map(|(block_number, _)| Output(block_number))
             .ok_or(Error::NoBlocks)

--- a/crates/rpc/src/method/call.rs
+++ b/crates/rpc/src/method/call.rs
@@ -146,7 +146,7 @@ pub async fn call(
             other => {
                 let block_id = other
                     .to_common_or_panic(&db_tx)
-                    .or_else(|_| Err(CallError::BlockNotFound))?;
+                    .map_err(|_| CallError::BlockNotFound)?;
 
                 let header = db_tx
                     .block_header(block_id)

--- a/crates/rpc/src/method/call.rs
+++ b/crates/rpc/src/method/call.rs
@@ -145,7 +145,7 @@ pub async fn call(
             }
             other => {
                 let block_id = other
-                    .to_finalized_or_panic(&db_tx)
+                    .to_common_or_panic(&db_tx)
                     .or_else(|_| Err(CallError::BlockNotFound))?;
 
                 let header = db_tx

--- a/crates/rpc/src/method/call.rs
+++ b/crates/rpc/src/method/call.rs
@@ -144,7 +144,9 @@ pub async fn call(
                 (pending.header(), Some(pending.state_update()))
             }
             other => {
-                let block_id = other.to_finalized_or_panic();
+                let block_id = other
+                    .to_finalized_or_panic(&db_tx)
+                    .or_else(|_| Err(CallError::BlockNotFound))?;
 
                 let header = db_tx
                     .block_header(block_id)

--- a/crates/rpc/src/method/call.rs
+++ b/crates/rpc/src/method/call.rs
@@ -1,10 +1,11 @@
 use anyhow::Context;
-use pathfinder_common::{BlockId, CallParam, CallResultValue, ContractAddress, EntryPoint};
+use pathfinder_common::{CallParam, CallResultValue, ContractAddress, EntryPoint};
 use pathfinder_executor::{ExecutionState, L1BlobDataAvailability};
 
 use crate::context::RpcContext;
 use crate::error::ApplicationError;
 use crate::executor::CALLDATA_LIMIT;
+use crate::types::BlockId;
 use crate::RpcVersion;
 
 #[derive(Debug)]

--- a/crates/rpc/src/method/estimate_fee.rs
+++ b/crates/rpc/src/method/estimate_fee.rs
@@ -91,7 +91,7 @@ pub async fn estimate_fee(
             other => {
                 let block_id = other
                     .to_common_or_panic(&db_tx)
-                    .or_else(|_| Err(EstimateFeeError::BlockNotFound))?;
+                    .map_err(|_| EstimateFeeError::BlockNotFound)?;
 
                 let header = db_tx
                     .block_header(block_id)

--- a/crates/rpc/src/method/estimate_fee.rs
+++ b/crates/rpc/src/method/estimate_fee.rs
@@ -1,5 +1,4 @@
 use anyhow::Context;
-use pathfinder_common::BlockId;
 use pathfinder_executor::{ExecutionState, L1BlobDataAvailability};
 use serde::de::Error;
 
@@ -12,6 +11,7 @@ use crate::executor::{
     SIGNATURE_ELEMENT_LIMIT,
 };
 use crate::types::request::BroadcastedTransaction;
+use crate::types::BlockId;
 use crate::RpcVersion;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -225,7 +225,7 @@ mod tests {
     use pathfinder_common::macro_prelude::*;
     use pathfinder_common::prelude::*;
     use pathfinder_common::transaction::{DataAvailabilityMode, ResourceBound, ResourceBounds};
-    use pathfinder_common::{felt, BlockId, ResourceAmount, ResourcePricePerUnit, Tip};
+    use pathfinder_common::{felt, ResourceAmount, ResourcePricePerUnit, Tip};
     use pathfinder_executor::types::{FeeEstimate, PriceUnit};
     use pretty_assertions_sorted::assert_eq;
 
@@ -242,7 +242,7 @@ mod tests {
         BroadcastedInvokeTransactionV3,
         BroadcastedTransaction,
     };
-    use crate::types::{ContractClass, SierraContractClass};
+    use crate::types::{BlockId, ContractClass, SierraContractClass};
     use crate::RpcVersion;
 
     const RPC_VERSION: RpcVersion = RpcVersion::V09;

--- a/crates/rpc/src/method/estimate_fee.rs
+++ b/crates/rpc/src/method/estimate_fee.rs
@@ -90,7 +90,7 @@ pub async fn estimate_fee(
             }
             other => {
                 let block_id = other
-                    .to_finalized_or_panic(&db_tx)
+                    .to_common_or_panic(&db_tx)
                     .or_else(|_| Err(EstimateFeeError::BlockNotFound))?;
 
                 let header = db_tx

--- a/crates/rpc/src/method/estimate_fee.rs
+++ b/crates/rpc/src/method/estimate_fee.rs
@@ -89,7 +89,9 @@ pub async fn estimate_fee(
                 (pending.header(), Some(pending.state_update()))
             }
             other => {
-                let block_id = other.to_finalized_or_panic();
+                let block_id = other
+                    .to_finalized_or_panic(&db_tx)
+                    .or_else(|_| Err(EstimateFeeError::BlockNotFound))?;
 
                 let header = db_tx
                     .block_header(block_id)

--- a/crates/rpc/src/method/estimate_message_fee.rs
+++ b/crates/rpc/src/method/estimate_message_fee.rs
@@ -87,7 +87,7 @@ pub async fn estimate_message_fee(
             }
             other => {
                 let block_id = other
-                    .to_finalized_or_panic(&db_tx)
+                    .to_common_or_panic(&db_tx)
                     .or_else(|_| Err(EstimateMessageFeeError::BlockNotFound))?;
 
                 let header = db_tx

--- a/crates/rpc/src/method/estimate_message_fee.rs
+++ b/crates/rpc/src/method/estimate_message_fee.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use pathfinder_common::prelude::*;
-use pathfinder_common::BlockId;
 use pathfinder_crypto::Felt;
 use pathfinder_executor::{ExecutionState, IntoStarkFelt, L1BlobDataAvailability};
 use starknet_api::core::PatriciaKey;
@@ -11,6 +10,7 @@ use starknet_api::transaction::fields::{Calldata, Fee};
 use crate::context::RpcContext;
 use crate::error::ApplicationError;
 use crate::executor::CALLDATA_LIMIT;
+use crate::types::BlockId;
 use crate::RpcVersion;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -260,13 +260,14 @@ mod tests {
     use assert_matches::assert_matches;
     use pathfinder_common::macro_prelude::*;
     use pathfinder_common::prelude::*;
-    use pathfinder_common::{BlockId, L1DataAvailabilityMode};
+    use pathfinder_common::L1DataAvailabilityMode;
     use pathfinder_storage::StorageBuilder;
     use primitive_types::H160;
 
     use super::*;
     use crate::context::RpcContext;
     use crate::dto::{SerializeForVersion, Serializer};
+    use crate::types::BlockId;
     use crate::RpcVersion;
 
     enum Setup {

--- a/crates/rpc/src/method/estimate_message_fee.rs
+++ b/crates/rpc/src/method/estimate_message_fee.rs
@@ -86,7 +86,9 @@ pub async fn estimate_message_fee(
                 (pending.header(), Some(pending.state_update()))
             }
             other => {
-                let block_id = other.to_finalized_or_panic();
+                let block_id = other
+                    .to_finalized_or_panic(&db_tx)
+                    .or_else(|_| Err(EstimateMessageFeeError::BlockNotFound))?;
 
                 let header = db_tx
                     .block_header(block_id)

--- a/crates/rpc/src/method/estimate_message_fee.rs
+++ b/crates/rpc/src/method/estimate_message_fee.rs
@@ -88,7 +88,7 @@ pub async fn estimate_message_fee(
             other => {
                 let block_id = other
                     .to_common_or_panic(&db_tx)
-                    .or_else(|_| Err(EstimateMessageFeeError::BlockNotFound))?;
+                    .map_err(|_| EstimateMessageFeeError::BlockNotFound)?;
 
                 let header = db_tx
                     .block_header(block_id)

--- a/crates/rpc/src/method/get_block_transaction_count.rs
+++ b/crates/rpc/src/method/get_block_transaction_count.rs
@@ -49,7 +49,10 @@ pub async fn get_block_transaction_count(
                     .len() as u64;
                 return Ok(Output(count));
             }
-            other => other.to_finalized_or_panic(),
+
+            other => other
+                .to_finalized_or_panic(&db)
+                .or_else(|_| Err(Error::BlockNotFound))?,
         };
 
         let exists = db

--- a/crates/rpc/src/method/get_block_transaction_count.rs
+++ b/crates/rpc/src/method/get_block_transaction_count.rs
@@ -52,7 +52,7 @@ pub async fn get_block_transaction_count(
 
             other => other
                 .to_common_or_panic(&db)
-                .or_else(|_| Err(Error::BlockNotFound))?,
+                .map_err(|_| Error::BlockNotFound)?,
         };
 
         let exists = db

--- a/crates/rpc/src/method/get_block_transaction_count.rs
+++ b/crates/rpc/src/method/get_block_transaction_count.rs
@@ -1,12 +1,12 @@
 use anyhow::Context;
-use pathfinder_common::BlockId;
 
 use crate::context::RpcContext;
+use crate::types::BlockId;
 use crate::RpcVersion;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Input {
-    block_id: pathfinder_common::BlockId,
+    block_id: BlockId,
 }
 
 impl crate::dto::DeserializeForVersion for Input {

--- a/crates/rpc/src/method/get_block_transaction_count.rs
+++ b/crates/rpc/src/method/get_block_transaction_count.rs
@@ -51,7 +51,7 @@ pub async fn get_block_transaction_count(
             }
 
             other => other
-                .to_finalized_or_panic(&db)
+                .to_common_or_panic(&db)
                 .or_else(|_| Err(Error::BlockNotFound))?,
         };
 

--- a/crates/rpc/src/method/get_block_with_receipts.rs
+++ b/crates/rpc/src/method/get_block_with_receipts.rs
@@ -67,7 +67,7 @@ pub async fn get_block_with_receipts(
                 });
             }
             other => other
-                .to_finalized_or_panic(&db)
+                .to_common_or_panic(&db)
                 .or_else(|_| Err(Error::BlockNotFound))?,
         };
 

--- a/crates/rpc/src/method/get_block_with_receipts.rs
+++ b/crates/rpc/src/method/get_block_with_receipts.rs
@@ -68,7 +68,7 @@ pub async fn get_block_with_receipts(
             }
             other => other
                 .to_common_or_panic(&db)
-                .or_else(|_| Err(Error::BlockNotFound))?,
+                .map_err(|_| Error::BlockNotFound)?,
         };
 
         let header = db

--- a/crates/rpc/src/method/get_block_with_receipts.rs
+++ b/crates/rpc/src/method/get_block_with_receipts.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use anyhow::Context;
-use pathfinder_common::BlockId;
 
 use crate::context::RpcContext;
 use crate::pending::PendingBlockVariant;
+use crate::types::BlockId;
 use crate::RpcVersion;
 
 pub enum Output {

--- a/crates/rpc/src/method/get_block_with_receipts.rs
+++ b/crates/rpc/src/method/get_block_with_receipts.rs
@@ -66,7 +66,9 @@ pub async fn get_block_with_receipts(
                     block_number: pending.block_number(),
                 });
             }
-            other => other.to_finalized_or_panic(),
+            other => other
+                .to_finalized_or_panic(&db)
+                .or_else(|_| Err(Error::BlockNotFound))?,
         };
 
         let header = db

--- a/crates/rpc/src/method/get_block_with_tx_hashes.rs
+++ b/crates/rpc/src/method/get_block_with_tx_hashes.rs
@@ -1,10 +1,11 @@
 use std::sync::Arc;
 
 use anyhow::Context;
-use pathfinder_common::{BlockHeader, BlockId, BlockNumber, TransactionHash};
+use pathfinder_common::{BlockHeader, BlockNumber, TransactionHash};
 
 use crate::context::RpcContext;
 use crate::pending::PendingBlockVariant;
+use crate::types::BlockId;
 use crate::RpcVersion;
 
 crate::error::generate_rpc_error_subset!(Error: BlockNotFound);

--- a/crates/rpc/src/method/get_block_with_tx_hashes.rs
+++ b/crates/rpc/src/method/get_block_with_tx_hashes.rs
@@ -72,7 +72,7 @@ pub async fn get_block_with_tx_hashes(
                 });
             }
             other => other
-                .to_finalized_or_panic(&transaction)
+                .to_common_or_panic(&transaction)
                 .or_else(|_| Err(Error::BlockNotFound))?,
         };
 

--- a/crates/rpc/src/method/get_block_with_tx_hashes.rs
+++ b/crates/rpc/src/method/get_block_with_tx_hashes.rs
@@ -71,7 +71,9 @@ pub async fn get_block_with_tx_hashes(
                     transactions,
                 });
             }
-            other => other.to_finalized_or_panic(),
+            other => other
+                .to_finalized_or_panic(&transaction)
+                .or_else(|_| Err(Error::BlockNotFound))?,
         };
 
         let header = transaction

--- a/crates/rpc/src/method/get_block_with_tx_hashes.rs
+++ b/crates/rpc/src/method/get_block_with_tx_hashes.rs
@@ -73,7 +73,7 @@ pub async fn get_block_with_tx_hashes(
             }
             other => other
                 .to_common_or_panic(&transaction)
-                .or_else(|_| Err(Error::BlockNotFound))?,
+                .map_err(|_| Error::BlockNotFound)?,
         };
 
         let header = transaction

--- a/crates/rpc/src/method/get_block_with_txs.rs
+++ b/crates/rpc/src/method/get_block_with_txs.rs
@@ -73,7 +73,7 @@ pub async fn get_block_with_txs(
                 });
             }
             other => other
-                .to_finalized_or_panic(&transaction)
+                .to_common_or_panic(&transaction)
                 .or_else(|_| Err(Error::BlockNotFound))?,
         };
 

--- a/crates/rpc/src/method/get_block_with_txs.rs
+++ b/crates/rpc/src/method/get_block_with_txs.rs
@@ -2,10 +2,11 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use pathfinder_common::transaction::Transaction;
-use pathfinder_common::{BlockHeader, BlockId};
+use pathfinder_common::BlockHeader;
 
 use crate::context::RpcContext;
 use crate::pending::PendingBlockVariant;
+use crate::types::BlockId;
 use crate::RpcVersion;
 
 crate::error::generate_rpc_error_subset!(Error: BlockNotFound);

--- a/crates/rpc/src/method/get_block_with_txs.rs
+++ b/crates/rpc/src/method/get_block_with_txs.rs
@@ -72,7 +72,9 @@ pub async fn get_block_with_txs(
                     transactions,
                 });
             }
-            other => other.to_finalized_or_panic(),
+            other => other
+                .to_finalized_or_panic(&transaction)
+                .or_else(|_| Err(Error::BlockNotFound))?,
         };
 
         let header = transaction

--- a/crates/rpc/src/method/get_block_with_txs.rs
+++ b/crates/rpc/src/method/get_block_with_txs.rs
@@ -74,7 +74,7 @@ pub async fn get_block_with_txs(
             }
             other => other
                 .to_common_or_panic(&transaction)
-                .or_else(|_| Err(Error::BlockNotFound))?,
+                .map_err(|_| Error::BlockNotFound)?,
         };
 
         let header = transaction

--- a/crates/rpc/src/method/get_class.rs
+++ b/crates/rpc/src/method/get_class.rs
@@ -3,14 +3,14 @@ use pathfinder_common::ClassHash;
 
 use crate::context::RpcContext;
 use crate::dto::SerializeForVersion;
-use crate::types::{CairoContractClass, ContractClass, SierraContractClass};
+use crate::types::{BlockId, CairoContractClass, ContractClass, SierraContractClass};
 use crate::{dto, RpcVersion};
 
 crate::error::generate_rpc_error_subset!(Error: BlockNotFound, ClassHashNotFound);
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Input {
-    block_id: pathfinder_common::BlockId,
+    block_id: BlockId,
     class_hash: pathfinder_common::ClassHash,
 }
 
@@ -107,7 +107,6 @@ impl SerializeForVersion for Output {
 mod tests {
     use assert_matches::assert_matches;
     use pathfinder_common::macro_prelude::*;
-    use pathfinder_common::BlockId;
 
     use super::*;
 

--- a/crates/rpc/src/method/get_class.rs
+++ b/crates/rpc/src/method/get_class.rs
@@ -66,7 +66,10 @@ pub async fn get_class(
             false
         };
 
-        let block_id = input.block_id.to_finalized_coerced();
+        let block_id = input
+            .block_id
+            .to_finalized_coerced(&tx)
+            .or_else(|_| Err(Error::BlockNotFound))?;
         if !tx.block_exists(block_id)? {
             return Err(Error::BlockNotFound);
         }

--- a/crates/rpc/src/method/get_class.rs
+++ b/crates/rpc/src/method/get_class.rs
@@ -68,7 +68,7 @@ pub async fn get_class(
 
         let block_id = input
             .block_id
-            .to_finalized_coerced(&tx)
+            .to_common_coerced(&tx)
             .or_else(|_| Err(Error::BlockNotFound))?;
         if !tx.block_exists(block_id)? {
             return Err(Error::BlockNotFound);

--- a/crates/rpc/src/method/get_class.rs
+++ b/crates/rpc/src/method/get_class.rs
@@ -69,7 +69,7 @@ pub async fn get_class(
         let block_id = input
             .block_id
             .to_common_coerced(&tx)
-            .or_else(|_| Err(Error::BlockNotFound))?;
+            .map_err(|_| Error::BlockNotFound)?;
         if !tx.block_exists(block_id)? {
             return Err(Error::BlockNotFound);
         }

--- a/crates/rpc/src/method/get_class_at.rs
+++ b/crates/rpc/src/method/get_class_at.rs
@@ -79,7 +79,7 @@ pub async fn get_class_at(
         let block_id = input
             .block_id
             .to_common_or_panic(&tx)
-            .or_else(|_| Err(Error::BlockNotFound))?;
+            .map_err(|_| Error::BlockNotFound)?;
         if !tx.block_exists(block_id)? {
             return Err(Error::BlockNotFound);
         }

--- a/crates/rpc/src/method/get_class_at.rs
+++ b/crates/rpc/src/method/get_class_at.rs
@@ -78,7 +78,7 @@ pub async fn get_class_at(
 
         let block_id = input
             .block_id
-            .to_finalized_or_panic(&tx)
+            .to_common_or_panic(&tx)
             .or_else(|_| Err(Error::BlockNotFound))?;
         if !tx.block_exists(block_id)? {
             return Err(Error::BlockNotFound);

--- a/crates/rpc/src/method/get_class_at.rs
+++ b/crates/rpc/src/method/get_class_at.rs
@@ -76,7 +76,10 @@ pub async fn get_class_at(
             None
         };
 
-        let block_id = input.block_id.to_finalized_coerced();
+        let block_id = input
+            .block_id
+            .to_finalized_or_panic(&tx)
+            .or_else(|_| Err(Error::BlockNotFound))?;
         if !tx.block_exists(block_id)? {
             return Err(Error::BlockNotFound);
         }

--- a/crates/rpc/src/method/get_class_at.rs
+++ b/crates/rpc/src/method/get_class_at.rs
@@ -1,16 +1,16 @@
 use anyhow::Context;
-use pathfinder_common::{BlockId, ContractAddress};
+use pathfinder_common::ContractAddress;
 
 use crate::context::RpcContext;
 use crate::dto::SerializeForVersion;
-use crate::types::{CairoContractClass, ContractClass, SierraContractClass};
+use crate::types::{BlockId, CairoContractClass, ContractClass, SierraContractClass};
 use crate::{dto, RpcVersion};
 
 crate::error::generate_rpc_error_subset!(Error: BlockNotFound, ContractNotFound);
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Input {
-    block_id: pathfinder_common::BlockId,
+    block_id: BlockId,
     contract_address: pathfinder_common::ContractAddress,
 }
 

--- a/crates/rpc/src/method/get_class_at.rs
+++ b/crates/rpc/src/method/get_class_at.rs
@@ -78,7 +78,7 @@ pub async fn get_class_at(
 
         let block_id = input
             .block_id
-            .to_common_or_panic(&tx)
+            .to_common_coerced(&tx)
             .map_err(|_| Error::BlockNotFound)?;
         if !tx.block_exists(block_id)? {
             return Err(Error::BlockNotFound);

--- a/crates/rpc/src/method/get_class_hash_at.rs
+++ b/crates/rpc/src/method/get_class_hash_at.rs
@@ -1,7 +1,8 @@
 use anyhow::Context;
-use pathfinder_common::{BlockId, ClassHash, ContractAddress};
+use pathfinder_common::{ClassHash, ContractAddress};
 
 use crate::context::RpcContext;
+use crate::types::BlockId;
 use crate::RpcVersion;
 
 crate::error::generate_rpc_error_subset!(Error: BlockNotFound, ContractNotFound);

--- a/crates/rpc/src/method/get_class_hash_at.rs
+++ b/crates/rpc/src/method/get_class_hash_at.rs
@@ -58,7 +58,7 @@ pub async fn get_class_hash_at(
         let block_id = input
             .block_id
             .to_common_coerced(&tx)
-            .or_else(|_| Err(Error::BlockNotFound))?;
+            .map_err(|_| Error::BlockNotFound)?;
         if !tx.block_exists(block_id)? {
             return Err(Error::BlockNotFound);
         }

--- a/crates/rpc/src/method/get_class_hash_at.rs
+++ b/crates/rpc/src/method/get_class_hash_at.rs
@@ -55,7 +55,10 @@ pub async fn get_class_hash_at(
             }
         }
 
-        let block_id = input.block_id.to_finalized_coerced();
+        let block_id = input
+            .block_id
+            .to_finalized_coerced(&tx)
+            .or_else(|_| Err(Error::BlockNotFound))?;
         if !tx.block_exists(block_id)? {
             return Err(Error::BlockNotFound);
         }

--- a/crates/rpc/src/method/get_class_hash_at.rs
+++ b/crates/rpc/src/method/get_class_hash_at.rs
@@ -57,7 +57,7 @@ pub async fn get_class_hash_at(
 
         let block_id = input
             .block_id
-            .to_finalized_coerced(&tx)
+            .to_common_coerced(&tx)
             .or_else(|_| Err(Error::BlockNotFound))?;
         if !tx.block_exists(block_id)? {
             return Err(Error::BlockNotFound);

--- a/crates/rpc/src/method/get_events.rs
+++ b/crates/rpc/src/method/get_events.rs
@@ -2,13 +2,13 @@ use std::str::FromStr;
 
 use anyhow::Context;
 use pathfinder_common::prelude::*;
-use pathfinder_common::BlockId;
 use pathfinder_storage::{EventFilterError, EVENT_KEY_FILTER_LIMIT};
 use tokio::task::JoinHandle;
 
 use crate::context::RpcContext;
 use crate::dto::{self, SerializeForVersion, Serializer};
 use crate::pending::{PendingBlockVariant, PendingData};
+use crate::types::BlockId;
 use crate::RpcVersion;
 
 pub const EVENT_PAGE_SIZE_LIMIT: usize = 1024;

--- a/crates/rpc/src/method/get_events.rs
+++ b/crates/rpc/src/method/get_events.rs
@@ -399,7 +399,7 @@ fn map_from_block_to_number(
         Some(Number(number)) => Ok(Some(number)),
         Some(Pending) | Some(Latest) => {
             let number = tx
-                .block_id(pathfinder_common::FinalizedBlockId::Latest)
+                .block_id(pathfinder_common::BlockId::Latest)
                 .context("Querying latest block number")?
                 .ok_or(GetEventsError::BlockNotFound)?
                 .0;

--- a/crates/rpc/src/method/get_events.rs
+++ b/crates/rpc/src/method/get_events.rs
@@ -371,6 +371,14 @@ fn map_to_block_to_number(
             Ok(Some(number))
         }
         Some(Number(number)) => Ok(Some(number)),
+        Some(L1Accepted) => {
+            let number = tx
+                .l1_l2_pointer()
+                .context("Querying L1-L2 pointer")?
+                .ok_or(GetEventsError::BlockNotFound)?;
+
+            Ok(Some(number))
+        }
         Some(Pending) | Some(Latest) | None => Ok(None),
     }
 }
@@ -397,6 +405,14 @@ fn map_from_block_to_number(
             Ok(Some(number))
         }
         Some(Number(number)) => Ok(Some(number)),
+        Some(L1Accepted) => {
+            let number = tx
+                .l1_l2_pointer()
+                .context("Querying L1-L2 pointer")?
+                .ok_or(GetEventsError::BlockNotFound)?;
+
+            Ok(Some(number))
+        }
         Some(Pending) | Some(Latest) => {
             let number = tx
                 .block_id(pathfinder_common::BlockId::Latest)

--- a/crates/rpc/src/method/get_nonce.rs
+++ b/crates/rpc/src/method/get_nonce.rs
@@ -139,6 +139,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn l1_accepted() {
+        let context = RpcContext::for_tests();
+
+        // This contract is created in `setup_storage` at block 1,
+        // so we expect the nonce to be 0x0 at block 1 (L1 accepted)
+        let input = Input {
+            block_id: BlockId::L1Accepted,
+            contract_address: contract_address_bytes!(b"contract 1"),
+        };
+        let nonce = get_nonce(context, input, RPC_VERSION).await.unwrap();
+        assert_eq!(nonce.0, contract_nonce!("0x0"));
+    }
+
+    #[tokio::test]
     async fn latest() {
         let context = RpcContext::for_tests();
 

--- a/crates/rpc/src/method/get_nonce.rs
+++ b/crates/rpc/src/method/get_nonce.rs
@@ -55,7 +55,10 @@ pub async fn get_nonce(
 
         // Check that block exists. This should occur first as the block number
         // isn't checked explicitly (i.e. nonce fetch just uses <= number).
-        let block_id = input.block_id.to_finalized_coerced();
+        let block_id = input
+            .block_id
+            .to_finalized_coerced(&tx)
+            .or_else(|_| Err(Error::BlockNotFound))?;
         if !tx.block_exists(block_id)? {
             return Err(Error::BlockNotFound);
         }

--- a/crates/rpc/src/method/get_nonce.rs
+++ b/crates/rpc/src/method/get_nonce.rs
@@ -58,7 +58,7 @@ pub async fn get_nonce(
         let block_id = input
             .block_id
             .to_common_coerced(&tx)
-            .or_else(|_| Err(Error::BlockNotFound))?;
+            .map_err(|_| Error::BlockNotFound)?;
         if !tx.block_exists(block_id)? {
             return Err(Error::BlockNotFound);
         }

--- a/crates/rpc/src/method/get_nonce.rs
+++ b/crates/rpc/src/method/get_nonce.rs
@@ -1,7 +1,8 @@
 use anyhow::Context;
-use pathfinder_common::{BlockId, ContractAddress, ContractNonce};
+use pathfinder_common::{ContractAddress, ContractNonce};
 
 use crate::context::RpcContext;
+use crate::types::BlockId;
 use crate::RpcVersion;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -96,10 +97,11 @@ impl crate::dto::SerializeForVersion for Output {
 mod tests {
     use assert_matches::assert_matches;
     use pathfinder_common::macro_prelude::*;
-    use pathfinder_common::{BlockId, BlockNumber, ContractNonce};
+    use pathfinder_common::{BlockNumber, ContractNonce};
 
     use super::{get_nonce, Error, Input};
     use crate::context::RpcContext;
+    use crate::types::BlockId;
     use crate::RpcVersion;
 
     const RPC_VERSION: RpcVersion = RpcVersion::V09;

--- a/crates/rpc/src/method/get_nonce.rs
+++ b/crates/rpc/src/method/get_nonce.rs
@@ -57,7 +57,7 @@ pub async fn get_nonce(
         // isn't checked explicitly (i.e. nonce fetch just uses <= number).
         let block_id = input
             .block_id
-            .to_finalized_coerced(&tx)
+            .to_common_coerced(&tx)
             .or_else(|_| Err(Error::BlockNotFound))?;
         if !tx.block_exists(block_id)? {
             return Err(Error::BlockNotFound);

--- a/crates/rpc/src/method/get_state_update.rs
+++ b/crates/rpc/src/method/get_state_update.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
 use anyhow::Context;
-use pathfinder_common::{BlockId, StateUpdate};
+use pathfinder_common::StateUpdate;
 
+use crate::types::BlockId;
 use crate::{dto, RpcContext, RpcVersion};
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/rpc/src/method/get_state_update.rs
+++ b/crates/rpc/src/method/get_state_update.rs
@@ -65,7 +65,7 @@ pub async fn get_state_update(
 
         let block_id = input
             .block_id
-            .to_finalized_or_panic(&tx)
+            .to_common_or_panic(&tx)
             .or_else(|_| Err(Error::BlockNotFound))?;
 
         let Some(block_number) = tx.block_number(block_id).context("Fetching block number")? else {

--- a/crates/rpc/src/method/get_state_update.rs
+++ b/crates/rpc/src/method/get_state_update.rs
@@ -66,7 +66,7 @@ pub async fn get_state_update(
         let block_id = input
             .block_id
             .to_common_or_panic(&tx)
-            .or_else(|_| Err(Error::BlockNotFound))?;
+            .map_err(|_| Error::BlockNotFound)?;
 
         let Some(block_number) = tx.block_number(block_id).context("Fetching block number")? else {
             return Err(Error::BlockNotFound);

--- a/crates/rpc/src/method/get_state_update.rs
+++ b/crates/rpc/src/method/get_state_update.rs
@@ -63,7 +63,10 @@ pub async fn get_state_update(
             return Ok(Output::Pending(state_update));
         }
 
-        let block_id = input.block_id.to_finalized_or_panic();
+        let block_id = input
+            .block_id
+            .to_finalized_or_panic(&tx)
+            .or_else(|_| Err(Error::BlockNotFound))?;
 
         let Some(block_number) = tx.block_number(block_id).context("Fetching block number")? else {
             return Err(Error::BlockNotFound);

--- a/crates/rpc/src/method/get_storage_at.rs
+++ b/crates/rpc/src/method/get_storage_at.rs
@@ -216,6 +216,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn l1_accepted() {
+        let ctx = RpcContext::for_tests_with_pending().await;
+        let contract_address = contract_address_bytes!(b"contract 1");
+        let key = storage_address_bytes!(b"storage addr 0");
+        let block_id = BlockId::L1Accepted;
+
+        let result = get_storage_at(
+            ctx,
+            Input {
+                contract_address,
+                key,
+                block_id,
+            },
+            RPC_VERSION,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.0, storage_value_bytes!(b"storage value 1"));
+    }
+
+    #[tokio::test]
     async fn defaults_to_zero() {
         let ctx = RpcContext::for_tests_with_pending().await;
         let contract_address = contract_address_bytes!(b"contract 1");

--- a/crates/rpc/src/method/get_storage_at.rs
+++ b/crates/rpc/src/method/get_storage_at.rs
@@ -60,7 +60,7 @@ pub async fn get_storage_at(
         let block_id = input
             .block_id
             .to_common_coerced(&tx)
-            .or_else(|_| Err(Error::BlockNotFound))?;
+            .map_err(|_| Error::BlockNotFound)?;
         if !tx.block_exists(block_id)? {
             return Err(Error::BlockNotFound);
         }

--- a/crates/rpc/src/method/get_storage_at.rs
+++ b/crates/rpc/src/method/get_storage_at.rs
@@ -59,7 +59,7 @@ pub async fn get_storage_at(
 
         let block_id = input
             .block_id
-            .to_finalized_coerced(&tx)
+            .to_common_coerced(&tx)
             .or_else(|_| Err(Error::BlockNotFound))?;
         if !tx.block_exists(block_id)? {
             return Err(Error::BlockNotFound);

--- a/crates/rpc/src/method/get_storage_at.rs
+++ b/crates/rpc/src/method/get_storage_at.rs
@@ -1,7 +1,8 @@
 use anyhow::Context;
-use pathfinder_common::{BlockId, ContractAddress, StorageAddress, StorageValue};
+use pathfinder_common::{ContractAddress, StorageAddress, StorageValue};
 
 use crate::context::RpcContext;
+use crate::types::BlockId;
 use crate::RpcVersion;
 
 #[derive(Debug, PartialEq, Eq)]

--- a/crates/rpc/src/method/get_storage_at.rs
+++ b/crates/rpc/src/method/get_storage_at.rs
@@ -57,7 +57,10 @@ pub async fn get_storage_at(
             }
         }
 
-        let block_id = input.block_id.to_finalized_coerced();
+        let block_id = input
+            .block_id
+            .to_finalized_coerced(&tx)
+            .or_else(|_| Err(Error::BlockNotFound))?;
         if !tx.block_exists(block_id)? {
             return Err(Error::BlockNotFound);
         }

--- a/crates/rpc/src/method/get_storage_proof.rs
+++ b/crates/rpc/src/method/get_storage_proof.rs
@@ -294,7 +294,7 @@ pub async fn get_storage_proof(context: RpcContext, input: Input) -> Result<Outp
                 return Err(Error::ProofMissing);
             }
             other => other
-                .to_finalized_or_panic(&tx)
+                .to_common_or_panic(&tx)
                 .or_else(|_| Err(Error::BlockNotFound))?,
         };
 

--- a/crates/rpc/src/method/get_storage_proof.rs
+++ b/crates/rpc/src/method/get_storage_proof.rs
@@ -3,7 +3,6 @@ use std::collections::HashSet;
 use anyhow::Context;
 use pathfinder_common::prelude::*;
 use pathfinder_common::trie::TrieNode;
-use pathfinder_common::BlockId;
 use pathfinder_crypto::Felt;
 use pathfinder_merkle_tree::tree::GetProofError;
 use pathfinder_merkle_tree::{ClassCommitmentTree, ContractsStorageTree, StorageCommitmentTree};
@@ -11,6 +10,7 @@ use pathfinder_storage::Transaction;
 
 use crate::context::RpcContext;
 use crate::dto::{DeserializeForVersion, SerializeForVersion};
+use crate::types::BlockId;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ContractStorageKeys {
@@ -507,6 +507,7 @@ mod tests {
 
     use super::*;
     use crate::dto::SerializeForVersion;
+    use crate::types::BlockId;
 
     mod serialization {
         use bitvec::bitvec;

--- a/crates/rpc/src/method/get_storage_proof.rs
+++ b/crates/rpc/src/method/get_storage_proof.rs
@@ -295,7 +295,7 @@ pub async fn get_storage_proof(context: RpcContext, input: Input) -> Result<Outp
             }
             other => other
                 .to_common_or_panic(&tx)
-                .or_else(|_| Err(Error::BlockNotFound))?,
+                .map_err(|_| Error::BlockNotFound)?,
         };
 
         // Use internal error to indicate that the process of querying for a particular

--- a/crates/rpc/src/method/get_transaction_by_block_id_and_index.rs
+++ b/crates/rpc/src/method/get_transaction_by_block_id_and_index.rs
@@ -65,7 +65,7 @@ pub async fn get_transaction_by_block_id_and_index(
                 return result.map(Output);
             }
             other => other
-                .to_finalized_or_panic(&db_tx)
+                .to_common_or_panic(&db_tx)
                 .or_else(|_| Err(GetTransactionByBlockIdAndIndexError::BlockNotFound))?,
         };
 

--- a/crates/rpc/src/method/get_transaction_by_block_id_and_index.rs
+++ b/crates/rpc/src/method/get_transaction_by_block_id_and_index.rs
@@ -1,8 +1,9 @@
 use anyhow::Context;
 use pathfinder_common::transaction::Transaction;
-use pathfinder_common::{BlockId, TransactionIndex};
+use pathfinder_common::TransactionIndex;
 
 use crate::context::RpcContext;
+use crate::types::BlockId;
 use crate::RpcVersion;
 
 #[derive(Debug, PartialEq, Eq)]

--- a/crates/rpc/src/method/get_transaction_by_block_id_and_index.rs
+++ b/crates/rpc/src/method/get_transaction_by_block_id_and_index.rs
@@ -64,7 +64,9 @@ pub async fn get_transaction_by_block_id_and_index(
                     .ok_or(GetTransactionByBlockIdAndIndexError::InvalidTxnIndex);
                 return result.map(Output);
             }
-            other => other.to_finalized_or_panic(),
+            other => other
+                .to_finalized_or_panic(&db_tx)
+                .or_else(|_| Err(GetTransactionByBlockIdAndIndexError::BlockNotFound))?,
         };
 
         // Get the transaction from storage.

--- a/crates/rpc/src/method/get_transaction_by_block_id_and_index.rs
+++ b/crates/rpc/src/method/get_transaction_by_block_id_and_index.rs
@@ -66,7 +66,7 @@ pub async fn get_transaction_by_block_id_and_index(
             }
             other => other
                 .to_common_or_panic(&db_tx)
-                .or_else(|_| Err(GetTransactionByBlockIdAndIndexError::BlockNotFound))?,
+                .map_err(|_| GetTransactionByBlockIdAndIndexError::BlockNotFound)?,
         };
 
         // Get the transaction from storage.

--- a/crates/rpc/src/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/method/get_transaction_receipt.rs
@@ -162,10 +162,36 @@ mod tests {
     #[case::v08(RpcVersion::V08)]
     #[case::v09(RpcVersion::V09)]
     #[tokio::test]
+    async fn l1_accepted(#[case] version: RpcVersion) {
+        let context = RpcContext::for_tests();
+        // This transaction is in block 1 which is L1 accepted.
+        let tx_hash = transaction_hash_bytes!(b"txn 1");
+        let input = Input {
+            transaction_hash: tx_hash,
+        };
+        let output = get_transaction_receipt(context, input, version)
+            .await
+            .unwrap();
+
+        let output_json = output.serialize(Serializer { version }).unwrap();
+
+        crate::assert_json_matches_fixture!(
+            output_json,
+            version,
+            "transactions/receipt_l1_accepted.json"
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::v06(RpcVersion::V06)]
+    #[case::v07(RpcVersion::V07)]
+    #[case::v08(RpcVersion::V08)]
+    #[case::v09(RpcVersion::V09)]
+    #[tokio::test]
     async fn l2_accepted(#[case] version: RpcVersion) {
         let context = RpcContext::for_tests();
-        // This transaction is in block 1 which is not L1 accepted.
-        let tx_hash = transaction_hash_bytes!(b"txn 1");
+        // This transaction is in block 2 which is L2 accepted.
+        let tx_hash = transaction_hash_bytes!(b"txn 3");
         let input = Input {
             transaction_hash: tx_hash,
         };

--- a/crates/rpc/src/method/get_transaction_status.rs
+++ b/crates/rpc/src/method/get_transaction_status.rs
@@ -257,8 +257,8 @@ mod tests {
     #[tokio::test]
     async fn l1_accepted() {
         let context = RpcContext::for_tests();
-        // This transaction is in block 0 which is L1 accepted.
-        let tx_hash = transaction_hash_bytes!(b"txn 0");
+        // This transaction is in block 1 which is L1 accepted.
+        let tx_hash = transaction_hash_bytes!(b"txn 1");
         let input = Input {
             transaction_hash: tx_hash,
         };
@@ -277,8 +277,8 @@ mod tests {
     #[tokio::test]
     async fn l2_accepted(#[case] version: RpcVersion) {
         let context = RpcContext::for_tests();
-        // This transaction is in block 1 which is not L1 accepted.
-        let tx_hash = transaction_hash_bytes!(b"txn 1");
+        // This transaction is in block 2 which is not L1 accepted.
+        let tx_hash = transaction_hash_bytes!(b"txn 3");
         let input = Input {
             transaction_hash: tx_hash,
         };

--- a/crates/rpc/src/method/last_l1_accepted_block_hash_and_number.rs
+++ b/crates/rpc/src/method/last_l1_accepted_block_hash_and_number.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use pathfinder_common::FinalizedBlockId;
+use pathfinder_common::BlockId;
 
 use crate::context::RpcContext;
 
@@ -25,7 +25,7 @@ pub async fn last_l1_accepted_block_hash_and_number(context: RpcContext) -> Resu
         let opt_block_number = db_tx.l1_l2_pointer().context("Querying L1-L2 pointer")?;
         let last_block_number = opt_block_number.ok_or(Error::NoBlocks)?;
         db_tx
-            .block_id(FinalizedBlockId::Number(last_block_number))
+            .block_id(BlockId::Number(last_block_number))
             .context("Reading latest accepted block number and hash from database")?
             .map(|(number, hash)| Output { number, hash })
             .ok_or(Error::NoBlocks)
@@ -48,7 +48,7 @@ impl crate::dto::SerializeForVersion for Output {
 
 #[cfg(test)]
 mod tests {
-    use pathfinder_common::{felt, BlockHash, BlockNumber};
+    use pathfinder_common::{block_hash_bytes, BlockNumber};
     use pathfinder_storage::{StorageBuilder, TriePruneMode};
     use pretty_assertions_sorted::assert_eq;
     use serde_json::json;
@@ -65,8 +65,8 @@ mod tests {
             .unwrap();
 
         let expected = Output {
-            number: BlockNumber::GENESIS,
-            hash: BlockHash(felt!("0x67656E65736973")),
+            number: BlockNumber::new_or_panic(1),
+            hash: block_hash_bytes!(b"block 1"),
         };
         assert_eq!(actual, expected);
     }

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -91,7 +91,9 @@ pub async fn simulate_transactions(
                 (pending.header(), Some(pending.state_update()))
             }
             other => {
-                let block_id = other.to_finalized_or_panic();
+                let block_id = other
+                    .to_finalized_or_panic(&db_tx)
+                    .or_else(|_| Err(SimulateTransactionError::BlockNotFound))?;
 
                 let header = db_tx
                     .block_header(block_id)

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -1,5 +1,4 @@
 use anyhow::Context;
-use pathfinder_common::BlockId;
 use pathfinder_executor::TransactionExecutionError;
 
 use crate::context::RpcContext;
@@ -11,6 +10,7 @@ use crate::executor::{
     SIGNATURE_ELEMENT_LIMIT,
 };
 use crate::types::request::BroadcastedTransaction;
+use crate::types::BlockId;
 use crate::RpcVersion;
 
 #[derive(Debug)]
@@ -239,7 +239,6 @@ pub(crate) mod tests {
     use assert_matches::assert_matches;
     use pathfinder_common::macro_prelude::*;
     use pathfinder_common::prelude::*;
-    use pathfinder_common::BlockId;
     use pathfinder_crypto::Felt;
     use pathfinder_executor::types::{
         DeclareTransactionExecutionInfo,
@@ -261,6 +260,7 @@ pub(crate) mod tests {
         BroadcastedDeclareTransactionV1,
         BroadcastedTransaction,
     };
+    use crate::types::BlockId;
     use crate::RpcVersion;
 
     pub(crate) async fn setup_storage_with_starknet_version(

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -93,7 +93,7 @@ pub async fn simulate_transactions(
             other => {
                 let block_id = other
                     .to_common_or_panic(&db_tx)
-                    .or_else(|_| Err(SimulateTransactionError::BlockNotFound))?;
+                    .map_err(|_| SimulateTransactionError::BlockNotFound)?;
 
                 let header = db_tx
                     .block_header(block_id)

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -92,7 +92,7 @@ pub async fn simulate_transactions(
             }
             other => {
                 let block_id = other
-                    .to_finalized_or_panic(&db_tx)
+                    .to_common_or_panic(&db_tx)
                     .or_else(|_| Err(SimulateTransactionError::BlockNotFound))?;
 
                 let header = db_tx

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -145,7 +145,7 @@ pub async fn trace_block_transactions(
 
     context
         .sequencer
-        .block_traces(input.block_id)
+        .block_traces(input.block_id.into())
         .await
         .context("Forwarding to feeder gateway")
         .map_err(TraceBlockTransactionsError::from)

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -79,7 +79,7 @@ pub async fn trace_block_transactions(
             other => {
                 let block_id = other
                     .to_common_or_panic(&db_tx)
-                    .or_else(|_| Err(TraceBlockTransactionsError::BlockNotFound))?;
+                    .map_err(|_| TraceBlockTransactionsError::BlockNotFound)?;
 
                 let header = db_tx
                     .block_header(block_id)?

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -1,5 +1,4 @@
 use anyhow::Context;
-use pathfinder_common::BlockId;
 use pathfinder_executor::types::InnerCallExecutionResources;
 use pathfinder_executor::TransactionExecutionError;
 use starknet_gateway_client::GatewayApi;
@@ -9,6 +8,7 @@ use crate::executor::{
     ExecutionStateError,
     VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEWAY,
 };
+use crate::types::BlockId;
 use crate::{compose_executor_transaction, RpcVersion};
 
 #[derive(Debug, Clone)]

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -78,7 +78,7 @@ pub async fn trace_block_transactions(
             }
             other => {
                 let block_id = other
-                    .to_finalized_or_panic(&db_tx)
+                    .to_common_or_panic(&db_tx)
                     .or_else(|_| Err(TraceBlockTransactionsError::BlockNotFound))?;
 
                 let header = db_tx

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -350,7 +350,7 @@ impl PendingWatcher {
         }
 
         let latest = tx
-            .block_header(pathfinder_common::FinalizedBlockId::Latest)
+            .block_header(pathfinder_common::BlockId::Latest)
             .context("Querying latest block header")?
             .unwrap_or_default();
 

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -54,7 +54,7 @@ pub mod request {
         /// # Panics
         ///
         /// If this [BlockId] is [`BlockId::Pending`].
-        pub fn to_finalized_or_panic(
+        pub fn to_common_or_panic(
             self,
             tx: &pathfinder_storage::Transaction<'_>,
         ) -> anyhow::Result<pathfinder_common::BlockId> {
@@ -80,7 +80,7 @@ pub mod request {
         ///
         /// Coerces [`BlockId::Pending`] to
         /// [`pathfinder_common::BlockId::Latest`].
-        pub fn to_finalized_coerced(
+        pub fn to_common_coerced(
             self,
             tx: &pathfinder_storage::Transaction<'_>,
         ) -> anyhow::Result<pathfinder_common::BlockId> {

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -11,7 +11,7 @@ pub use request::BlockId;
 pub mod request {
     use pathfinder_common::prelude::*;
     use pathfinder_common::transaction::{DataAvailabilityMode, ResourceBounds};
-    use pathfinder_common::{FinalizedBlockId, TipHex};
+    use pathfinder_common::TipHex;
     use serde::de::Error;
     use serde::Deserialize;
     use serde_with::serde_as;
@@ -44,28 +44,29 @@ pub mod request {
             matches!(self, BlockId::Pending)
         }
 
-        /// Converts this [BlockId] to a [FinalizedBlockId].
+        /// Converts this [BlockId] to a [pathfinder_common::BlockId].
         ///
         /// # Panics
         ///
         /// If this [BlockId] is [`BlockId::Pending`].
-        pub fn to_finalized_or_panic(self) -> FinalizedBlockId {
+        pub fn to_finalized_or_panic(self) -> pathfinder_common::BlockId {
             match self {
-                BlockId::Number(number) => FinalizedBlockId::Number(number),
-                BlockId::Hash(hash) => FinalizedBlockId::Hash(hash),
-                BlockId::Latest => FinalizedBlockId::Latest,
+                BlockId::Number(number) => pathfinder_common::BlockId::Number(number),
+                BlockId::Hash(hash) => pathfinder_common::BlockId::Hash(hash),
+                BlockId::Latest => pathfinder_common::BlockId::Latest,
                 BlockId::Pending => panic!("Cannot convert BlockId::Pending to FinalizedBlockId"),
             }
         }
 
-        /// Converts this [BlockId] to a [FinalizedBlockId].
+        /// Converts this [BlockId] to a [pathfinder_common::BlockId].
         ///
-        /// Coerces [`BlockId::Pending`] to [`FinalizedBlockId::Latest`].
-        pub fn to_finalized_coerced(self) -> FinalizedBlockId {
+        /// Coerces [`BlockId::Pending`] to
+        /// [`pathfinder_common::BlockId::Latest`].
+        pub fn to_finalized_coerced(self) -> pathfinder_common::BlockId {
             match self {
-                BlockId::Number(number) => FinalizedBlockId::Number(number),
-                BlockId::Hash(hash) => FinalizedBlockId::Hash(hash),
-                BlockId::Latest | BlockId::Pending => FinalizedBlockId::Latest,
+                BlockId::Number(number) => pathfinder_common::BlockId::Number(number),
+                BlockId::Hash(hash) => pathfinder_common::BlockId::Hash(hash),
+                BlockId::Latest | BlockId::Pending => pathfinder_common::BlockId::Latest,
             }
         }
     }
@@ -91,16 +92,16 @@ pub mod request {
         Latest,
     }
 
-    impl From<SubscriptionBlockId> for pathfinder_common::FinalizedBlockId {
+    impl From<SubscriptionBlockId> for pathfinder_common::BlockId {
         fn from(value: SubscriptionBlockId) -> Self {
             match value {
                 SubscriptionBlockId::Number(block_number) => {
-                    pathfinder_common::FinalizedBlockId::Number(block_number)
+                    pathfinder_common::BlockId::Number(block_number)
                 }
                 SubscriptionBlockId::Hash(block_hash) => {
-                    pathfinder_common::FinalizedBlockId::Hash(block_hash)
+                    pathfinder_common::BlockId::Hash(block_hash)
                 }
-                SubscriptionBlockId::Latest => pathfinder_common::FinalizedBlockId::Latest,
+                SubscriptionBlockId::Latest => pathfinder_common::BlockId::Latest,
             }
         }
     }

--- a/crates/storage/src/connection/event.rs
+++ b/crates/storage/src/connection/event.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use anyhow::{Context, Result};
 use pathfinder_common::event::Event;
 use pathfinder_common::prelude::*;
-use pathfinder_common::FinalizedBlockId;
+use pathfinder_common::BlockId;
 use rusqlite::types::Value;
 
 use crate::bloom::{AggregateBloom, BlockRange, BloomFilter};
@@ -157,7 +157,7 @@ impl Transaction<'_> {
         contract_address: Option<ContractAddress>,
         mut keys: Vec<Vec<EventKey>>,
     ) -> anyhow::Result<(Vec<EmittedEvent>, Option<BlockNumber>)> {
-        let Some(latest_block) = self.block_number(FinalizedBlockId::Latest)? else {
+        let Some(latest_block) = self.block_number(BlockId::Latest)? else {
             // No blocks in the database.
             return Ok((vec![], None));
         };
@@ -195,7 +195,7 @@ impl Transaction<'_> {
         let mut emitted_events = vec![];
 
         for block in blocks_to_scan {
-            let Some(block_header) = self.block_header(FinalizedBlockId::Number(block))? else {
+            let Some(block_header) = self.block_header(BlockId::Number(block))? else {
                 break;
             };
 
@@ -254,7 +254,7 @@ impl Transaction<'_> {
             return Err(EventFilterError::PageSizeTooSmall);
         }
 
-        let Some(latest_block) = self.block_number(FinalizedBlockId::Latest)? else {
+        let Some(latest_block) = self.block_number(BlockId::Latest)? else {
             // No blocks in the database.
             return Ok(PageOfEvents {
                 events: vec![],
@@ -321,7 +321,7 @@ impl Transaction<'_> {
             tracing::trace!(%block, %events_required, "Processing block");
 
             let block_header = self
-                .block_header(FinalizedBlockId::Number(block))?
+                .block_header(BlockId::Number(block))?
                 .expect("Only existing blocks should be scanned");
 
             let events = match self.events_for_block(block.into())? {

--- a/crates/storage/src/connection/state_update.rs
+++ b/crates/storage/src/connection/state_update.rs
@@ -10,7 +10,7 @@ use pathfinder_common::state_update::{
     StateUpdateData,
     SystemContractUpdate,
 };
-use pathfinder_common::FinalizedBlockId;
+use pathfinder_common::BlockId;
 
 use crate::prelude::*;
 
@@ -249,7 +249,7 @@ impl Transaction<'_> {
 
     fn block_details(
         &self,
-        block: FinalizedBlockId,
+        block: BlockId,
     ) -> anyhow::Result<Option<(BlockNumber, BlockHash, StateCommitment, StateCommitment)>> {
         use const_format::formatcp;
 
@@ -284,15 +284,15 @@ impl Transaction<'_> {
         let tx = self.inner();
 
         match block {
-            FinalizedBlockId::Latest => tx.query_row(LATEST, [], handle_row),
-            FinalizedBlockId::Number(number) => tx.query_row(NUMBER, params![&number], handle_row),
-            FinalizedBlockId::Hash(hash) => tx.query_row(HASH, params![&hash], handle_row),
+            BlockId::Latest => tx.query_row(LATEST, [], handle_row),
+            BlockId::Number(number) => tx.query_row(NUMBER, params![&number], handle_row),
+            BlockId::Hash(hash) => tx.query_row(HASH, params![&hash], handle_row),
         }
         .optional()
         .map_err(Into::into)
     }
 
-    pub fn state_update(&self, block: FinalizedBlockId) -> anyhow::Result<Option<StateUpdate>> {
+    pub fn state_update(&self, block: BlockId) -> anyhow::Result<Option<StateUpdate>> {
         let Some((block_number, block_hash, state_commitment, parent_state_commitment)) =
             self.block_details(block).context("Querying block header")?
         else {
@@ -531,10 +531,7 @@ impl Transaction<'_> {
     }
 
     /// Returns hashes of Cairo and Sierra classes declared at a given block.
-    pub fn declared_classes_at(
-        &self,
-        block: FinalizedBlockId,
-    ) -> anyhow::Result<Option<Vec<ClassHash>>> {
+    pub fn declared_classes_at(&self, block: BlockId) -> anyhow::Result<Option<Vec<ClassHash>>> {
         let Some((block_number, _)) = self.block_id(block).context("Querying block header")? else {
             return Ok(None);
         };
@@ -583,12 +580,12 @@ impl Transaction<'_> {
 
     pub fn storage_value(
         &self,
-        block: FinalizedBlockId,
+        block: BlockId,
         contract_address: ContractAddress,
         key: StorageAddress,
     ) -> anyhow::Result<Option<StorageValue>> {
         match block {
-            FinalizedBlockId::Latest => {
+            BlockId::Latest => {
                 let mut stmt = self.inner().prepare_cached(
                     r"
                     SELECT storage_value
@@ -603,7 +600,7 @@ impl Transaction<'_> {
                     row.get_storage_value(0)
                 })
             }
-            FinalizedBlockId::Number(number) => {
+            BlockId::Number(number) => {
                 let mut stmt = self.inner().prepare_cached(
                     r"
                     SELECT storage_value
@@ -618,7 +615,7 @@ impl Transaction<'_> {
                     row.get_storage_value(0)
                 })
             }
-            FinalizedBlockId::Hash(hash) => {
+            BlockId::Hash(hash) => {
                 let mut stmt = self.inner().prepare_cached(
                     r"
                     SELECT storage_value
@@ -643,10 +640,10 @@ impl Transaction<'_> {
     pub fn contract_exists(
         &self,
         contract_address: ContractAddress,
-        block_id: FinalizedBlockId,
+        block_id: BlockId,
     ) -> anyhow::Result<bool> {
         match block_id {
-            FinalizedBlockId::Number(number) => {
+            BlockId::Number(number) => {
                 let mut stmt = self.inner().prepare_cached(
                     "SELECT EXISTS(SELECT 1 FROM contract_updates WHERE contract_address = ? AND block_number <= ?)",
                 )?;
@@ -655,7 +652,7 @@ impl Transaction<'_> {
                     |row| row.get(0),
                 )
             }
-            FinalizedBlockId::Hash(hash) => {
+            BlockId::Hash(hash) => {
                 let mut stmt = self.inner().prepare_cached(
                     r"SELECT EXISTS(
                         SELECT 1 FROM contract_updates WHERE contract_address = ? AND block_number <= (
@@ -668,7 +665,7 @@ impl Transaction<'_> {
                     |row| row.get(0),
                 )
             }
-            FinalizedBlockId::Latest => {
+            BlockId::Latest => {
                 let mut stmt = self.inner().prepare_cached(
                     "SELECT EXISTS(SELECT 1 FROM contract_updates WHERE contract_address = ?)",
                 )?;
@@ -684,10 +681,10 @@ impl Transaction<'_> {
     pub fn contract_nonce(
         &self,
         contract_address: ContractAddress,
-        block_id: FinalizedBlockId,
+        block_id: BlockId,
     ) -> anyhow::Result<Option<ContractNonce>> {
         match block_id {
-            FinalizedBlockId::Latest => {
+            BlockId::Latest => {
                 let mut stmt = self.inner().prepare_cached(
                     r"
                     SELECT nonce FROM nonce_updates
@@ -698,7 +695,7 @@ impl Transaction<'_> {
                 )?;
                 stmt.query_row(params![&contract_address], |row| row.get_contract_nonce(0))
             }
-            FinalizedBlockId::Number(number) => {
+            BlockId::Number(number) => {
                 let mut stmt = self.inner().prepare_cached(
                     r"
                     SELECT nonce FROM nonce_updates
@@ -711,7 +708,7 @@ impl Transaction<'_> {
                     row.get_contract_nonce(0)
                 })
             }
-            FinalizedBlockId::Hash(hash) => {
+            BlockId::Hash(hash) => {
                 let mut stmt = self.inner().prepare_cached(
                     r"
                     SELECT nonce FROM nonce_updates
@@ -733,11 +730,11 @@ impl Transaction<'_> {
 
     pub fn contract_class_hash(
         &self,
-        block_id: FinalizedBlockId,
+        block_id: BlockId,
         contract_address: ContractAddress,
     ) -> anyhow::Result<Option<ClassHash>> {
         match block_id {
-            FinalizedBlockId::Latest => {
+            BlockId::Latest => {
                 let mut stmt = self.inner().prepare_cached(
                     r"SELECT class_hash FROM contract_updates
                 WHERE contract_address = ?
@@ -745,7 +742,7 @@ impl Transaction<'_> {
                 )?;
                 stmt.query_row(params![&contract_address], |row| row.get_class_hash(0))
             }
-            FinalizedBlockId::Number(number) => {
+            BlockId::Number(number) => {
                 let mut stmt = self.inner().prepare_cached(
                     r"SELECT class_hash FROM contract_updates
                 WHERE contract_address = ? AND block_number <= ?
@@ -755,7 +752,7 @@ impl Transaction<'_> {
                     row.get_class_hash(0)
                 })
             }
-            FinalizedBlockId::Hash(hash) => {
+            BlockId::Hash(hash) => {
                 let mut stmt = self.inner().prepare_cached(
                     r"SELECT class_hash FROM contract_updates
                 WHERE contract_address = ? AND block_number <= (
@@ -1248,13 +1245,13 @@ mod tests {
 
             // check getters for compiled class
             let hash = tx
-                .casm_hash_at(FinalizedBlockId::Latest, ClassHash(SIERRA_HASH.0))
+                .casm_hash_at(BlockId::Latest, ClassHash(SIERRA_HASH.0))
                 .unwrap()
                 .unwrap();
             assert_eq!(hash, casm_hash_bytes!(b"casm hash"));
 
             let definition = tx
-                .casm_definition_at(FinalizedBlockId::Latest, ClassHash(SIERRA_HASH.0))
+                .casm_definition_at(BlockId::Latest, ClassHash(SIERRA_HASH.0))
                 .unwrap()
                 .unwrap();
             assert_eq!(definition, b"casm definition");
@@ -1404,7 +1401,7 @@ mod tests {
                 .unwrap();
 
             let latest = tx
-                .contract_nonce(contract, FinalizedBlockId::Latest)
+                .contract_nonce(contract, BlockId::Latest)
                 .unwrap()
                 .unwrap();
             assert_eq!(latest, expected);
@@ -1432,7 +1429,7 @@ mod tests {
                 .unwrap();
 
             let latest = tx
-                .contract_nonce(contract, FinalizedBlockId::Latest)
+                .contract_nonce(contract, BlockId::Latest)
                 .unwrap()
                 .unwrap();
             assert_eq!(latest, expected);
@@ -1452,7 +1449,7 @@ mod tests {
             // Invalid i.e. missing contract should be None
             let invalid_contract = contract_address_bytes!(b"invalid");
             let invalid_latest = tx
-                .contract_nonce(invalid_contract, FinalizedBlockId::Latest)
+                .contract_nonce(invalid_contract, BlockId::Latest)
                 .unwrap();
             assert_eq!(invalid_latest, None);
             let invalid_by_hash = tx
@@ -1484,7 +1481,7 @@ mod tests {
 
             // Valid key and contract.
             let latest = tx
-                .storage_value(FinalizedBlockId::Latest, contract, key)
+                .storage_value(BlockId::Latest, contract, key)
                 .unwrap()
                 .unwrap();
             assert_eq!(latest, expected);
@@ -1502,7 +1499,7 @@ mod tests {
             // Invalid key should be none
             let invalid_key = storage_address_bytes!(b"invalid key");
             let latest = tx
-                .storage_value(FinalizedBlockId::Latest, contract, invalid_key)
+                .storage_value(BlockId::Latest, contract, invalid_key)
                 .unwrap();
             assert_eq!(latest, None);
             let by_hash = tx
@@ -1517,7 +1514,7 @@ mod tests {
             // Invalid contract should be none
             let invalid_contract = contract_address_bytes!(b"invalid");
             let latest = tx
-                .storage_value(FinalizedBlockId::Latest, invalid_contract, key)
+                .storage_value(BlockId::Latest, invalid_contract, key)
                 .unwrap();
             assert_eq!(latest, None);
             let by_hash = tx

--- a/crates/storage/src/connection/transaction.rs
+++ b/crates/storage/src/connection/transaction.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use pathfinder_common::event::Event;
 use pathfinder_common::receipt::Receipt;
 use pathfinder_common::transaction::Transaction as StarknetTransaction;
-use pathfinder_common::{BlockHash, BlockNumber, FinalizedBlockId, TransactionHash};
+use pathfinder_common::{BlockHash, BlockId, BlockNumber, TransactionHash};
 
 use super::{EventsForBlock, TransactionDataForBlock, TransactionWithReceipt};
 use crate::prelude::*;
@@ -238,7 +238,7 @@ impl Transaction<'_> {
 
     pub fn transaction_at_block(
         &self,
-        block: FinalizedBlockId,
+        block: BlockId,
         index: usize,
     ) -> anyhow::Result<Option<StarknetTransaction>> {
         let Some(block_number) = self.block_number(block)? else {
@@ -250,7 +250,7 @@ impl Transaction<'_> {
             .map(|(transaction, ..)| transaction.clone()))
     }
 
-    pub fn transaction_count(&self, block: FinalizedBlockId) -> anyhow::Result<usize> {
+    pub fn transaction_count(&self, block: BlockId) -> anyhow::Result<usize> {
         let Some(block_number) = self.block_number(block)? else {
             return Ok(0);
         };
@@ -259,7 +259,7 @@ impl Transaction<'_> {
 
     pub fn transaction_data_for_block(
         &self,
-        block: FinalizedBlockId,
+        block: BlockId,
     ) -> anyhow::Result<Option<Vec<TransactionDataForBlock>>> {
         let Some(block_number) = self.block_number(block)? else {
             return Ok(None);
@@ -278,7 +278,7 @@ impl Transaction<'_> {
 
     pub fn transactions_for_block(
         &self,
-        block: FinalizedBlockId,
+        block: BlockId,
     ) -> anyhow::Result<Option<Vec<StarknetTransaction>>> {
         let Some(block_number) = self.block_number(block)? else {
             return Ok(None);
@@ -294,7 +294,7 @@ impl Transaction<'_> {
 
     pub fn transactions_with_receipts_for_block(
         &self,
-        block: FinalizedBlockId,
+        block: BlockId,
     ) -> anyhow::Result<Option<Vec<(StarknetTransaction, Receipt)>>> {
         let Some(block_number) = self.block_number(block)? else {
             return Ok(None);
@@ -308,10 +308,7 @@ impl Transaction<'_> {
         ))
     }
 
-    pub fn events_for_block(
-        &self,
-        block: FinalizedBlockId,
-    ) -> anyhow::Result<Option<Vec<EventsForBlock>>> {
+    pub fn events_for_block(&self, block: BlockId) -> anyhow::Result<Option<Vec<EventsForBlock>>> {
         let Some(block_number) = self.block_number(block)? else {
             return Ok(None);
         };
@@ -339,7 +336,7 @@ impl Transaction<'_> {
 
     pub fn transaction_hashes_for_block(
         &self,
-        block: FinalizedBlockId,
+        block: BlockId,
     ) -> anyhow::Result<Option<Vec<TransactionHash>>> {
         let Some(block_number) = self.block_number(block)? else {
             return Ok(None);
@@ -3220,9 +3217,7 @@ mod tests {
         assert_eq!(by_number, expected);
         let by_hash = tx.transaction_at_block(header.hash.into(), idx).unwrap();
         assert_eq!(by_hash, expected);
-        let by_latest = tx
-            .transaction_at_block(FinalizedBlockId::Latest, idx)
-            .unwrap();
+        let by_latest = tx.transaction_at_block(BlockId::Latest, idx).unwrap();
         assert_eq!(by_latest, expected);
 
         let invalid_index = tx
@@ -3241,7 +3236,7 @@ mod tests {
         let (mut db, header, body) = setup();
         let tx = db.transaction().unwrap();
 
-        let by_latest = tx.transaction_count(FinalizedBlockId::Latest).unwrap();
+        let by_latest = tx.transaction_count(BlockId::Latest).unwrap();
         assert_eq!(by_latest, body.len());
         let by_number = tx.transaction_count(header.number.into()).unwrap();
         assert_eq!(by_number, body.len());
@@ -3264,9 +3259,7 @@ mod tests {
         assert_eq!(by_number, expected);
         let by_hash = tx.transaction_data_for_block(header.hash.into()).unwrap();
         assert_eq!(by_hash, expected);
-        let by_latest = tx
-            .transaction_data_for_block(FinalizedBlockId::Latest)
-            .unwrap();
+        let by_latest = tx.transaction_data_for_block(BlockId::Latest).unwrap();
         assert_eq!(by_latest, expected);
 
         let invalid_block = tx
@@ -3286,7 +3279,7 @@ mod tests {
         assert_eq!(by_number, expected);
         let by_hash = tx.transactions_for_block(header.hash.into()).unwrap();
         assert_eq!(by_hash, expected);
-        let by_latest = tx.transactions_for_block(FinalizedBlockId::Latest).unwrap();
+        let by_latest = tx.transactions_for_block(BlockId::Latest).unwrap();
         assert_eq!(by_latest, expected);
 
         let invalid_block = tx
@@ -3317,9 +3310,7 @@ mod tests {
         assert_eq!(by_number, expected);
         let by_hash = tx.transaction_hashes_for_block(header.hash.into()).unwrap();
         assert_eq!(by_hash, expected);
-        let by_latest = tx
-            .transaction_hashes_for_block(FinalizedBlockId::Latest)
-            .unwrap();
+        let by_latest = tx.transaction_hashes_for_block(BlockId::Latest).unwrap();
         assert_eq!(by_latest, expected);
 
         let invalid_block = tx

--- a/crates/storage/src/connection/trie.rs
+++ b/crates/storage/src/connection/trie.rs
@@ -376,8 +376,7 @@ impl Transaction<'_> {
     /// Prune tries by removing nodes that are no longer needed at the given
     /// block.
     pub fn prune_tries(&self) -> anyhow::Result<()> {
-        let Some(block_number) = self.block_number(pathfinder_common::FinalizedBlockId::Latest)?
-        else {
+        let Some(block_number) = self.block_number(pathfinder_common::BlockId::Latest)? else {
             return Ok(());
         };
         let TriePruneMode::Prune { num_blocks_kept } = self.trie_prune_mode else {


### PR DESCRIPTION
This PR is quite big, but is more easily reviewed commit-by-commit. 

The first part is a refactor: `pathfinder_common::BlockId` exists solely because it has a pending variant, but pending is used only in two components of our code base: the feeder gateway client (requests targeting the pending block) and the RPC implementation (where pending is a valid input block tag).

The refactor part adds a crate specific BlockId type to `starknet_gateway_client` and `pathfinder_rpc` and then gets rid of `pathfinder_common::BlockId` completely. This then allows us to rename `FinalizedBlockId` to just `BlockId` again while keeping the same semantics (no pending).

With the JSON-RPC specific `BlockId` type in place we can now implement an `l1_accepted` block tag fairly easily. All JSON-RPC methods convert the input block ID to the `pathfinder_common::BlockId` type to make DB lookups. This PR implements this conversion for the `L1Accepted` variant by looking up the last known L1 accepted block number and converting to `BlockId::Number(last_l1_accepted_block_number)`.

The result is that we now accept the `l1_accepted` block tag in addition to `latest` and `pending`/`pre_committed` wherever the JSON-RPC specification uses a `BLOCK_ID` in the method parameters. This is a compatible extension of the JSON-RPC specification, which allows users to just reference the latest L1 confirmed state without doing a lookup for the matching block number first.
