### PR TITLE
chore(rpc): update Starknet RPC specs to 0.10.2

### DIFF
--- a/crates/rpc/src/v10.rs
+++ b/crates/rpc/src/v10.rs
@@ -43,7 +43,7 @@ pub fn register_routes() -> RpcRouterBuilder {
         .register("starknet_subscribeNewTransactions",            SubscribeNewTransactions)
         .register("starknet_subscribeEvents",                     SubscribeEvents)
         .register("starknet_subscribeTransactionStatus",          SubscribeTransactionStatus)
-        .register("starknet_specVersion",                         || "0.10.1")
+        .register("starknet_specVersion",                         || "0.10.2")
         .register("starknet_syncing",                             crate::method::syncing)
         .register("starknet_traceBlockTransactions",              crate::method::trace_block_transactions)
         .register("starknet_traceTransaction",                    crate::method::trace_transaction)

--- a/specs/rpc/v10/starknet_api_openrpc.json
+++ b/specs/rpc/v10/starknet_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.1",
+    "version": "0.10.2",
     "title": "StarkNet Node API",
     "license": {}
   },
@@ -2391,7 +2391,7 @@
             "properties": {
               "proof": {
                 "title": "Proof",
-                "description": "Optional proof for the transaction, encoded as a base64 string of big-endian packed u32 values",
+                "description": "Optional proof for the transaction, as a base64 string-encoded byte array",
                 "type": "string",
                 "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$"
               }

--- a/specs/rpc/v10/starknet_executables.json
+++ b/specs/rpc/v10/starknet_executables.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0",
   "info": {
-    "version": "0.10.1",
+    "version": "0.10.2",
     "title": "API for getting Starknet executables from nodes that store compiled artifacts",
     "license": {}
   },

--- a/specs/rpc/v10/starknet_metadata.json
+++ b/specs/rpc/v10/starknet_metadata.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0",
   "info": {
-    "version": "0.10.1",
+    "version": "0.10.2",
     "title": "Starknet ABI specs"
   },
   "methods": [],

--- a/specs/rpc/v10/starknet_trace_api_openrpc.json
+++ b/specs/rpc/v10/starknet_trace_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.1",
+    "version": "0.10.2",
     "title": "StarkNet Trace API",
     "license": {}
   },

--- a/specs/rpc/v10/starknet_write_api.json
+++ b/specs/rpc/v10/starknet_write_api.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.1",
+    "version": "0.10.2",
     "title": "StarkNet Node Write API",
     "license": {}
   },

--- a/specs/rpc/v10/starknet_ws_api.json
+++ b/specs/rpc/v10/starknet_ws_api.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.3.2",
   "info": {
-    "version": "0.10.1",
+    "version": "0.10.2",
     "title": "StarkNet WebSocket RPC API",
     "license": {}
   },


### PR DESCRIPTION
As per the latest release from Starkware.

https://github.com/starkware-libs/starknet-specs/releases/tag/v0.10.2