### PR TITLE
feat(ci): skip heavy jobs if there are no code changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-24.04
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.github/workflows/**'
+
   test-all-features:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     env:
       CARGO_TERM_COLOR: always
@@ -65,6 +83,8 @@ jobs:
           if-no-files-found: warn
 
   test-consensus:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     env:
       CARGO_TERM_COLOR: always
@@ -94,6 +114,8 @@ jobs:
       - name: Run consensus integration tests
         run: PATHFINDER_CONSENSUS_TEST_DUMP_CHILD_LOGS_ON_FAIL=1 PATHFINDER_TEST_ENABLE_PORT_MARKER_FILES=1 timeout 10m cargo nextest run --test consensus -p pathfinder --features p2p,consensus-integration-tests --locked --retries 2
   test-default-features:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     env:
       CARGO_TERM_COLOR: always
@@ -130,6 +152,8 @@ jobs:
           if-no-files-found: warn
 
   clippy:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     env:
       MLIR_SYS_190_PREFIX: "/usr/lib/llvm-19"
@@ -174,6 +198,8 @@ jobs:
           cargo +nightly fmt --all --manifest-path crates/load-test/Cargo.toml -- --check
 
   doc:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     env:
       RUSTDOCFLAGS: "-D warnings"
@@ -210,6 +236,8 @@ jobs:
           files: .
 
   load_test:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
It has always bugged me that all these heavy jobs still run when you're just updating the CHANGELOG.md or any other non-code change.

This PR adds a filter to these jobs that should prevent them from running when there are no "code" changes.

The "code changes" filter can be tuned as much as we want. These feel like sane defaults to start of.