### PR TITLE
fix(ci): remove `auto-tag` requirement from `create-draft-release` job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,6 @@ permissions:
   contents: write
 
 on:
-  push:
-    tags:
-      - v[0-9]+.*
   pull_request:
     types: [closed]
     branches:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Extract version from branch name
         id: extract_version
         run: |
@@ -28,7 +28,7 @@ jobs:
           VERSION="${BRANCH_NAME#release/v}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=v$VERSION" >> $GITHUB_OUTPUT
-      
+
       - name: Create and push tag
         run: |
           git config --local user.email "action@github.com"
@@ -38,7 +38,6 @@ jobs:
 
   create-draft-release:
     needs: auto-tag
-    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -50,7 +49,6 @@ jobs:
 
   upload-assets:
     needs: create-draft-release
-    if: startsWith(github.ref, 'refs/tags/v')
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Here's what I think is going on:

1. When a `release/vX.Y.Z` branch is merged, the `auto-tag` job runs and creates the tag.
2. The `create-draft-release` job has `needs: auto-tag` but also `if: startsWith(github.ref, 'refs/tags/v')`
3. Since the workflow was triggered by a PR merge (not a tag push), `github.ref` is `refs/heads/main`, not `refs/tags/vX.Y.Z`
4. So the `create-draft-release` job gets skipped