### PR TITLE
test(gas/l2): fetch versioned constants from apollo

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,0 @@
-[env]
-# Required for mdbx-sys (via apollo_consensus_orchestrator) to compile with
-# gcc 15.1.
-#
-# See also: https://github.com/vorot93/libmdbx-rs/issues/38
-CFLAGS = "-std=gnu17"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,17 +91,12 @@ dependencies = [
  "alloy-contract",
  "alloy-core",
  "alloy-eips",
- "alloy-genesis",
- "alloy-json-rpc",
  "alloy-network",
- "alloy-node-bindings",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types",
  "alloy-serde",
- "alloy-signer",
- "alloy-signer-local",
  "alloy-transport",
  "alloy-transport-http",
  "alloy-transport-ws",
@@ -134,7 +129,7 @@ dependencies = [
  "auto_impl",
  "borsh",
  "c-kzg",
- "derive_more 2.1.1",
+ "derive_more",
  "either",
  "k256",
  "once_cell",
@@ -279,39 +274,11 @@ dependencies = [
  "auto_impl",
  "borsh",
  "c-kzg",
- "derive_more 2.1.1",
+ "derive_more",
  "either",
  "serde",
  "serde_with",
  "sha2 0.10.9",
-]
-
-[[package]]
-name = "alloy-genesis"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf9480307b09d22876efb67d30cadd9013134c21f3a17ec9f93fd7536d38024"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-serde",
- "alloy-trie",
- "borsh",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "alloy-hardforks"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165210652f71dfc094b051602bafd691f506c54050a174b1cba18fb5ef706a3"
-dependencies = [
- "alloy-chains",
- "alloy-eip2124",
- "alloy-primitives",
- "auto_impl",
- "dyn-clone",
 ]
 
 [[package]]
@@ -360,7 +327,7 @@ dependencies = [
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
- "derive_more 2.1.1",
+ "derive_more",
  "futures-utils-wasm",
  "serde",
  "serde_json",
@@ -381,28 +348,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-node-bindings"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b2fda91b56bb08907cd44c5068130360e027e46a8c17612d386869fa7940be"
-dependencies = [
- "alloy-genesis",
- "alloy-hardforks",
- "alloy-network",
- "alloy-primitives",
- "alloy-signer",
- "alloy-signer-local",
- "k256",
- "libc",
- "rand 0.8.5",
- "serde_json",
- "tempfile",
- "thiserror 2.0.18",
- "tracing",
- "url",
-]
-
-[[package]]
 name = "alloy-primitives"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,7 +357,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more 2.1.1",
+ "derive_more",
  "foldhash 0.2.0",
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
@@ -441,11 +386,9 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
- "alloy-node-bindings",
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-rpc-client",
- "alloy-rpc-types-anvil",
  "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-sol-types",
@@ -554,18 +497,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-rpc-types-anvil"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47df51bedb3e6062cb9981187a51e86d0d64a4de66eb0855e9efe6574b044ddf"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "serde",
-]
-
-[[package]]
 name = "alloy-rpc-types-any"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,22 +551,6 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "alloy-signer-local"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f721f4bf2e4812e5505aaf5de16ef3065a8e26b9139ac885862d00b5a55a659a"
-dependencies = [
- "alloy-consensus",
- "alloy-network",
- "alloy-primitives",
- "alloy-signer",
- "async-trait",
- "k256",
- "rand 0.8.5",
  "thiserror 2.0.18",
 ]
 
@@ -721,7 +636,7 @@ dependencies = [
  "alloy-json-rpc",
  "auto_impl",
  "base64 0.22.1",
- "derive_more 2.1.1",
+ "derive_more",
  "futures",
  "futures-utils-wasm",
  "parking_lot 0.12.5",
@@ -778,7 +693,7 @@ checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "derive_more 2.1.1",
+ "derive_more",
  "nybbles",
  "serde",
  "smallvec",
@@ -870,152 +785,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "apollo_batcher"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_batcher_config",
- "apollo_batcher_types",
- "apollo_class_manager_types",
- "apollo_committer_types",
- "apollo_config_manager_types",
- "apollo_infra",
- "apollo_infra_utils 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_l1_provider_types",
- "apollo_mempool_types",
- "apollo_metrics 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_proc_macros 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_proof_manager_types",
- "apollo_reverts",
- "apollo_starknet_client",
- "apollo_state_reader",
- "apollo_state_sync_types",
- "apollo_storage",
- "apollo_transaction_converter",
- "async-trait",
- "blockifier 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "cairo-vm",
- "chrono",
- "futures",
- "indexmap 2.13.0",
- "lru 0.12.5",
- "reqwest 0.12.28",
- "serde",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "strum",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "url",
- "validator",
-]
-
-[[package]]
-name = "apollo_batcher_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_storage",
- "blockifier 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "serde",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "url",
- "validator",
-]
-
-[[package]]
-name = "apollo_batcher_types"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_infra",
- "apollo_metrics 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_state_sync_types",
- "async-trait",
- "blockifier 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "chrono",
- "derive_more 2.1.1",
- "indexmap 2.13.0",
- "serde",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "strum",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "apollo_central_sync_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_starknet_client",
- "itertools 0.12.1",
- "serde",
- "url",
- "validator",
-]
-
-[[package]]
-name = "apollo_class_manager_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_storage",
- "serde",
- "validator",
-]
-
-[[package]]
-name = "apollo_class_manager_types"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_compile_to_casm_types",
- "apollo_infra",
- "async-trait",
- "serde",
- "serde_json",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "strum",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "apollo_committer_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "serde",
- "starknet_committer",
- "starknet_patricia_storage",
- "validator",
-]
-
-[[package]]
-name = "apollo_committer_types"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_infra",
- "apollo_metrics 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "async-trait",
- "serde",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "starknet_committer",
- "strum",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "apollo_compilation_utils"
 version = "0.18.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a67f3331354ca1f12d0e020ca49f4e7186b7608de0839e47c721282fd5729dd8"
 dependencies = [
- "apollo_infra_utils 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "apollo_infra_utils",
  "cairo-lang-sierra 2.17.0-rc.4",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils 2.17.0-rc.4",
@@ -1023,41 +798,8 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet_api",
  "tempfile",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "apollo_compilation_utils"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_infra_utils 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "cairo-lang-sierra 2.17.0-rc.4",
- "cairo-lang-starknet-classes",
- "cairo-lang-utils 2.17.0-rc.4",
- "rlimit",
- "serde",
- "serde_json",
- "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "tempfile",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "apollo_compile_to_casm_types"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_infra",
- "apollo_metrics 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "async-trait",
- "serde",
- "serde_json",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "strum",
  "thiserror 1.0.69",
 ]
 
@@ -1067,9 +809,9 @@ version = "0.18.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa476e7f3f471ac5097214a8e5ca79947762bbafb0bb9303359705524c20c70e"
 dependencies = [
- "apollo_compilation_utils 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "apollo_compile_to_native_types 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "apollo_infra_utils 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "apollo_compilation_utils",
+ "apollo_compile_to_native_types",
+ "apollo_infra_utils",
  "cairo-lang-starknet-classes",
  "cairo-native",
  "tempfile",
@@ -1081,17 +823,7 @@ version = "0.18.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2166124835b4bcea3d494e4e9e3fbde72d28e1e2c9b67cde6d950337f7e1cc12"
 dependencies = [
- "apollo_config 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
- "validator",
-]
-
-[[package]]
-name = "apollo_compile_to_native_types"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
+ "apollo_config",
  "serde",
  "validator",
 ]
