### PR TITLE
fix(rpc): `class_at` now returns offsets as hex as per the spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - JSON-RPC response reflects an inconsistent state after receiving a notification over a Websocket subscription.
+- `starknet_getClassAt` now returns `DEPRECATED_CAIRO_ENTRY_POINT.offset` as a hex string instead of an integer. This change aligns the response format with the specification, which expects `NUM_AS_HEX` for this field.
 
 ## [0.19.0] - 2025-08-12
 

--- a/crates/rpc/fixtures/0.6.0/class_at/cairo0.json
+++ b/crates/rpc/fixtures/0.6.0/class_at/cairo0.json
@@ -55,15 +55,15 @@
       "CONSTRUCTOR": [],
       "EXTERNAL": [
         {
-          "offset": 117,
+          "offset": "0x75",
           "selector": "0x26813d396fdb198e9ead934e4f7a592a8b88a059e45ab0eb6ee53494e8d45b0"
         },
         {
-          "offset": 85,
+          "offset": "0x55",
           "selector": "0x3033d3588abc2928b334742248e380daa139fc6b2bba31d609282d2c641a450"
         },
         {
-          "offset": 61,
+          "offset": "0x3d",
           "selector": "0x34c4c150632e67baf44fc50e9a685184d72a822510a26a66f72058b5e7b2892"
         }
       ],

--- a/crates/rpc/fixtures/0.7.0/class_at/cairo0.json
+++ b/crates/rpc/fixtures/0.7.0/class_at/cairo0.json
@@ -61,15 +61,15 @@
         ],
         "EXTERNAL":[
             {
-                "offset":117,
+                "offset":"0x75",
                 "selector":"0x26813d396fdb198e9ead934e4f7a592a8b88a059e45ab0eb6ee53494e8d45b0"
             },
             {
-                "offset":85,
+                "offset":"0x55",
                 "selector":"0x3033d3588abc2928b334742248e380daa139fc6b2bba31d609282d2c641a450"
             },
             {
-                "offset":61,
+                "offset":"0x3d",
                 "selector":"0x34c4c150632e67baf44fc50e9a685184d72a822510a26a66f72058b5e7b2892"
             }
         ],

--- a/crates/rpc/fixtures/0.8.0/class_at/cairo0.json
+++ b/crates/rpc/fixtures/0.8.0/class_at/cairo0.json
@@ -61,15 +61,15 @@
         ],
         "EXTERNAL":[
             {
-                "offset":117,
+                "offset":"0x75",
                 "selector":"0x26813d396fdb198e9ead934e4f7a592a8b88a059e45ab0eb6ee53494e8d45b0"
             },
             {
-                "offset":85,
+                "offset":"0x55",
                 "selector":"0x3033d3588abc2928b334742248e380daa139fc6b2bba31d609282d2c641a450"
             },
             {
-                "offset":61,
+                "offset":"0x3d",
                 "selector":"0x34c4c150632e67baf44fc50e9a685184d72a822510a26a66f72058b5e7b2892"
             }
         ],

--- a/crates/rpc/fixtures/0.9.0/class_at/cairo0.json
+++ b/crates/rpc/fixtures/0.9.0/class_at/cairo0.json
@@ -61,15 +61,15 @@
         ],
         "EXTERNAL":[
             {
-                "offset":117,
+                "offset":"0x75",
                 "selector":"0x26813d396fdb198e9ead934e4f7a592a8b88a059e45ab0eb6ee53494e8d45b0"
             },
             {
-                "offset":85,
+                "offset":"0x55",
                 "selector":"0x3033d3588abc2928b334742248e380daa139fc6b2bba31d609282d2c641a450"
             },
             {
-                "offset":61,
+                "offset":"0x3d",
                 "selector":"0x34c4c150632e67baf44fc50e9a685184d72a822510a26a66f72058b5e7b2892"
             }
         ],

--- a/crates/rpc/src/dto/class.rs
+++ b/crates/rpc/src/dto/class.rs
@@ -100,7 +100,7 @@ impl SerializeForVersion for &types::ContractEntryPoint {
     ) -> Result<crate::dto::Ok, crate::dto::Error> {
         let mut serializer = serializer.serialize_struct()?;
 
-        serializer.serialize_field("offset", &self.offset)?;
+        serializer.serialize_field("offset", &U64Hex(self.offset))?;
         serializer.serialize_field("selector", &self.selector)?;
 
         serializer.end()


### PR DESCRIPTION
Closes #2952 

Note: This is a breaking change, for all RPC versions. We'll have to highlight it in the release notes.