### PR TITLE
chore: fixed dump_events generator

### DIFF
--- a/crates/pathfinder/examples/dump_events.rs
+++ b/crates/pathfinder/examples/dump_events.rs
@@ -136,7 +136,7 @@ fn main() -> anyhow::Result<()> {
         let bn = BlockNumber::new(n).context(format!("invalid block number {n}"))?;
         if let Some(pairs) = db_tx.events_for_block(bn.into())? {
             for pair in pairs {
-                let tx_hash = pair.0;
+                let tx_hash = pair.0 .0;
                 for event in &pair.1 {
                     let accept_address = if let Some(addr) = address {
                         event.from_address == addr


### PR DESCRIPTION
Extracting transaction hash from the return value of `events_for_block`.
