### PR TITLE
fix(pathfinder/sync/l2): properly check for reorgs during bulk sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `starknet_subscribeNewTransactions` doesn't accept the `RECEIVED` finality status filter.
+- Pathfinder gets stuck in a loop and prints "State root mismatch" errors after starting up from a database with current state that has been re-orged.
 
 ## [0.20.1] - 2025-09-02
 

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -821,6 +821,17 @@ where
                     ),
                 ) = ordered_blocks.pop_first().expect("num_to_emit > 0");
 
+                if let Some(some_head) = &head {
+                    if some_head.1 != block.parent_block_hash {
+                        tracing::info!(
+                            block_number=%block.block_number,
+                            "Reorg detected during bulk sync, falling back to normal sync to handle reorg"
+                        );
+
+                        return Ok(());
+                    }
+                }
+
                 *head = Some((
                     block.block_number,
                     block.block_hash,


### PR DESCRIPTION
When performing a bulk sync, we need to validate that the blocks we are receiving are indeed a continuation of our current chain. This is done after performing all other validations.

Note that we do _not_ handle reorgs during bulk sync, but simply give up bulk syncing and revert back to the block-by-block sync algorithm that then handles the reorg itself.

Closes #2992 