@@ -1102,7 +834,7 @@ version = "0.18.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcc050ef9fa92477c3543998d4208bd948afb42b859044e3fbbc2e432e28402"
 dependencies = [
- "apollo_infra_utils 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "apollo_infra_utils",
  "clap",
  "const_format",
  "itertools 0.12.1",
@@ -1112,230 +844,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "url",
- "validator",
-]
-
-[[package]]
-name = "apollo_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_infra_utils 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "clap",
- "const_format",
- "itertools 0.12.1",
- "serde",
- "serde_json",
- "strum",
- "thiserror 1.0.69",
- "tracing",
- "url",
- "validator",
-]
-
-[[package]]
-name = "apollo_config_manager_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "serde",
- "validator",
-]
-
-[[package]]
-name = "apollo_config_manager_types"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_batcher_config",
- "apollo_class_manager_config",
- "apollo_consensus_config",
- "apollo_consensus_orchestrator_config",
- "apollo_http_server_config",
- "apollo_infra",
- "apollo_mempool_config",
- "apollo_metrics 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_node_config",
- "apollo_staking_config",
- "apollo_state_sync_config",
- "async-trait",
- "serde",
- "strum",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "apollo_consensus"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_batcher_types",
- "apollo_config_manager_types",
- "apollo_consensus_config",
- "apollo_infra_utils 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_metrics 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_network",
- "apollo_network_types",
- "apollo_protobuf",
- "apollo_staking",
- "apollo_storage",
- "apollo_time 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "async-trait",
- "futures",
- "lazy_static",
- "lru 0.12.5",
- "prost 0.12.6",
- "serde",
- "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "strum",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "apollo_consensus_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_protobuf",
- "apollo_storage",
- "serde",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "validator",
-]
-
-[[package]]
-name = "apollo_consensus_manager_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_consensus_config",
- "apollo_consensus_orchestrator_config",
- "apollo_network",
- "apollo_reverts",
- "apollo_staking_config",
- "serde",
- "validator",
-]
-
-[[package]]
-name = "apollo_consensus_orchestrator"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_batcher",
- "apollo_batcher_types",
- "apollo_class_manager_types",
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_config_manager_types",
- "apollo_consensus",
- "apollo_consensus_orchestrator_config",
- "apollo_infra_utils 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_l1_gas_price_types",
- "apollo_metrics 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_network",
- "apollo_proc_macros 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_proof_manager_types",
- "apollo_protobuf",
- "apollo_sizeof 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_state_sync_types",
- "apollo_time 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_transaction_converter",
- "async-trait",
- "blockifier 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "cairo-lang-starknet-classes",
- "chrono",
- "ethnum",
- "futures",
- "indexmap 2.13.0",
- "num-rational",
- "paste",
- "reqwest 0.12.28",
- "reqwest-middleware",
- "reqwest-retry",
- "serde",
- "serde_json",
- "shared_execution_objects",
- "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "strum",
- "thiserror 1.0.69",
- "tokio",
- "tokio-util",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "apollo_consensus_orchestrator_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "serde",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "url",
- "validator",
-]
-
-[[package]]
-name = "apollo_gateway_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_compilation_utils 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "blockifier 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "cairo-lang-starknet-classes",
- "serde",
- "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "thiserror 1.0.69",
- "validator",
-]
-
-[[package]]
-name = "apollo_http_server_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "serde",
- "validator",
-]
-
-[[package]]
-name = "apollo_infra"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_infra_utils 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_metrics 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "async-trait",
- "bytes",
- "derive_more 2.1.1",
- "http 1.4.0",
- "http-body-util",
- "hyper 1.9.0",
- "hyper-util",
- "metrics-exporter-prometheus 0.16.2",
- "rand 0.8.5",
- "rstest 0.26.1",
- "serde",
- "serde_json",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "thiserror 1.0.69",
- "time",
- "tokio",
- "tokio-metrics",
- "tracing",
- "tracing-subscriber",
  "validator",
 ]
 
@@ -1345,7 +853,7 @@ version = "0.18.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccac84e014c1f56323caa62db9d69555433fa0cce29abf59c6add18ddc2448de"
 dependencies = [
- "apollo_proc_macros 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "apollo_proc_macros",
  "assert-json-diff",
  "colored 3.1.1",
  "num_enum",
@@ -1363,249 +871,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "apollo_infra_utils"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_proc_macros 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "num_enum",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "url",
-]
-
-[[package]]
-name = "apollo_l1_gas_price_provider_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "serde",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "url",
- "validator",
-]
-
-[[package]]
-name = "apollo_l1_gas_price_types"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_infra",
- "apollo_metrics 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "async-trait",
- "mockall 0.12.1",
- "papyrus_base_layer",
- "reqwest 0.12.28",
- "serde",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "strum",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "apollo_l1_provider_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "serde",
- "validator",
-]
-
-[[package]]
-name = "apollo_l1_provider_types"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_infra",
- "apollo_metrics 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "async-trait",
- "indexmap 2.13.0",
- "papyrus_base_layer",
- "serde",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "strum",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "apollo_l1_scraper_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "serde",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "validator",
-]
-
-[[package]]
-name = "apollo_mempool_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "serde",
- "url",
- "validator",
-]
-
-[[package]]
-name = "apollo_mempool_p2p_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_network",
- "serde",
- "validator",
-]
-
-[[package]]
-name = "apollo_mempool_types"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_infra",
- "apollo_metrics 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_network_types",
- "async-trait",
- "indexmap 2.13.0",
- "serde",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "strum",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "apollo_metrics"
 version = "0.18.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "779a12979955eae309c494d9736f38cb64c723ed24aa457fb9b045fb89ef1026"
 dependencies = [
- "apollo_time 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "apollo_time",
  "indexmap 2.13.0",
  "metrics",
  "num-traits",
  "paste",
  "regex",
  "strum",
-]
-
-[[package]]
-name = "apollo_metrics"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_time 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "indexmap 2.13.0",
- "metrics",
- "num-traits",
- "paste",
- "regex",
- "strum",
-]
-
-[[package]]
-name = "apollo_monitoring_endpoint_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "serde",
- "validator",
-]
-
-[[package]]
-name = "apollo_network"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_metrics 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_network_types",
- "async-stream",
- "async-trait",
- "bytes",
- "derive_more 2.1.1",
- "futures",
- "lazy_static",
- "libp2p",
- "replace_with",
- "serde",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "strum",
- "thiserror 1.0.69",
- "tokio",
- "tokio-retry",
- "tracing",
- "unsigned-varint 0.8.0",
- "validator",
-]
-
-[[package]]
-name = "apollo_network_types"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "lazy_static",
- "libp2p",
- "serde",
-]
-
-[[package]]
-name = "apollo_node_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_batcher_config",
- "apollo_class_manager_config",
- "apollo_committer_config",
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_config_manager_config",
- "apollo_consensus_config",
- "apollo_consensus_manager_config",
- "apollo_consensus_orchestrator_config",
- "apollo_gateway_config",
- "apollo_http_server_config",
- "apollo_infra",
- "apollo_infra_utils 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_l1_gas_price_provider_config",
- "apollo_l1_provider_config",
- "apollo_l1_scraper_config",
- "apollo_mempool_config",
- "apollo_mempool_p2p_config",
- "apollo_monitoring_endpoint_config",
- "apollo_proof_manager_config",
- "apollo_reverts",
- "apollo_sierra_compilation_config",
- "apollo_staking_config",
- "apollo_state_sync_config",
- "blockifier 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "clap",
- "const_format",
- "papyrus_base_layer",
- "serde",
- "serde_json",
- "tracing",
- "validator",
-]
-
-[[package]]
-name = "apollo_p2p_sync_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "serde",
- "validator",
 ]
 
 [[package]]
