### PR TITLE
fix(rpc/method/get_storage_proof/tests): fix storage setup

### DIFF
--- a/crates/rpc/src/method/get_storage_proof.rs
+++ b/crates/rpc/src/method/get_storage_proof.rs
@@ -506,6 +506,7 @@ mod tests {
     use pathfinder_common::*;
     use pathfinder_merkle_tree::starknet_state::update_starknet_state;
     use pathfinder_storage::fake::{Block, Config, OccurrencePerBlock};
+    use pathfinder_storage::TriePruneMode;
 
     use super::*;
     use crate::dto::SerializeForVersion;
@@ -813,7 +814,12 @@ mod tests {
 
     #[tokio::test]
     async fn chain_without_declarations_and_contract_updates() {
-        let storage = pathfinder_storage::StorageBuilder::in_memory().unwrap();
+        let storage =
+            pathfinder_storage::StorageBuilder::in_tempdir_with_trie_pruning_and_pool_size(
+                TriePruneMode::Archive,
+                NonZeroU32::new(32).unwrap(),
+            )
+            .unwrap();
         let blocks = pathfinder_storage::fake::generate::with_config(
             1,
             Config {


### PR DESCRIPTION
We're calling `starknet_update_state()` with our storage, which requires a connection pool with multiple connections that can be used concurrently. Using the `in_memory()` variant causes the test take 30s because of the timeouts SQLite imposes if the database is locked.

Turns out we also have to disable pruning, otherwise the test will fail when trying to access a completely empty classes tree.

This PR "fixes" the test in the sense that it no longer takes 30s to run.
