### PR TITLE
fix(ci): markdown documents not being filtered out for checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           filters: |
             code:
               - 'crates/**'
+              - '!**/*.md'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - '.github/workflows/**'


### PR DESCRIPTION
Adds markdown files to the `detect-changes` filter so we're not running all PR checks when just markdown files are updated.

Somehow left this out in the original PR.

See also https://github.com/eqlabs/pathfinder/pull/3169