### PR TITLE
refactor: use anyhow::Context::context instead of ok_or_else paired with anyhow::anyhow

### DIFF
--- a/crates/feeder-gateway/src/main.rs
+++ b/crates/feeder-gateway/src/main.rs
@@ -568,7 +568,7 @@ fn resolve_class(
     let definition = tx
         .class_definition(class_hash)
         .context("Reading class definition from database")?
-        .ok_or_else(|| anyhow::anyhow!("No such class found"))?;
+        .context("No such class found")?;
 
     Ok(definition)
 }

--- a/crates/p2p/src/sync/client/peer_agnostic.rs
+++ b/crates/p2p/src/sync/client/peer_agnostic.rs
@@ -5,6 +5,7 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use anyhow::Context;
 use futures::channel::mpsc as fmpsc;
 use futures::{Stream, StreamExt, TryStreamExt};
 use libp2p::PeerId;
@@ -312,7 +313,7 @@ impl BlockClient for Client {
                             Receipt::try_from((
                                 tx_with_receipt.receipt,
                                 TransactionIndex::new(i.try_into().unwrap())
-                                    .ok_or_else(|| anyhow::anyhow!("Invalid transaction index"))?,
+                                    .context("Invalid transaction index")?,
                             ))?,
                         )),
                         Err(error) => {

--- a/crates/pathfinder/examples/dump_events.rs
+++ b/crates/pathfinder/examples/dump_events.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::num::NonZeroU32;
 use std::path::PathBuf;
 
-use anyhow::anyhow;
+use anyhow::Context;
 use clap::Parser;
 use pathfinder_common::{BlockNumber, ContractAddress, EventKey};
 use pathfinder_crypto::{Felt, HexParseError};
@@ -133,7 +133,7 @@ fn main() -> anyhow::Result<()> {
     };
 
     for n in cli.from_block..=cli.to_block {
-        let bn = BlockNumber::new(n).ok_or_else(|| anyhow!("invalid block number {}", n))?;
+        let bn = BlockNumber::new(n).context(format!("invalid block number {n}"))?;
         if let Some(pairs) = db_tx.events_for_block(bn.into())? {
             for pair in pairs {
                 let tx_hash = pair.0;

--- a/crates/pathfinder/src/p2p_network/consensus.rs
+++ b/crates/pathfinder/src/p2p_network/consensus.rs
@@ -95,7 +95,7 @@ mod inner {
                     Protocol::P2p(peer_id) => Some(peer_id),
                     _ => None,
                 })
-                .ok_or_else(|| anyhow::anyhow!(msg))
+                .context(msg)
         };
 
         for bootstrap_address in bootstrap_addresses {

--- a/crates/pathfinder/src/p2p_network/sync.rs
+++ b/crates/pathfinder/src/p2p_network/sync.rs
@@ -112,7 +112,7 @@ mod inner {
                     Protocol::P2p(peer_id) => Some(peer_id),
                     _ => None,
                 })
-                .ok_or_else(|| anyhow::anyhow!(msg))
+                .context(msg)
         };
 
         for bootstrap_address in bootstrap_addresses {

--- a/crates/pathfinder/src/p2p_network/sync/sync_handlers.rs
+++ b/crates/pathfinder/src/p2p_network/sync/sync_handlers.rs
@@ -159,13 +159,9 @@ fn get_classes_for_block(
         |block_number: BlockNumber, class_hash| -> anyhow::Result<ClassDefinition> {
             let definition = db_tx
                 .class_definition_at(block_number.into(), class_hash)?
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "Class definition {} not found at block {}",
-                        class_hash,
-                        block_number
-                    )
-                })?;
+                .context(format!(
+                    "Class definition {class_hash} not found at block {block_number}",
+                ))?;
             let casm_definition = db_tx.casm_definition(class_hash)?;
             Ok(match casm_definition {
                 Some(_casm) => ClassDefinition::Sierra {

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -9,6 +9,7 @@ pub use request::BlockId;
 
 /// Groups all strictly input types of the RPC API.
 pub mod request {
+    use anyhow::Context;
     use pathfinder_common::prelude::*;
     use pathfinder_common::transaction::{DataAvailabilityMode, ResourceBounds};
     use pathfinder_common::TipHex;
@@ -64,7 +65,7 @@ pub mod request {
                 BlockId::L1Accepted => {
                     let block_number = tx
                         .l1_l2_pointer()?
-                        .ok_or_else(|| anyhow::anyhow!("L1 accepted block number not found"))?;
+                        .context("L1 accepted block number not found")?;
                     Ok(pathfinder_common::BlockId::Number(block_number))
                 }
                 BlockId::Latest => Ok(pathfinder_common::BlockId::Latest),
@@ -90,7 +91,7 @@ pub mod request {
                 BlockId::L1Accepted => {
                     let block_number = tx
                         .l1_l2_pointer()?
-                        .ok_or_else(|| anyhow::anyhow!("L1 accepted block number not found"))?;
+                        .context("L1 accepted block number not found")?;
                     Ok(pathfinder_common::BlockId::Number(block_number))
                 }
                 BlockId::Latest | BlockId::Pending => Ok(pathfinder_common::BlockId::Latest),


### PR DESCRIPTION
... for Options used in functions/closures returning `anyhow::Result`.

[Because `Option` implements `Context::context`.](https://docs.rs/anyhow/latest/src/anyhow/context.rs.html#90-113)