### PR TITLE
fix(consensus): query consensus db first on `is_outdated_p2p_event`

### DIFF
--- a/crates/pathfinder/src/consensus/inner/p2p_task.rs
+++ b/crates/pathfinder/src/consensus/inner/p2p_task.rs
@@ -198,7 +198,12 @@ pub fn spawn(
                         // This call may yield unreliable results if history_depth is too small and
                         // the currently decided upon and finalized block has not been committed by
                         // the sync task yet, because we're only checking the main DB here.
-                        if is_outdated_p2p_event(&main_db_tx, &event.kind, config.history_depth)? {
+                        if is_outdated_p2p_event(
+                            &main_db_tx,
+                            &event.kind,
+                            config.history_depth,
+                            &proposals_db,
+                        )? {
                             return Ok(ComputationSuccess::ChangePeerScore {
                                 peer_id: event.source,
                                 delta: peer_score::penalty::OUTDATED_MESSAGE,
@@ -868,20 +873,58 @@ fn is_outdated_p2p_event(
     db_tx: &Transaction<'_>,
     event: &EventKind,
     history_depth: u64,
+    proposals_db: &ConsensusProposals<'_>,
 ) -> anyhow::Result<bool> {
     // Ignore messages that refer to already committed blocks.
     let incoming_height = event.height();
-    let latest_committed = db_tx.block_number(BlockId::Latest)?;
-    if let Some(latest_committed) = latest_committed {
-        if incoming_height < latest_committed.get().saturating_sub(history_depth) {
+
+    // Check the consensus database for the latest finalized height, which
+    // represents blocks that consensus has decided upon (even if not yet
+    // committed to main DB).
+    let latest_finalized = proposals_db
+        .inner()
+        .latest_finalized_height()
+        .map_err(|e| {
+            anyhow::Error::from(e)
+                .context("Failed to query latest finalized height from consensus database")
+        })?;
+
+    if let Some(latest_finalized) = latest_finalized {
+        let threshold = latest_finalized.saturating_sub(history_depth);
+        if incoming_height < threshold {
             tracing::info!(
                 "🖧  ⛔ ignoring incoming p2p event {} for height {incoming_height} because latest \
-                 committed block is {latest_committed} and history depth is {history_depth}",
+                 finalized height is {latest_finalized} and history depth is {history_depth}",
                 event.type_name()
             );
             return Ok(true);
         }
+    } else {
+        // Fallback to main database if no finalized blocks in consensus DB yet
+        let latest_committed = db_tx
+            .block_number(BlockId::Latest)
+            .context("Failed to query latest committed block for outdated event check")?;
+
+        if let Some(latest_committed) = latest_committed {
+            let threshold = latest_committed.get().saturating_sub(history_depth);
+            if incoming_height < threshold {
+                tracing::info!(
+                    "🖧  ⛔ ignoring incoming p2p event {} for height {incoming_height} because \
+                     latest committed block is {latest_committed} and history depth is \
+                     {history_depth}",
+                    event.type_name()
+                );
+                return Ok(true);
+            }
+        } else {
+            tracing::debug!(
+                "🖧  No committed blocks found in database, cannot determine if event {} for \
+                 height {incoming_height} is outdated",
+                event.type_name()
+            );
+        }
     }
+
     Ok(false)
 }
 

--- a/crates/pathfinder/src/consensus/inner/persist_proposals.rs
+++ b/crates/pathfinder/src/consensus/inner/persist_proposals.rs
@@ -19,6 +19,11 @@ impl<'tx> ConsensusProposals<'tx> {
         Self { tx }
     }
 
+    /// Get a reference to the inner transaction.
+    pub fn inner(&self) -> &ConsensusTransaction<'tx> {
+        &self.tx
+    }
+
     /// Commit the underlying transaction.
     pub fn commit(self) -> Result<(), StorageError> {
         self.tx

--- a/crates/pathfinder/tests/consensus.rs
+++ b/crates/pathfinder/tests/consensus.rs
@@ -210,7 +210,6 @@ mod test {
     #[rstest]
     #[ignore = "We need a custom fgw to actually test consensus ahead of fgw"]
     #[case::consensus_ahead_of_fgw(true)]
-    #[ignore = "It's flaky, fix it"]
     #[case::fgw_ahead_of_consensus(false)]
     #[tokio::test]
     async fn consensus_3_nodes_outdated_votes_lead_to_peer_score_changes(

--- a/crates/storage/src/connection/consensus.rs
+++ b/crates/storage/src/connection/consensus.rs
@@ -378,6 +378,24 @@ impl ConsensusTransaction<'_> {
             .map_err(StorageError::from)
     }
 
+    /// Get the highest finalized block height from the consensus database.
+    /// This represents the latest height that consensus has decided upon,
+    /// which may be ahead of what's committed to the main database.
+    pub fn latest_finalized_height(&self) -> Result<Option<u64>, StorageError> {
+        self.0
+            .inner()
+            .query_row(
+                r"SELECT height
+                FROM consensus_finalized_blocks
+                ORDER BY height DESC
+                LIMIT 1",
+                [],
+                |row| row.get_i64(0).map(|h| h as u64),
+            )
+            .optional()
+            .map_err(StorageError::from)
+    }
+
     /// Remove all finalized blocks for the given height **except** the one from
     /// `commit_round`.
     pub fn remove_uncommitted_consensus_finalized_blocks(


### PR DESCRIPTION
The `is_outdated_p2p_event` function queried the main database instead of the consensus database to detect outdated votes. I think this is what prevented peer score penalties...


**Context:**

- Consensus blocks are finalized in the consensus database before being committed to the main database. 
- The sync task eventually commits these blocks to the main db _asynchronously_.

So, there's a potential (race?) condition here:
1. Consensus decides on a block -> stored in consensus DB immediately
2. Sync task commits block -> stored in main DB later

**Proposed fix:**

Update `is_outdated_p2p_event` to:
1. First check the consensus database for the latest finalized height
2. Fall back to the main database if no finalized blocks exist in the consensus DB yet

This gives us the actual state of consensus decisions rather than the committed state in the main database, which may lag behind.