### PR TITLE
refactor(ethereum): remove `EthereumApi` trait

### DIFF
--- a/crates/ethereum/src/lib.rs
+++ b/crates/ethereum/src/lib.rs
@@ -87,29 +87,6 @@ fn compute_blob_fee(excess_blob_gas: Option<u64>) -> u128 {
         .unwrap_or(alloy::eips::eip4844::BLOB_TX_MIN_BLOB_GASPRICE)
 }
 
-/// Ethereum API trait
-pub trait EthereumApi {
-    fn get_starknet_state(
-        &self,
-        address: &H160,
-    ) -> impl Future<Output = anyhow::Result<EthereumStateUpdate>>;
-    fn get_chain(&self) -> impl Future<Output = anyhow::Result<EthereumChain>>;
-    fn get_l1_handler_txs(
-        &self,
-        address: &H160,
-        tx_hash: &L1TransactionHash,
-    ) -> impl Future<Output = anyhow::Result<Vec<L1HandlerTransaction>>>;
-    fn sync_and_listen<F, Fut>(
-        &mut self,
-        address: &H160,
-        poll_interval: Duration,
-        callback: F,
-    ) -> impl Future<Output = anyhow::Result<()>>
-    where
-        F: Fn(EthereumStateUpdate) -> Fut + Send + 'static,
-        Fut: Future<Output = ()> + Send + 'static;
-}
-
 /// Ethereum client
 #[derive(Clone)]
 pub struct EthereumClient {
@@ -269,11 +246,11 @@ impl EthereumClient {
     }
 }
 
-impl EthereumApi for EthereumClient {
+impl EthereumClient {
     /// Listens for Ethereum events and notifies the caller using the provided
     /// callback. State updates will only be emitted once they belong to a
     /// finalized block.
-    async fn sync_and_listen<F, Fut>(
+    pub async fn sync_and_listen<F, Fut>(
         &mut self,
         address: &H160,
         poll_interval: Duration,
@@ -398,7 +375,7 @@ impl EthereumApi for EthereumClient {
         }
     }
 
-    async fn get_l1_handler_txs(
+    pub async fn get_l1_handler_txs(
         &self,
         address: &H160,
         tx_hash: &L1TransactionHash,
@@ -465,7 +442,7 @@ impl EthereumApi for EthereumClient {
     }
 
     /// Get the Starknet state
-    async fn get_starknet_state(&self, address: &H160) -> anyhow::Result<EthereumStateUpdate> {
+    pub async fn get_starknet_state(&self, address: &H160) -> anyhow::Result<EthereumStateUpdate> {
         let provider = self.provider().await?;
 
         // Create the StarknetCoreContract instance
@@ -490,7 +467,7 @@ impl EthereumApi for EthereumClient {
     }
 
     /// Get the Ethereum chain
-    async fn get_chain(&self) -> anyhow::Result<EthereumChain> {
+    pub async fn get_chain(&self) -> anyhow::Result<EthereumChain> {
         let provider = self.provider().await?;
         let chain_id = provider.get_chain_id().await?;
         let chain_id = U256::from(chain_id);

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -12,7 +12,7 @@ use anyhow::Context;
 use config::BlockchainHistory;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use pathfinder_common::{BlockNumber, Chain, ChainId, EthereumChain};
-use pathfinder_ethereum::{EthereumApi, EthereumClient};
+use pathfinder_ethereum::EthereumClient;
 use pathfinder_lib::consensus::{ConsensusChannels, ConsensusTaskHandles};
 use pathfinder_lib::gas_price::{L1GasPriceConfig, L1GasPriceProvider};
 use pathfinder_lib::state::{sync_gas_prices, L1GasPriceSyncConfig, SyncContext};

--- a/crates/pathfinder/src/state/sync/l1.rs
+++ b/crates/pathfinder/src/state/sync/l1.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use pathfinder_common::{Chain, L1BlockNumber};
-use pathfinder_ethereum::{EthereumApi, EthereumClient};
+use pathfinder_ethereum::EthereumClient;
 use primitive_types::H160;
 use tokio::sync::mpsc;
 
@@ -23,13 +23,10 @@ pub struct L1SyncContext<EthereumClient> {
 ///
 /// Emits [Ethereum state update](pathfinder_ethereum::EthereumStateUpdate)
 /// which should be handled to update storage and respond to queries.
-pub async fn sync<T>(
+pub async fn sync(
     tx_event: mpsc::Sender<SyncEvent>,
-    context: L1SyncContext<T>,
-) -> anyhow::Result<()>
-where
-    T: EthereumApi + Clone,
-{
+    context: L1SyncContext<EthereumClient>,
+) -> anyhow::Result<()> {
     let L1SyncContext {
         mut ethereum,
         chain: _,

--- a/crates/pathfinder/src/sync.rs
+++ b/crates/pathfinder/src/sync.rs
@@ -87,7 +87,6 @@ where
     /// errors are transient. We cannot proceed without a checkpoint, so we
     /// retry until we get one.
     async fn get_checkpoint(&self) -> pathfinder_ethereum::EthereumStateUpdate {
-        use pathfinder_ethereum::EthereumApi;
         if let Some(forced) = &self.l1_checkpoint_override {
             return *forced;
         }

--- a/crates/pathfinder/src/sync/checkpoint.rs
+++ b/crates/pathfinder/src/sync/checkpoint.rs
@@ -101,8 +101,6 @@ where
         &self,
         checkpoint: EthereumStateUpdate,
     ) -> Result<(BlockNumber, BlockHash), SyncError> {
-        use pathfinder_ethereum::EthereumApi;
-
         let local_state = LocalState::from_db(self.storage.clone(), checkpoint)
             .await
             .context("Querying local state")?;

--- a/crates/rpc/src/method/get_messages_status.rs
+++ b/crates/rpc/src/method/get_messages_status.rs
@@ -1,6 +1,5 @@
 use anyhow::Context;
 use pathfinder_common::{L1TransactionHash, TransactionHash};
-use pathfinder_ethereum::EthereumApi;
 
 use crate::context::RpcContext;
 use crate::dto::TxnExecutionStatus;


### PR DESCRIPTION
This trait is totally useless.

Closes #3176 