### PR TITLE
chore: migrate org name everywhere except docker hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-More expansive patch notes and explanations may be found in the specific [pathfinder release notes](https://github.com/eqlabs/pathfinder/releases).
+More expansive patch notes and explanations may be found in the specific [pathfinder release notes](https://github.com/equilibriumco/pathfinder/releases).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -307,7 +307,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     b. The latest L2 block if it is behind the latest L1 checkpoint or no L1 checkpoints have been received by the node (practically unreachable)
 
 - `starknet_getTransactionStatus` now returns RECEIVED even when the gateway cannot find the transaction, provided the transaction was successfully sent by the responding node within the last 5 minutes.
-- Pathfinder now allows the users to configure the number of historical messages to be streamed via the [webscoket API](https://eqlabs.github.io/pathfinder/interacting-with-pathfinder/websocket-api). This can be done using the `--rpc.websocket.max-history` CLI option.
+- Pathfinder now allows the users to configure the number of historical messages to be streamed via the [webscoket API](https://equilibriumco.github.io/pathfinder/interacting-with-pathfinder/websocket-api). This can be done using the `--rpc.websocket.max-history` CLI option.
   - Accepted values are:
     - "unlimited" - All historical messages will be streamed.
     - "N" - An integer specifying the number of historical messages to be streamed.
@@ -357,7 +357,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `starknet_subscribeEvents` subscriptions stop sending notifications.
-- Broken aggregate bloom filter migration has been updated to work properly. If you migrated from a database running in archived mode, please [re-download our latest snapshot](https://eqlabs.github.io/pathfinder/database-snapshots) and re-run the migrations.
+- Broken aggregate bloom filter migration has been updated to work properly. If you migrated from a database running in archived mode, please [re-download our latest snapshot](https://equilibriumco.github.io/pathfinder/database-snapshots) and re-run the migrations.
 - `starknet_getStateUpdate` has `new_root` and `old_root` swapped.
 
 ### Changed
@@ -1146,10 +1146,10 @@ Users should not use this version.
 
 ### Removed
 
-- `--config` configuration option (deprecated in [v0.4.1](https://github.com/eqlabs/pathfinder/releases/tag/v0.4.1))
-- `--integration` configuration option (deprecated in [v0.4.1](https://github.com/eqlabs/pathfinder/releases/tag/v0.4.1))
-- `--sequencer-url` configuration option (deprecated in [v0.4.1](https://github.com/eqlabs/pathfinder/releases/tag/v0.4.1))
-- `--testnet2` configuration option (deprecated in [v0.4.1](https://github.com/eqlabs/pathfinder/releases/tag/v0.4.1))
+- `--config` configuration option (deprecated in [v0.4.1](https://github.com/equilibriumco/pathfinder/releases/tag/v0.4.1))
+- `--integration` configuration option (deprecated in [v0.4.1](https://github.com/equilibriumco/pathfinder/releases/tag/v0.4.1))
+- `--sequencer-url` configuration option (deprecated in [v0.4.1](https://github.com/equilibriumco/pathfinder/releases/tag/v0.4.1))
+- `--testnet2` configuration option (deprecated in [v0.4.1](https://github.com/equilibriumco/pathfinder/releases/tag/v0.4.1))
 - `starknet_addDeployTransaction` as this is no longer an allowed transaction
 - RPC api version `0.1`, which used to be served on path `/rpc/v0.1`
 
@@ -1230,4 +1230,4 @@ Users should not use this version.
 
 ## Ancient History
 
-Older history may be found in the [pathfinder release notes](https://github.com/eqlabs/pathfinder/releases).
+Older history may be found in the [pathfinder release notes](https://github.com/equilibriumco/pathfinder/releases).

--- a/crates/class-hash/Cargo.toml
+++ b/crates/class-hash/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 license = { workspace = true }
 rust-version = { workspace = true }
 description = "Pathfinder's class hash computation and verification"
-repository = "https://github.com/eqlabs/pathfinder"
+repository = "https://github.com/equilibriumco/pathfinder"
 keywords = ["starknet", "ethereum", "web3", "cryptography", "hash"]
 categories = [
     "cryptography",

--- a/crates/class-hash/README.md
+++ b/crates/class-hash/README.md
@@ -2,7 +2,7 @@
 
 [![Documentation](https://docs.rs/pathfinder-class-hash/badge.svg)](https://docs.rs/pathfinder-class-hash)
 [![Crates.io](https://img.shields.io/crates/v/pathfinder-class-hash)](https://crates.io/crates/pathfinder-class-hash)
-[![License](https://img.shields.io/crates/l/pathfinder-class-hash)](https://github.com/eqlabs/pathfinder/blob/main/LICENSE-MIT)
+[![License](https://img.shields.io/crates/l/pathfinder-class-hash)](https://github.com/equilibriumco/pathfinder/blob/main/LICENSE-MIT)
 
 
 This crate provides functionality to compute class hashes for both Cairo 0.x and Sierra (Cairo 1.x+) contracts in the Starknet ecosystem. It implements the official Starknet class hash computation algorithm, handling special cases for different Cairo versions and maintaining compatibility with the network's expectations.

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 license = { workspace = true }
 rust-version = { workspace = true }
 description = "Common types and utilities for Pathfinder"
-repository = "https://github.com/eqlabs/pathfinder"
+repository = "https://github.com/equilibriumco/pathfinder"
 keywords = ["starknet", "ethereum", "blockchain", "web3", "types"]
 categories = [
     "cryptography::cryptocurrencies",

--- a/crates/consensus/src/internal/wal.rs
+++ b/crates/consensus/src/internal/wal.rs
@@ -150,7 +150,7 @@ pub(crate) fn convert_wal_entry_to_input<
                 },
             };
             // TODO Differentiate between consensus and sync proposed values once catch up
-            // using sync protocol is implemented, related issue https://github.com/eqlabs/pathfinder/issues/2934
+            // using sync protocol is implemented, related issue https://github.com/equilibriumco/pathfinder/issues/2934
             Input::ProposedValue(proposed_value, malachite_types::ValueOrigin::Consensus)
         }
         _ => unreachable!(),

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -550,7 +550,7 @@ impl<
                 let vote_round = internal_consensus.recover_from_wal(entries);
                 if let Some(round) = vote_round {
                     // Schedule rebroadcast timeout.
-                    // See https://github.com/eqlabs/pathfinder/issues/3286 for motivation.
+                    // See https://github.com/equilibriumco/pathfinder/issues/3286 for motivation.
                     internal_consensus.schedule_rebroadcast(round);
                 }
 

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 license = { workspace = true }
 rust-version = { workspace = true }
 description = "Cryptographic primitives used by Pathfinder"
-repository = "https://github.com/eqlabs/pathfinder"
+repository = "https://github.com/equilibriumco/pathfinder"
 keywords = ["starknet", "cryptography", "pedersen", "poseidon", "ecdsa"]
 categories = [
     "cryptography",

--- a/crates/p2p_stream/README.md
+++ b/crates/p2p_stream/README.md
@@ -20,7 +20,7 @@ This crate is a derivative of Parity Technologies' [`libp2p request/response`](h
 
 <br>
 
-*): [`pathfinder`](https://github.com/eqlabs/pathfinder) uses this crate with its own [Starknet](https://www.starknet.io/) specific [protocol](https://github.com/starknet-io/starknet-p2p-specs) and decided to drop unnecessary features
+*): [`pathfinder`](https://github.com/equilibriumco/pathfinder) uses this crate with its own [Starknet](https://www.starknet.io/) specific [protocol](https://github.com/starknet-io/starknet-p2p-specs) and decided to drop unnecessary features
 
 # Acknowledgements
 

--- a/crates/pathfinder/src/bin/pathfinder/update.rs
+++ b/crates/pathfinder/src/bin/pathfinder/update.rs
@@ -126,7 +126,8 @@ async fn fetch_latest_github_release(
 ) -> UpdateResult {
     use reqwest::{StatusCode, Url};
 
-    let url = Url::parse("https://api.github.com/repos/eqlabs/pathfinder/releases/latest").unwrap();
+    let url = Url::parse("https://api.github.com/repos/equilibriumco/pathfinder/releases/latest")
+        .unwrap();
 
     let mut request = client.get(url);
 

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -39,7 +39,7 @@ const COMPILER_CPU_TIME_ALLOWED_RANGE: std::ops::RangeInclusive<u64> =
 #[command(version = pathfinder_version::VERSION)]
 #[command(propagate_version = true)]
 #[command(
-    about = "A Starknet node implemented by Equilibrium Labs. Submit bug reports and issues at https://github.com/eqlabs/pathfinder."
+    about = "A Starknet node implemented by Equilibrium Labs. Submit bug reports and issues at https://github.com/equilibriumco/pathfinder."
 )]
 pub struct Cli {
     #[command(subcommand)]

--- a/crates/pathfinder/src/consensus/inner/consensus_task.rs
+++ b/crates/pathfinder/src/consensus/inner/consensus_task.rs
@@ -80,7 +80,7 @@ pub fn spawn(
                     .with_history_depth(config.history_depth)
                     .with_wal_dir(wal_directory),
                 // TODO use a dynamic validator set provider, once fetching the validator set from
-                // the staking contract is implemented. Related issue: https://github.com/eqlabs/pathfinder/issues/2936
+                // the staking contract is implemented. Related issue: https://github.com/equilibriumco/pathfinder/issues/2936
                 Arc::new(validator_set_provider.clone()),
                 proposer_selector,
                 highest_committed,

--- a/crates/pathfinder/src/p2p_network/common.rs
+++ b/crates/pathfinder/src/p2p_network/common.rs
@@ -28,7 +28,7 @@ pub async fn dial_bootnodes<C>(
 
         // TODO: Use exponential backoff with a max retry limit, at least one boot node
         // needs to be reachable for the node to be useful.
-        // https://github.com/eqlabs/pathfinder/issues/2937
+        // https://github.com/equilibriumco/pathfinder/issues/2937
         for _ in 0..5 {
             match core_client.dial(peer_id, bootstrap_address.clone()).await {
                 Ok(_) => {

--- a/crates/pathfinder/src/p2p_network/sync/sync_handlers.rs
+++ b/crates/pathfinder/src/p2p_network/sync/sync_handlers.rs
@@ -402,7 +402,7 @@ fn get_start_block_number(
 /// This function must detach the thread used to run the blocking DB operation
 /// otherwise the entire p2p swarm will be blocked.
 ///
-/// Related issue: <https://github.com/eqlabs/pathfinder/issues/2351>
+/// Related issue: <https://github.com/equilibriumco/pathfinder/issues/2351>
 async fn spawn_blocking_get<Request, Response, Getter>(
     request: Request,
     storage: Storage,

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -637,7 +637,7 @@ mod tests {
     /// we must make sure that inconsistencies in the gateway responses do not
     /// cause the polling task to emit inconsistent updates.
     ///
-    /// See also <https://github.com/eqlabs/pathfinder/issues/3081>.
+    /// See also <https://github.com/equilibriumco/pathfinder/issues/3081>.
     #[tokio::test]
     async fn ignores_inconsistent_pre_latest_from_gateway() {
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);

--- a/crates/rpc/src/dto/transaction.rs
+++ b/crates/rpc/src/dto/transaction.rs
@@ -234,7 +234,7 @@ impl SerializeForVersion for pathfinder_common::transaction::ResourceBounds {
         serializer.serialize_field("l2_gas", &self.l2_gas)?;
         if serializer.version >= RpcVersion::V08 {
             // `l1_data_gas` is serialized as (0, 0) in v0.8+ even if it's not set
-            // See https://github.com/eqlabs/pathfinder/issues/2571
+            // See https://github.com/equilibriumco/pathfinder/issues/2571
             serializer.serialize_field("l1_data_gas", &self.l1_data_gas.unwrap_or_default())?;
         }
         serializer.end()
@@ -250,7 +250,7 @@ impl DeserializeForVersion for pathfinder_common::transaction::ResourceBounds {
                 l2_gas: value.deserialize("l2_gas")?,
                 l1_data_gas: if version >= RpcVersion::V08 {
                     // `l1_data_gas` is *required* in v0.8+
-                    // See https://github.com/eqlabs/pathfinder/issues/2571
+                    // See https://github.com/equilibriumco/pathfinder/issues/2571
                     Some(value.deserialize("l1_data_gas")?)
                 } else {
                     None

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -121,9 +121,9 @@ impl PendingBlocks {
 
     pub fn finality_status(&self) -> crate::dto::TxnFinalityStatus {
         // For more info:
-        //  - on why `AcceptedOnL2` is wrong: https://github.com/eqlabs/pathfinder/issues/3259
+        //  - on why `AcceptedOnL2` is wrong: https://github.com/equilibriumco/pathfinder/issues/3259
         //  - on why `PendingBlockVariant::Pending` case was dead code:
-        //  https://github.com/eqlabs/pathfinder/issues/3272
+        //  https://github.com/equilibriumco/pathfinder/issues/3272
         crate::dto::TxnFinalityStatus::PreConfirmed
     }
 }

--- a/crates/serde/Cargo.toml
+++ b/crates/serde/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 license = { workspace = true }
 rust-version = { workspace = true }
 description = "Starknet-specific serialization utilities for Pathfinder"
-repository = "https://github.com/eqlabs/pathfinder"
+repository = "https://github.com/equilibriumco/pathfinder"
 keywords = ["starknet", "ethereum", "serde", "serialization", "web3"]
 categories = [
     "encoding",

--- a/crates/storage/src/schema/revision_0073.rs
+++ b/crates/storage/src/schema/revision_0073.rs
@@ -1,7 +1,7 @@
 //! The purpose if this migration is to repair any database instances that were
 //! affected by a combination of a bug introduced in
 //! [revision 71](super::revision_0071) and a reorg described in the issue that
-//! can be found [here](https://github.com/eqlabs/pathfinder/issues/2920).
+//! can be found [here](https://github.com/equilibriumco/pathfinder/issues/2920).
 //!
 //! The revision also contains a suite of
 //! [regression checks](reorg_regression_checks) that will be used to verify

--- a/crates/storage/src/schema/revision_0074.rs
+++ b/crates/storage/src/schema/revision_0074.rs
@@ -10,7 +10,7 @@
 //! This entire migration should be applied only to Sepolia testnet, as Mainnet
 //! is not on v0.14.0 yet.
 //!
-//! More info [here](https://github.com/eqlabs/pathfinder/issues/2925).
+//! More info [here](https://github.com/equilibriumco/pathfinder/issues/2925).
 
 use std::time::Instant;
 

--- a/crates/tagged-debug-derive/Cargo.toml
+++ b/crates/tagged-debug-derive/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 license = { workspace = true }
 rust-version = { workspace = true }
 description = "Debug trait derive macro for pathfinder-tagged types"
-repository = "https://github.com/eqlabs/pathfinder"
+repository = "https://github.com/equilibriumco/pathfinder"
 keywords = ["starknet", "derive", "debug", "proc-macro"]
 categories = ["development-tools::procedural-macro-helpers"]
 

--- a/crates/tagged/Cargo.toml
+++ b/crates/tagged/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 license = { workspace = true }
 rust-version = { workspace = true }
 description = "Type tagging utilities for the Pathfinder Starknet node implementation"
-repository = "https://github.com/eqlabs/pathfinder"
+repository = "https://github.com/equilibriumco/pathfinder"
 keywords = ["starknet", "ethereum", "web3", "type-safety"]
 categories = ["development-tools"]
 

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -5,7 +5,7 @@ slug: /faq
 
 # Frequently Asked Questions
 
-This section addresses common issues and questions that might arise while running or developing with Pathfinder. If you don’t find your answer here, consider searching the [GitHub issues](https://github.com/eqlabs/pathfinder/issues) or asking in the [Starknet Discord channel](https://discord.com/invite/QypNMzkHbc).
+This section addresses common issues and questions that might arise while running or developing with Pathfinder. If you don’t find your answer here, consider searching the [GitHub issues](https://github.com/equilibriumco/pathfinder/issues) or asking in the [Starknet Discord channel](https://discord.com/invite/QypNMzkHbc).
 
 <details>
 <summary><strong>What is Pathfinder?</strong></summary>
@@ -46,7 +46,7 @@ You can interact with Pathfinder using the [JSON-RPC API](interacting-with-pathf
 <details>
 <summary><strong>Can I switch from archive mode to pruned mode (or vice versa) without re-syncing?</strong></summary>
 
-Currently, you cannot switch directly between archive and pruned modes mid-run. You may, however, change the k value in pruned mode between runs. If you need to go from archive to pruned, consider downloading a pruned Database Snapshot or re-sync with the `--storage.state-tries=<k>` option. 
+Currently, you cannot switch directly between archive and pruned modes mid-run. You may, however, change the k value in pruned mode between runs. If you need to go from archive to pruned, consider downloading a pruned Database Snapshot or re-sync with the `--storage.state-tries=<k>` option.
 </details>
 
 <details>
@@ -82,7 +82,7 @@ Yes, Pathfinder provides database snapshots that can be downloaded and used to s
 <details>
 <summary><strong>How can I contribute to Pathfinder?</strong></summary>
 
-You can contribute by opening issues, submitting pull requests, or joining the Starknet community on Discord to provide feedback and collaborate with other developers. For more details, refer to the [contribution guidelines](https://github.com/eqlabs/pathfinder/blob/main/contributing.md).
+You can contribute by opening issues, submitting pull requests, or joining the Starknet community on Discord to provide feedback and collaborate with other developers. For more details, refer to the [contribution guidelines](https://github.com/equilibriumco/pathfinder/blob/main/contributing.md).
 </details>
 
 <details>

--- a/docs/docs/getting-started/running-pathfinder.md
+++ b/docs/docs/getting-started/running-pathfinder.md
@@ -6,17 +6,17 @@ sidebar_position: 2
 
 Pathfinder can be set up using one of the following methods:
 
-* [Docker container](#docker-container)  
+* [Docker container](#docker-container)
 * [Building from source](#building-from-source)
-        
+
 
 ## Docker Container
 
-The simplest way to run Pathfinder is using Docker. This method is recommended for beginners as it requires minimal setup and configuration.  
+The simplest way to run Pathfinder is using Docker. This method is recommended for beginners as it requires minimal setup and configuration.
 
 ### Installing Docker
 
-Follow the official [Docker installation guide](https://docs.docker.com/get-docker/) for your operating system. 
+Follow the official [Docker installation guide](https://docs.docker.com/get-docker/) for your operating system.
 
 ### Setting Up the Ethereum API URL
 
@@ -131,7 +131,7 @@ If needed, you can get the latest `protoc` from the [releases page](https://gith
 Clone the Pathfinder repository and check out the latest release:
 
 ```bash
-git clone https://github.com/eqlabs/pathfinder.git
+git clone https://github.com/equilibriumco/pathfinder.git
 cd pathfinder
 git checkout <latest-version-tag>
 ```

--- a/docs/docs/incidents/2023-06-17_mainnet_incident.md
+++ b/docs/docs/incidents/2023-06-17_mainnet_incident.md
@@ -30,7 +30,7 @@ But then how did this ever work? It turns out most string encodings produce iden
 
 ## Resolution
 
-The [fix PR](https://github.com/eqlabs/pathfinder/pull/1142) takes any non-ASCII characters and re-encodes them to match the formatting used by the sequencer. 
+The [fix PR](https://github.com/equilibriumco/pathfinder/pull/1142) takes any non-ASCII characters and re-encodes them to match the formatting used by the sequencer. 
 
 The PR was merged and Pathfinder v0.6.1 was released. The fix was also backported to create v0.5.7 for users who had not yet upgraded to v0.6.
 

--- a/docs/docs/interacting-with-pathfinder/json-rpc-api.md
+++ b/docs/docs/interacting-with-pathfinder/json-rpc-api.md
@@ -7,18 +7,18 @@ sidebar_position: 1
 The JSON-RPC interface allows you to query Starknet data, send transactions, and perform contract calls without going through a formal transaction on-chain. Pathfinder currently supports multiple API versions and a distinct set of custom extensions.
 
 ## Supported Versions
-- **JSON-RPC v0.6.0**  
+- **JSON-RPC v0.6.0**
   Accessible at the `/rpc/v0_6` endpoint.
-- **JSON-RPC v0.7.1**  
+- **JSON-RPC v0.7.1**
   Accessible at the `/rpc/v0_7` endpoint.
-- **JSON-RPC v0.8.1**  
+- **JSON-RPC v0.8.1**
   Accessible at the `/rpc/v0_8` endpoint.
 - **JSON-RPC v0.9.0**
   Accessible at the `/rpc/v0_9` endpoint.
-- **Pathfinder Extension**  
+- **Pathfinder Extension**
   Exposed via `/rpc/pathfinder/v0_1`.
 
-:::note 
+:::note
 The API served at the root path (`/` for HTTP and `/ws` for WebSocket) can be set via the `--rpc.root-version` parameter (or `RPC_ROOT_VERSION` environment variable). Since a version upgrade _might_ change the version of the JSON-RPC API exposed on this path using this path is not recommended. Please use one of the explicitly versioned paths above.
 :::
 
@@ -49,7 +49,7 @@ A successful response might look like this:
 {
   "jsonrpc": "2.0",
   "id": 1,
-  "result": "0x534e5f4d41494e" 
+  "result": "0x534e5f4d41494e"
 }
 ```
 
@@ -82,5 +82,5 @@ For advanced use cases like verifying storage proofs or generating special debug
 ```
 /rpc/pathfinder/v0_1
 ```
-The complete specification for these JSON-only extension methods can be found in the [Pathfinder repository](https://github.com/eqlabs/pathfinder/blob/main/specs/rpc/pathfinder_rpc_api.json).
+The complete specification for these JSON-only extension methods can be found in the [Pathfinder repository](https://github.com/equilibriumco/pathfinder/blob/main/specs/rpc/pathfinder_rpc_api.json).
 

--- a/docs/docs/interacting-with-pathfinder/websocket-api.md
+++ b/docs/docs/interacting-with-pathfinder/websocket-api.md
@@ -5,17 +5,17 @@ sidebar_position: 2
 # WebSocket API
 
 The WebSocket interface serves the same API versions and extension endpoints as HTTP, but in a stateful, two-way communication channel. This can be especially useful for real-time notifications, subscription-based events, or building interactive dashboards.
- 
+
 ## Supported Versions
-- **JSON-RPC v0.6.0**  
+- **JSON-RPC v0.6.0**
   Accessible at `/ws/rpc/v0_6`.
-- **JSON-RPC v0.7.1**  
+- **JSON-RPC v0.7.1**
   Accessible at `/ws/rpc/v0_7`.
-- **JSON-RPC v0.8.1**  
+- **JSON-RPC v0.8.1**
   Accessible at `/rpc/v0_8` and `/ws/rpc/v0_8` (deprecated).
 - **JSON-RPC v0.9.0**
   Accessible at `/rpc/v0_9` and `/ws/rpc/v0_9` (deprecated).
-- **Pathfinder Extension**  
+- **Pathfinder Extension**
   Exposed via `/ws/rpc/pathfinder/v0_1`
 
 > **Note:** The WebSocket interface is disabled by default. To enable it, use the `--rpc.websocket.enabled` CLI flag. The default root endpoint (i.e., `/ws`) can be configured using the `--rpc.root-version` parameter.
@@ -48,4 +48,4 @@ As with the [JSON extensions](json-rpc-api#pathfinder-json-extensions), Pathfind
 /ws/rpc/pathfinder/v0_1
 ```
 
-You can find the complete list of WebSocket extensions in the [Pathfinder repository](https://github.com/eqlabs/pathfinder/blob/main/specs/rpc/pathfinder_ws.json).
+You can find the complete list of WebSocket extensions in the [Pathfinder repository](https://github.com/equilibriumco/pathfinder/blob/main/specs/rpc/pathfinder_ws.json).

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -9,12 +9,12 @@ Pathfinder is a Rust implementation of a [Starknet](https://www.starknet.io) ful
 
 ## Key features
 
-* **Full Starknet State Access**: Retrieve the full history, including contracts, transactions, and storage. 
+* **Full Starknet State Access**: Retrieve the full history, including contracts, transactions, and storage.
 * **Verification via Ethereum**: Verifies the state of Starknet using Ethereum, calculating Patricia-Merkle Trie roots to ensure the correctness of data.
 * **JSON-RPC Support**: Implements the Starknet JSON-RPC API, providing full support for interacting with the blockchain through tools like [starknet.js](https://starknetjs.com/) and [starknet.py](https://starknetpy.readthedocs.io/en/latest/).
 * **State Functionality without Transactions**: Execute Starknet functions locally without requiring an actual transaction on the network.
 * **Transaction Fee Estimation**: Estimate the gas fees for a transaction before submitting it to the network.
-    
+
 
 ## Getting Started
 
@@ -74,7 +74,7 @@ import Card from '@site/src/components/Card';
 <p/>
 ```
 
-If you are looking to use the Pathfinder full node as part of a validator setup, install the [attestation tool](https://github.com/eqlabs/starknet-validator-attestation) with the node.
+If you are looking to use the Pathfinder full node as part of a validator setup, install the [attestation tool](https://github.com/equilibriumco/starknet-validator-attestation) with the node.
 
 ## Community and Support
 
@@ -82,9 +82,9 @@ We highly value community engagement, especially during this alpha phase. Whethe
 
 You can contribute to Pathfinder by:
 
-* **Opening an Issue**: If you encounter bugs or have feature requests, please open an issue on our [GitHub repository](https://github.com/eqlabs/pathfinder/issues/new).
+* **Opening an Issue**: If you encounter bugs or have feature requests, please open an issue on our [GitHub repository](https://github.com/equilibriumco/pathfinder/issues/new).
 * **Joining our Community**: Connect with other users and developers by joining the Starknet [Discord channel](https://discord.com/invite/starknet-community).
-* **Contributing to the Codebase**: If you’re interested in contributing to Pathfinder, check out our [contributing guidelines](https://github.com/eqlabs/pathfinder/blob/main/contributing.md) and [open issues](https://github.com/eqlabs/pathfinder/issues) on GitHub.
-    
+* **Contributing to the Codebase**: If you’re interested in contributing to Pathfinder, check out our [contributing guidelines](https://github.com/equilibriumco/pathfinder/blob/main/contributing.md) and [open issues](https://github.com/equilibriumco/pathfinder/issues) on GitHub.
+
 
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -13,14 +13,14 @@ const config = {
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
-  url: 'https://eqlabs.github.io/',
+  url: 'https://equilibriumco.github.io/',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/pathfinder/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'eqlabs', // Usually your GitHub org/user name.
+  organizationName: 'equilibriumco', // Usually your GitHub org/user name.
   projectName: 'pathfinder', // Usually your repo name.
 
   onBrokenLinks: 'throw',
@@ -68,7 +68,7 @@ const config = {
             position: 'right',
           },
           {
-            href: 'https://github.com/eqlabs/pathfinder',
+            href: 'https://github.com/equilibriumco/pathfinder',
             label: 'GitHub',
             position: 'right',
           },
@@ -84,14 +84,14 @@ const config = {
                 label: 'Running Pathfinder',
                 to: '/getting-started/running-pathfinder',
               },
-							{
-								label: 'Configuring Pathfinder',
-								to: '/getting-started/configuration',
-							},
-							{
-								label: 'Interfacing with Pathfinder',
-								to: '/interacting-with-pathfinder/json-rpc-api',
-							},
+              {
+                label: 'Configuring Pathfinder',
+                to: '/getting-started/configuration',
+              },
+              {
+                label: 'Interfacing with Pathfinder',
+                to: '/interacting-with-pathfinder/json-rpc-api',
+              },
             ],
           },
           {
@@ -99,7 +99,7 @@ const config = {
             items: [
               {
                 label: 'GitHub',
-                href: 'https://github.com/eqlabs/pathfinder',
+                href: 'https://github.com/equilibriumco/pathfinder',
               },
             ],
           },


### PR DESCRIPTION
fixes all occurences of `eqlabs`, except for dockerhub links, which are kept as is