### PR TITLE
fix(rpc): multiple address filters in starknet_subscribeEvents

### DIFF
--- a/crates/rpc/src/method/get_events.rs
+++ b/crates/rpc/src/method/get_events.rs
@@ -75,7 +75,9 @@ pub struct EventFilter {
 
 impl EventFilter {
     fn get_addresses(&self) -> Vec<ContractAddress> {
-        self.addresses.iter().cloned().collect()
+        let mut addresses: Vec<ContractAddress> = self.addresses.iter().cloned().collect();
+        addresses.sort();
+        addresses
     }
 }
 


### PR DESCRIPTION
Analogically to `starknet_getEvents`.

Fixes https://github.com/eqlabs/pathfinder/issues/3216 .
