### PR TITLE
refactor(validator): make `pathfinder-validator` an optional dependency

### DIFF
--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 cairo-native = ["pathfinder-executor/cairo-native"]
 consensus-integration-tests = []
 tokio-console = ["console-subscriber", "tokio/tracing"]
-p2p = ["pathfinder-consensus", "pathfinder-validator", "pathfinder-validator/p2p"]
+p2p = ["pathfinder-consensus", "pathfinder-validator"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 cairo-native = ["pathfinder-executor/cairo-native"]
 consensus-integration-tests = []
 tokio-console = ["console-subscriber", "tokio/tracing"]
-p2p = ["pathfinder-consensus", "pathfinder-validator/p2p"]
+p2p = ["pathfinder-consensus", "pathfinder-validator", "pathfinder-validator/p2p"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -55,7 +55,7 @@ pathfinder-retry = { path = "../retry" }
 pathfinder-rpc = { path = "../rpc" }
 pathfinder-serde = { path = "../serde" }
 pathfinder-storage = { path = "../storage" }
-pathfinder-validator = { path = "../validator" }
+pathfinder-validator = { path = "../validator", optional = true }
 pathfinder-version = { path = "../version" }
 primitive-types = { workspace = true }
 rand = { workspace = true }

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -14,9 +14,14 @@ use metrics_exporter_prometheus::PrometheusBuilder;
 use pathfinder_common::{BlockNumber, Chain, ChainId, EthereumChain};
 use pathfinder_ethereum::EthereumClient;
 use pathfinder_gas_price::{L1GasPriceConfig, L1GasPriceProvider};
-use pathfinder_lib::consensus::{ConsensusChannels, ConsensusTaskHandles};
+#[cfg(feature = "p2p")]
+use pathfinder_lib::consensus::ConsensusTaskHandles;
 use pathfinder_lib::state::{sync_gas_prices, L1GasPriceSyncConfig, SyncContext};
+use pathfinder_lib::ConsensusChannels;
+#[cfg(feature = "p2p")]
 use pathfinder_lib::{config, consensus, monitoring, p2p_network, state};
+#[cfg(not(feature = "p2p"))]
+use pathfinder_lib::{config, monitoring, p2p_network, state};
 use pathfinder_rpc::context::{EthContractAddresses, WebsocketContext};
 use pathfinder_rpc::{Notifications, SyncState};
 use pathfinder_storage::Storage;
@@ -359,42 +364,57 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
         None
     };
 
-    let ConsensusTaskHandles {
+    #[cfg(feature = "p2p")]
+    let (
         consensus_p2p_event_processing_handle,
         consensus_engine_handle,
         consensus_channels,
         worker_pool,
-    } = if let Some(consensus_config) = &config.consensus {
-        let wal_directory = config.data_directory.join("consensus").join("wal");
-        if !wal_directory.exists() {
-            std::fs::DirBuilder::new()
-                .recursive(true)
-                .create(&wal_directory)
-                .context("Creating consensus wal directory")?;
-        }
+    ) = {
+        let handles = if let Some(consensus_config) = &config.consensus {
+            let wal_directory = config.data_directory.join("consensus").join("wal");
+            if !wal_directory.exists() {
+                std::fs::DirBuilder::new()
+                    .recursive(true)
+                    .create(&wal_directory)
+                    .context("Creating consensus wal directory")?;
+            }
 
-        if let Some((event_rx, client)) = consensus_p2p_client_and_event_rx {
-            consensus::start(
-                consensus_config.clone(),
-                chain_id,
-                consensus_storage,
-                client,
-                event_rx,
-                wal_directory,
-                &config.data_directory,
-                gas_price_provider.clone(),
-                config.verify_tree_hashes,
-                config.compiler_resource_limits,
-                config.blockifier_libfuncs,
-                // Does nothing in production builds. Used for integration testing only.
-                integration_testing_config.inject_failure_config(),
-            )
+            if let Some((event_rx, client)) = consensus_p2p_client_and_event_rx {
+                consensus::start(
+                    consensus_config.clone(),
+                    chain_id,
+                    consensus_storage,
+                    client,
+                    event_rx,
+                    wal_directory,
+                    &config.data_directory,
+                    gas_price_provider.clone(),
+                    config.verify_tree_hashes,
+                    config.compiler_resource_limits,
+                    config.blockifier_libfuncs,
+                    integration_testing_config.inject_failure_config(),
+                )
+            } else {
+                ConsensusTaskHandles::pending()
+            }
         } else {
             ConsensusTaskHandles::pending()
-        }
-    } else {
-        ConsensusTaskHandles::pending()
+        };
+        (
+            handles.consensus_p2p_event_processing_handle,
+            handles.consensus_engine_handle,
+            handles.consensus_channels,
+            handles.worker_pool,
+        )
     };
+
+    #[cfg(not(feature = "p2p"))]
+    let (consensus_p2p_event_processing_handle, consensus_engine_handle, consensus_channels) = (
+        tokio::task::spawn(std::future::pending::<anyhow::Result<()>>()),
+        tokio::task::spawn(std::future::pending::<anyhow::Result<()>>()),
+        None::<ConsensusChannels>,
+    );
 
     let context = if let Some(consensus_info_watch) = consensus_channels
         .as_ref()
@@ -514,6 +534,7 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
 
     // Join all worker pool threads so that they don't panic when the `p2p_task` is
     // cancelled.
+    #[cfg(feature = "p2p")]
     if let Some(worker_pool) = worker_pool {
         match Arc::try_unwrap(worker_pool) {
             Ok(pool) => pool.join(),

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -393,6 +393,7 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
                     config.verify_tree_hashes,
                     config.compiler_resource_limits,
                     config.blockifier_libfuncs,
+                    // Does nothing in production builds. Used for integration testing only.
                     integration_testing_config.inject_failure_config(),
                 )
             } else {
@@ -410,11 +411,18 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
     };
 
     #[cfg(not(feature = "p2p"))]
-    let (consensus_p2p_event_processing_handle, consensus_engine_handle, consensus_channels) = (
-        tokio::task::spawn(std::future::pending::<anyhow::Result<()>>()),
-        tokio::task::spawn(std::future::pending::<anyhow::Result<()>>()),
-        None::<ConsensusChannels>,
-    );
+    let (consensus_p2p_event_processing_handle, consensus_engine_handle, consensus_channels) = {
+        let _ = (
+            consensus_storage,
+            consensus_p2p_client_and_event_rx,
+            gas_price_provider,
+        );
+        (
+            tokio::task::spawn(std::future::pending::<anyhow::Result<()>>()),
+            tokio::task::spawn(std::future::pending::<anyhow::Result<()>>()),
+            None::<ConsensusChannels>,
+        )
+    };
 
     let context = if let Some(consensus_info_watch) = consensus_channels
         .as_ref()

--- a/crates/pathfinder/src/consensus.rs
+++ b/crates/pathfinder/src/consensus.rs
@@ -1,15 +1,14 @@
 use std::path::{Path, PathBuf};
 
 use p2p::consensus::Event;
-use pathfinder_common::{consensus_info, ChainId};
+use pathfinder_common::ChainId;
 use pathfinder_gas_price::L1GasPriceProvider;
 use pathfinder_storage::Storage;
 use pathfinder_validator::ValidatorWorkerPool;
-use tokio::sync::{mpsc, watch};
+use tokio::sync::mpsc;
 
 use crate::config::integration_testing::InjectFailureConfig;
 use crate::config::ConsensusConfig;
-use crate::SyncMessageToConsensus;
 
 mod inner;
 

--- a/crates/pathfinder/src/consensus.rs
+++ b/crates/pathfinder/src/consensus.rs
@@ -26,14 +26,7 @@ pub struct ConsensusTaskHandles {
     pub worker_pool: Option<ValidatorWorkerPool>,
 }
 
-/// Various channels used to communicate with the consensus engine.
-#[derive(Clone)]
-pub struct ConsensusChannels {
-    /// Watcher for the latest [consensus_info::ConsensusInfo].
-    pub consensus_info_watch: watch::Receiver<consensus_info::ConsensusInfo>,
-    /// Channel for the sync task to send requests to consensus.
-    pub sync_to_consensus_tx: mpsc::Sender<SyncMessageToConsensus>,
-}
+pub use crate::ConsensusChannels;
 
 impl ConsensusTaskHandles {
     pub fn pending() -> Self {

--- a/crates/pathfinder/src/consensus.rs
+++ b/crates/pathfinder/src/consensus.rs
@@ -11,7 +11,6 @@ use crate::config::integration_testing::InjectFailureConfig;
 use crate::config::ConsensusConfig;
 use crate::SyncMessageToConsensus;
 
-#[cfg(feature = "p2p")]
 mod inner;
 
 pub type ConsensusP2PEventProcessingTaskHandle = tokio::task::JoinHandle<anyhow::Result<()>>;
@@ -69,27 +68,4 @@ pub fn start(
         blockifier_libfuncs,
         inject_failure_config,
     )
-}
-
-#[cfg(not(feature = "p2p"))]
-mod inner {
-    use super::*;
-
-    #[allow(clippy::too_many_arguments)]
-    pub fn start(
-        _: ConsensusConfig,
-        _: ChainId,
-        _: Storage,
-        _: p2p::consensus::Client,
-        _: mpsc::UnboundedReceiver<Event>,
-        _: PathBuf,
-        _: &Path,
-        _: Option<L1GasPriceProvider>,
-        _: bool,
-        _: pathfinder_compiler::ResourceLimits,
-        _: pathfinder_compiler::BlockifierLibfuncs,
-        _: Option<InjectFailureConfig>,
-    ) -> ConsensusTaskHandles {
-        ConsensusTaskHandles::pending()
-    }
 }

--- a/crates/pathfinder/src/lib.rs
+++ b/crates/pathfinder/src/lib.rs
@@ -44,7 +44,8 @@ pub type ValidateBlockReply = tokio::sync::oneshot::Sender<pathfinder_validator:
 /// Various channels used to communicate with the consensus engine.
 #[derive(Clone)]
 pub struct ConsensusChannels {
-    /// Watcher for the latest [consensus_info::ConsensusInfo].
+    /// Watcher for the latest
+    /// [pathfinder_common::consensus_info::ConsensusInfo].
     pub consensus_info_watch:
         tokio::sync::watch::Receiver<pathfinder_common::consensus_info::ConsensusInfo>,
     /// Channel for the sync task to send requests to consensus.

--- a/crates/pathfinder/src/lib.rs
+++ b/crates/pathfinder/src/lib.rs
@@ -24,6 +24,7 @@ pub enum SyncMessageToConsensus {
     ConfirmBlockCommitted {
         number: pathfinder_common::BlockNumber,
     },
+    #[cfg(feature = "p2p")]
     ValidateBlock {
         // TODO: Stubbed for now, as an example. When used by P2P sync it should contain the block
         // commit certificate. Also, since this is never sent, the result is not used. In the
@@ -37,6 +38,7 @@ pub enum SyncMessageToConsensus {
 pub type ConsensusFinalizedBlockReply =
     tokio::sync::oneshot::Sender<Option<Box<pathfinder_common::ConsensusFinalizedL2Block>>>;
 
+#[cfg(feature = "p2p")]
 pub type ValidateBlockReply = tokio::sync::oneshot::Sender<pathfinder_validator::ValidationResult>;
 
 /// Various channels used to communicate with the consensus engine.

--- a/crates/pathfinder/src/lib.rs
+++ b/crates/pathfinder/src/lib.rs
@@ -1,7 +1,9 @@
 #![deny(rust_2018_idioms)]
 
 pub mod config;
+#[cfg(feature = "p2p")]
 pub mod consensus;
+#[cfg(feature = "p2p")]
 pub mod devnet;
 pub mod monitoring;
 pub mod p2p_network;

--- a/crates/pathfinder/src/lib.rs
+++ b/crates/pathfinder/src/lib.rs
@@ -36,3 +36,13 @@ pub type ConsensusFinalizedBlockReply =
     tokio::sync::oneshot::Sender<Option<Box<pathfinder_common::ConsensusFinalizedL2Block>>>;
 
 pub type ValidateBlockReply = tokio::sync::oneshot::Sender<pathfinder_validator::ValidationResult>;
+
+/// Various channels used to communicate with the consensus engine.
+#[derive(Clone)]
+pub struct ConsensusChannels {
+    /// Watcher for the latest [consensus_info::ConsensusInfo].
+    pub consensus_info_watch:
+        tokio::sync::watch::Receiver<pathfinder_common::consensus_info::ConsensusInfo>,
+    /// Channel for the sync task to send requests to consensus.
+    pub sync_to_consensus_tx: tokio::sync::mpsc::Sender<SyncMessageToConsensus>,
+}

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -35,10 +35,9 @@ use starknet_gateway_types::reply::{Block, GasPrices, PreConfirmedBlock, PreLate
 use tokio::sync::mpsc::{self, Receiver};
 use tokio::sync::watch::{self, Sender as WatchSender};
 
-use crate::consensus::ConsensusChannels;
 use crate::state::l1::L1SyncContext;
 use crate::state::l2::{BlockChain, L2SyncContext};
-use crate::SyncMessageToConsensus;
+use crate::{ConsensusChannels, SyncMessageToConsensus};
 
 /// Delay before restarting L1 or L2 tasks if they fail. This delay helps
 /// prevent DoS if these tasks are crashing.

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -20,10 +20,9 @@ use starknet_gateway_types::reply::{Block, BlockSignature, Status};
 use tokio::sync::{mpsc, watch};
 use tracing::Instrument;
 
-use crate::consensus::ConsensusChannels;
 use crate::state::sync::class::{download_class, DownloadedClass};
 use crate::state::sync::SyncEvent;
-use crate::SyncMessageToConsensus;
+use crate::{ConsensusChannels, SyncMessageToConsensus};
 
 #[derive(Default, Debug, Clone, Copy)]
 pub struct Timings {

--- a/crates/validator/Cargo.toml
+++ b/crates/validator/Cargo.toml
@@ -7,7 +7,6 @@ license = { workspace = true }
 rust-version = { workspace = true }
 
 [features]
-p2p = []
 skip-commitment-validation = []
 
 [dependencies]

--- a/crates/validator/src/lib.rs
+++ b/crates/validator/src/lib.rs
@@ -276,7 +276,6 @@ impl ValidatorBlockInfoStage {
     /// [ValidatorTransactionBatchStage].
     ///
     /// Used only for testing and dummy proposal creation.
-    #[cfg(any(test, feature = "p2p"))]
     pub fn skip_validation(
         self,
         block_info: BlockInfo,


### PR DESCRIPTION
[This comment](https://github.com/equilibriumco/pathfinder/pull/3343#discussion_r3088748024) brought me down the rabbit hole of our `p2p` flag in pathfinder and how we had structured our code around it.

The `consensus` module wasn't being guarded behind this flag, and it only makes sense that it is (consensus is just relevant in p2p context). So I propose we change this. I only had to move `ConsensusChannels` out of the `consensus` module (since sync code needs it, regardless of p2p).

Also gated `devnet` - @CHr15F0x correct me if this should not be the case, but I think it's just p2p testing infra.

So `pathfinder-validator` is now optional, just as `pathfinder-consensus` is.

Also, back to the initial comment, `skip_validation` no longer needs its own feature guard, as the crate itself acts as the gate.