### PR TITLE
fix: provide correct starting block when emitting `Reorg` event

### DIFF
--- a/crates/rpc/src/dto/block.rs
+++ b/crates/rpc/src/dto/block.rs
@@ -246,10 +246,10 @@ impl crate::dto::SerializeForVersion for Reorg {
         serializer: crate::dto::Serializer,
     ) -> Result<crate::dto::Ok, crate::dto::Error> {
         let mut serializer = serializer.serialize_struct()?;
-        serializer.serialize_field("first_block_number", &self.first_block_number.get())?;
-        serializer.serialize_field("first_block_hash", &self.first_block_hash)?;
-        serializer.serialize_field("last_block_number", &self.last_block_number.get())?;
-        serializer.serialize_field("last_block_hash", &self.last_block_hash)?;
+        serializer.serialize_field("starting_block_number", &self.starting_block_number.get())?;
+        serializer.serialize_field("starting_block_hash", &self.starting_block_hash)?;
+        serializer.serialize_field("ending_block_number", &self.ending_block_number.get())?;
+        serializer.serialize_field("ending_block_hash", &self.ending_block_hash)?;
         serializer.end()
     }
 }

--- a/crates/rpc/src/jsonrpc.rs
+++ b/crates/rpc/src/jsonrpc.rs
@@ -48,10 +48,14 @@ pub struct Notifications {
 
 #[derive(Debug, Clone)]
 pub struct Reorg {
-    pub first_block_number: BlockNumber,
-    pub first_block_hash: BlockHash,
-    pub last_block_number: BlockNumber,
-    pub last_block_hash: BlockHash,
+    /// First known block of the orphaned chain.
+    pub starting_block_number: BlockNumber,
+    /// [BlockHash] of [Reorg::starting_block_number].
+    pub starting_block_hash: BlockHash,
+    /// Last known block of the orphaned chain.
+    pub ending_block_number: BlockNumber,
+    /// [BlockHash] of [Reorg::ending_block_number].
+    pub ending_block_hash: BlockHash,
 }
 
 impl Default for Notifications {

--- a/crates/rpc/src/method/subscribe_events.rs
+++ b/crates/rpc/src/method/subscribe_events.rs
@@ -204,7 +204,7 @@ impl RpcSubscriptionFlow for SubscribeEvents {
                 reorg = reorgs.recv() => {
                     match reorg {
                         Ok(reorg) => {
-                            let block_number = reorg.first_block_number;
+                            let block_number = reorg.starting_block_number;
                             if tx.send(SubscriptionMessage {
                                 notification: Notification::Reorg(reorg),
                                 block_number,
@@ -918,10 +918,10 @@ mod tests {
         retry(|| {
             router.context.notifications.reorgs.send(
                 Reorg {
-                    first_block_number: BlockNumber::new_or_panic(1),
-                    first_block_hash: BlockHash(felt!("0x1")),
-                    last_block_number: BlockNumber::new_or_panic(2),
-                    last_block_hash: BlockHash(felt!("0x2")),
+                    starting_block_number: BlockNumber::new_or_panic(1),
+                    starting_block_hash: BlockHash(felt!("0x1")),
+                    ending_block_number: BlockNumber::new_or_panic(2),
+                    ending_block_hash: BlockHash(felt!("0x2")),
                 }
                 .into(),
             )
@@ -940,10 +940,10 @@ mod tests {
                 "method": "starknet_subscriptionReorg",
                 "params": {
                     "result": {
-                        "first_block_hash": "0x1",
-                        "first_block_number": 1,
-                        "last_block_hash": "0x2",
-                        "last_block_number": 2
+                        "starting_block_hash": "0x1",
+                        "starting_block_number": 1,
+                        "ending_block_hash": "0x2",
+                        "ending_block_number": 2
                     },
                     "subscription_id": subscription_id.to_string()
                 }

--- a/crates/rpc/src/method/subscribe_new_heads.rs
+++ b/crates/rpc/src/method/subscribe_new_heads.rs
@@ -106,7 +106,7 @@ impl RpcSubscriptionFlow for SubscribeNewHeads {
                 reorg = reorgs.recv() => {
                     match reorg {
                         Ok(reorg) => {
-                            let block_number = reorg.first_block_number;
+                            let block_number = reorg.starting_block_number;
                             if tx.send(SubscriptionMessage {
                                 notification: Notification::Reorg(reorg),
                                 block_number,
@@ -195,10 +195,10 @@ mod tests {
             .reorgs
             .send(
                 Reorg {
-                    first_block_number: BlockNumber::new_or_panic(1),
-                    first_block_hash: BlockHash(felt!("0x1")),
-                    last_block_number: BlockNumber::new_or_panic(2),
-                    last_block_hash: BlockHash(felt!("0x2")),
+                    starting_block_number: BlockNumber::new_or_panic(1),
+                    starting_block_hash: BlockHash(felt!("0x1")),
+                    ending_block_number: BlockNumber::new_or_panic(2),
+                    ending_block_hash: BlockHash(felt!("0x2")),
                 }
                 .into(),
             )
@@ -215,10 +215,10 @@ mod tests {
                 "method": "starknet_subscriptionReorg",
                 "params": {
                     "result": {
-                        "first_block_hash": "0x1",
-                        "first_block_number": 1,
-                        "last_block_hash": "0x2",
-                        "last_block_number": 2
+                        "starting_block_hash": "0x1",
+                        "starting_block_number": 1,
+                        "ending_block_hash": "0x2",
+                        "ending_block_number": 2
                     },
                     "subscription_id": subscription_id.0.to_string()
                 }

--- a/crates/rpc/src/method/subscribe_transaction_status.rs
+++ b/crates/rpc/src/method/subscribe_transaction_status.rs
@@ -767,10 +767,10 @@ mod tests {
                     }
                 })),
                 TestEvent::Reorg(Reorg {
-                    first_block_number: BlockNumber::GENESIS + 4,
-                    first_block_hash: BlockHash(Felt::from_u64(4)),
-                    last_block_number: BlockNumber::GENESIS + 5,
-                    last_block_hash: BlockHash(Felt::from_u64(5)),
+                    starting_block_number: BlockNumber::GENESIS + 4,
+                    starting_block_hash: BlockHash(Felt::from_u64(4)),
+                    ending_block_number: BlockNumber::GENESIS + 5,
+                    ending_block_hash: BlockHash(Felt::from_u64(5)),
                 }),
                 TestEvent::Message(serde_json::json!({
                     "jsonrpc": "2.0",
@@ -778,10 +778,10 @@ mod tests {
                     "params": {
                         "subscription_id": subscription_id,
                         "result": {
-                            "first_block_number": 4,
-                            "first_block_hash": "0x4",
-                            "last_block_number": 5,
-                            "last_block_hash": "0x5",
+                            "starting_block_number": 4,
+                            "starting_block_hash": "0x4",
+                            "ending_block_number": 5,
+                            "ending_block_hash": "0x5",
                         }
                     }
                 })),


### PR DESCRIPTION
This fixes two bugs:
- We used non-spec compliant names in our `Reorg` event JSON, probably because they got renamed in the spec and we forget to rename them in our code.
- We returned an incorrect block hash/number combination in the `Reorg` event in some cases.