### PR TITLE
fix: optional trace_flags of starknet_traceBlockTransactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- `starknet_traceBlockTransactions` parameter `trace_flags` is not optional (as required by the spec)
+
 ## [0.22.0-beta.2] - 2026-02-16
 
 ### Fixed

--- a/crates/rpc/src/dto/simulation.rs
+++ b/crates/rpc/src/dto/simulation.rs
@@ -660,7 +660,7 @@ impl crate::dto::SerializeForVersion for CallType {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
 pub struct TraceFlags(pub Vec<TraceFlag>);
 
 impl TraceFlags {

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -28,9 +28,11 @@ impl crate::dto::DeserializeForVersion for TraceBlockTransactionsInput {
             Ok(Self {
                 block_id: value.deserialize("block_id")?,
                 trace_flags: if rpc_version >= RpcVersion::V10 {
-                    value.deserialize("trace_flags")?
+                    value
+                        .deserialize_optional("trace_flags")?
+                        .unwrap_or_default()
                 } else if !value.contains_key("trace_flags") {
-                    crate::dto::TraceFlags::new()
+                    crate::dto::TraceFlags::default()
                 } else {
                     let err = serde_json::Error::custom(format!(
                         "Trace flags are not supported in RPC version {}. Use RPC version {} or \


### PR DESCRIPTION
As required by https://github.com/starkware-libs/starknet-specs/blob/b57ccf8fcbc32f89a42f088ff9c8b93115bfd40a/api/starknet_trace_api_openrpc.json#L164 .

Fixes https://github.com/eqlabs/pathfinder/issues/3239 .