### PR TITLE
fix(executor): handle selector as Option in Cairo1RevertFrame conversion

### DIFF
--- a/crates/executor/src/error_stack.rs
+++ b/crates/executor/src/error_stack.rs
@@ -69,7 +69,7 @@ impl From<Cairo1RevertFrame> for Frame {
             storage_address: ContractAddress(value.contract_address.0.into_felt()),
             // FIXME: what should we do here if the frame has no class hash?
             class_hash: ClassHash(value.class_hash.unwrap_or_default().0.into_felt()),
-            selector: Some(EntryPoint(value.selector.0.into_felt())),
+            selector: value.selector.map(|s| EntryPoint(s.0.into_felt())),
         })
     }
 }


### PR DESCRIPTION
Fix selector field from always Some() to proper Option handling

- Change: selector: Some(EntryPoint(value.selector.0.into_felt()))
- To: selector: value.selector.map(|s| EntryPoint(s.0.into_felt()))

Prevents panics when selector is None and ensures consistency with 
ErrorStackSegment::EntryPoint behavior.