### PR TITLE
fix(executor): update latest version to 0.14.1

### DIFF
--- a/crates/executor/src/execution_state.rs
+++ b/crates/executor/src/execution_state.rs
@@ -60,7 +60,7 @@ impl VersionedConstantsMap {
     }
 
     pub fn latest_version() -> StarknetVersion {
-        versions::STARKNET_VERSION_0_14_0
+        versions::STARKNET_VERSION_0_14_1
     }
 
     fn fill_default(data: &mut BTreeMap<StarknetVersion, Cow<'static, VersionedConstants>>) {


### PR DESCRIPTION
This fixes compatibility with the obsolete version of setting custom versioned constants (without the explicit version -> constants mapping).
