### PR TITLE
chore: fix typo

### DIFF
--- a/crates/gateway-types/src/error.rs
+++ b/crates/gateway-types/src/error.rs
@@ -63,7 +63,7 @@ pub enum KnownStarknetErrorCode {
     #[serde(rename = "StarknetErrorCode.TRANSACTION_FAILED")]
     TransactionFailed,
     #[serde(rename = "StarknetErrorCode.UNINITIALIZED_CONTRACT")]
-    UninitializedContract,
+    UninitalizedContract,
     #[serde(rename = "StarknetErrorCode.OUT_OF_RANGE_BLOCK_HASH")]
     OutOfRangeBlockHash,
     #[serde(rename = "StarknetErrorCode.OUT_OF_RANGE_TRANSACTION_HASH")]


### PR DESCRIPTION
Fixed: "UninitializedContract" → "UninitalizedContract" (missing 'i')

Delete once completed:
- [ ] link any issues closed by this pull-request
- [ ] add all user-facing changes to `CHANGELOG.md`
- [ ] new dependencies were added to the workspace toml
