### PR TITLE
fix(executor): unsafe starkfee conversion

### DIFF
--- a/crates/executor/src/fee.rs
+++ b/crates/executor/src/fee.rs
@@ -1,0 +1,24 @@
+use pathfinder_common::Fee;
+use starknet_api::transaction::fields::Fee as StarkFee;
+
+pub trait TryIntoStarkFee {
+    fn try_into_starkfee(self) -> anyhow::Result<StarkFee>
+    where
+        Self: Sized;
+}
+
+pub trait IntoFee {
+    fn into_fee(self) -> Fee;
+}
+
+impl IntoFee for StarkFee {
+    fn into_fee(self) -> Fee {
+        Fee(self.0.into())
+    }
+}
+
+impl TryIntoStarkFee for Fee {
+    fn try_into_starkfee(self) -> anyhow::Result<StarkFee> {
+        Ok(StarkFee(self.0.try_into()?))
+    }
+}

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -5,6 +5,7 @@ pub(crate) mod error;
 pub(crate) mod error_stack;
 pub(crate) mod estimate;
 pub(crate) mod execution_state;
+pub(crate) mod fee;
 pub(crate) mod felt;
 pub(crate) mod lru_cache;
 pub(crate) mod pending;
@@ -33,6 +34,7 @@ pub use execution_state::{
     PathfinderExecutionState,
     VersionedConstantsMap,
 };
+pub use fee::{IntoFee, TryIntoStarkFee};
 pub use felt::{IntoFelt, IntoStarkFelt};
 pub use simulate::{simulate, trace, BlockTraces, TraceCache, TransactionTraces};
 pub use starknet_api::contract_class::ClassInfo;

--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -30,10 +30,9 @@ use starknet_api::transaction::fields::{
     ValidResourceBounds,
 };
 
-use super::felt::IntoFelt;
 use crate::execution_state::PathfinderExecutionState;
 use crate::state_reader::StorageAdapter;
