### PR TITLE
test: fix flaky `transaction_found_in_pre_confirmed_block` test

### DIFF
--- a/crates/rpc/src/method/subscribe_transaction_status.rs
+++ b/crates/rpc/src/method/subscribe_transaction_status.rs
@@ -176,6 +176,7 @@ impl RpcSubscriptionFlow for SubscribeTransactionStatus {
             interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
             loop {
                 tokio::select! {
+                    biased;
                     _ = interval.tick() => {
                         match state.sequencer.transaction_status(params.transaction_hash).await {
                             Ok(status) => {


### PR DESCRIPTION
Problem was that a `select!` would sometimes pick the wrong path (because `select!` by default picks a path by random if multiple futures are ready). So sometimes the test would fail. Adding `biased` to the `select!` should fix the issue.