### PR TITLE
fix: do not download pre confirmed classes

### DIFF
--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -238,12 +238,11 @@ pub async fn poll_starknet_0_14_0<S: GatewayApi + Clone + Send + 'static>(
                 tracing::error!(error=%e, "Event channel closed unexpectedly. Ending pre-confirmed stream.");
                 break;
             }
-
-            tokio::time::sleep_until(t_fetch + poll_interval).await;
         } else {
             tracing::trace!("No change in pre-confirmed block data");
-            tokio::time::sleep_until(t_fetch + poll_interval).await;
         }
+
+        tokio::time::sleep_until(t_fetch + poll_interval).await;
     }
 }
 


### PR DESCRIPTION
- With recent changes on the Starknet feeder gateway `get_class_by_hash` endpoint `blockNumber=pending` is effectively mapped to `blockNumber=latest`. This means that if a new DECLARE transaction is added to the pre-confirmed (or pre-latest) block we're pretty much guaranteed to get an error.

Closes #3281