### PR TITLE
fix(p2p_proto): check for minimum required python version on `make sync`

### DIFF
--- a/crates/p2p_proto/Makefile
+++ b/crates/p2p_proto/Makefile
@@ -5,9 +5,21 @@ PYTHON := $(shell command -v python3 2> /dev/null || command -v python 2> /dev/n
 
 # Check if Python was found
 ifeq ($(PYTHON),)
-    $(error "Python not found. Please install Python 3.x")
+    $(error "Python not found. Please install Python 3.10+")
 endif
 
+# Check Python version
+PYTHON_VERSION := $(shell $(PYTHON) -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null)
+PYTHON_VERSION_CHECK := $(shell $(PYTHON) -c "import sys; exit(0 if sys.version_info >= (3, 10) else 1)" 2>/dev/null && echo "ok" || echo "fail")
+
 sync:
+	@echo "Using Python: $$($(PYTHON) --version)"
+	@if [ "$(PYTHON_VERSION_CHECK)" != "ok" ]; then \
+		echo "❌ Error: Python 3.10+ required, but found $(PYTHON_VERSION)"; \
+		echo "   Please upgrade your Python installation."; \
+		echo "   Your current version: $$($(PYTHON) --version)"; \
+		exit 1; \
+	fi
+	@echo "✅ Python version check passed"
 	$(PYTHON) scripts/sync_protos.py
 	$(PYTHON) scripts/generate_bindings.py

--- a/crates/p2p_proto/README.md
+++ b/crates/p2p_proto/README.md
@@ -1,0 +1,21 @@
+# P2P Protocol Buffers
+
+This crate contains the Protocol Buffer definitions and generated Rust code for the Starknet P2P protocol.
+
+## Syncing Protocol Definitions
+
+To sync the protocol definitions with the latest from Starkware:
+
+```bash
+make sync
+```
+
+This will fetch the latest protocol definitions from the [starknet-p2p-specs](https://github.com/starknet-io/starknet-p2p-specs) repository and update the Rust module structure accordingly.
+
+**Requirements:**
+- Python 3.10+ (the scripts will check and give a clear error if your version is too old)
+- Git (for fetching the latest specs)
+
+## Generated Code
+
+The generated Rust code is automatically included in the build process via `build.rs`. The protocol definitions are located in the `proto/` directory and the generated bindings are included in `src/lib.rs`.


### PR DESCRIPTION
Checks for minimum required Python version before attempting to run the `sync` scripts.

Otherwise, the user gets a really ugly error.

Also, added a simple README.md