### PR TITLE
fix(rpc): use non-strict nonce checking for estimation / simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `blockifier` has been upgraded to version 0.15.0-rc.2.
 - The default JSON-RPC listen address has been changed to the IPv6 wildcard address in our Docker images. This avoids problems on IPv6-enabled hosts where `localhost` resolves to `::1`.
+- JSON-RPC `starknet_estimateFee` and `starknet_simulateTransactions` now use non-strict nonce checking when using the `SKIP_VALIDATE` flag. That is, the nonce value needs to be larger than the last used value but no exact match is required.
 
 ## [0.18.0] - 2025-07-14
 

--- a/crates/rpc/src/executor.rs
+++ b/crates/rpc/src/executor.rs
@@ -208,7 +208,7 @@ pub(crate) fn map_broadcasted_transaction(
         only_query: has_query_version,
         validate: !skip_validate,
         charge_fee: !skip_fee_charge,
-        strict_nonce_check: true,
+        strict_nonce_check: !skip_validate,
     };
 
     let transaction = transaction.clone().into_common(chain_id);


### PR DESCRIPTION
This commit updates the RPC executor to use non-strict nonce checking when estimating or simulating transactions. This matches the behavior of Starknet 0.14.0, where nonce checking does not require that the nonce is exactly one more than the last known nonce.
