### PR TITLE
fix(validator): prevent 0x1 state diff missmatch on rollback

### DIFF
--- a/crates/pathfinder/src/validator.rs
+++ b/crates/pathfinder/src/validator.rs
@@ -360,12 +360,15 @@ impl<E: BlockExecutorExt> ValidatorTransactionBatchStage<E> {
         state_update_data: &StateUpdateData,
     ) -> Result<E, ProposalHandlingError> {
         // Convert StateUpdateData to StateUpdate
+        //
+        // NOTE: We intentionally exclude `system_contract_updates` from the
+        // pending_state (see https://github.com/eqlabs/pathfinder/issues/3207)
         let state_update = StateUpdate {
             block_hash: pathfinder_common::BlockHash::ZERO,
             parent_state_commitment: pathfinder_common::StateCommitment::ZERO,
             state_commitment: pathfinder_common::StateCommitment::ZERO,
             contract_updates: state_update_data.contract_updates.clone(),
-            system_contract_updates: state_update_data.system_contract_updates.clone(),
+            system_contract_updates: Default::default(),
             declared_cairo_classes: state_update_data.declared_cairo_classes.clone(),
             declared_sierra_classes: state_update_data.declared_sierra_classes.clone(),
             migrated_compiled_classes: state_update_data.migrated_compiled_classes.clone(),


### PR DESCRIPTION
This was a painful one to find. It all comes down to a [nuance](https://github.com/starkware-libs/sequencer/blob/main/crates/blockifier/src/state/cached_state.rs#L73-L74) in how blockifier's `CachedState` works.

The problematic scenario in #3206 is the following:

1. We execute batches 0, 1, 2 and extract cumulative state diffs (which include 0x1)
2. We are then requested to rollback to batch 1.
3. The 0x1 contract disappears from the final state diff.


**Why?**

1. When executing batches, we extract their cumulative state diffs (which include 0x1).
2. When rolling back to batch N, we passed `system_contract_updates` (containing 0x1) to the `pending_state` that we then used to reconstruct the executor.
3. When blockifier's `pre_process_block` ran again, it tried to write to 0x1...
4. But `PendingStateReader` said _"I already have that value!"_
5. So blockifier sees write == initial read and thinks _"no change here"_
6. Which causes the final diff to exclude the 0x1, causing the commitment mismatch

--

Tried to explain as best as possible, I know it's confusing. I have some tests that I used to trace all this. I don't think they should be part of pathfinder, hence why they're not included in the PR. But if anyone thinks otherwise or wants to see them I can share them.

--

Closes #3207 