### PR TITLE
fix(storage/schema/revision_0074): update block range in running event filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Pathfinder panics with "Block number Z is not in the range X..=Y" after starting up from an old Sepolia testnet database snapshot.
+
 ## [0.20.3] - 2025-09-09
 
 ### Changed

--- a/crates/storage/src/schema/revision_0074.rs
+++ b/crates/storage/src/schema/revision_0074.rs
@@ -134,10 +134,12 @@ pub(crate) fn migrate(tx: &rusqlite::Transaction<'_>) -> anyhow::Result<()> {
     tx.execute(
         r"
         UPDATE running_event_filter
-        SET bitmap = ?, next_block = ?
+        SET from_block = ?, to_block = ?, bitmap = ?, next_block = ?
         WHERE id = 1
         ",
         params![
+            &rebuilt_running_event_filter.from_block,
+            &rebuilt_running_event_filter.to_block,
             &rebuilt_running_event_filter.compress_bitmap(),
             &(latest + 1)
         ],


### PR DESCRIPTION
When rebuilding the running event filter, ensure that the block range (from_block to to_block) is also updated to reflect the range of blocks covered by the rebuilt filter.

The database might have a completely outdated running event filter, so it's important to ensure that the correct block range is set.

Closes: #2983 