### PR TITLE
feat: reorg notifications for `starknet_subscribeNewTransactions` and `starknet_subscribeNewTransactionReceipts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `--rpc.disable-batch-requests` CLI option, for instances not wishing to support batch requests.
+- reorg notifications for 1starknet_subscribeNewTransactions` and `starknet_subscribeNewTransactionReceipts`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `--rpc.disable-batch-requests` CLI option, for instances not wishing to support batch requests.
-- reorg notifications for 1starknet_subscribeNewTransactions` and `starknet_subscribeNewTransactionReceipts`
+- reorg notifications for `starknet_subscribeNewTransactions` and `starknet_subscribeNewTransactionReceipts`
 
 ### Fixed
 


### PR DESCRIPTION
Analogous to `starknet_subscribeEvents`.

Fixes https://github.com/eqlabs/pathfinder/issues/2947 .
