### PR TITLE
chore(ci): dispatch pathfinder-infra version bump on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -90,3 +90,18 @@ jobs:
       - name: Tag image with 'latest'
         if: ${{ !github.event.release.prerelease }}
         run: docker buildx imagetools create -t eqlabs/pathfinder:latest eqlabs/pathfinder:snapshot-${{ github.sha }}
+
+  # Dispatch the version bump workflow on pathfinder-infra
+  update-infra:
+    if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
+    needs: tag-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch pathfinder-infra version bump
+        env:
+          GH_TOKEN: ${{ secrets.PATHFINDER_INFRA_DISPATCH_TOKEN }}
+        run: |
+          gh workflow run update-pathfinder-version.yml \
+            --repo equilibriumco/pathfinder-infra \
+            --ref main \
+            --field version=${{ github.event.release.tag_name }}


### PR DESCRIPTION
Automatically dispatch the version bump of pathfinder in pathfinder-infra. This will create a PR in the infra repo with new version, that still needs to be merged to take an effect.

This will require setting up a fine-grained personal access token with permissions on `pathfinder-infra`: `actions: read + write`. I think @CHr15F0x should be the owner :thinking:

No good way to test it, I think we should just remember to check if it worked during the next release :see_no_evil: 

