### PR TITLE
chore: disable some rusqlite features

### DIFF
--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -36,13 +36,7 @@ r2d2 = { workspace = true }
 r2d2_sqlite = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
-rusqlite = { workspace = true, features = [
-    "bundled",
-    "functions",
-    "vtab",
-    "array",
-    "hooks",
-] }
+rusqlite = { workspace = true, features = ["bundled", "array", "hooks"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = [
     "arbitrary_precision",


### PR DESCRIPTION
Both the `functions` and `vtab` features were unused since we've transitioned away from using `fts5` for event storage.

