### PR TITLE
feat(ci): add tag creation to our release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -90,15 +90,33 @@ fi
 # Push changes
 git push --set-upstream origin release/v${VERSION}
 
-# Wait for manual PR creation and merge
-echo -e "\n"
-echo "=========================================="
-echo "Next steps:"
-echo "1. Create a PR for branch 'release/v${VERSION}'"
-echo "2. Review and merge the PR to 'main'"
-echo "3. Come back here and press Enter to continue"
-echo "=========================================="
-echo -e "\nPress Enter once the PR has been merged to continue..."
+# Try to create PR automatically if gh CLI is available
+if command -v gh &> /dev/null; then
+    echo -e "\nCreating PR automatically with gh CLI..."
+    if PR_URL=$(gh pr create --title "chore: bump version to ${VERSION}" --body "Automated release PR for version ${VERSION}" --base main --head release/v${VERSION} 2>/dev/null); then
+        echo "PR created: $PR_URL"
+        echo -e "\nPlease review and merge the PR, then come back here and press Enter to continue..."
+    else
+        echo "Failed to create PR with gh CLI. Falling back to manual instructions..."
+        echo -e "\n"
+        echo "=========================================="
+        echo "Next steps:"
+        echo "1. Create a PR for branch 'release/v${VERSION}'"
+        echo "2. Review and merge the PR to 'main'"
+        echo "3. Come back here and press Enter to continue"
+        echo "=========================================="
+        echo -e "\nPress Enter once the PR has been merged to continue..."
+    fi
+else
+    echo -e "\n"
+    echo "=========================================="
+    echo "Next steps:"
+    echo "1. Create a PR for branch 'release/v${VERSION}'"
+    echo "2. Review and merge the PR to 'main'"
+    echo "3. Come back here and press Enter to continue"
+    echo "=========================================="
+    echo -e "\nPress Enter once the PR has been merged to continue..."
+fi
 read -r
 
 # Switch to main and pull latest

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -66,11 +66,11 @@ popd
 # Create and checkout new release branch
 git checkout -b release/v${VERSION}
 
-# Create git commit and tag
+# Create git commit
 git add Cargo.toml Cargo.lock **/Cargo.toml **/Cargo.lock CHANGELOG.md
 git commit -m "chore: bump version to ${VERSION}"
 
-# Quik recap of what was done
+# Quick recap of what was done
 echo -e "\nChanges made:"
 echo "- Updated workspace version to ${VERSION}"
 echo "- Updated CHANGELOG.md with version ${VERSION} and date ${CURRENT_DATE}"
@@ -89,3 +89,38 @@ fi
 
 # Push changes
 git push --set-upstream origin release/v${VERSION}
+
+# Wait for manual PR creation and merge
+echo -e "\n"
+echo "=========================================="
+echo "Next steps:"
+echo "1. Create a PR for branch 'release/v${VERSION}'"
+echo "2. Review and merge the PR to 'main'"
+echo "3. Come back here and press Enter to continue"
+echo "=========================================="
+echo -e "\nPress Enter once the PR has been merged to continue..."
+read -r
+
+# Switch to main and pull latest
+git checkout main
+git pull origin main
+
+# Confirmation before creating tag
+echo -e "\nReady to create and push tag 'v${VERSION}'"
+echo "This will trigger the Release and Docker workflows."
+echo -e "\nCreate and push tag 'v${VERSION}'? (Y/n)"
+read -r answer
+if [[ "$answer" == "n" ]] || [[ "$answer" == "N" ]]; then
+    echo "Aborting tag creation."
+    exit 1
+fi
+
+# Create and push tag
+echo "Creating and pushing tag v${VERSION}..."
+git tag -a v${VERSION} -m "Pathfinder v${VERSION}"
+git push origin v${VERSION}
+
+# Done
+echo -e "\n✅ Tag 'v${VERSION}' has been pushed!"
+echo "The Release and Docker workflows should now be triggered."
+echo "You can monitor their progress in the GitHub Actions tab."


### PR DESCRIPTION
The whole goal of [automating tag creation](https://github.com/eqlabs/pathfinder/pull/2967) was that anyone, without prior knowledge, could cut a release.

Apparently, the auto-tag feature won't work due to a Github limitation that prevents other workflows (e.g. Docker) from triggering.

So I've [rolled back](https://github.com/eqlabs/pathfinder/pull/3028) the auto-tag and instead added it to our release script. This preserves my initial intention of guiding anyone through the process seamlessly, while circumventing this dumb Github restriction.

🍻 

---

See also #3028 