### PR TITLE
fix(Dockerfile): change default JSON-RPC listen address IPv6 wildcard address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `blockifier` has been upgraded to version 0.15.0-rc.2.
+- The default JSON-RPC listen address has been changed to the IPv6 wildcard address in our Docker images. This avoids problems on IPv6-enabled hosts where `localhost` resolves to `::1`.
 
 ## [0.18.0] - 2025-07-14
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ EXPOSE 9545
 WORKDIR /usr/share/pathfinder/data
 
 # this is required to have exposing ports work from docker, the default is not this.
-ENV PATHFINDER_HTTP_RPC_ADDRESS="0.0.0.0:9545"
+ENV PATHFINDER_HTTP_RPC_ADDRESS="[::]:9545"
 
 # this has been changed in #335 to follow docker best practices example; every
 # time it is changed it will be a breaking change. this allows `docker run


### PR DESCRIPTION
This is especially useful for running Pathfinder on an IPv6-enabled host, where `localhost` might resolve to `::1` and exposing the JSON-RPC port via Docker requires internally binding to the IPv6 wildcard address `[::]`.