@@ -1621,163 +898,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "apollo_proc_macros"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "lazy_static",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "apollo_proof_manager_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "serde",
- "validator",
-]
-
-[[package]]
-name = "apollo_proof_manager_types"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_infra",
- "apollo_metrics 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "async-trait",
- "mockall 0.12.1",
- "serde",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "strum",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "apollo_protobuf"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_batcher_types",
- "asynchronous-codec",
- "bytes",
- "derive_more 2.1.1",
- "indexmap 2.13.0",
- "lazy_static",
- "papyrus_common",
- "primitive-types",
- "prost 0.12.6",
- "serde",
- "serde_json",
- "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "thiserror 1.0.69",
- "tracing",
- "unsigned-varint 0.8.0",
-]
-
-[[package]]
-name = "apollo_reverts"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_metrics 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_storage",
- "futures",
- "serde",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "tokio",
- "tracing",
- "validator",
-]
-
-[[package]]
-name = "apollo_rpc"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "anyhow",
- "apollo_class_manager_types",
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_proc_macros 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_rpc_execution",
- "apollo_starknet_client",
- "apollo_storage",
- "async-trait",
- "base64 0.13.1",
- "cairo-lang-starknet-classes",
- "flate2",
- "hex",
- "jsonrpsee",
- "lazy_static",
- "metrics",
- "papyrus_common",
- "regex",
- "serde",
- "serde_json",
- "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "tokio",
- "tower 0.5.3",
- "tracing",
- "validator",
-]
-
-[[package]]
-name = "apollo_rpc_execution"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "anyhow",
- "apollo_class_manager_types",
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_storage",
- "blockifier 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "cairo-lang-starknet-classes",
- "cairo-vm",
- "indexmap 2.13.0",
- "itertools 0.12.1",
- "lazy_static",
- "papyrus_common",
- "serde",
- "serde_json",
- "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "apollo_sierra_compilation_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "serde",
- "validator",
-]
-
-[[package]]
 name = "apollo_sizeof"
 version = "0.18.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96b3080899396e91925dd0eff941108e2880cd6983d748573f9de1d725b5163b"
 dependencies = [
- "apollo_sizeof_macros 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core",
-]
-
-[[package]]
-name = "apollo_sizeof"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_sizeof_macros 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
+ "apollo_sizeof_macros",
  "starknet-types-core",
 ]
 
@@ -1793,194 +919,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "apollo_sizeof_macros"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "apollo_staking"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_batcher_types",
- "apollo_config_manager_types",
- "apollo_metrics 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_protobuf",
- "apollo_staking_config",
- "apollo_state_sync_types",
- "async-trait",
- "blockifier 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "mockall 0.12.1",
- "sha2 0.10.9",
- "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "static_assertions",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "apollo_staking_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "serde",
- "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "validator",
-]
-
-[[package]]
-name = "apollo_starknet_client"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "async-trait",
- "cairo-lang-starknet-classes",
- "indexmap 2.13.0",
- "os_info",
- "papyrus_common",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "serde_repr",
- "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "strum",
- "thiserror 1.0.69",
- "tokio",
- "tokio-retry",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "apollo_state_reader"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_class_manager_types",
- "apollo_storage",
- "blockifier 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "cairo-lang-starknet-classes",
- "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "tokio",
-]
-
-[[package]]
-name = "apollo_state_sync_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_central_sync_config",
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_network",
- "apollo_p2p_sync_config",
- "apollo_reverts",
- "apollo_rpc",
- "apollo_storage",
- "serde",
- "validator",
-]
-
-[[package]]
-name = "apollo_state_sync_types"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_infra",
- "apollo_metrics 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_starknet_client",
- "apollo_storage",
- "async-trait",
- "futures",
- "serde",
- "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "strum",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "apollo_storage"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_metrics 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_proc_macros 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "async-trait",
- "axum",
- "byteorder",
- "cairo-lang-casm 2.17.0-rc.4",
- "cairo-lang-starknet-classes",
- "cairo-lang-utils 2.17.0-rc.4",
- "http 1.4.0",
- "http-body-util",
- "human_bytes",
- "indexmap 2.13.0",
- "integer-encoding",
- "libmdbx",
- "memmap2",
- "metrics",
- "num-bigint 0.4.6",
- "page_size",
- "papyrus_common",
- "parity-scale-codec",
- "primitive-types",
- "serde",
- "serde_json",
- "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "validator",
- "zstd",
-]
-
-[[package]]
 name = "apollo_time"
 version = "0.18.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fade79dc45af880ec43aefc347cb3c276a802bc9a15e34fe94ecfdba2dd14538"
 dependencies = [
  "chrono",
-]
-
-[[package]]
-name = "apollo_time"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "chrono",
- "tokio",
-]
-
-[[package]]
-name = "apollo_transaction_converter"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_class_manager_types",
- "apollo_metrics 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_proof_manager_types",
- "async-trait",
- "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "starknet_proof_verifier",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2663,31 +1607,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "bigdecimal"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
-dependencies = [
- "num-bigint 0.4.6",
- "num-integer",
- "num-traits",
- "serde",
-]
-
-[[package]]
 name = "bimap"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bincode"
