### PR TITLE
Fix proof field serialization from JSON array to base64 string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8531,6 +8531,7 @@ name = "pathfinder-common"
 version = "0.22.0-beta.2"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "bitvec",
  "fake",
  "metrics",

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -21,6 +21,7 @@ full-serde = []
 
 [dependencies]
 anyhow = { workspace = true }
+base64 = { workspace = true }
 bitvec = { workspace = true }
 fake = { workspace = true, features = ["derive"] }
 metrics = { workspace = true }

--- a/crates/gateway-types/src/request.rs
+++ b/crates/gateway-types/src/request.rs
@@ -12,7 +12,7 @@ pub mod add_transaction {
         CallParam,
         ContractAddress,
         Fee,
-        ProofElem,
+        Proof,
         ProofFactElem,
         TransactionSignatureElem,
     };
@@ -140,8 +140,8 @@ pub mod add_transaction {
         pub account_deployment_data: Vec<AccountDeploymentDataElem>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         pub proof_facts: Vec<ProofFactElem>,
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        pub proof: Vec<ProofElem>,
+        #[serde(default, skip_serializing_if = "Proof::is_empty")]
+        pub proof: Proof,
     }
 
     /// Declare transaction details.

--- a/crates/rpc/fixtures/0.10.0/broadcasted_transactions.json
+++ b/crates/rpc/fixtures/0.10.0/broadcasted_transactions.json
@@ -186,10 +186,7 @@
             "0xabc",
             "0xdef"
         ],
-        "proof": [
-            11,
-            22
-        ]
+        "proof": "AAAACwAAABY="
     },
     {
         "type": "DEPLOY_ACCOUNT",

--- a/crates/rpc/src/dto/primitives.rs
+++ b/crates/rpc/src/dto/primitives.rs
@@ -815,9 +815,13 @@ mod pathfinder_common_types {
         }
     }
 
-    impl SerializeForVersion for &pathfinder_common::ProofElem {
+    impl SerializeForVersion for &pathfinder_common::Proof {
         fn serialize(&self, serializer: Serializer) -> Result<crate::dto::Ok, crate::dto::Error> {
-            serializer.serialize_u32(self.0)
+            use base64::Engine;
+
+            let bytes: Vec<u8> = self.0.iter().flat_map(|v| v.to_be_bytes()).collect();
+            let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+            serializer.serialize_str(&encoded)
         }
     }
 }

--- a/crates/rpc/src/dto/transaction.rs
+++ b/crates/rpc/src/dto/transaction.rs
@@ -372,12 +372,12 @@ impl crate::dto::SerializeForVersion for Vec<pathfinder_common::ProofFactElem> {
     }
 }
 
-impl crate::dto::SerializeForVersion for Vec<pathfinder_common::ProofElem> {
+impl crate::dto::SerializeForVersion for pathfinder_common::Proof {
     fn serialize(
         &self,
         serializer: crate::dto::Serializer,
     ) -> Result<crate::dto::Ok, crate::dto::Error> {
-        serializer.serialize_iter(self.len(), &mut self.iter())
+        (&self).serialize(serializer)
     }
 }
 

--- a/crates/rpc/src/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/method/add_invoke_transaction.rs
@@ -327,7 +327,7 @@ impl crate::dto::SerializeForVersion for Output {
 mod tests {
     use pathfinder_common::macro_prelude::*;
     use pathfinder_common::transaction::{DataAvailabilityMode, ResourceBound, ResourceBounds};
-    use pathfinder_common::{ResourceAmount, ResourcePricePerUnit, Tip, TransactionVersion};
+    use pathfinder_common::{Proof, ResourceAmount, ResourcePricePerUnit, Tip, TransactionVersion};
 
     use super::*;
     use crate::types::request::BroadcastedInvokeTransactionV1;
@@ -565,7 +565,7 @@ mod tests {
                 call_param!("0x613816405e6334ab420e53d4b38a0451cb2ebca2755171315958c87d303cf6"),
             ],
             proof_facts: vec![],
-            proof: vec![],
+            proof: Proof::default(),
         };
 
         let input = Input {

--- a/crates/rpc/src/method/estimate_fee.rs
+++ b/crates/rpc/src/method/estimate_fee.rs
@@ -397,7 +397,7 @@ mod tests {
                 nonce_data_availability_mode: DataAvailabilityMode::L1,
                 fee_data_availability_mode: DataAvailabilityMode::L1,
                 proof_facts: vec![],
-                proof: vec![],
+                proof: Default::default(),
             },
         ))
     }
@@ -703,7 +703,7 @@ mod tests {
                     call_param!("0x0"),
                 ],
                 proof_facts: vec![],
-                proof: vec![],
+                proof: Default::default(),
             },
         ))
     }
