### PR TITLE
feat(rpc/v09): implement `subscribe_newTransactionReceipts` RPC method

### DIFF
--- a/crates/common/src/transaction.rs
+++ b/crates/common/src/transaction.rs
@@ -195,6 +195,23 @@ impl TransactionVariant {
             _ => {}
         }
     }
+
+    pub fn sender_address(&self) -> ContractAddress {
+        match self {
+            TransactionVariant::DeclareV0(tx) => tx.sender_address,
+            TransactionVariant::DeclareV1(tx) => tx.sender_address,
+            TransactionVariant::DeclareV2(tx) => tx.sender_address,
+            TransactionVariant::DeclareV3(tx) => tx.sender_address,
+            TransactionVariant::DeployV0(tx) => tx.contract_address,
+            TransactionVariant::DeployV1(tx) => tx.contract_address,
+            TransactionVariant::DeployAccountV1(tx) => tx.contract_address,
+            TransactionVariant::DeployAccountV3(tx) => tx.contract_address,
+            TransactionVariant::InvokeV0(tx) => tx.sender_address,
+            TransactionVariant::InvokeV1(tx) => tx.sender_address,
+            TransactionVariant::InvokeV3(tx) => tx.sender_address,
+            TransactionVariant::L1Handler(tx) => tx.contract_address,
+        }
+    }
 }
 
 impl From<DeclareTransactionV2> for TransactionVariant {

--- a/crates/rpc/src/dto/receipt.rs
+++ b/crates/rpc/src/dto/receipt.rs
@@ -41,7 +41,7 @@ impl From<&pathfinder_common::receipt::ExecutionStatus> for TxnExecutionStatus {
 
 struct TxnExecutionStatusWithRevertReason<'a>(pub &'a pathfinder_common::receipt::ExecutionStatus);
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum TxnFinalityStatus {
     PreConfirmed,
     AcceptedOnL2,
@@ -140,6 +140,21 @@ impl SerializeForVersion for TxnFinalityStatus {
             TxnFinalityStatus::AcceptedOnL1 => "ACCEPTED_ON_L1",
         }
         .serialize(serializer)
+    }
+}
+
+impl crate::dto::DeserializeForVersion for TxnFinalityStatus {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        let s: String = value.deserialize()?;
+        match s.as_str() {
+            "ACCEPTED_ON_L1" => Ok(Self::AcceptedOnL1),
+            "ACCEPTED_ON_L2" => Ok(Self::AcceptedOnL2),
+            "PRE_CONFIRMED" => Ok(Self::PreConfirmed),
+            _ => Err(serde::de::Error::unknown_variant(
+                &s,
+                &["ACCEPTED_ON_L1", "ACCEPTED_ON_L2", "PRE_CONFIRMED"],
+            )),
+        }
     }
 }
 

--- a/crates/rpc/src/method.rs
+++ b/crates/rpc/src/method.rs
@@ -29,6 +29,7 @@ pub mod last_l1_accepted_block_hash_and_number;
 pub mod simulate_transactions;
 pub mod subscribe_events;
 pub mod subscribe_new_heads;
+pub mod subscribe_new_transaction_receipts;
 pub mod subscribe_pending_transactions;
 pub mod subscribe_transaction_status;
 pub mod syncing;

