### PR TITLE
Fix proof_facts field propagation to GW

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -692,7 +692,19 @@ pub fn calculate_class_commitment_leaf_hash(
 }
 
 /// A SNOS stwo proof element.
-#[derive(Copy, Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Copy,
+    Debug,
+    Clone,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub struct ProofElem(pub u32);
 
 #[cfg(test)]

--- a/crates/gateway-types/src/request.rs
+++ b/crates/gateway-types/src/request.rs
@@ -8,7 +8,14 @@ pub mod add_transaction {
         SelectorAndOffset,
     };
     use pathfinder_common::prelude::*;
-    use pathfinder_common::{CallParam, ContractAddress, Fee, TransactionSignatureElem};
+    use pathfinder_common::{
+        CallParam,
+        ContractAddress,
+        Fee,
+        ProofElem,
+        ProofFactElem,
+        TransactionSignatureElem,
+    };
     use pathfinder_serde::{CallParamAsDecimalStr, TransactionSignatureElemAsDecimalStr};
     use serde_with::serde_as;
 
@@ -131,6 +138,10 @@ pub mod add_transaction {
         pub sender_address: ContractAddress,
         pub calldata: Vec<CallParam>,
         pub account_deployment_data: Vec<AccountDeploymentDataElem>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        pub proof_facts: Vec<ProofFactElem>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        pub proof: Vec<ProofElem>,
     }
 
     /// Declare transaction details.

--- a/crates/rpc/src/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/method/add_invoke_transaction.rs
@@ -285,6 +285,8 @@ pub(crate) async fn add_invoke_transaction_impl(
                         sender_address: tx.sender_address,
                         calldata: tx.calldata.clone(),
                         account_deployment_data: tx.account_deployment_data.clone(),
+                        proof_facts: tx.proof_facts.clone(),
+                        proof: tx.proof.clone(),
                     },
                 ))
                 .await?;


### PR DESCRIPTION
  ---

  Forward proof_facts and proof fields to the sequencer gateway for invoke v3 transactions.

  ---
 
  PR #3190 added support for proof_facts and proof fields in invoke transaction v3 — deserializing from RPC input, storing locally, computing hashes, and returning in
  responses. However, these fields were not forwarded to the sequencer gateway, meaning proof data was silently dropped.

  This PR adds the two fields to the gateway's InvokeFunctionV3 struct and populates them when constructing the gateway request in add_invoke_transaction. Both fields
  use skip_serializing_if = "Vec::is_empty" to maintain backward compatibility — empty vecs are omitted from the serialized JSON.

  Also adds serde::Serialize and serde::Deserialize derives to ProofElem, which were missing and needed for gateway serialization. (ProofFactElem already had serde
  derives via the felt_newtypes! macro.)

  Only InvokeFunctionV3 is affected — DeclareV3 and DeployAccountV3 do not have proof fields in their RPC input types.

  ---

  No new dependencies.

Delete once completed:
- [ ] link any issues closed by this pull-request
- [ ] add all user-facing changes to `CHANGELOG.md`
- [ ] new dependencies were added to the workspace toml
