### PR TITLE
fix(config): description for `--log-output-json` is wrong

### DIFF
--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -249,7 +249,7 @@ Examples:
 
     #[arg(
         long = "log-output-json",
-        long_help = "This flag controls when to use colors in the output logs.",
+        long_help = "Enable JSON structured logging output.",
         default_value = "false",
         env = "PATHFINDER_LOG_OUTPUT_JSON",
         value_name = "BOOL"


### PR DESCRIPTION
Self-explanatory.