### PR TITLE
feat(consensus): purge proposal parts after recoverable errors

### DIFF
--- a/crates/pathfinder/src/consensus/inner/p2p_task.rs
+++ b/crates/pathfinder/src/consensus/inner/p2p_task.rs
@@ -255,6 +255,24 @@ pub fn spawn(
                                                 error = %error.error_message(),
                                                 "Invalid proposal part from peer - skipping, continuing operation"
                                             );
+                                            // Purge the proposal from storage
+                                            if let Err(purge_err) = proposals_db.remove_parts(
+                                                height_and_round.height(),
+                                                Some(height_and_round.round()),
+                                            ) {
+                                                tracing::error!(
+                                                    validator = %validator_address,
+                                                    height_and_round = %height_and_round,
+                                                    error = %purge_err,
+                                                    "Failed to purge proposal parts after recoverable error"
+                                                );
+                                            } else {
+                                                tracing::debug!(
+                                                    validator = %validator_address,
+                                                    height_and_round = %height_and_round,
+                                                    "Purged proposal parts after recoverable error"
+                                                );
+                                            }
                                             Ok(ComputationSuccess::Continue)
                                         } else {
                                             tracing::error!(


### PR DESCRIPTION
Follow up of #3153

This is the last PR of this series, where we finally leverage all the previous work and design decisions to purge proposals on recoverable errors.

Closes #3143 