@@ -754,7 +754,7 @@ mod tests {
                 nonce_data_availability_mode: DataAvailabilityMode::L2,
                 fee_data_availability_mode: DataAvailabilityMode::L2,
                 proof_facts: vec![],
-                proof: vec![],
+                proof: Default::default(),
             },
         ))
     }
@@ -971,7 +971,7 @@ mod tests {
                 nonce_data_availability_mode: DataAvailabilityMode::L2,
                 fee_data_availability_mode: DataAvailabilityMode::L2,
                 proof_facts: vec![],
-                proof: vec![],
+                proof: Default::default(),
             },
         ))
     }
@@ -1279,7 +1279,7 @@ mod tests {
                 fee_data_availability_mode: DataAvailabilityMode::L1,
                 sender_address: contract_address!("0xdeadbeef"),
                 proof_facts: vec![],
-                proof: vec![],
+                proof: Default::default(),
             },
         );
 
@@ -1319,7 +1319,7 @@ mod tests {
                 sender_address: contract_address!("0xdeadbeef"),
                 calldata: vec![],
                 proof_facts: vec![],
-                proof: vec![],
+                proof: Default::default(),
             },
         );
 

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -1038,7 +1038,7 @@ pub(crate) mod tests {
                             call_param!("0"),
                         ],
                         proof_facts: vec![],
-                        proof: vec![],
+                        proof: Default::default(),
                     },
                 ))
             }
@@ -1083,7 +1083,7 @@ pub(crate) mod tests {
                             call_param!("0"),
                         ],
                         proof_facts: vec![],
-                        proof: vec![],
+                        proof: Default::default(),
                     },
                 ))
             }

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -11,7 +11,7 @@ pub mod request {
     use anyhow::Context;
     use pathfinder_common::prelude::*;
     use pathfinder_common::transaction::{DataAvailabilityMode, ResourceBounds};
-    use pathfinder_common::{ProofElem, ProofFactElem, TipHex};
+    use pathfinder_common::{Proof, ProofFactElem, TipHex};
     use serde::de::Error;
     use serde::Deserialize;
     use serde_with::serde_as;
@@ -1038,9 +1038,7 @@ pub mod request {
                         })?
                         .unwrap_or_default(),
                     proof: value
-                        .deserialize_optional_array("proof", |value| {
-                            value.deserialize().map(ProofElem)
-                        })?
+                        .deserialize_optional_serde::<Proof>("proof")?
                         .unwrap_or_default(),
                 })),
                 _ => Err(serde_json::Error::custom("unknown transaction version")),
@@ -1180,7 +1178,7 @@ pub mod request {
         pub calldata: Vec<CallParam>,
 
         pub proof_facts: Vec<ProofFactElem>,
-        pub proof: Vec<ProofElem>,
+        pub proof: Proof,
     }
 
     impl crate::dto::SerializeForVersion for BroadcastedInvokeTransactionV3 {
@@ -1251,9 +1249,7 @@ pub mod request {
                         })?
                         .unwrap_or_default(),
                     proof: value
-                        .deserialize_optional_array("proof", |value| {
-                            value.deserialize().map(ProofElem)
-                        })?
+                        .deserialize_optional_serde::<Proof>("proof")?
                         .unwrap_or_default(),
                 })
             })
@@ -1607,7 +1603,7 @@ pub mod request {
                             sender_address: contract_address!("0xaaa"),
                             calldata: vec![call_param!("0xff")],
                             proof_facts: vec![proof_fact_elem!("0xabc"), proof_fact_elem!("0xdef")],
-                            proof: vec![ProofElem(11), ProofElem(22)],
+                            proof: Proof(vec![11, 22]),
                         },
                     )),
                     BroadcastedTransaction::DeployAccount(BroadcastedDeployAccountTransaction::V3(


### PR DESCRIPTION
Fix proof field serialization: serialize as base64 string instead of JSON array of numbers.

  ---
  The Starknet sequencer expects the invoke v3 proof field as a base64-encoded string of big-endian packed u32 values (e.g. "AAABAAADAA=="), but Pathfinder was
  serializing it as a JSON array (e.g. [1, 2, 3]). This caused proof data to be corrupted when forwarded to the sequencer, resulting in transaction rejection.

  This PR replaces ProofElem(pub u32) with a new Proof(pub Vec<u32>) type that has custom serde using base64 encoding, matching the wire format defined in the
  sequencer's starknet_api crate (main-v0.14.2 branch, crates/starknet_api/src/transaction/fields.rs). We define our own type rather than pulling in starknet_api
  directly, since that crate is only used in executor/compiler and would be a heavy dependency for common/gateway-types/rpc.

  ---
  Added base64 (workspace dependency, already defined as 0.22.1) to pathfinder-common. It was already used by the rpc crate and is needed for the custom serde
  implementation on the Proof type.
  

Closes #3244 