### PR TITLE
refactor(rpc): fix flaky gateway tests

### DIFF
--- a/crates/rpc/src/method/add_declare_transaction.rs
+++ b/crates/rpc/src/method/add_declare_transaction.rs
@@ -694,28 +694,30 @@ mod tests {
     }
 
     #[test_log::test(tokio::test)]
-    #[ignore = "gateway 429"]
     async fn invalid_contract_definition_v1() {
-        let context = RpcContext::for_tests();
+        use gateway_test_utils::response_from;
+        use starknet_gateway_types::error::KnownStarknetErrorCode;
 
-        let invalid_contract_class = CairoContractClass {
-            program: "".to_owned(),
-            ..CONTRACT_CLASS.clone()
-        };
-
-        let declare_transaction = Transaction::Declare(BroadcastedDeclareTransaction::V1(
-            BroadcastedDeclareTransactionV1 {
-                version: TransactionVersion::ONE,
-                max_fee: Fee(Default::default()),
-                signature: vec![],
-                nonce: TransactionNonce(Default::default()),
-                contract_class: invalid_contract_class,
-                sender_address: ContractAddress::new_or_panic(Felt::from_u64(1)),
-            },
-        ));
+        let (_handle, url) = gateway_test_utils::setup([(
+            "/gateway/add_transaction",
+            response_from(KnownStarknetErrorCode::InvalidContractDefinition),
+        )]);
+        let mut context = RpcContext::for_tests();
+        context.sequencer = starknet_gateway_client::Client::for_test(url)
+            .unwrap()
+            .disable_retry_for_tests();
 
         let input = Input {
-            declare_transaction,
+            declare_transaction: Transaction::Declare(BroadcastedDeclareTransaction::V1(
+                BroadcastedDeclareTransactionV1 {
+                    version: TransactionVersion::ONE,
+                    max_fee: Fee(Default::default()),
+                    signature: vec![],
+                    nonce: TransactionNonce(Default::default()),
+                    contract_class: CONTRACT_CLASS.clone(),
+                    sender_address: ContractAddress::new_or_panic(Felt::from_u64(1)),
+                },
+            )),
             token: None,
         };
         let error = add_declare_transaction(context, input).await.unwrap_err();
@@ -723,33 +725,33 @@ mod tests {
     }
 
     #[test_log::test(tokio::test)]
-    #[ignore = "gateway 429"]
     async fn invalid_contract_definition_v2() {
-        let context = RpcContext::for_tests_on(pathfinder_common::Chain::SepoliaIntegration);
+        use gateway_test_utils::response_from;
+        use starknet_gateway_types::error::KnownStarknetErrorCode;
 
-        let invalid_contract_class = SierraContractClass {
-            sierra_program: vec![],
-            ..SIERRA_CLASS.clone()
-        };
-
-        let declare_transaction = Transaction::Declare(BroadcastedDeclareTransaction::V2(
-            BroadcastedDeclareTransactionV2 {
-                version: TransactionVersion::TWO,
-                max_fee: Fee(Felt::from_be_slice(&u64::MAX.to_be_bytes()).unwrap()),
-                signature: vec![],
-                nonce: TransactionNonce(Default::default()),
-                contract_class: invalid_contract_class,
-                sender_address: ContractAddress::new_or_panic(Felt::from_u64(1)),
-                // Taken from
-                // https://external.integration.starknet.io/feeder_gateway/get_state_update?blockNumber=283364
-                compiled_class_hash: casm_hash!(
-                    "0x711c0c3e56863e29d3158804aac47f424241eda64db33e2cc2999d60ee5105"
-                ),
-            },
-        ));
+        let (_handle, url) = gateway_test_utils::setup([(
+            "/gateway/add_transaction",
+            response_from(KnownStarknetErrorCode::InvalidContractDefinition),
+        )]);
+        let mut context = RpcContext::for_tests_on(pathfinder_common::Chain::SepoliaIntegration);
+        context.sequencer = starknet_gateway_client::Client::for_test(url)
+            .unwrap()
+            .disable_retry_for_tests();
 
         let input = Input {
-            declare_transaction,
+            declare_transaction: Transaction::Declare(BroadcastedDeclareTransaction::V2(
+                BroadcastedDeclareTransactionV2 {
+                    version: TransactionVersion::TWO,
+                    max_fee: Fee(Felt::from_be_slice(&u64::MAX.to_be_bytes()).unwrap()),
+                    signature: vec![],
+                    nonce: TransactionNonce(Default::default()),
+                    contract_class: SIERRA_CLASS.clone(),
+                    sender_address: ContractAddress::new_or_panic(Felt::from_u64(1)),
+                    compiled_class_hash: casm_hash!(
+                        "0x711c0c3e56863e29d3158804aac47f424241eda64db33e2cc2999d60ee5105"
+                    ),
+                },
+            )),
             token: None,
         };
         let error = add_declare_transaction(context, input).await.unwrap_err();
@@ -757,23 +759,30 @@ mod tests {
     }
 
     #[test_log::test(tokio::test)]
-    #[ignore = "gateway 429"]
     async fn invalid_contract_class() {
-        let context = RpcContext::for_tests();
+        use gateway_test_utils::response_from;
+        use starknet_gateway_types::error::KnownStarknetErrorCode;
 
-        let declare_transaction = Transaction::Declare(BroadcastedDeclareTransaction::V1(
-            BroadcastedDeclareTransactionV1 {
-                version: TransactionVersion::ONE,
-                max_fee: fee!("0xfffffffffff"),
-                signature: vec![],
-                nonce: TransactionNonce(Default::default()),
-                contract_class: CONTRACT_CLASS_WITH_INVALID_PRIME.clone(),
-                sender_address: ContractAddress::new_or_panic(Felt::from_u64(1)),
-            },
-        ));
+        let (_handle, url) = gateway_test_utils::setup([(
+            "/gateway/add_transaction",
+            response_from(KnownStarknetErrorCode::InvalidProgram),
+        )]);
+        let mut context = RpcContext::for_tests();
+        context.sequencer = starknet_gateway_client::Client::for_test(url)
+            .unwrap()
+            .disable_retry_for_tests();
 
         let input = Input {
-            declare_transaction,
+            declare_transaction: Transaction::Declare(BroadcastedDeclareTransaction::V1(
+                BroadcastedDeclareTransactionV1 {
+                    version: TransactionVersion::ONE,
+                    max_fee: fee!("0xfffffffffff"),
+                    signature: vec![],
+                    nonce: TransactionNonce(Default::default()),
+                    contract_class: CONTRACT_CLASS_WITH_INVALID_PRIME.clone(),
+                    sender_address: ContractAddress::new_or_panic(Felt::from_u64(1)),
+                },
+            )),
             token: None,
         };
         let error = add_declare_transaction(context, input).await.unwrap_err();
@@ -781,23 +790,30 @@ mod tests {
     }
 
     #[test_log::test(tokio::test)]
-    #[ignore = "gateway 429"]
     async fn duplicate_transaction() {
-        let context = RpcContext::for_tests();
+        use gateway_test_utils::response_from;
+        use starknet_gateway_types::error::KnownStarknetErrorCode;
 
-        let declare_transaction = Transaction::Declare(BroadcastedDeclareTransaction::V1(
-            BroadcastedDeclareTransactionV1 {
-                version: TransactionVersion::ONE,
-                max_fee: Fee(Felt::from_be_slice(&u64::MAX.to_be_bytes()).unwrap()),
-                signature: vec![],
-                nonce: TransactionNonce(Default::default()),
-                contract_class: CONTRACT_CLASS.clone(),
-                sender_address: ContractAddress::new_or_panic(Felt::from_u64(1)),
-            },
-        ));
+        let (_handle, url) = gateway_test_utils::setup([(
+            "/gateway/add_transaction",
+            response_from(KnownStarknetErrorCode::DuplicatedTransaction),
+        )]);
+        let mut context = RpcContext::for_tests();
+        context.sequencer = starknet_gateway_client::Client::for_test(url)
+            .unwrap()
+            .disable_retry_for_tests();
 
         let input = Input {
-            declare_transaction,
+            declare_transaction: Transaction::Declare(BroadcastedDeclareTransaction::V1(
+                BroadcastedDeclareTransactionV1 {
+                    version: TransactionVersion::ONE,
+                    max_fee: Fee(Felt::from_be_slice(&u64::MAX.to_be_bytes()).unwrap()),
+                    signature: vec![],
+                    nonce: TransactionNonce(Default::default()),
+                    contract_class: CONTRACT_CLASS.clone(),
+                    sender_address: ContractAddress::new_or_panic(Felt::from_u64(1)),
+                },
+            )),
             token: None,
         };
         let error = add_declare_transaction(context, input).await.unwrap_err();
@@ -805,26 +821,33 @@ mod tests {
     }
 
     #[test_log::test(tokio::test)]
-    #[ignore = "gateway 429"]
     async fn insufficient_max_fee() {
-        let context = RpcContext::for_tests_on(pathfinder_common::Chain::SepoliaIntegration);
+        use gateway_test_utils::response_from;
+        use starknet_gateway_types::error::KnownStarknetErrorCode;
 
-        let declare_transaction = Transaction::Declare(BroadcastedDeclareTransaction::V2(
-            BroadcastedDeclareTransactionV2 {
-                version: TransactionVersion::TWO,
-                max_fee: Fee(felt!("0x01")),
-                signature: vec![],
-                nonce: TransactionNonce(Default::default()),
-                contract_class: SIERRA_CLASS.clone(),
-                sender_address: ContractAddress::new_or_panic(Felt::from_u64(1)),
-                compiled_class_hash: casm_hash!(
-                    "0x688e44b1d8612222a25cf742c8e1493af4640fa74b1a7707bde2002df51ea8c"
-                ),
-            },
-        ));
+        let (_handle, url) = gateway_test_utils::setup([(
+            "/gateway/add_transaction",
+            response_from(KnownStarknetErrorCode::InsufficientAccountBalance),
+        )]);
+        let mut context = RpcContext::for_tests_on(pathfinder_common::Chain::SepoliaIntegration);
+        context.sequencer = starknet_gateway_client::Client::for_test(url)
+            .unwrap()
+            .disable_retry_for_tests();
 
         let input = Input {
-            declare_transaction,
+            declare_transaction: Transaction::Declare(BroadcastedDeclareTransaction::V2(
+                BroadcastedDeclareTransactionV2 {
+                    version: TransactionVersion::TWO,
+                    max_fee: Fee(felt!("0x01")),
+                    signature: vec![],
+                    nonce: TransactionNonce(Default::default()),
+                    contract_class: SIERRA_CLASS.clone(),
+                    sender_address: ContractAddress::new_or_panic(Felt::from_u64(1)),
+                    compiled_class_hash: casm_hash!(
+                        "0x688e44b1d8612222a25cf742c8e1493af4640fa74b1a7707bde2002df51ea8c"
+                    ),
+                },
+            )),
             token: None,
         };
         let err = add_declare_transaction(context, input).await.unwrap_err();
@@ -835,26 +858,33 @@ mod tests {
     }
 
     #[test_log::test(tokio::test)]
-    #[ignore = "gateway 429"]
     async fn insufficient_account_balance() {
-        let context = RpcContext::for_tests_on(pathfinder_common::Chain::SepoliaIntegration);
+        use gateway_test_utils::response_from;
+        use starknet_gateway_types::error::KnownStarknetErrorCode;
 
-        let declare_transaction = Transaction::Declare(BroadcastedDeclareTransaction::V2(
-            BroadcastedDeclareTransactionV2 {
-                version: TransactionVersion::TWO,
-                max_fee: Fee(Felt::from_be_slice(&u64::MAX.to_be_bytes()).unwrap()),
-                signature: vec![],
-                nonce: TransactionNonce(Default::default()),
-                contract_class: SIERRA_CLASS.clone(),
-                sender_address: ContractAddress::new_or_panic(Felt::from_u64(1)),
-                compiled_class_hash: casm_hash!(
-                    "0x688e44b1d8612222a25cf742c8e1493af4640fa74b1a7707bde2002df51ea8c"
-                ),
-            },
-        ));
+        let (_handle, url) = gateway_test_utils::setup([(
+            "/gateway/add_transaction",
+            response_from(KnownStarknetErrorCode::InsufficientAccountBalance),
+        )]);
+        let mut context = RpcContext::for_tests_on(pathfinder_common::Chain::SepoliaIntegration);
+        context.sequencer = starknet_gateway_client::Client::for_test(url)
+            .unwrap()
+            .disable_retry_for_tests();
 
         let input = Input {
-            declare_transaction,
+            declare_transaction: Transaction::Declare(BroadcastedDeclareTransaction::V2(
+                BroadcastedDeclareTransactionV2 {
+                    version: TransactionVersion::TWO,
+                    max_fee: Fee(Felt::from_be_slice(&u64::MAX.to_be_bytes()).unwrap()),
+                    signature: vec![],
+                    nonce: TransactionNonce(Default::default()),
+                    contract_class: SIERRA_CLASS.clone(),
+                    sender_address: ContractAddress::new_or_panic(Felt::from_u64(1)),
+                    compiled_class_hash: casm_hash!(
+                        "0x688e44b1d8612222a25cf742c8e1493af4640fa74b1a7707bde2002df51ea8c"
+                    ),
+                },
+            )),
             token: None,
         };
         let err = add_declare_transaction(context, input).await.unwrap_err();
@@ -865,49 +895,51 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "gateway 429"]
     // https://external.integration.starknet.io/feeder_gateway/get_transaction?transactionHash=0x41d1f5206ef58a443e7d3d1ca073171ec25fa75313394318fc83a074a6631c3
     async fn duplicate_v3_transaction() {
-        let context = RpcContext::for_tests_on(pathfinder_common::Chain::SepoliaIntegration);
+        use gateway_test_utils::response_from;
+        use starknet_gateway_types::error::KnownStarknetErrorCode;
 
-        let input = BroadcastedDeclareTransactionV3 {
-            version: TransactionVersion::THREE,
-            signature: vec![
-                transaction_signature_elem!(
-                    "0x29a49dff154fede73dd7b5ca5a0beadf40b4b069f3a850cd8428e54dc809ccc"
-                ),
-                transaction_signature_elem!(
-                    "0x429d142a17223b4f2acde0f5ecb9ad453e188b245003c86fab5c109bad58fc3"
-                ),
-            ],
-            nonce: transaction_nonce!("0x1"),
-            resource_bounds: ResourceBounds {
-                l1_gas: ResourceBound {
-                    max_amount: ResourceAmount(0x186a0),
-                    max_price_per_unit: ResourcePricePerUnit(0x5af3107a4000),
-                },
-                l2_gas: ResourceBound {
-                    max_amount: ResourceAmount(0),
-                    max_price_per_unit: ResourcePricePerUnit(0),
-                },
-                l1_data_gas: None,
-            },
-            tip: Tip(0),
-            paymaster_data: vec![],
-            account_deployment_data: vec![],
-            nonce_data_availability_mode: DataAvailabilityMode::L1,
-            fee_data_availability_mode: DataAvailabilityMode::L1,
-            compiled_class_hash: casm_hash!(
-                "0x1add56d64bebf8140f3b8a38bdf102b7874437f0c861ab4ca7526ec33b4d0f8"
-            ),
-            contract_class: INTEGRATION_SIERRA_CLASS.clone(),
-            sender_address: contract_address!(
-                "0x2fab82e4aef1d8664874e1f194951856d48463c3e6bf9a8c68e234a629a6f50"
-            ),
-        };
+        let (_handle, url) = gateway_test_utils::setup([(
+            "/gateway/add_transaction",
+            response_from(KnownStarknetErrorCode::InsufficientAccountBalance),
+        )]);
+        let mut context = RpcContext::for_tests_on(pathfinder_common::Chain::SepoliaIntegration);
+        context.sequencer = starknet_gateway_client::Client::for_test(url)
+            .unwrap()
+            .disable_retry_for_tests();
 
         let input = Input {
-            declare_transaction: Transaction::Declare(BroadcastedDeclareTransaction::V3(input)),
+            declare_transaction: Transaction::Declare(BroadcastedDeclareTransaction::V3(
+                BroadcastedDeclareTransactionV3 {
+                    version: TransactionVersion::THREE,
+                    signature: vec![],
+                    nonce: transaction_nonce!("0x1"),
+                    resource_bounds: ResourceBounds {
+                        l1_gas: ResourceBound {
+                            max_amount: ResourceAmount(0x186a0),
+                            max_price_per_unit: ResourcePricePerUnit(0x5af3107a4000),
+                        },
+                        l2_gas: ResourceBound {
+                            max_amount: ResourceAmount(0),
+                            max_price_per_unit: ResourcePricePerUnit(0),
+                        },
+                        l1_data_gas: None,
+                    },
+                    tip: Tip(0),
+                    paymaster_data: vec![],
+                    account_deployment_data: vec![],
+                    nonce_data_availability_mode: DataAvailabilityMode::L1,
+                    fee_data_availability_mode: DataAvailabilityMode::L1,
+                    compiled_class_hash: casm_hash!(
+                        "0x1add56d64bebf8140f3b8a38bdf102b7874437f0c861ab4ca7526ec33b4d0f8"
+                    ),
+                    contract_class: INTEGRATION_SIERRA_CLASS.clone(),
+                    sender_address: contract_address!(
+                        "0x2fab82e4aef1d8664874e1f194951856d48463c3e6bf9a8c68e234a629a6f50"
+                    ),
+                },
+            )),
             token: None,
         };
 

--- a/crates/rpc/src/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/method/add_deploy_account_transaction.rs
@@ -446,13 +446,20 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "gateway 429"]
     async fn duplicate_transaction() {
-        let context = RpcContext::for_tests();
+        use gateway_test_utils::response_from;
+        use starknet_gateway_types::error::KnownStarknetErrorCode;
 
-        let input = get_input();
+        let (_handle, url) = gateway_test_utils::setup([(
+            "/gateway/add_transaction",
+            response_from(KnownStarknetErrorCode::DuplicatedTransaction),
+        )]);
+        let mut context = RpcContext::for_tests();
+        context.sequencer = starknet_gateway_client::Client::for_test(url)
+            .unwrap()
+            .disable_retry_for_tests();
 
-        let error = add_deploy_account_transaction(context, input)
+        let error = add_deploy_account_transaction(context, get_input())
             .await
             .expect_err("add_deploy_account_transaction");
         assert_matches::assert_matches!(
@@ -462,49 +469,49 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "gateway 429"]
     // https://external.integration.starknet.io/feeder_gateway/get_transaction?transactionHash=0x29fd7881f14380842414cdfdd8d6c0b1f2174f8916edcfeb1ede1eb26ac3ef0
     async fn duplicate_v3_transaction() {
-        let context = RpcContext::for_tests_on(pathfinder_common::Chain::SepoliaIntegration);
+        use gateway_test_utils::response_from;
+        use starknet_gateway_types::error::KnownStarknetErrorCode;
 
-        let input = BroadcastedDeployAccountTransactionV3 {
-            version: TransactionVersion::THREE,
-            signature: vec![
-                transaction_signature_elem!(
-                    "0x6d756e754793d828c6c1a89c13f7ec70dbd8837dfeea5028a673b80e0d6b4ec"
-                ),
-                transaction_signature_elem!(
-                    "0x4daebba599f860daee8f6e100601d98873052e1c61530c630cc4375c6bd48e3"
-                ),
-            ],
-            nonce: transaction_nonce!("0x0"),
-            resource_bounds: ResourceBounds {
-                l1_gas: ResourceBound {
-                    max_amount: ResourceAmount(0x186a0),
-                    max_price_per_unit: ResourcePricePerUnit(0x5af3107a4000),
-                },
-                l2_gas: ResourceBound {
-                    max_amount: ResourceAmount(0),
-                    max_price_per_unit: ResourcePricePerUnit(0),
-                },
-                l1_data_gas: None,
-            },
-            tip: Tip(0),
-            paymaster_data: vec![],
-            nonce_data_availability_mode: DataAvailabilityMode::L1,
-            fee_data_availability_mode: DataAvailabilityMode::L1,
-            contract_address_salt: contract_address_salt!("0x0"),
-            constructor_calldata: vec![call_param!(
-                "0x5cd65f3d7daea6c63939d659b8473ea0c5cd81576035a4d34e52fb06840196c"
-            )],
-            class_hash: class_hash!(
-                "0x2338634f11772ea342365abd5be9d9dc8a6f44f159ad782fdebd3db5d969738"
-            ),
-        };
+        let (_handle, url) = gateway_test_utils::setup([(
+            "/gateway/add_transaction",
+            response_from(KnownStarknetErrorCode::DuplicatedTransaction),
+        )]);
+        let mut context = RpcContext::for_tests_on(pathfinder_common::Chain::SepoliaIntegration);
+        context.sequencer = starknet_gateway_client::Client::for_test(url)
+            .unwrap()
+            .disable_retry_for_tests();
 
         let input = Input {
             deploy_account_transaction: Transaction::DeployAccount(
-                BroadcastedDeployAccountTransaction::V3(input),
+                BroadcastedDeployAccountTransaction::V3(BroadcastedDeployAccountTransactionV3 {
+                    version: TransactionVersion::THREE,
+                    signature: vec![],
+                    nonce: transaction_nonce!("0x0"),
+                    resource_bounds: ResourceBounds {
+                        l1_gas: ResourceBound {
+                            max_amount: ResourceAmount(0x186a0),
+                            max_price_per_unit: ResourcePricePerUnit(0x5af3107a4000),
+                        },
+                        l2_gas: ResourceBound {
+                            max_amount: ResourceAmount(0),
+                            max_price_per_unit: ResourcePricePerUnit(0),
+                        },
+                        l1_data_gas: None,
+                    },
+                    tip: Tip(0),
+                    paymaster_data: vec![],
+                    nonce_data_availability_mode: DataAvailabilityMode::L1,
+                    fee_data_availability_mode: DataAvailabilityMode::L1,
+                    contract_address_salt: contract_address_salt!("0x0"),
+                    constructor_calldata: vec![call_param!(
+                        "0x5cd65f3d7daea6c63939d659b8473ea0c5cd81576035a4d34e52fb06840196c"
+                    )],
+                    class_hash: class_hash!(
+                        "0x2338634f11772ea342365abd5be9d9dc8a6f44f159ad782fdebd3db5d969738"
+                    ),
+                }),
             ),
         };
 

--- a/crates/rpc/src/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/method/add_invoke_transaction.rs
@@ -486,39 +486,32 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "gateway 429"]
     async fn duplicate_transaction() {
-        use crate::types::request::BroadcastedInvokeTransactionV1;
+        use gateway_test_utils::response_from;
+        use starknet_gateway_types::error::KnownStarknetErrorCode;
 
-        let context = RpcContext::for_tests();
-        let input = BroadcastedInvokeTransactionV1 {
-            version: TransactionVersion::ONE,
-            max_fee: fee!("0x630a0aff77"),
-            signature: vec![
-                transaction_signature_elem!(
-                    "07ccc81b438581c9360120e0ba0ef52c7d031bdf20a4c2bc3820391b29a8945f"
-                ),
-                transaction_signature_elem!(
-                    "02c11c60d11daaa0043eccdc824bb44f87bc7eb2e9c2437e1654876ab8fa7cad"
-                ),
-            ],
-            nonce: transaction_nonce!("0x2"),
-            sender_address: contract_address!(
-                "03fdcbeb68e607c8febf01d7ef274cbf68091a0bd1556c0b8f8e80d732f7850f"
-            ),
-            calldata: vec![
-                call_param!("0x1"),
-                call_param!("01d809111da75d5e735b6f9573a1ddff78fb6ff7633a0b34273e0c5ddeae349a"),
-                call_param!("0362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320"),
-                call_param!("0x0"),
-                call_param!("0x1"),
-                call_param!("0x1"),
-                call_param!("0x1"),
-            ],
-        };
+        let (_handle, url) = gateway_test_utils::setup([(
+            "/gateway/add_transaction",
+            response_from(KnownStarknetErrorCode::DuplicatedTransaction),
+        )]);
+        let mut context = RpcContext::for_tests();
+        context.sequencer = starknet_gateway_client::Client::for_test(url)
+            .unwrap()
+            .disable_retry_for_tests();
 
         let input = Input {
-            invoke_transaction: Transaction::Invoke(BroadcastedInvokeTransaction::V1(input)),
+            invoke_transaction: Transaction::Invoke(BroadcastedInvokeTransaction::V1(
+                crate::types::request::BroadcastedInvokeTransactionV1 {
+                    version: TransactionVersion::ONE,
+                    max_fee: fee!("0x630a0aff77"),
+                    signature: vec![],
+                    nonce: transaction_nonce!("0x2"),
+                    sender_address: contract_address!(
+                        "03fdcbeb68e607c8febf01d7ef274cbf68091a0bd1556c0b8f8e80d732f7850f"
+                    ),
+                    calldata: vec![],
+                },
+            )),
         };
 
         let error = add_invoke_transaction(context, input).await.unwrap_err();
@@ -526,66 +519,50 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "gateway 429"]
     // https://external.integration.starknet.io/feeder_gateway/get_transaction?transactionHash=0x41906f1c314cca5f43170ea75d3b1904196a10101190d2b12a41cc61cfd17c
     async fn duplicate_v3_transaction() {
-        use crate::types::request::BroadcastedInvokeTransactionV3;
+        use gateway_test_utils::response_from;
+        use starknet_gateway_types::error::KnownStarknetErrorCode;
 
-        let context = RpcContext::for_tests_on(pathfinder_common::Chain::SepoliaIntegration);
-        let input = BroadcastedInvokeTransactionV3 {
-            version: TransactionVersion::THREE,
-            signature: vec![
-                transaction_signature_elem!(
-                    "0xef42616755b8a9b7c97d2deb1ba4a4176d3c838a20c367072f141af446ee7"
-                ),
-                transaction_signature_elem!(
-                    "0xc6514ea8a88bcb0f4b2a40ddc609461a35af802ba0b35586ade6d8a4be2934"
-                ),
-            ],
-            nonce: transaction_nonce!("0x8a9"),
-            resource_bounds: ResourceBounds {
-                l1_gas: ResourceBound {
-                    max_amount: ResourceAmount(0x186a0),
-                    max_price_per_unit: ResourcePricePerUnit(0x5af3107a4000),
-                },
-                l2_gas: ResourceBound {
-                    max_amount: ResourceAmount(0),
-                    max_price_per_unit: ResourcePricePerUnit(0),
-                },
-                l1_data_gas: None,
-            },
-            tip: Tip(0),
-            paymaster_data: vec![],
-            account_deployment_data: vec![],
-            nonce_data_availability_mode: DataAvailabilityMode::L1,
-            fee_data_availability_mode: DataAvailabilityMode::L1,
-            sender_address: contract_address!(
-                "0x3f6f3bc663aedc5285d6013cc3ffcbc4341d86ab488b8b68d297f8258793c41"
-            ),
-            calldata: vec![
-                call_param!("0x2"),
-                call_param!("0x4c312760dfd17a954cdd09e76aa9f149f806d88ec3e402ffaf5c4926f568a42"),
-                call_param!("0x31aafc75f498fdfa7528880ad27246b4c15af4954f96228c9a132b328de1c92"),
-                call_param!("0x0"),
-                call_param!("0x6"),
-                call_param!("0x450703c32370cf7ffff540b9352e7ee4ad583af143a361155f2b485c0c39684"),
-                call_param!("0xb17d8a2731ba7ca1816631e6be14f0fc1b8390422d649fa27f0fbb0c91eea8"),
-                call_param!("0x6"),
-                call_param!("0x0"),
-                call_param!("0x6"),
-                call_param!("0x6333f10b24ed58cc33e9bac40b0d52e067e32a175a97ca9e2ce89fe2b002d82"),
-                call_param!("0x3"),
-                call_param!("0x602e89fe5703e5b093d13d0a81c9e6d213338dc15c59f4d3ff3542d1d7dfb7d"),
-                call_param!("0x20d621301bea11ffd9108af1d65847e9049412159294d0883585d4ad43ad61b"),
-                call_param!("0x276faadb842bfcbba834f3af948386a2eb694f7006e118ad6c80305791d3247"),
-                call_param!("0x613816405e6334ab420e53d4b38a0451cb2ebca2755171315958c87d303cf6"),
-            ],
-            proof_facts: vec![],
-            proof: Proof::default(),
-        };
+        let (_handle, url) = gateway_test_utils::setup([(
+            "/gateway/add_transaction",
+            response_from(KnownStarknetErrorCode::DuplicatedTransaction),
+        )]);
+        let mut context = RpcContext::for_tests_on(pathfinder_common::Chain::SepoliaIntegration);
+        context.sequencer = starknet_gateway_client::Client::for_test(url)
+            .unwrap()
+            .disable_retry_for_tests();
 
         let input = Input {
-            invoke_transaction: Transaction::Invoke(BroadcastedInvokeTransaction::V3(input)),
+            invoke_transaction: Transaction::Invoke(BroadcastedInvokeTransaction::V3(
+                crate::types::request::BroadcastedInvokeTransactionV3 {
+                    version: TransactionVersion::THREE,
+                    signature: vec![],
+                    nonce: transaction_nonce!("0x8a9"),
+                    resource_bounds: ResourceBounds {
+                        l1_gas: ResourceBound {
+                            max_amount: ResourceAmount(0x186a0),
+                            max_price_per_unit: ResourcePricePerUnit(0x5af3107a4000),
+                        },
+                        l2_gas: ResourceBound {
+                            max_amount: ResourceAmount(0),
+                            max_price_per_unit: ResourcePricePerUnit(0),
+                        },
+                        l1_data_gas: None,
+                    },
+                    tip: Tip(0),
+                    paymaster_data: vec![],
+                    account_deployment_data: vec![],
+                    nonce_data_availability_mode: DataAvailabilityMode::L1,
+                    fee_data_availability_mode: DataAvailabilityMode::L1,
+                    sender_address: contract_address!(
+                        "0x3f6f3bc663aedc5285d6013cc3ffcbc4341d86ab488b8b68d297f8258793c41"
+                    ),
+                    calldata: vec![],
+                    proof_facts: vec![],
+                    proof: Proof::default(),
+                },
+            )),
         };
 
         let error = add_invoke_transaction(context, input).await.unwrap_err();

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -1606,8 +1606,12 @@ pub(crate) mod tests {
         async fn setup(
             starknet_version: StarknetVersion,
             block_num_to_insert: BlockNumber,
-        ) -> anyhow::Result<(RpcContext, TraceBlockTransactionsInput)> {
-            let (context, _, _) = setup_multi_tx_trace_test_with_starknet_version_and_chain(
+        ) -> anyhow::Result<(
+            RpcContext,
+            TraceBlockTransactionsInput,
+            Option<tokio::task::JoinHandle<()>>,
+        )> {
+            let (mut context, _, _) = setup_multi_tx_trace_test_with_starknet_version_and_chain(
                 starknet_version,
                 Chain::Mainnet,
             )
@@ -1622,6 +1626,16 @@ pub(crate) mod tests {
             })?;
             tx.commit()?;
 
+            let path = format!(
+                "/feeder_gateway/get_block_traces?blockNumber={}",
+                block_num_to_insert.get()
+            );
+            let (handle, url) =
+                gateway_test_utils::setup([(path, (r#"{"traces":[]}"#.to_string(), 200u16))]);
+            context.sequencer = starknet_gateway_client::Client::for_test(url)
+                .unwrap()
+                .disable_retry_for_tests();
+
             let input = TraceBlockTransactionsInput {
                 block_id: block_num_to_insert.into(),
                 trace_flags: crate::dto::TraceFlags(vec![
@@ -1629,7 +1643,7 @@ pub(crate) mod tests {
                 ]),
             };
 
-            Ok((context, input))
+            Ok((context, input, handle))
         }
 
         // First test that with a Starknet version that requires fetching traces from
@@ -1643,7 +1657,8 @@ pub(crate) mod tests {
             starknet_version_with_fallback
                 < VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEWAY,
         );
-        let (context, input) = setup(starknet_version_with_fallback, block_with_fallback).await?;
+        let (context, input, _handle) =
+            setup(starknet_version_with_fallback, block_with_fallback).await?;
 
         let output_json = trace_block_transactions(context, input, rpc_version)
             .await
@@ -1670,7 +1685,7 @@ pub(crate) mod tests {
             re_execution_impossible_starknet_version
                 >= VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEWAY,
         );
-        let (context, input) = setup(
+        let (context, input, _handle) = setup(
             re_execution_impossible_starknet_version,
             re_execution_impossible_block,
         )

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -1709,7 +1709,7 @@ pub(crate) mod tests {
     /// with blockifier.
     #[tokio::test]
     async fn mainnet_blockifier_backwards_incompatible_transaction_tracing() {
-        let context = RpcContext::for_tests_on(pathfinder_common::Chain::Mainnet);
+        let mut context = RpcContext::for_tests_on(pathfinder_common::Chain::Mainnet);
         let mut connection = context.storage.connection().unwrap();
         let transaction = connection.transaction().unwrap();
 
@@ -1784,6 +1784,17 @@ pub(crate) mod tests {
         transaction.commit().unwrap();
         drop(connection);
 
+        let (_handle, url) = gateway_test_utils::setup([(
+            format!(
+                "/feeder_gateway/get_block_traces?blockNumber={}",
+                block.block_number.get()
+            ),
+            (r#"{"traces":[]}"#.to_string(), 200u16),
+        )]);
+        context.sequencer = starknet_gateway_client::Client::for_test(url)
+            .unwrap()
+            .disable_retry_for_tests();
+
         // The tracing succeeds.
         trace_block_transactions(
             context.clone(),
@@ -1801,7 +1812,7 @@ pub(crate) mod tests {
     /// traces are missing the `call_type` field.
     #[tokio::test]
     async fn mainnet_pre_0_9_traces() {
-        let context = RpcContext::for_tests_on(pathfinder_common::Chain::Mainnet);
+        let mut context = RpcContext::for_tests_on(pathfinder_common::Chain::Mainnet);
         let mut connection = context.storage.connection().unwrap();
         let transaction = connection.transaction().unwrap();
 
@@ -1875,6 +1886,22 @@ pub(crate) mod tests {
             .unwrap();
         transaction.commit().unwrap();
         drop(connection);
+
+        // Use a pre-0.9 format trace fixture (no `call_type` field) to verify
+        // that the gateway fallback path handles the old schema correctly.
+        let traces_json =
+            String::from_utf8(starknet_gateway_test_fixtures::traces::TESTNET_GENESIS.to_vec())
+                .unwrap();
+        let (_handle, url) = gateway_test_utils::setup([(
+            format!(
+                "/feeder_gateway/get_block_traces?blockNumber={}",
+                block.block_number.get()
+            ),
+            (traces_json, 200u16),
+        )]);
+        context.sequencer = starknet_gateway_client::Client::for_test(url)
+            .unwrap()
+            .disable_retry_for_tests();
 
         // The tracing succeeds.
         trace_block_transactions(


### PR DESCRIPTION
These tests no longer use the gateway.

The fun fact here is that they never really had to in the first place. None were really validating gateway behavior afaiu. They would just validate our own logic (error mapping, output format, fallbacks...).

So yeah, the gateway was a side-effect dependency that was never necessary.

This means that a bunch of tests that were `#[ignore]`d are now back and running deterministically :)