### PR TITLE
fix(rpc/v0_8/subscribe_pending_transactions): avoid busy loop with Starknet 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `starknet_subscribeNewTransactions` doesn't accept the `RECEIVED` finality status filter.
 - Pathfinder gets stuck in a loop and prints "State root mismatch" errors after starting up from a database with current state that has been re-orged.
 - `starknet_traceTransaction` and `starknet_traceBlockTransactions` falls back to fetching transaction traces for Starknet mainnet block range 1943704-1952704 (inclusive). Local re-execution would lead to a different result due to a sequencer issue that was present when these blocks were produced.
+- Pathfinder gets stuck syncing and stops responding to JSON-RPC requests.
 
 ## [0.20.1] - 2025-09-02
 

--- a/crates/rpc/src/method/subscribe_pending_transactions.rs
+++ b/crates/rpc/src/method/subscribe_pending_transactions.rs
@@ -86,6 +86,10 @@ impl RpcSubscriptionFlow for SubscribePendingTransactions {
             // since after the Starknet 0.14.0 update no transactions will be
             // sent over this subscription.
             if pending.is_pre_confirmed() {
+                if pending_data.changed().await.is_err() {
+                    tracing::debug!("Pending data channel closed, stopping subscription");
+                    return Ok(());
+                }
                 continue;
             }
 


### PR DESCRIPTION
After the Starknet 0.14.0 update, the pending block is no more. Some code has been added to the `subscribe_pendingTransactions` handler to ignore pre-confirmed block updates, but unfortunately it has resulted in a busy loop, as we never actually wait for a new pending update before checking the block again.

This change fixes that loop and makes sure we actually wait for an update before performing the check again.
