### PR TITLE
feat(storage): introduce `StorageError` wrapper type

### DIFF
--- a/crates/pathfinder/src/consensus/inner/p2p_task.rs
+++ b/crates/pathfinder/src/consensus/inner/p2p_task.rs
@@ -1078,9 +1078,7 @@ fn handle_incoming_proposal_part<E: BlockExecutorExt, T: TransactionExt>(
             let tx_batch = tx_batch.clone();
             append_and_persist_part(height_and_round, proposal_part, proposals_db, &mut parts)?;
 
-            let mut main_db_conn = main_readonly_storage
-                .connection()
-                .map_err(ProposalHandlingError::Fatal)?;
+            let mut main_db_conn = main_readonly_storage.connection()?;
             let main_db_tx = main_db_conn
                 .transaction()
                 .map_err(ProposalHandlingError::Fatal)?;
@@ -1257,9 +1255,7 @@ fn handle_incoming_proposal_part<E: BlockExecutorExt, T: TransactionExt>(
                     )?;
 
                     let valid_round = valid_round_from_parts(&parts, &height_and_round)?;
-                    let mut main_db_conn = main_readonly_storage
-                        .connection()
-                        .map_err(ProposalHandlingError::Fatal)?;
+                    let mut main_db_conn = main_readonly_storage.connection()?;
                     let main_db_tx = main_db_conn
                         .transaction()
                         .map_err(ProposalHandlingError::Fatal)?;

--- a/crates/pathfinder/src/consensus/inner/proposal_error.rs
+++ b/crates/pathfinder/src/consensus/inner/proposal_error.rs
@@ -71,3 +71,9 @@ impl ProposalHandlingError {
         }
     }
 }
+
+impl From<pathfinder_storage::StorageError> for ProposalHandlingError {
+    fn from(value: pathfinder_storage::StorageError) -> Self {
+        Self::Fatal(value.into())
+    }
+}

--- a/crates/pathfinder/src/sync/error.rs
+++ b/crates/pathfinder/src/sync/error.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use p2p::libp2p::PeerId;
 use p2p::PeerData;
 use pathfinder_common::{BlockNumber, ClassHash, SignedBlockHeader};
+use pathfinder_storage::StorageError;
 
 #[derive(Debug, thiserror::Error, Clone)]
 pub(super) enum SyncError {
@@ -117,5 +118,12 @@ impl PartialEq for SyncError {
 impl From<anyhow::Error> for SyncError {
     fn from(e: anyhow::Error) -> Self {
         Self::Fatal(Arc::new(e))
+    }
+}
+
+impl From<StorageError> for SyncError {
+    fn from(e: StorageError) -> Self {
+        // StorageError is always fatal
+        Self::Fatal(Arc::new(e.into()))
     }
 }

--- a/crates/rpc/src/jsonrpc/error.rs
+++ b/crates/rpc/src/jsonrpc/error.rs
@@ -99,3 +99,9 @@ where
         Self::ApplicationError(value.into())
     }
 }
+
+impl From<pathfinder_storage::StorageError> for RpcError {
+    fn from(value: pathfinder_storage::StorageError) -> Self {
+        Self::InternalError(value.into())
+    }
+}

