### PR TITLE
JSON-RPC: block_number is now required in TXN_RECEIPT_WITH_BLOCK_INFO

### DIFF
--- a/crates/rpc/fixtures/0.9.0/transactions/receipt_pending.json
+++ b/crates/rpc/fixtures/0.9.0/transactions/receipt_pending.json
@@ -3,6 +3,7 @@
     "amount": "0x0",
     "unit": "WEI"
   },
+  "block_number": 3,
   "events": [
     {
       "data": [],

--- a/crates/rpc/fixtures/0.9.0/transactions/receipt_pre_confirmed.json
+++ b/crates/rpc/fixtures/0.9.0/transactions/receipt_pre_confirmed.json
@@ -3,6 +3,7 @@
     "amount": "0x0",
     "unit": "WEI"
   },
+  "block_number": 3,
   "events": [
     {
       "data": [],

--- a/crates/rpc/fixtures/0.9.0/transactions/receipt_reverted_pending.json
+++ b/crates/rpc/fixtures/0.9.0/transactions/receipt_reverted_pending.json
@@ -3,6 +3,7 @@
     "amount": "0x0",
     "unit": "WEI"
   },
+  "block_number": 3,
   "events": [],
   "execution_resources": {
     "l1_data_gas": 0,

--- a/crates/rpc/src/dto/receipt.rs
+++ b/crates/rpc/src/dto/receipt.rs
@@ -181,8 +181,11 @@ impl SerializeForVersion for TxnReceiptWithBlockInfo<'_> {
         })?;
 
         serializer.serialize_optional("block_hash", block_hash.cloned())?;
-        if (serializer.version == RpcVersion::V09)
-            || (serializer.version != RpcVersion::V09 && block_hash.is_some())
+        // Block number is required for V09 and later versions. For older versions
+        // we only ever serialize it if `block_hash` is present, that is, the block is
+        // finalized.
+        if (serializer.version >= RpcVersion::V09)
+            || (serializer.version < RpcVersion::V09 && block_hash.is_some())
         {
             serializer.serialize_optional("block_number", *block_number)?;
         }

--- a/crates/rpc/src/dto/receipt.rs
+++ b/crates/rpc/src/dto/receipt.rs
@@ -51,7 +51,7 @@ pub enum TxnFinalityStatus {
 
 pub struct TxnReceiptWithBlockInfo<'a> {
     pub block_hash: Option<&'a BlockHash>,
-    pub block_number: Option<BlockNumber>,
+    pub block_number: BlockNumber,
     pub receipt: &'a Receipt,
     pub transaction: &'a Transaction,
     pub events: &'a [Event],
@@ -187,7 +187,7 @@ impl SerializeForVersion for TxnReceiptWithBlockInfo<'_> {
         if (serializer.version >= RpcVersion::V09)
             || (serializer.version < RpcVersion::V09 && block_hash.is_some())
         {
-            serializer.serialize_optional("block_number", *block_number)?;
+            serializer.serialize_field("block_number", block_number)?;
         }
 
         serializer.end()

--- a/crates/rpc/src/dto/receipt.rs
+++ b/crates/rpc/src/dto/receipt.rs
@@ -171,7 +171,6 @@ impl SerializeForVersion for TxnReceiptWithBlockInfo<'_> {
             events,
             finality,
         } = self;
-
         let mut serializer = serializer.serialize_struct()?;
 
         serializer.flatten(&TxnReceipt {
@@ -182,7 +181,11 @@ impl SerializeForVersion for TxnReceiptWithBlockInfo<'_> {
         })?;
 
         serializer.serialize_optional("block_hash", block_hash.cloned())?;
-        serializer.serialize_optional("block_number", *block_number)?;
+        if serializer.version == RpcVersion::V09 {
+            serializer.serialize_optional("block_number", *block_number)?;
+        } else if serializer.version != RpcVersion::V09 && block_hash.is_some() {
+            serializer.serialize_optional("block_number", *block_number)?;
+        }
 
         serializer.end()
     }

