### PR TITLE
feat(consensus): Configurable proposer selection

### DIFF
--- a/crates/consensus/tests/common.rs
+++ b/crates/consensus/tests/common.rs
@@ -1,7 +1,13 @@
 use std::fmt::Display;
 use std::time::Duration;
 
-use pathfinder_consensus::{Consensus, ConsensusEvent, ValidatorAddress, ValuePayload};
+use pathfinder_consensus::{
+    Consensus,
+    ConsensusEvent,
+    ProposerSelector,
+    ValidatorAddress,
+    ValuePayload,
+};
 use serde::{Deserialize, Serialize};
 use tokio::time::advance;
 use tracing_subscriber::EnvFilter;
@@ -35,8 +41,13 @@ impl Display for ConsensusValue {
 /// Advances simulated time and polls `Consensus` until a matching event is seen
 /// or max attempts are hit. Returns the matching event if found.
 #[allow(dead_code)]
-pub async fn drive_until<V: ValuePayload + 'static, A: ValidatorAddress + 'static, F>(
-    consensus: &mut Consensus<V, A>,
+pub async fn drive_until<
+    V: ValuePayload + 'static,
+    A: ValidatorAddress + 'static,
+    P: ProposerSelector<A> + Send + Sync + 'static,
+    F,
+>(
+    consensus: &mut Consensus<V, A, P>,
     tick: Duration,
     max_attempts: usize,
     mut match_fn: F,

--- a/crates/consensus/tests/consensus_sim.rs
+++ b/crates/consensus/tests/consensus_sim.rs
@@ -71,7 +71,8 @@ async fn consensus_simulation() {
             while current_height <= NUM_HEIGHTS {
                 let height = current_height;
                 let config = Config::new(addr.clone()).with_wal_dir(wal_dir.clone());
-                let mut consensus = Consensus::new(config);
+                let mut consensus: DefaultConsensus<ConsensusValue, NodeAddress> =
+                    DefaultConsensus::new(config);
                 consensus
                     .handle_command(ConsensusCommand::StartHeight(height, validator_set.clone()));
 

--- a/crates/consensus/tests/custom_proposer.rs
+++ b/crates/consensus/tests/custom_proposer.rs
@@ -1,0 +1,85 @@
+use pathfinder_consensus::{ProposerSelector, PublicKey, SigningKey, Validator, ValidatorSet};
+
+mod common;
+use common::NodeAddress;
+
+/// A proposer selector that always selects the first validator
+#[derive(Clone)]
+struct FirstValidatorSelector;
+
+impl ProposerSelector<NodeAddress> for FirstValidatorSelector {
+    fn select_proposer<'a>(
+        &self,
+        validator_set: &'a ValidatorSet<NodeAddress>,
+        _height: u64,
+        _round: u32,
+    ) -> &'a Validator<NodeAddress> {
+        &validator_set.validators[0]
+    }
+}
+
+/// A proposer selector that always selects the last validator
+#[derive(Clone)]
+struct LastValidatorSelector;
+
+impl ProposerSelector<NodeAddress> for LastValidatorSelector {
+    fn select_proposer<'a>(
+        &self,
+        validator_set: &'a ValidatorSet<NodeAddress>,
+        _height: u64,
+        _round: u32,
+    ) -> &'a Validator<NodeAddress> {
+        let last_index = validator_set.validators.len() - 1;
+        &validator_set.validators[last_index]
+    }
+}
+
+#[test]
+fn test_proposer_selection_logic_direct() {
+    // Create validators with distinct addresses
+    let sk1 = SigningKey::new(rand::rngs::OsRng);
+    let pk1 = sk1.verification_key();
+    let sk2 = SigningKey::new(rand::rngs::OsRng);
+    let pk2 = sk2.verification_key();
+    let sk3 = SigningKey::new(rand::rngs::OsRng);
+    let pk3 = sk3.verification_key();
+
+    let validator1 = NodeAddress("validator_1".to_string());
+    let validator2 = NodeAddress("validator_2".to_string());
+    let validator3 = NodeAddress("validator_3".to_string());
+
+    let validators = ValidatorSet::new(vec![
+        Validator::new(validator1.clone(), PublicKey::from_bytes(pk1.to_bytes())),
+        Validator::new(validator2.clone(), PublicKey::from_bytes(pk2.to_bytes())),
+        Validator::new(validator3.clone(), PublicKey::from_bytes(pk3.to_bytes())),
+    ]);
+
+    // Test first validator selector
+    let first_selector = FirstValidatorSelector;
+    let selected = first_selector.select_proposer(&validators, 1, 0);
+    assert_eq!(selected.address, validator1);
+
+    // Test last validator selector
+    let last_selector = LastValidatorSelector;
+    let selected = last_selector.select_proposer(&validators, 1, 0);
+    assert_eq!(selected.address, validator3);
+
+    // Test round-robin selector
+    let round_robin = pathfinder_consensus::RoundRobinProposerSelector;
+
+    // Round 0 should select first validator
+    let selected = round_robin.select_proposer(&validators, 1, 0);
+    assert_eq!(selected.address, validator1);
+
+    // Round 1 should select second validator
+    let selected = round_robin.select_proposer(&validators, 1, 1);
+    assert_eq!(selected.address, validator2);
+
+    // Round 2 should select third validator
+    let selected = round_robin.select_proposer(&validators, 1, 2);
+    assert_eq!(selected.address, validator3);
+
+    // Round 3 should wrap around to first validator
+    let selected = round_robin.select_proposer(&validators, 1, 3);
+    assert_eq!(selected.address, validator1);
+}

--- a/crates/consensus/tests/timeouts.rs
+++ b/crates/consensus/tests/timeouts.rs
@@ -2,9 +2,9 @@ use std::time::Duration;
 
 use pathfinder_consensus::{
     Config,
-    Consensus,
     ConsensusCommand,
     ConsensusEvent,
+    DefaultConsensus,
     Proposal,
     PublicKey,
     Round,
@@ -45,7 +45,8 @@ async fn single_node_propose_timeout_advances_round() {
 
     // Create consensus instance
     let config = Config::new(addr.clone()).with_wal_dir(temp_dir);
-    let mut consensus: Consensus<ConsensusValue, NodeAddress> = Consensus::new(config);
+    let mut consensus: DefaultConsensus<ConsensusValue, NodeAddress> =
+        DefaultConsensus::new(config);
     let height = 1;
     consensus.handle_command(ConsensusCommand::StartHeight(height, validators));
 
@@ -98,7 +99,8 @@ async fn single_node_prevote_timeout_advances_round() {
 
     // Create consensus instance
     let config = Config::new(addr.clone()).with_wal_dir(temp_dir);
-    let mut consensus = Consensus::new(config);
+    let mut consensus: DefaultConsensus<ConsensusValue, NodeAddress> =
+        DefaultConsensus::new(config);
     let height = 1;
     consensus.handle_command(ConsensusCommand::StartHeight(height, validators));
 
@@ -165,7 +167,8 @@ async fn single_node_precommit_timeout_advances_round() {
 
     // Create consensus instance
     let config = Config::new(addr.clone()).with_wal_dir(temp_dir);
-    let mut consensus = Consensus::new(config);
+    let mut consensus: DefaultConsensus<ConsensusValue, NodeAddress> =
+        DefaultConsensus::new(config);
     let height = 1;
     consensus.handle_command(ConsensusCommand::StartHeight(height, validators));
 

--- a/crates/consensus/tests/wal.rs
+++ b/crates/consensus/tests/wal.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use pathfinder_consensus::*;
+use pathfinder_consensus::{DefaultConsensus, *};
 use tokio::sync::mpsc;
 use tokio::time::{pause, sleep, Duration};
 use tracing::{debug, error, info};
@@ -65,7 +65,8 @@ async fn wal_concurrent_heights_retention_test() {
 
         let handle = tokio::spawn(async move {
             let config = Config::new(addr.clone()).with_wal_dir(wal_dir);
-            let mut consensus = Consensus::new(config);
+            let mut consensus: DefaultConsensus<ConsensusValue, NodeAddress> =
+                DefaultConsensus::new(config);
             // Start all heights up front
             for current_height in 1..=NUM_HEIGHTS {
                 let height = current_height;
@@ -178,7 +179,6 @@ async fn recover_from_wal_restores_and_continues() {
 
     use pathfinder_consensus::{
         Config,
-        Consensus,
         ConsensusCommand,
         ConsensusEvent,
         Proposal,
@@ -212,7 +212,8 @@ async fn recover_from_wal_restores_and_continues() {
 
     // Create and run consensus to log data to WAL
     {
-        let mut consensus = Consensus::new(config.clone());
+        let mut consensus: DefaultConsensus<ConsensusValue, NodeAddress> =
+            DefaultConsensus::new(config.clone());
         consensus.handle_command(ConsensusCommand::StartHeight(height, validators.clone()));
 
         // Expect RequestProposal for round 0
@@ -255,8 +256,8 @@ async fn recover_from_wal_restores_and_continues() {
     debug!("---------------------- Recovering from WAL ----------------------");
 
     // Now recover from WAL
-    let mut consensus: Consensus<ConsensusValue, NodeAddress> =
-        Consensus::recover(config.clone(), Arc::new(StaticSet(validators))).unwrap();
+    let mut consensus: DefaultConsensus<ConsensusValue, NodeAddress> =
+        DefaultConsensus::recover(config.clone(), Arc::new(StaticSet(validators))).unwrap();
 
     debug!("------------ Driving consensus post WAL recovery ----------------");
 

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -33,10 +33,10 @@ use p2p::{P2PConsensusConfig, P2PSyncConfig};
 struct Cli {
     #[arg(
         long,
-        value_name = "DIR", 
+        value_name = "DIR",
         value_hint = clap::ValueHint::DirPath,
         long_help = "Directory where the node should store its data",
-        env = "PATHFINDER_DATA_DIRECTORY", 
+        env = "PATHFINDER_DATA_DIRECTORY",
         default_value_os_t = (&std::path::Component::CurDir).into()
     )]
     data_directory: PathBuf,
@@ -45,7 +45,7 @@ struct Cli {
         long = "ethereum.password",
         long_help = "The optional password to use for the Ethereum API",
         value_name = None,
-        env = "PATHFINDER_ETHEREUM_API_PASSWORD", 
+        env = "PATHFINDER_ETHEREUM_API_PASSWORD",
     )]
     ethereum_password: Option<String>,
 
@@ -58,7 +58,7 @@ Examples:
     geth:    wss://localhost:8545",
         value_name = "HTTP(s) URL",
         value_hint = clap::ValueHint::Url,
-        env = "PATHFINDER_ETHEREUM_API_URL", 
+        env = "PATHFINDER_ETHEREUM_API_URL",
     )]
     ethereum_url: Url,
 
@@ -76,7 +76,7 @@ Examples:
         long_help = r"Comma separated list of domains from which Cross-Origin requests will be accepted by the RPC server.
 
 Use '*' to indicate any domain and an empty list to disable CORS.
-        
+
 Examples:
     single: http://one.io
     a list: http://first.com,http://second.com:1234
@@ -119,7 +119,7 @@ Examples:
         long_help = "Enable SQLite write-ahead logging",
         action = clap::ArgAction::Set,
         default_value = "true",
-        env = "PATHFINDER_SQLITE_WAL", 
+        env = "PATHFINDER_SQLITE_WAL",
     )]
     sqlite_wal: bool,
 
@@ -329,7 +329,7 @@ This should only be enabled for debugging purposes as it adds substantial proces
     #[arg(
         long = "rpc.get-events-event-filter-block-range-limit",
         long_help = format!(
-            "The maximum number of blocks to be covered by aggregate Bloom filters when querying for events. Each filter covers a {} block range. 
+            "The maximum number of blocks to be covered by aggregate Bloom filters when querying for events. Each filter covers a {} block range.
             This limit is used to prevent queries from taking too long.",
             pathfinder_storage::AGGREGATE_BLOOM_BLOCK_RANGE_LEN
         ),
@@ -547,7 +547,7 @@ Note that 'custom' requires also setting the --gateway-url and --feeder-gateway-
         value_name = "URL",
         value_hint = clap::ValueHint::Url,
         long_help = "Specify a custom Starknet feeder gateway url. Can be used to run pathfinder on a custom Starknet network, or to use a gateway proxy. Requires '--network custom'.",
-        env = "PATHFINDER_FEEDER_GATEWAY_URL", 
+        env = "PATHFINDER_FEEDER_GATEWAY_URL",
         required_if_eq("network", Network::Custom),
     )]
     feeder_gateway: Option<Url>,
@@ -880,9 +880,12 @@ pub struct NativeExecutionConfig;
 #[cfg(feature = "p2p")]
 #[derive(Clone)]
 pub struct ConsensusConfig {
-    /// Initially there will only be one proposer, operated by StarkWare.
-    pub proposer_address: ContractAddress,
+    /// Optionally, you can specify a fixed proposer address. Otherwise,  a
+    /// proposer will be chosen among the validators.
+    pub proposer_address: Option<ContractAddress>,
+    /// The validator address of the current node.
     pub my_validator_address: ContractAddress,
+    /// The validator addresses of all validators in the validator set.
     pub validator_addresses: Vec<ContractAddress>,
 }
 
@@ -1022,10 +1025,7 @@ impl ConsensusConfig {
             }
 
             Self {
-                proposer_address: ContractAddress(
-                    args.proposer_address
-                        .expect("Required if `is_consensus_enabled` is true"),
-                ),
+                proposer_address: args.proposer_address.map(ContractAddress),
                 my_validator_address: ContractAddress(
                     args.my_validator_address
                         .expect("Required if `is_consensus_enabled` is true"),

--- a/crates/pathfinder/src/consensus/inner.rs
+++ b/crates/pathfinder/src/consensus/inner.rs
@@ -1,6 +1,7 @@
 mod consensus_task;
 mod fetch_validators;
 mod p2p_task;
+mod select_proposer;
 
 use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};

--- a/crates/pathfinder/src/consensus/inner/consensus_task.rs
+++ b/crates/pathfinder/src/consensus/inner/consensus_task.rs
@@ -27,6 +27,7 @@ use pathfinder_consensus::{
     ConsensusEvent,
     NetworkMessage,
     Proposal,
+    ProposerSelector,
     Round,
     SignedVote,
     ValidatorSet,
@@ -36,6 +37,7 @@ use pathfinder_storage::Storage;
 use tokio::sync::{mpsc, watch};
 
 use super::fetch_validators::L2ValidatorSetProvider;
+use super::select_proposer::FixedProposerSelector;
 use super::{ConsensusTaskEvent, ConsensusValue, HeightExt, P2PTaskEvent};
 use crate::config::ConsensusConfig;
 use crate::validator::{FinalizedBlock, ValidatorBlockInfoStage};
@@ -54,22 +56,29 @@ pub fn spawn(
     util::task::spawn(async move {
         // Get the validator address and validator set provider
         let validator_address = config.my_validator_address;
-        let validator_set_provider = L2ValidatorSetProvider::new(storage.clone(), chain_id, config);
+        let validator_set_provider =
+            L2ValidatorSetProvider::new(storage.clone(), chain_id, config.clone());
 
-        let mut consensus = Consensus::recover(
-            Config::new(validator_address)
-                .with_wal_dir(wal_directory)
-                .with_history_depth(
-                    // TODO: We don't support round certificates yet, and we want to limit
-                    // rebroadcasting to a minimum. Rebroadcast timeouts will happen for historical
-                    // engines which are finalized because the effect `CancelAllTimeouts` is only
-                    // triggered upon a new round or a new height.
-                    0,
-                ),
-            // TODO use a dynamic validator set provider, once fetching the validator set from the
-            // staking contract is implemented. Related issue: https://github.com/eqlabs/pathfinder/issues/2936
-            Arc::new(validator_set_provider.clone()),
-        )?;
+        // Enforce a fixed proposer for now
+        let proposer_selector = FixedProposerSelector::new(config.proposer_address);
+
+        let mut consensus =
+            Consensus::<ConsensusValue, ContractAddress, FixedProposerSelector>::recover(
+                Config::new(validator_address)
+                    .with_wal_dir(wal_directory)
+                    .with_history_depth(
+                        // TODO: We don't support round certificates yet, and we want to limit
+                        // rebroadcasting to a minimum. Rebroadcast timeouts will happen for
+                        // historical engines which are finalized because
+                        // the effect `CancelAllTimeouts` is only triggered
+                        // upon a new round or a new height.
+                        0,
+                    ),
+                // TODO use a dynamic validator set provider, once fetching the validator set from
+                // the staking contract is implemented. Related issue: https://github.com/eqlabs/pathfinder/issues/2936
+                Arc::new(validator_set_provider.clone()),
+            )?
+            .with_proposer_selector(proposer_selector);
 
         // Get the current height
         let mut current_height = consensus.current_height().unwrap_or_default();
@@ -316,7 +325,11 @@ pub fn spawn(
 }
 
 fn start_height(
-    consensus: &mut Consensus<ConsensusValue, ContractAddress>,
+    consensus: &mut Consensus<
+        ConsensusValue,
+        ContractAddress,
+        impl ProposerSelector<ContractAddress>,
+    >,
     started_heights: &mut HashSet<u64>,
     height: u64,
     validator_set: ValidatorSet<ContractAddress>,

--- a/crates/pathfinder/src/consensus/inner/select_proposer.rs
+++ b/crates/pathfinder/src/consensus/inner/select_proposer.rs
@@ -1,5 +1,45 @@
 use pathfinder_common::ContractAddress;
-use pathfinder_consensus::{Validator, ValidatorSet};
+use pathfinder_consensus::{RoundRobinProposerSelector, Validator, ValidatorSet};
+
+use crate::config::ConsensusConfig;
+
+/// A proposer selector that can be either fixed or round-robin.
+#[derive(Clone)]
+pub enum ProposerSelector {
+    Fixed(FixedProposerSelector),
+    RoundRobin(RoundRobinProposerSelector),
+}
+
+impl pathfinder_consensus::ProposerSelector<ContractAddress> for ProposerSelector {
+    fn select_proposer<'a>(
+        &self,
+        validator_set: &'a ValidatorSet<ContractAddress>,
+        height: u64,
+        round: u32,
+    ) -> &'a Validator<ContractAddress> {
+        match self {
+            ProposerSelector::Fixed(selector) => {
+                selector.select_proposer(validator_set, height, round)
+            }
+            ProposerSelector::RoundRobin(selector) => {
+                selector.select_proposer(validator_set, height, round)
+            }
+        }
+    }
+}
+
+/// Get the proposer selector based on the consensus config.
+///
+/// If a proposer address is provided, use a fixed proposer selector,
+/// otherwise, use a round-robin proposer selector.
+pub fn get_proposer_selector(config: &ConsensusConfig) -> ProposerSelector {
+    match config.proposer_address {
+        Some(proposer_address) => {
+            ProposerSelector::Fixed(FixedProposerSelector::new(proposer_address))
+        }
+        None => ProposerSelector::RoundRobin(RoundRobinProposerSelector),
+    }
+}
 
 /// A proposer selector that always selects the same proposer.
 /// Note that the proposer must be in the validator set!

--- a/crates/pathfinder/src/consensus/inner/select_proposer.rs
+++ b/crates/pathfinder/src/consensus/inner/select_proposer.rs
@@ -1,0 +1,30 @@
+use pathfinder_common::ContractAddress;
+use pathfinder_consensus::{Validator, ValidatorSet};
+
+/// A proposer selector that always selects the same proposer.
+/// Note that the proposer must be in the validator set!
+#[derive(Clone)]
+pub struct FixedProposerSelector {
+    proposer_address: ContractAddress,
+}
+
+impl FixedProposerSelector {
+    pub fn new(proposer_address: ContractAddress) -> Self {
+        Self { proposer_address }
+    }
+}
+
+impl pathfinder_consensus::ProposerSelector<ContractAddress> for FixedProposerSelector {
+    fn select_proposer<'a>(
+        &self,
+        validator_set: &'a ValidatorSet<ContractAddress>,
+        _height: u64,
+        _round: u32,
+    ) -> &'a Validator<ContractAddress> {
+        validator_set
+            .validators
+            .iter()
+            .find(|v| v.address == self.proposer_address)
+            .expect("Fixed proposer must be in validator set")
+    }
+}


### PR DESCRIPTION
This PR adds the ability to customize how proposers are selected in the consensus engine. Instead of being stuck with round-robin, you can now plug in your own proposer selection logic via the new `ProposerSelector<A>` trait.

I've tried to keep the API as backwards-compatible as possible, leaving the previous `new(..)` and `recover(..)` methods untouched.

To set your own proposer selection logic, you can use the builder pattern: 

```rust
Consensus::new(config)
    .with_proposer_selector(your_selector);
```

Using `recover(..)` will default to the `RoundRobinProposerSelector` (we can always change that), unless chained with `.with_proposer_selector(your_selector)`. So again, same easy, backwards-compatible logic.

```rust
// Will default to round-robin
Consensus::recover(..)?;

// Will use your selector
Consensus::recover(..)?
    .with_proposer_selector(your_selector);
```

### Changes to Pathfinder

Pathfinder's `proposer_address` consensus CLI parameter is now optional, and its inclusion will dictate whether or not a fixed proposer is used vs. the default round robin over existing validators.

---

See also #2942 