### PR TITLE
fix(rpc/websocket): set max message size for websocket connections

### DIFF
--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -201,10 +201,11 @@ pub async fn rpc_handler(
                 return StatusCode::FORBIDDEN.into_response();
             }
 
-            ws.on_upgrade(|ws| async move {
-                let (ws_tx, ws_rx) = split_ws(ws, state.version);
-                handle_json_rpc_socket(state, ws_tx, ws_rx);
-            })
+            ws.max_message_size(crate::REQUEST_MAX_SIZE)
+                .on_upgrade(|ws| async move {
+                    let (ws_tx, ws_rx) = split_ws(ws, state.version);
+                    handle_json_rpc_socket(state, ws_tx, ws_rx);
+                })
         }
         Err(_) => {
             if method != http::Method::POST {


### PR DESCRIPTION
We set it to the same REQUEST_MAX_SIZE used for HTTP requests to prevent clients from sending excessively large messages over websockets.
