### PR TITLE
feat(rpc/v09): implement `starknet_subscribeNewTransactions`

### DIFF
--- a/crates/rpc/src/dto/receipt.rs
+++ b/crates/rpc/src/dto/receipt.rs
@@ -41,8 +41,9 @@ impl From<&pathfinder_common::receipt::ExecutionStatus> for TxnExecutionStatus {
 
 struct TxnExecutionStatusWithRevertReason<'a>(pub &'a pathfinder_common::receipt::ExecutionStatus);
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum TxnFinalityStatus {
+    Candidate,
     PreConfirmed,
     AcceptedOnL2,
     AcceptedOnL1,
@@ -135,6 +136,7 @@ impl SerializeForVersion for TxnExecutionStatusWithRevertReason<'_> {
 impl SerializeForVersion for TxnFinalityStatus {
     fn serialize(&self, serializer: Serializer) -> Result<crate::dto::Ok, crate::dto::Error> {
         match self {
+            TxnFinalityStatus::Candidate => "CANDIDATE",
             TxnFinalityStatus::PreConfirmed => "PRE_CONFIRMED",
             TxnFinalityStatus::AcceptedOnL2 => "ACCEPTED_ON_L2",
             TxnFinalityStatus::AcceptedOnL1 => "ACCEPTED_ON_L1",
@@ -147,6 +149,7 @@ impl crate::dto::DeserializeForVersion for TxnFinalityStatus {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
         let s: String = value.deserialize()?;
         match s.as_str() {
+            "CANDIDATE" => Ok(Self::Candidate),
             "ACCEPTED_ON_L1" => Ok(Self::AcceptedOnL1),
             "ACCEPTED_ON_L2" => Ok(Self::AcceptedOnL2),
             "PRE_CONFIRMED" => Ok(Self::PreConfirmed),

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1167,9 +1167,10 @@ mod tests {
         // "starknet_subscription*" methods are in fact notifications
         &[
             "starknet_subscriptionNewHeads",
-            "starknet_subscriptionPendingTransactions",
             "starknet_subscriptionTransactionStatus",
             "starknet_subscriptionEvents",
+            "starknet_subscriptionNewTransactionReceipts",
+            "starknet_subscriptionNewTransaction",
             "starknet_subscriptionReorg"
         ],
         Api::WebsocketOnly)]
@@ -1184,9 +1185,10 @@ mod tests {
         // "starknet_subscription*" methods are in fact notifications
         &[
             "starknet_subscriptionNewHeads",
-            "starknet_subscriptionPendingTransactions",
             "starknet_subscriptionTransactionStatus",
             "starknet_subscriptionEvents",
+            "starknet_subscriptionNewTransactionReceipts",
+            "starknet_subscriptionNewTransaction",
             "starknet_subscriptionReorg"
         ],
         Api::WebsocketOnly)]

--- a/crates/rpc/src/method.rs
+++ b/crates/rpc/src/method.rs
@@ -30,6 +30,7 @@ pub mod simulate_transactions;
 pub mod subscribe_events;
 pub mod subscribe_new_heads;
 pub mod subscribe_new_transaction_receipts;
+pub mod subscribe_new_transactions;
 pub mod subscribe_pending_transactions;
 pub mod subscribe_transaction_status;
 pub mod syncing;

--- a/crates/rpc/src/method/get_transaction_status.rs
+++ b/crates/rpc/src/method/get_transaction_status.rs
@@ -68,6 +68,9 @@ pub async fn get_transaction_status(
             .find(|(rx, _)| rx.transaction_hash == input.transaction_hash)
         {
             let output = match pending_data.block().finality_status() {
+                // This is not possible here (candidate transactions do not have receipts) but we're
+                // handling it for completeness.
+                crate::dto::TxnFinalityStatus::Candidate => Output::Candidate,
                 crate::dto::TxnFinalityStatus::PreConfirmed => {
                     Output::PreConfirmed((&receipt.execution_status).into())
                 }

--- a/crates/rpc/src/method/subscribe_new_transactions.rs
+++ b/crates/rpc/src/method/subscribe_new_transactions.rs
@@ -1,0 +1,1029 @@
+use std::collections::HashSet;
+
+use pathfinder_common::transaction::Transaction;
+use pathfinder_common::{BlockNumber, ContractAddress};
+use tokio::sync::mpsc;
+
+use crate::context::RpcContext;
+use crate::dto::{TransactionWithHash, TxnFinalityStatus};
+use crate::jsonrpc::{RpcError, RpcSubscriptionFlow, SubscriptionMessage};
+use crate::RpcVersion;
+
+pub struct SubscribeNewTransactions;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Params {
+    finality_status: Vec<TxnFinalityStatus>,
+    sender_address: Option<HashSet<ContractAddress>>,
+}
+
+impl Default for Params {
+    fn default() -> Self {
+        Params {
+            finality_status: vec![TxnFinalityStatus::AcceptedOnL2],
+            sender_address: None,
+        }
+    }
+}
+
+impl Params {
+    fn matches(&self, sender_address: &ContractAddress, finality: TxnFinalityStatus) -> bool {
+        if let Some(addresses) = &self.sender_address {
+            if !addresses.contains(sender_address) {
+                return false;
+            }
+        }
+        if !self.finality_status.contains(&finality) {
+            return false;
+        }
+        true
+    }
+}
+
+impl crate::dto::DeserializeForVersion for Option<Params> {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        if value.is_null() {
+            return Ok(None);
+        }
+        value.deserialize_map(|value| {
+            Ok(Some(Params {
+                finality_status: value
+                    .deserialize_optional_array("finality_status", |v| {
+                        v.deserialize::<TxnFinalityStatusWithoutL1Accepted>()
+                            .map(Into::into)
+                    })?
+                    .unwrap_or_else(|| vec![TxnFinalityStatus::AcceptedOnL2]),
+                sender_address: value
+                    .deserialize_optional_array("sender_address", |addr| {
+                        Ok(ContractAddress(addr.deserialize()?))
+                    })?
+                    .map(|addrs| addrs.into_iter().collect()),
+            }))
+        })
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum TxnFinalityStatusWithoutL1Accepted {
+    Candidate,
+    PreConfirmed,
+    AcceptedOnL2,
+}
+
+impl crate::dto::DeserializeForVersion for TxnFinalityStatusWithoutL1Accepted {
+    fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
+        let s: String = value.deserialize()?;
+        match s.as_str() {
+            "CANDIDATE" => Ok(Self::Candidate),
+            "ACCEPTED_ON_L2" => Ok(Self::AcceptedOnL2),
+            "PRE_CONFIRMED" => Ok(Self::PreConfirmed),
+            _ => Err(serde::de::Error::unknown_variant(
+                &s,
+                &["ACCEPTED_ON_L2", "PRE_CONFIRMED", "CANDIDATE"],
+            )),
+        }
+    }
+}
+
+impl From<TxnFinalityStatusWithoutL1Accepted> for TxnFinalityStatus {
+    fn from(status: TxnFinalityStatusWithoutL1Accepted) -> Self {
+        match status {
+            TxnFinalityStatusWithoutL1Accepted::Candidate => TxnFinalityStatus::Candidate,
+            TxnFinalityStatusWithoutL1Accepted::PreConfirmed => TxnFinalityStatus::PreConfirmed,
+            TxnFinalityStatusWithoutL1Accepted::AcceptedOnL2 => TxnFinalityStatus::AcceptedOnL2,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Notification {
+    transaction: Transaction,
+    finality: TxnFinalityStatus,
+}
+
+impl crate::dto::SerializeForVersion for Notification {
+    fn serialize(
+        &self,
+        serializer: crate::dto::Serializer,
+    ) -> Result<crate::dto::Ok, crate::dto::Error> {
+        let mut serializer = serializer.serialize_struct()?;
+        serializer.flatten(&TransactionWithHash(&self.transaction))?;
+        serializer.serialize_field("finality_status", &self.finality)?;
+        serializer.end()
+    }
+}
+
+const SUBSCRIPTION_NAME: &str = "starknet_subscriptionNewTransactions";
+
+impl RpcSubscriptionFlow for SubscribeNewTransactions {
+    type Params = Option<Params>;
+    type Notification = Notification;
+
+    async fn subscribe(
+        state: RpcContext,
+        _version: RpcVersion,
+        params: Self::Params,
+        tx: mpsc::Sender<SubscriptionMessage<Self::Notification>>,
+    ) -> Result<(), RpcError> {
+        let params = params.unwrap_or_default();
+        let mut blocks = state.notifications.l2_blocks.subscribe();
+        let mut pending_data = state.pending_data.0.clone();
+
+        // Last block sent to the subscriber. Initial value doesn't really matter.
+        let mut last_pre_confirmed_block = BlockNumber::GENESIS;
+
+        // Set to keep track of sent transactions to avoid duplicates.
+        let mut pre_confirmed_sent_txs = HashSet::new();
+
+        loop {
+            tokio::select! {
+                block = blocks.recv() => {
+                    match block {
+                        Err(e) => {
+                            tracing::debug!(error=%e, "Block channel closed, stopping subscription");
+                            return Ok(());
+                        }
+                        Ok(block) => {
+                            tracing::trace!(block_number=%block.block_number, "New block header");
+
+                            if block.block_number == last_pre_confirmed_block {
+                                // Send all transactions that might have been missed in the pre-confirmed block.
+                                for transaction in block.transactions.iter() {
+                                    if !params.matches(&transaction.variant.sender_address(), TxnFinalityStatus::AcceptedOnL2) {
+                                        continue;
+                                    }
+
+                                    let notification = Notification {
+                                        transaction: transaction.clone(),
+                                        finality: TxnFinalityStatus::AcceptedOnL2,
+                                    };
+                                    if tx
+                                        .send(SubscriptionMessage {
+                                            notification,
+                                            block_number: block.block_number,
+                                            subscription_name: SUBSCRIPTION_NAME,
+                                        })
+                                        .await
+                                        .is_err()
+                                    {
+                                        // Close subscription.
+                                        return Ok(());
+                                    }
+                                }
+
+                                // Clear the sent transactions set.
+                                pre_confirmed_sent_txs.clear();
+                            }
+                        }
+                    }
+                }
+                pending_changed = pending_data.changed() => {
+                    if let Err(e) = pending_changed {
+                        tracing::debug!(error=%e, "Pending data channel closed, stopping subscription");
+                        return Ok(());
+                    }
+
+                    let pending = pending_data.borrow_and_update().clone();
+                    let finality_status = pending.block().finality_status();
+
+                    tracing::trace!(block_number=%pending.block_number(), ?finality_status, "Pre-confirmed block update");
+
+                    if pending.block_number() != last_pre_confirmed_block {
+                        last_pre_confirmed_block = pending.block_number();
+                        pre_confirmed_sent_txs.clear();
+                    }
+
+                    for (transaction, finality_status) in pending.transactions().iter().zip(std::iter::repeat(finality_status)).chain(
+                        pending.candidate_transactions().into_iter().flatten().zip(std::iter::repeat(TxnFinalityStatus::Candidate))
+                    ) {
+                        if pre_confirmed_sent_txs.contains(&(transaction.hash, finality_status)) {
+                            continue;
+                        }
+
+                        if !params.matches(&transaction.variant.sender_address(), finality_status) {
+                            continue;
+                        }
+
+                        let notification = Notification {
+                            transaction: transaction.clone(),
+                            finality: finality_status,
+                        };
+                        pre_confirmed_sent_txs.insert((transaction.hash, finality_status));
+                        if tx
+                            .send(SubscriptionMessage {
+                                notification,
+                                block_number: pending.block_number(),
+                                subscription_name: SUBSCRIPTION_NAME,
+                            })
+                            .await
+                            .is_err()
+                        {
+                            // Close subscription.
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::extract::ws::Message;
+    use pathfinder_common::macro_prelude::*;
+    use pathfinder_common::prelude::*;
+    use pathfinder_common::transaction::{DeclareTransactionV0V1, Transaction, TransactionVariant};
+    use pathfinder_crypto::Felt;
+    use pathfinder_storage::StorageBuilder;
+    use starknet_gateway_types::reply::PreConfirmedBlock;
+    use tokio::sync::{mpsc, watch};
+
+    use super::Params;
+    use crate::context::{RpcContext, WebsocketContext};
+    use crate::dto::TxnFinalityStatus;
+    use crate::jsonrpc::websocket::WebsocketHistory;
+    use crate::jsonrpc::{handle_json_rpc_socket, RpcResponse};
+    use crate::{v09, Notifications, PendingData, RpcVersion};
+
+    #[test]
+    fn parse_params() {
+        let params = crate::dto::Value::new(
+            serde_json::json!({
+                "finality_status": ["ACCEPTED_ON_L2", "PRE_CONFIRMED", "CANDIDATE"],
+                "sender_address": ["0x1", "0x2"]
+            }),
+            RpcVersion::V09,
+        );
+        let params: Option<Params> = params.deserialize().unwrap();
+        assert_eq!(
+            params.unwrap(),
+            Params {
+                finality_status: vec![
+                    TxnFinalityStatus::AcceptedOnL2,
+                    TxnFinalityStatus::PreConfirmed,
+                    TxnFinalityStatus::Candidate
+                ],
+                sender_address: Some(
+                    [contract_address!("0x1"), contract_address!("0x2")]
+                        .iter()
+                        .cloned()
+                        .collect()
+                ),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_params_fails_for_invalid_finality_status() {
+        let params = crate::dto::Value::new(
+            serde_json::json!({
+                "finality_status": ["ACCEPTED_ON_L2", "ACCEPTED_ON_L1"],
+                "sender_address": ["0x1", "0x2"]
+            }),
+            RpcVersion::V09,
+        );
+        let error = params.deserialize::<Option<Params>>().unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "unknown variant `ACCEPTED_ON_L1`, expected one of `ACCEPTED_ON_L2`, `PRE_CONFIRMED`, \
+             `CANDIDATE`"
+                .to_string()
+        );
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn pre_confirmed_no_filtering() {
+        let Setup {
+            tx,
+            mut rx,
+            pending_data_tx,
+            ..
+        } = setup();
+        tx.send(Ok(Message::Text(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "starknet_subscribeNewTransactions",
+                "params": {
+                    "finality_status": ["ACCEPTED_ON_L2", "PRE_CONFIRMED"]
+                }
+            })
+            .to_string(),
+        )))
+        .await
+        .unwrap();
+        let response = rx.recv().await.unwrap().unwrap();
+        let subscription_id = match response {
+            Message::Text(json) => {
+                let json: serde_json::Value = serde_json::from_str(&json).unwrap();
+                assert_eq!(json["jsonrpc"], "2.0");
+                assert_eq!(json["id"], 1);
+                json["result"].as_str().unwrap().parse().unwrap()
+            }
+            _ => {
+                panic!("Expected text message");
+            }
+        };
+        assert_recv_nothing(&mut rx).await;
+
+        // First pre-confirmed block update.
+        pending_data_tx
+            .send(sample_pre_confirmed_block(
+                BlockNumber::new_or_panic(1),
+                vec![
+                    (contract_address!("0x1"), transaction_hash!("0x3")),
+                    (contract_address!("0x2"), transaction_hash!("0x4")),
+                ],
+                vec![],
+            ))
+            .unwrap();
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_transaction_message("0x1", "0x3", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_transaction_message("0x2", "0x4", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+
+        // We expect that the second pre-confirmed block update will ignore
+        // transactions that were already sent.
+        pending_data_tx
+            .send(sample_pre_confirmed_block(
+                BlockNumber::new_or_panic(1),
+                vec![
+                    (contract_address!("0x1"), transaction_hash!("0x3")),
+                    (contract_address!("0x2"), transaction_hash!("0x4")),
+                    (contract_address!("0x1"), transaction_hash!("0x5")),
+                    (contract_address!("0x2"), transaction_hash!("0x6")),
+                ],
+                vec![],
+            ))
+            .unwrap();
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_transaction_message("0x1", "0x5", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_transaction_message("0x2", "0x6", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn pre_confirmed_with_candidate() {
+        let Setup {
+            tx,
+            mut rx,
+            pending_data_tx,
+            ..
+        } = setup();
+        tx.send(Ok(Message::Text(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "starknet_subscribeNewTransactions",
+                "params": {
+                    "finality_status": ["ACCEPTED_ON_L2", "PRE_CONFIRMED", "CANDIDATE"]
+                }
+            })
+            .to_string(),
+        )))
+        .await
+        .unwrap();
+        let response = rx.recv().await.unwrap().unwrap();
+        let subscription_id = match response {
+            Message::Text(json) => {
+                let json: serde_json::Value = serde_json::from_str(&json).unwrap();
+                assert_eq!(json["jsonrpc"], "2.0");
+                assert_eq!(json["id"], 1);
+                json["result"].as_str().unwrap().parse().unwrap()
+            }
+            _ => {
+                panic!("Expected text message");
+            }
+        };
+        assert_recv_nothing(&mut rx).await;
+
+        // First pre-confirmed block update.
+        pending_data_tx
+            .send(sample_pre_confirmed_block(
+                BlockNumber::new_or_panic(1),
+                vec![
+                    (contract_address!("0x1"), transaction_hash!("0x3")),
+                    (contract_address!("0x2"), transaction_hash!("0x4")),
+                ],
+                vec![],
+            ))
+            .unwrap();
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_transaction_message("0x1", "0x3", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_transaction_message("0x2", "0x4", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+
+        // We expect that the second pre-confirmed block update will ignore
+        // transactions that were already sent. This includes a candidate transaction
+        // that was not sent before.
+        pending_data_tx
+            .send(sample_pre_confirmed_block(
+                BlockNumber::new_or_panic(1),
+                vec![
+                    (contract_address!("0x1"), transaction_hash!("0x3")),
+                    (contract_address!("0x2"), transaction_hash!("0x4")),
+                    (contract_address!("0x1"), transaction_hash!("0x5")),
+                ],
+                vec![(contract_address!("0x2"), transaction_hash!("0x6"))],
+            ))
+            .unwrap();
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_transaction_message("0x1", "0x5", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_candidate_transaction_message("0x2", "0x6", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+
+        // The next pre-confirmed block does have a receipt for the previously sent
+        // candidate transaction. We expect the transaction to be re-sent with
+        // PRE_CONFIRMED status.
+        pending_data_tx
+            .send(sample_pre_confirmed_block(
+                BlockNumber::new_or_panic(1),
+                vec![
+                    (contract_address!("0x1"), transaction_hash!("0x3")),
+                    (contract_address!("0x2"), transaction_hash!("0x4")),
+                    (contract_address!("0x1"), transaction_hash!("0x5")),
+                    (contract_address!("0x2"), transaction_hash!("0x6")),
+                ],
+                vec![],
+            ))
+            .unwrap();
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_transaction_message("0x2", "0x6", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+    }
+
+    #[tokio::test]
+    async fn pre_confirmed_filtering_one_address() {
+        let Setup {
+            tx,
+            mut rx,
+            pending_data_tx,
+            ..
+        } = setup();
+        tx.send(Ok(Message::Text(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "starknet_subscribeNewTransactions",
+                "params": {
+                    "sender_address": ["0x1"],
+                    "finality_status": ["ACCEPTED_ON_L2", "PRE_CONFIRMED"]
+                }
+            })
+            .to_string(),
+        )))
+        .await
+        .unwrap();
+        let response = rx.recv().await.unwrap().unwrap();
+        let subscription_id = match response {
+            Message::Text(json) => {
+                let json: serde_json::Value = serde_json::from_str(&json).unwrap();
+                assert_eq!(json["jsonrpc"], "2.0");
+                assert_eq!(json["id"], 1);
+                json["result"].as_str().unwrap().parse().unwrap()
+            }
+            _ => {
+                panic!("Expected text message");
+            }
+        };
+        assert_recv_nothing(&mut rx).await;
+        pending_data_tx
+            .send(sample_pre_confirmed_block(
+                BlockNumber::new_or_panic(1),
+                vec![
+                    (contract_address!("0x1"), transaction_hash!("0x1")),
+                    (contract_address!("0x2"), transaction_hash!("0x2")),
+                ],
+                vec![],
+            ))
+            .unwrap();
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_transaction_message("0x1", "0x1", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+    }
+
+    #[tokio::test]
+    async fn pre_confirmed_filtering_two_addresses() {
+        let Setup {
+            tx,
+            mut rx,
+            pending_data_tx,
+            ..
+        } = setup();
+        tx.send(Ok(Message::Text(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "starknet_subscribeNewTransactions",
+                "params": {
+                    "sender_address": ["0x1", "0x2"],
+                    "finality_status": ["ACCEPTED_ON_L2", "PRE_CONFIRMED"]
+                }
+            })
+            .to_string(),
+        )))
+        .await
+        .unwrap();
+        let response = rx.recv().await.unwrap().unwrap();
+        let subscription_id = match response {
+            Message::Text(json) => {
+                let json: serde_json::Value = serde_json::from_str(&json).unwrap();
+                assert_eq!(json["jsonrpc"], "2.0");
+                assert_eq!(json["id"], 1);
+                json["result"].as_str().unwrap().parse().unwrap()
+            }
+            _ => {
+                panic!("Expected text message");
+            }
+        };
+        assert_recv_nothing(&mut rx).await;
+        pending_data_tx
+            .send(sample_pre_confirmed_block(
+                BlockNumber::new_or_panic(1),
+                vec![
+                    (contract_address!("0x1"), transaction_hash!("0x3")),
+                    (contract_address!("0x2"), transaction_hash!("0x4")),
+                    (contract_address!("0x3"), transaction_hash!("0x5")),
+                ],
+                vec![],
+            ))
+            .unwrap();
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_transaction_message("0x1", "0x3", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_transaction_message("0x2", "0x4", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn pre_confirmed_followed_by_block_with_extra_transactions() {
+        let Setup {
+            tx,
+            mut rx,
+            pending_data_tx,
+            notifications,
+        } = setup();
+        tx.send(Ok(Message::Text(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "starknet_subscribeNewTransactions",
+                "params": {
+                    "finality_status": ["ACCEPTED_ON_L2", "PRE_CONFIRMED"]
+                }
+            })
+            .to_string(),
+        )))
+        .await
+        .unwrap();
+        let response = rx.recv().await.unwrap().unwrap();
+        let subscription_id = match response {
+            Message::Text(json) => {
+                let json: serde_json::Value = serde_json::from_str(&json).unwrap();
+                assert_eq!(json["jsonrpc"], "2.0");
+                assert_eq!(json["id"], 1);
+                json["result"].as_str().unwrap().parse().unwrap()
+            }
+            _ => {
+                panic!("Expected text message");
+            }
+        };
+        assert_recv_nothing(&mut rx).await;
+
+        // Send a pre-confirmed block with two transactions.
+        pending_data_tx
+            .send(sample_pre_confirmed_block(
+                BlockNumber::new_or_panic(1),
+                vec![
+                    (contract_address!("0x1"), transaction_hash!("0x3")),
+                    (contract_address!("0x2"), transaction_hash!("0x4")),
+                ],
+                vec![],
+            ))
+            .unwrap();
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_transaction_message("0x1", "0x3", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_transaction_message("0x2", "0x4", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+
+        // The finalized block is sent after the pre-confirmed block, but contains more
+        // transactions
+        notifications
+            .l2_blocks
+            .send(
+                sample_block(
+                    BlockNumber::new_or_panic(1),
+                    vec![
+                        (contract_address!("0x1"), transaction_hash!("0x3")),
+                        (contract_address!("0x2"), transaction_hash!("0x4")),
+                        (contract_address!("0x1"), transaction_hash!("0x5")),
+                        (contract_address!("0x2"), transaction_hash!("0x6")),
+                    ],
+                )
+                .into(),
+            )
+            .unwrap();
+        // We expect transactions 0x3 and 0x4 to be re-sent, since the finality status
+        // has changed to ACCEPTED_ON_L2.
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_transaction_message("0x1", "0x3", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_transaction_message("0x2", "0x4", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_transaction_message("0x1", "0x5", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_transaction_message("0x2", "0x6", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+
+        // The next pre-confirmed block is sent.
+        pending_data_tx
+            .send(sample_pre_confirmed_block(
+                BlockNumber::new_or_panic(2),
+                vec![
+                    (contract_address!("0x1"), transaction_hash!("0x7")),
+                    (contract_address!("0x2"), transaction_hash!("0x8")),
+                ],
+                vec![],
+            ))
+            .unwrap();
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_transaction_message("0x1", "0x7", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_transaction_message("0x2", "0x8", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn pre_confirmed_followed_by_block_with_filter_on_finality_status() {
+        let Setup {
+            tx,
+            mut rx,
+            pending_data_tx,
+            notifications,
+        } = setup();
+        tx.send(Ok(Message::Text(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "starknet_subscribeNewTransactions",
+                "params": {
+                    "finality_status": ["ACCEPTED_ON_L2"]
+                }
+            })
+            .to_string(),
+        )))
+        .await
+        .unwrap();
+        let response = rx.recv().await.unwrap().unwrap();
+        let subscription_id = match response {
+            Message::Text(json) => {
+                let json: serde_json::Value = serde_json::from_str(&json).unwrap();
+                assert_eq!(json["jsonrpc"], "2.0");
+                assert_eq!(json["id"], 1);
+                json["result"].as_str().unwrap().parse().unwrap()
+            }
+            _ => {
+                panic!("Expected text message");
+            }
+        };
+        assert_recv_nothing(&mut rx).await;
+
+        notifications
+            .l2_blocks
+            .send(
+                sample_block(
+                    BlockNumber::new_or_panic(0),
+                    vec![(contract_address!("0x1"), transaction_hash!("0x1"))],
+                )
+                .into(),
+            )
+            .unwrap();
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_transaction_message("0x1", "0x1", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+
+        // Send a pre-confirmed block with two transactions: since we're filtering on
+        // finality status ACCEPTED_ON_L2, we expect that the pre-confirmed
+        // block will not send any receipts.
+        pending_data_tx
+            .send(sample_pre_confirmed_block(
+                BlockNumber::new_or_panic(1),
+                vec![
+                    (contract_address!("0x1"), transaction_hash!("0x3")),
+                    (contract_address!("0x2"), transaction_hash!("0x4")),
+                ],
+                vec![],
+            ))
+            .unwrap();
+        assert_recv_nothing(&mut rx).await;
+
+        // The finalized block is sent after the pre-confirmed block, but contains more
+        // transactions.
+        notifications
+            .l2_blocks
+            .send(
+                sample_block(
+                    BlockNumber::new_or_panic(1),
+                    vec![
+                        (contract_address!("0x1"), transaction_hash!("0x3")),
+                        (contract_address!("0x2"), transaction_hash!("0x4")),
+                        (contract_address!("0x1"), transaction_hash!("0x5")),
+                        (contract_address!("0x2"), transaction_hash!("0x6")),
+                    ],
+                )
+                .into(),
+            )
+            .unwrap();
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_transaction_message("0x1", "0x3", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_transaction_message("0x2", "0x4", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_transaction_message("0x1", "0x5", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_transaction_message("0x2", "0x6", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+
+        // The next pre-confirmed block is sent, we expect no receipts.
+        pending_data_tx
+            .send(sample_pre_confirmed_block(
+                BlockNumber::new_or_panic(2),
+                vec![
+                    (contract_address!("0x1"), transaction_hash!("0x7")),
+                    (contract_address!("0x2"), transaction_hash!("0x8")),
+                ],
+                vec![],
+            ))
+            .unwrap();
+        assert_recv_nothing(&mut rx).await;
+    }
+
+    async fn recv(rx: &mut mpsc::Receiver<Result<Message, RpcResponse>>) -> serde_json::Value {
+        let res = rx.recv().await.unwrap().unwrap();
+        match res {
+            Message::Text(json) => serde_json::from_str(&json).unwrap(),
+            _ => panic!("Expected text message"),
+        }
+    }
+
+    /// Waits for the receiver to receive nothing within a short timeout.
+    /// If it receives a message, it panics.
+    async fn assert_recv_nothing(rx: &mut mpsc::Receiver<Result<Message, RpcResponse>>) {
+        let timeout = std::time::Duration::from_millis(100);
+        tokio::time::timeout(timeout, rx.recv())
+            .await
+            .expect_err("Message received when none was expected");
+    }
+
+    fn sample_pre_confirmed_block(
+        block_number: BlockNumber,
+        txs: Vec<(ContractAddress, TransactionHash)>,
+        candidate_txs: Vec<(ContractAddress, TransactionHash)>,
+    ) -> PendingData {
+        let pre_confirmed_block = PreConfirmedBlock {
+            status: starknet_gateway_types::reply::Status::PreConfirmed,
+            transactions: txs
+                .iter()
+                .map(|(sender_address, hash)| Transaction {
+                    variant: TransactionVariant::DeclareV0(DeclareTransactionV0V1 {
+                        sender_address: *sender_address,
+                        ..Default::default()
+                    }),
+                    hash: *hash,
+                })
+                .chain(
+                    candidate_txs
+                        .iter()
+                        .map(|(sender_address, hash)| Transaction {
+                            variant: TransactionVariant::DeclareV0(DeclareTransactionV0V1 {
+                                sender_address: *sender_address,
+                                ..Default::default()
+                            }),
+                            hash: *hash,
+                        }),
+                )
+                .collect(),
+            transaction_receipts: txs
+                .iter()
+                .map(|(_sender_address, hash)| {
+                    Some((
+                        pathfinder_common::receipt::Receipt {
+                            transaction_hash: *hash,
+                            ..Default::default()
+                        },
+                        vec![],
+                    ))
+                })
+                .chain(candidate_txs.iter().map(|_| None))
+                .collect(),
+            transaction_state_diffs: vec![],
+            ..Default::default()
+        };
+        PendingData::from_pre_confirmed_block(pre_confirmed_block, block_number)
+    }
+
+    fn sample_pre_confirmed_transaction_message(
+        sender_address: &str,
+        hash: &str,
+        subscription_id: u64,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "jsonrpc":"2.0",
+            "method":"starknet_subscriptionNewTransactions",
+            "params": {
+                "result": {
+                    "class_hash": "0x0",
+                    "max_fee": "0x0",
+                    "sender_address": sender_address,
+                    "signature": [],
+                    "transaction_hash": hash,
+                    "type": "DECLARE",
+                    "version": "0x0",
+                    "finality_status": "PRE_CONFIRMED",
+                },
+                "subscription_id": subscription_id.to_string()
+            }
+        })
+    }
+
+    fn sample_candidate_transaction_message(
+        sender_address: &str,
+        hash: &str,
+        subscription_id: u64,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "jsonrpc":"2.0",
+            "method":"starknet_subscriptionNewTransactions",
+            "params": {
+                "result": {
+                    "class_hash": "0x0",
+                    "max_fee": "0x0",
+                    "sender_address": sender_address,
+                    "signature": [],
+                    "transaction_hash": hash,
+                    "type": "DECLARE",
+                    "version": "0x0",
+                    "finality_status": "CANDIDATE",
+                },
+                "subscription_id": subscription_id.to_string()
+            }
+        })
+    }
+
+    fn sample_transaction_message(
+        sender_address: &str,
+        hash: &str,
+        subscription_id: u64,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "jsonrpc":"2.0",
+            "method":"starknet_subscriptionNewTransactions",
+            "params": {
+                "result": {
+                    "class_hash": "0x0",
+                    "max_fee": "0x0",
+                    "sender_address": sender_address,
+                    "signature": [],
+                    "transaction_hash": hash,
+                    "type": "DECLARE",
+                    "version": "0x0",
+                    "finality_status": "ACCEPTED_ON_L2",
+                },
+                "subscription_id": subscription_id.to_string()
+            }
+        })
+    }
+
+    fn sample_block(
+        block_number: BlockNumber,
+        txs: Vec<(ContractAddress, TransactionHash)>,
+    ) -> starknet_gateway_types::reply::Block {
+        starknet_gateway_types::reply::Block {
+            block_hash: BlockHash(Felt::from_u64(block_number.get())),
+            block_number,
+            parent_block_hash: BlockHash::ZERO,
+            transactions: txs
+                .iter()
+                .map(|(sender_address, hash)| Transaction {
+                    variant: TransactionVariant::DeclareV0(DeclareTransactionV0V1 {
+                        sender_address: *sender_address,
+                        ..Default::default()
+                    }),
+                    hash: *hash,
+                })
+                .collect(),
+            transaction_receipts: txs
+                .iter()
+                .map(|(_sender_address, hash)| {
+                    (
+                        pathfinder_common::receipt::Receipt {
+                            transaction_hash: *hash,
+                            ..Default::default()
+                        },
+                        vec![],
+                    )
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    fn sample_header(block_number: u64) -> BlockHeader {
+        BlockHeader {
+            hash: BlockHash(Felt::from_u64(block_number)),
+            number: BlockNumber::new_or_panic(block_number),
+            parent_hash: BlockHash::ZERO,
+            ..Default::default()
+        }
+    }
+
+    fn setup() -> Setup {
+        let storage = StorageBuilder::in_memory().unwrap();
+        {
+            let mut conn = storage.connection().unwrap();
+            let db = conn.transaction().unwrap();
+            db.insert_block_header(&sample_header(0)).unwrap();
+            db.commit().unwrap();
+        }
+        let (pending_data_tx, pending_data) = tokio::sync::watch::channel(Default::default());
+        let notifications = Notifications::default();
+        let ctx = RpcContext::for_tests()
+            .with_storage(storage)
+            .with_notifications(notifications.clone())
+            .with_pending_data(pending_data.clone())
+            .with_websockets(WebsocketContext::new(WebsocketHistory::Unlimited));
+        let router = v09::register_routes().build(ctx);
+        let (sender_tx, sender_rx) = mpsc::channel(1024);
+        let (receiver_tx, receiver_rx) = mpsc::channel(1024);
+        handle_json_rpc_socket(router.clone(), sender_tx, receiver_rx);
+        Setup {
+            tx: receiver_tx,
+            rx: sender_rx,
+            pending_data_tx,
+            notifications,
+        }
+    }
+
+    struct Setup {
+        tx: mpsc::Sender<Result<Message, axum::Error>>,
+        rx: mpsc::Receiver<Result<Message, RpcResponse>>,
+        pending_data_tx: watch::Sender<PendingData>,
+        notifications: Notifications,
+    }
+}

--- a/crates/rpc/src/v09.rs
+++ b/crates/rpc/src/v09.rs
@@ -2,6 +2,7 @@ use crate::jsonrpc::{RpcRouter, RpcRouterBuilder};
 use crate::method::subscribe_events::SubscribeEvents;
 use crate::method::subscribe_new_heads::SubscribeNewHeads;
 use crate::method::subscribe_new_transaction_receipts::SubscribeNewTransactionReceipts;
+use crate::method::subscribe_new_transactions::SubscribeNewTransactions;
 use crate::method::subscribe_pending_transactions::SubscribePendingTransactions;
 use crate::method::subscribe_transaction_status::SubscribeTransactionStatus;
 // re-using v08-specific methods
@@ -41,6 +42,7 @@ pub fn register_routes() -> RpcRouterBuilder {
         .register("starknet_subscribeNewHeads",                   SubscribeNewHeads)
         .register("starknet_subscribePendingTransactions",        SubscribePendingTransactions)
         .register("starknet_subscribeNewTransactionReceipts",     SubscribeNewTransactionReceipts)
+        .register("starknet_subscribeNewTransactions",            SubscribeNewTransactions)
         .register("starknet_subscribeEvents",                     SubscribeEvents)
         .register("starknet_subscribeTransactionStatus",          SubscribeTransactionStatus)
         .register("starknet_specVersion",                         || "0.9.0-rc.2")

--- a/crates/rpc/src/v09.rs
+++ b/crates/rpc/src/v09.rs
@@ -3,7 +3,6 @@ use crate::method::subscribe_events::SubscribeEvents;
 use crate::method::subscribe_new_heads::SubscribeNewHeads;
 use crate::method::subscribe_new_transaction_receipts::SubscribeNewTransactionReceipts;
 use crate::method::subscribe_new_transactions::SubscribeNewTransactions;
-use crate::method::subscribe_pending_transactions::SubscribePendingTransactions;
 use crate::method::subscribe_transaction_status::SubscribeTransactionStatus;
 // re-using v08-specific methods
 use crate::v08::method as v08_method;
@@ -40,7 +39,6 @@ pub fn register_routes() -> RpcRouterBuilder {
         .register("starknet_getBlockWithReceipts",                crate::method::get_block_with_receipts)
         .register("starknet_simulateTransactions",                crate::method::simulate_transactions)
         .register("starknet_subscribeNewHeads",                   SubscribeNewHeads)
-        .register("starknet_subscribePendingTransactions",        SubscribePendingTransactions)
         .register("starknet_subscribeNewTransactionReceipts",     SubscribeNewTransactionReceipts)
         .register("starknet_subscribeNewTransactions",            SubscribeNewTransactions)
         .register("starknet_subscribeEvents",                     SubscribeEvents)

--- a/specs/rpc/v09/starknet_api_openrpc.json
+++ b/specs/rpc/v09/starknet_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.9.0-rc.1",
+    "version": "0.9.0-rc.3",
     "title": "StarkNet Node API",
     "license": {}
   },
@@ -276,16 +276,7 @@
               },
               "finality_status": {
                 "title": "finality status",
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/TXN_STATUS"
-                  },
-                  {
-                    "not": {
-                      "enum": ["RECEIVED", "CANDIDATE"]
-                    }
-                  }
-                ]
+                "$ref": "#/components/schemas/TXN_FINALITY_STATUS"
               },
               "execution_status": {
                 "title": "execution status",
@@ -1239,8 +1230,8 @@
       "BLOCK_TAG": {
         "title": "Block tag",
         "type": "string",
-        "description": "A tag specifying a dynamic reference to a block",
-        "enum": ["latest", "pre_confirmed"]
+        "description": "A tag specifying a dynamic reference to a block. Tag `l1_accepted` refers to the latest Starknet block which was included in a state update on L1 and finalized by the consensus on L1. Tag `latest` refers to the latest Starknet block finalized by the consensus on L2. Tag `pre_confirmed` refers to the block which is currently being built by the block proposer in height `latest` + 1.",
+        "enum": ["l1_accepted", "latest", "pre_confirmed"]
       },
       "SYNC_STATUS": {
         "title": "Sync status",
@@ -1689,10 +1680,7 @@
           "l1_data_gas_price",
           "l1_da_mode",
           "starknet_version"
-        ],
-        "not": {
-          "required": ["block_hash", "new_root"]
-        }
+        ]
       },
       "BLOCK_WITH_TX_HASHES": {
         "title": "Block with transaction hashes",
@@ -3033,10 +3021,10 @@
               },
               "block_number": {
                 "title": "Block number",
-                "$ref": "#/components/schemas/BLOCK_NUMBER",
-                "description": "If this field is missing, it means the receipt belongs to the pre-confirmed block"
+                "$ref": "#/components/schemas/BLOCK_NUMBER"
               }
-            }
+            },
+            "required": ["block_number"]
           }
         ]
       },
@@ -3113,7 +3101,7 @@
           },
           "failure_reason": {
             "title": "failure reason",
-            "description": "the failure reason, only appears if finality_status is REJECTED or execution_status is REVERTED",
+            "description": "the failure reason, only appears if execution_status is REVERTED",
             "type": "string"
           }
         },
@@ -3152,12 +3140,7 @@
       "BLOCK_STATUS": {
         "title": "Block status",
         "type": "string",
-        "enum": [
-          "PRE_CONFIRMED",
-          "ACCEPTED_ON_L2",
-          "ACCEPTED_ON_L1",
-          "REJECTED"
-        ],
+        "enum": ["PRE_CONFIRMED", "ACCEPTED_ON_L2", "ACCEPTED_ON_L1"],
         "description": "The status of the block"
       },
       "FUNCTION_CALL": {

--- a/specs/rpc/v09/starknet_executables.json
+++ b/specs/rpc/v09/starknet_executables.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0",
   "info": {
-    "version": "0.9.0-rc.1",
+    "version": "0.9.0-rc.3",
     "title": "API for getting Starknet executables from nodes that store compiled artifacts",
     "license": {}
   },

--- a/specs/rpc/v09/starknet_trace_api_openrpc.json
+++ b/specs/rpc/v09/starknet_trace_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.9.0-rc.1",
+    "version": "0.9.0-rc.3",
     "title": "StarkNet Trace API",
     "license": {}
   },

--- a/specs/rpc/v09/starknet_write_api.json
+++ b/specs/rpc/v09/starknet_write_api.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.9.0-rc.1",
+    "version": "0.9.0-rc.3",
     "title": "StarkNet Node Write API",
     "license": {}
   },

--- a/specs/rpc/v09/starknet_ws_api.json
+++ b/specs/rpc/v09/starknet_ws_api.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.3.2",
   "info": {
-    "version": "0.9.0-rc.1",
+    "version": "0.9.0-rc.3",
     "title": "StarkNet WebSocket RPC API",
     "license": {}
   },
@@ -58,7 +58,7 @@
     {
       "name": "starknet_subscribeEvents",
       "summary": "Events subscription",
-      "description": "Creates a WebSocket stream which will fire events for new Starknet events with applied filters",
+      "description": "Creates a WebSocket stream which will fire events for new Starknet events with applied filters. Events are emitted for all events from the specified block_id, up to the latest block",
       "params": [
         {
           "name": "from_address",
@@ -84,6 +84,15 @@
           "schema": {
             "$ref": "#/components/schemas/SUBSCRIPTION_BLOCK_ID"
           }
+        },
+        {
+          "name": "finality_status",
+          "summary": "The finality status of the most recent events to include, default is ACCEPTED_ON_L2",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "enum": ["PRE_CONFIRMED", "ACCEPTED_ON_L2"]
+          }
         }
       ],
       "result": {
@@ -107,7 +116,7 @@
     {
       "name": "starknet_subscriptionEvents",
       "summary": "New events notification",
-      "description": "Notification to the client of a new event",
+      "description": "Notification to the client of a new event. The event also includes the finality status of the transaction emitting the event",
       "params": [
         {
           "name": "subscription_id",
@@ -118,7 +127,14 @@
         {
           "name": "result",
           "schema": {
-            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/EMITTED_EVENT"
+            "allOf": [
+              {
+                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/EMITTED_EVENT"
+              },
+              {
+                "$ref": "#/components/schemas/TXN_FINALITY_STATUS"
+              }
+            ]
           }
         }
       ],
@@ -167,21 +183,34 @@
       "errors": []
     },
     {
-      "name": "starknet_subscribePendingTransactions",
-      "summary": "New Pending Transactions subscription",
-      "description": "Creates a WebSocket stream which will fire events when a new pending transaction is added. While there is no mempool, this notifies of transactions in the pending block",
+      "name": "starknet_subscribeNewTransactionReceipts",
+      "summary": "New transactions receipts subscription",
+      "description": "Creates a WebSocket stream which will fire events when new transaction receipts are created. The endpoint receives a vector of finality statuses. An event is fired for each finality status update. It is possible for receipts for pre-confirmed transactions to be received multiple times, or not at all.",
       "params": [
         {
-          "name": "transaction_details",
-          "summary": "Get all transaction details, and not only the hash. If not provided, only hash is returned. Default is false",
+          "name": "finality_status",
+          "summary": "A vector of finality statuses to receive updates for, default is [ACCEPTED_ON_L2]",
           "required": false,
           "schema": {
-            "type": "boolean"
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN_FINALITY_STATUS"
+                },
+                {
+                  "not": {
+                    "type": "string",
+                    "enum": ["ACCEPTED_ON_L1"]
+                  }
+                }
+              ]
+            }
           }
         },
         {
           "name": "sender_address",
-          "summary": "Filter transactions to only receive notification from address list",
+          "summary": "Filter transaction receipts to only include transactions sent by the specified addresses",
           "required": false,
           "schema": {
             "type": "array",
@@ -204,9 +233,9 @@
       ]
     },
     {
-      "name": "starknet_subscriptionPendingTransactions",
-      "summary": "New pending transaction notification",
-      "description": "Notification to the client of a new pending transaction",
+      "name": "starknet_subscriptionNewTransactionReceipts",
+      "summary": "New transaction receipt notification",
+      "description": "Notification to the client of a new transaction receipt, with its current finality status",
       "params": [
         {
           "name": "subscription_id",
@@ -216,14 +245,84 @@
         },
         {
           "name": "result",
-          "description": "Either a tranasaction hash or full transaction details, based on subscription",
+          "description": "A transaction receipt",
           "schema": {
-            "oneOf": [
-              {
-                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN_HASH"
-              },
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN_RECEIPT_WITH_BLOCK_INFO"
+          }
+        }
+      ],
+      "errors": []
+    },
+    {
+      "name": "starknet_subscribeNewTransactions",
+      "summary": "New transactions subscription",
+      "description": "Creates a WebSocket stream which will fire events when new transaction are created. The endpoint receives a vector of finality statuses. An event is fired for each finality status update. It is possible for events for pre-confirmed and candidate transactions to be received multiple times, or not at all.",
+      "params": [
+        {
+          "name": "finality_status",
+          "summary": "A vector of finality statuses to receive updates for, default is [ACCEPTED_ON_L2]",
+          "required": false,
+          "schema": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/TXN_STATUS_WITHOUT_L1"
+              }
+            }
+          }
+        },
+        {
+          "name": "sender_address",
+          "summary": "Filter to only include transactions sent by the specified addresses",
+          "required": false,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ADDRESS"
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "subscription_id",
+        "schema": {
+          "$ref": "#/components/schemas/SUBSCRIPTION_ID"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/TOO_MANY_ADDRESSES_IN_FILTER"
+        }
+      ]
+    },
+    {
+      "name": "starknet_subscriptionNewTransaction",
+      "summary": "New transaction notification",
+      "description": "Notification to the client of a new transaction, with its current finality status",
+      "params": [
+        {
+          "name": "subscription_id",
+          "schema": {
+            "$ref": "#/components/schemas/SUBSCRIPTION_ID"
+          }
+        },
+        {
+          "name": "result",
+          "description": "A transaction and its current finality status",
+          "schema": {
+            "allOf": [
               {
                 "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN_WITH_HASH"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "finality_status": {
+                    "description": "Finality status of the transaction",
+                    "$ref": "#/components/schemas/TXN_STATUS_WITHOUT_L1"
+                  }
+                },
+                "required": ["finality_status"]
               }
             ]
           }
@@ -308,42 +407,38 @@
       },
       "SUBSCRIPTION_BLOCK_ID": {
         "title": "Subscription Block id",
-        "description": "Block hash, number or tag, same as BLOCK_ID, but without 'pending'",
-        "oneOf": [
-          {
-            "title": "Block hash",
-            "type": "object",
-            "properties": {
-              "block_hash": {
-                "title": "Block hash",
-                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_HASH"
-              }
+        "description": "Block hash, number or tag, same as BLOCK_ID, but without 'pre_confirmed' or 'l1_accepted'",
+        "schema": {
+          "title": "Block id",
+          "allOf": [
+            {
+              "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_ID"
             },
-            "required": ["block_hash"]
+            {
+              "not": {
+                "type": "string",
+                "enum": ["l1_accepted", "pre_confirmed"]
+              }
+            }
+          ]
+        }
+      },
+      "TXN_STATUS_WITHOUT_L1": {
+        "title": "Transaction status without ACCEPTED_ON_L1",
+        "description": "Transaction status for new transactions subscription",
+        "allOf": [
+          {
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN_STATUS"
           },
           {
-            "title": "Block number",
-            "type": "object",
-            "properties": {
-              "block_number": {
-                "title": "Block number",
-                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_NUMBER"
-              }
-            },
-            "required": ["block_number"]
-          },
-          {
-            "title": "Block tag",
-            "$ref": "#/components/schemas/SUBSCRIPTION_BLOCK_TAG"
+            "not": {
+              "type": "string",
+              "enum": ["ACCEPTED_ON_L1"]
+            }
           }
         ]
       },
-      "SUBSCRIPTION_BLOCK_TAG": {
-        "title": "Subscription Block tag",
-        "type": "string",
-        "description": "Same as BLOCK_TAG, but without 'pending'",
-        "enum": ["latest"]
-      },
+
       "REORG_DATA": {
         "name": "Reorg Data",
         "description": "Data about reorganized blocks, starting and ending block number and hash",


### PR DESCRIPTION
JSON-RPC 0.9.0-rc.3 has introduced `starknet_subscribeNewTransactions` that is an extension of the previous `starknet_subscribePendingTransactions`.

It implements reliable streaming of transactions candidate/pre-confirmed/accepted_on_l2 transactions, where a new notification is sent for each new transaction and each finality status change.

This PR also updates the in-tree OpenRPC specification files to 0.9.0-rc.3.