--- a/crates/rpc/src/method/subscribe_new_transaction_receipts.rs
+++ b/crates/rpc/src/method/subscribe_new_transaction_receipts.rs
@@ -1,0 +1,909 @@
+use std::collections::HashSet;
+
+use pathfinder_common::event::Event;
+use pathfinder_common::receipt::Receipt;
+use pathfinder_common::transaction::Transaction;
+use pathfinder_common::{BlockHash, BlockNumber, ContractAddress};
+use tokio::sync::mpsc;
+
+use crate::context::RpcContext;
+use crate::dto::{TxnFinalityStatus, TxnReceiptWithBlockInfo};
+use crate::jsonrpc::{RpcError, RpcSubscriptionFlow, SubscriptionMessage};
+use crate::RpcVersion;
+
+pub struct SubscribeNewTransactionReceipts;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Params {
+    finality_status: Vec<TxnFinalityStatus>,
+    sender_address: Option<HashSet<ContractAddress>>,
+}
+
+impl Default for Params {
+    fn default() -> Self {
+        Params {
+            finality_status: vec![TxnFinalityStatus::AcceptedOnL2],
+            sender_address: None,
+        }
+    }
+}
+
+impl Params {
+    fn matches(&self, sender_address: &ContractAddress, finality: TxnFinalityStatus) -> bool {
+        if let Some(addresses) = &self.sender_address {
+            if !addresses.contains(sender_address) {
+                return false;
+            }
+        }
+        self.finality_status.contains(&finality)
+    }
+}
+
+impl crate::dto::DeserializeForVersion for Option<Params> {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        if value.is_null() {
+            return Ok(None);
+        }
+        value.deserialize_map(|value| {
+            Ok(Some(Params {
+                finality_status: value
+                    .deserialize_optional_array("finality_status", |v| {
+                        v.deserialize::<TxnFinalityStatusWithoutL1Accepted>()
+                            .map(Into::into)
+                    })?
+                    .unwrap_or_else(|| vec![TxnFinalityStatus::AcceptedOnL2]),
+                sender_address: value
+                    .deserialize_optional_array("sender_address", |addr| {
+                        Ok(ContractAddress(addr.deserialize()?))
+                    })?
+                    .map(|addrs| addrs.into_iter().collect()),
+            }))
+        })
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum TxnFinalityStatusWithoutL1Accepted {
+    PreConfirmed,
+    AcceptedOnL2,
+}
+
+impl crate::dto::DeserializeForVersion for TxnFinalityStatusWithoutL1Accepted {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        let s: String = value.deserialize()?;
+        match s.as_str() {
+            "ACCEPTED_ON_L2" => Ok(Self::AcceptedOnL2),
+            "PRE_CONFIRMED" => Ok(Self::PreConfirmed),
+            _ => Err(serde::de::Error::unknown_variant(
+                &s,
+                &["ACCEPTED_ON_L2", "PRE_CONFIRMED"],
+            )),
+        }
+    }
+}
+
+impl From<TxnFinalityStatusWithoutL1Accepted> for TxnFinalityStatus {
+    fn from(status: TxnFinalityStatusWithoutL1Accepted) -> Self {
+        match status {
+            TxnFinalityStatusWithoutL1Accepted::PreConfirmed => TxnFinalityStatus::PreConfirmed,
+            TxnFinalityStatusWithoutL1Accepted::AcceptedOnL2 => TxnFinalityStatus::AcceptedOnL2,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Notification {
+    block_hash: Option<BlockHash>,
+    block_number: Option<BlockNumber>,
+    receipt: Receipt,
+    transaction: Transaction,
+    events: Vec<Event>,
+    finality: TxnFinalityStatus,
+}
+
+impl crate::dto::SerializeForVersion for Notification {
+    fn serialize(
+        &self,
+        serializer: crate::dto::Serializer,
+    ) -> Result<crate::dto::Ok, crate::dto::Error> {
+        TxnReceiptWithBlockInfo {
+            receipt: &self.receipt,
+            transaction: &self.transaction,
+            events: &self.events,
+            finality: self.finality,
+            block_hash: self.block_hash.as_ref(),
+            block_number: self.block_number,
+        }
+        .serialize(serializer)
+    }
+}
+
+const SUBSCRIPTION_NAME: &str = "starknet_subscriptionNewTransactionReceipts";
+
+impl RpcSubscriptionFlow for SubscribeNewTransactionReceipts {
+    type Params = Option<Params>;
+    type Notification = Notification;
+
+    async fn subscribe(
+        state: RpcContext,
+        _version: RpcVersion,
+        params: Self::Params,
+        tx: mpsc::Sender<SubscriptionMessage<Self::Notification>>,
+    ) -> Result<(), RpcError> {
+        let params = params.unwrap_or_default();
+        let mut blocks = state.notifications.l2_blocks.subscribe();
+        let mut pending_data = state.pending_data.0.clone();
+
+        // Last block sent to the subscriber. Initial value doesn't really matter.
+        let mut last_pre_confirmed_block = BlockNumber::GENESIS;
+
+        // Set to keep track of sent transactions to avoid duplicates.
+        let mut pre_confirmed_sent_txs = HashSet::new();
+
+        loop {
+            tokio::select! {
+                block = blocks.recv() => {
+                    match block {
+                        Err(e) => {
+                            tracing::debug!(error=%e, "Block channel closed, stopping subscription");
+                            return Ok(());
+                        }
+                        Ok(block) => {
+                            tracing::trace!(block_number=%block.block_number, "New block header");
+
+                            if block.block_number == last_pre_confirmed_block {
+                                // Send all transactions that might have been missed in the pre-confirmed block.
+                                for (transaction, (receipt, events)) in block.transactions.iter().zip(block.transaction_receipts.iter()) {
+                                    if !params.matches(&transaction.variant.sender_address(), TxnFinalityStatus::AcceptedOnL2) {
+                                        continue;
+                                    }
+
+                                    let notification = Notification {
+                                        block_hash: Some(block.block_hash),
+                                        block_number: Some(block.block_number),
+                                        receipt: receipt.clone(),
+                                        transaction: transaction.clone(),
+                                        events: events.clone(),
+                                        finality: TxnFinalityStatus::AcceptedOnL2,
+                                    };
+                                    if tx
+                                        .send(SubscriptionMessage {
+                                            notification,
+                                            block_number: block.block_number,
+                                            subscription_name: SUBSCRIPTION_NAME,
+                                        })
+                                        .await
+                                        .is_err()
+                                    {
+                                        // Close subscription.
+                                        return Ok(());
+                                    }
+                                }
+
+                                // Clear the sent transactions set.
+                                pre_confirmed_sent_txs.clear();
+                            }
+                        }
+                    }
+                }
+                pending_changed = pending_data.changed() => {
+                    if let Err(e) = pending_changed {
+                        tracing::debug!(error=%e, "Pending data channel closed, stopping subscription");
+                        return Ok(());
+                    }
+
+                    let pending = pending_data.borrow_and_update().clone();
+                    let finality_status = pending.block().finality_status();
+
+                    tracing::trace!(block_number=%pending.block_number(), ?finality_status, "Pre-confirmed block update");
+
+                    if pending.block_number() != last_pre_confirmed_block {
+                        last_pre_confirmed_block = pending.block_number();
+                        pre_confirmed_sent_txs.clear();
+                    }
+
+                    for (transaction, (receipt, events)) in pending.transactions().iter().zip(pending.transaction_receipts_and_events().iter()) {
+                        if pre_confirmed_sent_txs.contains(&transaction.hash) {
+                            continue;
+                        }
+
+                        if !params.matches(&transaction.variant.sender_address(), finality_status) {
+                            continue;
+                        }
+
+                        let notification = Notification {
+                            block_hash: None,
+                            block_number: Some(pending.block_number()),
+                            receipt: receipt.clone(),
+                            transaction: transaction.clone(),
+                            events: events.clone(),
+                            finality: finality_status,
+                        };
+                        pre_confirmed_sent_txs.insert(transaction.hash);
+                        if tx
+                            .send(SubscriptionMessage {
+                                notification,
+                                block_number: pending.block_number(),
+                                subscription_name: SUBSCRIPTION_NAME,
+                            })
+                            .await
+                            .is_err()
+                        {
+                            // Close subscription.
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::extract::ws::Message;
+    use pathfinder_common::macro_prelude::*;
+    use pathfinder_common::prelude::*;
+    use pathfinder_common::transaction::{DeclareTransactionV0V1, Transaction, TransactionVariant};
+    use pathfinder_crypto::Felt;
+    use pathfinder_storage::StorageBuilder;
+    use pretty_assertions_sorted::assert_eq;
+    use starknet_gateway_types::reply::PreConfirmedBlock;
+    use tokio::sync::{mpsc, watch};
+
+    use super::Params;
+    use crate::context::{RpcContext, WebsocketContext};
+    use crate::dto::TxnFinalityStatus;
+    use crate::jsonrpc::websocket::WebsocketHistory;
+    use crate::jsonrpc::{handle_json_rpc_socket, RpcResponse};
+    use crate::{v09, Notifications, PendingData, RpcVersion};
+
+    #[test]
+    fn parse_params() {
+        let params = crate::dto::Value::new(
+            serde_json::json!({
+                "finality_status": ["ACCEPTED_ON_L2", "PRE_CONFIRMED"],
+                "sender_address": ["0x1", "0x2"]
+            }),
+            RpcVersion::V09,
+        );
+        let params: Option<Params> = params.deserialize().unwrap();
+        assert_eq!(
+            params.unwrap(),
+            Params {
+                finality_status: vec![
+                    TxnFinalityStatus::AcceptedOnL2,
+                    TxnFinalityStatus::PreConfirmed
+                ],
+                sender_address: Some(
+                    [contract_address!("0x1"), contract_address!("0x2")]
+                        .iter()
+                        .cloned()
+                        .collect()
+                ),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_params_fails_for_invalid_finality_status() {
+        let params = crate::dto::Value::new(
+            serde_json::json!({
+                "finality_status": ["ACCEPTED_ON_L2", "ACCEPTED_ON_L1"],
+                "sender_address": ["0x1", "0x2"]
+            }),
+            RpcVersion::V09,
+        );
+        let error = params.deserialize::<Option<Params>>().unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "unknown variant `ACCEPTED_ON_L1`, expected `ACCEPTED_ON_L2` or `PRE_CONFIRMED`"
+                .to_string()
+        );
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn pre_confirmed_no_filtering() {
+        let Setup {
+            tx,
+            mut rx,
+            pending_data_tx,
+            ..
+        } = setup();
+        tx.send(Ok(Message::Text(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "starknet_subscribeNewTransactionReceipts",
+                "params": {
+                    "finality_status": ["ACCEPTED_ON_L2", "PRE_CONFIRMED"]
+                }
+            })
+            .to_string(),
+        )))
+        .await
+        .unwrap();
+        let response = rx.recv().await.unwrap().unwrap();
+        let subscription_id = match response {
+            Message::Text(json) => {
+                let json: serde_json::Value = serde_json::from_str(&json).unwrap();
+                assert_eq!(json["jsonrpc"], "2.0");
+                assert_eq!(json["id"], 1);
+                json["result"].as_str().unwrap().parse().unwrap()
+            }
+            _ => {
+                panic!("Expected text message");
+            }
+        };
+        assert_recv_nothing(&mut rx).await;
+
+        // First pre-confirmed block update.
+        pending_data_tx
+            .send(sample_pre_confirmed_block(
+                BlockNumber::new_or_panic(1),
+                vec![
+                    (contract_address!("0x1"), transaction_hash!("0x3")),
+                    (contract_address!("0x2"), transaction_hash!("0x4")),
+                ],
+            ))
+            .unwrap();
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_receipt_message(1, "0x3", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_receipt_message(1, "0x4", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+
+        // We expect that the second pre-confirmed block update will ignore
+        // transactions that were already sent.
+        pending_data_tx
+            .send(sample_pre_confirmed_block(
+                BlockNumber::new_or_panic(1),
+                vec![
+                    (contract_address!("0x1"), transaction_hash!("0x3")),
+                    (contract_address!("0x2"), transaction_hash!("0x4")),
+                    (contract_address!("0x1"), transaction_hash!("0x5")),
+                    (contract_address!("0x2"), transaction_hash!("0x6")),
+                ],
+            ))
+            .unwrap();
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_receipt_message(1, "0x5", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_receipt_message(1, "0x6", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+    }
+
+    #[tokio::test]
+    async fn pre_confirmed_filtering_one_address() {
+        let Setup {
+            tx,
+            mut rx,
+            pending_data_tx,
+            ..
+        } = setup();
+        tx.send(Ok(Message::Text(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "starknet_subscribeNewTransactionReceipts",
+                "params": {
+                    "sender_address": ["0x1"],
+                    "finality_status": ["ACCEPTED_ON_L2", "PRE_CONFIRMED"]
+                }
+            })
+            .to_string(),
+        )))
+        .await
+        .unwrap();
+        let response = rx.recv().await.unwrap().unwrap();
+        let subscription_id = match response {
+            Message::Text(json) => {
+                let json: serde_json::Value = serde_json::from_str(&json).unwrap();
+                assert_eq!(json["jsonrpc"], "2.0");
+                assert_eq!(json["id"], 1);
+                json["result"].as_str().unwrap().parse().unwrap()
+            }
+            _ => {
+                panic!("Expected text message");
+            }
+        };
+        assert_recv_nothing(&mut rx).await;
+        pending_data_tx
+            .send(sample_pre_confirmed_block(
+                BlockNumber::new_or_panic(1),
+                vec![
+                    (contract_address!("0x1"), transaction_hash!("0x1")),
+                    (contract_address!("0x2"), transaction_hash!("0x2")),
+                ],
+            ))
+            .unwrap();
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_receipt_message(1, "0x1", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+    }
+
+    #[tokio::test]
+    async fn pre_confirmed_filtering_two_addresses() {
+        let Setup {
+            tx,
+            mut rx,
+            pending_data_tx,
+            ..
+        } = setup();
+        tx.send(Ok(Message::Text(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "starknet_subscribeNewTransactionReceipts",
+                "params": {
+                    "sender_address": ["0x1", "0x2"],
+                    "finality_status": ["ACCEPTED_ON_L2", "PRE_CONFIRMED"]
+                }
+            })
+            .to_string(),
+        )))
+        .await
+        .unwrap();
+        let response = rx.recv().await.unwrap().unwrap();
+        let subscription_id = match response {
+            Message::Text(json) => {
+                let json: serde_json::Value = serde_json::from_str(&json).unwrap();
+                assert_eq!(json["jsonrpc"], "2.0");
+                assert_eq!(json["id"], 1);
+                json["result"].as_str().unwrap().parse().unwrap()
+            }
+            _ => {
+                panic!("Expected text message");
+            }
+        };
+        assert_recv_nothing(&mut rx).await;
+        pending_data_tx
+            .send(sample_pre_confirmed_block(
+                BlockNumber::new_or_panic(1),
+                vec![
+                    (contract_address!("0x1"), transaction_hash!("0x3")),
+                    (contract_address!("0x2"), transaction_hash!("0x4")),
+                    (contract_address!("0x3"), transaction_hash!("0x5")),
+                ],
+            ))
+            .unwrap();
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_receipt_message(1, "0x3", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_receipt_message(1, "0x4", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn pre_confirmed_followed_by_block_with_extra_transactions() {
+        let Setup {
+            tx,
+            mut rx,
+            pending_data_tx,
+            notifications,
+        } = setup();
+        tx.send(Ok(Message::Text(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "starknet_subscribeNewTransactionReceipts",
+                "params": {
+                    "finality_status": ["ACCEPTED_ON_L2", "PRE_CONFIRMED"]
+                }
+            })
+            .to_string(),
+        )))
+        .await
+        .unwrap();
+        let response = rx.recv().await.unwrap().unwrap();
+        let subscription_id = match response {
+            Message::Text(json) => {
+                let json: serde_json::Value = serde_json::from_str(&json).unwrap();
+                assert_eq!(json["jsonrpc"], "2.0");
+                assert_eq!(json["id"], 1);
+                json["result"].as_str().unwrap().parse().unwrap()
+            }
+            _ => {
+                panic!("Expected text message");
+            }
+        };
+        assert_recv_nothing(&mut rx).await;
+
+        // Send a pre-confirmed block with two transactions.
+        pending_data_tx
+            .send(sample_pre_confirmed_block(
+                BlockNumber::new_or_panic(1),
+                vec![
+                    (contract_address!("0x1"), transaction_hash!("0x3")),
+                    (contract_address!("0x2"), transaction_hash!("0x4")),
+                ],
+            ))
+            .unwrap();
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_receipt_message(1, "0x3", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_receipt_message(1, "0x4", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+
+        // The finalized block is sent after the pre-confirmed block, but contains more
+        // transactions
+        notifications
+            .l2_blocks
+            .send(
+                sample_block(
+                    BlockNumber::new_or_panic(1),
+                    vec![
+                        (contract_address!("0x1"), transaction_hash!("0x3")),
+                        (contract_address!("0x2"), transaction_hash!("0x4")),
+                        (contract_address!("0x1"), transaction_hash!("0x5")),
+                        (contract_address!("0x2"), transaction_hash!("0x6")),
+                    ],
+                )
+                .into(),
+            )
+            .unwrap();
+        // We expect transactions 0x3 and 0x4 to be re-sent, since the finality status
+        // has changed to ACCEPTED_ON_L2.
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_receipt_message(1, "0x3", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_receipt_message(1, "0x4", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_receipt_message(1, "0x5", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_receipt_message(1, "0x6", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+
+        // The next pre-confirmed block is sent.
+        pending_data_tx
+            .send(sample_pre_confirmed_block(
+                BlockNumber::new_or_panic(2),
+                vec![
+                    (contract_address!("0x1"), transaction_hash!("0x7")),
+                    (contract_address!("0x2"), transaction_hash!("0x8")),
+                ],
+            ))
+            .unwrap();
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_receipt_message(2, "0x7", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_receipt_message(2, "0x8", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn pre_confirmed_followed_by_block_with_filter_on_finality_status() {
+        let Setup {
+            tx,
+            mut rx,
+            pending_data_tx,
+            notifications,
+        } = setup();
+        tx.send(Ok(Message::Text(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "starknet_subscribeNewTransactionReceipts",
+                "params": {
+                    "finality_status": ["ACCEPTED_ON_L2"]
+                }
+            })
+            .to_string(),
+        )))
+        .await
+        .unwrap();
+        let response = rx.recv().await.unwrap().unwrap();
+        let subscription_id = match response {
+            Message::Text(json) => {
+                let json: serde_json::Value = serde_json::from_str(&json).unwrap();
+                assert_eq!(json["jsonrpc"], "2.0");
+                assert_eq!(json["id"], 1);
+                json["result"].as_str().unwrap().parse().unwrap()
+            }
+            _ => {
+                panic!("Expected text message");
+            }
+        };
+        assert_recv_nothing(&mut rx).await;
+
+        notifications
+            .l2_blocks
+            .send(
+                sample_block(
+                    BlockNumber::new_or_panic(0),
+                    vec![(contract_address!("0x1"), transaction_hash!("0x1"))],
+                )
+                .into(),
+            )
+            .unwrap();
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_receipt_message(0, "0x1", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+
+        // Send a pre-confirmed block with two transactions: since we're filtering on
+        // finality status ACCEPTED_ON_L2, we expect that the pre-confirmed
+        // block will not send any receipts.
+        pending_data_tx
+            .send(sample_pre_confirmed_block(
+                BlockNumber::new_or_panic(1),
+                vec![
+                    (contract_address!("0x1"), transaction_hash!("0x3")),
+                    (contract_address!("0x2"), transaction_hash!("0x4")),
+                ],
+            ))
+            .unwrap();
+        assert_recv_nothing(&mut rx).await;
+
+        // The finalized block is sent after the pre-confirmed block, but contains more
+        // transactions.
+        notifications
+            .l2_blocks
+            .send(
+                sample_block(
+                    BlockNumber::new_or_panic(1),
+                    vec![
+                        (contract_address!("0x1"), transaction_hash!("0x3")),
+                        (contract_address!("0x2"), transaction_hash!("0x4")),
+                        (contract_address!("0x1"), transaction_hash!("0x5")),
+                        (contract_address!("0x2"), transaction_hash!("0x6")),
+                    ],
+                )
+                .into(),
+            )
+            .unwrap();
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_receipt_message(1, "0x3", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_receipt_message(1, "0x4", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_receipt_message(1, "0x5", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_receipt_message(1, "0x6", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+
+        // The next pre-confirmed block is sent, we expect no receipts.
+        pending_data_tx
+            .send(sample_pre_confirmed_block(
+                BlockNumber::new_or_panic(2),
+                vec![
+                    (contract_address!("0x1"), transaction_hash!("0x7")),
+                    (contract_address!("0x2"), transaction_hash!("0x8")),
+                ],
+            ))
+            .unwrap();
+        assert_recv_nothing(&mut rx).await;
+    }
+
+    async fn recv(rx: &mut mpsc::Receiver<Result<Message, RpcResponse>>) -> serde_json::Value {
+        let res = rx.recv().await.unwrap().unwrap();
+        match res {
+            Message::Text(json) => serde_json::from_str(&json).unwrap(),
+            _ => panic!("Expected text message"),
+        }
+    }
+
+    /// Waits for the receiver to receive nothing within a short timeout.
+    /// If it receives a message, it panics.
+    async fn assert_recv_nothing(rx: &mut mpsc::Receiver<Result<Message, RpcResponse>>) {
+        let timeout = std::time::Duration::from_millis(100);
+        tokio::time::timeout(timeout, rx.recv())
+            .await
+            .expect_err("Message received when none was expected");
+    }
+
+    fn sample_pre_confirmed_block(
+        block_number: BlockNumber,
+        txs: Vec<(ContractAddress, TransactionHash)>,
+    ) -> PendingData {
+        let pre_confirmed_block = PreConfirmedBlock {
+            status: starknet_gateway_types::reply::Status::PreConfirmed,
+            transactions: txs
+                .iter()
+                .map(|(sender_address, hash)| Transaction {
+                    variant: TransactionVariant::DeclareV0(DeclareTransactionV0V1 {
+                        sender_address: *sender_address,
+                        ..Default::default()
+                    }),
+                    hash: *hash,
+                })
+                .collect(),
+            transaction_receipts: txs
+                .iter()
+                .map(|(_sender_address, hash)| {
+                    Some((
+                        pathfinder_common::receipt::Receipt {
+                            transaction_hash: *hash,
+                            ..Default::default()
+                        },
+                        vec![],
+                    ))
+                })
+                .collect(),
+            transaction_state_diffs: vec![],
+            ..Default::default()
+        };
+        PendingData::from_pre_confirmed_block(pre_confirmed_block, block_number)
+    }
+
+    fn sample_pre_confirmed_receipt_message(
+        block_number: u64,
+        hash: &str,
+        subscription_id: u64,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "jsonrpc":"2.0",
+            "method":"starknet_subscriptionNewTransactionReceipts",
+            "params": {
+                "result": {
+                    "block_number": block_number,
+                    "type": "DECLARE",
+                    "transaction_hash": hash,
+                    "actual_fee": {
+                        "amount": "0x0",
+                        "unit": "WEI"
+                    },
+                    "finality_status": "PRE_CONFIRMED",
+                    "execution_status": "SUCCEEDED",
+                    "messages_sent": [],
+                    "events": [],
+                    "execution_resources": {
+                        "l1_gas": 0,
+                        "l1_data_gas": 0,
+                        "l2_gas": 0,
+                    }
+                },
+                "subscription_id": subscription_id.to_string()
+            }
+        })
+    }
+
+    fn sample_receipt_message(
+        block_number: u64,
+        hash: &str,
+        subscription_id: u64,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "jsonrpc":"2.0",
+            "method":"starknet_subscriptionNewTransactionReceipts",
+            "params": {
+                "result": {
+                    "block_hash": Felt::from_u64(block_number),
+                    "block_number": block_number,
+                    "type": "DECLARE",
+                    "transaction_hash": hash,
+                    "actual_fee": {
+                        "amount": "0x0",
+                        "unit": "WEI"
+                    },
+                    "finality_status": "ACCEPTED_ON_L2",
+                    "execution_status": "SUCCEEDED",
+                    "messages_sent": [],
+                    "events": [],
+                    "execution_resources": {
+                        "l1_gas": 0,
+                        "l1_data_gas": 0,
+                        "l2_gas": 0,
+                    }
+                },
+                "subscription_id": subscription_id.to_string()
+            }
+        })
+    }
+
+    fn sample_block(
+        block_number: BlockNumber,
+        txs: Vec<(ContractAddress, TransactionHash)>,
+    ) -> starknet_gateway_types::reply::Block {
+        starknet_gateway_types::reply::Block {
+            block_hash: BlockHash(Felt::from_u64(block_number.get())),
+            block_number,
+            parent_block_hash: BlockHash::ZERO,
+            transactions: txs
+                .iter()
+                .map(|(sender_address, hash)| Transaction {
+                    variant: TransactionVariant::DeclareV0(DeclareTransactionV0V1 {
+                        sender_address: *sender_address,
+                        ..Default::default()
+                    }),
+                    hash: *hash,
+                })
+                .collect(),
+            transaction_receipts: txs
+                .iter()
+                .map(|(_sender_address, hash)| {
+                    (
+                        pathfinder_common::receipt::Receipt {
+                            transaction_hash: *hash,
+                            ..Default::default()
+                        },
+                        vec![],
+                    )
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    fn sample_header(block_number: u64) -> BlockHeader {
+        BlockHeader {
+            hash: BlockHash(Felt::from_u64(block_number)),
+            number: BlockNumber::new_or_panic(block_number),
+            parent_hash: BlockHash::ZERO,
+            ..Default::default()
+        }
+    }
+
+    fn setup() -> Setup {
+        let storage = StorageBuilder::in_memory().unwrap();
+        {
+            let mut conn = storage.connection().unwrap();
+            let db = conn.transaction().unwrap();
+            db.insert_block_header(&sample_header(0)).unwrap();
+            db.commit().unwrap();
+        }
+        let (pending_data_tx, pending_data) = tokio::sync::watch::channel(Default::default());
+        let notifications = Notifications::default();
+        let ctx = RpcContext::for_tests()
+            .with_storage(storage)
+            .with_notifications(notifications.clone())
+            .with_pending_data(pending_data.clone())
+            .with_websockets(WebsocketContext::new(WebsocketHistory::Unlimited));
+        let router = v09::register_routes().build(ctx);
+        let (sender_tx, sender_rx) = mpsc::channel(1024);
+        let (receiver_tx, receiver_rx) = mpsc::channel(1024);
+        handle_json_rpc_socket(router.clone(), sender_tx, receiver_rx);
+        Setup {
+            tx: receiver_tx,
+            rx: sender_rx,
+            pending_data_tx,
+            notifications,
+        }
+    }
+
+    struct Setup {
+        tx: mpsc::Sender<Result<Message, axum::Error>>,
+        rx: mpsc::Receiver<Result<Message, RpcResponse>>,
+        pending_data_tx: watch::Sender<PendingData>,
+        notifications: Notifications,
+    }
+}

--- a/crates/rpc/src/types/receipt.rs
+++ b/crates/rpc/src/types/receipt.rs
@@ -156,37 +156,6 @@ impl crate::dto::SerializeForVersion for ExecutionStatus {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(test, derive(serde::Deserialize))]
-pub enum FinalityStatus {
-    AcceptedOnL2,
-    //AcceptedOnL1,
-}
-
-impl crate::dto::SerializeForVersion for FinalityStatus {
-    fn serialize(
-        &self,
-        serializer: crate::dto::Serializer,
-    ) -> Result<crate::dto::Ok, crate::dto::Error> {
-        match self {
-            Self::AcceptedOnL2 => serializer.serialize_str("ACCEPTED_ON_L2"),
-        }
-    }
-}
-
-impl crate::dto::DeserializeForVersion for FinalityStatus {
-    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
-        let s: String = value.deserialize()?;
-        match s.as_str() {
-            "ACCEPTED_ON_L2" => Ok(Self::AcceptedOnL2),
-            _ => Err(serde::de::Error::unknown_variant(
-                "Unknown finality status",
-                &["ACCEPTED_ON_L2"],
-            )),
-        }
-    }
-}
-
 /// Message sent from L2 to L1.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(test, derive(serde::Deserialize))]

--- a/crates/rpc/src/v09.rs
+++ b/crates/rpc/src/v09.rs
@@ -1,6 +1,7 @@
 use crate::jsonrpc::{RpcRouter, RpcRouterBuilder};
 use crate::method::subscribe_events::SubscribeEvents;
 use crate::method::subscribe_new_heads::SubscribeNewHeads;
+use crate::method::subscribe_new_transaction_receipts::SubscribeNewTransactionReceipts;
 use crate::method::subscribe_pending_transactions::SubscribePendingTransactions;
 use crate::method::subscribe_transaction_status::SubscribeTransactionStatus;
 // re-using v08-specific methods
@@ -39,6 +40,7 @@ pub fn register_routes() -> RpcRouterBuilder {
         .register("starknet_simulateTransactions",                crate::method::simulate_transactions)
         .register("starknet_subscribeNewHeads",                   SubscribeNewHeads)
         .register("starknet_subscribePendingTransactions",        SubscribePendingTransactions)
+        .register("starknet_subscribeNewTransactionReceipts",     SubscribeNewTransactionReceipts)
         .register("starknet_subscribeEvents",                     SubscribeEvents)
         .register("starknet_subscribeTransactionStatus",          SubscribeTransactionStatus)
         .register("starknet_specVersion",                         || "0.9.0-rc.2")


### PR DESCRIPTION
This PR adds an implementation for the `subscribe_newTransactionReceipts` JSON-RPC method introduced in JSON-RPC 0.9.0-rc.3.

This method sends notifications for new transaction receipts with a finality state specified in the request (defaults to ACCEPTED_ON_L2, but users can request PRE_CONFIRMED receipts as well).