### PR TITLE
chore(ci): publish `consensus` crate

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -50,3 +50,7 @@ jobs:
 
           # Finally publish class-hash which depends on common, crypto and serde
           publish_with_retry pathfinder-class-hash
+          sleep 30
+
+          # Publish other crates...
+          publish_with_retry pathfinder-consensus


### PR DESCRIPTION
Publishing the `consensus` crate not only allows it to be used by anyone, but more importantly it is the only way I've found that will make the [docs link](https://github.com/eqlabs/pathfinder/tree/main/crates/consensus) work.