### PR TITLE
feat(sync): new incremental pre-confirmed block for Starknet 0.14.3

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -529,6 +529,7 @@ impl StarknetVersion {
     // Poseidon hash, even when `class_commitment` is zero.
     pub const V_0_14_0: Self = Self::new(0, 14, 0, 0);
     pub const V_0_14_1: Self = Self::new(0, 14, 1, 0);
+    pub const V_0_14_3: Self = Self::new(0, 14, 3, 0);
 }
 
 impl FromStr for StarknetVersion {

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -12,7 +12,11 @@ use pathfinder_common::class_definition::{
 use pathfinder_common::prelude::*;
 use reqwest::Url;
 use starknet_gateway_types::error::SequencerError;
-use starknet_gateway_types::reply::{PreConfirmedBlock, PreLatestBlock};
+use starknet_gateway_types::reply::{
+    PreConfirmedPollResponse,
+    PreConfirmedPollResponseWire,
+    PreLatestBlock,
+};
 use starknet_gateway_types::trace::{BlockTrace, TransactionTrace};
 use starknet_gateway_types::{reply, request};
 
@@ -61,9 +65,9 @@ pub trait GatewayApi: Sync {
     async fn preconfirmed_block(
         &self,
         block: BlockId,
-        round: u64,
-        transaction_count: u64,
-    ) -> Result<PreConfirmedBlock, SequencerError> {
+        known_block_identifier: Option<String>,
+        known_transaction_count: u64,
+    ) -> Result<PreConfirmedPollResponse, SequencerError> {
         unimplemented!();
     }
 
@@ -163,11 +167,11 @@ impl<T: GatewayApi + Sync + Send> GatewayApi for Arc<T> {
     async fn preconfirmed_block(
         &self,
         block: BlockId,
-        round: u64,
-        transaction_count: u64,
-    ) -> Result<PreConfirmedBlock, SequencerError> {
+        known_block_identifier: Option<String>,
+        known_transaction_count: u64,
+    ) -> Result<PreConfirmedPollResponse, SequencerError> {
         self.as_ref()
-            .preconfirmed_block(block, round, transaction_count)
+            .preconfirmed_block(block, known_block_identifier, known_transaction_count)
             .await
     }
 
@@ -518,23 +522,27 @@ impl GatewayApi for Client {
     async fn preconfirmed_block(
         &self,
         block: BlockId,
-        round: u64,
-        transaction_count: u64,
-    ) -> Result<PreConfirmedBlock, SequencerError> {
+        known_block_identifier: Option<String>,
+        known_transaction_count: u64,
+    ) -> Result<PreConfirmedPollResponse, SequencerError> {
         // Note that we don't do retries here.
         // The pre-confirmed block is polled continuously by the sync logic,
         // so retries are not needed.
-        let result = self
+        let id = known_block_identifier.as_deref().unwrap_or("");
+        let wire: PreConfirmedPollResponseWire = self
             .feeder_gateway_request()
             .get_preconfirmed_block()
             .block(block)
-            .param("round", &round.to_string())
-            .param("transactionCount", &transaction_count.to_string())
+            .param("knownBlockIdentifier", id)
+            .param(
+                "knownTransactionCount",
+                &known_transaction_count.to_string(),
+            )
             .retry(false)
             .get()
             .await?;
 
-        Ok(result)
+        Ok(wire.into())
     }
 
     #[tracing::instrument(skip(self))]

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -61,6 +61,8 @@ pub trait GatewayApi: Sync {
     async fn preconfirmed_block(
         &self,
         block: BlockId,
+        round: u64,
+        transaction_count: u64,
     ) -> Result<PreConfirmedBlock, SequencerError> {
         unimplemented!();
     }
@@ -161,8 +163,12 @@ impl<T: GatewayApi + Sync + Send> GatewayApi for Arc<T> {
     async fn preconfirmed_block(
         &self,
         block: BlockId,
+        round: u64,
+        transaction_count: u64,
     ) -> Result<PreConfirmedBlock, SequencerError> {
-        self.as_ref().preconfirmed_block(block).await
+        self.as_ref()
+            .preconfirmed_block(block, round, transaction_count)
+            .await
     }
 
     async fn block_header(
@@ -512,6 +518,8 @@ impl GatewayApi for Client {
     async fn preconfirmed_block(
         &self,
         block: BlockId,
+        round: u64,
+        transaction_count: u64,
     ) -> Result<PreConfirmedBlock, SequencerError> {
         // Note that we don't do retries here.
         // The pre-confirmed block is polled continuously by the sync logic,
@@ -520,6 +528,8 @@ impl GatewayApi for Client {
             .feeder_gateway_request()
             .get_preconfirmed_block()
             .block(block)
+            .param("round", &round.to_string())
+            .param("transactionCount", &transaction_count.to_string())
             .retry(false)
             .get()
             .await?;

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -117,14 +117,160 @@ pub struct PreConfirmedBlock {
     >,
 
     pub transaction_state_diffs: Vec<Option<state_update::StateDiff>>,
+}
 
-    /// Current consensus round at this height (TODO: Pending spec confirmation)
-    ///
-    /// From Starknet 0.14.3 onward, the pre-confirmed block endpoint returns
-    /// transactions added after the caller-supplied `transaction_count`.
-    /// Will default to `None` for earlier versions.
+/// Flat wire struct that deserializes all response shapes returned by the
+/// feeder gateway's `get_preconfirmed_block` endpoint.
+///
+/// The `changed` field is the discriminant:
+/// - absent: legacy 0.14.2 full block (no `known_block_identifier`)
+/// - `false`: `Unchanged`
+/// - `true` + `status` present: new-style `Full`
+/// - `true` + `status` absent: `Delta`
+#[serde_as]
+#[derive(Debug, Deserialize)]
+struct PreConfirmedPollResponseWire {
     #[serde(default)]
-    pub round: Option<u64>,
+    changed: Option<bool>,
+
+    #[serde(default)]
+    known_block_identifier: Option<String>,
+
+    // Block-header fields: present on legacy and new-style Full responses.
+    #[serde(default)]
+    l1_gas_price: Option<GasPrices>,
+    #[serde(default)]
+    l1_data_gas_price: Option<GasPrices>,
+    #[serde(default)]
+    l2_gas_price: Option<GasPrices>,
+    #[serde(default)]
+    sequencer_address: Option<SequencerAddress>,
+    #[serde(default)]
+    status: Option<Status>,
+    #[serde(default)]
+    timestamp: Option<BlockTimestamp>,
+    #[serde(default)]
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    starknet_version: Option<StarknetVersion>,
+    #[serde(default)]
+    l1_da_mode: Option<L1DataAvailabilityMode>,
+
+    // Transaction vecs: present on Delta and Full responses.
+    #[serde(default)]
+    #[serde_as(as = "Vec<transaction::Transaction>")]
+    transactions: Vec<pathfinder_common::transaction::Transaction>,
+    #[serde(default)]
+    #[serde_as(as = "Vec<Option<transaction::Receipt>>")]
+    transaction_receipts: Vec<
+        Option<(
+            pathfinder_common::receipt::Receipt,
+            Vec<pathfinder_common::event::Event>,
+        )>,
+    >,
+    #[serde(default)]
+    transaction_state_diffs: Vec<Option<state_update::StateDiff>>,
+}
+
+/// The result of polling `get_preconfirmed_block`.
+///
+/// Three modes are possible:
+/// - `Unchanged` — the server confirms the caller's view is still current.
+/// - `Delta`     — the identifier matches; only new transactions are returned.
+/// - `Full`      — a complete block view is returned (identifier mismatch,
+///   first poll, or legacy 0.14.2 response).
+///
+/// Note: `Full` responses converted from the legacy 0.14.2 wire shape (no
+/// `changed` field) will have an empty string as `identifier`.
+#[derive(Debug, PartialEq)]
+pub enum PreConfirmedPollResponse {
+    Unchanged,
+
+    Delta {
+        identifier: String,
+        new_transactions: Vec<pathfinder_common::transaction::Transaction>,
+        new_receipts: Vec<
+            Option<(
+                pathfinder_common::receipt::Receipt,
+                Vec<pathfinder_common::event::Event>,
+            )>,
+        >,
+        new_state_diffs: Vec<Option<state_update::StateDiff>>,
+    },
+
+    Full {
+        identifier: String,
+        block: PreConfirmedBlock,
+    },
+}
+
+fn build_block(wire: &mut PreConfirmedPollResponseWire) -> PreConfirmedBlock {
+    PreConfirmedBlock {
+        l1_gas_price: wire
+            .l1_gas_price
+            .take()
+            .expect("l1_gas_price missing in pre-confirmed full block"),
+        l1_data_gas_price: wire
+            .l1_data_gas_price
+            .take()
+            .expect("l1_data_gas_price missing in pre-confirmed full block"),
+        l2_gas_price: wire
+            .l2_gas_price
+            .take()
+            .expect("l2_gas_price missing in pre-confirmed full block"),
+        sequencer_address: wire
+            .sequencer_address
+            .take()
+            .expect("sequencer_address missing in pre-confirmed full block"),
+        status: wire
+            .status
+            .take()
+            .expect("status missing in pre-confirmed full block"),
+        timestamp: wire
+            .timestamp
+            .take()
+            .expect("timestamp missing in pre-confirmed full block"),
+        starknet_version: wire
+            .starknet_version
+            .take()
+            .expect("starknet_version missing in pre-confirmed full block"),
+        l1_da_mode: wire
+            .l1_da_mode
+            .take()
+            .expect("l1_da_mode missing in pre-confirmed full block"),
+        transactions: std::mem::take(&mut wire.transactions),
+        transaction_receipts: std::mem::take(&mut wire.transaction_receipts),
+        transaction_state_diffs: std::mem::take(&mut wire.transaction_state_diffs),
+    }
+}
+
+impl From<PreConfirmedPollResponseWire> for PreConfirmedPollResponse {
+    fn from(mut wire: PreConfirmedPollResponseWire) -> Self {
+        match wire.changed {
+            // Legacy 0.14.2 shape: no `changed` field, all block fields present.
+            None => Self::Full {
+                identifier: String::new(),
+                block: build_block(&mut wire),
+            },
+            Some(false) => Self::Unchanged,
+            Some(true) if wire.status.is_some() => {
+                // New-style Full: block-header fields are present.
+                let identifier = wire.known_block_identifier.take().unwrap_or_default();
+                Self::Full {
+                    identifier,
+                    block: build_block(&mut wire),
+                }
+            }
+            Some(true) => {
+                // Delta: only transaction vecs are present; no block-header fields.
+                Self::Delta {
+                    identifier: wire.known_block_identifier.take().unwrap_or_default(),
+                    new_transactions: wire.transactions,
+                    new_receipts: wire.transaction_receipts,
+                    new_state_diffs: wire.transaction_state_diffs,
+                }
+            }
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, Default, Deserialize, PartialEq, Eq, serde::Serialize)]
@@ -2573,45 +2719,135 @@ mod tests {
 
             let _pre_confirmed_block: PreConfirmedBlock = serde_json::from_str(json).unwrap();
         }
+    }
 
-        mod round_field {
-            use super::super::super::PreConfirmedBlock;
+    mod preconfirmed_poll_response {
+        use pathfinder_common::{felt, GasPrice, TransactionHash};
 
-            fn pre_confirmed_block_json(round: Option<u64>) -> serde_json::Value {
-                let mut body = serde_json::json!({
-                    "l1_gas_price":     {"price_in_wei": "0x0", "price_in_fri": "0x0"},
-                    "l1_data_gas_price":{"price_in_wei": "0x0", "price_in_fri": "0x0"},
-                    "l2_gas_price":     {"price_in_wei": "0x0", "price_in_fri": "0x0"},
-                    "sequencer_address": "0x0",
-                    "status":            "PRE_CONFIRMED",
-                    "timestamp":         0,
-                    "starknet_version":  "0.14.3",
-                    "l1_da_mode":        "BLOB",
-                    "transactions":          [],
-                    "transaction_receipts":  [],
-                    "transaction_state_diffs": [],
-                });
-                if let Some(r) = round {
-                    body.as_object_mut()
-                        .unwrap()
-                        .insert("round".into(), r.into());
+        use super::super::{
+            GasPrices,
+            PreConfirmedPollResponse,
+            PreConfirmedPollResponseWire,
+            Status,
+        };
+
+        fn minimal_block_json() -> serde_json::Value {
+            serde_json::json!({
+                "l1_gas_price":       {"price_in_wei": "0xabcdef", "price_in_fri": "0x123456"},
+                "l1_data_gas_price":  {"price_in_wei": "0x0", "price_in_fri": "0x0"},
+                "l2_gas_price":       {"price_in_wei": "0x0", "price_in_fri": "0x0"},
+                "sequencer_address":  "0x0",
+                "status":             "PRE_CONFIRMED",
+                "timestamp":          42,
+                "starknet_version":   "0.14.3",
+                "l1_da_mode":         "BLOB",
+                "transactions":           [],
+                "transaction_receipts":   [],
+                "transaction_state_diffs": []
+            })
+        }
+
+        #[test]
+        fn unchanged() {
+            let wire: PreConfirmedPollResponseWire =
+                serde_json::from_value(serde_json::json!({"changed": false})).unwrap();
+            assert_eq!(
+                PreConfirmedPollResponse::from(wire),
+                PreConfirmedPollResponse::Unchanged
+            );
+        }
+
+        #[test]
+        fn delta() {
+            let json = serde_json::json!({
+                "changed": true,
+                "known_block_identifier": "abc",
+                "transactions": [
+                    {
+                        "type": "INVOKE_FUNCTION",
+                        "version": "0x1",
+                        "transaction_hash": "0x1",
+                        "sender_address": "0x1",
+                        "calldata": ["1"],
+                        "max_fee": "0x0",
+                        "signature": [],
+                        "nonce": "0x0"
+                    }
+                ],
+                "transaction_receipts": [],
+                "transaction_state_diffs": []
+            });
+            let wire: PreConfirmedPollResponseWire = serde_json::from_value(json).unwrap();
+            let response = PreConfirmedPollResponse::from(wire);
+
+            match response {
+                PreConfirmedPollResponse::Delta {
+                    identifier,
+                    new_transactions,
+                    new_receipts,
+                    new_state_diffs,
+                } => {
+                    assert_eq!(identifier, "abc");
+                    assert_eq!(new_transactions.len(), 1);
+                    assert_eq!(new_transactions[0].hash, TransactionHash(felt!("0x1")));
+                    assert_eq!(new_receipts.len(), 0);
+                    assert_eq!(new_state_diffs.len(), 0);
                 }
-                body
-            }
-
-            #[test]
-            fn round_present_parses_to_some() {
-                let body = pre_confirmed_block_json(Some(5));
-                let block: PreConfirmedBlock = serde_json::from_value(body).unwrap();
-                assert_eq!(block.round, Some(5));
-            }
-
-            #[test]
-            fn round_absent_parses_to_none() {
-                let body = pre_confirmed_block_json(None);
-                let block: PreConfirmedBlock = serde_json::from_value(body).unwrap();
-                assert_eq!(block.round, None);
+                other => panic!("expected Delta, got {other:?}"),
             }
         }
+
+        #[test]
+        fn full_new_style() {
+            let mut json = minimal_block_json();
+            json.as_object_mut()
+                .unwrap()
+                .insert("changed".into(), true.into());
+            json.as_object_mut()
+                .unwrap()
+                .insert("known_block_identifier".into(), "xyz".into());
+
+            let wire: PreConfirmedPollResponseWire = serde_json::from_value(json).unwrap();
+            let response = PreConfirmedPollResponse::from(wire);
+
+            match response {
+                PreConfirmedPollResponse::Full { identifier, block } => {
+                    assert_eq!(identifier, "xyz");
+                    assert_eq!(
+                        block.l1_gas_price,
+                        GasPrices {
+                            price_in_wei: GasPrice(0xabcdef),
+                            price_in_fri: GasPrice(0x123456),
+                        }
+                    );
+                    assert_eq!(block.timestamp.get(), 42);
+                    assert_eq!(block.starknet_version.to_string(), "0.14.3");
+                }
+                other => panic!("expected Full, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn legacy_full_no_identifier() {
+            let json = minimal_block_json();
+            let wire: PreConfirmedPollResponseWire = serde_json::from_value(json).unwrap();
+            let response = PreConfirmedPollResponse::from(wire);
+
+            match response {
+                PreConfirmedPollResponse::Full { identifier, block } => {
+                    assert!(identifier.is_empty());
+                    assert_eq!(
+                        block.l1_gas_price,
+                        GasPrices {
+                            price_in_wei: GasPrice(0xabcdef),
+                            price_in_fri: GasPrice(0x123456),
+                        }
+                    );
+                    assert_eq!(block.starknet_version.to_string(), "0.14.3");
+                }
+                other => panic!("expected Full, got {other:?}"),
+            }
+        }
+
     }
 }

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -2724,12 +2724,7 @@ mod tests {
     mod preconfirmed_poll_response {
         use pathfinder_common::{felt, GasPrice, TransactionHash};
 
-        use super::super::{
-            GasPrices,
-            PreConfirmedPollResponse,
-            PreConfirmedPollResponseWire,
-            Status,
-        };
+        use super::super::{GasPrices, PreConfirmedPollResponse, PreConfirmedPollResponseWire};
 
         fn minimal_block_json() -> serde_json::Value {
             serde_json::json!({

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -117,6 +117,14 @@ pub struct PreConfirmedBlock {
     >,
 
     pub transaction_state_diffs: Vec<Option<state_update::StateDiff>>,
+
+    /// Current consensus round at this height (TODO: Pending spec confirmation)
+    ///
+    /// From Starknet 0.14.3 onward, the pre-confirmed block endpoint returns
+    /// transactions added after the caller-supplied `transaction_count`.
+    /// Will default to `None` for earlier versions.
+    #[serde(default)]
+    pub round: Option<u64>,
 }
 
 #[derive(Copy, Clone, Debug, Default, Deserialize, PartialEq, Eq, serde::Serialize)]

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -2573,5 +2573,45 @@ mod tests {
 
             let _pre_confirmed_block: PreConfirmedBlock = serde_json::from_str(json).unwrap();
         }
+
+        mod round_field {
+            use super::super::super::PreConfirmedBlock;
+
+            fn pre_confirmed_block_json(round: Option<u64>) -> serde_json::Value {
+                let mut body = serde_json::json!({
+                    "l1_gas_price":     {"price_in_wei": "0x0", "price_in_fri": "0x0"},
+                    "l1_data_gas_price":{"price_in_wei": "0x0", "price_in_fri": "0x0"},
+                    "l2_gas_price":     {"price_in_wei": "0x0", "price_in_fri": "0x0"},
+                    "sequencer_address": "0x0",
+                    "status":            "PRE_CONFIRMED",
+                    "timestamp":         0,
+                    "starknet_version":  "0.14.3",
+                    "l1_da_mode":        "BLOB",
+                    "transactions":          [],
+                    "transaction_receipts":  [],
+                    "transaction_state_diffs": [],
+                });
+                if let Some(r) = round {
+                    body.as_object_mut()
+                        .unwrap()
+                        .insert("round".into(), r.into());
+                }
+                body
+            }
+
+            #[test]
+            fn round_present_parses_to_some() {
+                let body = pre_confirmed_block_json(Some(5));
+                let block: PreConfirmedBlock = serde_json::from_value(body).unwrap();
+                assert_eq!(block.round, Some(5));
+            }
+
+            #[test]
+            fn round_absent_parses_to_none() {
+                let body = pre_confirmed_block_json(None);
+                let block: PreConfirmedBlock = serde_json::from_value(body).unwrap();
+                assert_eq!(block.round, None);
+            }
+        }
     }
 }

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -129,7 +129,7 @@ pub struct PreConfirmedBlock {
 /// - `true` + `status` absent: `Delta`
 #[serde_as]
 #[derive(Debug, Deserialize)]
-struct PreConfirmedPollResponseWire {
+pub struct PreConfirmedPollResponseWire {
     #[serde(default)]
     changed: Option<bool>,
 
@@ -2848,6 +2848,5 @@ mod tests {
                 other => panic!("expected Full, got {other:?}"),
             }
         }
-
     }
 }

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -119,24 +119,22 @@ pub struct PreConfirmedBlock {
     pub transaction_state_diffs: Vec<Option<state_update::StateDiff>>,
 }
 
-/// Flat wire struct that deserializes all response shapes returned by the
+/// Flat wire struct that deserializes any response shape returned by the
 /// feeder gateway's `get_preconfirmed_block` endpoint.
 ///
 /// The `changed` field is the discriminant:
-/// - absent: legacy 0.14.2 full block (no `known_block_identifier`)
 /// - `false`: `Unchanged`
-/// - `true` + `status` present: new-style `Full`
+/// - `true` + `status` present: `Full`
 /// - `true` + `status` absent: `Delta`
 #[serde_as]
 #[derive(Debug, Deserialize)]
 pub struct PreConfirmedPollResponseWire {
-    #[serde(default)]
-    changed: Option<bool>,
+    changed: bool,
 
     #[serde(default)]
     known_block_identifier: Option<String>,
 
-    // Block-header fields: present on legacy and new-style Full responses.
+    // Block-header fields: present on Full responses only.
     #[serde(default)]
     l1_gas_price: Option<GasPrices>,
     #[serde(default)]
@@ -176,11 +174,8 @@ pub struct PreConfirmedPollResponseWire {
 /// Three modes are possible:
 /// - `Unchanged` — the server confirms the caller's view is still current.
 /// - `Delta`     — the identifier matches; only new transactions are returned.
-/// - `Full`      — a complete block view is returned (identifier mismatch,
-///   first poll, or legacy 0.14.2 response).
-///
-/// Note: `Full` responses converted from the legacy 0.14.2 wire shape (no
-/// `changed` field) will have an empty string as `identifier`.
+/// - `Full`      — a complete block view is returned (identifier mismatch or
+///   first poll).
 #[derive(Debug, PartialEq)]
 pub enum PreConfirmedPollResponse {
     Unchanged,
@@ -245,29 +240,23 @@ fn build_block(wire: &mut PreConfirmedPollResponseWire) -> PreConfirmedBlock {
 
 impl From<PreConfirmedPollResponseWire> for PreConfirmedPollResponse {
     fn from(mut wire: PreConfirmedPollResponseWire) -> Self {
-        match wire.changed {
-            // Legacy 0.14.2 shape: no `changed` field, all block fields present.
-            None => Self::Full {
-                identifier: String::new(),
+        if !wire.changed {
+            return Self::Unchanged;
+        }
+        let identifier = wire.known_block_identifier.take().unwrap_or_default();
+        if wire.status.is_some() {
+            // Full: block-header fields are present.
+            Self::Full {
+                identifier,
                 block: build_block(&mut wire),
-            },
-            Some(false) => Self::Unchanged,
-            Some(true) if wire.status.is_some() => {
-                // New-style Full: block-header fields are present.
-                let identifier = wire.known_block_identifier.take().unwrap_or_default();
-                Self::Full {
-                    identifier,
-                    block: build_block(&mut wire),
-                }
             }
-            Some(true) => {
-                // Delta: only transaction vecs are present; no block-header fields.
-                Self::Delta {
-                    identifier: wire.known_block_identifier.take().unwrap_or_default(),
-                    new_transactions: wire.transactions,
-                    new_receipts: wire.transaction_receipts,
-                    new_state_diffs: wire.transaction_state_diffs,
-                }
+        } else {
+            // Delta: only transaction vecs; no block-header fields.
+            Self::Delta {
+                identifier,
+                new_transactions: wire.transactions,
+                new_receipts: wire.transaction_receipts,
+                new_state_diffs: wire.transaction_state_diffs,
             }
         }
     }
@@ -2816,28 +2805,6 @@ mod tests {
                         }
                     );
                     assert_eq!(block.timestamp.get(), 42);
-                    assert_eq!(block.starknet_version.to_string(), "0.14.3");
-                }
-                other => panic!("expected Full, got {other:?}"),
-            }
-        }
-
-        #[test]
-        fn legacy_full_no_identifier() {
-            let json = minimal_block_json();
-            let wire: PreConfirmedPollResponseWire = serde_json::from_value(json).unwrap();
-            let response = PreConfirmedPollResponse::from(wire);
-
-            match response {
-                PreConfirmedPollResponse::Full { identifier, block } => {
-                    assert!(identifier.is_empty());
-                    assert_eq!(
-                        block.l1_gas_price,
-                        GasPrices {
-                            price_in_wei: GasPrice(0xabcdef),
-                            price_in_fri: GasPrice(0x123456),
-                        }
-                    );
                     assert_eq!(block.starknet_version.to_string(), "0.14.3");
                 }
                 other => panic!("expected Full, got {other:?}"),

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -729,6 +729,233 @@ mod tests {
         assert!(result.is_err(), "No event should be emitted for stale data");
     }
 
+    mod apply {
+        use pathfinder_common::macro_prelude::*;
+        use pathfinder_common::transaction::{
+            L1HandlerTransaction,
+            Transaction,
+            TransactionVariant,
+        };
+        use starknet_gateway_types::reply::{PreConfirmedBlock, PreConfirmedPollResponse};
+
+        use super::super::{BlockNumber, State};
+
+        fn placeholder_tx(index: usize) -> Transaction {
+            let hash = match index {
+                0 => transaction_hash!("0x1"),
+                1 => transaction_hash!("0x2"),
+                _ => transaction_hash!("0x3"),
+            };
+            Transaction {
+                hash,
+                variant: TransactionVariant::L1Handler(L1HandlerTransaction {
+                    contract_address: contract_address!("0x1"),
+                    entry_point_selector: entry_point!("0x55"),
+                    nonce: transaction_nonce!("0x0"),
+                    calldata: Vec::new(),
+                }),
+            }
+        }
+
+        /// Build a minimal `PreConfirmedBlock` with `n` placeholder
+        /// transactions and matching empty receipt/state-diff slots.
+        /// Other fields use `Default`.
+        fn block_with_txs(n: usize) -> PreConfirmedBlock {
+            let txs: Vec<Transaction> = (0..n).map(placeholder_tx).collect();
+            let receipts = vec![None; n];
+            let state_diffs = vec![None; n];
+            PreConfirmedBlock {
+                transactions: txs,
+                transaction_receipts: receipts,
+                transaction_state_diffs: state_diffs,
+                ..Default::default()
+            }
+        }
+
+        fn state(identifier: Option<&str>, txs: usize, pre_latest: bool) -> State {
+            State {
+                block_number: BlockNumber::new_or_panic(10),
+                block_identifier: identifier.map(String::from),
+                accumulated: if identifier.is_some() {
+                    Some(block_with_txs(txs))
+                } else {
+                    None
+                },
+                pre_latest_data_present: pre_latest,
+            }
+        }
+
+        #[test]
+        fn unchanged_response_is_noop() {
+            let mut s = state(Some("abc"), 1, false);
+            let original_accumulated = s.accumulated.clone();
+            let original_identifier = s.block_identifier.clone();
+            let original_number = s.block_number;
+
+            let emitted = s.apply(PreConfirmedPollResponse::Unchanged, true);
+
+            assert!(!emitted);
+            assert_eq!(s.accumulated, original_accumulated);
+            assert_eq!(s.block_identifier, original_identifier);
+            assert_eq!(s.block_number, original_number);
+            // apply always writes the new pre-latest presence
+            assert!(s.pre_latest_data_present);
+        }
+
+        #[test]
+        fn delta_with_mismatching_identifier_is_skipped() {
+            let mut s = state(Some("abc"), 1, false);
+            let original_accumulated = s.accumulated.clone();
+
+            let emitted = s.apply(
+                PreConfirmedPollResponse::Delta {
+                    identifier: "xyz".into(),
+                    new_transactions: vec![Transaction {
+                        hash: transaction_hash!("0x99"),
+                        variant: TransactionVariant::L1Handler(L1HandlerTransaction {
+                            contract_address: contract_address!("0x1"),
+                            entry_point_selector: entry_point!("0x55"),
+                            nonce: transaction_nonce!("0x0"),
+                            calldata: Vec::new(),
+                        }),
+                    }],
+                    new_receipts: vec![None],
+                    new_state_diffs: vec![None],
+                },
+                false,
+            );
+
+            assert!(!emitted);
+            assert_eq!(s.accumulated, original_accumulated);
+            assert_eq!(s.block_identifier, Some("abc".into()));
+        }
+
+        #[test]
+        fn delta_with_matching_identifier_and_empty_transactions_is_noop() {
+            let mut s = state(Some("abc"), 1, false);
+            let original_accumulated = s.accumulated.clone();
+
+            let emitted = s.apply(
+                PreConfirmedPollResponse::Delta {
+                    identifier: "abc".into(),
+                    new_transactions: vec![],
+                    new_receipts: vec![],
+                    new_state_diffs: vec![],
+                },
+                false,
+            );
+
+            assert!(!emitted);
+            assert_eq!(s.accumulated, original_accumulated);
+            assert_eq!(s.block_identifier, Some("abc".into()));
+        }
+
+        #[test]
+        fn delta_with_matching_identifier_appends() {
+            let mut s = state(Some("abc"), 1, false);
+
+            let new_tx = Transaction {
+                hash: transaction_hash!("0x99"),
+                variant: TransactionVariant::L1Handler(L1HandlerTransaction {
+                    contract_address: contract_address!("0x1"),
+                    entry_point_selector: entry_point!("0x55"),
+                    nonce: transaction_nonce!("0x0"),
+                    calldata: Vec::new(),
+                }),
+            };
+
+            let emitted = s.apply(
+                PreConfirmedPollResponse::Delta {
+                    identifier: "abc".into(),
+                    new_transactions: vec![new_tx],
+                    new_receipts: vec![None],
+                    new_state_diffs: vec![None],
+                },
+                false,
+            );
+
+            assert!(emitted);
+            let acc = s.accumulated.as_ref().unwrap();
+            assert_eq!(acc.transactions.len(), 2);
+            assert_eq!(acc.transaction_receipts.len(), 2);
+            assert_eq!(acc.transaction_state_diffs.len(), 2);
+            assert_eq!(s.block_identifier, Some("abc".into()));
+        }
+
+        #[test]
+        fn full_with_changed_identifier_emits() {
+            let mut s = state(Some("abc"), 1, false);
+            let new_block = block_with_txs(1);
+
+            let emitted = s.apply(
+                PreConfirmedPollResponse::Full {
+                    identifier: "xyz".into(),
+                    block: new_block.clone(),
+                },
+                false,
+            );
+
+            assert!(emitted);
+            assert_eq!(s.block_identifier, Some("xyz".into()));
+            assert_eq!(s.accumulated, Some(new_block));
+        }
+
+        #[test]
+        fn full_with_more_transactions_emits() {
+            let mut s = state(Some("abc"), 1, false);
+            let new_block = block_with_txs(2);
+
+            let emitted = s.apply(
+                PreConfirmedPollResponse::Full {
+                    identifier: "abc".into(),
+                    block: new_block.clone(),
+                },
+                false,
+            );
+
+            assert!(emitted);
+            assert_eq!(s.accumulated.as_ref().unwrap().transactions.len(), 2);
+        }
+
+        #[test]
+        fn full_with_pre_latest_finalised_emits() {
+            let mut s = state(Some("abc"), 2, true);
+            let same_block = block_with_txs(2);
+
+            // pre_latest transitions true → false: should force an emit
+            let emitted = s.apply(
+                PreConfirmedPollResponse::Full {
+                    identifier: "abc".into(),
+                    block: same_block.clone(),
+                },
+                false,
+            );
+
+            assert!(emitted);
+            assert_eq!(s.accumulated, Some(same_block));
+        }
+
+        #[test]
+        fn full_with_no_signals_is_deduped() {
+            let mut s = state(Some("abc"), 2, false);
+            let same_block = block_with_txs(2);
+            let original_accumulated = s.accumulated.clone();
+
+            // Same identifier, no new txs, no pre-latest transition: nothing to emit
+            let emitted = s.apply(
+                PreConfirmedPollResponse::Full {
+                    identifier: "abc".into(),
+                    block: same_block,
+                },
+                false,
+            );
+
+            assert!(!emitted);
+            assert_eq!(s.accumulated, original_accumulated);
+            assert_eq!(s.block_identifier, Some("abc".into()));
+        }
+    }
+
     /// The expected sequence for Starknet v0.14.0+ goes something like this:
     ///   1) Node is on block N
     ///   2) Sequencer is producing pre-confirmed block N + 1 (N is still

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -342,6 +342,7 @@ mod tests {
                 }),
                 None,
             ],
+            round: None,
         });
 
     /// Arbitrary timeout for receiving emits on the tokio channel. Otherwise

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
-use pathfinder_common::{BlockHash, BlockNumber, StarknetVersion};
+use pathfinder_common::{BlockHash, BlockNumber};
 use starknet_gateway_client::GatewayApi;
-use starknet_gateway_types::reply::PreConfirmedBlock;
+use starknet_gateway_types::reply::{PreConfirmedBlock, PreConfirmedPollResponse};
 use tokio::sync::watch;
 use tokio::time::Instant;
 
@@ -15,10 +15,10 @@ const IN_SYNC_THRESHOLD: u64 = 6;
 struct State {
     /// Height we're currently polling.
     block_number: BlockNumber,
-    /// `None` until we've seen a 0.14.3+ response for this height. Once
-    /// set, we track the round we're currently following and treat
-    /// any response with a higher round as a full reset.
-    round: Option<u64>,
+    /// Server-given block identifier from the last successful poll. `None`
+    /// until we've completed our first poll for this height. The server uses
+    /// this to detect when our view is stale and needs a full rebuild.
+    block_identifier: Option<String>,
     /// Running merged view of the preconfirmed block at `block_number`.
     /// `None` until we've received our first response for this height.
     accumulated: Option<PreConfirmedBlock>,
@@ -30,7 +30,7 @@ impl Default for State {
     fn default() -> Self {
         Self {
             block_number: BlockNumber::GENESIS,
-            round: None,
+            block_identifier: None,
             accumulated: None,
             pre_latest_data_present: false,
         }
@@ -48,96 +48,63 @@ impl State {
     /// Apply a fresh poll response, given the pre-latest presence
     /// observed for this poll. Returns `true` if `accumulated` was
     /// updated and the caller should emit the new view.
-    fn apply(&mut self, response: PreConfirmedBlock, new_pre_latest: bool) -> bool {
-        use std::cmp::Ordering;
-
+    fn apply(&mut self, response: PreConfirmedPollResponse, new_pre_latest: bool) -> bool {
         let prev_pre_latest = self.pre_latest_data_present;
         self.pre_latest_data_present = new_pre_latest;
 
-        // Starknet 0.14.3 introduced the incremental API: responses carry a
-        // `round` field and contain only the transactions added since the
-        // count we sent.
-        let is_delta_capable = response.starknet_version >= StarknetVersion::V_0_14_3;
+        match response {
+            PreConfirmedPollResponse::Unchanged => false,
 
-        if !is_delta_capable {
-            // Pre-0.14.3: response is always the full current view, but the
-            // gateway may re-serve the same view across polls. Suppress
-            // emissions that carry no new information.
-            let prev_tx_count = self.tx_count();
-            let new_tx_count = response.transactions.len() as u64;
-
-            let should_update = match new_tx_count.cmp(&prev_tx_count) {
-                Ordering::Greater => true,
-                Ordering::Less => false, // stale: same height, fewer txs
-                Ordering::Equal => prev_pre_latest && !new_pre_latest,
-            };
-
-            if should_update {
-                self.round = None;
-                self.accumulated = Some(response);
-            }
-            return should_update;
-        }
-
-        match (self.round, response.round) {
-            (_, None) => {
-                // Server claims ≥ 0.14.3 but omitted `round`. Treat as a
-                // malformed payload: full-replace, but don't advance our
-                // tracked round so we keep retrying without committing to
-                // a phantom round number.
-                tracing::warn!(
-                    "pre-confirmed response claims version {} but omits round; falling back to \
-                     full replace",
-                    response.starknet_version
-                );
-                self.round = None;
-                self.accumulated = Some(response);
-                true
-            }
-            (None, Some(r)) => {
-                // First 0.14.3 response for this height. Adopt verbatim.
-                self.round = Some(r);
-                self.accumulated = Some(response);
-                true
-            }
-            (Some(ours), Some(r)) => match r.cmp(&ours) {
-                Ordering::Greater => {
-                    // Round bumped: the sequencer abandoned the prior
-                    // proposal at this height, so any txs/header we'd
-                    // accumulated are no longer valid.
-                    self.round = Some(r);
-                    self.accumulated = Some(response);
-                    true
-                }
-                Ordering::Equal => {
-                    if response.transactions.is_empty() {
-                        false
-                    } else {
-                        // Delta at the same round — append.
-                        let acc = self
-                            .accumulated
-                            .as_mut()
-                            .expect("accumulated block present whenever round is Some");
-                        acc.transactions.extend(response.transactions);
-                        acc.transaction_receipts
-                            .extend(response.transaction_receipts);
-                        acc.transaction_state_diffs
-                            .extend(response.transaction_state_diffs);
-                        true
-                    }
-                }
-                Ordering::Less => {
-                    // Server is on an older round than we are; this should
-                    // never happen in normal operation. Hold our state
-                    // and wait for a fresh response.
+            PreConfirmedPollResponse::Delta {
+                identifier,
+                new_transactions,
+                new_receipts,
+                new_state_diffs,
+            } => {
+                // Per spec, the server only sends a delta when its identifier matches
+                // ours. A mismatch indicates a server bug or local state corruption;
+                // skip defensively and wait for the next poll (which our stored identifier
+                // will not match server's, triggering a full rebuild).
+                if self.block_identifier.as_ref() != Some(&identifier) {
                     tracing::warn!(
-                        our_round = ours,
-                        server_round = r,
-                        "pre-confirmed response carries an older round than ours; ignoring"
+                        ours = ?self.block_identifier,
+                        theirs = %identifier,
+                        "delta response identifier doesn't match ours; skipping"
                     );
+                    return false;
+                }
+                if new_transactions.is_empty() {
+                    return false;
+                }
+                let acc = self
+                    .accumulated
+                    .as_mut()
+                    .expect("accumulated present whenever block_identifier is Some");
+                acc.transactions.extend(new_transactions);
+                acc.transaction_receipts.extend(new_receipts);
+                acc.transaction_state_diffs.extend(new_state_diffs);
+                true
+            }
+
+            PreConfirmedPollResponse::Full { identifier, block } => {
+                // Emit on any of three independent signals:
+                //  - the server's identifier changed (round bump, new height, or first poll)
+                //  - new transactions arrived
+                //  - pre-latest just finalised
+                // Otherwise suppress: pre-0.14.3 gateways re-serve the same view across
+                // polls and we don't want to bombard downstream with redundant events.
+                let identifier_changed = self.block_identifier.as_ref() != Some(&identifier);
+                let new_txs_arrived = (block.transactions.len() as u64) > self.tx_count();
+                let pre_latest_finalised = prev_pre_latest && !new_pre_latest;
+
+                if identifier_changed || new_txs_arrived || pre_latest_finalised {
+                    self.block_identifier = Some(identifier);
+                    self.accumulated = Some(block);
+                    true
+                } else {
                     false
                 }
-            },
+            }
         }
     }
 }
@@ -211,11 +178,12 @@ pub async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
             };
         }
 
-        let req_round = state.round.unwrap_or(0);
-        let req_count = state.tx_count();
-
         let response = match sequencer
-            .preconfirmed_block(pre_confirmed_block_number.into(), req_round, req_count)
+            .preconfirmed_block(
+                pre_confirmed_block_number.into(),
+                state.block_identifier.clone(),
+                state.tx_count(),
+            )
             .await
         {
             Ok(r) => r,
@@ -310,6 +278,7 @@ mod tests {
         GasPrices,
         L1DataAvailabilityMode,
         PreConfirmedBlock,
+        PreConfirmedPollResponse,
         PreLatestBlock,
         Status,
     };
@@ -470,7 +439,6 @@ mod tests {
                 }),
                 None,
             ],
-            round: None,
         });
 
     /// Arbitrary timeout for receiving emits on the tokio channel. Otherwise
@@ -487,7 +455,12 @@ mod tests {
             .returning(|| Ok((PRE_LATEST_BLOCK.clone(), PENDING_UPDATE.clone())));
         sequencer
             .expect_preconfirmed_block()
-            .returning(move |_, _, _| Ok(PRE_CONFIRMED_BLOCK.clone()));
+            .returning(move |_, _, _| {
+                Ok(PreConfirmedPollResponse::Full {
+                    identifier: String::new(),
+                    block: PRE_CONFIRMED_BLOCK.clone(),
+                })
+            });
 
         let latest_hash = PRE_LATEST_BLOCK.parent_hash;
         let latest_block_number = BlockNumber::new_or_panic(1);
@@ -573,7 +546,10 @@ mod tests {
                     _ => b1_copy.clone(),
                 };
 
-                Ok(block)
+                Ok(PreConfirmedPollResponse::Full {
+                    identifier: String::new(),
+                    block,
+                })
             });
 
         let sequencer = Arc::new(sequencer);
@@ -723,7 +699,10 @@ mod tests {
                     }
                 };
 
-                Ok(block)
+                Ok(PreConfirmedPollResponse::Full {
+                    identifier: String::new(),
+                    block,
+                })
             });
 
         let latest_block_number = BlockNumber::new_or_panic(10);
@@ -811,7 +790,12 @@ mod tests {
         });
         sequencer
             .expect_preconfirmed_block()
-            .returning(move |_, _, _| Ok(PRE_CONFIRMED_BLOCK.clone()));
+            .returning(move |_, _, _| {
+                Ok(PreConfirmedPollResponse::Full {
+                    identifier: String::new(),
+                    block: PRE_CONFIRMED_BLOCK.clone(),
+                })
+            });
 
         let latest_block_number = BlockNumber::new_or_panic(10);
 

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -1,10 +1,146 @@
 use anyhow::Context;
-use pathfinder_common::{BlockHash, BlockNumber};
+use pathfinder_common::{BlockHash, BlockNumber, StarknetVersion};
 use starknet_gateway_client::GatewayApi;
+use starknet_gateway_types::reply::PreConfirmedBlock;
 use tokio::sync::watch;
 use tokio::time::Instant;
 
 use crate::state::sync::SyncEvent;
+
+/// Maximum gap, in blocks, between `current` and `latest` for pre-confirmed
+/// polling. Beyond this we skip as the node is still catching up.
+const IN_SYNC_THRESHOLD: u64 = 6;
+
+#[derive(Debug)]
+struct State {
+    /// Height we're currently polling.
+    block_number: BlockNumber,
+    /// `None` until we've seen a 0.14.3+ response for this height. Once
+    /// set, we track the round we're currently following and treat
+    /// any response with a higher round as a full reset.
+    round: Option<u64>,
+    /// Running merged view of the preconfirmed block at `block_number`.
+    /// `None` until we've received our first response for this height.
+    accumulated: Option<PreConfirmedBlock>,
+    /// Whether the pre-latest block was present at the last poll.
+    pre_latest_data_present: bool,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            block_number: BlockNumber::GENESIS,
+            round: None,
+            accumulated: None,
+            pre_latest_data_present: false,
+        }
+    }
+}
+
+impl State {
+    fn tx_count(&self) -> u64 {
+        self.accumulated
+            .as_ref()
+            .map(|b| b.transactions.len() as u64)
+            .unwrap_or(0)
+    }
+
+    /// Apply a fresh poll response, given the pre-latest presence
+    /// observed for this poll. Returns `true` if `accumulated` was
+    /// updated and the caller should emit the new view.
+    fn apply(&mut self, response: PreConfirmedBlock, new_pre_latest: bool) -> bool {
+        use std::cmp::Ordering;
+
+        let prev_pre_latest = self.pre_latest_data_present;
+        self.pre_latest_data_present = new_pre_latest;
+
+        // Starknet 0.14.3 introduced the incremental API: responses carry a
+        // `round` field and contain only the transactions added since the
+        // count we sent.
+        let is_delta_capable = response.starknet_version >= StarknetVersion::V_0_14_3;
+
+        if !is_delta_capable {
+            // Pre-0.14.3: response is always the full current view, but the
+            // gateway may re-serve the same view across polls. Suppress
+            // emissions that carry no new information.
+            let prev_tx_count = self.tx_count();
+            let new_tx_count = response.transactions.len() as u64;
+
+            let should_update = match new_tx_count.cmp(&prev_tx_count) {
+                Ordering::Greater => true,
+                Ordering::Less => false, // stale: same height, fewer txs
+                Ordering::Equal => prev_pre_latest && !new_pre_latest,
+            };
+
+            if should_update {
+                self.round = None;
+                self.accumulated = Some(response);
+            }
+            return should_update;
+        }
+
+        match (self.round, response.round) {
+            (_, None) => {
+                // Server claims ≥ 0.14.3 but omitted `round`. Treat as a
+                // malformed payload: full-replace, but don't advance our
+                // tracked round so we keep retrying without committing to
+                // a phantom round number.
+                tracing::warn!(
+                    "pre-confirmed response claims version {} but omits round; falling back to \
+                     full replace",
+                    response.starknet_version
+                );
+                self.round = None;
+                self.accumulated = Some(response);
+                true
+            }
+            (None, Some(r)) => {
+                // First 0.14.3 response for this height. Adopt verbatim.
+                self.round = Some(r);
+                self.accumulated = Some(response);
+                true
+            }
+            (Some(ours), Some(r)) => match r.cmp(&ours) {
+                Ordering::Greater => {
+                    // Round bumped: the sequencer abandoned the prior
+                    // proposal at this height, so any txs/header we'd
+                    // accumulated are no longer valid.
+                    self.round = Some(r);
+                    self.accumulated = Some(response);
+                    true
+                }
+                Ordering::Equal => {
+                    if response.transactions.is_empty() {
+                        false
+                    } else {
+                        // Delta at the same round — append.
+                        let acc = self
+                            .accumulated
+                            .as_mut()
+                            .expect("accumulated block present whenever round is Some");
+                        acc.transactions.extend(response.transactions);
+                        acc.transaction_receipts
+                            .extend(response.transaction_receipts);
+                        acc.transaction_state_diffs
+                            .extend(response.transaction_state_diffs);
+                        true
+                    }
+                }
+                Ordering::Less => {
+                    // Server is on an older round than we are; this should
+                    // never happen in normal operation. Hold our state
+                    // and wait for a fresh response.
+                    tracing::warn!(
+                        our_round = ours,
+                        server_round = r,
+                        "pre-confirmed response carries an older round than ours; ignoring"
+                    );
+                    false
+                }
+            },
+        }
+    }
+}
 
 /// Emits new pending data events while the current block is close to the latest
 /// block.
@@ -16,42 +152,6 @@ pub async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
     latest: watch::Receiver<(BlockNumber, BlockHash)>,
     current: watch::Receiver<(BlockNumber, BlockHash)>,
 ) {
-    const IN_SYNC_THRESHOLD: u64 = 6;
-
-    #[derive(Debug, Default)]
-    struct State {
-        block_number: BlockNumber,
-        tx_count: usize,
-        pre_latest_data_present: bool,
-    }
-
-    impl State {
-        /// Returns `true` if the state was updated, `false` otherwise.
-        fn update(&mut self, new_state: Self) -> bool {
-            use std::cmp::Ordering;
-
-            let should_update = match new_state.block_number.get().cmp(&self.block_number.get()) {
-                Ordering::Less => false,   // Stale pre-confirmed data (older block).
-                Ordering::Greater => true, // New pre-confirmed block.
-                Ordering::Equal => match new_state.tx_count.cmp(&self.tx_count) {
-                    Ordering::Less => false,   // Stale pre-confirmed data (fewer txs).
-                    Ordering::Greater => true, // New transactions available.
-                    Ordering::Equal => {
-                        // Check if pre-latest data got cleared (because it has been finalized),
-                        // which is a valid update if both block number and transaction count are
-                        // same.
-                        self.pre_latest_data_present && !new_state.pre_latest_data_present
-                    }
-                },
-            };
-
-            if should_update {
-                *self = new_state;
-            }
-            should_update
-        }
-    }
-
     let mut state = State::default();
 
     loop {
@@ -69,6 +169,9 @@ pub async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
             continue;
         }
 
+        // Fetch the pre-latest block.
+        // Its presence determines the pre-confirmed block number we poll below,
+        // and it is later forwarded downstream in the emitted event.
         let pre_latest_data = match fetch_pre_latest(&sequencer, latest_number, latest_hash).await {
             Ok(r) => r.map(Box::new),
             Err(e) => {
@@ -85,8 +188,34 @@ pub async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
         } else {
             latest_number + 1
         };
-        let pre_confirmed_block = match sequencer
-            .preconfirmed_block(pre_confirmed_block_number.into(), 0, 0)
+
+        // A transient gateway inconsistency (e.g. the pre-latest block briefly
+        // disappears) can cause this poll's pre-confirmed block number to drop
+        // below the height we're already tracking. Just skip the poll, the state
+        // we've accumulated for the higher height is still valid for later.
+        if pre_confirmed_block_number < state.block_number {
+            tracing::debug!(
+                pre_confirmed_block_number = %pre_confirmed_block_number,
+                current = %state.block_number,
+                "Pre-confirmed block number stepped backwards; skipping poll"
+            );
+            tokio::time::sleep_until(t_fetch + poll_interval).await;
+            continue;
+        }
+
+        // New height. Invalidate any state from prior height.
+        if pre_confirmed_block_number > state.block_number {
+            state = State {
+                block_number: pre_confirmed_block_number,
+                ..State::default()
+            };
+        }
+
+        let req_round = state.round.unwrap_or(0);
+        let req_count = state.tx_count();
+
+        let response = match sequencer
+            .preconfirmed_block(pre_confirmed_block_number.into(), req_round, req_count)
             .await
         {
             Ok(r) => r,
@@ -97,17 +226,16 @@ pub async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
             }
         };
 
-        let new_state = State {
-            block_number: pre_confirmed_block_number,
-            tx_count: pre_confirmed_block.transactions.len(),
-            pre_latest_data_present: pre_latest_data.is_some(),
-        };
-        if state.update(new_state) {
+        if state.apply(response, pre_latest_data.is_some()) {
+            let accumulated = state
+                .accumulated
+                .as_ref()
+                .expect("accumulated block present after a successful update");
             tracing::trace!("Emitting a pre-confirmed update");
             if let Err(e) = tx_event
                 .send(SyncEvent::PreConfirmed {
                     number: pre_confirmed_block_number,
-                    block: pre_confirmed_block.into(),
+                    block: accumulated.clone().into(),
                     pre_latest_data,
                 })
                 .await

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -86,7 +86,7 @@ pub async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
             latest_number + 1
         };
         let pre_confirmed_block = match sequencer
-            .preconfirmed_block(pre_confirmed_block_number.into())
+            .preconfirmed_block(pre_confirmed_block_number.into(), 0, 0)
             .await
         {
             Ok(r) => r,
@@ -359,7 +359,7 @@ mod tests {
             .returning(|| Ok((PRE_LATEST_BLOCK.clone(), PENDING_UPDATE.clone())));
         sequencer
             .expect_preconfirmed_block()
-            .returning(move |_| Ok(PRE_CONFIRMED_BLOCK.clone()));
+            .returning(move |_, _, _| Ok(PRE_CONFIRMED_BLOCK.clone()));
 
         let latest_hash = PRE_LATEST_BLOCK.parent_hash;
         let latest_block_number = BlockNumber::new_or_panic(1);
@@ -433,18 +433,20 @@ mod tests {
         sequencer
             .expect_pending_block()
             .returning(move || Ok((PRE_LATEST_BLOCK.clone(), PENDING_UPDATE.clone())));
-        sequencer.expect_preconfirmed_block().returning(move |_| {
-            let mut count = COUNT.lock().unwrap();
-            *count += 1;
+        sequencer
+            .expect_preconfirmed_block()
+            .returning(move |_, _, _| {
+                let mut count = COUNT.lock().unwrap();
+                *count += 1;
 
-            let block = match *count {
-                1 => b0_copy.clone(),
-                2 => PRE_CONFIRMED_BLOCK.clone(),
-                _ => b1_copy.clone(),
-            };
+                let block = match *count {
+                    1 => b0_copy.clone(),
+                    2 => PRE_CONFIRMED_BLOCK.clone(),
+                    _ => b1_copy.clone(),
+                };
 
-            Ok(block)
-        });
+                Ok(block)
+            });
 
         let sequencer = Arc::new(sequencer);
         let latest_hash = PRE_LATEST_BLOCK.parent_hash;
@@ -571,28 +573,30 @@ mod tests {
         sequencer
             .expect_pending_block()
             .returning(move || Ok((PRE_LATEST_BLOCK.clone(), PENDING_UPDATE.clone())));
-        sequencer.expect_preconfirmed_block().returning(move |_| {
-            let mut count = COUNT.lock().unwrap();
-            let block = match *count {
-                0 => {
-                    *count += 1;
-                    // Polling task has default state at the start, so this should produce an
-                    // event.
-                    PRE_CONFIRMED_BLOCK.clone()
-                }
-                1 => {
-                    *count += 1;
-                    // Same transaction count as before, should be ignored.
-                    PRE_CONFIRMED_BLOCK.clone()
-                }
-                _ => {
-                    // Lower transaction count than before, should be ignored.
-                    stale_pre_confirmed.clone()
-                }
-            };
+        sequencer
+            .expect_preconfirmed_block()
+            .returning(move |_, _, _| {
+                let mut count = COUNT.lock().unwrap();
+                let block = match *count {
+                    0 => {
+                        *count += 1;
+                        // Polling task has default state at the start, so this should produce an
+                        // event.
+                        PRE_CONFIRMED_BLOCK.clone()
+                    }
+                    1 => {
+                        *count += 1;
+                        // Same transaction count as before, should be ignored.
+                        PRE_CONFIRMED_BLOCK.clone()
+                    }
+                    _ => {
+                        // Lower transaction count than before, should be ignored.
+                        stale_pre_confirmed.clone()
+                    }
+                };
 
-            Ok(block)
-        });
+                Ok(block)
+            });
 
         let latest_block_number = BlockNumber::new_or_panic(10);
 
@@ -679,7 +683,7 @@ mod tests {
         });
         sequencer
             .expect_preconfirmed_block()
-            .returning(move |_| Ok(PRE_CONFIRMED_BLOCK.clone()));
+            .returning(move |_, _, _| Ok(PRE_CONFIRMED_BLOCK.clone()));
 
         let latest_block_number = BlockNumber::new_or_panic(10);
 

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -1278,6 +1278,7 @@ pub(crate) mod tests {
                 starknet_version: last_block_header.starknet_version,
                 l1_da_mode: L1DataAvailabilityMode::Blob,
                 transaction_state_diffs: vec![],
+                ..Default::default()
             };
 
             tx.commit()?;
@@ -1408,6 +1409,7 @@ pub(crate) mod tests {
                 starknet_version: last_block_header.starknet_version,
                 l1_da_mode: L1DataAvailabilityMode::Blob,
                 transaction_state_diffs: vec![],
+                ..Default::default()
             };
 
             tx.commit()?;

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -1278,7 +1278,6 @@ pub(crate) mod tests {
                 starknet_version: last_block_header.starknet_version,
                 l1_da_mode: L1DataAvailabilityMode::Blob,
                 transaction_state_diffs: vec![],
-                ..Default::default()
             };
 
             tx.commit()?;
@@ -1409,7 +1408,6 @@ pub(crate) mod tests {
                 starknet_version: last_block_header.starknet_version,
                 l1_da_mode: L1DataAvailabilityMode::Blob,
                 transaction_state_diffs: vec![],
-                ..Default::default()
             };
 
             tx.commit()?;


### PR DESCRIPTION
Implements the new pre-confirmed block cumulative polling logic as per their provided spec document.

**Note:** I spent a lot of time tidying up the `pending.rs` file. The diff might be a mess. I encourage any reviewer to read the file itself instead. The code should now be clean and easy to follow.

Closes #3352