### PR TITLE
feat(p2p): preconfirmed p2p network scaffolding - part 1

### DIFF
--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -10,6 +10,9 @@ pub mod consensus;
 /// Core p2p network behaviour. This is the foundation for all the other
 /// application-specific behaviours.
 pub mod core;
+/// Application-specific p2p network behaviour. This one handles preconfirmed
+/// transactions.
+pub mod preconfirmed;
 /// Application-specific p2p network behaviour. This one handles sync.
 pub mod sync;
 
@@ -58,6 +61,21 @@ pub fn new_consensus(
 ) {
     Builder::new(keypair.clone(), core_config, chain_id)
         .app_behaviour(consensus::Behaviour::new(keypair))
+        .build()
+}
+
+/// Creates a new preconfirmed P2P network.
+pub fn new_preconfirmed(
+    keypair: Keypair,
+    core_config: core::Config,
+    chain_id: ChainId,
+) -> (
+    core::Client<preconfirmed::Command>,
+    mpsc::UnboundedReceiver<preconfirmed::Event>,
+    main_loop::MainLoop<preconfirmed::Behaviour>,
+) {
+    Builder::new(keypair.clone(), core_config, chain_id)
+        .app_behaviour(preconfirmed::Behaviour::new(keypair))
         .build()
 }
 

--- a/crates/p2p/src/preconfirmed.rs
+++ b/crates/p2p/src/preconfirmed.rs
@@ -1,0 +1,109 @@
+//! Preconfirmed behaviour and other related utilities for the preconfirmed p2p
+//! network.
+use libp2p::PeerId;
+#[cfg(test)]
+use tokio::sync::mpsc::Sender;
+
+mod behaviour;
+mod client;
+
+pub use behaviour::Behaviour;
+pub use client::Client;
+#[cfg(test)]
+use libp2p::gossipsub::PublishError;
+
+/// The topic for preconfirmed transactions in the network.
+pub const TOPIC_PRECONFIRMED_TRANSACTIONS: &str = "preconfirmed_transactions";
+
+/// Commands for the preconfirmed behaviour.
+#[derive(Debug, Clone)]
+pub enum Command {
+    /// Test command to gossip some dummy preconfirmed transactions. This is
+    /// necessary because by default Pathfinder is only supposed to be the
+    /// recipient of gossiped preconfirmed transactions, and thus doesn't
+    /// have a command in prod code to send them.
+    #[cfg(test)]
+    TestGossipPreconfirmedTransactions {
+        done_tx: Sender<Result<(), PublishError>>,
+    },
+}
+
+/// Events emitted by the preconfirmed behaviour.
+#[derive(Debug, Clone)]
+pub struct Event {
+    pub source: PeerId,
+    pub kind: EventKind,
+}
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone, PartialEq)]
+pub enum EventKind {
+    // TODO this is a placeholder
+    /// A batch of preconfirmed transactions.
+    PreconfirmedTransactionsPlaceholder,
+    Subscribed,
+}
+
+// TODO this is a placeholder
+/// The state of the preconfirmed P2P network.
+#[derive(Default, Debug)]
+pub struct State;
+
+impl State {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use libp2p::identity;
+
+    use super::*;
+    use crate::test_utils::peer::{create_and_connect_pair, TestPeer, TestPeerBuilder};
+
+    type PcTestPeer = TestPeer<Behaviour>;
+
+    fn create_peer() -> PcTestPeer {
+        TestPeerBuilder::new()
+            .app_behaviour(Behaviour::new(identity::Keypair::generate_ed25519()))
+            .build(crate::core::Config::for_test())
+    }
+
+    async fn create_peers() -> (PcTestPeer, PcTestPeer) {
+        create_and_connect_pair(create_peer).await
+    }
+
+    async fn wait_for_subscribed(peer: &mut PcTestPeer, expected_peer_id: PeerId) {
+        peer.wait_for_event(|e| {
+            (matches!(e.kind, EventKind::Subscribed) && expected_peer_id == e.source).then_some(())
+        })
+        .await
+        .unwrap();
+    }
+
+    /// A simple sanity test to check gossiping between two nodes.
+    #[tokio::test]
+    async fn sanity() {
+        let (mut server, mut client) = create_peers().await;
+        wait_for_subscribed(&mut client, server.peer_id).await;
+        wait_for_subscribed(&mut server, client.peer_id).await;
+
+        let (done_tx, mut done_rx) = tokio::sync::mpsc::channel(1);
+
+        client
+            .client
+            .send(Command::TestGossipPreconfirmedTransactions { done_tx })
+            .await
+            .unwrap();
+        // Wait for the gossip to complete
+        done_rx.recv().await.unwrap().unwrap();
+
+        server
+            .wait_for_event(|e| {
+                matches!(e.kind, EventKind::PreconfirmedTransactionsPlaceholder).then_some(())
+            })
+            .await
+            .unwrap();
+    }
+}

