### PR TITLE
fix: backward compatible with state commitment calculate

### DIFF
--- a/crates/common/src/header.rs
+++ b/crates/common/src/header.rs
@@ -93,7 +93,11 @@ impl BlockHeaderBuilder {
         storage_commitment: StorageCommitment,
         class_commitment: ClassCommitment,
     ) -> Self {
-        self.0.state_commitment = StateCommitment::calculate(storage_commitment, class_commitment);
+        self.0.state_commitment = StateCommitment::calculate(
+            storage_commitment,
+            class_commitment,
+            self.0.starknet_version,
+        );
         self
     }
 

--- a/crates/common/src/l2.rs
+++ b/crates/common/src/l2.rs
@@ -108,6 +108,13 @@ impl L2BlockToCommit {
             L2BlockToCommit::FromFgw(block) => &block.state_update,
         }
     }
+
+    pub fn starknet_version(&self) -> StarknetVersion {
+        match self {
+            L2BlockToCommit::FromConsensus(block) => block.header.starknet_version,
+            L2BlockToCommit::FromFgw(block) => block.header.starknet_version,
+        }
+    }
 }
 
 impl ConsensusFinalizedBlockHeader {

--- a/crates/merkle-tree/src/starknet_state.rs
+++ b/crates/merkle-tree/src/starknet_state.rs
@@ -149,3 +149,193 @@ pub fn update_starknet_state(
 
     Ok((storage_commitment, class_commitment))
 }
+
+#[cfg(test)]
+mod tests {
+    use pathfinder_common::prelude::*;
+    use pathfinder_common::{
+        class_commitment,
+        state_commitment,
+        storage_address,
+        storage_commitment,
+        storage_value,
+        ClassCommitment,
+        StarknetVersion,
+        StateCommitment,
+    };
+
+    use crate::contract_state::calculate_contract_state_hash;
+    use crate::{ContractsStorageTree, StorageCommitmentTree};
+
+    /// Regression test for state commitment calculation in Starknet v0.14+.
+    ///
+    /// In Starknet v0.14.0+, the state commitment formula changed: it now
+    /// always uses the Poseidon hash with STARKNET_STATE_V0 prefix, even
+    /// when the class_commitment is zero.
+    ///
+    /// Before v0.14:
+    ///   If class_commitment == 0: state = storage_commitment.
+    ///   Else: state = poseidon([STARKNET_STATE_V0, storage, class]).
+    ///
+    /// v0.14+:
+    ///   State = poseidon([STARKNET_STATE_V0, storage, class]) (always).
+    ///
+    /// Test data from feeder gateway get_state_update for blockNumber=0.
+    /// Expected state_root:
+    /// 0x68bcf9e9257ab6bffd9425833a208aaab6b85649fd21c787a546cb7cb9abf.
+    #[test]
+    fn state_commitment_v0_14_with_zero_class_commitment() {
+        let storage = pathfinder_storage::StorageBuilder::in_memory().unwrap();
+        let mut db = storage.connection().unwrap();
+        let tx = db.transaction().unwrap();
+
+        // Contract 0x2 is a system contract.
+        let contract_address = ContractAddress::TWO;
+
+        // Create contract storage tree with single entry: key 0x0 -> value 0x80.
+        let mut contract_tree = ContractsStorageTree::empty(&tx, contract_address);
+        contract_tree
+            .set(storage_address!("0x0"), storage_value!("0x80"))
+            .unwrap();
+        let (contract_root, _) = contract_tree.commit().unwrap();
+
+        // For system contracts: class_hash = 0, nonce = 0.
+        let contract_state_hash =
+            calculate_contract_state_hash(ClassHash::ZERO, contract_root, ContractNonce::ZERO);
+
+        // Create storage commitment tree with the contract.
+        let mut storage_commitment_tree = StorageCommitmentTree::empty(&tx);
+        storage_commitment_tree
+            .set(contract_address, contract_state_hash)
+            .unwrap();
+        let (storage_commitment, _) = storage_commitment_tree.commit().unwrap();
+
+        // Class commitment is ZERO (no declared classes).
+        let class_commitment = ClassCommitment::ZERO;
+
+        // Expected state commitment from feeder gateway.
+        let expected =
+            state_commitment!("0x68bcf9e9257ab6bffd9425833a208aaab6b85649fd21c787a546cb7cb9abf");
+
+        // Test v0.14 calculation (should match).
+        let state_commitment_v014 = StateCommitment::calculate(
+            storage_commitment,
+            class_commitment,
+            StarknetVersion::V_0_14_0,
+        );
+        assert_eq!(
+            state_commitment_v014, expected,
+            "v0.14 state commitment should match expected."
+        );
+
+        // Test pre-0.14 calculation (should NOT match for this case).
+        let state_commitment_v013 = StateCommitment::calculate(
+            storage_commitment,
+            class_commitment,
+            StarknetVersion::V_0_13_4,
+        );
+        assert_ne!(
+            state_commitment_v013, expected,
+            "Pre-0.14 calculation should NOT match for v0.14+ expected value."
+        );
+
+        // Verify pre-0.14 returns storage_commitment directly.
+        assert_eq!(
+            state_commitment_v013.0, storage_commitment.0,
+            "Pre-0.14 should return storage_commitment when class_commitment is zero."
+        );
+    }
+
+    /// Test that pre-v0.14 behavior is preserved for older versions.
+    #[test]
+    fn state_commitment_pre_v0_14_with_zero_class_commitment() {
+        let storage_commitment = storage_commitment!("0x1234");
+        let class_commitment = ClassCommitment::ZERO;
+
+        // Pre-v0.14: state_commitment should equal storage_commitment when class is
+        // zero.
+        let state_v013 = StateCommitment::calculate(
+            storage_commitment,
+            class_commitment,
+            StarknetVersion::V_0_13_4,
+        );
+        assert_eq!(
+            state_v013.0, storage_commitment.0,
+            "Pre-v0.14 should return storage_commitment when class_commitment is zero."
+        );
+
+        // v0.14+: state_commitment should use Poseidon formula.
+        let state_v014 = StateCommitment::calculate(
+            storage_commitment,
+            class_commitment,
+            StarknetVersion::V_0_14_0,
+        );
+        assert_ne!(
+            state_v014.0, storage_commitment.0,
+            "v0.14+ should NOT return storage_commitment directly when class_commitment is zero."
+        );
+    }
+
+    /// Test that non-zero class commitment uses Poseidon formula for all
+    /// versions.
+    #[test]
+    fn state_commitment_with_nonzero_class_commitment() {
+        let storage_commitment = storage_commitment!("0x1234");
+        let class_commitment = class_commitment!("0x5678");
+
+        // Both versions should use Poseidon formula when class_commitment is non-zero.
+        let state_v013 = StateCommitment::calculate(
+            storage_commitment,
+            class_commitment,
+            StarknetVersion::V_0_13_4,
+        );
+        let state_v014 = StateCommitment::calculate(
+            storage_commitment,
+            class_commitment,
+            StarknetVersion::V_0_14_0,
+        );
+
+        // Both should produce the same result (Poseidon hash).
+        assert_eq!(
+            state_v013, state_v014,
+            "Non-zero class: v0.13 and v0.14 should produce the same result."
+        );
+
+        // Neither should equal storage_commitment directly.
+        assert_ne!(
+            state_v013.0, storage_commitment.0,
+            "Non-zero class commitment should use Poseidon formula."
+        );
+    }
+
+    /// Test that both storage and class commitment being zero returns zero
+    /// state commitment.
+    #[test]
+    fn state_commitment_with_both_zero() {
+        let storage_commitment = StorageCommitment::ZERO;
+        let class_commitment = ClassCommitment::ZERO;
+
+        // When both are zero, state commitment should be zero for any version.
+        let state_v013 = StateCommitment::calculate(
+            storage_commitment,
+            class_commitment,
+            StarknetVersion::V_0_13_4,
+        );
+        let state_v014 = StateCommitment::calculate(
+            storage_commitment,
+            class_commitment,
+            StarknetVersion::V_0_14_0,
+        );
+
+        assert_eq!(
+            state_v013,
+            StateCommitment::ZERO,
+            "Both zero should return StateCommitment::ZERO for pre-0.14."
+        );
+        assert_eq!(
+            state_v014,
+            StateCommitment::ZERO,
+            "Both zero should return StateCommitment::ZERO for v0.14+."
+        );
+    }
+}

--- a/crates/pathfinder/src/consensus/inner/p2p_task.rs
+++ b/crates/pathfinder/src/consensus/inner/p2p_task.rs
@@ -433,6 +433,7 @@ pub fn spawn(
 
                                 use crate::validator;
 
+                                let starknet_version = block.header.starknet_version;
                                 let state_commitment = update_starknet_state(
                                     &main_db_tx,
                                     block.state_update.as_ref(),
@@ -441,7 +442,9 @@ pub fn spawn(
                                     main_readonly_storage.clone(),
                                 )
                                 .context("Updating Starknet state")
-                                .map(|(storage, class)| StateCommitment::calculate(storage, class));
+                                .map(|(storage, class)| {
+                                    StateCommitment::calculate(storage, class, starknet_version)
+                                });
 
                                 // Do not commit this.
                                 drop(main_db_tx);

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -1324,7 +1324,11 @@ fn l2_update(
         storage,
     )
     .context("Updating Starknet state")?;
-    let state_commitment = StateCommitment::calculate(storage_commitment, class_commitment);
+    let state_commitment = StateCommitment::calculate(
+        storage_commitment,
+        class_commitment,
+        block.starknet_version(),
+    );
 
     if let Some(expected_state_commitment) = block.state_commitment() {
         // Ensure that roots match.. what should we do if it doesn't? For now the whole

--- a/crates/pathfinder/src/state/sync/revert.rs
+++ b/crates/pathfinder/src/state/sync/revert.rs
@@ -34,7 +34,11 @@ pub fn revert_starknet_state(
     let storage_commitment = revert_contract_updates(transaction, head, target_block)?;
     let class_commitment = revert_class_updates(transaction, head, target_block)?;
 
-    let state_commitment = StateCommitment::calculate(storage_commitment, class_commitment);
+    let state_commitment = StateCommitment::calculate(
+        storage_commitment,
+        class_commitment,
+        target_header.starknet_version,
+    );
     if state_commitment != target_header.state_commitment {
         anyhow::bail!(
             "State commitment mismatch: expected {}, calculated {}",

--- a/crates/pathfinder/src/sync/state_updates.rs
+++ b/crates/pathfinder/src/sync/state_updates.rs
@@ -275,7 +275,13 @@ pub async fn batch_update_starknet_state(
                 error.context(format!("Updating Starknet state, tail {tail}")),
             )),
         })?;
-        let state_commitment = StateCommitment::calculate(storage_commitment, class_commitment);
+        let starknet_version = db
+            .block_header(tail.into())
+            .context("Querying block header for starknet version")?
+            .context("Block header not found")?
+            .starknet_version;
+        let state_commitment =
+            StateCommitment::calculate(storage_commitment, class_commitment, starknet_version);
         let expected_state_commitment = db
             .state_commitment(tail.into())
             .context("Querying state commitment")?

--- a/crates/pathfinder/src/sync/track.rs
+++ b/crates/pathfinder/src/sync/track.rs
@@ -810,7 +810,11 @@ impl ProcessStage for StoreBlock {
         .with_context(|| format!("Updating Starknet state, block_number {block_number}"))?;
 
         // Ensure that roots match.
-        let state_commitment = StateCommitment::calculate(storage_commitment, class_commitment);
+        let state_commitment = StateCommitment::calculate(
+            storage_commitment,
+            class_commitment,
+            header.starknet_version,
+        );
         let expected_state_commitment = header.state_commitment;
         if state_commitment != expected_state_commitment {
             tracing::debug!(

--- a/crates/storage/src/connection/block.rs
+++ b/crates/storage/src/connection/block.rs
@@ -685,7 +685,11 @@ mod tests {
             sequencer_address: sequencer_address_bytes!(b"sequencer address genesis"),
             starknet_version: StarknetVersion::default(),
             event_commitment: event_commitment_bytes!(b"event commitment genesis"),
-            state_commitment: StateCommitment::calculate(storage_commitment, class_commitment),
+            state_commitment: StateCommitment::calculate(
+                storage_commitment,
+                class_commitment,
+                StarknetVersion::default(),
+            ),
             transaction_commitment: transaction_commitment_bytes!(b"tx commitment genesis"),
             transaction_count: 37,
             event_count: 40,

--- a/crates/storage/src/fake.rs
+++ b/crates/storage/src/fake.rs
@@ -520,7 +520,11 @@ pub mod generate {
                 dummy_storage.clone(),
             )
             .unwrap();
-            let state_commitment = StateCommitment::calculate(storage_commitment, class_commitment);
+            let state_commitment = StateCommitment::calculate(
+                storage_commitment,
+                class_commitment,
+                header.header.starknet_version,
+            );
             header.header.state_commitment = state_commitment;
             state_update.state_commitment = state_commitment;
         }


### PR DESCRIPTION
Fix calculating StateCommitment according to the starknet version.

Before v0.14:
    If class_commitment == 0: state = storage_commitment.
    ///   Else: state = poseidon([STARKNET_STATE_V0, storage, class]).
    ///
    /// v0.14+:
    ///   State = poseidon([STARKNET_STATE_V0, storage, class]) (always).