### PR TITLE
fix: storage key name in initial_reads

### DIFF
--- a/crates/rpc/fixtures/0.10.0/simulations/simulate_transaction_with_return_initial_reads.json
+++ b/crates/rpc/fixtures/0.10.0/simulations/simulate_transaction_with_return_initial_reads.json
@@ -21,17 +21,17 @@
     "storage": [
       {
         "contract_address": "0xf3805e4f045a8b48e7e9e6cd5d910973a22360572207f3ae625c5cec2a3232",
-        "storage_key": "0x81ba5d1f84a6a8f0e7ae24720a20f43f81d9ee6eed98fd524ba8d53a49416b",
+        "key": "0x81ba5d1f84a6a8f0e7ae24720a20f43f81d9ee6eed98fd524ba8d53a49416b",
         "value": "0x0"
       },
       {
         "contract_address": "0xf3805e4f045a8b48e7e9e6cd5d910973a22360572207f3ae625c5cec2a3232",
-        "storage_key": "0x1379ac0624b939ceb9dede92211d7db5ee174fe28be72245b0a1a2abd81c98f",
+        "key": "0x1379ac0624b939ceb9dede92211d7db5ee174fe28be72245b0a1a2abd81c98f",
         "value": "0x0"
       },
       {
         "contract_address": "0xf3805e4f045a8b48e7e9e6cd5d910973a22360572207f3ae625c5cec2a3232",
-        "storage_key": "0x7e79bbb6be5d418acd50c88b675e697f6f7094e203c9d7e29c6ad6731f931dd",
+        "key": "0x7e79bbb6be5d418acd50c88b675e697f6f7094e203c9d7e29c6ad6731f931dd",
         "value": "0x0"
       }
     ]

--- a/crates/rpc/fixtures/0.10.0/traces/multiple_txs_with_initial_reads.json
+++ b/crates/rpc/fixtures/0.10.0/traces/multiple_txs_with_initial_reads.json
@@ -482,32 +482,32 @@
     "storage": [
       {
         "contract_address": "0xc01",
-        "storage_key": "0x1379ac0624b939ceb9dede92211d7db5ee174fe28be72245b0a1a2abd81c98f",
+        "key": "0x1379ac0624b939ceb9dede92211d7db5ee174fe28be72245b0a1a2abd81c98f",
         "value": "0x0"
       },
       {
         "contract_address": "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
-        "storage_key": "0x1275130f95dda36bcbb6e9d28796c1d7e10b6e9fd5ed083e0ede4b12f613528",
+        "key": "0x1275130f95dda36bcbb6e9d28796c1d7e10b6e9fd5ed083e0ede4b12f613528",
         "value": "0x9"
       },
       {
         "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "storage_key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
+        "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
         "value": "0x10000000000000000000000000000"
       },
       {
         "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "storage_key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408f",
+        "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408f",
         "value": "0x0"
       },
       {
         "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "storage_key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
+        "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
         "value": "0x0"
       },
       {
         "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "storage_key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9b",
+        "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9b",
         "value": "0x0"
       }
     ]

--- a/crates/rpc/src/dto/simulation.rs
+++ b/crates/rpc/src/dto/simulation.rs
@@ -538,7 +538,7 @@ impl crate::dto::SerializeForVersion for StorageValue<'_> {
     ) -> Result<crate::dto::Ok, crate::dto::Error> {
         let mut serializer = serializer.serialize_struct()?;
         serializer.serialize_field("contract_address", &self.0 .0 .0)?;
-        serializer.serialize_field("storage_key", &self.0 .0 .1)?;
+        serializer.serialize_field("key", &self.0 .0 .1)?;
         serializer.serialize_field("value", self.0 .1)?;
         serializer.end()
     }


### PR DESCRIPTION
From `storage_key` to the correct (see https://github.com/starkware-libs/starknet-specs/blob/b57ccf8fcbc32f89a42f088ff9c8b93115bfd40a/api/starknet_trace_api_openrpc.json#L390 ) `key`.
