### PR TITLE
fix(executor): detect and handle out-of-gas errors during validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- `starknet_estimateFee` fails if the validate entry point runs ouf of gas during L2 fee binary search.
+
 ## [0.20.4] - 2025-09-25
 
 ### Fixed


### PR DESCRIPTION
When a transaction runs out of gas during the validation phase, it should be re-attempted with a higher gas limit. Unlike execution phase failures, validation failures due to insufficient gas do not cause a transaction to be reverted.

This change introduces logic to detect out-of-gas errors during validation so that we correctly adjust the gas limit during the binary search for the appropriate gas limit.

Closes #3037
