### PR TITLE
fix(rpc/method/get_events): fix `starknet_getEvents` for empty blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `starknet_getTransactionStatus` now returns ACCEPTED_* only when that status is known locally, not when it's received from the gateway for an otherwise-unknown transaction.
 - value of the `--sync.poll-interval` command-line option can now specify fractional seconds
 
+### Fixed
+
+- `starknet_getEvents` returns an incomplete result set if the block range includes empty blocks.
+
 ## [0.18.0] - 2025-07-14
 
 ### Added

--- a/crates/storage/src/connection/transaction.rs
+++ b/crates/storage/src/connection/transaction.rs
@@ -313,9 +313,11 @@ impl Transaction<'_> {
             return Ok(None);
         };
 
-        let Some(events) = self.query_events_by_block(block_number)? else {
-            return Ok(None);
-        };
+        // We explicitly do _not_ stop here on no events: empty blocks are valid and
+        // fairly common since Starknet 0.14.0.
+        let events = self
+            .query_events_by_block(block_number)?
+            .unwrap_or_default();
 
         let transaction_hashes = self
             .query_transaction_hashes_by_block(block_number)


### PR DESCRIPTION
When processing a query with a block range that involves empty blocks (blocks with zero transactions / events) `starknet_getEvents` would stop scanning at the first empty block.

This is bad, because it doesn't even return a continuation token so users would have no way of knowing that there are more events.

The issue is that `query_events_by_block()` is returning an `Option`, and `None` is being interpreted as "no block found", which causes the scan to stop prematurely when encountering empty blocks.

To fix this, we need to ensure that we handle no events correctly in `events_for_block()` and just return an empty vector of events instead of returning `None`.

Closes #2913