--- a/crates/p2p/src/preconfirmed/behaviour.rs
+++ b/crates/p2p/src/preconfirmed/behaviour.rs
@@ -1,0 +1,123 @@
+use libp2p::gossipsub::{self, Sha256Topic};
+use libp2p::swarm::NetworkBehaviour;
+use libp2p::{identity, PeerId};
+use tokio::sync::mpsc;
+use tracing::error;
+
+use crate::preconfirmed::{EventKind, TOPIC_PRECONFIRMED_TRANSACTIONS};
+use crate::{preconfirmed, ApplicationBehaviour};
+
+/// The preconfirmed P2P network behaviour.
+#[derive(NetworkBehaviour)]
+pub struct Behaviour {
+    gossipsub: gossipsub::Behaviour,
+}
+
+impl ApplicationBehaviour for Behaviour {
+    type Command = preconfirmed::Command;
+    type Event = preconfirmed::Event;
+    type State = preconfirmed::State;
+
+    #[tracing::instrument(skip(self, _state))]
+    async fn handle_command(&mut self, command: Self::Command, _state: &mut Self::State) {
+        match command {
+            #[cfg(test)]
+            Self::Command::TestGossipPreconfirmedTransactions { done_tx } => {
+                let topic = Sha256Topic::new(TOPIC_PRECONFIRMED_TRANSACTIONS);
+
+                let tx_result = self
+                    .gossipsub
+                    // Note: we don't know the message structure yet, so we just send a single null
+                    // byte
+                    .publish(topic, vec![0])
+                    .inspect_err(|e| {
+                        error!("Failed to publish preconfirmed transaction message, error {e:?}");
+                    })
+                    .map(|_| ());
+
+                done_tx
+                    .send(tx_result)
+                    .await
+                    .expect("Receiver not to be dropped");
+            }
+        }
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn handle_event(
+        &mut self,
+        event: BehaviourEvent,
+        state: &mut Self::State,
+        event_sender: mpsc::UnboundedSender<Self::Event>,
+    ) {
+        use gossipsub::Event::*;
+        let BehaviourEvent::Gossipsub(e) = event;
+
+        tracing::trace!(event=?e, "Gossipsub event received");
+
+        let topic_hash = Sha256Topic::new(TOPIC_PRECONFIRMED_TRANSACTIONS).hash();
+
+        match e {
+            Message {
+                propagation_source,
+                message_id,
+                message,
+            } => match message.topic {
+                hash if hash == topic_hash => {
+                    // Note: we don't know the message structure yet, so we just send a single null
+                    // byte
+                    if message.data == vec![0] {
+                        let _ = event_sender.send(Self::Event {
+                            source: propagation_source,
+                            kind: EventKind::PreconfirmedTransactionsPlaceholder,
+                        });
+                    } else {
+                        error!("Failed to parse message with id: {}", message_id);
+                    }
+                }
+                _ => {}
+            },
+            Subscribed { peer_id, topic } if topic == topic_hash => {
+                let _ = event_sender.send(Self::Event {
+                    source: peer_id,
+                    kind: EventKind::Subscribed,
+                });
+            }
+            _ => {
+                // TODO: Do we care about any other Gossipsub events?
+            }
+        }
+    }
+
+    fn domain() -> &'static str {
+        "p2p_preconfirmed"
+    }
+}
+
+impl Behaviour {
+    /// Create a new preconfirmed behaviour.
+    pub fn new(keypair: identity::Keypair) -> Self {
+        let peer_id = PeerId::from(keypair.public());
+
+        let gossipsub_config = gossipsub::Config::default();
+        let mut gossipsub = gossipsub::Behaviour::new(
+            gossipsub::MessageAuthenticity::Signed(keypair),
+            gossipsub_config,
+        )
+        .expect("Failed to create gossipsub behaviour");
+
+        let topic = Sha256Topic::new(TOPIC_PRECONFIRMED_TRANSACTIONS);
+
+        gossipsub
+            .subscribe(&topic)
+            .expect("Failed to subscribe to preconfirmed transactions topic");
+
+        tracing::info!(
+            "Preconfirmed network node started with peer ID: {}",
+            peer_id
+        );
+        tracing::info!("Subscribed to topic: {}", topic);
+
+        Behaviour { gossipsub }
+    }
+}

