### PR TITLE
test(gas/l2): use `apollo_versioned_constants` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ version = "0.18.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a67f3331354ca1f12d0e020ca49f4e7186b7608de0839e47c721282fd5729dd8"
 dependencies = [
- "apollo_infra_utils",
+ "apollo_infra_utils 0.18.0-rc.1",
  "cairo-lang-sierra 2.17.0-rc.4",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils 2.17.0-rc.4",
@@ -798,7 +798,7 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet-types-core",
- "starknet_api",
+ "starknet_api 0.18.0-rc.1",
  "tempfile",
  "thiserror 1.0.69",
 ]
@@ -811,7 +811,7 @@ checksum = "aa476e7f3f471ac5097214a8e5ca79947762bbafb0bb9303359705524c20c70e"
 dependencies = [
  "apollo_compilation_utils",
  "apollo_compile_to_native_types",
- "apollo_infra_utils",
+ "apollo_infra_utils 0.18.0-rc.1",
  "cairo-lang-starknet-classes",
  "cairo-native",
  "tempfile",
@@ -834,7 +834,7 @@ version = "0.18.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcc050ef9fa92477c3543998d4208bd948afb42b859044e3fbbc2e432e28402"
 dependencies = [
- "apollo_infra_utils",
+ "apollo_infra_utils 0.18.0-rc.1",
  "clap",
  "const_format",
  "itertools 0.12.1",
@@ -849,11 +849,27 @@ dependencies = [
 
 [[package]]
 name = "apollo_infra_utils"
+version = "0.0.0"
+source = "git+https://github.com/starkware-libs/sequencer?rev=bc76748a37e660e700cff97b5dd1fb95d1a37c3e#bc76748a37e660e700cff97b5dd1fb95d1a37c3e"
+dependencies = [
+ "apollo_proc_macros 0.0.0",
+ "num_enum",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "apollo_infra_utils"
 version = "0.18.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccac84e014c1f56323caa62db9d69555433fa0cce29abf59c6add18ddc2448de"
 dependencies = [
- "apollo_proc_macros",
+ "apollo_proc_macros 0.18.0-rc.1",
  "assert-json-diff",
  "colored 3.1.1",
  "num_enum",
@@ -887,6 +903,17 @@ dependencies = [
 
 [[package]]
 name = "apollo_proc_macros"
+version = "0.0.0"
+source = "git+https://github.com/starkware-libs/sequencer?rev=bc76748a37e660e700cff97b5dd1fb95d1a37c3e#bc76748a37e660e700cff97b5dd1fb95d1a37c3e"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "apollo_proc_macros"
 version = "0.18.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3f4078d3e701d15584fabbe3573b302a56e28eeec24ae6c5e7362d9bb5b1d81"
@@ -899,12 +926,31 @@ dependencies = [
 
 [[package]]
 name = "apollo_sizeof"
+version = "0.0.0"
+source = "git+https://github.com/starkware-libs/sequencer?rev=bc76748a37e660e700cff97b5dd1fb95d1a37c3e#bc76748a37e660e700cff97b5dd1fb95d1a37c3e"
+dependencies = [
+ "apollo_sizeof_macros 0.0.0",
+ "starknet-types-core",
+]
+
+[[package]]
+name = "apollo_sizeof"
 version = "0.18.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96b3080899396e91925dd0eff941108e2880cd6983d748573f9de1d725b5163b"
 dependencies = [
- "apollo_sizeof_macros",
+ "apollo_sizeof_macros 0.18.0-rc.1",
  "starknet-types-core",
+]
+
+[[package]]
+name = "apollo_sizeof_macros"
+version = "0.0.0"
+source = "git+https://github.com/starkware-libs/sequencer?rev=bc76748a37e660e700cff97b5dd1fb95d1a37c3e#bc76748a37e660e700cff97b5dd1fb95d1a37c3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -925,6 +971,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fade79dc45af880ec43aefc347cb3c276a802bc9a15e34fe94ecfdba2dd14538"
 dependencies = [
  "chrono",
+]
+
+[[package]]
+name = "apollo_versioned_constants"
+version = "0.0.0"
+source = "git+https://github.com/starkware-libs/sequencer?rev=bc76748a37e660e700cff97b5dd1fb95d1a37c3e#bc76748a37e660e700cff97b5dd1fb95d1a37c3e"
+dependencies = [
+ "serde",
+ "serde_json",
+ "starknet_api 0.0.0",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1739,7 +1796,7 @@ dependencies = [
  "apollo_compile_to_native",
  "apollo_compile_to_native_types",
  "apollo_config",
- "apollo_infra_utils",
+ "apollo_infra_utils 0.18.0-rc.1",
  "apollo_metrics",
  "ark-ec",
  "ark-ff 0.5.0",
@@ -1771,7 +1828,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "starknet-types-core",
- "starknet_api",
+ "starknet_api 0.18.0-rc.1",
  "strum",
  "thiserror 1.0.69",
  "validator",
@@ -1783,13 +1840,13 @@ version = "0.18.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7077372e5e198c7976bfda59443f68521040c05337b6f4e6f034d8f9f0b361"
 dependencies = [
- "apollo_infra_utils",
+ "apollo_infra_utils 0.18.0-rc.1",
  "cairo-lang-starknet-classes",
  "digest 0.10.7",
  "serde_json",
  "sha2 0.10.9",
  "starknet-types-core",
- "starknet_api",
+ "starknet_api 0.18.0-rc.1",
  "strum",
  "tempfile",
  "tracing",
@@ -3731,16 +3788,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "zip",
-]
-
-[[package]]
-name = "cargo_toml"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
-dependencies = [
- "serde",
- "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -8386,7 +8433,7 @@ dependencies = [
  "starknet-gateway-client",
  "starknet-gateway-test-fixtures",
  "starknet-gateway-types",
- "starknet_api",
+ "starknet_api 0.18.0-rc.1",
  "tempfile",
  "test-log",
  "thiserror 2.0.18",
@@ -8499,7 +8546,7 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet-gateway-test-fixtures",
- "starknet_api",
+ "starknet_api 0.18.0-rc.1",
  "tracing",
 ]
 
@@ -8595,7 +8642,7 @@ dependencies = [
  "primitive-types",
  "serde_json",
  "starknet-types-core",
- "starknet_api",
+ "starknet_api 0.18.0-rc.1",
  "tokio",
  "tokio-util",
  "tracing",
@@ -8606,17 +8653,12 @@ dependencies = [
 name = "pathfinder-gas-price"
 version = "0.22.3"
 dependencies = [
- "anyhow",
- "cargo_toml",
+ "apollo_versioned_constants",
  "mockall 0.11.4",
  "pathfinder-common",
  "pathfinder-ethereum",
- "reqwest 0.12.28",
  "rstest",
- "serde",
- "starknet_api",
  "thiserror 2.0.18",
- "tokio",
  "tracing",
 ]
 
@@ -8690,7 +8732,7 @@ dependencies = [
  "starknet-gateway-test-fixtures",
  "starknet-gateway-types",
  "starknet-types-core",
- "starknet_api",
+ "starknet_api 0.18.0-rc.1",
  "tempfile",
  "test-log",
  "thiserror 2.0.18",
@@ -8804,7 +8846,7 @@ dependencies = [
  "rayon",
  "rstest",
  "serde_json",
- "starknet_api",
+ "starknet_api 0.18.0-rc.1",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10910,12 +10952,49 @@ dependencies = [
 
 [[package]]
 name = "starknet_api"
+version = "0.0.0"
+source = "git+https://github.com/starkware-libs/sequencer?rev=bc76748a37e660e700cff97b5dd1fb95d1a37c3e#bc76748a37e660e700cff97b5dd1fb95d1a37c3e"
+dependencies = [
+ "apollo_infra_utils 0.0.0",
+ "apollo_sizeof 0.0.0",
+ "base64 0.13.1",
+ "bitvec",
+ "cached",
+ "cairo-lang-runner",
+ "cairo-lang-starknet-classes",
+ "cairo-lang-utils 2.17.0-rc.4",
+ "derive_more",
+ "flate2",
+ "hex",
+ "indexmap 2.13.0",
+ "itertools 0.12.1",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "paste",
+ "pretty_assertions",
+ "primitive-types",
+ "rand 0.8.5",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+ "sha3",
+ "starknet-core",
+ "starknet-crypto",
+ "starknet-types-core",
+ "strum",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+]
+
+[[package]]
+name = "starknet_api"
 version = "0.18.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94f3991e6f1afe218357fa16e3ed9a72cdbb1d9b6ccc472d37851b5cf268bd39"
 dependencies = [
- "apollo_infra_utils",
- "apollo_sizeof",
+ "apollo_infra_utils 0.18.0-rc.1",
+ "apollo_sizeof 0.18.0-rc.1",
  "base64 0.13.1",
  "bitvec",
  "cached",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,10 @@ authors = ["Equilibrium Labs <info@equilibrium.co>"]
 
 [workspace.dependencies]
 anyhow = "1.0.102"
+# TODO: There is no tag yet that includes the commit that added `apollo_versioned_constants`.
+# Once such a tag exists, we should update the dependency to use that tag instead of a specific
+# commit.
+apollo_versioned_constants = { package = "apollo_versioned_constants", git = "https://github.com/starkware-libs/sequencer", rev = "bc76748a37e660e700cff97b5dd1fb95d1a37c3e" }
 ark-ff = "0.5.0"
 assert_matches = "1.5.0"
 async-trait = "0.1.89"

--- a/crates/gas-price/Cargo.toml
+++ b/crates/gas-price/Cargo.toml
@@ -13,13 +13,6 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-anyhow = { workspace = true }
-cargo_toml = "0.22.3"
+apollo_versioned_constants = { workspace = true }
 mockall = { workspace = true }
-pathfinder-common = { path = "../common" }
-pathfinder-ethereum = { path = "../ethereum" }
-reqwest = { workspace = true }
 rstest = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
-starknet_api = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/gas-price/src/l2.rs
+++ b/crates/gas-price/src/l2.rs
@@ -160,39 +160,29 @@ impl L2GasPriceProvider {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-    use std::time::Duration;
-
-    use anyhow::Context;
     use rstest::rstest;
-    use serde::Deserialize;
 
     use super::*;
 
     const TEST_PRICE: u128 = 30_000_000_000;
-
-    /// Apollo versioned constants as they are defined in the
-    /// `apollo_consensus_orchestrator` crate.
-    #[derive(Debug, Deserialize)]
-    struct ApolloVersionedConstants {
-        gas_price_max_change_denominator: u128,
-        gas_target: starknet_api::execution_resources::GasAmount,
-        max_block_size: starknet_api::execution_resources::GasAmount,
-        min_gas_price: starknet_api::block::GasPrice,
-    }
 
     #[rstest]
     #[case::v0_13_2(StarknetVersion::V_0_13_2)]
     #[case::v0_13_4(StarknetVersion::V_0_13_4)]
     #[case::v0_14_0(StarknetVersion::V_0_14_0)]
     #[case::v0_14_1(StarknetVersion::V_0_14_1)]
-    #[tokio::test]
-    async fn l2_gas_constants_match_with_apollo(#[case] version: StarknetVersion) {
+    fn l2_gas_constants_match_with_apollo(#[case] version: StarknetVersion) {
         let pathfinder_c = L2GasPriceConstants::for_version(version);
-        let blockifier_tag = blockifier_tag_from_manifest().unwrap();
-        let apollo_c = fetch_apollo_constants_for(version, blockifier_tag)
-            .await
-            .unwrap();
+        let apollo_c = match version {
+            // Apollo's constants are only versioned starting from v0.14.0, so for older
+            // versions (which are expected to be same as v0.14.0) we use the v0.14.0
+            // constants.
+            StarknetVersion::V_0_13_2 | StarknetVersion::V_0_13_4 | StarknetVersion::V_0_14_0 => {
+                &*apollo_versioned_constants::VERSIONED_CONSTANTS_V0_14_0
+            }
+            StarknetVersion::V_0_14_1 => &*apollo_versioned_constants::VERSIONED_CONSTANTS_V0_14_1,
+            _ => unreachable!("not covered by the test cases"),
+        };
 
         assert_eq!(
             pathfinder_c.gas_price_max_change_denominator,
@@ -204,66 +194,6 @@ mod tests {
             apollo_c.max_block_size.0 as u128
         );
         assert_eq!(pathfinder_c.min_gas_price, apollo_c.min_gas_price.0);
-    }
-
-    // Parses the workspace Cargo.toml to find the version of blockifier, which is
-    // then used to construct the blockier tag in the form of
-    // `blockifier-v{version-from-workspace-Cargo-toml}`.
-    fn blockifier_tag_from_manifest() -> anyhow::Result<String> {
-        let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("..")
-            .join("..")
-            .join("Cargo.toml");
-        let manifest = cargo_toml::Manifest::from_path(manifest_path)
-            .context("loading workspace Cargo.toml")?;
-        let workspace = manifest
-            .workspace
-            .context("getting workspace dependencies")?;
-        let blockifier_version = workspace
-            .dependencies
-            .get("blockifier")
-            .and_then(|dep| dep.try_req().ok())
-            .context("parsing blockifier version from Cargo.toml")?;
-        let blockifier_tag = format!("blockifier-v{blockifier_version}");
-        Ok(blockifier_tag)
-    }
-
-    async fn fetch_apollo_constants_for(
-        version: StarknetVersion,
-        blockifier_tag: impl AsRef<str>,
-    ) -> anyhow::Result<ApolloVersionedConstants> {
-        // Apollo's constants are only versioned starting from v0.14.0, so for older
-        // versions (which are expected to be same as v0.14.0) we fetch the v0.14.0
-        // constants.
-        let version = if version < StarknetVersion::V_0_14_0 {
-            StarknetVersion::V_0_14_0
-        } else {
-            version
-        };
-
-        let url = format!(
-            "https://raw.githubusercontent.com/starkware-libs/sequencer/\
-                refs/tags/{}/\
-                crates/apollo_consensus_orchestrator/resources/orchestrator_versioned_constants_{}_{}_{}.json",
-            blockifier_tag.as_ref(),
-            version.major(),
-            version.minor(),
-            version.patch()
-        );
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(30))
-            .build()
-            .context("building http client")?;
-        let resp = client
-            .get(url)
-            .send()
-            .await
-            .context("fetching apollo constants")?;
-        resp.error_for_status()
-            .context("http get failed")?
-            .json()
-            .await
-            .context("parsing apollo constants")
     }
 
     // Apollo test vectors (from fee_market/test.rs)


### PR DESCRIPTION
Adds `apollo_versioned_constants` crate as a dependency and uses the L2 gas price constants defined in it to check against ours.

Removes the code that fetches and deserializes Apollo constants from raw GitHub files as it's no longer needed. Also removes dev dependencies used only by that code.
