### PR TITLE
test(gas_price/l2): get blockifier version from workspace manifest file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3755,6 +3755,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_toml"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
+dependencies = [
+ "serde",
+ "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
 name = "caseless"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8675,6 +8685,7 @@ name = "pathfinder-gas-price"
 version = "0.22.2"
 dependencies = [
  "anyhow",
+ "cargo_toml",
  "mockall 0.11.4",
  "pathfinder-common",
  "pathfinder-ethereum",

--- a/crates/gas-price/Cargo.toml
+++ b/crates/gas-price/Cargo.toml
@@ -14,6 +14,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+cargo_toml = "0.22.3"
 mockall = { workspace = true }
 pathfinder-common = { path = "../common" }
 pathfinder-ethereum = { path = "../ethereum" }

--- a/crates/gas-price/src/l2.rs
+++ b/crates/gas-price/src/l2.rs
@@ -160,6 +160,7 @@ impl L2GasPriceProvider {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
     use std::time::Duration;
 
     use anyhow::Context;
@@ -188,7 +189,10 @@ mod tests {
     #[tokio::test]
     async fn l2_gas_constants_match_with_apollo(#[case] version: StarknetVersion) {
         let pathfinder_c = L2GasPriceConstants::for_version(version);
-        let apollo_c = fetch_apollo_constants_for(version).await.unwrap();
+        let blockifier_tag = blockifier_tag_from_manifest().unwrap();
+        let apollo_c = fetch_apollo_constants_for(version, blockifier_tag)
+            .await
+            .unwrap();
 
         assert_eq!(
             pathfinder_c.gas_price_max_change_denominator,
@@ -202,14 +206,32 @@ mod tests {
         assert_eq!(pathfinder_c.min_gas_price, apollo_c.min_gas_price.0);
     }
 
+    // Parses the workspace Cargo.toml to find the version of blockifier, which is
+    // then used to construct the blockier tag in the form of
+    // `blockifier-v{version-from-workspace-Cargo-toml}`.
+    fn blockifier_tag_from_manifest() -> anyhow::Result<String> {
+        let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("Cargo.toml");
+        let manifest = cargo_toml::Manifest::from_path(manifest_path)
+            .context("loading workspace Cargo.toml")?;
+        let workspace = manifest
+            .workspace
+            .context("getting workspace dependencies")?;
+        let blockifier_version = workspace
+            .dependencies
+            .get("blockifier")
+            .and_then(|dep| dep.try_req().ok())
+            .context("parsing blockifier version from Cargo.toml")?;
+        let blockifier_tag = format!("blockifier-v{blockifier_version}");
+        Ok(blockifier_tag)
+    }
+
     async fn fetch_apollo_constants_for(
         version: StarknetVersion,
+        blockifier_tag: impl AsRef<str>,
     ) -> anyhow::Result<ApolloVersionedConstants> {
-        // Pin the constants URL to the most recent blockifier tag for stability.
-        // Update the tag when the current one does not have the constants for the
-        // tested version.
-        const LATEST_BLOCKIFIER_TAG: &str = "blockifier-v0.18.0-rc.1";
-
         // Apollo's constants are only versioned starting from v0.14.0, so for older
         // versions (which are expected to be same as v0.14.0) we fetch the v0.14.0
         // constants.
@@ -223,7 +245,7 @@ mod tests {
             "https://raw.githubusercontent.com/starkware-libs/sequencer/\
                 refs/tags/{}/\
                 crates/apollo_consensus_orchestrator/resources/orchestrator_versioned_constants_{}_{}_{}.json",
-            LATEST_BLOCKIFIER_TAG,
+            blockifier_tag.as_ref(),
             version.major(),
             version.minor(),
             version.patch()


### PR DESCRIPTION
Fixes: https://github.com/equilibriumco/pathfinder/issues/3329