### PR TITLE
chore: update integration tests running instructions

### DIFF
--- a/crates/pathfinder/tests/consensus.rs
+++ b/crates/pathfinder/tests/consensus.rs
@@ -1,6 +1,7 @@
-//! Build pathfinder in debug:
+//! Build pathfinder and simulated feeder gateway in debug:
 //! ```
 //! cargo build -p pathfinder --bin pathfinder -F p2p -F consensus-integration-tests
+//! cargo build -p feeder-gateway -F small_aggregate_filters --bin feeder-gateway
 //! ```
 //!
 //! Run the test:


### PR DESCRIPTION
Specifically, include the compilation of the simulated feeder gateway (which is non-obvious, as it must use a non-default feature).