### PR TITLE
fix(sync): bump block cache size to 10k blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `--rpc.disable-batch-requests` CLI option, for instances not wishing to support batch requests.
 
+### Fixed
+
+- Pathfinder cannot recover after a reorg involving more than 1000 blocks. L2 reorg fails with error "Reorg exceeded local blockchain cache".
+
 ## [0.20.0] - 2025-08-26
 
 ### Changed

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -592,7 +592,7 @@ fn start_feeder_gateway_sync(
         submitted_tx_tracker,
         block_validation_mode: state::l2::BlockValidationMode::Strict,
         notifications,
-        block_cache_size: 1_000,
+        block_cache_size: 10_000,
         restart_delay: config.debug.restart_delay,
         verify_tree_hashes: config.verify_tree_hashes,
         sequencer_public_key: gateway_public_key,

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -224,7 +224,7 @@ where
     let latest_blocks = latest_n_blocks(&mut db_conn, block_cache_size)
         .await
         .context("Fetching latest blocks from storage")?;
-    let block_chain = BlockChain::with_capacity(1_000, latest_blocks);
+    let block_chain = BlockChain::with_capacity(block_cache_size, latest_blocks);
 
     // Start L2 producer task. Clone the event sender so that the channel remains
     // open even if the producer task fails.


### PR DESCRIPTION
Pathfinder can only do reorgs within the capacity of the block cache.

Unfortunately the recent L2 reorg on Starknet Mainnet was larger than the previous cache size of 1k blocks, which caused the reorg attempt to fail and Pathfinder was stuck in a loop trying to do the reorg again and again.