### PR TITLE
feat: pre-latest block

### DIFF
--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -84,6 +84,14 @@ pub struct PendingBlock {
     pub l1_da_mode: L1DataAvailabilityMode,
 }
 
+/// Represents the "pre-latest" block in Starknet, which is a block that has
+/// been closed in consensus but is still awaiting commitment calculations
+/// before being finalized.
+///
+/// Obtained by querying the gateway for the pending block on Starknet >
+/// v0.14.0.
+pub type PreLatestBlock = PendingBlock;
+
 #[serde_as]
 #[derive(Clone, Default, Debug, Deserialize, PartialEq, Eq)]
 #[cfg_attr(test, derive(serde::Serialize))]
@@ -2026,7 +2034,7 @@ pub mod transaction {
 }
 
 /// Used to deserialize replies to StarkNet state update requests.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct StateUpdate {
     /// Gets default value for pending state updates.

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -690,13 +690,11 @@ async fn consumer(
                             number,
                             pre_latest_data,
                         );
-                        let number_of_transactions = pending
-                            .pre_latest_transactions()
-                            .map(|txs| txs.len())
-                            .unwrap_or(0)
-                            + pending.pending_transactions().len();
+                        let pre_latest_tx_count =
+                            pending.pre_latest_transactions().map(|txs| txs.len());
+                        let pre_confirmed_tx_count = pending.pending_transactions().len();
                         pending_data.send_replace(pending);
-                        tracing::debug!(block_number = %number, %number_of_transactions, "Updated pre-confirmed data");
+                        tracing::debug!(block_number = %number, %pre_confirmed_tx_count, ?pre_latest_tx_count, "Updated pre-confirmed data");
                     }
 
                     None

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -20,7 +20,13 @@ use pathfinder_storage::pruning::BlockchainHistoryMode;
 use pathfinder_storage::{Connection, Storage, Transaction, TransactionBehavior};
 use primitive_types::H160;
 use starknet_gateway_client::GatewayApi;
-use starknet_gateway_types::reply::{Block, GasPrices, PendingBlock, PreConfirmedBlock};
+use starknet_gateway_types::reply::{
+    Block,
+    GasPrices,
+    PendingBlock,
+    PreConfirmedBlock,
+    PreLatestBlock,
+};
 use tokio::sync::mpsc::{self, Receiver};
 use tokio::sync::watch::Sender as WatchSender;
 
@@ -66,8 +72,13 @@ pub enum SyncEvent {
     },
     /// A new L2 pending update was polled.
     Pending((Box<PendingBlock>, Box<StateUpdate>)),
