### PR TITLE
fix(rpc/subscribe_events): fix event subscription task leak

### DIFF
--- a/crates/rpc/src/jsonrpc/router/subscription.rs
+++ b/crates/rpc/src/jsonrpc/router/subscription.rs
@@ -328,8 +328,9 @@ where
                     if let Err(e) = T::subscribe(context, rpc_version, params, tx1).await {
                         tx.send_err(e).await.ok();
                     }
+                    tracing::trace!("Subscription task exited");
                 }
-            }.in_current_span());
+            }.instrument(tracing::debug_span!("subscribe_task")));
             let first_msg = match rx1.recv().await {
                 Some(msg) => msg,
                 None => {
@@ -393,6 +394,9 @@ where
                     break;
                 }
             }
+
+            rx1.close();
+            tracing::trace!("Subscription closed");
         }.instrument(tracing::debug_span!("subscription", subscription_id=%subscription_id.0))))
     }
 }

--- a/crates/rpc/src/method/subscribe_events.rs
+++ b/crates/rpc/src/method/subscribe_events.rs
@@ -212,7 +212,7 @@ impl RpcSubscriptionFlow for SubscribeEvents {
                                 block_number,
                                 subscription_name: REORG_SUBSCRIPTION_NAME,
                             }).await.is_err() {
-                                break;
+                                return Ok(());
                             }
                         }
                         Err(e) => {
@@ -221,7 +221,7 @@ impl RpcSubscriptionFlow for SubscribeEvents {
                                  lagging: {:?}",
                                 e
                             );
-                            break;
+                            return Ok(());
                         }
                     }
                 }
@@ -268,7 +268,7 @@ impl RpcSubscriptionFlow for SubscribeEvents {
                                         block_number,
                                         subscription_name: SUBSCRIPTION_NAME,
                                     }).await.is_err() {
-                                        break;
+                                        return Ok(());
                                     }
                                 }
                             }
@@ -279,14 +279,14 @@ impl RpcSubscriptionFlow for SubscribeEvents {
                                  lagging: {:?}",
                                 e
                             );
-                            break;
+                            return Ok(());
                         }
                     }
                 }
                 pending_changed = pending_data.changed() => {
                     if let Err(e) = pending_changed {
                         tracing::debug!(error=%e, "Pending data channel closed, stopping subscription");
-                        break;
+                        return Ok(());
                     }
 
                     let pending = pending_data.borrow_and_update().clone();
@@ -337,14 +337,13 @@ impl RpcSubscriptionFlow for SubscribeEvents {
                                 block_number,
                                 subscription_name: SUBSCRIPTION_NAME,
                             }).await.is_err() {
-                                break;
+                                return Ok(());
                             }
                         }
                     }
                 }
             }
         }
-        Ok(())
     }
 }
 


### PR DESCRIPTION
The `SubscribeEvents::subscribe()` method did not exit properly if sending the notification failed due to the channel being closed (usually triggered by the underlying Websocket connection closing).

The issue was that for some error cases `break` was being used inside a `for` loop that simply exited that loop instead of exiting the method.
