### PR TITLE
refactor(ethereum): faster reconnections with state preservation

### DIFF
--- a/crates/ethereum/src/lib.rs
+++ b/crates/ethereum/src/lib.rs
@@ -91,6 +91,11 @@ fn compute_blob_fee(excess_blob_gas: Option<u64>) -> u128 {
         .unwrap_or(alloy::eips::eip4844::BLOB_TX_MIN_BLOB_GASPRICE)
 }
 
+/// Delay between reconnection attempts to the Ethereum WebSocket provider.
+/// Alloy already retries internally (~30s with exponential backoff) before
+/// reporting a failure, so a short fixed delay here is sufficient.
+const RECONNECT_DELAY: Duration = Duration::from_secs(5);
+
 /// Ethereum client
 #[derive(Clone)]
 pub struct EthereumClient {
@@ -226,39 +231,62 @@ impl EthereumClient {
     ///
     /// This uses a dedicated WebSocket connection for the subscription stream.
     /// Re-subscribes automatically if the stream ends due to errors.
+    /// If the underlying provider dies, creates a fresh connection and
+    /// re-subscribes.
     /// Returns `Ok(())` if the receiver is dropped (clean shutdown).
-    /// Returns `Err` if the WebSocket connection cannot be re-established.
     pub async fn subscribe_block_headers(
         &self,
         tx: tokio::sync::mpsc::Sender<L1GasPriceData>,
     ) -> anyhow::Result<()> {
-        // Create a dedicated WebSocket connection for subscriptions
-        let ws = WsConnect::new(self.url.clone());
-        let provider = ProviderBuilder::new().connect_ws(ws).await?;
-
-        // Subscribe to new block headers
-        let mut block_stream = provider.subscribe_blocks().await?;
-
         loop {
-            match block_stream.recv().await {
-                Ok(header) => {
-                    let data = L1GasPriceData {
-                        block_number: L1BlockNumber::new_or_panic(header.number),
-                        block_hash: L1BlockHash::from(header.hash.0),
-                        parent_hash: L1BlockHash::from(header.parent_hash.0),
-                        timestamp: header.timestamp,
-                        base_fee_per_gas: header.base_fee_per_gas.unwrap_or(0) as u128,
-                        blob_fee: compute_blob_fee(header.excess_blob_gas),
-                    };
-                    if tx.send(data).await.is_err() {
-                        return Ok(());
+            // Create a dedicated WebSocket connection for subscriptions
+            let ws = WsConnect::new(self.url.clone());
+            let provider = match ProviderBuilder::new().connect_ws(ws).await {
+                Ok(provider) => provider,
+                Err(e) => {
+                    tracing::warn!(error=%e, "Failed to connect to Ethereum node for block header subscription, retrying in {RECONNECT_DELAY:?}");
+                    tokio::time::sleep(RECONNECT_DELAY).await;
+                    continue;
+                }
+            };
+
+            // Subscribe to new block headers
+            let mut block_stream = match provider.subscribe_blocks().await {
+                Ok(sub) => sub,
+                Err(e) => {
+                    tracing::warn!(error=%e, "Failed to subscribe to block headers, retrying in {RECONNECT_DELAY:?}");
+                    tokio::time::sleep(RECONNECT_DELAY).await;
+                    continue;
+                }
+            };
+
+            let error: anyhow::Error = loop {
+                match block_stream.recv().await {
+                    Ok(header) => {
+                        let data = L1GasPriceData {
+                            block_number: L1BlockNumber::new_or_panic(header.number),
+                            block_hash: L1BlockHash::from(header.hash.0),
+                            parent_hash: L1BlockHash::from(header.parent_hash.0),
+                            timestamp: header.timestamp,
+                            base_fee_per_gas: header.base_fee_per_gas.unwrap_or(0) as u128,
+                            blob_fee: compute_blob_fee(header.excess_blob_gas),
+                        };
+                        if tx.send(data).await.is_err() {
+                            return Ok(());
+                        }
+                    }
+                    Err(e) => {
+                        tracing::debug!(error=%e, "Block subscription ended, re-subscribing");
+                        match provider.subscribe_blocks().await {
+                            Ok(sub) => block_stream = sub,
+                            Err(e) => break e.into(),
+                        }
                     }
                 }
-                Err(e) => {
-                    tracing::debug!(error = %e, "Block subscription ended, re-subscribing");
-                    block_stream = provider.subscribe_blocks().await?;
-                }
-            }
+            };
+
+            tracing::warn!(error=%error, "Block header subscription connection lost, reconnecting in {RECONNECT_DELAY:?}");
+            tokio::time::sleep(RECONNECT_DELAY).await;
         }
     }
 }
@@ -277,118 +305,134 @@ impl EthereumClient {
         F: Fn(EthereumStateUpdate) -> Fut + Send + 'static,
         Fut: Future<Output = ()> + Send + 'static,
     {
-        // This method maintains its own dedicated WebSocket connection for
-        // subscriptions. We keep it separate from the shared query connection
-        // because:
-        // 1. Subscriptions are long-lived and stream events continuously
-        // 2. Isolates subscription failures from query failures
-        // 3. Simplifies reconnection logic (no need to re-establish subscriptions)
-        let ws = WsConnect::new(self.url.clone());
-        let provider = ProviderBuilder::new().connect_ws(ws).await?;
-
         // Fetch the current Starknet state from Ethereum
         let state_update = self.get_starknet_state(address).await?;
         let _ = callback(state_update).await;
 
-        // Create the StarknetCoreContract instance
         let core_address = Address::new((*address).into());
-        let core_contract = StarknetCoreContract::new(core_address, provider.clone());
 
-        // Listen for state update events
-        let filter = core_contract.LogStateUpdate_filter().filter;
-        let mut state_updates = provider.subscribe_logs(&filter).await?;
+        loop {
+            let ws = WsConnect::new(self.url.clone());
+            let provider = match ProviderBuilder::new().connect_ws(ws).await {
+                Ok(provider) => provider,
+                Err(e) => {
+                    tracing::warn!(error=%e, "Failed to connect to Ethereum node, retrying in {RECONNECT_DELAY:?}");
+                    tokio::time::sleep(RECONNECT_DELAY).await;
+                    continue;
+                }
+            };
 
-        // Poll regularly for finalized block number
-        let provider_clone = provider.clone();
-        let (finalized_block_tx, mut finalized_block_rx) =
-            tokio::sync::mpsc::channel::<L1BlockNumber>(1);
+            let core_contract = StarknetCoreContract::new(core_address, provider.clone());
 
-        util::task::spawn(async move {
-            let mut interval = tokio::time::interval(poll_interval);
-            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
-            loop {
-                interval.tick().await;
+            // Listen for state update events
+            let filter = core_contract.LogStateUpdate_filter().filter;
+            let mut state_updates = match provider.subscribe_logs(&filter).await {
+                Ok(sub) => sub,
+                Err(e) => {
+                    tracing::warn!(error=%e, "Failed to subscribe to state update events, retrying in {RECONNECT_DELAY:?}");
+                    tokio::time::sleep(RECONNECT_DELAY).await;
+                    continue;
+                }
+            };
 
-                match provider_clone
-                    .get_block_by_number(BlockNumberOrTag::Finalized)
-                    .await
-                {
-                    Ok(Some(finalized_block)) => {
-                        let block_number =
-                            L1BlockNumber::new_or_panic(finalized_block.header.number);
-                        if finalized_block_tx.send(block_number).await.is_err() {
-                            tracing::debug!("L1 finalized block channel closed");
-                            return;
+            // Poll regularly for finalized block number
+            let provider_clone = provider.clone();
+            let (finalized_block_tx, mut finalized_block_rx) =
+                tokio::sync::mpsc::channel::<L1BlockNumber>(1);
+
+            util::task::spawn(async move {
+                let mut interval = tokio::time::interval(poll_interval);
+                // Don't fire missed ticks if a poll takes longer than the interval. We want to
+                // avoid rapid "catch up" bursts if for whatever reason there's a slow down.
+                interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+                loop {
+                    interval.tick().await;
+
+                    match provider_clone
+                        .get_block_by_number(BlockNumberOrTag::Finalized)
+                        .await
+                    {
+                        Ok(Some(finalized_block)) => {
+                            let block_number =
+                                L1BlockNumber::new_or_panic(finalized_block.header.number);
+                            if finalized_block_tx.send(block_number).await.is_err() {
+                                tracing::debug!("L1 finalized block channel closed");
+                                return;
+                            }
+                        }
+                        Ok(None) => {
+                            tracing::error!("No L1 finalized block found");
+                        }
+                        Err(e) => {
+                            tracing::warn!(error=%e, "Error fetching L1 finalized block, will retry");
                         }
                     }
-                    Ok(None) => {
-                        tracing::error!("No L1 finalized block found");
-                    }
-                    Err(e) => {
-                        tracing::error!(error=%e, "Error fetching L1 finalized block");
-                        return;
-                    }
                 }
-            }
-        });
+            });
 
-        // Process incoming events
-        loop {
-            select! {
-                maybe_state_update = state_updates.recv() => {
-                    match maybe_state_update {
-                        Ok(state_update) => {
-                            tracing::trace!(?state_update, "Processing LogStateUpdate event");
-                            // one would expect this to always be true, but in fact it isn't...
-                            if filter.address.matches(&state_update.inner.address) {
-                                // Decode the state update
-                                let eth_block = L1BlockNumber::new_or_panic(
-                                    state_update.block_number.expect("missing eth block number")
-                                );
-                                let state_update: Log<StarknetCoreContract::LogStateUpdate> = state_update.log_decode()?;
-                                let block_number = get_block_number(state_update.inner.blockNumber);
-                                // Add or remove to/from pending state updates accordingly
-                                if !state_update.removed {
-                                    let state_update = EthereumStateUpdate {
-                                        block_number,
-                                        block_hash: get_block_hash(state_update.inner.blockHash),
-                                        state_root: get_state_root(state_update.inner.globalRoot),
-                                    };
-                                    self.pending_state_updates.insert(eth_block, state_update);
-                                } else {
-                                    self.pending_state_updates.remove(&eth_block);
+            // Process incoming events until the connection is lost
+            let error: anyhow::Error = loop {
+                select! {
+                    maybe_state_update = state_updates.recv() => {
+                        match maybe_state_update {
+                            Ok(state_update) => {
+                                tracing::trace!(?state_update, "Processing LogStateUpdate event");
+                                // One would expect this to always be true, but in fact it isn't...
+                                if filter.address.matches(&state_update.inner.address) {
+                                    // Decode the state update
+                                    let eth_block = L1BlockNumber::new_or_panic(
+                                        state_update.block_number.expect("missing eth block number")
+                                    );
+                                    let state_update: Log<StarknetCoreContract::LogStateUpdate> = state_update.log_decode()?;
+                                    let block_number = get_block_number(state_update.inner.blockNumber);
+                                    // Add or remove to/from pending state updates accordingly
+                                    if !state_update.removed {
+                                        let state_update = EthereumStateUpdate {
+                                            block_number,
+                                            block_hash: get_block_hash(state_update.inner.blockHash),
+                                            state_root: get_state_root(state_update.inner.globalRoot),
+                                        };
+                                        self.pending_state_updates.insert(eth_block, state_update);
+                                    } else {
+                                        self.pending_state_updates.remove(&eth_block);
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                tracing::debug!(error=%e, "LogStateUpdate stream ended, re-subscribing");
+                                match provider.subscribe_logs(&filter).await {
+                                    Ok(sub) => state_updates = sub,
+                                    Err(e) => break e.into(),
                                 }
                             }
                         }
-                        Err(e) => {
-                            tracing::debug!(error=%e, "LogStateUpdate stream ended, re-subscribing");
-                            state_updates = provider.subscribe_logs(&filter).await?;
-                        }
                     }
-                }
-                maybe_block_number = finalized_block_rx.recv() => {
-                    match maybe_block_number {
-                        Some(block_number) => {
-                            tracing::trace!(%block_number, "Processing L1 finalized block");
-                            // Collect all state updates up to (and including) the finalized block
-                            let pending_state_updates: Vec<EthereumStateUpdate> = self.pending_state_updates
-                                .range(..=block_number)
-                                .map(|(_, &update)| update)
-                                .collect();
-                            // Remove emitted updates from the map
-                            self.pending_state_updates.retain(|&k, _| k > block_number);
-                            // Emit the state updates
-                            for state_update in pending_state_updates {
-                                let _ = callback(state_update).await;
+                    maybe_block_number = finalized_block_rx.recv() => {
+                        match maybe_block_number {
+                            Some(block_number) => {
+                                tracing::trace!(%block_number, "Processing L1 finalized block");
+                                // Collect all state updates up to (and including) the finalized block
+                                let pending_state_updates: Vec<EthereumStateUpdate> = self.pending_state_updates
+                                    .range(..=block_number)
+                                    .map(|(_, &update)| update)
+                                    .collect();
+                                // Remove emitted updates from the map
+                                self.pending_state_updates.retain(|&k, _| k > block_number);
+                                // Emit the state updates
+                                for state_update in pending_state_updates {
+                                    let _ = callback(state_update).await;
+                                }
+                            }
+                            None => {
+                                break anyhow::anyhow!("L1 finalized block channel closed");
                             }
                         }
-                        None => {
-                            tracing::debug!("L1 finalized block channel closed");
-                            anyhow::bail!("L1 finalized block channel closed");
-                        }
                     }
                 }
-            }
+            };
+
+            tracing::warn!(error=%error, "L1 sync connection lost, reconnecting in {RECONNECT_DELAY:?}");
+            tokio::time::sleep(RECONNECT_DELAY).await;
         }
     }
 


### PR DESCRIPTION
I noticed this after invesetigating the recent issue we've been dealing with in the L1 Sync side.

While this doesn't solve the issue, I think it's worth considering.

**Basically, before this change, the failure path was:**

1. ws connection dies
2. `alloy` retries internally: 30s until it gives up
3. `sync_and_listen` propagates the error (via `?`) up to the caller in `sync.rs`
4. `sync.rs` sleeps 60s (`RESET_DELAY_ON_FAILURE`) before restarting from scratch (reconnect, re-fetch state, re-subscribe...)

Total downtime: ~90s

**After the change:**

1. ws connection dies
2. `alloy` retries internally: 30s until it gives up
3. re-subscribe attempt on the dead provider fails, we break out of the new inner loop
4. outer loop logs a warning, sleeps for 5s (`RECONNECT_DELAY`), and creates a fresh WS connection. re-subscribes without leaving `sync_and_listen`

Total downtime: ~35s


Also, given that we never leave `sync_and_listen` on provider errors, we now get state preservation for free. Previously any state updates that had been received but not yet finalized were lost, whereas now `pending_state_updates` survives reconnection :)

I think it's a win, even though it's not really solving the problem.