### PR TITLE
chore(Dockerfile): add version to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7-labs
 # Our Dockerfile relies on the PATHFINDER_FORCE_VERSION build-time variable being set.
 # This is required so that we don't have to copy the .git directory into the layer which
 # might cause caches to be invalidated even if that's unnecessary.


### PR DESCRIPTION
According to the Dockerfile [reference](https://docs.docker.com/reference/dockerfile/#copy) the `--exclude` COPY option is only available starting from the `1.7-labs` Dockerfile version.