### PR TITLE
ci: lock cargo-sort at 2.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-sort
-          version: "^2.0.1"
+          version: "=2.0.1"
       - run: |
           cargo sort --check --workspace
 


### PR DESCRIPTION
This should fix the issue with ci using cargo sort v.2.1.0.