-    /// A new L2 pre-confirmed update was polled.
-    PreConfirmed((BlockNumber, Box<PreConfirmedBlock>)),
+    /// A new L2 pre-confirmed update was polled. Optionally contains
+    /// [pre latest](PreLatestBlock) data.
+    PreConfirmed {
+        number: BlockNumber,
+        block: Box<PreConfirmedBlock>,
+        pre_latest_data: Option<Box<(BlockNumber, PreLatestBlock, StateUpdate)>>,
+    },
 }
 
 pub struct SyncContext<G, E> {
@@ -657,20 +668,35 @@ async fn consumer(
 
                     None
                 }
-                PreConfirmed((block_number, pre_confirmed_block)) => {
+                PreConfirmed {
+                    number,
+                    block,
+                    pre_latest_data,
+                } => {
+                    tracing::trace!("Updating pre-confirmed data");
                     let (latest_block_number, _) = tx
                         .block_id(BlockId::Latest)
                         .context("Fetching latest block hash")?
                         .unwrap_or_default();
 
-                    if block_number == latest_block_number + 1 {
-                        let pending = PendingData::from_pre_confirmed_block(
-                            *pre_confirmed_block,
-                            block_number,
+                    let next_block_number = pre_latest_data
+                        .as_ref()
+                        .map(|pre_latest| pre_latest.0)
+                        .unwrap_or(number);
+
+                    if next_block_number == latest_block_number + 1 {
+                        let pending = PendingData::from_pre_confirmed_and_pre_latest(
+                            block,
+                            number,
+                            pre_latest_data,
                         );
-                        let number_of_transactions = pending.transactions().len();
+                        let number_of_transactions = pending
+                            .pre_latest_transactions()
+                            .map(|txs| txs.len())
+                            .unwrap_or(0)
+                            + pending.pending_transactions().len();
                         pending_data.send_replace(pending);
-                        tracing::debug!(%block_number, %number_of_transactions, "Updated pre-confirmed data");
+                        tracing::debug!(block_number = %number, %number_of_transactions, "Updated pre-confirmed data");
                     }
 
                     None
@@ -683,7 +709,7 @@ async fn consumer(
             let commit_result = tx.commit().context("Committing database transaction");
 
             // Now that the changes have been committed to storage we can send out the
-            // notification. It is important that this is only ever dont _after_
+            // notification. It is important that this is only ever done _after_
             // the commit otherwise clients could potentially see inconsistent
             // state.
             if let Some(notification) = notification {

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -258,7 +258,7 @@ async fn fetch_pre_latest<S: GatewayApi + Send + 'static>(
     let (pending_block, state_update) = sequencer
         .pending_block()
         .await
-        .context("Fetching pre-latest block from sequncer")?;
+        .context("Fetching pre-latest block from sequencer")?;
 
     let pre_latest_data = (pending_block.parent_hash == our_latest_hash).then_some((
         our_latest_number + 1,

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use pathfinder_common::{BlockHash, BlockNumber, StarknetVersion};
 use pathfinder_storage::Storage;
 use starknet_gateway_client::GatewayApi;
@@ -132,20 +133,31 @@ pub async fn poll_starknet_0_14_0<S: GatewayApi + Clone + Send + 'static>(
     latest: &watch::Receiver<(BlockNumber, BlockHash)>,
     current: &watch::Receiver<(BlockNumber, BlockHash)>,
 ) {
+    const IN_SYNC_THRESHOLD: u64 = 6;
+
     #[derive(Default)]
     struct State {
         block_number: BlockNumber,
         tx_count: usize,
+        pre_latest_tx_count: Option<usize>,
     }
 
     impl State {
         /// Returns `true` if the state was updated, `false` otherwise.
-        fn update(&mut self, block_number: BlockNumber, tx_count: usize) -> bool {
-            if self.block_number == block_number && self.tx_count >= tx_count {
+        fn update(&mut self, new_state: Self) -> bool {
+            let pre_confirmed_same =
+                self.block_number == new_state.block_number && self.tx_count >= new_state.tx_count;
+            let pre_latest_same = match (self.pre_latest_tx_count, new_state.pre_latest_tx_count) {
+                (Some(current), Some(new)) if current >= new => true,
+                (Some(_current), None) => true,
+                _ => false,
+            };
+
+            if pre_confirmed_same && pre_latest_same {
                 return false;
             }
-            self.block_number = block_number;
-            self.tx_count = tx_count;
+
+            *self = new_state;
             true
         }
     }
@@ -156,15 +168,34 @@ pub async fn poll_starknet_0_14_0<S: GatewayApi + Clone + Send + 'static>(
         let t_fetch = Instant::now();
 
         let latest = latest.borrow().0.get();
-        let current = current.borrow().0.get();
+        let (current_number, current_hash) = *current.borrow();
 
-        if latest.abs_diff(current) > 6 {
-            tracing::debug!(%latest, %current, "Not in sync yet; skipping pre-confirmed block download");
+        if latest.abs_diff(current_number.get()) > IN_SYNC_THRESHOLD {
+            tracing::debug!(
+                %latest, current = %current_number.get(),
+                "Not in sync yet; skipping pre-confirmed block download"
+            );
             tokio::time::sleep_until(t_fetch + poll_interval).await;
             continue;
         }
 
-        let pre_confirmed_block_number = BlockNumber::new_or_panic(latest + 1);
+        let pre_latest_data = match fetch_pre_latest(sequencer, current_number, current_hash).await
+        {
+            Ok(r) => r.map(Box::new),
+            Err(e) => {
+                tracing::debug!(%e, "Failed to fetch pre-latest block");
+                tokio::time::sleep_until(t_fetch + poll_interval).await;
+                continue;
+            }
+        };
+
+        let pre_confirmed_block_number = if pre_latest_data.is_some() {
+            // Pre-latest block exists which means that the sequencer has already started
+            // building the next pre-confirmed block.
+            BlockNumber::new_or_panic(latest) + 2
+        } else {
+            BlockNumber::new_or_panic(latest) + 1
+        };
 
         let pre_confirmed_block = match sequencer
             .preconfirmed_block(pre_confirmed_block_number.into())
@@ -178,32 +209,63 @@ pub async fn poll_starknet_0_14_0<S: GatewayApi + Clone + Send + 'static>(
             }
         };
 
-        match state.update(
-            pre_confirmed_block_number,
-            pre_confirmed_block.transactions.len(),
-        ) {
-            false => {
-                tracing::trace!("No change in pre-confirmed block data");
-                tokio::time::sleep_until(t_fetch + poll_interval).await;
-                continue;
+        let new_state = State {
+            block_number: pre_confirmed_block_number,
+            tx_count: pre_confirmed_block.transactions.len(),
+            pre_latest_tx_count: pre_latest_data
+                .as_ref()
+                .map(|pre_latest| pre_latest.1.transactions.len()),
+        };
+        if state.update(new_state) {
+            tracing::trace!("Emitting a pre-confirmed update");
+            if let Err(e) = tx_event
+                .send(SyncEvent::PreConfirmed {
+                    number: pre_confirmed_block_number,
+                    block: pre_confirmed_block.into(),
+                    pre_latest_data,
+                })
+                .await
+            {
+                tracing::error!(error=%e, "Event channel closed unexpectedly. Ending pre-confirmed stream.");
+                break;
             }
-            true => {
-                tracing::trace!("Emitting a pre-confirmed update");
-                if let Err(e) = tx_event
-                    .send(SyncEvent::PreConfirmed((
-                        pre_confirmed_block_number,
-                        pre_confirmed_block.into(),
-                    )))
-                    .await
-                {
-                    tracing::error!(error=%e, "Event channel closed unexpectedly. Ending pre-confirmed stream.");
-                    break;
-                }
 
-                tokio::time::sleep_until(t_fetch + poll_interval).await;
-            }
+            tokio::time::sleep_until(t_fetch + poll_interval).await;
+        } else {
+            tracing::trace!("No change in pre-confirmed block data");
+            tokio::time::sleep_until(t_fetch + poll_interval).await;
         }
     }
+}
+
+/// Fetch the pending block from the sequencer and classify it as
+/// [pre-latest](starknet_gateway_types::reply::PreLatestBlock) if its parent
+/// hash matches our latest block hash.
+///
+/// If the pre-latest block (N) exists, the sequencer has already started
+/// building the next pre-confirmed block (N + 1).
+async fn fetch_pre_latest<S: GatewayApi + Send + 'static>(
+    sequencer: &S,
+    our_latest_number: BlockNumber,
+    our_latest_hash: BlockHash,
+) -> anyhow::Result<
+    Option<(
+        BlockNumber,
+        starknet_gateway_types::reply::PreLatestBlock,
+        pathfinder_common::StateUpdate,
+    )>,
+> {
+    let (pending_block, state_update) = sequencer
+        .pending_block()
+        .await
+        .context("Fetching pre-latest block from sequncer")?;
+
+    let pre_latest_data = (pending_block.parent_hash == our_latest_hash).then_some((
+        our_latest_number + 1,
+        pending_block,
+        state_update,
+    ));
+    Ok(pre_latest_data)
 }
 
 #[cfg(test)]
@@ -236,6 +298,7 @@ mod tests {
         L1DataAvailabilityMode,
         PendingBlock,
         PreConfirmedBlock,
+        PreLatestBlock,
         Status,
     };
     use tokio::sync::watch;
@@ -296,6 +359,11 @@ mod tests {
         }],
         starknet_version: StarknetVersion::default(),
         l1_da_mode: L1DataAvailabilityMode::Calldata,
+    });
+
+    pub static PRE_LATEST_BLOCK: LazyLock<PreLatestBlock> = LazyLock::new(|| PreLatestBlock {
+        starknet_version: StarknetVersion::new(0, 14, 0, 0),
+        ..PENDING_BLOCK.clone()
     });
 
     pub static PRE_CONFIRMED_BLOCK: LazyLock<PreConfirmedBlock> =
@@ -525,6 +593,9 @@ mod tests {
 
         sequencer
             .expect_pending_block()
+            .returning(move || Ok((pending_block.clone(), PENDING_UPDATE.clone())));
+        sequencer
+            .expect_pending_block()
             .returning(move || Ok((pending_block_copy.clone(), PENDING_UPDATE.clone())));
         sequencer
             .expect_preconfirmed_block()
@@ -551,6 +622,120 @@ mod tests {
             .expect("Event should be emitted")
             .unwrap();
 
-        assert_matches!(result1, SyncEvent::PreConfirmed((block_number, pre_confirmed_block)) if block_number == BlockNumber::new_or_panic(1) && *pre_confirmed_block == *PRE_CONFIRMED_BLOCK);
+        assert_matches!(
+            result1,
+            SyncEvent::PreConfirmed {
+                number,
+                block,
+                ..
+            } if number == BlockNumber::new_or_panic(1) && *block == *PRE_CONFIRMED_BLOCK
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_pre_latest_returns_some_when_parent_matches() {
+        let mut sequencer = MockGatewayApi::new();
+        let our_latest_number = NEXT_BLOCK.block_number - 1;
+        let our_latest_hash = NEXT_BLOCK.parent_block_hash;
+
+        sequencer
+            .expect_pending_block()
+            .returning(move || Ok((PENDING_BLOCK.clone(), PENDING_UPDATE.clone())));
+
+        let (number, block, state_update) =
+            super::fetch_pre_latest(&sequencer, our_latest_number, our_latest_hash)
+                .await
+                .unwrap()
+                .unwrap();
+
+        assert_eq!(number, NEXT_BLOCK.block_number);
+        assert_eq!(block.parent_hash, our_latest_hash);
+        assert_eq!(state_update, PENDING_UPDATE.clone());
+    }
+
+    #[tokio::test]
+    async fn fetch_pre_latest_returns_none_when_parent_differs() {
+        let mut sequencer = MockGatewayApi::new();
+        let our_latest_number = NEXT_BLOCK.block_number - 1;
+        let our_latest_hash = NEXT_BLOCK.parent_block_hash;
+        let different_hash = block_hash!("0xdeadbeef");
+
+        let pending_block = PendingBlock {
+            parent_hash: different_hash,
+            ..PENDING_BLOCK.clone()
+        };
+
+        sequencer
+            .expect_pending_block()
+            .returning(move || Ok((pending_block.clone(), PENDING_UPDATE.clone())));
+
+        let result = super::fetch_pre_latest(&sequencer, our_latest_number, our_latest_hash)
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn poll_starknet_0_14_0_with_pre_latest_data() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(2);
+        let mut sequencer = MockGatewayApi::new();
+
+        let our_latest_hash = PRE_LATEST_BLOCK.parent_hash;
+
+        // Make sure that the pending block triggers a transition to Starknet 0.14.0
+        // polling. Note that this block is ignored as `poll_pre_starknet_0_14_0`
+        // does not handle pre-latest blocks.
+        sequencer
+            .expect_pending_block()
+            .returning(move || Ok((PRE_LATEST_BLOCK.clone(), PENDING_UPDATE.clone())));
+        // This will be polled by `poll_starknet_0_14_0` and will not be ignored.
+        sequencer
+            .expect_pending_block()
+            .returning(move || Ok((PRE_LATEST_BLOCK.clone(), PENDING_UPDATE.clone())));
+        sequencer
+            .expect_preconfirmed_block()
+            .returning(move |_| Ok(PRE_CONFIRMED_BLOCK.clone()));
+
+        let latest_block_number = BlockNumber::new_or_panic(10);
+
+        let (_, rx_latest) = watch::channel((latest_block_number, our_latest_hash));
+        let (_, rx_current) = watch::channel((latest_block_number, our_latest_hash));
+
+        let sequencer = Arc::new(sequencer);
+        let _jh = tokio::spawn(async move {
+            super::poll_pending(
+                tx,
+                sequencer,
+                std::time::Duration::ZERO,
+                StorageBuilder::in_memory().unwrap(),
+                rx_latest,
+                rx_current,
+                false,
+            )
+            .await
+        });
+
+        let event = tokio::time::timeout(TEST_TIMEOUT, rx.recv())
+            .await
+            .expect("Event should be emitted")
+            .unwrap();
+
+        let expected_pre_latest_data = Some(Box::new((
+            latest_block_number + 1,
+            PRE_LATEST_BLOCK.clone(),
+            PENDING_UPDATE.clone(),
+        )));
+
+        assert_matches!(
+            event,
+            SyncEvent::PreConfirmed {
+                number,
+                block,
+                pre_latest_data
+            } if number == latest_block_number + 2
+                && *block == *PRE_CONFIRMED_BLOCK
+                && pre_latest_data == expected_pre_latest_data
+        );
     }
 }

--- a/crates/rpc/fixtures/0.9.0/transactions/receipt_pre_latest.json
+++ b/crates/rpc/fixtures/0.9.0/transactions/receipt_pre_latest.json
@@ -30,7 +30,7 @@
     "l2_gas": 0
   },
   "execution_status": "SUCCEEDED",
-  "finality_status": "PRE_CONFIRMED",
+  "finality_status": "ACCEPTED_ON_L2",
   "messages_sent": [],
   "transaction_hash": "0x7072656c617465737420747820686173682030",
   "type": "INVOKE"

--- a/crates/rpc/fixtures/0.9.0/transactions/receipt_pre_latest.json
+++ b/crates/rpc/fixtures/0.9.0/transactions/receipt_pre_latest.json
@@ -1,0 +1,37 @@
+{
+  "actual_fee": {
+    "amount": "0x0",
+    "unit": "WEI"
+  },
+  "block_number": 3,
+  "events": [
+    {
+      "data": [],
+      "from_address": "0xabcddddddd",
+      "keys": ["0x7072656c6174657374206b6579"]
+    },
+    {
+      "data": [],
+      "from_address": "0xabcddddddd",
+      "keys": [
+        "0x7072656c6174657374206b6579",
+        "0x7365636f6e64207072656c6174657374206b6579"
+      ]
+    },
+    {
+      "data": [],
+      "from_address": "0xabcaaaaaaa",
+      "keys": ["0x7072656c6174657374206b65792032"]
+    }
+  ],
+  "execution_resources": {
+    "l1_data_gas": 0,
+    "l1_gas": 0,
+    "l2_gas": 0
+  },
+  "execution_status": "SUCCEEDED",
+  "finality_status": "PRE_CONFIRMED",
+  "messages_sent": [],
+  "transaction_hash": "0x7072656c617465737420747820686173682030",
+  "type": "INVOKE"
+}

--- a/crates/rpc/fixtures/0.9.0/transactions/status_pre_latest.json
+++ b/crates/rpc/fixtures/0.9.0/transactions/status_pre_latest.json
@@ -1,0 +1,4 @@
+{
+  "execution_status": "SUCCEEDED",
+  "finality_status": "ACCEPTED_ON_L2"
+}

--- a/crates/rpc/fixtures/0.9.0/transactions/txn_pre_latest_hash_0.json
+++ b/crates/rpc/fixtures/0.9.0/transactions/txn_pre_latest_hash_0.json
@@ -1,0 +1,10 @@
+{
+  "calldata": [],
+  "contract_address": "0x7072656c617465737420636f6e747261637420616464722030",
+  "entry_point_selector": "0x656e74727920706f696e742030",
+  "max_fee": "0x0",
+  "signature": [],
+  "transaction_hash": "0x7072656c617465737420747820686173682030",
+  "type": "INVOKE",
+  "version": "0x0"
+}

--- a/crates/rpc/src/context.rs
+++ b/crates/rpc/src/context.rs
@@ -285,4 +285,17 @@ impl RpcContext {
 
         context.with_pending_data(rx)
     }
+
+    #[cfg(test)]
+    pub async fn for_tests_with_pre_latest_and_pre_confirmed() -> Self {
+        let context = Self::for_tests();
+        let pending_data =
+            super::test_utils::create_pre_confirmed_data_with_pre_latest(context.storage.clone())
+                .await;
+
+        let (tx, rx) = tokio_watch::channel(Default::default());
+        tx.send(pending_data).unwrap();
+
+        context.with_pending_data(rx)
+    }
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1321,8 +1321,8 @@ pub mod test_utils {
 
         let pre_confirmed_contract1 = contract_address_bytes!(b"preconfirmed contract 1 address");
         let pre_confirmed_state_update = StateUpdate::default()
-            .with_declared_cairo_class(class_hash_bytes!(b"pre-confirmed class 0 hash"))
-            .with_declared_cairo_class(class_hash_bytes!(b"pre-confirmed class 1 hash"))
+            .with_declared_cairo_class(class_hash_bytes!(b"preconfirmed class 0 hash"))
+            .with_declared_cairo_class(class_hash_bytes!(b"preconfirmed class 1 hash"))
             .with_deployed_contract(
                 contract_address_bytes!(b"preconfirmed contract 0 address"),
                 class_hash_bytes!(b"preconfirmed class 0 hash"),

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -30,7 +30,7 @@ pub use executor::compose_executor_transaction;
 use http_body::Body;
 pub use jsonrpc::{Notifications, Reorg};
 use pathfinder_common::AllowedOrigins;
-pub use pending::{PendingBlockVariant, PendingData};
+pub use pending::{FinalizedTxData, PendingBlockVariant, PendingData};
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tower_http::cors::CorsLayer;

--- a/crates/rpc/src/method/call.rs
+++ b/crates/rpc/src/method/call.rs
@@ -141,7 +141,10 @@ pub async fn call(
                     .get(&db_tx, rpc_version)
                     .context("Querying pending data")?;
 
-                (pending.header(), Some(pending.state_update()))
+                (
+                    pending.pending_header(),
+                    Some(pending.pending_state_update()),
+                )
             }
             other => {
                 let block_id = other
@@ -564,8 +567,10 @@ mod tests {
                         transactions: vec![],
                         starknet_version: last_block_header.starknet_version,
                         l1_da_mode: L1DataAvailabilityMode::Blob.into(),
-                    },
+                    }
+                    .into(),
                     candidate_transactions: vec![],
+                    pre_latest_data: None,
                 },
                 state_update,
                 last_block_header.number + 1,

--- a/crates/rpc/src/method/estimate_fee.rs
+++ b/crates/rpc/src/method/estimate_fee.rs
@@ -86,7 +86,10 @@ pub async fn estimate_fee(
                     .get(&db_tx, rpc_version)
                     .context("Querying pending data")?;
 
-                (pending.header(), Some(pending.state_update()))
+                (
+                    pending.pending_header(),
+                    Some(pending.pending_state_update()),
+                )
             }
             other => {
                 let block_id = other

--- a/crates/rpc/src/method/estimate_message_fee.rs
+++ b/crates/rpc/src/method/estimate_message_fee.rs
@@ -83,7 +83,10 @@ pub async fn estimate_message_fee(
                     .get(&db_tx, rpc_version)
                     .context("Querying pending data")?;
 
-                (pending.header(), Some(pending.state_update()))
+                (
+                    pending.pending_header(),
+                    Some(pending.pending_state_update()),
+                )
             }
             other => {
                 let block_id = other

--- a/crates/rpc/src/method/get_block_transaction_count.rs
+++ b/crates/rpc/src/method/get_block_transaction_count.rs
@@ -45,7 +45,7 @@ pub async fn get_block_transaction_count(
                     .pending_data
                     .get(&db, rpc_version)
                     .context("Querying pending data")?
-                    .transactions()
+                    .pending_transactions()
                     .len() as u64;
                 return Ok(Output(count));
             }

--- a/crates/rpc/src/method/get_block_with_receipts.rs
+++ b/crates/rpc/src/method/get_block_with_receipts.rs
@@ -62,8 +62,8 @@ pub async fn get_block_with_receipts(
                     .context("Querying pending data")?;
 
                 return Ok(Output::Pending {
-                    block: pending.block(),
-                    block_number: pending.block_number(),
+                    block: pending.pending_block(),
+                    block_number: pending.pending_block_number(),
                 });
             }
             other => other
@@ -146,7 +146,7 @@ impl crate::dto::SerializeForVersion for Output {
                     &mut block
                         .transactions()
                         .iter()
-                        .zip(block.transaction_receipts_and_events().iter())
+                        .zip(block.tx_receipts_and_events().iter())
                         .map(|(transaction, (receipt, events))| TransactionWithReceipt {
                             transaction,
                             receipt,

--- a/crates/rpc/src/method/get_block_with_tx_hashes.rs
+++ b/crates/rpc/src/method/get_block_with_tx_hashes.rs
@@ -63,11 +63,15 @@ pub async fn get_block_with_tx_hashes(
                     .get(&transaction, rpc_version)
                     .context("Querying pending data")?;
 
-                let transactions = pending.transactions().iter().map(|t| t.hash).collect();
+                let transactions = pending
+                    .pending_transactions()
+                    .iter()
+                    .map(|t| t.hash)
+                    .collect();
 
                 return Ok(Output::Pending {
-                    header: pending.block(),
-                    block_number: pending.block_number(),
+                    header: pending.pending_block(),
+                    block_number: pending.pending_block_number(),
                     transactions,
                 });
             }

--- a/crates/rpc/src/method/get_block_with_txs.rs
+++ b/crates/rpc/src/method/get_block_with_txs.rs
@@ -64,11 +64,11 @@ pub async fn get_block_with_txs(
                     .get(&transaction, rpc_version)
                     .context("Querying pending data")?;
 
-                let transactions = pending.transactions().to_vec();
+                let transactions = pending.pending_transactions().to_vec();
 
                 return Ok(Output::Pending {
-                    header: pending.block(),
-                    block_number: pending.block_number(),
+                    header: pending.pending_block(),
+                    block_number: pending.pending_block_number(),
                     transactions,
                 });
             }

--- a/crates/rpc/src/method/get_class.rs
+++ b/crates/rpc/src/method/get_class.rs
@@ -55,15 +55,12 @@ pub async fn get_class(
             .context("Opening database connection")?;
         let tx = db.transaction().context("Creating database transaction")?;
 
-        let is_pending = if input.block_id.is_pending() {
+        let is_pending = input.block_id.is_pending() && {
             context
                 .pending_data
                 .get(&tx, rpc_version)
                 .context("Querying pending data")?
-                .state_update()
                 .class_is_declared(input.class_hash)
-        } else {
-            false
         };
 
         let block_id = input

--- a/crates/rpc/src/method/get_class_at.rs
+++ b/crates/rpc/src/method/get_class_at.rs
@@ -65,13 +65,12 @@ pub async fn get_class_at(
 
         let tx = db.transaction().context("Creating database transaction")?;
 
-        let pending_class_hash = if input.block_id == BlockId::Pending {
+        let pending_class_hash = if input.block_id.is_pending() {
             context
                 .pending_data
                 .get(&tx, rpc_version)
                 .context("Querying pending data")?
-                .state_update()
-                .contract_class(input.contract_address)
+                .find_contract_class(input.contract_address)
         } else {
             None
         };

--- a/crates/rpc/src/method/get_class_at.rs
+++ b/crates/rpc/src/method/get_class_at.rs
@@ -223,4 +223,51 @@ mod tests {
         let error = get_class_at(context, input, RPC_VERSION).await.unwrap_err();
         assert_matches!(error, Error::BlockNotFound);
     }
+
+    #[tokio::test]
+    async fn pending() {
+        let context = RpcContext::for_tests_with_pending().await;
+        let input = Input {
+            block_id: BlockId::Pending,
+            contract_address: contract_address_bytes!(b"pending contract 0 address"),
+        };
+
+        get_class_at(context, input, RPC_VERSION).await.unwrap();
+    }
+
+    #[rstest::rstest]
+    #[case::v06(RpcVersion::V06)]
+    #[case::v07(RpcVersion::V07)]
+    #[case::v08(RpcVersion::V08)]
+    #[case::v09(RpcVersion::V09)]
+    #[tokio::test]
+    async fn pre_latest_and_pre_confirmed(#[case] version: RpcVersion) {
+        let context = RpcContext::for_tests_with_pre_latest_and_pre_confirmed().await;
+
+        let input = Input {
+            block_id: BlockId::Pending,
+            contract_address: contract_address_bytes!(b"prelatest contract 0 address"),
+        };
+        let r = get_class_at(context.clone(), input, version).await;
+        if version >= RpcVersion::V09 {
+            r.unwrap();
+        } else {
+            // JSON-RPC version before 0.9 are expected to ignore the pre-latest block.
+            let err = r.unwrap_err();
+            assert_matches!(err, Error::ContractNotFound);
+        }
+
+        let input = Input {
+            block_id: BlockId::Pending,
+            contract_address: contract_address_bytes!(b"preconfirmed contract 0 address"),
+        };
+        let r = get_class_at(context, input, version).await;
+        if version >= RpcVersion::V09 {
+            r.unwrap();
+        } else {
+            // JSON-RPC version before 0.9 are expected to ignore the pre-confirmed block.
+            let err = r.unwrap_err();
+            assert_matches!(err, Error::ContractNotFound);
+        }
+    }
 }

--- a/crates/rpc/src/method/get_class_hash_at.rs
+++ b/crates/rpc/src/method/get_class_hash_at.rs
@@ -42,16 +42,15 @@ pub async fn get_class_hash_at(
 
         let tx = db.transaction().context("Creating database transaction")?;
 
-        if input.block_id == BlockId::Pending {
-            let pending = context
+        if input.block_id.is_pending() {
+            let class_hash = context
                 .pending_data
                 .get(&tx, rpc_version)
                 .context("Querying pending data")?
-                .state_update()
-                .contract_class(input.contract_address);
+                .find_contract_class(input.contract_address);
 
-            if let Some(pending) = pending {
-                return Ok(Output(pending));
+            if let Some(class_hash) = class_hash {
+                return Ok(Output(class_hash));
             }
         }
 

--- a/crates/rpc/src/method/get_events.rs
+++ b/crates/rpc/src/method/get_events.rs
@@ -1418,7 +1418,6 @@ mod tests {
                 .unwrap();
             assert!(!result.events.is_empty());
             // Events from pending data do not have a block number/hash.
-            // TODO: But they could?
             assert!(result.events.iter().all(|e| e.block_number.is_none()));
 
             input.filter.from_block = Some(BlockId::Number(PRE_CONFIRMED_BLOCK));
@@ -1429,7 +1428,6 @@ mod tests {
                 .unwrap();
             assert!(!result.events.is_empty());
             // Events from pending data do not have a block number/hash.
-            // TODO: But they could?
             assert!(result.events.iter().all(|e| e.block_number.is_none()));
 
             input.filter.from_block = Some(BlockId::Number(PRE_LATEST_BLOCK));
@@ -1438,7 +1436,6 @@ mod tests {
             let result = get_events(context, input, RPC_VERSION).await.unwrap();
             assert!(!result.events.is_empty());
             // Events from pending data do not have a block number/hash.
-            // TODO: But they could?
             assert!(result.events.iter().all(|e| e.block_number.is_none()));
         }
     }

--- a/crates/rpc/src/method/get_state_update.rs
+++ b/crates/rpc/src/method/get_state_update.rs
@@ -58,7 +58,7 @@ pub async fn get_state_update(
                 .pending_data
                 .get(&tx, rpc_version)
                 .context("Query pending data")?
-                .state_update();
+                .pending_state_update();
 
             return Ok(Output::Pending(state_update));
         }
@@ -766,7 +766,7 @@ mod tests {
             block_id: BlockId::Pending,
         };
 
-        let expected = context.pending_data.get_unchecked().state_update();
+        let expected = context.pending_data.get_unchecked().pending_state_update();
 
         let result = get_state_update(context, input, RPC_VERSION)
             .await
@@ -783,7 +783,7 @@ mod tests {
             block_id: BlockId::Pending,
         };
 
-        let expected = context.pending_data.get_unchecked().state_update();
+        let expected = context.pending_data.get_unchecked().pending_state_update();
 
         let result = get_state_update(context.clone(), input.clone(), RpcVersion::V09)
             .await

--- a/crates/rpc/src/method/get_storage_at.rs
+++ b/crates/rpc/src/method/get_storage_at.rs
@@ -168,7 +168,7 @@ mod tests {
             storage_value_bytes!(b"preconfirmed storage value 0")
         );
 
-        // JSON-RPC version before 0.9 are expected to ignore the pre-latest block.
+        // JSON-RPC version before 0.9 are expected to ignore the pre-confirmed block.
         let err = get_storage_at(ctx, input, RpcVersion::V08)
             .await
             .unwrap_err();

--- a/crates/rpc/src/method/get_storage_at.rs
+++ b/crates/rpc/src/method/get_storage_at.rs
@@ -5,7 +5,7 @@ use crate::context::RpcContext;
 use crate::types::BlockId;
 use crate::RpcVersion;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Input {
     pub contract_address: ContractAddress,
     pub key: StorageAddress,
@@ -46,13 +46,13 @@ pub async fn get_storage_at(
         let tx = db.transaction().context("Creating database transaction")?;
 
         if input.block_id.is_pending() {
-            if let Some(value) = context
+            let storage_value = context
                 .pending_data
                 .get(&tx, rpc_version)
                 .context("Querying pending data")?
-                .state_update()
-                .storage_value(input.contract_address, input.key)
-            {
+                .find_storage_value(input.contract_address, input.key);
+
+            if let Some(value) = storage_value {
                 return Ok(Output(value));
             }
         }
@@ -146,6 +146,57 @@ mod tests {
         .unwrap();
 
         assert_eq!(result.0, storage_value_bytes!(b"pending storage value 0"));
+    }
+
+    #[tokio::test]
+    async fn pre_confirmed() {
+        let ctx = RpcContext::for_tests_with_pre_confirmed().await;
+
+        // This contract is created during storage setup and has a storage value set in
+        // the pre-confirmed block.
+        let input = Input {
+            contract_address: contract_address_bytes!(b"preconfirmed contract 1 address"),
+            key: storage_address_bytes!(b"preconfirmed storage key 0"),
+            block_id: BlockId::Pending,
+        };
+
+        let result = get_storage_at(ctx.clone(), input.clone(), RpcVersion::V09)
+            .await
+            .unwrap();
+        assert_eq!(
+            result.0,
+            storage_value_bytes!(b"preconfirmed storage value 0")
+        );
+
+        // JSON-RPC version before 0.9 are expected to ignore the pre-latest block.
+        let err = get_storage_at(ctx, input, RpcVersion::V08)
+            .await
+            .unwrap_err();
+        assert_matches!(err, Error::ContractNotFound);
+    }
+
+    #[tokio::test]
+    async fn pre_latest() {
+        let ctx = RpcContext::for_tests_with_pre_latest_and_pre_confirmed().await;
+
+        // This contract is created during storage setup and has a storage value set in
+        // the pre-latest block.
+        let input = Input {
+            contract_address: contract_address_bytes!(b"prelatest contract 1 address"),
+            key: storage_address_bytes!(b"prelatest storage key 0"),
+            block_id: BlockId::Pending,
+        };
+
+        let result = get_storage_at(ctx.clone(), input.clone(), RpcVersion::V09)
+            .await
+            .unwrap();
+        assert_eq!(result.0, storage_value_bytes!(b"prelatest storage value 0"));
+
+        // JSON-RPC version before 0.9 are expected to ignore the pre-latest block.
+        let err = get_storage_at(ctx, input, RpcVersion::V08)
+            .await
+            .unwrap_err();
+        assert_matches!(err, Error::ContractNotFound);
     }
 
     #[tokio::test]

--- a/crates/rpc/src/method/get_transaction_by_block_id_and_index.rs
+++ b/crates/rpc/src/method/get_transaction_by_block_id_and_index.rs
@@ -58,7 +58,7 @@ pub async fn get_transaction_by_block_id_and_index(
                     .pending_data
                     .get(&db_tx, rpc_version)
                     .context("Querying pending dat")?
-                    .transactions()
+                    .pending_transactions()
                     .get(index)
                     .cloned()
                     .ok_or(GetTransactionByBlockIdAndIndexError::InvalidTxnIndex);

--- a/crates/rpc/src/method/get_transaction_status.rs
+++ b/crates/rpc/src/method/get_transaction_status.rs
@@ -360,7 +360,7 @@ mod tests {
             RpcVersion::V09 => {
                 let output_json = result.unwrap().serialize(Serializer { version }).unwrap();
                 let expected_json: serde_json::Value = serde_json::from_str(include_str!(
-                    "../../fixtures/0.9.0/transactions/status_pre_confirmed.json"
+                    "../../fixtures/0.9.0/transactions/status_pre_latest.json"
                 ))
                 .unwrap();
                 assert_eq!(output_json, expected_json);

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -1627,6 +1627,790 @@ pub(crate) mod tests {
                 }
             }
         }
+
+        pub mod expected_output_0_14_0_0 {
+
+            use pathfinder_common::{BlockHeader, ContractAddress, SierraHash, StorageValue};
+
+            use super::*;
+            use crate::method::get_state_update::types::{StorageDiff, StorageEntry};
+
+            const DECLARE_OVERALL_FEE: u64 = 1266;
+            const DECLARE_GAS_CONSUMED: u64 = 882;
+            const DECLARE_DATA_GAS_CONSUMED: u64 = 192;
+            pub fn declare(
+                account_contract_address: ContractAddress,
+                last_block_header: &BlockHeader,
+            ) -> pathfinder_executor::types::TransactionSimulation {
+                pathfinder_executor::types::TransactionSimulation {
+                    fee_estimation: pathfinder_executor::types::FeeEstimate {
+                        l1_gas_consumed: DECLARE_GAS_CONSUMED.into(),
+                        l1_gas_price: 1.into(),
+                        l1_data_gas_consumed: DECLARE_DATA_GAS_CONSUMED.into(),
+                        l1_data_gas_price: 2.into(),
+                        l2_gas_consumed: 0.into(),
+                        l2_gas_price: 1.into(),
+                        overall_fee: DECLARE_OVERALL_FEE.into(),
+                        unit: pathfinder_executor::types::PriceUnit::Wei,
+                    },
+                    trace: pathfinder_executor::types::TransactionTrace::Declare(
+                        pathfinder_executor::types::DeclareTransactionTrace {
+                            execution_info: DeclareTransactionExecutionInfo {
+                                fee_transfer_invocation: Some(declare_fee_transfer(
+                                    account_contract_address,
+                                    last_block_header,
+                                )),
+                                validate_invocation: Some(declare_validate(
+                                    account_contract_address,
+                                )),
+                                execution_resources:
+                                    pathfinder_executor::types::ExecutionResources {
+                                        computation_resources:
+                                            declare_validate_computation_resources()
+                                                + declare_fee_transfer_computation_resources(),
+                                        data_availability:
+                                            pathfinder_executor::types::DataAvailabilityResources {
+                                                l1_gas: 0,
+                                                l1_data_gas: 192,
+                                            },
+                                        l1_gas: DECLARE_GAS_CONSUMED.into(),
+                                        l1_data_gas: DECLARE_DATA_GAS_CONSUMED.into(),
+                                        l2_gas: 0,
+                                    },
+                            },
+                            state_diff: declare_state_diff(
+                                account_contract_address,
+                                declare_fee_transfer_storage_diffs(),
+                            ),
+                        },
+                    ),
+                }
+            }
+
+            fn declare_validate_computation_resources(
+            ) -> pathfinder_executor::types::ComputationResources {
+                pathfinder_executor::types::ComputationResources {
+                    memory_holes: 1,
+                    range_check_builtin_applications: 4,
+                    steps: 203,
+                    ..Default::default()
+                }
+            }
+
+            fn declare_fee_transfer_computation_resources(
+            ) -> pathfinder_executor::types::ComputationResources {
+                pathfinder_executor::types::ComputationResources {
+                    steps: 1354,
+                    memory_holes: 59,
+                    range_check_builtin_applications: 31,
+                    pedersen_builtin_applications: 4,
+                    ..Default::default()
+                }
+            }
+
+            fn declare_state_diff(
+                account_contract_address: ContractAddress,
+                storage_diffs: Vec<StorageDiff>,
+            ) -> pathfinder_executor::types::StateDiff {
+                pathfinder_executor::types::StateDiff {
+                    storage_diffs: BTreeMap::from_iter(
+                        storage_diffs
+                            .into_iter()
+                            .map(|diff| {
+                                (
+                                    diff.address,
+                                    diff.storage_entries
+                                        .into_iter()
+                                        .map(|entry| pathfinder_executor::types::StorageDiff {
+                                            key: entry.key,
+                                            value: entry.value,
+                                        })
+                                        .collect(),
+                                )
+                            })
+                            .collect::<Vec<_>>(),
+                    ),
+                    deprecated_declared_classes: HashSet::new(),
+                    declared_classes: vec![pathfinder_executor::types::DeclaredSierraClass {
+                        class_hash: SierraHash(SIERRA_HASH.0),
+                        compiled_class_hash: CASM_HASH,
+                    }],
+                    deployed_contracts: vec![],
+                    replaced_classes: vec![],
+                    nonces: BTreeMap::from([(account_contract_address, contract_nonce!("0x1"))]),
+                }
+            }
+
+            fn declare_fee_transfer_storage_diffs() -> Vec<StorageDiff> {
+                vec![StorageDiff {
+                    address: ETH_FEE_TOKEN_ADDRESS,
+                    storage_entries: vec![
+                        StorageEntry {
+                            key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
+                            value: storage_value!("0x000000000000000000000000000000000000fffffffffffffffffffffffffb12")
+                        },
+                        StorageEntry {
+                            key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
+                            value: StorageValue(DECLARE_OVERALL_FEE.into()),
+                        },
+                    ],
+                }]
+            }
+
+            fn declare_fee_transfer(
+                account_contract_address: ContractAddress,
+                last_block_header: &BlockHeader,
+            ) -> pathfinder_executor::types::FunctionInvocation {
+                pathfinder_executor::types::FunctionInvocation {
+                    call_type: Some(pathfinder_executor::types::CallType::Call),
+                    caller_address: *account_contract_address.get(),
+                    class_hash: Some(ERC20_CONTRACT_DEFINITION_CLASS_HASH.0),
+                    entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
+                    events: vec![pathfinder_executor::types::Event {
+                        order: 0,
+                        data: vec![
+                            *account_contract_address.get(),
+                            last_block_header.sequencer_address.0,
+                            Felt::from_u64(DECLARE_OVERALL_FEE),
+                            felt!("0x0"),
+                        ],
+                        keys: vec![felt!(
+                            "0x0099CD8BDE557814842A3121E8DDFD433A539B8C9F14BF31EBF108D12E6196E9"
+                        )],
+                    }],
+                    calldata: vec![
+                        last_block_header.sequencer_address.0,
+                        Felt::from_u64(DECLARE_OVERALL_FEE),
+                        felt!("0x0"),
+                    ],
+                    contract_address: ETH_FEE_TOKEN_ADDRESS,
+                    selector: Some(EntryPoint::hashed(b"transfer").0),
+                    internal_calls: vec![],
+                    messages: vec![],
+                    result: vec![felt!("0x1")],
+                    computation_resources: declare_fee_transfer_computation_resources(),
+                    execution_resources: pathfinder_executor::types::InnerCallExecutionResources {
+                        l1_gas: 4,
+                        l2_gas: 0,
+                    },
+                    is_reverted: false,
+                }
+            }
+
+            fn declare_validate(
+                account_contract_address: ContractAddress,
+            ) -> pathfinder_executor::types::FunctionInvocation {
+                pathfinder_executor::types::FunctionInvocation {
+                    call_type: Some(pathfinder_executor::types::CallType::Call),
+                    caller_address: felt!("0x0"),
+                    class_hash: Some(crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH.0),
+                    entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
+                    events: vec![],
+                    contract_address: account_contract_address,
+                    selector: Some(EntryPoint::hashed(b"__validate_declare__").0),
+                    calldata: vec![SIERRA_HASH.0],
+                    internal_calls: vec![],
+                    messages: vec![],
+                    result: vec![felt!("0x56414c4944")],
+                    computation_resources: declare_validate_computation_resources(),
+                    execution_resources: pathfinder_executor::types::InnerCallExecutionResources {
+                        l1_gas: 1,
+                        l2_gas: 0,
+                    },
+                    is_reverted: false,
+                }
+            }
+
+            const UNIVERSAL_DEPLOYER_OVERALL_FEE: u64 = 473;
+            const UNIVERSAL_DEPLOYER_GAS_CONSUMED: u64 = 19;
+            const UNIVERSAL_DEPLOYER_DATA_GAS_CONSUMED: u64 = 224;
+            pub fn universal_deployer(
+                account_contract_address: ContractAddress,
+                last_block_header: &BlockHeader,
+                universal_deployer_address: ContractAddress,
+            ) -> pathfinder_executor::types::TransactionSimulation {
+                pathfinder_executor::types::TransactionSimulation {
+                    fee_estimation: pathfinder_executor::types::FeeEstimate {
+                        l1_gas_consumed: UNIVERSAL_DEPLOYER_GAS_CONSUMED.into(),
+                        l1_gas_price: 1.into(),
+                        l1_data_gas_consumed: UNIVERSAL_DEPLOYER_DATA_GAS_CONSUMED.into(),
+                        l1_data_gas_price: 2.into(),
+                        l2_gas_consumed: 0.into(),
+                        l2_gas_price: 1.into(),
+                        overall_fee: UNIVERSAL_DEPLOYER_OVERALL_FEE.into(),
+                        unit: pathfinder_executor::types::PriceUnit::Wei,
+                    },
+                    trace: pathfinder_executor::types::TransactionTrace::Invoke(
+                        pathfinder_executor::types::InvokeTransactionTrace {
+                            execution_info: pathfinder_executor::types::InvokeTransactionExecutionInfo {
+                                validate_invocation: Some(universal_deployer_validate(
+                                    account_contract_address,
+                                    universal_deployer_address,
+                                )),
+                                execute_invocation:
+                                    pathfinder_executor::types::RevertibleFunctionInvocation::FunctionInvocation(Some(
+                                        universal_deployer_execute(
+                                            account_contract_address,
+                                            universal_deployer_address,
+                                        ),
+                                    )),
+                                fee_transfer_invocation: Some(universal_deployer_fee_transfer(
+                                    account_contract_address,
+                                    last_block_header,
+                                    0,
+                                )),
+                                execution_resources: pathfinder_executor::types::ExecutionResources {
+                                    computation_resources: universal_deployer_validate_computation_resources()
+                                        + universal_deployer_execute_computation_resources()
+                                        + universal_deployer_fee_transfer_computation_resources(),
+                                    data_availability: pathfinder_executor::types::DataAvailabilityResources {
+                                        l1_gas: 0,
+                                        l1_data_gas: 224,
+                                    },
+                                    l1_gas: 25,
+                                    l1_data_gas: 224,
+                                    l2_gas: 0,
+                                },
+                            },
+                            state_diff: universal_deployer_state_diff(
+                                account_contract_address,
+                                universal_deployer_fee_transfer_storage_diffs(0),
+                            ),
+                        },
+                    ),
+                }
+            }
+
+            fn universal_deployer_validate_computation_resources(
+            ) -> pathfinder_executor::types::ComputationResources {
+                pathfinder_executor::types::ComputationResources {
+                    memory_holes: 4,
+                    range_check_builtin_applications: 14,
+                    steps: 341,
+                    ..Default::default()
+                }
+            }
+
+            fn universal_deployer_execute_computation_resources(
+            ) -> pathfinder_executor::types::ComputationResources {
+                pathfinder_executor::types::ComputationResources {
+                    steps: 2574,
+                    memory_holes: 20,
+                    range_check_builtin_applications: 66,
+                    pedersen_builtin_applications: 7,
+                    ..Default::default()
+                }
+            }
+
+            fn universal_deployer_fee_transfer_computation_resources(
+            ) -> pathfinder_executor::types::ComputationResources {
+                pathfinder_executor::types::ComputationResources {
+                    steps: 1354,
+                    memory_holes: 59,
+                    range_check_builtin_applications: 31,
+                    pedersen_builtin_applications: 4,
+                    ..Default::default()
+                }
+            }
+
+            fn universal_deployer_state_diff(
+                account_contract_address: ContractAddress,
+                storage_diffs: Vec<StorageDiff>,
+            ) -> pathfinder_executor::types::StateDiff {
+                pathfinder_executor::types::StateDiff {
+                    storage_diffs: BTreeMap::from_iter(
+                        storage_diffs
+                            .into_iter()
+                            .map(|diff| {
+                                (
+                                    diff.address,
+                                    diff.storage_entries
+                                        .into_iter()
+                                        .map(|entry| pathfinder_executor::types::StorageDiff {
+                                            key: entry.key,
+                                            value: entry.value,
+                                        })
+                                        .collect(),
+                                )
+                            })
+                            .collect::<Vec<_>>(),
+                    ),
+                    deprecated_declared_classes: HashSet::new(),
+                    declared_classes: vec![],
+                    deployed_contracts: vec![pathfinder_executor::types::DeployedContract {
+                        address: DEPLOYED_CONTRACT_ADDRESS,
+                        class_hash: SIERRA_HASH,
+                    }],
+                    replaced_classes: vec![],
+                    nonces: BTreeMap::from([(account_contract_address, contract_nonce!("0x2"))]),
+                }
+            }
+
+            fn universal_deployer_fee_transfer_storage_diffs(
+                overall_fee_correction: u64,
+            ) -> Vec<StorageDiff> {
+                vec![StorageDiff {
+                    address: ETH_FEE_TOKEN_ADDRESS,
+                    storage_entries: vec![
+                        StorageEntry {
+                            key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
+                            value: StorageValue((0xfffffffffffffffffffffffff93fu128 + u128::from(overall_fee_correction)).into()),
+                        },
+                        StorageEntry {
+                            key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
+                            value: StorageValue((DECLARE_OVERALL_FEE + UNIVERSAL_DEPLOYER_OVERALL_FEE - overall_fee_correction).into()),
+                        },
+                    ],
+                }]
+            }
+
+            fn universal_deployer_validate(
+                account_contract_address: ContractAddress,
+                universal_deployer_address: ContractAddress,
+            ) -> pathfinder_executor::types::FunctionInvocation {
+                pathfinder_executor::types::FunctionInvocation {
+                    call_type: Some(pathfinder_executor::types::CallType::Call),
+                    caller_address: felt!("0x0"),
+                    class_hash: Some(crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH.0),
+                    entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
+                    internal_calls: vec![],
+                    events: vec![],
+                    contract_address: account_contract_address,
+                    selector: Some(EntryPoint::hashed(b"__validate__").0),
+                    calldata: vec![
+                        call_param!("0x1").0,
+                        universal_deployer_address.0,
+                        EntryPoint::hashed(b"deployContract").0,
+                        // calldata_len
+                        call_param!("0x4").0,
+                        // classHash
+                        SIERRA_HASH.0,
+                        // salt
+                        call_param!("0x0").0,
+                        // unique
+                        call_param!("0x0").0,
+                        // calldata_len
+                        call_param!("0x0").0,
+                    ],
+                    messages: vec![],
+                    result: vec![felt!("0x56414c4944")],
+                    computation_resources: universal_deployer_validate_computation_resources(),
+                    execution_resources: pathfinder_executor::types::InnerCallExecutionResources {
+                        l1_gas: 2,
+                        l2_gas: 0,
+                    },
+                    is_reverted: false,
+                }
+            }
+
+            fn universal_deployer_execute(
+                account_contract_address: ContractAddress,
+                universal_deployer_address: ContractAddress,
+            ) -> pathfinder_executor::types::FunctionInvocation {
+                pathfinder_executor::types::FunctionInvocation {
+                    call_type: Some(pathfinder_executor::types::CallType::Call),
+                    caller_address: felt!("0x0"),
+                    internal_calls: vec![
+                        pathfinder_executor::types::FunctionInvocation {
+                            call_type: Some(pathfinder_executor::types::CallType::Call),
+                            caller_address: *account_contract_address.get(),
+                            internal_calls: vec![
+                                pathfinder_executor::types::FunctionInvocation {
+                                    call_type: Some(pathfinder_executor::types::CallType::Call),
+                                    caller_address: *universal_deployer_address.get(),
+                                    internal_calls: vec![],
+                                    class_hash: Some(SIERRA_HASH.0),
+                                    entry_point_type: Some(pathfinder_executor::types::EntryPointType::Constructor),
+                                    events: vec![],
+                                    contract_address: DEPLOYED_CONTRACT_ADDRESS,
+                                    selector: Some(EntryPoint::hashed(b"constructor").0),
+                                    calldata: vec![],
+                                    messages: vec![],
+                                    result: vec![],
+                                    computation_resources: pathfinder_executor::types::ComputationResources::default(),
+                                    execution_resources: pathfinder_executor::types::InnerCallExecutionResources::default(),
+                                    is_reverted: false,
+                                },
+                            ],
+                            class_hash: Some(UNIVERSAL_DEPLOYER_CLASS_HASH.0),
+                            entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
+                            events: vec![
+                                pathfinder_executor::types::Event {
+                                    order: 0,
+                                    data: vec![
+                                        *DEPLOYED_CONTRACT_ADDRESS.get(),
+                                        *account_contract_address.get(),
+                                        felt!("0x0"),
+                                        SIERRA_HASH.0,
+                                        felt!("0x0"),
+                                        felt!("0x0"),
+                                    ],
+                                    keys: vec![
+                                        felt!("0x026B160F10156DEA0639BEC90696772C640B9706A47F5B8C52EA1ABE5858B34D"),
+                                    ]
+                                },
+                            ],
+                            contract_address: universal_deployer_address,
+                            selector: Some(EntryPoint::hashed(b"deployContract").0),
+                            calldata: vec![
+                                // classHash
+                                SIERRA_HASH.0,
+                                // salt
+                                call_param!("0x0").0,
+                                // unique
+                                call_param!("0x0").0,
+                                //  calldata_len
+                                call_param!("0x0").0,
+                            ],
+                            messages: vec![],
+                            result: vec![
+                                *DEPLOYED_CONTRACT_ADDRESS.get(),
+                            ],
+                            computation_resources: pathfinder_executor::types::ComputationResources {
+                                steps: 1262,
+                                memory_holes: 2,
+                                range_check_builtin_applications: 23,
+                                pedersen_builtin_applications: 7,
+                                ..Default::default()
+                            },
+                            execution_resources: pathfinder_executor::types::InnerCallExecutionResources { l1_gas: 5, l2_gas: 0 },
+                            is_reverted: false,
+                        }
+                    ],
+                    class_hash: Some(crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH.0),
+                    entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
+                    events: vec![],
+                    contract_address: account_contract_address,
+                    selector: Some(EntryPoint::hashed(b"__execute__").0),
+                    calldata: vec![
+                        call_param!("0x1").0,
+                        universal_deployer_address.0,
+                        EntryPoint::hashed(b"deployContract").0,
+                        call_param!("0x4").0,
+                        // classHash
+                        SIERRA_HASH.0,
+                        // salt
+                        call_param!("0x0").0,
+                        // unique
+                        call_param!("0x0").0,
+                        // calldata_len
+                        call_param!("0x0").0,
+                    ],
+                    messages: vec![],
+                    result: vec![
+                        felt!("0x1"),
+                        felt!("0x1"),
+                        *DEPLOYED_CONTRACT_ADDRESS.get(),
+                    ],
+                    computation_resources: universal_deployer_execute_computation_resources(),
+                    execution_resources: pathfinder_executor::types::InnerCallExecutionResources {
+                        l1_gas: 10,
+                        l2_gas: 0,
+                    },
+                    is_reverted: false,
+                }
+            }
+
+            fn universal_deployer_fee_transfer(
+                account_contract_address: ContractAddress,
+                last_block_header: &BlockHeader,
+                overall_fee_correction: u64,
+            ) -> pathfinder_executor::types::FunctionInvocation {
+                pathfinder_executor::types::FunctionInvocation {
+                    call_type: Some(pathfinder_executor::types::CallType::Call),
+                    caller_address: *account_contract_address.get(),
+                    internal_calls: vec![],
+                    class_hash: Some(ERC20_CONTRACT_DEFINITION_CLASS_HASH.0),
+                    entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
+                    events: vec![pathfinder_executor::types::Event {
+                        order: 0,
+                        data: vec![
+                            *account_contract_address.get(),
+                            last_block_header.sequencer_address.0,
+                            (UNIVERSAL_DEPLOYER_OVERALL_FEE - overall_fee_correction).into(),
+                            felt!("0x0"),
+                        ],
+                        keys: vec![felt!(
+                            "0x0099CD8BDE557814842A3121E8DDFD433A539B8C9F14BF31EBF108D12E6196E9"
+                        )],
+                    }],
+                    calldata: vec![
+                        last_block_header.sequencer_address.0,
+                        (UNIVERSAL_DEPLOYER_OVERALL_FEE - overall_fee_correction).into(),
+                        // calldata_len
+                        call_param!("0x0").0,
+                    ],
+                    contract_address: ETH_FEE_TOKEN_ADDRESS,
+                    selector: Some(EntryPoint::hashed(b"transfer").0),
+                    messages: vec![],
+                    result: vec![felt!("0x1")],
+                    computation_resources: universal_deployer_fee_transfer_computation_resources(),
+                    execution_resources: pathfinder_executor::types::InnerCallExecutionResources {
+                        l1_gas: 4,
+                        l2_gas: 0,
+                    },
+                    is_reverted: false,
+                }
+            }
+
+            const INVOKE_OVERALL_FEE: u64 = 275;
+            const INVOKE_GAS_CONSUMED: u64 = 14;
+            const INVOKE_DATA_GAS_CONSUMED: u64 = 128;
+            pub fn invoke(
+                account_contract_address: ContractAddress,
+                last_block_header: &BlockHeader,
+                test_storage_value: StorageValue,
+            ) -> pathfinder_executor::types::TransactionSimulation {
+                pathfinder_executor::types::TransactionSimulation {
+                    fee_estimation: pathfinder_executor::types::FeeEstimate {
+                        l1_gas_consumed: INVOKE_GAS_CONSUMED.into(),
+                        l1_gas_price: 1.into(),
+                        l1_data_gas_consumed: INVOKE_DATA_GAS_CONSUMED.into(),
+                        l1_data_gas_price: 2.into(),
+                        l2_gas_consumed: 0.into(),
+                        l2_gas_price: 1.into(),
+                        overall_fee: INVOKE_OVERALL_FEE.into(),
+                        unit: pathfinder_executor::types::PriceUnit::Wei,
+                    },
+                    trace: pathfinder_executor::types::TransactionTrace::Invoke(
+                        pathfinder_executor::types::InvokeTransactionTrace {
+                            execution_info: pathfinder_executor::types::InvokeTransactionExecutionInfo {
+                                validate_invocation: Some(invoke_validate(account_contract_address)),
+                                execute_invocation:
+                                    pathfinder_executor::types::RevertibleFunctionInvocation::FunctionInvocation(Some(
+                                        invoke_execute(account_contract_address, test_storage_value),
+                                    )),
+                                fee_transfer_invocation: Some(invoke_fee_transfer(
+                                    account_contract_address,
+                                    last_block_header,
+                                    0,
+                                )),
+                                execution_resources: pathfinder_executor::types::ExecutionResources {
+                                    computation_resources: invoke_validate_computation_resources()
+                                        + invoke_execute_computation_resources()
+                                        + invoke_fee_transfer_computation_resources(),
+                                    data_availability: pathfinder_executor::types::DataAvailabilityResources {
+                                        l1_gas: 0,
+                                        l1_data_gas: 128,
+                                    },
+                                    l1_gas: 19,
+                                    l1_data_gas: 128,
+                                    l2_gas: 0,
+                                },
+                            },
+                            state_diff: invoke_state_diff(
+                                account_contract_address,
+                                invoke_fee_transfer_storage_diffs(0),
+                            ),
+                        },
+                    ),
+                }
+            }
+
+            fn invoke_validate_computation_resources(
+            ) -> pathfinder_executor::types::ComputationResources {
+                pathfinder_executor::types::ComputationResources {
+                    steps: 341,
+                    range_check_builtin_applications: 14,
+                    memory_holes: 4,
+                    ..Default::default()
+                }
+            }
+
+            fn invoke_execute_computation_resources(
+            ) -> pathfinder_executor::types::ComputationResources {
+                pathfinder_executor::types::ComputationResources {
+                    steps: 1477,
+                    range_check_builtin_applications: 46,
+                    memory_holes: 18,
+                    ..Default::default()
+                }
+            }
+
+            fn invoke_fee_transfer_computation_resources(
+            ) -> pathfinder_executor::types::ComputationResources {
+                pathfinder_executor::types::ComputationResources {
+                    steps: 1354,
+                    memory_holes: 59,
+                    range_check_builtin_applications: 31,
+                    pedersen_builtin_applications: 4,
+                    ..Default::default()
+                }
+            }
+
+            fn invoke_state_diff(
+                account_contract_address: ContractAddress,
+                storage_diffs: Vec<StorageDiff>,
+            ) -> pathfinder_executor::types::StateDiff {
+                pathfinder_executor::types::StateDiff {
+                    storage_diffs: BTreeMap::from_iter(
+                        storage_diffs
+                            .into_iter()
+                            .map(|diff| {
+                                (
+                                    diff.address,
+                                    diff.storage_entries
+                                        .into_iter()
+                                        .map(|entry| pathfinder_executor::types::StorageDiff {
+                                            key: entry.key,
+                                            value: entry.value,
+                                        })
+                                        .collect(),
+                                )
+                            })
+                            .collect::<Vec<_>>(),
+                    ),
+                    deprecated_declared_classes: HashSet::new(),
+                    declared_classes: vec![],
+                    deployed_contracts: vec![],
+                    replaced_classes: vec![],
+                    nonces: BTreeMap::from([(account_contract_address, contract_nonce!("0x3"))]),
+                }
+            }
+
+            fn invoke_fee_transfer_storage_diffs(overall_fee_correction: u64) -> Vec<StorageDiff> {
+                vec![StorageDiff {
+                    address: ETH_FEE_TOKEN_ADDRESS,
+                    storage_entries: vec![
+                        StorageEntry {
+                            key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
+                            value: StorageValue((0xfffffffffffffffffffffffff831u128 + u128::from(2 * overall_fee_correction)).into()),
+                        },
+                        StorageEntry {
+                            key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
+                            value: StorageValue((DECLARE_OVERALL_FEE + UNIVERSAL_DEPLOYER_OVERALL_FEE + INVOKE_OVERALL_FEE - 2 * overall_fee_correction).into()),
+                        },
+                    ],
+                }]
+            }
+
+            fn invoke_validate(
+                account_contract_address: ContractAddress,
+            ) -> pathfinder_executor::types::FunctionInvocation {
+                pathfinder_executor::types::FunctionInvocation {
+                    call_type: Some(pathfinder_executor::types::CallType::Call),
+                    caller_address: felt!("0x0"),
+                    class_hash: Some(crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH.0),
+                    entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
+                    internal_calls: vec![],
+                    events: vec![],
+                    contract_address: account_contract_address,
+                    selector: Some(EntryPoint::hashed(b"__validate__").0),
+                    calldata: vec![
+                        call_param!("0x1").0,
+                        DEPLOYED_CONTRACT_ADDRESS.0,
+                        EntryPoint::hashed(b"get_data").0,
+                        // calldata_len
+                        call_param!("0x0").0,
+                    ],
+                    messages: vec![],
+                    result: vec![felt!("0x56414c4944")],
+                    execution_resources: pathfinder_executor::types::InnerCallExecutionResources {
+                        l1_gas: 2,
+                        l2_gas: 0,
+                    },
+                    computation_resources: invoke_validate_computation_resources(),
+                    is_reverted: false,
+                }
+            }
+
+            fn invoke_execute(
+                account_contract_address: ContractAddress,
+                test_storage_value: StorageValue,
+            ) -> pathfinder_executor::types::FunctionInvocation {
+                pathfinder_executor::types::FunctionInvocation {
+                    call_type: Some(pathfinder_executor::types::CallType::Call),
+                    caller_address: felt!("0x0"),
+                    internal_calls: vec![pathfinder_executor::types::FunctionInvocation {
+                        call_type: Some(pathfinder_executor::types::CallType::Call),
+                        caller_address: *account_contract_address.get(),
+                        class_hash: Some(SIERRA_HASH.0),
+                        entry_point_type: Some(
+                            pathfinder_executor::types::EntryPointType::External,
+                        ),
+                        events: vec![],
+                        internal_calls: vec![],
+                        contract_address: DEPLOYED_CONTRACT_ADDRESS,
+                        selector: Some(EntryPoint::hashed(b"get_data").0),
+                        calldata: vec![],
+                        messages: vec![],
+                        result: vec![test_storage_value.0],
+                        computation_resources: pathfinder_executor::types::ComputationResources {
+                            steps: 165,
+                            range_check_builtin_applications: 3,
+                            ..Default::default()
+                        },
+                        execution_resources:
+                            pathfinder_executor::types::InnerCallExecutionResources {
+                                l1_gas: 1,
+                                l2_gas: 0,
+                            },
+                        is_reverted: false,
+                    }],
+                    class_hash: Some(crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH.0),
+                    entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
+                    events: vec![],
+                    contract_address: account_contract_address,
+                    selector: Some(EntryPoint::hashed(b"__execute__").0),
+                    calldata: vec![
+                        call_param!("0x1").0,
+                        DEPLOYED_CONTRACT_ADDRESS.0,
+                        EntryPoint::hashed(b"get_data").0,
+                        // calldata_len
+                        call_param!("0x0").0,
+                    ],
+                    messages: vec![],
+                    result: vec![felt!("0x1"), felt!("0x1"), test_storage_value.0],
+                    computation_resources: invoke_execute_computation_resources(),
+                    execution_resources: pathfinder_executor::types::InnerCallExecutionResources {
+                        l1_gas: 6,
+                        l2_gas: 0,
+                    },
+                    is_reverted: false,
+                }
+            }
+
+            fn invoke_fee_transfer(
+                account_contract_address: ContractAddress,
+                last_block_header: &BlockHeader,
+                overall_fee_correction: u64,
+            ) -> pathfinder_executor::types::FunctionInvocation {
+                pathfinder_executor::types::FunctionInvocation {
+                    call_type: Some(pathfinder_executor::types::CallType::Call),
+                    caller_address: *account_contract_address.get(),
+                    class_hash: Some(ERC20_CONTRACT_DEFINITION_CLASS_HASH.0),
+                    entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
+                    internal_calls: vec![],
+                    events: vec![pathfinder_executor::types::Event {
+                        order: 0,
+                        data: vec![
+                            *account_contract_address.get(),
+                            last_block_header.sequencer_address.0,
+                            Felt::from_u64(INVOKE_OVERALL_FEE - overall_fee_correction),
+                            felt!("0x0"),
+                        ],
+                        keys: vec![felt!(
+                            "0x0099CD8BDE557814842A3121E8DDFD433A539B8C9F14BF31EBF108D12E6196E9"
+                        )],
+                    }],
+                    calldata: vec![
+                        last_block_header.sequencer_address.0,
+                        Felt::from_u64(INVOKE_OVERALL_FEE - overall_fee_correction),
+                        call_param!("0x0").0,
+                    ],
+                    contract_address: ETH_FEE_TOKEN_ADDRESS,
+                    selector: Some(EntryPoint::hashed(b"transfer").0),
+                    messages: vec![],
+                    result: vec![felt!("0x1")],
+                    computation_resources: invoke_fee_transfer_computation_resources(),
+                    execution_resources: pathfinder_executor::types::InnerCallExecutionResources {
+                        l1_gas: 4,
+                        l2_gas: 0,
+                    },
+                    is_reverted: false,
+                }
+            }
+        }
     }
 
     #[rstest::rstest]

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -88,7 +88,10 @@ pub async fn simulate_transactions(
                     .get(&db_tx, rpc_version)
                     .context("Querying pending data")?;
 
-                (pending.header(), Some(pending.state_update()))
+                (
+                    pending.pending_header(),
+                    Some(pending.pending_state_update()),
+                )
             }
             other => {
                 let block_id = other

--- a/crates/rpc/src/method/subscribe_events.rs
+++ b/crates/rpc/src/method/subscribe_events.rs
@@ -350,10 +350,10 @@ impl RpcSubscriptionFlow for SubscribeEvents {
                         continue;
                     }
 
-                    tracing::trace!(block_number=%pending.block_number(), "Received pending block update");
+                    tracing::trace!(block_number=%pending.pending_block_number(), "Received pending block update");
 
                     let finality = pending.finality_status();
-                    let block_number = pending.block_number();
+                    let block_number = pending.pending_block_number();
                     if block_number != current_block {
                         tracing::trace!(
                             %block_number,
@@ -363,7 +363,7 @@ impl RpcSubscriptionFlow for SubscribeEvents {
                         sent_txs.clear();
                         current_block = block_number;
                     }
-                    for (receipt, events) in pending.transaction_receipts_and_events().iter() {
+                    for (receipt, events) in pending.pending_tx_receipts_and_events().iter() {
                         if sent_txs.contains(&(receipt.transaction_hash, finality)) {
                             tracing::trace!(
                                 transaction_hash=%receipt.transaction_hash,
@@ -830,7 +830,7 @@ mod tests {
         // Send pre-confirmed data, expecting it to be ignored.
         pending_data_tx
             .send(crate::PendingData::from_pre_confirmed_block(
-                sample_pre_confirmed_block(num_blocks),
+                sample_pre_confirmed_block(num_blocks).into(),
                 BlockNumber::new_or_panic(num_blocks),
             ))
             .unwrap();
@@ -910,7 +910,7 @@ mod tests {
         // Send pre-confirmed data.
         pending_data_tx
             .send(crate::PendingData::from_pre_confirmed_block(
-                sample_pre_confirmed_block(num_blocks),
+                sample_pre_confirmed_block(num_blocks).into(),
                 BlockNumber::new_or_panic(num_blocks),
             ))
             .unwrap();

--- a/crates/rpc/src/method/subscribe_pending_transactions.rs
+++ b/crates/rpc/src/method/subscribe_pending_transactions.rs
@@ -93,11 +93,11 @@ impl RpcSubscriptionFlow for SubscribePendingTransactions {
                 continue;
             }
 
-            if pending.block_number() != last_block {
-                last_block = pending.block_number();
+            if pending.pending_block_number() != last_block {
+                last_block = pending.pending_block_number();
                 sent_txs.clear();
             }
-            for transaction in pending.transactions().iter() {
+            for transaction in pending.pending_transactions().iter() {
                 if sent_txs.contains(&transaction.hash) {
                     continue;
                 }
@@ -130,7 +130,7 @@ impl RpcSubscriptionFlow for SubscribePendingTransactions {
                 if tx
                     .send(SubscriptionMessage {
                         notification,
-                        block_number: pending.block_number(),
+                        block_number: pending.pending_block_number(),
                         subscription_name: SUBSCRIPTION_NAME,
                     })
                     .await

--- a/crates/rpc/src/method/subscribe_transaction_status.rs
+++ b/crates/rpc/src/method/subscribe_transaction_status.rs
@@ -391,6 +391,18 @@ fn pending_data_tx_status(
     pending_data: &PendingData,
     tx_hash: TransactionHash,
 ) -> Option<(BlockNumber, FinalityStatus, Option<ExecutionStatus>)> {
+    if let Some(pre_latest_block) = pending_data.pre_latest_block() {
+        let status_in_pre_latest = find_tx_receipt(&pre_latest_block.transaction_receipts, tx_hash)
+            .map(|r| r.execution_status.clone());
+        if status_in_pre_latest.is_some() {
+            return Some((
+                pre_latest_block.number,
+                FinalityStatus::AcceptedOnL2,
+                status_in_pre_latest,
+            ));
+        }
+    }
+
     let block_number = pending_data.pending_block_number();
     match pending_data.pending_block().as_ref() {
         PendingBlockVariant::Pending(block) => {
@@ -505,7 +517,7 @@ mod tests {
     use pathfinder_ethereum::EthereumStateUpdate;
     use pathfinder_storage::StorageBuilder;
     use pretty_assertions_sorted::assert_eq;
-    use starknet_gateway_types::reply::{Block, PendingBlock, PreConfirmedBlock};
+    use starknet_gateway_types::reply::{Block, PendingBlock, PreConfirmedBlock, PreLatestBlock};
     use tokio::sync::mpsc;
 
     use crate::context::{RpcContext, WebsocketContext};
@@ -1065,6 +1077,157 @@ mod tests {
                         "subscription_id": subscription_id
                     }
                 })),
+            ]
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn transaction_found_in_pre_latest_and_and_l2_block_sends_update_once() {
+        test_transaction_status_streaming(|subscription_id| {
+            vec![
+                TestEvent::Pending(PendingData::from_pre_confirmed_block(
+                    PreConfirmedBlock {
+                        transactions: vec![Transaction {
+                            hash: TransactionHash(Felt::from_u64(2)),
+                            variant: Default::default(),
+                        }],
+                        ..Default::default()
+                    }
+                    .into(),
+                    BlockNumber::GENESIS + 1,
+                )),
+                TestEvent::L2Block(
+                    Block {
+                        block_number: BlockNumber::GENESIS + 1,
+                        block_hash: BlockHash(Felt::from_u64(1)),
+                        ..Default::default()
+                    }
+                    .into(),
+                ),
+                TestEvent::Pending(PendingData::from_pre_confirmed_block(
+                    PreConfirmedBlock {
+                        transactions: vec![Transaction {
+                            hash: TARGET_TX_HASH,
+                            variant: Default::default(),
+                        }],
+                        // The fact that the receipt is present for this transaction means that it
+                        // belongs to the pre-confirmed block.
+                        transaction_receipts: vec![Some((
+                            Receipt {
+                                transaction_hash: TARGET_TX_HASH,
+                                ..Default::default()
+                            },
+                            vec![],
+                        ))],
+                        ..Default::default()
+                    }
+                    .into(),
+                    BlockNumber::GENESIS + 2,
+                )),
+                TestEvent::Message(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "method": "starknet_subscriptionTransactionStatus",
+                    "params": {
+                        "result": {
+                            "transaction_hash": "0x1",
+                            "status": {
+                                "finality_status": "PRE_CONFIRMED",
+                                "execution_status": "SUCCEEDED"
+                            }
+                        },
+                        "subscription_id": subscription_id
+                    }
+                })),
+                TestEvent::Pending(PendingData::from_pre_confirmed_and_pre_latest(
+                    PreConfirmedBlock {
+                        transactions: vec![Transaction {
+                            hash: TransactionHash(Felt::from_u64(3)),
+                            variant: Default::default(),
+                        }],
+                        transaction_receipts: vec![Some((
+                            Receipt {
+                                transaction_hash: TransactionHash(Felt::from_u64(3)),
+                                ..Default::default()
+                            },
+                            vec![],
+                        ))],
+                        ..Default::default()
+                    }
+                    .into(),
+                    BlockNumber::GENESIS + 3,
+                    Some(Box::new((
+                        // Previous block promoted to pre-latest.
+                        BlockNumber::GENESIS + 2,
+                        PreLatestBlock {
+                            parent_hash: BlockHash(Felt::from_u64(2)),
+                            transaction_receipts: vec![
+                                (
+                                    Receipt {
+                                        transaction_hash: TARGET_TX_HASH,
+                                        ..Default::default()
+                                    },
+                                    vec![],
+                                ),
+                                // Random tx receipt.
+                                (
+                                    Receipt {
+                                        transaction_hash: TransactionHash(Felt::from_u64(123)),
+                                        ..Default::default()
+                                    },
+                                    vec![],
+                                ),
+                            ],
+                            transactions: vec![
+                                Transaction {
+                                    hash: TARGET_TX_HASH,
+                                    variant: Default::default(),
+                                },
+                                // Random transaction.
+                                Transaction {
+                                    hash: TransactionHash(Felt::from_u64(123)),
+                                    variant: Default::default(),
+                                },
+                            ],
+                            ..Default::default()
+                        },
+                        StateUpdate::default(),
+                    ))),
+                )),
+                TestEvent::Message(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "method": "starknet_subscriptionTransactionStatus",
+                    "params": {
+                        "result": {
+                            "transaction_hash": "0x1",
+                            "status": {
+                                "finality_status": "ACCEPTED_ON_L2",
+                                "execution_status": "SUCCEEDED"
+                            }
+                        },
+                        "subscription_id": subscription_id
+                    }
+                })),
+                TestEvent::L2Block(
+                    Block {
+                        block_number: BlockNumber::GENESIS + 2,
+                        block_hash: BlockHash(Felt::from_u64(2)),
+                        transactions: vec![Transaction {
+                            hash: TARGET_TX_HASH,
+                            ..Default::default()
+                        }],
+                        transaction_receipts: vec![(
+                            Receipt {
+                                transaction_hash: TARGET_TX_HASH,
+                                ..Default::default()
+                            },
+                            vec![],
+                        )],
+                        ..Default::default()
+                    }
+                    .into(),
+                ),
+                // No message received with a duplicate ACCEPTED_ON_L2 status.
             ]
         })
         .await;

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -68,8 +68,8 @@ pub async fn trace_block_transactions(
                     .get(&db_tx, rpc_version)
                     .context("Querying pending data")?;
 
-                let header = pending.header();
-                let transactions = pending.transactions().to_vec();
+                let header = pending.pending_header();
+                let transactions = pending.pending_transactions().to_vec();
 
                 (
                     None,

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -1006,6 +1006,271 @@ pub(crate) mod tests {
         Ok((context, traces))
     }
 
+    pub(crate) async fn setup_multi_tx_trace_pre_latest_test(
+    ) -> anyhow::Result<(RpcContext, Vec<Trace>)> {
+        use super::super::simulate_transactions::tests::{
+            fixtures,
+            setup_storage_with_starknet_version,
+        };
+
+        let (
+            storage,
+            last_block_header,
+            account_contract_address,
+            universal_deployer_address,
+            test_storage_value,
+        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 14, 0, 0)).await;
+        let context = RpcContext::for_tests().with_storage(storage.clone());
+
+        let pre_latest_transactions = vec![
+            fixtures::input::declare(account_contract_address).into_common(context.chain_id),
+            fixtures::input::universal_deployer(
+                account_contract_address,
+                universal_deployer_address,
+            )
+            .into_common(context.chain_id),
+            fixtures::input::invoke(account_contract_address).into_common(context.chain_id),
+        ];
+
+        let traces = vec![
+            fixtures::expected_output_0_14_0_0::declare(
+                account_contract_address,
+                &last_block_header,
+            ),
+            fixtures::expected_output_0_14_0_0::universal_deployer(
+                account_contract_address,
+                &last_block_header,
+                universal_deployer_address,
+            ),
+            fixtures::expected_output_0_14_0_0::invoke(
+                account_contract_address,
+                &last_block_header,
+                test_storage_value,
+            ),
+        ];
+
+        let pending_data = {
+            let mut db = storage.connection()?;
+            let tx = db.transaction()?;
+
+            tx.insert_sierra_class(
+                &SierraHash(fixtures::SIERRA_HASH.0),
+                fixtures::SIERRA_DEFINITION,
+                &fixtures::CASM_HASH,
+                fixtures::CASM_DEFINITION,
+            )?;
+
+            let dummy_receipt = Receipt {
+                transaction_hash: TransactionHash(felt!("0x1")),
+                transaction_index: TransactionIndex::new_or_panic(0),
+                ..Default::default()
+            };
+
+            let transaction_receipts = vec![(dummy_receipt, vec![]); pre_latest_transactions.len()];
+
+            let pre_latest_block = starknet_gateway_types::reply::PreLatestBlock {
+                l1_gas_price: GasPrices {
+                    price_in_wei: last_block_header.eth_l1_gas_price,
+                    price_in_fri: last_block_header.strk_l1_gas_price,
+                },
+                l1_data_gas_price: GasPrices {
+                    price_in_wei: last_block_header.eth_l1_data_gas_price,
+                    price_in_fri: last_block_header.strk_l1_data_gas_price,
+                },
+                l2_gas_price: GasPrices {
+                    price_in_wei: last_block_header.eth_l2_gas_price,
+                    price_in_fri: last_block_header.strk_l2_gas_price,
+                },
+                parent_hash: last_block_header.hash,
+                sequencer_address: last_block_header.sequencer_address,
+                // TODO: Double check this.
+                status: starknet_gateway_types::reply::Status::AcceptedOnL2,
+                timestamp: last_block_header.timestamp,
+                transaction_receipts,
+                transactions: pre_latest_transactions.clone(),
+                starknet_version: last_block_header.starknet_version,
+                l1_da_mode: L1DataAvailabilityMode::Blob,
+            };
+
+            let pre_confirmed_block = starknet_gateway_types::reply::PreConfirmedBlock {
+                l1_gas_price: GasPrices {
+                    price_in_wei: last_block_header.eth_l1_gas_price,
+                    price_in_fri: last_block_header.strk_l1_gas_price,
+                },
+                l1_data_gas_price: GasPrices {
+                    price_in_wei: last_block_header.eth_l1_data_gas_price,
+                    price_in_fri: last_block_header.strk_l1_data_gas_price,
+                },
+                l2_gas_price: GasPrices {
+                    price_in_wei: last_block_header.eth_l2_gas_price,
+                    price_in_fri: last_block_header.strk_l2_gas_price,
+                },
+                sequencer_address: last_block_header.sequencer_address,
+                status: starknet_gateway_types::reply::Status::PreConfirmed,
+                timestamp: last_block_header.timestamp,
+                transaction_receipts: vec![],
+                transactions: vec![],
+                starknet_version: last_block_header.starknet_version,
+                l1_da_mode: L1DataAvailabilityMode::Blob,
+                transaction_state_diffs: vec![],
+            };
+
+            tx.commit()?;
+
+            crate::pending::PendingData::from_pre_confirmed_and_pre_latest(
+                Box::new(pre_confirmed_block),
+                // Last L2 block, then pre-latest then this, so +2.
+                last_block_header.number + 2,
+                Some(Box::new((
+                    last_block_header.number + 1,
+                    pre_latest_block,
+                    StateUpdate::default(),
+                ))),
+            )
+        };
+
+        let (tx, rx) = tokio::sync::watch::channel(Default::default());
+        tx.send(pending_data).unwrap();
+
+        let context = context.with_pending_data(rx);
+
+        let traces = vec![
+            Trace {
+                transaction_hash: pre_latest_transactions[0].hash,
+                trace_root: traces[0].trace.clone(),
+            },
+            Trace {
+                transaction_hash: pre_latest_transactions[1].hash,
+                trace_root: traces[1].trace.clone(),
+            },
+            Trace {
+                transaction_hash: pre_latest_transactions[2].hash,
+                trace_root: traces[2].trace.clone(),
+            },
+        ];
+
+        Ok((context, traces))
+    }
+
+    pub(crate) async fn setup_multi_tx_trace_pre_confirmed_test(
+    ) -> anyhow::Result<(RpcContext, Vec<Trace>)> {
+        use super::super::simulate_transactions::tests::{
+            fixtures,
+            setup_storage_with_starknet_version,
+        };
+
+        let (
+            storage,
+            last_block_header,
+            account_contract_address,
+            universal_deployer_address,
+            test_storage_value,
+        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 14, 0, 0)).await;
+        let context = RpcContext::for_tests().with_storage(storage.clone());
+
+        let pre_confirmed_transactions = vec![
+            fixtures::input::declare(account_contract_address).into_common(context.chain_id),
+            fixtures::input::universal_deployer(
+                account_contract_address,
+                universal_deployer_address,
+            )
+            .into_common(context.chain_id),
+            fixtures::input::invoke(account_contract_address).into_common(context.chain_id),
+        ];
+
+        let traces = vec![
+            fixtures::expected_output_0_14_0_0::declare(
+                account_contract_address,
+                &last_block_header,
+            ),
+            fixtures::expected_output_0_14_0_0::universal_deployer(
+                account_contract_address,
+                &last_block_header,
+                universal_deployer_address,
+            ),
+            fixtures::expected_output_0_14_0_0::invoke(
+                account_contract_address,
+                &last_block_header,
+                test_storage_value,
+            ),
+        ];
+
+        let pending_data = {
+            let mut db = storage.connection()?;
+            let tx = db.transaction()?;
+
+            tx.insert_sierra_class(
+                &SierraHash(fixtures::SIERRA_HASH.0),
+                fixtures::SIERRA_DEFINITION,
+                &fixtures::CASM_HASH,
+                fixtures::CASM_DEFINITION,
+            )?;
+
+            let dummy_receipt = Receipt {
+                transaction_hash: TransactionHash(felt!("0x1")),
+                transaction_index: TransactionIndex::new_or_panic(0),
+                ..Default::default()
+            };
+
+            let transaction_receipts =
+                vec![Some((dummy_receipt, vec![])); pre_confirmed_transactions.len()];
+
+            let pre_confirmed_block = starknet_gateway_types::reply::PreConfirmedBlock {
+                l1_gas_price: GasPrices {
+                    price_in_wei: last_block_header.eth_l1_gas_price,
+                    price_in_fri: last_block_header.strk_l1_gas_price,
+                },
+                l1_data_gas_price: GasPrices {
+                    price_in_wei: last_block_header.eth_l1_data_gas_price,
+                    price_in_fri: last_block_header.strk_l1_data_gas_price,
+                },
+                l2_gas_price: GasPrices {
+                    price_in_wei: last_block_header.eth_l2_gas_price,
+                    price_in_fri: last_block_header.strk_l2_gas_price,
+                },
+                sequencer_address: last_block_header.sequencer_address,
+                status: starknet_gateway_types::reply::Status::PreConfirmed,
+                timestamp: last_block_header.timestamp,
+                transaction_receipts,
+                transactions: pre_confirmed_transactions.clone(),
+                starknet_version: last_block_header.starknet_version,
+                l1_da_mode: L1DataAvailabilityMode::Blob,
+                transaction_state_diffs: vec![],
+            };
+
+            tx.commit()?;
+
+            crate::pending::PendingData::from_pre_confirmed_and_pre_latest(
+                Box::new(pre_confirmed_block),
+                // No pre-latest block, so +1.
+                last_block_header.number + 1,
+                None,
+            )
+        };
+
+        let (tx, rx) = tokio::sync::watch::channel(Default::default());
+        tx.send(pending_data).unwrap();
+
+        let context = context.with_pending_data(rx);
+
+        let traces = vec![
+            Trace {
+                transaction_hash: pre_confirmed_transactions[0].hash,
+                trace_root: traces[0].trace.clone(),
+            },
+            Trace {
+                transaction_hash: pre_confirmed_transactions[1].hash,
+                trace_root: traces[1].trace.clone(),
+            },
+            Trace {
+                transaction_hash: pre_confirmed_transactions[2].hash,
+                trace_root: traces[2].trace.clone(),
+            },
+        ];
+
+        Ok((context, traces))
+    }
+
     #[rstest::rstest]
     #[case::v07(RpcVersion::V07)]
     #[case::v08(RpcVersion::V08)]

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -1083,8 +1083,7 @@ pub(crate) mod tests {
                 },
                 parent_hash: last_block_header.hash,
                 sequencer_address: last_block_header.sequencer_address,
-                // TODO: Double check this.
-                status: starknet_gateway_types::reply::Status::AcceptedOnL2,
+                status: starknet_gateway_types::reply::Status::Pending,
                 timestamp: last_block_header.timestamp,
                 transaction_receipts,
                 transactions: pre_latest_transactions.clone(),

--- a/crates/rpc/src/method/trace_transaction.rs
+++ b/crates/rpc/src/method/trace_transaction.rs
@@ -73,11 +73,11 @@ pub async fn trace_transaction(
                 .context("Querying pending data")?;
 
             let (header, transactions, cache) = if let Some(pending_tx) = pending
-                .transactions()
-                .iter()
+                .pending_transactions()
+                .into_iter()
                 .find(|tx| tx.hash == input.transaction_hash)
             {
-                let header = pending.header();
+                let header = pending.pending_header();
 
                 if header.starknet_version
                     < VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEWAY
@@ -87,7 +87,7 @@ pub async fn trace_transaction(
 
                 (
                     header,
-                    pending.transactions().to_vec(),
+                    pending.pending_transactions().to_vec(),
                     // Can't use the cache for pending blocks since they have no block hash.
                     pathfinder_executor::TraceCache::default(),
                 )

--- a/crates/rpc/src/method/trace_transaction.rs
+++ b/crates/rpc/src/method/trace_transaction.rs
@@ -74,7 +74,7 @@ pub async fn trace_transaction(
 
             let (header, transactions, cache) = if let Some(pending_tx) = pending
                 .pending_transactions()
-                .into_iter()
+                .iter()
                 .find(|tx| tx.hash == input.transaction_hash)
             {
                 let header = pending.pending_header();

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -281,8 +281,7 @@ impl PendingData {
                 l1_data_gas_price: pre_latest_block.l1_data_gas_price,
                 l2_gas_price: pre_latest_block.l2_gas_price,
                 sequencer_address: pre_latest_block.sequencer_address,
-                // TODO: Add its own status?
-                status: Status::PreConfirmed,
+                status: Status::Pending,
                 timestamp: pre_latest_block.timestamp,
                 starknet_version: pre_latest_block.starknet_version,
                 l1_da_mode: pre_latest_block.l1_da_mode.into(),
@@ -935,7 +934,7 @@ mod tests {
             l1_data_gas_price: Default::default(),
             l2_gas_price: Default::default(),
             sequencer_address: sequencer_address!("0x1234"),
-            status: Status::PreConfirmed,
+            status: Status::Pending,
             timestamp: BlockTimestamp::new_or_panic(112233),
             starknet_version: StarknetVersion::new(0, 14, 0, 0),
             l1_da_mode: L1DataAvailabilityMode::Blob,

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -669,8 +669,7 @@ impl PendingData {
                     transaction: pre_latest_tx.clone(),
                     receipt,
                     events,
-                    // TODO: Double check this.
-                    finality_status: crate::dto::TxnFinalityStatus::PreConfirmed,
+                    finality_status: crate::dto::TxnFinalityStatus::AcceptedOnL2,
                 });
             }
         }

--- a/crates/storage/src/test_utils.rs
+++ b/crates/storage/src/test_utils.rs
@@ -57,7 +57,7 @@ pub(crate) fn create_transactions_and_receipts(
     let n_transactions = n_blocks * transactions_per_block;
     assert!(
         n_transactions < 64,
-        "Too many transactions ({} > {}), `Felt::from_hex_str() will overflow.",
+        "Too many transactions ({} > {}), `Felt::from_hex_str()` will overflow.",
         n_transactions,
         64
     );


### PR DESCRIPTION
- Introduce the concept of a pre-latest block into the pending data related code in sync (post Starknet v0.14.0) and RPC.
- Refactor `PendingData` in the RPC crate to better deal with the additional complexity that the pre-latest block introduces.
- Consult the pre-latest block in the RPC methods that query pending data.
- Add unit tests to verify the new logic.

Closes https://github.com/eqlabs/pathfinder/issues/2926.