--- a/crates/p2p/src/preconfirmed/client.rs
+++ b/crates/p2p/src/preconfirmed/client.rs
@@ -1,0 +1,40 @@
+#[cfg(test)]
+use libp2p::gossipsub::PublishError;
+use libp2p::PeerId;
+use tokio::sync::mpsc;
+
+use crate::core;
+use crate::preconfirmed::Command;
+
+#[derive(Clone, Debug)]
+pub struct Client {
+    _sender: mpsc::UnboundedSender<core::Command<Command>>,
+    local_peer_id: PeerId,
+}
+
+impl From<(PeerId, mpsc::UnboundedSender<core::Command<Command>>)> for Client {
+    fn from((peer_id, sender): (PeerId, mpsc::UnboundedSender<core::Command<Command>>)) -> Self {
+        Self {
+            _sender: sender,
+            local_peer_id: peer_id,
+        }
+    }
+}
+
+impl Client {
+    pub fn local_peer_id(&self) -> &PeerId {
+        &self.local_peer_id
+    }
+
+    #[cfg(test)]
+    pub async fn gossip_preconfirmed_transactions(&self) -> Result<(), PublishError> {
+        let (done_tx, mut rx) = mpsc::channel(1);
+        self._sender
+            .send(core::Command::Application(
+                Command::TestGossipPreconfirmedTransactions { done_tx },
+            ))
+            .expect("Command receiver not to be dropped");
+
+        rx.recv().await.expect("Sender not to be dropped")
+    }
+}

--- a/crates/p2p/src/sync/tests.rs
+++ b/crates/p2p/src/sync/tests.rs
@@ -11,7 +11,7 @@ use crate::sync::behaviour::Behaviour;
 use crate::sync::client::Client;
 use crate::sync::protocol::codec;
 use crate::sync::{Config, Event};
-use crate::test_utils::peer::{TestPeer, TestPeerBuilder};
+use crate::test_utils::peer::{create_and_connect_pair, TestPeer, TestPeerBuilder};
 
 type SyncTestPeer = TestPeer<Behaviour>;
 
@@ -22,21 +22,7 @@ fn create_peer() -> SyncTestPeer {
 }
 
 async fn create_peers() -> (SyncTestPeer, SyncTestPeer) {
-    let mut server = create_peer();
-    let client = create_peer();
-
-    let server_addr = server.start_listening().await.unwrap();
-
-    tracing::info!(%server.peer_id, %server_addr, "Server");
-    tracing::info!(%client.peer_id, "Client");
-
-    client
-        .client
-        .dial(server.peer_id, server_addr)
-        .await
-        .unwrap();
-
-    (server, client)
+    create_and_connect_pair(create_peer).await
 }
 
 async fn server_to_client() -> (SyncTestPeer, SyncTestPeer) {

--- a/crates/p2p/src/test_utils/peer.rs
+++ b/crates/p2p/src/test_utils/peer.rs
@@ -17,6 +17,36 @@ use crate::core::{Client, Config, TestEvent};
 use crate::peers::Peer;
 use crate::ApplicationBehaviour;
 
+/// Create a pair of connected peers. The first peer is the server that listens
+/// for incoming connections, and the second peer is the client that dials the
+/// server. `create_peer_fn` is a function that creates a new peer with the
+/// desired applicationbehaviour.
+pub async fn create_and_connect_pair<F, B>(create_peer_fn: F) -> (TestPeer<B>, TestPeer<B>)
+where
+    F: Fn() -> TestPeer<B>,
+    B: ApplicationBehaviour + Send,
+    <B as NetworkBehaviour>::ToSwarm: Debug,
+    <B as ApplicationBehaviour>::Command: Debug + Send,
+    <B as ApplicationBehaviour>::Event: Send,
+    <B as ApplicationBehaviour>::State: Default + Send,
+{
+    let mut server = create_peer_fn();
+    let client = create_peer_fn();
+
+    let server_addr = server.start_listening().await.unwrap();
+
+    tracing::info!(%server.peer_id, %server_addr, "Server");
+    tracing::info!(%client.peer_id, "Client");
+
+    client
+        .client
+        .dial(server.peer_id, server_addr)
+        .await
+        .unwrap();
+
+    (server, client)
+}
+
 #[allow(dead_code)]
 #[derive(Debug)]
 pub struct TestPeer<B>
@@ -147,7 +177,7 @@ where
     }
 
     /// Start listening on a specified address
-    pub async fn start_listening_on(&mut self, addr: Multiaddr) -> Result<Multiaddr> {
+    async fn start_listening_on(&mut self, addr: Multiaddr) -> Result<Multiaddr> {
         self.client
             .start_listening(addr)
             .await


### PR DESCRIPTION
Preconfirmed P2P network tracking issue: https://github.com/equilibriumco/pathfinder/issues/3349

Fixes: https://github.com/equilibriumco/pathfinder/issues/3376

This PR adds a submodule to the `p2p` crate. The network behavior contrains plain gossipsub and no message encoding scheme is used. Just a null byte is sent for sanity testing.

---------------------

I'd like to add 2 more follow up PRs (so far):
- part 2, extend cli with the new network config
- part 3, wire up the network creation code in main