-use crate::IntoStarkFelt as _;
+use crate::{IntoFee as _, IntoFelt, IntoStarkFelt as _, TryIntoStarkFee as _};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Receipt {
@@ -1017,7 +1016,7 @@ pub(crate) fn to_receipt_and_events(
     versioned_constants: &VersionedConstants,
     gas_vector_computation_mode: &GasVectorComputationMode,
 ) -> anyhow::Result<(Receipt, Vec<pathfinder_common::event::Event>)> {
-    let actual_fee = Fee(Felt::from_u128(execution_info.receipt.fee.0));
+    let actual_fee = execution_info.receipt.fee.into_fee();
     let execution_info = to_execution_info(
         transaction_type,
         execution_info,
@@ -1380,14 +1379,12 @@ pub(crate) fn to_execution_info(
 pub fn to_starknet_api_transaction(
     variant: TransactionVariant,
 ) -> anyhow::Result<starknet_api::transaction::Transaction> {
-    use starknet_api::transaction::fields::{ContractAddressSalt, Fee, Tip};
+    use starknet_api::transaction::fields::{ContractAddressSalt, Tip};
 
     match variant {
         TransactionVariant::DeclareV0(tx) => {
             let tx = starknet_api::transaction::DeclareTransactionV0V1 {
-                max_fee: Fee(u128::from_be_bytes(
-                    tx.max_fee.0.to_be_bytes()[16..].try_into().unwrap(),
-                )),
+                max_fee: tx.max_fee.try_into_starkfee()?,
                 signature: TransactionSignature(Arc::new(
                     tx.signature.iter().map(|s| s.0.into_starkfelt()).collect(),
                 )),
@@ -1405,9 +1402,7 @@ pub fn to_starknet_api_transaction(
         }
         TransactionVariant::DeclareV1(tx) => {
             let tx = starknet_api::transaction::DeclareTransactionV0V1 {
-                max_fee: Fee(u128::from_be_bytes(
-                    tx.max_fee.0.to_be_bytes()[16..].try_into().unwrap(),
-                )),
+                max_fee: tx.max_fee.try_into_starkfee()?,
                 signature: TransactionSignature(Arc::new(
                     tx.signature.iter().map(|s| s.0.into_starkfelt()).collect(),
                 )),
@@ -1425,9 +1420,7 @@ pub fn to_starknet_api_transaction(
         }
         TransactionVariant::DeclareV2(tx) => {
             let tx = starknet_api::transaction::DeclareTransactionV2 {
-                max_fee: Fee(u128::from_be_bytes(
-                    tx.max_fee.0.to_be_bytes()[16..].try_into().unwrap(),
-                )),
+                max_fee: tx.max_fee.try_into_starkfee()?,
                 signature: TransactionSignature(Arc::new(
                     tx.signature.iter().map(|s| s.0.into_starkfelt()).collect(),
                 )),
@@ -1494,9 +1487,7 @@ pub fn to_starknet_api_transaction(
         TransactionVariant::DeployAccountV1(tx) => {
             let tx = starknet_api::transaction::DeployAccountTransaction::V1(
                 starknet_api::transaction::DeployAccountTransactionV1 {
-                    max_fee: Fee(u128::from_be_bytes(
-                        tx.max_fee.0.to_be_bytes()[16..].try_into().unwrap(),
-                    )),
+                    max_fee: tx.max_fee.try_into_starkfee()?,
                     signature: TransactionSignature(Arc::new(
                         tx.signature.iter().map(|s| s.0.into_starkfelt()).collect(),
                     )),
@@ -1559,10 +1550,7 @@ pub fn to_starknet_api_transaction(
         }
         TransactionVariant::InvokeV0(tx) => {
             let tx = starknet_api::transaction::InvokeTransactionV0 {
-                // TODO: maybe we should store tx.max_fee as u128 internally?
-                max_fee: Fee(u128::from_be_bytes(
-                    tx.max_fee.0.to_be_bytes()[16..].try_into().unwrap(),
-                )),
+                max_fee: tx.max_fee.try_into_starkfee()?,
                 signature: TransactionSignature(Arc::new(
                     tx.signature.iter().map(|s| s.0.into_starkfelt()).collect(),
                 )),
@@ -1584,10 +1572,7 @@ pub fn to_starknet_api_transaction(
         }
         TransactionVariant::InvokeV1(tx) => {
             let tx = starknet_api::transaction::InvokeTransactionV1 {
-                // TODO: maybe we should store tx.max_fee as u128 internally?
-                max_fee: Fee(u128::from_be_bytes(
-                    tx.max_fee.0.to_be_bytes()[16..].try_into().unwrap(),
-                )),
+                max_fee: tx.max_fee.try_into_starkfee()?,
                 signature: TransactionSignature(Arc::new(
                     tx.signature.iter().map(|s| s.0.into_starkfelt()).collect(),
                 )),

--- a/crates/pathfinder/examples/re_execute.rs
+++ b/crates/pathfinder/examples/re_execute.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use pathfinder_common::receipt::Receipt;
 use pathfinder_common::transaction::Transaction;
 use pathfinder_common::{BlockHeader, BlockId, BlockNumber, ChainId};
-use pathfinder_executor::{ExecutionState, NativeClassCache};
+use pathfinder_executor::{ExecutionState, NativeClassCache, TryIntoStarkFee as _};
 use pathfinder_rpc::context::{ETH_FEE_TOKEN_ADDRESS, STRK_FEE_TOKEN_ADDRESS};
 use pathfinder_storage::Storage;
 use rayon::prelude::*;
@@ -191,9 +191,11 @@ fn execute(
                     tracing::warn!(block_number=%work.header.number, transaction_hash=%receipt.transaction_hash, ?simulated_revert_reason, ?actual_revert_reason, "Revert status differs");
                 }
 
-                let actual_fee = u128::from_be_bytes(
-                    receipt.actual_fee.0.to_be_bytes()[16..].try_into().unwrap(),
-                );
+                let actual_fee = receipt
+                    .actual_fee
+                    .try_into_starkfee()
+                    .expect("Fee fits into u128")
+                    .0;
 
                 // L1 handler transactions have a fee of zero in the receipt.
                 if actual_fee == 0 {


### PR DESCRIPTION
This PR removes TODOs and `unwrap()`s in conversion code in the executor crate.