### PR TITLE
feat(p2p): preconfirmed p2p network scaffolding - part 2 - core p2p CLI options

### DIFF
--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -22,8 +22,8 @@ pub mod integration_testing;
 pub mod p2p;
 
 #[cfg(feature = "p2p")]
-use p2p::cli::{P2PConsensusCli, P2PSyncCli};
-use p2p::{P2PConsensusConfig, P2PSyncConfig};
+use p2p::cli::{P2PConsensusCli, P2PPreconfirmedCli, P2PSyncCli};
+use p2p::{P2PConsensusConfig, P2PPreconfirmedConfig, P2PSyncConfig};
 
 const COMPILER_MEMORY_USAGE_ALLOWED_RANGE: std::ops::RangeInclusive<u64> =
     (pathfinder_compiler::ResourceLimits::RECOMMENDED_MEMORY_USAGE_LIMIT_MIB / 2)
@@ -278,6 +278,14 @@ Examples:
     #[cfg(feature = "p2p")]
     #[clap(flatten)]
     consensus: ConsensusCli,
+
+    #[cfg(feature = "p2p")]
+    #[clap(flatten)]
+    p2p_preconfirmed: P2PPreconfirmedCli,
+
+    #[cfg(not(feature = "p2p"))]
+    #[clap(skip)]
+    p2p_preconfirmed: (),
 
     #[cfg(not(feature = "p2p"))]
     #[clap(skip)]
