### PR TITLE
Change Proof inner representation from Vec<u32> to Vec<u8>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- The `proof` field in broadcasted invoke v3 transactions is now a base64-encoded byte blob (`Vec<u8>`) instead of base64-encoded packed `u32` values (`Vec<u32>`). This reflects the upstream change to use compressed proofs.
+
 ## [0.22.0] - 2026-03-19
 
 ### Fixed

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -697,10 +697,9 @@ pub fn calculate_class_commitment_leaf_hash(
     )
 }
 
-/// A SNOS stwo proof, serialized as a base64-encoded string of big-endian
-/// packed `u32` values.
+/// A SNOS stwo proof, serialized as a base64-encoded byte string.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
-pub struct Proof(pub Vec<u32>);
+pub struct Proof(pub Vec<u8>);
 
 impl Proof {
     pub fn is_empty(&self) -> bool {
@@ -712,8 +711,7 @@ impl serde::Serialize for Proof {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use base64::Engine;
 
-        let bytes: Vec<u8> = self.0.iter().flat_map(|v| v.to_be_bytes()).collect();
-        let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+        let encoded = base64::engine::general_purpose::STANDARD.encode(&self.0);
         serializer.serialize_str(&encoded)
     }
 }
@@ -729,17 +727,7 @@ impl<'de> serde::Deserialize<'de> for Proof {
         let bytes = base64::engine::general_purpose::STANDARD
             .decode(&s)
             .map_err(serde::de::Error::custom)?;
-        if bytes.len() % 4 != 0 {
-            return Err(serde::de::Error::custom(format!(
-                "proof base64 decoded length {} is not a multiple of 4",
-                bytes.len()
-            )));
-        }
-        let values = bytes
-            .chunks_exact(4)
-            .map(|chunk| u32::from_be_bytes(chunk.try_into().unwrap()))
-            .collect();
-        Ok(Proof(values))
+        Ok(Proof(bytes))
     }
 }
 
@@ -811,7 +799,7 @@ mod tests {
 
         #[test]
         fn round_trip() {
-            let proof = Proof(vec![0, 123, 456]);
+            let proof = Proof(vec![0, 0, 0, 0, 0, 0, 0, 123, 0, 0, 1, 200]);
             let json = serde_json::to_string(&proof).unwrap();
             assert_eq!(json, r#""AAAAAAAAAHsAAAHI""#);
             let deserialized: Proof = serde_json::from_str(&json).unwrap();
@@ -827,13 +815,6 @@ mod tests {
         #[test]
         fn invalid_base64_returns_error() {
             let result = serde_json::from_str::<Proof>(r#""not-valid-base64!@#""#);
-            assert!(result.is_err());
-        }
-
-        #[test]
-        fn non_multiple_of_4_length_returns_error() {
-            // 3 bytes is not a multiple of 4
-            let result = serde_json::from_str::<Proof>(r#""AAAA""#); // decodes to 3 bytes
             assert!(result.is_err());
         }
 

--- a/crates/p2p_proto/proto/transaction.proto
+++ b/crates/p2p_proto/proto/transaction.proto
@@ -68,7 +68,7 @@ message InvokeV3 {
 // Used in consensus and mempool contexts where proof is included.
 message InvokeV3WithProof {
     InvokeV3 invoke = 1;
-    repeated uint32 proof = 2;
+    bytes proof = 2;
 }
 
 // see https://external.integration.starknet.io/feeder_gateway/get_transaction?transactionHash=0x29fd7881f14380842414cdfdd8d6c0b1f2174f8916edcfeb1ede1eb26ac3ef0

--- a/crates/p2p_proto/src/transaction.rs
+++ b/crates/p2p_proto/src/transaction.rs
@@ -87,7 +87,7 @@ pub struct InvokeV3 {
 #[protobuf(name = "crate::proto::transaction::InvokeV3WithProof")]
 pub struct InvokeV3WithProof {
     pub invoke: InvokeV3,
-    pub proof: Vec<u32>,
+    pub proof: Vec<u8>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ToProtobuf, TryFromProtobuf, Dummy)]

--- a/crates/rpc/fixtures/0.10.0/broadcasted_transactions.json
+++ b/crates/rpc/fixtures/0.10.0/broadcasted_transactions.json
@@ -186,7 +186,7 @@
             "0xabc",
             "0xdef"
         ],
-        "proof": "AAAACwAAABY="
+        "proof": "CxY="
     },
     {
         "type": "DEPLOY_ACCOUNT",

--- a/crates/rpc/src/dto/primitives.rs
+++ b/crates/rpc/src/dto/primitives.rs
@@ -831,8 +831,7 @@ mod pathfinder_common_types {
         fn serialize(&self, serializer: Serializer) -> Result<crate::dto::Ok, crate::dto::Error> {
             use base64::Engine;
 
-            let bytes: Vec<u8> = self.0.iter().flat_map(|v| v.to_be_bytes()).collect();
-            let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+            let encoded = base64::engine::general_purpose::STANDARD.encode(&self.0);
             serializer.serialize_str(&encoded)
         }
     }


### PR DESCRIPTION
## Summary

  Changes the inner representation of the `Proof` type from `Vec<u32>` to `Vec<u8>` across RPC,
  gateway, and P2P layers.

  ## Rationale

  The proof is now compressed before being attached to the transaction, making it an opaque byte blob
  rather than a sequence of `u32` values. This was a last-minute change on the gateway side.

  Spec references:
  - RPC spec (WIP): https://github.com/starkware-libs/starknet-specs/pull/377
  - P2P spec:
  https://github.com/starknet-io/starknet-p2p-specs/commit/411d99256072ff6833ec4a79011daef19ee5304e

  ## Changes

  - **`crates/common/src/lib.rs`** — `Proof(Vec<u32>)` → `Proof(Vec<u8>)`; simplified serde to direct
  base64 encode/decode (no more u32 packing, no multiple-of-4 validation)
  - **`crates/rpc/src/dto/primitives.rs`** — removed intermediate `u32 → big-endian bytes` conversion
  step in DTO serialization
  - **`crates/p2p_proto/proto/transaction.proto`** — `repeated uint32 proof` → `bytes proof` in
  `InvokeV3WithProof`
  - **`crates/p2p_proto/src/transaction.rs`** — `proof: Vec<u32>` → `proof: Vec<u8>`
  - **`crates/rpc/fixtures/0.10.0/broadcasted_transactions.json`** — updated expected base64 value

  ## Notes

  - **RPC wire format** is still a base64 string — no change for clients sending raw byte payloads
  - **P2P wire format** is a breaking change (`repeated uint32` → `bytes`)
  - The `proof` field remains transient: accepted from clients, forwarded to the sequencer, propagated
  via mempool/consensus P2P, but never stored in the DB or included in the transaction hash (only
  `proof_facts` are)