### PR TITLE
fix(ci): manually free disk space

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,16 @@
+name: Free disk space
+description: Remove unused pre-installed software to free up disk space
+
+runs:
+  using: composite
+  steps:
+    - name: Free disk space
+      shell: bash
+      run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/.ghcup
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/share/swift
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        sudo docker image prune --all --force

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,8 @@ jobs:
       LLVM_SYS_191_PREFIX: "/usr/lib/llvm-19"
       TABLEGEN_190_PREFIX: "/usr/lib/llvm-19"
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v10
-        with:
-          root-reserve-mb: "16384"
-          temp-reserve-mb: "3072"
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/free-disk-space
       - uses: rui314/setup-mold@v1
       - uses: Swatinem/rust-cache@v2
         with:
@@ -90,12 +86,8 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v10
-        with:
-          root-reserve-mb: "3072"
-          temp-reserve-mb: "3072"
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/free-disk-space
       - uses: rui314/setup-mold@v1
       - uses: Swatinem/rust-cache@v2
         with:
@@ -123,12 +115,8 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: "3072"
-          temp-reserve-mb: "3072"
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/free-disk-space
       - uses: rui314/setup-mold@v1
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
Removed `easimon/maximize-build-space` from all 3 jobs and replaced it with a manual cleanup action.

Turns out that action wasn't really removing anything. It was just combining free space from `/` and `/mnt` into one logical volume.

Now we should be actually freeing a bunch of space from all the Github bloat.