### PR TITLE
commit decided upon block

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -549,6 +549,7 @@ macros::felt_newtypes!(
         L1ToL2MessagePayloadElem,
         L2ToL1MessagePayloadElem,
         PaymasterDataElem,
+        ProposalCommitment,
         PublicKey,
         SequencerAddress,
         StateCommitment,
@@ -673,7 +674,7 @@ pub fn calculate_class_commitment_leaf_hash(
 #[derive(Debug, Clone, Copy)]
 pub struct ConsensusInfo {
     pub highest_decided_height: BlockNumber,
-    pub highest_decided_value: BlockHash,
+    pub highest_decided_value: ProposalCommitment,
 }
 
 #[cfg(test)]

--- a/crates/consensus/src/internal.rs
+++ b/crates/consensus/src/internal.rs
@@ -290,7 +290,7 @@ fn handle_effect<V: crate::ValuePayload + 'static, A: crate::ValidatorAddress + 
             assert!(round.is_defined(), "Round is expected to be defined");
             output_queue.push_back(ConsensusEvent::RequestProposal {
                 height: height.as_u64(),
-                round: round.as_u32().unwrap(),
+                round: round.as_u32().expect("Round is not Nil"),
             });
             Ok(resume.resume_with(()))
         }
@@ -303,6 +303,7 @@ fn handle_effect<V: crate::ValuePayload + 'static, A: crate::ValidatorAddress + 
             );
             output_queue.push_back(ConsensusEvent::Decision {
                 height: cert.height.as_u64(),
+                round: cert.round.as_u32().expect("Round is not Nil"),
                 value: cert.value_id.clone(),
             });
             // We append the decision to the WAL so that in case of a crash,

--- a/crates/consensus/src/internal/wal.rs
+++ b/crates/consensus/src/internal/wal.rs
@@ -142,9 +142,9 @@ pub(crate) fn convert_wal_entry_to_input<V: crate::ValuePayload, A: crate::Valid
                     malachite_types::Validity::Invalid
                 },
             };
-            let peer_id = malachite_consensus::PeerId::from_bytes(&proposer.into())
-                .expect("Invalid proposer address");
-            Input::ProposedValue(proposed_value, malachite_types::ValueOrigin::Sync(peer_id))
+            // TODO Differentiate between consensus and sync proposed values once catch up
+            // using sync protocol is implemented, related issue https://github.com/eqlabs/pathfinder/issues/2934
+            Input::ProposedValue(proposed_value, malachite_types::ValueOrigin::Consensus)
         }
         _ => unreachable!(),
     }

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -571,6 +571,11 @@ impl<V: ValuePayload + 'static, A: ValidatorAddress + 'static> Consensus<V, A> {
             false
         }
     }
+
+    /// Get the current maximum height being tracked by the consensus engine.
+    pub fn current_height(&self) -> Option<u64> {
+        self.internal.keys().max().copied()
+    }
 }
 
 /// A round number (or `None` if the round is nil).
