### PR TITLE
fix(executor): account for tip when computing max L2 gas limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `starknet_getEvents` now returns `block_number` for events from pre-confirmed and pre-latest blocks.
 
+### Fixed
+
+- `starknet_estimateFee` and `starknet_simulateTransactions` rejecting transactions with a non-zero tip when the account balance could cover the fee. The maximum L2 gas bound now accounts for the tip, matching the blockifier's fee calculation (`max_amount * (max_price_per_unit + tip)`).
+
 ## [0.22.2] - 2026-04-07
 
 ### Changed

--- a/crates/executor/src/transaction.rs
+++ b/crates/executor/src/transaction.rs
@@ -632,12 +632,14 @@ fn get_max_l2_gas_amount_covered_by_balance(
 
             if balance > max_possible_fee_without_l2_gas.0.into() {
                 // The maximum amount of L2 gas that can be bought with the balance.
-                let max_amount = (balance - max_possible_fee_without_l2_gas.0)
-                    / initial_resource_bounds
-                        .l2_gas
-                        .max_price_per_unit
-                        .0
-                        .max(1u64.into());
+                // max_possible_fee = max_amount * (max_price + tip).
+                let effective_l2_price: u128 = initial_resource_bounds
+                    .l2_gas
+                    .max_price_per_unit
+                    .0
+                    .saturating_add(get_tip(tx).0.into())
+                    .max(1u64.into());
+                let max_amount = (balance - max_possible_fee_without_l2_gas.0) / effective_l2_price;
                 Ok(u64::try_from(max_amount).unwrap_or(u64::MAX).into())
             } else {
                 // Balance is less than committed L1 gas and L1 data gas, tx will fail


### PR DESCRIPTION
Account for the tip when computing the maximum L2 gas amount covered by the account balance during fee estimation.

---------------------------

**Problem**: `get_max_l2_gas_amount_covered_by_balance` divides remaining balance by `l2_gas.max_price_per_unit` to compute the max affordable L2 gas. However, the blockifier's `max_possible_fee` (used in `verify_can_pay_committed_bounds`) computes `max_amount * (max_price + tip)`. When tip > 0, the inflated L2 gas bound exceeds the account balance, causing `starknet_simulateTransactions` to reject transactions that succeeded on-chain.

**Fix**: Divide by `(max_price_per_unit + tip)` to match the blockifier's fee calculation.

**Impact**: Observed on mainnet block 8821583 (tx index 1, tip=1001). The old formula computed `max_l2_gas = 128,174,880,959`. The blockifier then checked `128,174,880,959 * (60,200,000,000 + 1001) = 7.716T > balance of 7.716T` — failing by ~128 trillion FRI due to the unaccounted tip. The fix computes `max_l2_gas = 128,174,878,828` which passes the balance check.

Note: Juno has the same bug in `calculate_max_l2_gas_covered` (`vm/rust/src/entrypoint/execute/process/binary_search_execution.rs:201`).

---------------------------

- [x] add all user-facing changes to `CHANGELOG.md`