--- a/crates/rpc/src/dto/receipt.rs
+++ b/crates/rpc/src/dto/receipt.rs
@@ -181,9 +181,9 @@ impl SerializeForVersion for TxnReceiptWithBlockInfo<'_> {
         })?;
 
         serializer.serialize_optional("block_hash", block_hash.cloned())?;
-        if serializer.version == RpcVersion::V09 {
-            serializer.serialize_optional("block_number", *block_number)?;
-        } else if serializer.version != RpcVersion::V09 && block_hash.is_some() {
+        if (serializer.version == RpcVersion::V09)
+            || (serializer.version != RpcVersion::V09 && block_hash.is_some())
+        {
             serializer.serialize_optional("block_number", *block_number)?;
         }
 

--- a/crates/rpc/src/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/method/get_transaction_receipt.rs
@@ -33,6 +33,7 @@ pub enum Output {
     },
     Pending {
         receipt: Receipt,
+        block_number: BlockNumber,
         transaction: Transaction,
         events: Vec<Event>,
         finality: dto::TxnFinalityStatus,
@@ -62,12 +63,13 @@ impl crate::dto::SerializeForVersion for Output {
             },
             Output::Pending {
                 receipt,
+                block_number,
                 transaction,
                 events,
                 finality,
             } => dto::TxnReceiptWithBlockInfo {
                 block_hash: None,
-                block_number: None,
+                block_number: Some(*block_number),
                 receipt,
                 transaction,
                 events,
@@ -109,6 +111,7 @@ pub async fn get_transaction_receipt(
         {
             return Ok(Output::Pending {
                 receipt,
+                block_number: pending.block_number(),
                 transaction,
                 events,
                 finality: pending.block().finality_status(),

--- a/crates/rpc/src/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/method/get_transaction_receipt.rs
@@ -55,7 +55,7 @@ impl crate::dto::SerializeForVersion for Output {
                 finality,
             } => dto::TxnReceiptWithBlockInfo {
                 block_hash: Some(block_hash),
-                block_number: Some(*block_number),
+                block_number: *block_number,
                 receipt,
                 transaction,
                 events,
@@ -69,7 +69,7 @@ impl crate::dto::SerializeForVersion for Output {
                 finality,
             } => dto::TxnReceiptWithBlockInfo {
                 block_hash: None,
-                block_number: Some(*block_number),
+                block_number: *block_number,
                 receipt,
                 transaction,
                 events,

--- a/crates/rpc/src/method/subscribe_new_transaction_receipts.rs
+++ b/crates/rpc/src/method/subscribe_new_transaction_receipts.rs
@@ -94,7 +94,7 @@ impl From<TxnFinalityStatusWithoutL1Accepted> for TxnFinalityStatus {
 #[derive(Debug)]
 pub struct Notification {
     block_hash: Option<BlockHash>,
-    block_number: Option<BlockNumber>,
+    block_number: BlockNumber,
     receipt: Receipt,
     transaction: Transaction,
     events: Vec<Event>,
@@ -160,7 +160,7 @@ impl RpcSubscriptionFlow for SubscribeNewTransactionReceipts {
 
                                     let notification = Notification {
                                         block_hash: Some(block.block_hash),
-                                        block_number: Some(block.block_number),
+                                        block_number: block.block_number,
                                         receipt: receipt.clone(),
                                         transaction: transaction.clone(),
                                         events: events.clone(),
@@ -213,7 +213,7 @@ impl RpcSubscriptionFlow for SubscribeNewTransactionReceipts {
 
                         let notification = Notification {
                             block_hash: None,
-                            block_number: Some(pending.block_number()),
+                            block_number: pending.block_number(),
                             receipt: receipt.clone(),
                             transaction: transaction.clone(),
                             events: events.clone(),


### PR DESCRIPTION
Short description of what this PR does.
---------------------

Adds `block_number` to `TXN_RECEIPT_WITH_BLOCK_INFO` for `Pending`
Fixes #2889 