@@ -1078,6 +1086,7 @@ pub struct Config {
     pub disable_version_update_check: bool,
     pub sync_p2p: P2PSyncConfig,
     pub consensus_p2p: P2PConsensusConfig,
+    pub preconfirmed_p2p: P2PPreconfirmedConfig,
     pub debug: DebugConfig,
     pub verify_tree_hashes: bool,
     pub rpc_batch_concurrency_limit: NonZeroUsize,
@@ -1373,6 +1382,7 @@ impl Config {
             disable_version_update_check: args.disable_version_update_check,
             sync_p2p: P2PSyncConfig::parse_or_exit(args.p2p_sync),
             consensus_p2p: P2PConsensusConfig::parse_or_exit(args.p2p_consensus),
+            preconfirmed_p2p: P2PPreconfirmedConfig::parse_or_exit(args.p2p_preconfirmed),
             debug: DebugConfig::parse(args.debug),
             verify_tree_hashes: args.verify_tree_node_data,
             rpc_batch_concurrency_limit: args.rpc_batch_concurrency_limit,

--- a/crates/pathfinder/src/config/p2p.rs
+++ b/crates/pathfinder/src/config/p2p.rs
@@ -6,7 +6,7 @@ mod config;
 #[cfg(feature = "p2p")]
 pub use cli::P2PConsensusCli;
 #[cfg(feature = "p2p")]
-pub use config::{P2PConsensusConfig, P2PSyncConfig};
+pub use config::{P2PConsensusConfig, P2PPreconfirmedConfig, P2PSyncConfig};
 
 #[cfg(not(feature = "p2p"))]
 #[derive(Clone)]
@@ -17,6 +17,10 @@ pub struct P2PSyncConfig;
 pub struct P2PConsensusConfig;
 
 #[cfg(not(feature = "p2p"))]
+#[derive(Clone)]
+pub struct P2PPreconfirmedConfig;
+
+#[cfg(not(feature = "p2p"))]
 impl P2PSyncConfig {
     pub(super) fn parse_or_exit(_: ()) -> Self {
         Self
@@ -25,6 +29,13 @@ impl P2PSyncConfig {
 
 #[cfg(not(feature = "p2p"))]
 impl P2PConsensusConfig {
+    pub(super) fn parse_or_exit(_: ()) -> Self {
+        Self
+    }
+}
+
+#[cfg(not(feature = "p2p"))]
+impl P2PPreconfirmedConfig {
     pub(super) fn parse_or_exit(_: ()) -> Self {
         Self
     }

--- a/crates/pathfinder/src/config/p2p/cli.rs
+++ b/crates/pathfinder/src/config/p2p/cli.rs
@@ -147,6 +147,7 @@ Example:
 
 define_p2p_core_cli! {"sync"}
 define_p2p_core_cli! {"consensus"}
+define_p2p_core_cli! {"preconfirmed"}
 
 #[derive(clap::Args)]
 pub(crate) struct P2PSyncCli {
@@ -207,4 +208,10 @@ pub(crate) struct P2PSyncCli {
 pub struct P2PConsensusCli {
     #[clap(flatten)]
     pub(super) core: P2PConsensusCoreCli,
+}
+
+#[derive(clap::Args)]
+pub struct P2PPreconfirmedCli {
+    #[clap(flatten)]
+    pub(super) core: P2PPreconfirmedCoreCli,
 }

--- a/crates/pathfinder/src/config/p2p/config.rs
+++ b/crates/pathfinder/src/config/p2p/config.rs
@@ -5,7 +5,14 @@ use clap::CommandFactory;
 use ipnet::IpNet;
 use p2p::libp2p::Multiaddr;
 
-use super::cli::{P2PConsensusCli, P2PConsensusCoreCli, P2PSyncCli, P2PSyncCoreCli};
+use super::cli::{
+    P2PConsensusCli,
+    P2PConsensusCoreCli,
+    P2PPreconfirmedCli,
+    P2PPreconfirmedCoreCli,
+    P2PSyncCli,
+    P2PSyncCoreCli,
+};
 use crate::config::Cli;
 
 #[derive(Clone)]
@@ -37,6 +44,11 @@ pub struct P2PSyncConfig {
 
 #[derive(Clone)]
 pub struct P2PConsensusConfig {
+    pub core: P2PCoreConfig,
+}
+
+#[derive(Clone)]
+pub struct P2PPreconfirmedConfig {
     pub core: P2PCoreConfig,
 }
 
@@ -143,8 +155,9 @@ Note: this is the minimum value that should provide normal P2P behaviour and avo
     };
 }
 
-impl_from_p2p_cli! {"sync"}
+impl_from_p2p_cli!("sync");
 impl_from_p2p_cli!("consensus");
+impl_from_p2p_cli!("preconfirmed");
 
 impl P2PSyncConfig {
     pub(crate) fn parse_or_exit(args: P2PSyncCli) -> Self {
@@ -196,6 +209,15 @@ fn parse_l1_checkpoint_or_exit(
 
 impl P2PConsensusConfig {
     pub fn parse_or_exit(args: P2PConsensusCli) -> Self {
+        Self {
+            // SAFETY: core conversion is safe because we exit the process on error
+            core: args.core.into(),
+        }
+    }
+}
+
+impl P2PPreconfirmedConfig {
+    pub fn parse_or_exit(args: P2PPreconfirmedCli) -> Self {
         Self {
             // SAFETY: core conversion is safe because we exit the process on error
             core: args.core.into(),


### PR DESCRIPTION
Preconfirmed p2p tracking issue: https://github.com/equilibriumco/pathfinder/issues/3349

Fixes: https://github.com/equilibriumco/pathfinder/issues/3377

Each p2p network that Pathfinder participates in has CLI options that share a common _core_ set of settings. This PR adds this set of CLI options in the `p2p.preconfirmed.*` namespace, as opposed to the already existing `p2p.sync.*` and `p2p.consensus.*` ones.

No _preconfirmed-p2p-network-specific_ options are added yet, because there is no spec yet.

Interestingly the consensus p2p network doesn't have its own specific [cli options either](https://github.com/equilibriumco/pathfinder/blob/dcd00a33bcbc24c862776fee6a782f58bc8b7665/crates/pathfinder/src/config/p2p/cli.rs#L208), as opposed to the [sync p2p network](https://github.com/equilibriumco/pathfinder/blob/dcd00a33bcbc24c862776fee6a782f58bc8b7665/crates/pathfinder/src/config/p2p/cli.rs#L156).

