### PR TITLE
chore(ci): pin cargo-sort version to 2.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-sort
-          version: "^2.0.1"
+          version: "~2.0.2"
       - run: |
           cargo sort --check --workspace
 


### PR DESCRIPTION
'^2.0.1' allows cargo-sort 2.1.0, which unfortunately has a breaking change that causes our CI to fail. Pinning to 2.0.2 should fix the issue until we can update our Cargo.toml files to be compatible with cargo-sort 2.1.0.