@@ -2711,26 +1634,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.66.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
-dependencies = [
- "bitflags 2.11.0",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
@@ -2741,24 +1644,6 @@ dependencies = [
  "itertools 0.13.0",
  "log",
  "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 2.1.2",
- "shlex",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags 2.11.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -2847,20 +1732,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake3"
-version = "1.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
- "cpufeatures 0.3.0",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2879,27 +1750,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "block2"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
-dependencies = [
- "objc2",
-]
-
-[[package]]
 name = "blockifier"
 version = "0.18.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d17e91934e751261cb3cfaf8fe3efe80cc431d8c386be67d3e701cda3c814552"
 dependencies = [
  "anyhow",
- "apollo_compilation_utils 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "apollo_compilation_utils",
  "apollo_compile_to_native",
- "apollo_compile_to_native_types 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "apollo_config 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "apollo_infra_utils 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "apollo_metrics 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "apollo_compile_to_native_types",
+ "apollo_config",
+ "apollo_infra_utils",
+ "apollo_metrics",
  "ark-ec",
  "ark-ff 0.5.0",
  "ark-secp256k1",
@@ -2913,7 +1775,7 @@ dependencies = [
  "cairo-native",
  "cairo-vm",
  "dashmap",
- "derive_more 2.1.1",
+ "derive_more",
  "indexmap 2.13.0",
  "itertools 0.12.1",
  "keccak",
@@ -2930,51 +1792,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "strum",
- "thiserror 1.0.69",
- "validator",
-]
-
-[[package]]
-name = "blockifier"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "anyhow",
- "apollo_compile_to_native_types 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_infra_utils 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_metrics 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "ark-ec",
- "ark-ff 0.5.0",
- "ark-secp256k1",
- "ark-secp256r1",
- "cached",
- "cairo-lang-casm 2.17.0-rc.4",
- "cairo-lang-runner",
- "cairo-lang-starknet-classes",
- "cairo-lang-utils 2.17.0-rc.4",
- "cairo-vm",
- "dashmap",
- "derive_more 2.1.1",
- "indexmap 2.13.0",
- "itertools 0.12.1",
- "keccak",
- "log",
- "mockall 0.12.1",
- "num-bigint 0.4.6",
- "num-integer",
- "num-rational",
- "num-traits",
- "paste",
- "phf",
- "semver 1.0.27",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
+ "starknet_api",
  "strum",
  "thiserror 1.0.69",
  "validator",
@@ -2986,13 +1804,13 @@ version = "0.18.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7077372e5e198c7976bfda59443f68521040c05337b6f4e6f034d8f9f0b361"
 dependencies = [
- "apollo_infra_utils 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "apollo_infra_utils",
  "cairo-lang-starknet-classes",
  "digest 0.10.7",
  "serde_json",
  "sha2 0.10.9",
  "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet_api",
  "strum",
  "tempfile",
  "tracing",
@@ -3072,26 +1890,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3104,26 +1902,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bzip2"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
-dependencies = [
- "bzip2-sys",
- "libbz2-rs-sys",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
 ]
 
 [[package]]
@@ -3176,33 +1954,6 @@ name = "cached_proc_macro_types"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
-
-[[package]]
-name = "cairo-air"
-version = "1.1.0"
-source = "git+https://github.com/starkware-libs/stwo-cairo?rev=467d5c6d#467d5c6d4d6d526c1db8ff69c14f2de6d57f4d73"
-dependencies = [
- "bincode 1.3.3",
- "bzip2",
- "clap",
- "itertools 0.12.1",
- "log",
- "num-traits",
- "paste",
- "rayon",
- "serde",
- "serde_json",
- "sonic-rs",
- "starknet-curve 0.6.0",
- "starknet-ff",
- "starknet-types-core",
- "stwo",
- "stwo-cairo-common",
- "stwo-cairo-serialize",
- "stwo-constraint-framework",
- "thiserror 2.0.18",
- "tracing",
-]
 
 [[package]]
 name = "cairo-felt"
@@ -4965,7 +3716,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "starknet-curve 0.6.0",
+ "starknet-curve",
  "starknet-types-core",
  "tempfile",
  "thiserror 2.0.18",
@@ -4981,7 +3732,6 @@ checksum = "38fb2559063ab5f35c1596b6b79a8a18809306a419a3cbd141c2149639386da9"
 dependencies = [
  "anyhow",
  "bitvec",
- "clap",
  "generic-array",
  "indoc 2.0.7",
  "keccak",
@@ -4997,7 +3747,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sha3",
- "starknet-crypto 0.8.1",
+ "starknet-crypto",
  "starknet-types-core",
  "thiserror 2.0.18",
  "tracing",
@@ -5143,90 +3893,6 @@ dependencies = [
  "crypto-common",
  "inout",
  "zeroize",
-]
-
-[[package]]
-name = "circuit-air"
-version = "0.1.0"
-source = "git+https://github.com/starkware-libs/stwo-circuits?rev=2591775#2591775ae8fd7634eda7b77c471f87c163f65eb1"
-dependencies = [
- "circuits",
- "circuits-stark-verifier",
- "itertools 0.12.1",
- "num-traits",
- "serde",
- "stwo",
- "stwo-cairo-common",
- "stwo-constraint-framework",
-]
-
-[[package]]
-name = "circuit-cairo-air"
-version = "0.1.0"
-source = "git+https://github.com/starkware-libs/stwo-circuits?rev=2591775#2591775ae8fd7634eda7b77c471f87c163f65eb1"
-dependencies = [
- "cairo-air",
- "circuit-common",
- "circuits",
- "circuits-stark-verifier",
- "indexmap 2.13.0",
- "itertools 0.12.1",
- "num-traits",
- "serde_json",
- "stwo",
- "stwo-cairo-common",
- "stwo-constraint-framework",
-]
-
-[[package]]
-name = "circuit-common"
-version = "0.1.0"
-source = "git+https://github.com/starkware-libs/stwo-circuits?rev=2591775#2591775ae8fd7634eda7b77c471f87c163f65eb1"
-dependencies = [
- "circuits",
- "itertools 0.12.1",
- "rand_chacha 0.3.1",
- "stwo",
- "stwo-cairo-common",
- "stwo-constraint-framework",
-]
-
-[[package]]
-name = "circuit-serialize"
-version = "0.1.0"
-source = "git+https://github.com/starkware-libs/stwo-circuits?rev=2591775#2591775ae8fd7634eda7b77c471f87c163f65eb1"
-dependencies = [
- "circuits",
- "circuits-stark-verifier",
- "num-traits",
- "stwo",
-]
-
-[[package]]
-name = "circuits"
-version = "0.1.0"
-source = "git+https://github.com/starkware-libs/stwo-circuits?rev=2591775#2591775ae8fd7634eda7b77c471f87c163f65eb1"
-dependencies = [
- "blake2",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
- "itertools 0.12.1",
- "num-traits",
- "stwo",
-]
-
-[[package]]
-name = "circuits-stark-verifier"
-version = "0.1.0"
-source = "git+https://github.com/starkware-libs/stwo-circuits?rev=2591775#2591775ae8fd7634eda7b77c471f87c163f65eb1"
-dependencies = [
- "circuits",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
- "itertools 0.12.1",
- "num-traits",
- "stwo",
- "stwo-constraint-framework",
 ]
 
 [[package]]
@@ -5478,18 +4144,6 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "convert_case"
@@ -6000,19 +4654,6 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
-dependencies = [
- "convert_case 0.4.0",
- "proc-macro2",
- "quote",
- "rustc_version 0.4.1",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
@@ -6101,16 +4742,6 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
-]
-
-[[package]]
-name = "dispatch2"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
 ]
 
 [[package]]
@@ -6403,12 +5034,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethnum"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
-
-[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6489,18 +5114,6 @@ dependencies = [
  "arrayvec",
  "auto_impl",
  "bytes",
-]
-
-[[package]]
-name = "faststr"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca7d44d22004409a61c393afb3369c8f7bb74abcae49fe249ee01dcc3002113"
-dependencies = [
- "bytes",
- "rkyv",
- "serde",
- "simdutf8",
 ]
 
 [[package]]
@@ -6634,21 +5247,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -7439,12 +6037,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "human_bytes"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f255a4535024abf7640cb288260811fc14794f62b063652ed349f9a6c2348e"
-
-[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7505,7 +6097,6 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
- "log",
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
@@ -7528,22 +6119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.9.0",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7561,11 +6136,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.3",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -7850,7 +6423,6 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
- "rayon",
  "serde",
  "serde_core",
 ]
@@ -7985,16 +6557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
-
-[[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "intrusive-collections"
@@ -8211,121 +6774,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpsee"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3f48dc3e6b8bd21e15436c1ddd0bc22a6a54e8ec46fedd6adf3425f396ec6a"
-dependencies = [
- "jsonrpsee-core",
- "jsonrpsee-http-client",
- "jsonrpsee-proc-macros",
- "jsonrpsee-server",
- "jsonrpsee-types",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-core"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "316c96719901f05d1137f19ba598b5fe9c9bc39f4335f67f6be8613921946480"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "jsonrpsee-types",
- "parking_lot 0.12.5",
- "pin-project",
- "rand 0.9.2",
- "rustc-hash 2.1.2",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tower 0.5.3",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-http-client"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790bedefcec85321e007ff3af84b4e417540d5c87b3c9779b9e247d1bcc3dab8"
-dependencies = [
- "base64 0.22.1",
- "http-body 1.0.1",
- "hyper 1.9.0",
- "hyper-rustls",
- "hyper-util",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "rustls",
- "rustls-platform-verifier 0.5.3",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tower 0.5.3",
- "url",
-]
-
-[[package]]
-name = "jsonrpsee-proc-macros"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da3f8ab5ce1bb124b6d082e62dffe997578ceaf0aeb9f3174a214589dc00f07"
-dependencies = [
- "heck 0.5.0",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "jsonrpsee-server"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c51b7c290bb68ce3af2d029648148403863b982f138484a73f02a9dd52dbd7f"
-dependencies = [
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.9.0",
- "hyper-util",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "pin-project",
- "route-recognizer",
- "serde",
- "serde_json",
- "soketto",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tower 0.5.3",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-types"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc88ff4688e43cc3fa9883a8a95c6fa27aa2e76c96e610b737b6554d650d7fd5"
-dependencies = [
- "http 1.4.0",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8460,22 +6908,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
-name = "libbz2-rs-sys"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0864a00c8d019e36216b69c2c4ce50b83b7bd966add3cf5ba554ec44f8bebcf5"
 
 [[package]]
 name = "libc"
@@ -8498,23 +6934,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "libmdbx"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f0bee397dc9a7003e7bd34fffc1dc2d4c4fdc96530a0c439a5f98c9402bc7bf"
-dependencies = [
- "bitflags 2.11.0",
- "byteorder",
- "derive_more 0.99.20",
- "indexmap 1.9.3",
- "libc",
- "lifetimed-bytes",
- "mdbx-sys",
- "parking_lot 0.12.5",
- "thiserror 1.0.69",
-]
 
 [[package]]
 name = "libp2p"
@@ -9058,26 +7477,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-sys"
-version = "1.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "lifetimed-bytes"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c970c8ea4c7b023a41cfa4af4c785a16694604c2f2a3b0d1f20a9bcb73fa550"
-dependencies = [
- "bytes",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9143,16 +7542,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "lz4-sys"
-version = "1.11.1+lz4-1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "macro-string"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9200,17 +7589,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mdbx-sys"
-version = "0.12.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a329f8d655fb646cc9511c00886eefcddb6ef131869ef2d4b02c24c66825ac"
-dependencies = [
- "bindgen 0.66.1",
- "cc",
- "libc",
-]
-
-[[package]]
 name = "melior"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9243,15 +7621,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "memmap2"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9272,27 +7641,6 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
-dependencies = [
- "base64 0.22.1",
- "http-body-util",
- "hyper 1.9.0",
- "hyper-rustls",
- "hyper-util",
- "indexmap 2.13.0",
- "ipnet",
- "metrics",
- "metrics-util 0.19.1",
- "quanta",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "metrics-exporter-prometheus"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
@@ -9300,25 +7648,9 @@ dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
  "metrics",
- "metrics-util 0.20.1",
+ "metrics-util",
  "quanta",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "metrics-util"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
- "hashbrown 0.15.5",
- "metrics",
- "quanta",
- "rand 0.9.2",
- "rand_xoshiro",
- "sketches-ddsketch",
 ]
 
 [[package]]
@@ -9397,7 +7729,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cee4047ffefa7e9853412025a98b38a66968584543918cf084a6e4df9144b71b"
 dependencies = [
- "bindgen 0.71.1",
+ "bindgen",
 ]
 
 [[package]]
@@ -9552,49 +7884,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "munge"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
-dependencies = [
- "munge_macro",
-]
-
-[[package]]
-name = "munge_macro"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom 0.2.17",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -9867,165 +8162,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
-dependencies = [
- "objc2-encode",
-]
-
-[[package]]
-name = "objc2-cloud-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-data"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
-dependencies = [
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags 2.11.0",
- "dispatch2",
- "objc2",
-]
-
-[[package]]
-name = "objc2-core-graphics"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
-dependencies = [
- "bitflags 2.11.0",
- "dispatch2",
- "objc2",
- "objc2-core-foundation",
- "objc2-io-surface",
-]
-
-[[package]]
-name = "objc2-core-image"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
-dependencies = [
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-location"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
-dependencies = [
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-text"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
- "objc2-core-foundation",
- "objc2-core-graphics",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
-name = "objc2-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
-dependencies = [
- "bitflags 2.11.0",
- "block2",
- "libc",
- "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-io-surface"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-quartz-core"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
- "objc2-core-foundation",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-ui-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
-dependencies = [
- "bitflags 2.11.0",
- "block2",
- "objc2",
- "objc2-cloud-kit",
- "objc2-core-data",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-core-image",
- "objc2-core-location",
- "objc2-core-text",
- "objc2-foundation",
- "objc2-quartz-core",
- "objc2-user-notifications",
-]
-
-[[package]]
-name = "objc2-user-notifications"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
-dependencies = [
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10063,48 +8199,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.112"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "ordered-float"
@@ -10113,22 +8211,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "os_info"
-version = "3.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
-dependencies = [
- "android_system_properties",
- "log",
- "nix",
- "objc2",
- "objc2-foundation",
- "objc2-ui-kit",
- "serde",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10155,7 +8237,7 @@ dependencies = [
  "primitive-types",
  "prost 0.13.5",
  "rand 0.8.5",
- "rstest 0.18.2",
+ "rstest",
  "serde",
  "serde_json",
  "sha3",
@@ -10210,58 +8292,12 @@ dependencies = [
  "libp2p",
  "libp2p-plaintext",
  "libp2p-swarm-test",
- "rstest 0.18.2",
+ "rstest",
  "test-log",
  "tokio",
  "tracing",
  "tracing-subscriber",
  "void",
-]
-
-[[package]]
-name = "page_size"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "papyrus_base_layer"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "alloy",
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_infra_utils 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "async-trait",
- "futures",
- "hex",
- "mockall 0.12.1",
- "serde",
- "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "url",
- "validator",
-]
-
-[[package]]
-name = "papyrus_common"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "cairo-lang-starknet-classes",
- "indexmap 2.13.0",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
 ]
 
 [[package]]
@@ -10378,12 +8414,11 @@ name = "pathfinder"
 version = "0.22.2"
 dependencies = [
  "anyhow",
- "apollo_consensus_orchestrator",
  "assert_matches",
  "async-trait",
  "axum",
  "base64 0.22.1",
- "bincode 2.0.1",
+ "bincode",
  "bitvec",
  "bytes",
  "clap",
@@ -10396,7 +8431,7 @@ dependencies = [
  "ipnet",
  "jemallocator",
  "metrics",
- "metrics-exporter-prometheus 0.18.1",
+ "metrics-exporter-prometheus",
  "mockall 0.11.4",
  "num-bigint 0.4.6",
  "p2p",
@@ -10425,7 +8460,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rayon",
  "reqwest 0.12.28",
- "rstest 0.18.2",
+ "rstest",
  "rusqlite",
  "rustls",
  "semver 1.0.27",
@@ -10436,7 +8471,7 @@ dependencies = [
  "starknet-gateway-client",
  "starknet-gateway-test-fixtures",
  "starknet-gateway-types",
- "starknet_api 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet_api",
  "tempfile",
  "test-log",
  "thiserror 2.0.18",
@@ -10504,7 +8539,7 @@ dependencies = [
  "pathfinder-tagged-debug-derive",
  "primitive-types",
  "rand 0.8.5",
- "rstest 0.18.2",
+ "rstest",
  "serde",
  "serde_json",
  "serde_with",
@@ -10527,11 +8562,11 @@ dependencies = [
  "num-bigint 0.4.6",
  "pathfinder-common",
  "pathfinder-crypto",
- "rstest 0.18.2",
+ "rstest",
  "serde",
  "serde_json",
  "starknet-gateway-test-fixtures",
- "starknet_api 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet_api",
  "tracing",
 ]
 
@@ -10614,7 +8649,7 @@ name = "pathfinder-executor"
 version = "0.22.2"
 dependencies = [
  "anyhow",
- "blockifier 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockifier",
  "cached",
  "cairo-lang-starknet-classes",
  "cairo-native",
@@ -10627,7 +8662,7 @@ dependencies = [
  "primitive-types",
  "serde_json",
  "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet_api",
  "tokio",
  "tokio-util",
  "tracing",
@@ -10697,7 +8732,7 @@ dependencies = [
  "primitive-types",
  "rayon",
  "reqwest 0.12.28",
- "rstest 0.18.2",
+ "rstest",
  "serde",
  "serde_json",
  "serde_with",
@@ -10705,7 +8740,7 @@ dependencies = [
  "starknet-gateway-test-fixtures",
  "starknet-gateway-types",
  "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet_api",
  "tempfile",
  "test-log",
  "thiserror 2.0.18",
@@ -10740,7 +8775,7 @@ version = "0.22.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "bincode 2.0.1",
+ "bincode",
  "bitvec",
  "cached",
  "const_format",
@@ -10762,7 +8797,7 @@ dependencies = [
  "r2d2_sqlite",
  "rand 0.8.5",
  "rayon",
- "rstest 0.18.2",
+ "rstest",
  "rusqlite",
  "serde",
  "serde_json",
@@ -10804,12 +8839,6 @@ version = "0.22.2"
 dependencies = [
  "vergen",
 ]
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
@@ -11169,36 +9198,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "privacy-circuit-verify"
-version = "1.1.0"
-source = "git+https://github.com/starkware-libs/proving-utils?rev=0305dbe#0305dbec6471bb57b8bdccd000b0a189d6c955a9"
-dependencies = [
- "anyhow",
- "cairo-air",
- "cairo-vm",
- "circuit-air",
- "circuit-cairo-air",
- "circuit-common",
- "circuit-serialize",
- "circuits",
- "circuits-stark-verifier",
- "clap",
- "itertools 0.12.1",
- "log",
- "num-traits",
- "serde",
- "serde_json",
- "sonic-rs",
- "starknet-ff",
- "starknet-types-core",
- "stwo",
- "stwo-cairo-common",
- "stwo-cairo-serialize",
- "tracing",
- "zstd",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11282,16 +9281,6 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
-dependencies = [
- "bytes",
- "prost-derive 0.12.6",
-]
-
-[[package]]
-name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
@@ -11328,19 +9317,6 @@ dependencies = [
  "regex",
  "syn 2.0.117",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
-dependencies = [
- "anyhow",
- "itertools 0.12.1",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -11385,26 +9361,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost 0.14.3",
-]
-
-[[package]]
-name = "ptr_meta"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -11557,15 +9513,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
-name = "rancor"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
-dependencies = [
- "ptr_meta",
-]
-
-[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11643,16 +9590,6 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
-
-[[package]]
-name = "rand_distr"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
-]
 
 [[package]]
 name = "rand_xorshift"
@@ -11826,18 +9763,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
-name = "rend"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
-
-[[package]]
-name = "replace_with"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
-
-[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11846,21 +9771,17 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
- "futures-util",
  "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -11872,7 +9793,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tower 0.5.3",
  "tower-http 0.6.8",
@@ -11905,7 +9825,7 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier 0.6.2",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
@@ -11921,56 +9841,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest-middleware"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
-dependencies = [
- "anyhow",
- "async-trait",
- "http 1.4.0",
- "reqwest 0.12.28",
- "serde",
- "thiserror 1.0.69",
- "tower-service",
-]
-
-[[package]]
-name = "reqwest-retry"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c73e4195a6bfbcb174b790d9b3407ab90646976c55de58a6515da25d851178"
-dependencies = [
- "anyhow",
- "async-trait",
- "futures",
- "getrandom 0.2.17",
- "http 1.4.0",
- "hyper 1.9.0",
- "parking_lot 0.11.2",
- "reqwest 0.12.28",
- "reqwest-middleware",
- "retry-policies",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "wasm-timer",
-]
-
-[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
-
-[[package]]
-name = "retry-policies"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
-dependencies = [
- "rand 0.8.5",
-]
 
 [[package]]
 name = "rfc6979"
@@ -11997,35 +9871,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rkyv"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a30e631b7f4a03dee9056b8ef6982e8ba371dd5bedb74d3ec86df4499132c70"
-dependencies = [
- "bytes",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
- "munge",
- "ptr_meta",
- "rancor",
- "rend",
- "rkyv_derive",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8100bb34c0a1d0f907143db3149e6b4eea3c33b9ee8b189720168e818303986f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "rlimit"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12045,12 +9890,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "route-recognizer"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
-
-[[package]]
 name = "rstest"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12058,19 +9897,8 @@ checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
 dependencies = [
  "futures",
  "futures-timer",
- "rstest_macros 0.18.2",
+ "rstest_macros",
  "rustc_version 0.4.1",
-]
-
-[[package]]
-name = "rstest"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
-dependencies = [
- "futures-timer",
- "futures-util",
- "rstest_macros 0.26.1",
 ]
 
 [[package]]
@@ -12081,24 +9909,6 @@ checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
 dependencies = [
  "cfg-if",
  "glob",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version 0.4.1",
- "syn 2.0.117",
- "unicode-ident",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro-crate",
  "proc-macro2",
  "quote",
  "regex",
@@ -12172,33 +9982,6 @@ dependencies = [
  "hashlink 0.10.0",
  "libsqlite3-sys",
  "smallvec",
-]
-
-[[package]]
-name = "rust-librocksdb-sys"
-version = "0.40.0+10.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00d2a200a5d3a21d9c2d39785d8542b2226cf3d132976c04f32eae31d3c0394"
-dependencies = [
- "bindgen 0.72.1",
- "bzip2-sys",
- "cc",
- "glob",
- "libc",
- "libz-sys",
- "lz4-sys",
- "zstd-sys",
-]
-
-[[package]]
-name = "rust-rocksdb"
-version = "0.44.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1139f88cb2ef35c4310f818025cd7e09e1895b42a44d1aed3ac6733d3e398b21"
-dependencies = [
- "libc",
- "parking_lot 0.12.5",
- "rust-librocksdb-sys",
 ]
 
 [[package]]
@@ -12309,27 +10092,6 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustls-platform-verifier"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
@@ -12345,7 +10107,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-root-certs 1.0.6",
+ "webpki-root-certs",
  "windows-sys 0.61.2",
 ]
 
@@ -12654,15 +10416,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_arrays"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38636132857f68ec3d5f3eb121166d2af33cb55174c4d5ff645db6165cbef0fd"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12736,17 +10489,6 @@ checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
 dependencies = [
  "regex",
  "serde",
-]
-
-[[package]]
-name = "serde_repr"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -12876,16 +10618,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shared_execution_objects"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "blockifier 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "serde",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12916,12 +10648,6 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -13032,60 +10758,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "soketto"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures",
- "http 1.4.0",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha1",
-]
-
-[[package]]
-name = "sonic-number"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3775c3390edf958191f1ab1e8c5c188907feebd0f3ce1604cb621f72961dbf32"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "sonic-rs"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0275f9f2f07d47556fe60c2759da8bc4be6083b047b491b2d476aa0bfa558eb1"
-dependencies = [
- "bumpalo",
- "bytes",
- "cfg-if",
- "faststr",
- "itoa",
- "ref-cast",
- "ryu",
- "serde",
- "simdutf8",
- "sonic-number",
- "sonic-simd",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "sonic-simd"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99e664ecd2d85a68c87e3c7a3cfe691f647ea9e835de984aba4d54a41f817d4"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13150,7 +10822,7 @@ dependencies = [
  "serde_with",
  "sha3",
  "starknet-core-derive",
- "starknet-crypto 0.8.1",
+ "starknet-crypto",
  "starknet-types-core",
 ]
 
@@ -13167,26 +10839,6 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e2c30c01e8eb0fc913c4ee3cf676389fffc1d1182bfe5bb9670e4e72e968064"
-dependencies = [
- "crypto-bigint",
- "hex",
- "hmac",
- "num-bigint 0.4.6",
- "num-integer",
- "num-traits",
- "rfc6979",
- "sha2 0.10.9",
- "starknet-crypto-codegen",
- "starknet-curve 0.4.2",
- "starknet-ff",
- "zeroize",
-]
-
-[[package]]
-name = "starknet-crypto"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1004a16c25dc6113c19d4f9d0c19ff97d85804829894bba22c0d0e9e7b249812"
@@ -13199,29 +10851,9 @@ dependencies = [
  "num-traits",
  "rfc6979",
  "sha2 0.10.9",
- "starknet-curve 0.6.0",
+ "starknet-curve",
  "starknet-types-core",
  "zeroize",
-]
-
-[[package]]
-name = "starknet-crypto-codegen"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbc159a1934c7be9761c237333a57febe060ace2bc9e3b337a59a37af206d19f"
-dependencies = [
- "starknet-curve 0.4.2",
- "starknet-ff",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "starknet-curve"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c383518bb312751e4be80f53e8644034aa99a0afb29d7ac41b89a997db875b"
-dependencies = [
- "starknet-ff",
 ]
 
 [[package]]
@@ -13231,20 +10863,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22c898ae81b6409532374cf237f1bd752d068b96c6ad500af9ebbd0d9bb712f6"
 dependencies = [
  "starknet-types-core",
-]
-
-[[package]]
-name = "starknet-ff"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abf1b44ec5b18d87c1ae5f54590ca9d0699ef4dd5b2ffa66fc97f24613ec585"
-dependencies = [
- "ark-ff 0.4.2",
- "bigdecimal",
- "crypto-bigint",
- "getrandom 0.2.17",
- "hex",
- "serde",
 ]
 
 [[package]]
@@ -13313,71 +10931,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "starknet-rust-core"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b1a74f23d96f4edf47d496b1625a863f0d17fc2f206b04767770705d8057a79"
-dependencies = [
- "base64 0.21.7",
- "crypto-bigint",
- "flate2",
- "foldhash 0.1.5",
- "hex",
- "indexmap 2.13.0",
- "num-traits",
- "semver 1.0.27",
- "serde",
- "serde_json",
- "serde_json_pythonic",
- "serde_with",
- "sha3",
- "starknet-rust-core-derive",
- "starknet-rust-crypto",
- "starknet-types-core",
-]
-
-[[package]]
-name = "starknet-rust-core-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fe79a81e657d7f500b9a3706a42cdb3691fd36049845e1ea4b7ea8181860cd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "starknet-rust-crypto"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9955e2572fc8e24bff60f238af9969c4062c4238680907423636a7d5e9aa736f"
-dependencies = [
- "blake2",
- "crypto-bigint",
- "digest 0.10.7",
- "hex",
- "hmac",
- "num-bigint 0.4.6",
- "num-integer",
- "num-traits",
- "rfc6979",
- "sha2 0.10.9",
- "starknet-rust-curve",
- "starknet-types-core",
- "zeroize",
-]
-
-[[package]]
-name = "starknet-rust-curve"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1977caca63a4e6439968abe0c9d8c0d2074df7641f1153e8a551f8200470d8da"
-dependencies = [
- "starknet-types-core",
-]
-
-[[package]]
 name = "starknet-types-core"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13402,15 +10955,15 @@ version = "0.18.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94f3991e6f1afe218357fa16e3ed9a72cdbb1d9b6ccc472d37851b5cf268bd39"
 dependencies = [
- "apollo_infra_utils 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "apollo_sizeof 0.18.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "apollo_infra_utils",
+ "apollo_sizeof",
  "base64 0.13.1",
  "bitvec",
  "cached",
  "cairo-lang-runner",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils 2.17.0-rc.4",
- "derive_more 2.1.1",
+ "derive_more",
  "expect-test",
  "flate2",
  "hex",
@@ -13427,124 +10980,12 @@ dependencies = [
  "serde_json",
  "sha3",
  "starknet-core",
- "starknet-crypto 0.8.1",
+ "starknet-crypto",
  "starknet-types-core",
  "strum",
  "thiserror 1.0.69",
  "time",
  "tokio",
-]
-
-[[package]]
-name = "starknet_api"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_infra_utils 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "apollo_sizeof 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "base64 0.13.1",
- "bitvec",
- "cached",
- "cairo-lang-runner",
- "cairo-lang-starknet-classes",
- "cairo-lang-utils 2.17.0-rc.4",
- "derive_more 2.1.1",
- "flate2",
- "hex",
- "indexmap 2.13.0",
- "itertools 0.12.1",
- "num-bigint 0.4.6",
- "num-traits",
- "pretty_assertions",
- "primitive-types",
- "rand 0.8.5",
- "semver 1.0.27",
- "serde",
- "serde_json",
- "sha3",
- "starknet-core",
- "starknet-crypto 0.8.1",
- "starknet-types-core",
- "strum",
- "thiserror 1.0.69",
- "time",
- "tokio",
-]
-
-[[package]]
-name = "starknet_committer"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "async-trait",
- "derive_more 2.1.1",
- "ethnum",
- "hex",
- "pretty_assertions",
- "rand 0.8.5",
- "rand_distr",
- "serde",
- "serde_json",
- "starknet-rust-core",
- "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "starknet_patricia",
- "starknet_patricia_storage",
- "strum",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "starknet_patricia"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "async-recursion",
- "derive_more 2.1.1",
- "ethnum",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "starknet-rust-core",
- "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "starknet_patricia_storage",
- "strum",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
-name = "starknet_patricia_storage"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "hex",
- "lru 0.12.5",
- "rust-rocksdb",
- "serde",
- "serde_json",
- "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "thiserror 1.0.69",
- "validator",
-]
-
-[[package]]
-name = "starknet_proof_verifier"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1#8b090b27bca8a8366c63ae864507f59c78c8bdc5"
-dependencies = [
- "apollo_sizeof 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "privacy-circuit-verify",
- "serde",
- "starknet-types-core",
- "starknet_api 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=blockifier-v0.18.0-rc.1)",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -13603,93 +11044,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "stwo"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/stwo?rev=aeceb74c#aeceb74c58184d7886ebd7f34a7453fee714ca40"
-dependencies = [
- "blake2",
- "blake3",
- "bytemuck",
- "cfg-if",
- "dashmap",
- "educe 0.5.11",
- "fnv",
- "hashbrown 0.16.1",
- "hex",
- "indexmap 2.13.0",
- "itertools 0.12.1",
- "num-traits",
- "rand 0.8.5",
- "rayon",
- "serde",
- "starknet-crypto 0.6.2",
- "starknet-ff",
- "stwo-std-shims",
- "thiserror 2.0.18",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "stwo-cairo-common"
-version = "1.1.0"
-source = "git+https://github.com/starkware-libs/stwo-cairo?rev=467d5c6d#467d5c6d4d6d526c1db8ff69c14f2de6d57f4d73"
-dependencies = [
- "bytemuck",
- "itertools 0.12.1",
- "rayon",
- "ruint",
- "serde",
- "serde_arrays",
- "starknet-curve 0.6.0",
- "starknet-ff",
- "starknet-types-core",
- "stwo",
- "stwo-cairo-serialize",
- "stwo-constraint-framework",
-]
-
-[[package]]
-name = "stwo-cairo-serialize"
-version = "1.1.0"
-source = "git+https://github.com/starkware-libs/stwo-cairo?rev=467d5c6d#467d5c6d4d6d526c1db8ff69c14f2de6d57f4d73"
-dependencies = [
- "starknet-ff",
- "stwo",
- "stwo-cairo-serialize-derive",
-]
-
-[[package]]
-name = "stwo-cairo-serialize-derive"
-version = "1.1.0"
-source = "git+https://github.com/starkware-libs/stwo-cairo?rev=467d5c6d#467d5c6d4d6d526c1db8ff69c14f2de6d57f4d73"
-dependencies = [
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "stwo-constraint-framework"
-version = "2.1.0"
-source = "git+https://github.com/starkware-libs/stwo?rev=aeceb74c#aeceb74c58184d7886ebd7f34a7453fee714ca40"
-dependencies = [
- "hashbrown 0.16.1",
- "itertools 0.12.1",
- "num-traits",
- "rand 0.8.5",
- "rayon",
- "stwo",
- "stwo-std-shims",
- "tracing",
-]
-
-[[package]]
-name = "stwo-std-shims"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c21e2c707fb8926e6c4355a87494c29e8e46640ff4796aa8fbb74952327dfdc"
 
 [[package]]
 name = "subtle"
@@ -13805,7 +11159,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c155c9310c9e11e6f642b4c8a30ae572ea0cad013d5c9e28bb264b52fa8163bb"
 dependencies = [
- "bindgen 0.71.1",
+ "bindgen",
  "cc",
  "paste",
  "thiserror 2.0.18",
@@ -14062,29 +11416,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-metrics"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0410015c6db7b67b9c9ab2a3af4d74a942d637ff248d0d055073750deac6f9"
-dependencies = [
- "futures-util",
- "metrics",
- "pin-project-lite",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-retry"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14165,7 +11496,6 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
- "futures-io",
  "futures-sink",
  "futures-util",
  "pin-project-lite",
@@ -14306,7 +11636,6 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "hdrhistogram",
  "indexmap 2.13.0",
  "pin-project-lite",
  "slab",
@@ -14986,21 +12315,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-timer"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot 0.11.2",
- "pin-utils",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15044,15 +12358,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
-dependencies = [
- "webpki-root-certs 1.0.6",
 ]
 
 [[package]]
@@ -15904,7 +13209,6 @@ version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
- "bindgen 0.72.1",
  "cc",
  "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ authors = ["Equilibrium Labs <info@equilibrium.co>"]
 
 [workspace.dependencies]
 anyhow = "1.0.102"
-apollo_consensus_orchestrator = { package = "apollo_consensus_orchestrator", git = "https://github.com/starkware-libs/sequencer", tag = "blockifier-v0.18.0-rc.1" }
 ark-ff = "0.5.0"
 assert_matches = "1.5.0"
 async-trait = "0.1.89"

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -503,6 +503,21 @@ impl StarknetVersion {
         StarknetVersion(a, b, c, d)
     }
 
+    #[inline]
+    pub fn major(&self) -> u8 {
+        self.0
+    }
+
+    #[inline]
+    pub fn minor(&self) -> u8 {
+        self.1
+    }
+
+    #[inline]
+    pub fn patch(&self) -> u8 {
+        self.2
+    }
+
     pub const V_0_13_2: Self = Self::new(0, 13, 2, 0);
 
     // TODO: version at which block hash definition changes taken from

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -80,7 +80,6 @@ zeroize = { workspace = true }
 zstd = { workspace = true }
 
 [dev-dependencies]
-apollo_consensus_orchestrator = { workspace = true }
 assert_matches = { workspace = true }
 const-decoder = { workspace = true }
 flate2 = { workspace = true }

--- a/crates/pathfinder/src/gas_price/l2.rs
+++ b/crates/pathfinder/src/gas_price/l2.rs
@@ -160,6 +160,8 @@ impl L2GasPriceProvider {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use anyhow::Context;
     use rstest::rstest;
     use serde::Deserialize;
@@ -226,13 +228,20 @@ mod tests {
             version.minor(),
             version.patch()
         );
-        let resp = reqwest::get(url)
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .context("building http client")?;
+        let resp = client
+            .get(url)
+            .send()
             .await
-            .context("fetching apollo constants")?
-            .error_for_status()
-            .context("http get failed")?;
-        let json = resp.bytes().await.context("reading apollo response body")?;
-        serde_json::from_slice(&json).context("parsing apollo constants JSON")
+            .context("fetching apollo constants")?;
+        resp.error_for_status()
+            .context("http get failed")?
+            .json()
+            .await
+            .context("parsing apollo constants")
     }
 
     // Apollo test vectors (from fee_market/test.rs)

--- a/crates/pathfinder/src/gas_price/l2.rs
+++ b/crates/pathfinder/src/gas_price/l2.rs
@@ -160,31 +160,33 @@ impl L2GasPriceProvider {
 
 #[cfg(test)]
 mod tests {
-    use apollo_consensus_orchestrator::orchestrator_versioned_constants;
+    use anyhow::Context;
     use rstest::rstest;
+    use serde::Deserialize;
 
     use super::*;
 
     const TEST_PRICE: u128 = 30_000_000_000;
+
+    /// Apollo versioned constants as they are defined in the
+    /// `apollo_consensus_orchestrator` crate.
+    #[derive(Debug, Deserialize)]
+    struct ApolloVersionedConstants {
+        gas_price_max_change_denominator: u128,
+        gas_target: starknet_api::execution_resources::GasAmount,
+        max_block_size: starknet_api::execution_resources::GasAmount,
+        min_gas_price: starknet_api::block::GasPrice,
+    }
 
     #[rstest]
     #[case::v0_13_2(StarknetVersion::V_0_13_2)]
     #[case::v0_13_4(StarknetVersion::V_0_13_4)]
     #[case::v0_14_0(StarknetVersion::V_0_14_0)]
     #[case::v0_14_1(StarknetVersion::V_0_14_1)]
-    fn l2_gas_constants_match_with_apollo(#[case] version: StarknetVersion) {
+    #[tokio::test]
+    async fn l2_gas_constants_match_with_apollo(#[case] version: StarknetVersion) {
         let pathfinder_c = L2GasPriceConstants::for_version(version);
-        let apollo_c = match version {
-            // Pre v0.14.1
-            StarknetVersion::V_0_13_2 | StarknetVersion::V_0_13_4 | StarknetVersion::V_0_14_0 => {
-                &*orchestrator_versioned_constants::VERSIONED_CONSTANTS_V0_14_0
-            }
-            // Post v0.14.1
-            StarknetVersion::V_0_14_1 => {
-                &*orchestrator_versioned_constants::VERSIONED_CONSTANTS_V0_14_1
-            }
-            _ => unreachable!("not covered by this test"),
-        };
+        let apollo_c = fetch_apollo_constants_for(version).await.unwrap();
 
         assert_eq!(
             pathfinder_c.gas_price_max_change_denominator,
@@ -196,6 +198,41 @@ mod tests {
             apollo_c.max_block_size.0 as u128
         );
         assert_eq!(pathfinder_c.min_gas_price, apollo_c.min_gas_price.0);
+    }
+
+    async fn fetch_apollo_constants_for(
+        version: StarknetVersion,
+    ) -> anyhow::Result<ApolloVersionedConstants> {
+        // Pin the constants URL to the most recent blockifier tag for stability.
+        // Update the tag when the current one does not have the constants for the
+        // tested version.
+        const LATEST_BLOCKIFIER_TAG: &str = "blockifier-v0.18.0-rc.1";
+
+        // Apollo's constants are only versioned starting from v0.14.0, so for older
+        // versions (which are expected to be same as v0.14.0) we fetch the v0.14.0
+        // constants.
+        let version = if version < StarknetVersion::V_0_14_0 {
+            StarknetVersion::V_0_14_0
+        } else {
+            version
+        };
+
+        let url = format!(
+            "https://raw.githubusercontent.com/starkware-libs/sequencer/\
+                refs/tags/{}/\
+                crates/apollo_consensus_orchestrator/resources/orchestrator_versioned_constants_{}_{}_{}.json",
+            LATEST_BLOCKIFIER_TAG,
+            version.major(),
+            version.minor(),
+            version.patch()
+        );
+        let resp = reqwest::get(url)
+            .await
+            .context("fetching apollo constants")?
+            .error_for_status()
+            .context("http get failed")?;
+        let json = resp.bytes().await.context("reading apollo response body")?;
+        serde_json::from_slice(&json).context("parsing apollo constants JSON")
     }
 
     // Apollo test vectors (from fee_market/test.rs)


### PR DESCRIPTION
Changes the test that checks our L2 gas constants against Apollo's to fetch Apollo versioned constants from GitHub instead of pulling them in through cargo. This is meant to be an alternative to adding the entire `apollo_consensus_orchestrator` crate as a (very heavy) dependency.

Since we no longer depend on `mdbx-sys` (via `apollo_consensus_orchestrator`), the cargo config that was needed for `mdbx-sys` to compile is removed.
