### PR TITLE
update configuration.md

### DIFF
--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -27,7 +27,8 @@ docker run \
   -v $HOME/pathfinder:/usr/share/pathfinder/data \
   eqlabs/pathfinder:latest \
   --network mainnet \
-  --monitor-address=0.0.0.0:9000
+  --monitor-address=0.0.0.0:9000 \
+  --rpc.websocket.enabled \
 ```
 
 If you built Pathfinder from source, pass options after `--` so cargo doesn’t parse them:


### PR DESCRIPTION
Short description of what this PR does.

The --rpc.websocket.enabled flag was missing in the official Pathfinder docs. Without it, the attestation tool fails to submit attestations properly.
