### PR TITLE
feat(rpc/unstable): relay round information too

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -677,9 +677,16 @@ pub fn calculate_class_commitment_leaf_hash(
 #[derive(Default, Debug, Clone, Copy)]
 pub struct ConsensusInfo {
     /// Highest decided height and value.
-    pub highest_decision: Option<(BlockNumber, ProposalCommitment)>,
+    pub highest_decision: Option<DecisionInfo>,
     /// Track the number of times peer scores were changed.
     pub peer_score_change_counter: u64,
+}
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct DecisionInfo {
+    pub height: BlockNumber,
+    pub round: u32,
+    pub value: ProposalCommitment,
 }
 
 #[cfg(test)]

--- a/crates/pathfinder/src/consensus/inner/p2p_task.rs
+++ b/crates/pathfinder/src/consensus/inner/p2p_task.rs
@@ -25,6 +25,7 @@ use pathfinder_common::{
     ChainId,
     ConsensusInfo,
     ContractAddress,
+    DecisionInfo,
     ProposalCommitment,
 };
 use pathfinder_consensus::{
@@ -592,17 +593,21 @@ pub fn spawn(
                         info_watch_tx.send_if_modified(|info| {
                             let do_update = match info.highest_decision {
                                 None => true,
-                                Some((highest_decided_height, highest_decided_value)) => {
+                                Some(decision) => {
                                     let new_height =
-                                        height_and_round.height() > highest_decided_height.get();
-                                    let new_value = value.0 != highest_decided_value;
+                                        height_and_round.height() > decision.height.get();
+                                    let new_value = value.0 != decision.value;
                                     new_height || new_value
                                 }
                             };
                             if do_update {
                                 let height = BlockNumber::new_or_panic(height_and_round.height());
                                 *info = ConsensusInfo {
-                                    highest_decision: Some((height, value.0)),
+                                    highest_decision: Some(DecisionInfo {
+                                        height,
+                                        round: height_and_round.round(),
+                                        value: value.0,
+                                    }),
                                     ..*info
                                 };
                             }

--- a/crates/rpc/src/method/consensus_info.rs
+++ b/crates/rpc/src/method/consensus_info.rs
@@ -2,9 +2,15 @@ use crate::context::RpcContext;
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct Output {
-    highest_decided_height: Option<pathfinder_common::BlockNumber>,
-    highest_decided_value: Option<pathfinder_common::ProposalCommitment>,
+    highest_decided: Option<DecisionMeta>,
     peer_score_change_counter: Option<u64>,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct DecisionMeta {
+    pub height: pathfinder_common::BlockNumber,
+    pub round: u32,
+    pub value: pathfinder_common::ProposalCommitment,
 }
 
 crate::error::generate_rpc_error_subset!(Error);
@@ -15,17 +21,13 @@ pub async fn consensus_info(context: RpcContext) -> Result<Output, Error> {
         let info = *borrow_ref;
         drop(borrow_ref);
 
-        if let Some((height, value)) = info.highest_decision {
-            Output {
-                highest_decided_height: Some(height),
-                highest_decided_value: Some(value),
-                peer_score_change_counter: Some(info.peer_score_change_counter),
-            }
-        } else {
-            Output {
-                peer_score_change_counter: Some(info.peer_score_change_counter),
-                ..Output::default()
-            }
+        Output {
+            highest_decided: info.highest_decision.map(|decision| DecisionMeta {
+                height: decision.height,
+                round: decision.round,
+                value: decision.value,
+            }),
+            peer_score_change_counter: Some(info.peer_score_change_counter),
         }
     } else {
         Output::default()
@@ -38,10 +40,22 @@ impl crate::dto::SerializeForVersion for Output {
         serializer: crate::dto::Serializer,
     ) -> Result<crate::dto::Ok, crate::dto::Error> {
         let mut serializer = serializer.serialize_struct()?;
-        serializer.serialize_optional("highest_decided_height", self.highest_decided_height)?;
-        serializer.serialize_optional("highest_decided_value", self.highest_decided_value)?;
+        serializer.serialize_optional("highest_decided", self.highest_decided.as_ref())?;
         serializer
             .serialize_optional("peer_score_change_counter", self.peer_score_change_counter)?;
+        serializer.end()
+    }
+}
+
+impl crate::dto::SerializeForVersion for &DecisionMeta {
+    fn serialize(
+        &self,
+        serializer: crate::dto::Serializer,
+    ) -> Result<crate::dto::Ok, crate::dto::Error> {
+        let mut serializer = serializer.serialize_struct()?;
+        serializer.serialize_field("height", &self.height)?;
+        serializer.serialize_field("round", &self.round)?;
+        serializer.serialize_field("value", &self.value)?;
         serializer.end()
     }
 }


### PR DESCRIPTION
Having information about the decided **round** allows to easily see if recovery works at all and what the mechanics of a particular consensus test case are, ie. if recovery **worked most of the time** at the expected height `H`, a positive decision at `H` should most of the time occur in `R=0`. Higher round indicates that the failing node failed to recover at `H,R=0` (and sometimes at `H+1,R=0`) and thus voted `Nil`.