### PR TITLE
fix(`p2p_proto`): add `derive` feature to `serde`

### DIFF
--- a/crates/p2p_proto/Cargo.toml
+++ b/crates/p2p_proto/Cargo.toml
@@ -18,7 +18,7 @@ primitive-types = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 rand = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["raw_value"] }
 
 [build-dependencies]


### PR DESCRIPTION
For some reason which I haven't dug into, this was missing, causing a simple `cargo c -p p2p_proto` to fail.