--- a/crates/rpc/src/jsonrpc/router/subscription.rs
+++ b/crates/rpc/src/jsonrpc/router/subscription.rs
@@ -209,7 +209,7 @@ where
         let starting_block = T::starting_block(&params);
 
         let mut current_block = util::task::spawn_blocking(move |_| -> Result<_, RpcError> {
-            let mut conn = storage.connection().map_err(RpcError::InternalError)?;
+            let mut conn = storage.connection()?;
             let db = conn.transaction().map_err(RpcError::InternalError)?;
 
             let starting_block = match starting_block {

--- a/crates/rpc/src/method/subscribe_events.rs
+++ b/crates/rpc/src/method/subscribe_events.rs
@@ -169,7 +169,7 @@ impl RpcSubscriptionFlow for SubscribeEvents {
         let params = params.clone().unwrap_or_default();
         let storage = state.storage.clone();
         let (events, last_l1_block, last_block) = util::task::spawn_blocking(move |_| -> Result<_, RpcError> {
-            let mut conn = storage.connection().map_err(RpcError::InternalError)?;
+            let mut conn = storage.connection()?;
             let db = conn.transaction().map_err(RpcError::InternalError)?;
 
             if db.blockchain_pruning_enabled() {

--- a/crates/rpc/src/method/subscribe_new_heads.rs
+++ b/crates/rpc/src/method/subscribe_new_heads.rs
@@ -69,7 +69,7 @@ impl RpcSubscriptionFlow for SubscribeNewHeads {
     ) -> Result<CatchUp<Self::Notification>, RpcError> {
         let storage = state.storage.clone();
         let headers = util::task::spawn_blocking(move |_| -> Result<_, RpcError> {
-            let mut conn = storage.connection().map_err(RpcError::InternalError)?;
+            let mut conn = storage.connection()?;
             let db = conn.transaction().map_err(RpcError::InternalError)?;
             db.block_range(from, to).map_err(RpcError::InternalError)
         })

--- a/crates/rpc/src/method/subscribe_transaction_status.rs
+++ b/crates/rpc/src/method/subscribe_transaction_status.rs
@@ -296,7 +296,7 @@ impl RpcSubscriptionFlow for SubscribeTransactionStatus {
                                 // 3. Transactions accepted on L1.
                                 let storage = state.storage.clone();
                                 let l1_state = util::task::spawn_blocking(move |_| -> Result<_, RpcError> {
-                                    let mut conn = storage.connection().map_err(RpcError::InternalError)?;
+                                    let mut conn = storage.connection()?;
                                     let db = conn.transaction().map_err(RpcError::InternalError)?;
                                     let l1_state = db.latest_l1_state().map_err(RpcError::InternalError)?;
                                     Ok(l1_state)
@@ -348,7 +348,7 @@ async fn current_known_tx_status(
     // pending data and DB, the DB would contain "fresher" transaction status
     // information.
     let (l1_state, tx_with_receipt) = util::task::spawn_blocking(move |_| -> Result<_, RpcError> {
-        let mut conn = storage.connection().map_err(RpcError::InternalError)?;
+        let mut conn = storage.connection()?;
         let db = conn.transaction().map_err(RpcError::InternalError)?;
         let l1_block_number = db.latest_l1_state().map_err(RpcError::InternalError)?;
         let tx_with_receipt = db

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -648,6 +648,12 @@ impl From<anyhow::Error> for TraceBlockTransactionsError {
     }
 }
 
+impl From<pathfinder_storage::StorageError> for TraceBlockTransactionsError {
+    fn from(value: pathfinder_storage::StorageError) -> Self {
+        Self::Internal(value.into())
+    }
+}
+
 impl From<TraceBlockTransactionsError> for crate::error::ApplicationError {
     fn from(value: TraceBlockTransactionsError) -> Self {
         match value {
@@ -719,7 +725,7 @@ pub(crate) mod tests {
         let context = RpcContext::for_tests().with_storage(storage.clone());
 
         let (next_block_header, transactions, traces) = {
-            let mut db = storage.connection()?;
+            let mut db = storage.connection().map_err(anyhow::Error::from)?;
             let tx = db.transaction()?;
 
             tx.insert_sierra_class_definition(
@@ -935,7 +941,7 @@ pub(crate) mod tests {
         ];
 
         let pending_block = {
-            let mut db = storage.connection()?;
+            let mut db = storage.connection().map_err(anyhow::Error::from)?;
             let tx = db.transaction()?;
 
             tx.insert_sierra_class_definition(
@@ -1054,7 +1060,7 @@ pub(crate) mod tests {
         ];
 
         let pending_data = {
-            let mut db = storage.connection()?;
+            let mut db = storage.connection().map_err(anyhow::Error::from)?;
             let tx = db.transaction()?;
 
             tx.insert_sierra_class_definition(
@@ -1200,7 +1206,7 @@ pub(crate) mod tests {
         ];
 
         let pending_data = {
-            let mut db = storage.connection()?;
+            let mut db = storage.connection().map_err(anyhow::Error::from)?;
             let tx = db.transaction()?;
 
             tx.insert_sierra_class_definition(

--- a/crates/storage/src/connection/consensus.rs
+++ b/crates/storage/src/connection/consensus.rs
@@ -61,7 +61,7 @@ impl ConsensusStorage {
     }
 
     pub fn connection(&self) -> anyhow::Result<ConsensusConnection> {
-        let conn = self.0.connection()?;
+        let conn = self.0.connection().map_err(anyhow::Error::from)?; // TODO: This will be updated to use StorageError
         Ok(ConsensusConnection(conn))
     }
 }

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -1,0 +1,31 @@
+//! Error types for storage operations.
+
+use thiserror::Error;
+
+/// Storage/database errors that occur during storage operations.
+///
+/// This error type represents all storage-related failures (connection errors,
+/// query failures, transaction errors, etc.). All storage errors are considered
+/// fatal as they likely indicate problems with our infra.
+///
+/// This is a simple wrapper around `anyhow::Error` that serves as a boundary
+/// marker, indicating that the error originated from storage operations. The
+/// underlying error chain is preserved for debugging.
+///
+/// Note: Because all storage errors are considered fatal, exposing different
+/// variants (e.g. `SqliteError`, `PoolError`, etc.) didn't seem relevant.
+#[derive(Debug, Error)]
+#[error(transparent)]
+pub struct StorageError(#[from] anyhow::Error);
+
+impl From<rusqlite::Error> for StorageError {
+    fn from(error: rusqlite::Error) -> Self {
+        Self(anyhow::Error::from(error))
+    }
+}
+
+impl From<r2d2::Error> for StorageError {
+    fn from(error: r2d2::Error) -> Self {
+        Self(anyhow::Error::from(error))
+    }
+}

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -10,6 +10,7 @@ use bloom::AggregateBloomCache;
 pub use bloom::AGGREGATE_BLOOM_BLOCK_RANGE_LEN;
 use connection::pruning::BlockchainHistoryMode;
 mod connection;
+mod error;
 pub mod fake;
 mod params;
 mod schema;
@@ -22,6 +23,7 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::Context;
 pub use connection::*;
+pub use error::StorageError;
 use event::RunningEventFilter;
 pub use event::EVENT_KEY_FILTER_LIMIT;
 use pathfinder_common::BlockNumber;
@@ -549,8 +551,8 @@ fn validate_mode_and_update_db(
 
 impl Storage {
     /// Returns a new Sqlite [Connection] to the database.
-    pub fn connection(&self) -> anyhow::Result<Connection> {
-        let conn = self.0.pool.get()?;
+    pub fn connection(&self) -> Result<Connection, StorageError> {
+        let conn = self.0.pool.get().map_err(StorageError::from)?;
         Ok(Connection::new(
             conn,
             self.0.event_filter_cache.clone(),


### PR DESCRIPTION
Introduces `StorageError` as the error type for storage operations and updates `Storage::connection()` to return it.

**Why:**
Foundation for validator error classification (See #3143)

All storage errors are fatal, and `StorageError` provides a clear boundary marker for errors from storage operations.

**Note:** Connection/transaction methods in the storage module still return `anyhow::Result` and will be migrated in a follow-up PR. Same goes for the consensus storage db.
