### PR TITLE
fix(consensus): using configured history depth

### DIFF
--- a/crates/pathfinder/src/consensus/inner/consensus_task.rs
+++ b/crates/pathfinder/src/consensus/inner/consensus_task.rs
@@ -90,6 +90,7 @@ pub fn spawn(
         let mut consensus =
             Consensus::<ConsensusValue, ContractAddress, L2ProposerSelector>::recover_with_proposal_selector(
                 Config::new(validator_address)
+                    .with_history_depth(config.history_depth)
                     .with_wal_dir(wal_directory),
                 // TODO use a dynamic validator set provider, once fetching the validator set from
                 // the staking contract is implemented. Related issue: https://github.com/eqlabs/pathfinder/issues/2936


### PR DESCRIPTION
Pathfinder consensus configuration has a `history_depth` parameter, which is used by pathfinder but wasn't passed to `Consensus` instances (whose config does have `history_depth`, but was only setting it to default).
