### PR TITLE
fix(sync): regression in fgw sync after consensus aware sync changes

### DIFF
--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -626,7 +626,6 @@ fn start_feeder_gateway_sync(
     notifications: Notifications,
     gateway_public_key: pathfinder_common::PublicKey,
 ) -> tokio::task::JoinHandle<anyhow::Result<()>> {
-    let (sync_to_consensus_tx, _) = tokio::sync::mpsc::channel(1);
     let sync_context = SyncContext {
         storage,
         ethereum: ethereum_client,
@@ -640,7 +639,7 @@ fn start_feeder_gateway_sync(
         pending_data: tx_pending,
         submitted_tx_tracker,
         // Only used in consensus-aware sync.
-        sync_to_consensus_tx,
+        sync_to_consensus_tx: None,
         block_validation_mode: state::l2::BlockValidationMode::Strict,
         notifications,
         block_cache_size: 10_000,
@@ -680,7 +679,7 @@ fn start_consensus_aware_fgw_sync(
         l1_poll_interval: config.l1_poll_interval,
         pending_data: tx_pending,
         submitted_tx_tracker,
-        sync_to_consensus_tx,
+        sync_to_consensus_tx: Some(sync_to_consensus_tx),
         block_validation_mode: state::l2::BlockValidationMode::Strict,
         notifications,
         block_cache_size: 10_000,

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -349,7 +349,7 @@ where
 ///   - interacts with consensus via [SyncMessageToConsensus]
 pub async fn consensus_sync<GatewayClient>(
     tx_event: mpsc::Sender<SyncEvent>,
-    sync_to_consensus_tx: mpsc::Sender<SyncMessageToConsensus>,
+    sync_to_consensus_tx: Option<mpsc::Sender<SyncMessageToConsensus>>,
     context: L2SyncContext<GatewayClient>,
     mut head: Option<(BlockNumber, BlockHash, StateCommitment)>,
     mut blocks: BlockChain,
@@ -385,6 +385,8 @@ where
             reply: tx,
         };
         sync_to_consensus_tx
+            .as_ref()
+            .expect("Channel is always available in consensus-aware sync")
             .send(request)
             .await
             .context("Requesting committed block")?;


### PR DESCRIPTION
The said channel should not be available in normal fgw sync at all.