@@ -917,7 +922,7 @@ pub enum ConsensusEvent<V, A> {
     ///
     /// This event indicates that consensus has been reached for the given
     /// height and the value should be committed to the blockchain.
-    Decision { height: u64, value: V },
+    Decision { height: u64, round: u32, value: V },
     /// An internal error occurred in consensus.
     ///
     /// The application should handle this error appropriately, possibly by
@@ -935,8 +940,12 @@ impl<V: Debug, A: Debug> std::fmt::Debug for ConsensusEvent<V, A> {
             ConsensusEvent::RequestProposal { height, round, .. } => {
                 write!(f, "RequestProposal(H:{height} R:{round})")
             }
-            ConsensusEvent::Decision { height, value } => {
-                write!(f, "Decision(H:{height} Val:{value:?})")
+            ConsensusEvent::Decision {
+                height,
+                round,
+                value,
+            } => {
+                write!(f, "Decision(H:{height} R: {round} Val:{value:?})")
             }
             ConsensusEvent::Error(error) => write!(f, "Error({error:?})"),
         }

--- a/crates/consensus/tests/consensus_sim.rs
+++ b/crates/consensus/tests/consensus_sim.rs
@@ -111,9 +111,13 @@ async fn consensus_simulation() {
                                 }
                             }
 
-                            ConsensusEvent::Decision { height: h, value } => {
+                            ConsensusEvent::Decision {
+                                height: h,
+                                round: r,
+                                value,
+                            } => {
                                 info!(
-                                    "✅ {} decided on {value:?} at height {h}",
+                                    "✅ {} decided on {value:?} at height {h} round {r}",
                                     pretty_addr(&addr)
                                 );
                                 let mut decisions = decisions.lock().unwrap();

--- a/crates/consensus/tests/wal.rs
+++ b/crates/consensus/tests/wal.rs
@@ -109,13 +109,17 @@ async fn wal_concurrent_heights_retention_test() {
                             }
                         }
 
-                        ConsensusEvent::Decision { height: h, value } => {
+                        ConsensusEvent::Decision {
+                            height: h,
+                            round: r,
+                            value,
+                        } => {
                             info!(
-                                "✅ {} decided on {value:?} at height {h}",
+                                "✅ {} decided on {value:?} at height {h} round {r}",
                                 pretty_addr(&addr)
                             );
                             let mut decisions = decisions.lock().unwrap();
-                            decisions.insert((addr.clone(), h), value);
+                            decisions.insert((addr.clone(), h, r), value);
                         }
 
                         ConsensusEvent::Error(error) => {

--- a/crates/consensus/tests/wal.rs
+++ b/crates/consensus/tests/wal.rs
@@ -119,7 +119,7 @@ async fn wal_concurrent_heights_retention_test() {
                                 pretty_addr(&addr)
                             );
                             let mut decisions = decisions.lock().unwrap();
-                            decisions.insert((addr.clone(), h, r), value);
+                            decisions.insert((addr.clone(), h), value);
                         }
 
                         ConsensusEvent::Error(error) => {

--- a/crates/ethereum/src/lib.rs
+++ b/crates/ethereum/src/lib.rs
@@ -224,7 +224,7 @@ impl EthereumApi for EthereumClient {
                         }
                         None => {
                             tracing::debug!("L1 finalized block channel closed");
-                            return Err(anyhow::anyhow!("L1 finalized block channel closed"));
+                            anyhow::bail!("L1 finalized block channel closed");
                         }
                     }
                 }

--- a/crates/executor/src/execution_state.rs
+++ b/crates/executor/src/execution_state.rs
@@ -229,14 +229,17 @@ impl ExecutionState {
         let chain_info = self.chain_info()?;
         let block_info = self.block_info()?;
 
-        // Perform system contract updates if we are executing ontop of a parent block.
+        // Perform system contract updates if we are executing on top of a parent block.
         // Currently this is only the block hash from 10 blocks ago.
         let old_block_number_and_hash = if self.block_info.number.get() >= 10 {
             let block_number_whose_hash_becomes_available =
                 pathfinder_common::BlockNumber::new_or_panic(self.block_info.number.get() - 10);
+
             let block_hash = storage_adapter
                 .block_hash(block_number_whose_hash_becomes_available.into())?
-                .context("Getting historical block hash")?;
+                .context(format!(
+                    "Getting hash of historical block {block_number_whose_hash_becomes_available}"
+                ))?;
 
             tracing::trace!(%block_number_whose_hash_becomes_available, %block_hash, "Setting historical block hash");
 

--- a/crates/feeder-gateway/Cargo.toml
+++ b/crates/feeder-gateway/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "feeder-gateway"
-version.workspace = true
-edition.workspace = true
-license.workspace = true
-rust-version.workspace = true
-authors.workspace = true
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/gateway-client/src/builder.rs
+++ b/crates/gateway-client/src/builder.rs
@@ -454,12 +454,12 @@ fn retry_condition(e: &SequencerError) -> bool {
     match e {
         SequencerError::ReqwestError(e) => {
             if e.is_timeout() {
-                info!(reason=%e, "Request failed, retrying. Fetching the response or parts of it timed out. Try increasing request timeout by using the `--gateway.request-timeout` CLI option.");
+                info!(reason=?e, "Request failed, retrying. Fetching the response or parts of it timed out. Try increasing request timeout by using the `--gateway.request-timeout` CLI option.");
                 return true;
             }
 
             if e.is_body() || e.is_connect() {
-                info!(reason=%e, "Request failed, retrying");
+                info!(reason=?e, "Request failed, retrying");
             } else if e.is_status() {
                 match e.status().expect("status related error") {
                     StatusCode::NOT_FOUND
@@ -467,24 +467,24 @@ fn retry_condition(e: &SequencerError) -> bool {
                     | StatusCode::BAD_GATEWAY
                     | StatusCode::SERVICE_UNAVAILABLE
                     | StatusCode::GATEWAY_TIMEOUT => {
-                        debug!(reason=%e, "Request failed, retrying");
+                        debug!(reason=?e, "Request failed, retrying");
                     }
                     StatusCode::INTERNAL_SERVER_ERROR => {
-                        error!(reason=%e, "Request failed, retrying");
+                        error!(reason=?e, "Request failed, retrying");
                     }
-                    _ => warn!(reason=%e, "Request failed, retrying"),
+                    _ => warn!(reason=?e, "Request failed, retrying"),
                 }
             } else if e.is_decode() {
-                error!(reason=%e, "Request failed, retrying");
+                error!(reason=?e, "Request failed, retrying");
             } else {
-                warn!(reason=%e, "Request failed, retrying");
+                warn!(reason=?e, "Request failed, retrying");
             }
 
             true
         }
         SequencerError::StarknetError(_) => false,
         SequencerError::InvalidStarknetErrorVariant => {
-            error!(reason=%e, "Request failed, retrying");
+            error!(reason=?e, "Request failed, retrying");
             true
         }
     }

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -905,7 +905,7 @@ async fn verify_database(
 
                 anyhow::ensure!(
                     database_genesis == gateway_hash,
-                    "Database genesis block does not match gateway. {} != {}",
+                    "Database genesis block {} does not match gateway {}.",
                     database_genesis,
                     gateway_hash
                 );

--- a/crates/pathfinder/src/consensus/inner/p2p_task.rs
+++ b/crates/pathfinder/src/consensus/inner/p2p_task.rs
@@ -526,7 +526,10 @@ async fn handle_incoming_proposal_part(
             .await
             .context("Joining blocking task")?
             .context("Verifying proposal commitment")?;
-            validator_cache.insert(height_and_round, ValidatorStage::Finalize(validator));
+            validator_cache.insert(
+                height_and_round,
+                ValidatorStage::Finalize(Box::new(validator)),
+            );
 
             Ok(Some((
                 ProposalCommitment(proposal_commitment.0),

--- a/crates/pathfinder/src/p2p_network/common.rs
+++ b/crates/pathfinder/src/p2p_network/common.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use anyhow::{Context, Result};
 use p2p::core::Client;
 use p2p::libp2p::multiaddr::Protocol;
@@ -23,16 +25,14 @@ pub async fn dial_bootnodes<C>(
                 continue;
             }
         };
+
         // TODO: Use exponential backoff with a max retry limit, at least one boot node
         // needs to be reachable for the node to be useful.
         // https://github.com/eqlabs/pathfinder/issues/2937
-        loop {
-            let dial_result = core_client.dial(peer_id, bootstrap_address.clone()).await;
-
-            match dial_result {
+        for _ in 0..5 {
+            match core_client.dial(peer_id, bootstrap_address.clone()).await {
                 Ok(_) => {
                     success = true;
-                    break;
                 }
                 Err(error) => {
                     tracing::warn!(
@@ -40,7 +40,7 @@ pub async fn dial_bootnodes<C>(
                         %error,
                         "Failed to dial bootstrap node, retrying",
                     );
-                    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                    tokio::time::sleep(Duration::from_secs(1)).await;
                 }
             }
         }

--- a/crates/pathfinder/src/p2p_network/common.rs
+++ b/crates/pathfinder/src/p2p_network/common.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::Context;
 use p2p::core::Client;
 use p2p::libp2p::multiaddr::Protocol;
 use p2p::libp2p::{Multiaddr, PeerId};
@@ -59,10 +59,7 @@ pub async fn dial_bootnodes<C>(
     success
 }
 
-pub fn ensure_peer_id_in_multiaddr(
-    addr: &Multiaddr,
-    msg: &'static str,
-) -> Result<PeerId, anyhow::Error> {
+pub fn ensure_peer_id_in_multiaddr(addr: &Multiaddr, msg: &'static str) -> anyhow::Result<PeerId> {
     addr.iter()
         .find_map(|p| match p {
             Protocol::P2p(peer_id) => Some(peer_id),

--- a/crates/pathfinder/src/sync.rs
+++ b/crates/pathfinder/src/sync.rs
@@ -782,7 +782,7 @@ mod tests {
                     tracing::debug!(%block,
                         "FakeP2PClient::transaction_stream triggering fatal error at",
                     );
-                    return Err(anyhow::anyhow!("Fatal error at block {block}",));
+                    anyhow::bail!("Fatal error at block {block}");
                 }
 
                 Ok(PeerData::for_tests((

--- a/crates/pathfinder/src/validator.rs
+++ b/crates/pathfinder/src/validator.rs
@@ -589,10 +589,7 @@ impl ValidatorFinalizeStage {
             start.elapsed().as_millis()
         );
 
-        let transactions_and_receipts = transactions
-            .into_iter()
-            .zip(receipts.into_iter())
-            .collect::<Vec<_>>();
+        let transactions_and_receipts = transactions.into_iter().zip(receipts).collect::<Vec<_>>();
 
         Ok(FinalizedBlock {
             header,
@@ -606,7 +603,7 @@ impl ValidatorFinalizeStage {
 pub enum ValidatorStage {
     BlockInfo(ValidatorBlockInfoStage),
     TransactionBatch(Box<ValidatorTransactionBatchStage>),
-    Finalize(ValidatorFinalizeStage),
+    Finalize(Box<ValidatorFinalizeStage>),
 }
 
 /// Maps consensus transaction to a pair of:

--- a/crates/pathfinder/src/validator.rs
+++ b/crates/pathfinder/src/validator.rs
@@ -558,9 +558,9 @@ impl ValidatorFinalizeStage {
             .context("Create database transaction")?;
 
         if let Some(parent_number) = header.number.parent() {
-            // Parent block hash for the genesis block is zero by definition.
             header.parent_hash = db_txn.block_hash(parent_number.into())?.unwrap_or_default();
         } else {
+            // Parent block hash for the genesis block is zero by definition.
             header.parent_hash = BlockHash::ZERO;
         }
 

--- a/crates/pathfinder/src/validator.rs
+++ b/crates/pathfinder/src/validator.rs
@@ -5,12 +5,7 @@ use anyhow::Context;
 use p2p::sync::client::conv::TryFromDto;
 use p2p_proto::class::Cairo1Class;
 use p2p_proto::common::Hash;
-use p2p_proto::consensus::{
-    BlockInfo,
-    ProposalFin,
-    ProposalInit,
-    TransactionVariant as ConsensusVariant,
-};
+use p2p_proto::consensus::{BlockInfo, ProposalInit, TransactionVariant as ConsensusVariant};
 use p2p_proto::sync::transaction::{DeclareV3WithoutClass, TransactionVariant as SyncVariant};
 use p2p_proto::transaction::DeclareV3WithClass;
 use pathfinder_common::class_definition::{SelectorAndFunctionIndex, SierraEntryPoints};
@@ -334,6 +329,9 @@ impl ValidatorTransactionBatchStage {
     /// `Ok(Ok(ValidatorFinalizeStage))` if the expected block header
     /// matches the computed one, `Ok(Err((expected, actual)))` if they do
     /// not match, `Err` if there was an error during finalization.
+    ///
+    /// TODO remove this fn and the example that uses it (or modify the example
+    /// to use proper API)
     pub fn finalize(
         self,
         mut expected_block_header: BlockHeader,
@@ -402,6 +400,9 @@ impl ValidatorTransactionBatchStage {
             Ok(Ok(ValidatorFinalizeStage {
                 header,
                 state_update,
+                transactions: self.transactions,
+                receipts: self.receipts,
+                events: self.events,
             }))
         } else {
             Ok(Err((expected_block_header, header)))
@@ -412,35 +413,44 @@ impl ValidatorTransactionBatchStage {
         self,
         proposal_commitment: Hash,
     ) -> anyhow::Result<ValidatorFinalizeStage> {
+        let Self {
+            block_info,
+            block_executor,
+            transactions,
+            receipts,
+            events,
+            ..
+        } = self;
+
         let _span = tracing::debug_span!(
             "Validator::consensus_finalize",
-            height = %self.block_info.number,
-            num_transactions = %self.transactions.len(),
+            height = %block_info.number,
+            num_transactions = %transactions.len(),
         )
         .entered();
 
         let start = Instant::now();
 
-        let state_diff = self.block_executor.finalize()?;
+        let state_diff = block_executor.finalize()?;
 
         let transaction_commitment =
-            calculate_transaction_commitment(&self.transactions, self.block_info.starknet_version)?;
-        let receipt_commitment = calculate_receipt_commitment(&self.receipts)?;
-        let events_ref_by_txn = self
-            .events
+            calculate_transaction_commitment(&transactions, block_info.starknet_version)?;
+        let receipt_commitment = calculate_receipt_commitment(&receipts)?;
+        let events_ref_by_txn = events
             .iter()
-            .zip(self.transactions.iter().map(|t| t.hash))
+            .zip(transactions.iter().map(|t| t.hash))
             .map(|(e, h)| (h, e.as_slice()))
             .collect::<Vec<_>>();
         let event_commitment =
-            calculate_event_commitment(&events_ref_by_txn, self.block_info.starknet_version)?;
+            calculate_event_commitment(&events_ref_by_txn, block_info.starknet_version)?;
 
         let state_update = StateUpdateData::from(state_diff);
         let state_diff_commitment = state_update.compute_state_diff_commitment();
 
         let header = BlockHeader {
-            hash: BlockHash::ZERO,        // UNUSED
-            parent_hash: BlockHash::ZERO, // UNUSED
+            // Computed in ValidatorFinalizeStage::finalize()
+            hash: BlockHash::ZERO,
+            parent_hash: BlockHash::ZERO,
             number: self.block_info.number,
             timestamp: self.block_info.timestamp,
             eth_l1_gas_price: self.block_info.eth_l1_gas_price,
@@ -452,10 +462,11 @@ impl ValidatorTransactionBatchStage {
             sequencer_address: self.block_info.sequencer_address,
             starknet_version: self.block_info.starknet_version,
             event_commitment,
-            state_commitment: StateCommitment::ZERO, // UNUSED
+            // Computed in ValidatorFinalizeStage::finalize()
+            state_commitment: StateCommitment::ZERO,
             transaction_commitment,
-            transaction_count: self.transactions.len(),
-            event_count: self.events.iter().flatten().count(),
+            transaction_count: transactions.len(),
+            event_count: events.iter().flatten().count(),
             l1_da_mode: self.block_info.l1_da_mode,
             receipt_commitment,
             state_diff_commitment,
@@ -472,6 +483,9 @@ impl ValidatorTransactionBatchStage {
             Ok(ValidatorFinalizeStage {
                 header,
                 state_update,
+                transactions,
+                receipts,
+                events,
             })
         } else {
             Err(anyhow::anyhow!(
@@ -481,35 +495,58 @@ impl ValidatorTransactionBatchStage {
             ))
         }
     }
+
+    /// This function is only used for dummy proposal creation.
+    /// TODO remove this function once more elaborate proposal creation for
+    /// tests is employed.
+    pub fn compute_proposal_commitment(self) -> anyhow::Result<Hash> {
+        let state_diff = self.block_executor.finalize()?;
+        let state_update = StateUpdateData::from(state_diff);
+        let state_diff_commitment = state_update.compute_state_diff_commitment();
+        Ok(Hash(state_diff_commitment.0))
+    }
 }
 
 pub struct ValidatorFinalizeStage {
     header: BlockHeader,
     state_update: StateUpdateData,
+    transactions: Vec<Transaction>,
+    receipts: Vec<Receipt>,
+    events: Vec<Vec<Event>>,
+}
+
+pub struct FinalizedBlock {
+    pub header: BlockHeader,
+    pub state_update: StateUpdateData,
+    pub transactions_and_receipts: Vec<(Transaction, Receipt)>,
+    pub events: Vec<Vec<Event>>,
 }
 
 impl ValidatorFinalizeStage {
-    // TODO(validator) we're using the block hash instead of the proposal commitment
-    // here, which is incorrect but we don't have the proposal commitment
-    // formula yet.
-    /// Updates the tries, computes the state commitment and block hash, and
-    /// validates that the computed block hash matches the one in the proposal
-    /// fin.
-    pub fn validate_block_hash(
-        mut self,
-        workaround_block_hash_in_proposal_fin: ProposalFin,
-        workaround_parent_hash: BlockHash,
-        storage: Storage,
-    ) -> anyhow::Result<bool> {
+    /// Updates the tries, computes the state commitment and block hash.
+    ///
+    /// ### Performance
+    ///
+    /// This function performs database operations and is computationally
+    /// and IO intensive.
+    pub fn finalize(self, storage: Storage) -> anyhow::Result<FinalizedBlock> {
         #[cfg(debug_assertions)]
         const VERIFY_HASHES: bool = true;
         #[cfg(not(debug_assertions))]
         const VERIFY_HASHES: bool = false;
 
+        let Self {
+            mut header,
+            state_update,
+            transactions,
+            receipts,
+            events,
+        } = self;
+
         let _span = tracing::debug_span!(
             "Validator::finalize",
-            height = %self.header.number,
-            num_transactions = %self.header.transaction_count,
+            height = %header.number,
+            num_transactions = %header.transaction_count,
         )
         .entered();
 
@@ -520,42 +557,56 @@ impl ValidatorFinalizeStage {
             .transaction()
             .context("Create database transaction")?;
 
+        if let Some(parent_number) = header.number.parent() {
+            // Parent block hash for the genesis block is zero by definition.
+            header.parent_hash = db_txn.block_hash(parent_number.into())?.unwrap_or_default();
+        } else {
+            header.parent_hash = BlockHash::ZERO;
+        }
+
         let (storage_commitment, class_commitment) = update_starknet_state(
             &db_txn,
-            (&self.state_update).into(),
+            (&state_update).into(),
             VERIFY_HASHES,
-            self.header.number,
+            header.number,
             storage.clone(),
         )?;
 
         debug!(
             "Block {} tries updated in {} ms",
-            self.header.number,
+            header.number,
             start.elapsed().as_millis()
         );
 
         let start = Instant::now();
-        self.header.parent_hash = workaround_parent_hash;
-        self.header.state_commitment =
-            StateCommitment::calculate(storage_commitment, class_commitment);
+        header.state_commitment = StateCommitment::calculate(storage_commitment, class_commitment);
 
-        let computed_block_hash = block_hash::compute_final_hash(&self.header);
-        let expected_block_hash =
-            BlockHash(workaround_block_hash_in_proposal_fin.proposal_commitment.0);
+        header.hash = block_hash::compute_final_hash(&header);
 
         debug!(
             "Block {} state commitment and block hash computed in {} ms",
-            self.header.number,
+            header.number,
             start.elapsed().as_millis()
         );
 
-        Ok(computed_block_hash == expected_block_hash)
+        let transactions_and_receipts = transactions
+            .into_iter()
+            .zip(receipts.into_iter())
+            .collect::<Vec<_>>();
+
+        Ok(FinalizedBlock {
+            header,
+            state_update,
+            transactions_and_receipts,
+            events,
+        })
     }
 }
 
 pub enum ValidatorStage {
     BlockInfo(ValidatorBlockInfoStage),
     TransactionBatch(Box<ValidatorTransactionBatchStage>),
+    Finalize(ValidatorFinalizeStage),
 }
 
 /// Maps consensus transaction to a pair of:

--- a/crates/pathfinder/tests/consensus_smoke.rs
+++ b/crates/pathfinder/tests/consensus_smoke.rs
@@ -23,8 +23,7 @@ mod test {
     #[tokio::test]
     async fn consensus_3_node_smoke_test() -> anyhow::Result<()> {
         const NUM_NODES: usize = 3;
-        // This is the max height at which system contract 0x1 is not available.
-        const MIN_REQUIRED_DECIDED_HEIGHT: u64 = 9;
+        const MIN_REQUIRED_DECIDED_HEIGHT: u64 = 20;
         const TEST_TIMEOUT: Duration = Duration::from_secs(120);
         const READY_POLL_INTERVAL: Duration = Duration::from_millis(500);
         const HEIGHT_POLL_INTERVAL: Duration = Duration::from_secs(1);

--- a/crates/rpc/src/dto/primitives.rs
+++ b/crates/rpc/src/dto/primitives.rs
@@ -676,6 +676,12 @@ mod pathfinder_common_types {
         }
     }
 
+    impl SerializeForVersion for pathfinder_common::ProposalCommitment {
+        fn serialize(&self, serializer: Serializer) -> Result<crate::dto::Ok, crate::dto::Error> {
+            serializer.serialize_str(&hex_str::bytes_to_hex_str_stripped(self.0.as_be_bytes()))
+        }
+    }
+
     impl SerializeForVersion for pathfinder_common::ReceiptCommitment {
         fn serialize(&self, serializer: Serializer) -> Result<crate::dto::Ok, crate::dto::Error> {
             serializer.serialize_str(&hex_str::bytes_to_hex_str_stripped(self.0.as_be_bytes()))

--- a/crates/rpc/src/method/consensus_info.rs
+++ b/crates/rpc/src/method/consensus_info.rs
@@ -3,7 +3,7 @@ use crate::context::RpcContext;
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct Output {
     highest_decided_height: Option<pathfinder_common::BlockNumber>,
-    highest_decided_value: Option<pathfinder_common::BlockHash>,
+    highest_decided_value: Option<pathfinder_common::ProposalCommitment>,
 }
 
 crate::error::generate_rpc_error_subset!(Error);


### PR DESCRIPTION
This PR introduces the following changes:
- Fixes: https://github.com/eqlabs/pathfinder/issues/2930
- Fixes: https://github.com/eqlabs/pathfinder/issues/2931
- Fixes: https://github.com/eqlabs/pathfinder/issues/2938
- a Pathfinder instance that is configured as a proposer will produce empty proposals which are consistent from genesis and beyond the 10th block boundary. Previously we just used a hard-coded proposal commitment that was only valid for block range `0..=9`, because from block `10` onward, the state diff contains system contract `0x1` with the historical block hash value (ie. 10 blocks back in history)

Important stuff when running a manual test:
- [scripts.zip](https://github.com/user-attachments/files/22256629/scripts.zip)
- a mock feeder gateway is used because it then enables testing restaring pathfinder processes that take part in consensus,
- restarting any of the actors from a non-clean state (ie. where the chain in the DB has already advanced beyond an empty DB) requires this local feeder mock to use the `custom.sqlite.genesis.SN_SEPOLIA` DB, the reason being restarting Pathfinder with a non-empty DB results in genesis block check vs the feeder, and the real (mainnet/sepolia) feeders obviously serve mismatching values (ie. genesis there is not empty),
- sometimes restarting any of the actors will fail, in the unfortunate scenario where a **consensus decision** was stored in WAL, and the given block was not committed to the DB, in such case the state of consensus cannot be recovered because persistent proposal cache is not implemented yet (see issue https://github.com/eqlabs/pathfinder/issues/2939).