### PR TITLE
fix(ci): remove `p2p_proto` dependency form `consensus`

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -52,5 +52,5 @@ jobs:
           publish_with_retry pathfinder-class-hash
           sleep 30
 
-          # Publish other crates...
+          # Publish consensus
           publish_with_retry pathfinder-consensus

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8511,7 +8511,6 @@ dependencies = [
  "informalsystems-malachitebft-core-types",
  "informalsystems-malachitebft-metrics",
  "informalsystems-malachitebft-signing-ed25519",
- "p2p_proto",
  "pathfinder-common",
  "pathfinder-crypto",
  "rand 0.8.5",

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -18,7 +18,6 @@ malachite-consensus = { package = "informalsystems-malachitebft-core-consensus",
 malachite-metrics = { package = "informalsystems-malachitebft-metrics", version = "0.3" }
 malachite-signing-ed25519 = { package = "informalsystems-malachitebft-signing-ed25519", version = "0.3", features = ["serde"] }
 malachite-types = { package = "informalsystems-malachitebft-core-types", version = "0.3" }
-p2p_proto = { path = "../p2p_proto" }
 pathfinder-common = { version = "0.19.0", path = "../common" }
 pathfinder-crypto = { version = "0.19.0", path = "../crypto" }
 rand = { workspace = true }

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -34,7 +34,7 @@ libp2p = { workspace = true, features = [
 ] }
 p2p_proto = { path = "../p2p_proto" }
 p2p_stream = { path = "../p2p_stream" }
-pathfinder-common = { version = "0.19.0", path = "../common" }
+pathfinder-common = { path = "../common" }
 pathfinder-crypto = { path = "../crypto" }
 pathfinder-tagged = { path = "../tagged" }
 pathfinder-tagged-debug-derive = { path = "../tagged-debug-derive" }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -43,9 +43,8 @@ do_sed "CHANGELOG.md" "s/## Unreleased/## [${VERSION}] - ${CURRENT_DATE}/"
 # Update workspace version
 do_sed "Cargo.toml" "s/^version = \".*\"/version = \"${VERSION}\"/"
 
-# List of crates to be published to crates.io
-# These require explicit version dependencies for publishing
-CRATES=("common" "crypto" "serde" "class-hash" "p2p" "consensus")
+# List of crates that require explicit version dependencies for publishing
+CRATES=("common" "crypto" "serde" "class-hash" "consensus")
 
 # Update versions in crate Cargo.toml files
 for crate in "${CRATES[@]}"; do


### PR DESCRIPTION
The `consensus` crate could not be published because it still had an old `p2p_proto` dependency sitting there.