### PR TITLE
refactor: use latest block  number when fetching classes

### DIFF
--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -66,16 +66,18 @@ pub trait GatewayApi: Sync {
         unimplemented!()
     }
 
-    async fn pending_class_by_hash(
+    async fn class_by_hash(
         &self,
         class_hash: ClassHash,
+        block: BlockId,
     ) -> Result<bytes::Bytes, SequencerError> {
         unimplemented!();
     }
 
-    async fn pending_casm_by_hash(
+    async fn casm_by_hash(
         &self,
         class_hash: ClassHash,
+        block: BlockId,
     ) -> Result<bytes::Bytes, SequencerError> {
         unimplemented!();
     }
@@ -167,18 +169,20 @@ impl<T: GatewayApi + Sync + Send> GatewayApi for std::sync::Arc<T> {
         self.as_ref().block_header(block).await
     }
 
-    async fn pending_class_by_hash(
+    async fn class_by_hash(
         &self,
         class_hash: ClassHash,
+        block: BlockId,
     ) -> Result<bytes::Bytes, SequencerError> {
-        self.as_ref().pending_class_by_hash(class_hash).await
+        self.as_ref().class_by_hash(class_hash, block).await
     }
 
-    async fn pending_casm_by_hash(
+    async fn casm_by_hash(
         &self,
         class_hash: ClassHash,
+        block: BlockId,
     ) -> Result<bytes::Bytes, SequencerError> {
-        self.as_ref().pending_casm_by_hash(class_hash).await
+        self.as_ref().casm_by_hash(class_hash, block).await
     }
 
     async fn transaction_status(
@@ -421,14 +425,15 @@ impl GatewayApi for Client {
 
     /// Gets class for a particular class hash.
     #[tracing::instrument(skip(self))]
-    async fn pending_class_by_hash(
+    async fn class_by_hash(
         &self,
         class_hash: ClassHash,
+        block: BlockId,
     ) -> Result<bytes::Bytes, SequencerError> {
         self.feeder_gateway_request()
             .get_class_by_hash()
             .class_hash(class_hash)
-            .block(BlockId::Pending)
+            .block(block)
             .retry(self.retry)
             .get_as_bytes()
             .await
@@ -436,14 +441,15 @@ impl GatewayApi for Client {
 
     /// Gets CASM for a particular class hash.
     #[tracing::instrument(skip(self))]
-    async fn pending_casm_by_hash(
+    async fn casm_by_hash(
         &self,
         class_hash: ClassHash,
+        block: BlockId,
     ) -> Result<bytes::Bytes, SequencerError> {
         self.feeder_gateway_request()
             .get_compiled_class_by_class_hash()
             .class_hash(class_hash)
-            .block(BlockId::Pending)
+            .block(block)
             .retry(self.retry)
             .get_as_bytes()
             .await

--- a/crates/pathfinder/src/state/sync/class.rs
+++ b/crates/pathfinder/src/state/sync/class.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use pathfinder_common::{CasmHash, ClassHash, SierraHash};
-use starknet_gateway_client::GatewayApi;
+use starknet_gateway_client::{BlockId, GatewayApi};
 
 pub enum DownloadedClass {
     Cairo {
@@ -23,7 +23,7 @@ pub async fn download_class<SequencerClient: GatewayApi>(
     use pathfinder_class_hash::compute_class_hash;
 
     let definition = sequencer
-        .pending_class_by_hash(class_hash)
+        .class_by_hash(class_hash, BlockId::Latest)
         .await
         .with_context(|| format!("Downloading class {}", class_hash.0))?
         .to_vec();
@@ -66,7 +66,7 @@ pub async fn download_class<SequencerClient: GatewayApi>(
                 (
                     definition,
                     sequencer
-                        .pending_casm_by_hash(class_hash)
+                        .casm_by_hash(class_hash, BlockId::Latest)
                         .await
                         .with_context(|| format!("Downloading CASM {}", class_hash.0))?
                         .to_vec(),
@@ -88,7 +88,7 @@ pub async fn download_class<SequencerClient: GatewayApi>(
                     Err(error) => {
                         tracing::info!(class_hash=%hash, ?error, "CASM compilation failed, falling back to fetching from gateway");
                         sequencer
-                            .pending_casm_by_hash(class_hash)
+                            .casm_by_hash(class_hash, BlockId::Latest)
                             .await
                             .with_context(|| format!("Downloading CASM {}", class_hash.0))?
                             .to_vec()

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -2103,11 +2103,11 @@ mod tests {
             class_hash: ClassHash,
             returned_result: Result<bytes::Bytes, SequencerError>,
         ) {
-            mock.expect_pending_class_by_hash()
-                .withf(move |x| x == &class_hash)
+            mock.expect_class_by_hash()
+                .withf(move |x, _| x == &class_hash)
                 .times(1)
                 .in_sequence(seq)
-                .return_once(|_| returned_result);
+                .return_once(|_, _| returned_result);
         }
 
         /// Convenience wrapper
@@ -2116,10 +2116,10 @@ mod tests {
             class_hash: ClassHash,
             returned_result: Result<bytes::Bytes, SequencerError>,
         ) {
-            mock.expect_pending_class_by_hash()
-                .withf(move |x| x == &class_hash)
+            mock.expect_class_by_hash()
+                .withf(move |x, _| x == &class_hash)
                 .times(1)
-                .return_once(|_| returned_result);
+                .return_once(|_, _| returned_result);
         }
 
         fn expect_class_by_hash_no_sequence_at_most_once(
@@ -2127,10 +2127,10 @@ mod tests {
             class_hash: ClassHash,
             returned_result: Result<bytes::Bytes, SequencerError>,
         ) {
-            mock.expect_pending_class_by_hash()
-                .withf(move |x| x == &class_hash)
+            mock.expect_class_by_hash()
+                .withf(move |x, _| x == &class_hash)
                 .times(..=1)
-                .return_once(|_| returned_result);
+                .return_once(|_, _| returned_result);
         }
 
         /// Convenience wrapper

--- a/crates/pathfinder/src/sync.rs
+++ b/crates/pathfinder/src/sync.rs
@@ -1061,7 +1061,11 @@ mod tests {
 
     #[async_trait::async_trait]
     impl GatewayApi for FakeFgw {
-        async fn pending_casm_by_hash(&self, _: ClassHash) -> Result<bytes::Bytes, SequencerError> {
+        async fn casm_by_hash(
+            &self,
+            _: ClassHash,
+            _: BlockId,
+        ) -> Result<bytes::Bytes, SequencerError> {
             Ok(bytes::Bytes::from_static(
                 starknet_gateway_test_fixtures::class_definitions::CAIRO_1_1_0_BALANCE_CASM_JSON,
             ))

--- a/crates/pathfinder/src/sync/checkpoint.rs
+++ b/crates/pathfinder/src/sync/checkpoint.rs
@@ -32,7 +32,7 @@ use pathfinder_ethereum::EthereumStateUpdate;
 use pathfinder_storage::Storage;
 use primitive_types::H160;
 use serde_json::de;
-use starknet_gateway_client::{Client, GatewayApi};
+use starknet_gateway_client::{BlockId, Client, GatewayApi};
 use tokio::sync::Mutex;
 use tracing::Instrument;
 
@@ -1386,9 +1386,10 @@ mod tests {
 
         #[async_trait::async_trait]
         impl GatewayApi for FakeFgw {
-            async fn pending_casm_by_hash(
+            async fn casm_by_hash(
                 &self,
                 _: ClassHash,
+                _: BlockId,
             ) -> Result<bytes::Bytes, SequencerError> {
                 Ok(bytes::Bytes::from_static(CASM2))
             }

--- a/crates/pathfinder/src/sync/class_definitions.rs
+++ b/crates/pathfinder/src/sync/class_definitions.rs
@@ -16,7 +16,7 @@ use pathfinder_common::{BlockNumber, CasmHash, ClassHash, SierraHash};
 use pathfinder_storage::{Storage, Transaction};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde_json::de;
-use starknet_gateway_client::GatewayApi;
+use starknet_gateway_client::{BlockId, GatewayApi};
 use starknet_gateway_types::error::SequencerError;
 use starknet_gateway_types::reply::call;
 use tokio::sync::mpsc::{self, Receiver};
@@ -487,7 +487,7 @@ fn compile_or_fetch_impl<SequencerClient: GatewayApi + Clone + Send + 'static>(
                 // that the class is declared and exists so if the gateway responds with an
                 // error we should restart the sync and retry later.
                 Err(_) => tokio_handle
-                    .block_on(fgw.pending_casm_by_hash(hash))
+                    .block_on(fgw.casm_by_hash(hash, BlockId::Latest))
                     .map_err(|error| {
                         tracing::debug!(%block_number, class_hash=%hash, %error, "Fetching casm from feeder gateway failed");
                         SyncError::FetchingCasmFailed


### PR DESCRIPTION


Replace `pending` block identifier with `latest` when fetching classes and CASM from the gateway during sync.

---------------------------
## Motivation

   The gateway API methods `pending_class_by_hash` and `pending_casm_by_hash` were hardcoded to use
   `BlockId::Pending`. This is unnecessarily specific — during sync we're fetching already-confirmed classes,
   so `BlockId::Latest` is the correct identifier. This also generalizes the API by renaming to `class_by_hash`
    / `casm_by_hash` and accepting a `BlockId` parameter, making the methods reusable for any block identifier.

  ## Changes

   - Renamed `pending_class_by_hash` → `class_by_hash` and `pending_casm_by_hash` → `casm_by_hash` in the
   `GatewayApi` trait
   - Added a `block: BlockId` parameter to both methods instead of hardcoding `BlockId::Pending`
   - Updated all call sites to pass `BlockId::Latest`
   - Updated tests to match the new signatures
   - 
---------------------------