### PR TITLE
feat(consensus): validate starknet version

### DIFF
--- a/crates/p2p/src/consensus.rs
+++ b/crates/p2p/src/consensus.rs
@@ -253,6 +253,7 @@ mod tests {
         VoteType,
     };
     use p2p_proto::transaction::L1HandlerV0;
+    use pathfinder_common::StarknetVersion;
     use pathfinder_crypto::Felt;
 
     use super::*;
@@ -308,7 +309,7 @@ mod tests {
             l1_data_gas_price_fri: 3000,
             l1_gas_price_wei: 4000,
             l1_data_gas_price_wei: 5000,
-            starknet_version: "".to_string(),
+            starknet_version: StarknetVersion::V_0_14_0.to_string(),
             version_constant_commitment: Default::default(),
         };
         let proposal = ProposalPart::Init(proposal_init);
@@ -354,7 +355,7 @@ mod tests {
             l1_data_gas_price_fri: 3000,
             l1_gas_price_wei: 4000,
             l1_data_gas_price_wei: 5000,
-            starknet_version: "".to_string(),
+            starknet_version: StarknetVersion::V_0_14_0.to_string(),
             version_constant_commitment: Default::default(),
         };
         let proposal = ProposalPart::Init(proposal_init);
@@ -590,7 +591,7 @@ mod tests {
             l1_data_gas_price_fri: 3000 + base as u128,
             l1_gas_price_wei: 4000 + base as u128,
             l1_data_gas_price_wei: 5000 + base as u128,
-            starknet_version: "".to_string(),
+            starknet_version: StarknetVersion::V_0_14_0.to_string(),
             version_constant_commitment: Default::default(),
         }));
 

--- a/crates/p2p/src/consensus/stream.rs
+++ b/crates/p2p/src/consensus/stream.rs
@@ -133,6 +133,7 @@ impl<T> OutgoingStreamState<T> {
 #[cfg(test)]
 mod tests {
     use p2p_proto::common::{Address, L1DataAvailabilityMode};
+    use pathfinder_common::StarknetVersion;
     use pathfinder_crypto::Felt;
 
     use super::*;
@@ -153,7 +154,7 @@ mod tests {
             l1_data_gas_price_fri: 3000,
             l1_gas_price_wei: 4000,
             l1_data_gas_price_wei: 5000,
-            starknet_version: "".to_string(),
+            starknet_version: StarknetVersion::V_0_14_0.to_string(),
             version_constant_commitment: Default::default(),
         };
         let proposal = p2p_proto::consensus::ProposalPart::Init(proposal_init);

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -1156,6 +1156,7 @@ pub struct NativeExecutionConfig;
 #[cfg(feature = "p2p")]
 #[derive(Clone)]
 pub struct ConsensusConfig {
+    pub my_starknet_version: StarknetVersion,
     /// The validator address of the current node.
     pub my_validator_address: ContractAddress,
     /// The validator addresses of all validators in the validator set.
@@ -1329,6 +1330,9 @@ impl ConsensusConfig {
             }
 
             Self {
+                // TODO: This is the only supported starknet version for consensus at the moment.
+                // TBD how a node's starknet version should be configured.
+                my_starknet_version: StarknetVersion::V_0_14_0,
                 my_validator_address: ContractAddress(
                     consensus_cli
                         .my_validator_address

--- a/crates/pathfinder/src/consensus/inner.rs
+++ b/crates/pathfinder/src/consensus/inner.rs
@@ -171,10 +171,6 @@ impl std::fmt::Display for ConsensusValue {
 /// the validator logic and storage usage patterns currently require a finalized
 /// block to be created even for empty proposals. For now, we create a (mostly)
 /// default block header with the necessary fields filled in.
-///
-/// NOTE: Until timestamps become part of an empty proposal, disseminating an
-/// empty proposal will cause timestamp discrepancies between nodes and
-/// validation errors.
 pub(crate) fn create_empty_block(
     height: u64,
     starknet_version: StarknetVersion,

--- a/crates/pathfinder/src/consensus/inner.rs
+++ b/crates/pathfinder/src/consensus/inner.rs
@@ -141,6 +141,7 @@ enum P2PTaskEvent {
 
 #[derive(Copy, Clone, Debug)]
 struct P2PTaskConfig {
+    my_starknet_version: StarknetVersion,
     my_validator_address: ContractAddress,
     history_depth: u64,
 }
@@ -148,6 +149,7 @@ struct P2PTaskConfig {
 impl From<&ConsensusConfig> for P2PTaskConfig {
     fn from(config: &ConsensusConfig) -> Self {
         Self {
+            my_starknet_version: config.my_starknet_version,
             my_validator_address: config.my_validator_address,
             history_depth: config.history_depth,
         }
@@ -173,14 +175,14 @@ impl std::fmt::Display for ConsensusValue {
 /// NOTE: Until timestamps become part of an empty proposal, disseminating an
 /// empty proposal will cause timestamp discrepancies between nodes and
 /// validation errors.
-pub(crate) fn create_empty_block(height: u64) -> ConsensusFinalizedL2Block {
+pub(crate) fn create_empty_block(
+    height: u64,
+    starknet_version: StarknetVersion,
+) -> ConsensusFinalizedL2Block {
     let timestamp = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-
-    // The only version handled by consensus, so far
-    let starknet_version = StarknetVersion::new(0, 14, 0, 0);
 
     ConsensusFinalizedL2Block {
         header: ConsensusFinalizedBlockHeader {

--- a/crates/pathfinder/src/consensus/inner/batch_execution.rs
+++ b/crates/pathfinder/src/consensus/inner/batch_execution.rs
@@ -10,7 +10,7 @@ use std::collections::{HashMap, HashSet};
 use anyhow::Context;
 use p2p::consensus::HeightAndRound;
 use p2p_proto::consensus as proto_consensus;
-use pathfinder_common::DecidedBlocks;
+use pathfinder_common::{DecidedBlocks, StarknetVersion};
 use pathfinder_gas_price::{L1GasPriceProvider, L2GasPriceProvider};
 use pathfinder_storage::Storage;
 use pathfinder_validator::error::ProposalHandlingError;
@@ -36,6 +36,7 @@ pub struct BatchExecutionManager {
     worker_pool: ValidatorWorkerPool,
     compiler_resource_limits: pathfinder_compiler::ResourceLimits,
     blockifier_libfuncs: pathfinder_compiler::BlockifierLibfuncs,
+    my_starknet_version: StarknetVersion,
 }
 
 impl BatchExecutionManager {
@@ -46,6 +47,7 @@ impl BatchExecutionManager {
         worker_pool: ValidatorWorkerPool,
         compiler_resource_limits: pathfinder_compiler::ResourceLimits,
         blockifier_libfuncs: pathfinder_compiler::BlockifierLibfuncs,
+        my_starknet_version: StarknetVersion,
     ) -> Self {
         Self {
             executing: HashSet::new(),
@@ -54,6 +56,7 @@ impl BatchExecutionManager {
             worker_pool,
             compiler_resource_limits,
             blockifier_libfuncs,
+            my_starknet_version,
         }
     }
 
@@ -132,6 +135,7 @@ impl BatchExecutionManager {
                         None, // TODO: Add L1ToFriValidator when oracle is available
                         self.l2_gas_price_provider.as_ref(),
                         self.worker_pool.clone(),
+                        self.my_starknet_version,
                     )?
                 }
                 ValidatorStage::TransactionBatch(stage) => stage,
@@ -382,7 +386,7 @@ mod tests {
             l1_data_gas_price_wei: 0,
             l1_gas_price_fri: 0,
             l1_data_gas_price_fri: 0,
-            starknet_version: "".to_string(),
+            starknet_version: StarknetVersion::V_0_14_0.to_string(),
             version_constant_commitment: Default::default(),
         }
     }
@@ -407,6 +411,7 @@ mod tests {
             worker_pool,
             pathfinder_compiler::ResourceLimits::for_test(),
             pathfinder_compiler::BlockifierLibfuncs::default(),
+            StarknetVersion::V_0_14_0,
         );
         let height_and_round = HeightAndRound::new(2, 1);
 
@@ -480,7 +485,7 @@ mod tests {
             l1_data_gas_price_fri: 0,
             l1_gas_price_wei: 0,
             l1_data_gas_price_wei: 0,
-            starknet_version: "".to_string(),
+            starknet_version: StarknetVersion::V_0_14_0.to_string(),
             version_constant_commitment: Default::default(),
         };
 
@@ -491,6 +496,7 @@ mod tests {
             worker_pool,
             pathfinder_compiler::ResourceLimits::for_test(),
             pathfinder_compiler::BlockifierLibfuncs::default(),
+            StarknetVersion::V_0_14_0,
         );
 
         let mut deferred_executions: std::collections::HashMap<HeightAndRound, DeferredExecution> =
@@ -589,6 +595,7 @@ mod tests {
             worker_pool.clone(),
             pathfinder_compiler::ResourceLimits::for_test(),
             pathfinder_compiler::BlockifierLibfuncs::default(),
+            StarknetVersion::V_0_14_0,
         );
 
         let mut deferred_executions: std::collections::HashMap<HeightAndRound, DeferredExecution> =
@@ -735,6 +742,7 @@ mod tests {
             worker_pool,
             pathfinder_compiler::ResourceLimits::for_test(),
             pathfinder_compiler::BlockifierLibfuncs::default(),
+            StarknetVersion::V_0_14_0,
         );
         let height_and_round = HeightAndRound::new(2, 1);
 
@@ -858,6 +866,7 @@ mod tests {
             worker_pool,
             pathfinder_compiler::ResourceLimits::for_test(),
             pathfinder_compiler::BlockifierLibfuncs::default(),
+            StarknetVersion::V_0_14_0,
         );
         let height_and_round = HeightAndRound::new(2, 1);
 
@@ -911,6 +920,7 @@ mod tests {
             worker_pool,
             pathfinder_compiler::ResourceLimits::for_test(),
             pathfinder_compiler::BlockifierLibfuncs::default(),
+            StarknetVersion::V_0_14_0,
         );
         let height_and_round = HeightAndRound::new(2, 1);
 
@@ -968,6 +978,7 @@ mod tests {
             worker_pool,
             pathfinder_compiler::ResourceLimits::for_test(),
             pathfinder_compiler::BlockifierLibfuncs::default(),
+            StarknetVersion::V_0_14_0,
         );
         let height_and_round = HeightAndRound::new(2, 1);
 

--- a/crates/pathfinder/src/consensus/inner/dummy_proposal.rs
+++ b/crates/pathfinder/src/consensus/inner/dummy_proposal.rs
@@ -17,6 +17,7 @@ use pathfinder_common::{
     ConsensusFinalizedL2Block,
     ContractAddress,
     DecidedBlocks,
+    StarknetVersion,
 };
 use pathfinder_consensus::Round;
 use pathfinder_crypto::Felt;
@@ -353,7 +354,7 @@ pub(crate) fn create_with_invalid_l1_handler_transactions(
         l1_data_gas_price_fri: 1_000_000,
         l1_gas_price_wei: 1_000_000,
         l1_data_gas_price_wei: 1_000_000,
-        starknet_version: "".to_string(),
+        starknet_version: StarknetVersion::V_0_14_0.to_string(),
         version_constant_commitment: Hash::ZERO,
     };
 
@@ -486,7 +487,7 @@ pub(crate) fn create_test_proposal_init(
         l1_data_gas_price_fri: 1,
         l1_gas_price_wei: 1_000_000_000,
         l1_data_gas_price_wei: 1,
-        starknet_version: "".to_string(),
+        starknet_version: StarknetVersion::V_0_14_0.to_string(),
         version_constant_commitment: Default::default(),
     }
 }

--- a/crates/pathfinder/src/consensus/inner/p2p_task.rs
+++ b/crates/pathfinder/src/consensus/inner/p2p_task.rs
@@ -29,6 +29,7 @@ use pathfinder_common::{
     DecidedBlock,
     DecidedBlocks,
     ProposalCommitment,
+    StarknetVersion,
 };
 use pathfinder_consensus::{
     ConsensusCommand,
@@ -166,6 +167,7 @@ pub fn spawn(
         worker_pool.clone(),
         compiler_resource_limits,
         blockifier_libfuncs,
+        config.my_starknet_version,
     );
     // Keep track of whether we've already emitted a warning about the
     // event channel size exceeding the limit, to avoid spamming the logs.
@@ -288,6 +290,7 @@ pub fn spawn(
                                     l2_gas_price_provider.clone(),
                                     inject_failure,
                                     worker_pool.clone(),
+                                    config.my_starknet_version,
                                 );
                                 match result {
                                     Ok(Some(commitment)) => {
@@ -420,6 +423,7 @@ pub fn spawn(
                                     gas_price_provider.clone(),
                                     &l2_gas_price_provider,
                                     worker_pool.clone(),
+                                    config.my_starknet_version,
                                 )?;
                                 Ok(success)
                             }
@@ -653,6 +657,7 @@ pub fn spawn(
                                 gas_price_provider.clone(),
                                 &l2_gas_price_provider,
                                 worker_pool.clone(),
+                                config.my_starknet_version,
                             )
                         } else {
                             Ok(ComputationSuccess::Continue)
@@ -779,6 +784,7 @@ fn on_finalized_block_decided(
     gas_price_provider: Option<L1GasPriceProvider>,
     l2_gas_price_provider: &Option<L2GasPriceProvider>,
     worker_pool: ValidatorWorkerPool,
+    my_starknet_version: StarknetVersion,
 ) -> Result<ComputationSuccess, anyhow::Error> {
     let exec_success = execute_deferred_for_next_height::<ProdTransactionMapper>(
         height.get(),
@@ -791,6 +797,7 @@ fn on_finalized_block_decided(
         gas_price_provider,
         l2_gas_price_provider.clone(),
         worker_pool,
+        my_starknet_version,
     )?;
     let success = match exec_success {
         Some((hnr, commitment)) => {
@@ -836,6 +843,7 @@ fn execute_deferred_for_next_height<T: TransactionExt>(
     gas_price_provider: Option<L1GasPriceProvider>,
     l2_gas_price_provider: Option<L2GasPriceProvider>,
     worker_pool: ValidatorWorkerPool,
+    my_starknet_version: StarknetVersion,
 ) -> anyhow::Result<Option<(HeightAndRound, ProposalCommitmentWithOrigin)>> {
     // Retrieve and execute any deferred transactions or proposal finalizations
     // for the next height, if any. Sort by (height, round) in ascending order.
@@ -864,6 +872,7 @@ fn execute_deferred_for_next_height<T: TransactionExt>(
                 None, // TODO: Add L1ToFriValidator when oracle is available
                 l2_gas_price_provider.as_ref(),
                 worker_pool,
+                my_starknet_version,
             )?;
 
         // Execute deferred transactions first.
@@ -1052,6 +1061,7 @@ fn handle_incoming_proposal_part<T: TransactionExt>(
     l2_gas_price_provider: Option<L2GasPriceProvider>,
     inject_failure_config: Option<InjectFailureConfig>,
     worker_pool: ValidatorWorkerPool,
+    my_starknet_version: StarknetVersion,
 ) -> Result<Option<ProposalCommitmentWithOrigin>, ProposalHandlingError> {
     let proposal_validator = incoming_proposals
         .entry(height_and_round)
@@ -1099,6 +1109,7 @@ fn handle_incoming_proposal_part<T: TransactionExt>(
                 None, // TODO: Add L1ToFriValidator when oracle is available
                 l2_gas_price_provider.as_ref(),
                 worker_pool,
+                my_starknet_version,
             )?;
             validator_cache.insert(
                 height_and_round,
@@ -1140,7 +1151,7 @@ fn handle_incoming_proposal_part<T: TransactionExt>(
 
             finalized_blocks.insert(
                 height_and_round,
-                create_empty_block(height_and_round.height()),
+                create_empty_block(height_and_round.height(), my_starknet_version),
             );
 
             let proposer_address = proposal_validator.proposer_address().ok_or_else(|| {
@@ -1193,6 +1204,7 @@ fn handle_incoming_proposal_part<T: TransactionExt>(
                 gas_price_provider.clone(),
                 l2_gas_price_provider.clone(),
                 worker_pool,
+                my_starknet_version,
             )
             // Note: We classify as recoverable by default. If there's a storage error in the
             // chain, it will be automatically detected and converted to fatal.
@@ -1223,6 +1235,7 @@ fn defer_or_execute_proposal_fin<T: TransactionExt>(
     gas_price_provider: Option<L1GasPriceProvider>,
     l2_gas_price_provider: Option<L2GasPriceProvider>,
     worker_pool: ValidatorWorkerPool,
+    my_starknet_version: StarknetVersion,
 ) -> anyhow::Result<Option<ProposalCommitmentWithOrigin>> {
     let commitment = ProposalCommitmentWithOrigin {
         proposal_commitment: ProposalCommitment(proposal_commitment.0),
@@ -1270,6 +1283,7 @@ fn defer_or_execute_proposal_fin<T: TransactionExt>(
                         None, // TODO: Add L1ToFriValidator when oracle is available
                         l2_gas_price_provider.as_ref(),
                         worker_pool,
+                        my_starknet_version,
                     )?
                 }
                 ValidatorStage::TransactionBatch(stage) => stage,
@@ -1511,6 +1525,7 @@ mod tests {
                 worker_pool.clone(),
                 ResourceLimits::for_test(),
                 BlockifierLibfuncs::default(),
+                StarknetVersion::V_0_14_0,
             );
             let dummy_data_dir = PathBuf::new();
 
@@ -1561,6 +1576,7 @@ mod tests {
                             None,
                             None,
                             worker_pool.clone(),
+                            StarknetVersion::V_0_14_0,
                         )
                         .unwrap();
                     if is_fin {

--- a/crates/pathfinder/src/consensus/inner/p2p_task/p2p_task_tests.rs
+++ b/crates/pathfinder/src/consensus/inner/p2p_task/p2p_task_tests.rs
@@ -95,6 +95,7 @@ impl TestEnvironment {
         let (handle, worker_pool) = p2p_task::spawn(
             chain_id,
             P2PTaskConfig {
+                my_starknet_version: StarknetVersion::V_0_14_0,
                 my_validator_address: validator_address,
                 history_depth: Self::HISTORY_DEPTH,
             },

--- a/crates/pathfinder/src/devnet.rs
+++ b/crates/pathfinder/src/devnet.rs
@@ -382,7 +382,7 @@ pub fn init_proposal_and_validator(
         l1_data_gas_price_fri: GAS_PRICE.0,
         l1_gas_price_wei: GAS_PRICE.0,
         l1_data_gas_price_wei: GAS_PRICE.0,
-        starknet_version: "".to_string(),
+        starknet_version: StarknetVersion::V_0_14_0.to_string(),
         version_constant_commitment: Hash::ZERO,
     };
     let validator = ValidatorBlockInfoStage::new(ChainId::SEPOLIA_TESTNET, proposal_init.clone())
@@ -395,6 +395,7 @@ pub fn init_proposal_and_validator(
         None,
         None,
         worker_pool.clone(),
+        StarknetVersion::V_0_14_0,
     )?;
     Ok((validator, vec![ProposalPart::Init(proposal_init)]))
 }

--- a/crates/validator/src/lib.rs
+++ b/crates/validator/src/lib.rs
@@ -50,12 +50,6 @@ use pathfinder_storage::{Storage, Transaction as DbTransaction};
 use rayon::prelude::*;
 use tracing::debug;
 
-/// Currently supported Starknet version for validation.
-///
-/// TODO: This is a temporary measure until we have a better way to provide
-/// validators with the Starknet version to validate against.
-const SUPPORTED_STARKNET_VERSION: StarknetVersion = StarknetVersion::new(0, 14, 0, 0);
-
 /// Type alias for the worker pool used by the concurrent executor.
 pub type ValidatorWorkerPool = Arc<
     pathfinder_executor::blockifier_reexports::WorkerPool<
@@ -176,6 +170,7 @@ impl ValidatorBlockInfoStage {
         l1_to_fri_validator: Option<&L1ToFriValidator>,
         l2_gas_price_provider: Option<&L2GasPriceProvider>,
         worker_pool: ValidatorWorkerPool,
+        my_starknet_version: StarknetVersion,
     ) -> Result<ValidatorTransactionBatchStage, ProposalHandlingError> {
         let Self {
             chain_id,
@@ -194,7 +189,7 @@ impl ValidatorBlockInfoStage {
             l1_data_gas_price_fri,
             l1_gas_price_wei,
             l1_data_gas_price_wei,
-            starknet_version: _,
+            starknet_version,
             version_constant_commitment: _,
         } = proposal_init;
         let _span = tracing::debug_span!(
@@ -205,6 +200,7 @@ impl ValidatorBlockInfoStage {
         )
         .entered();
 
+        let starknet_version = validate_starknet_version(starknet_version, my_starknet_version)?;
         validate_block_info_timestamp(height, timestamp, &main_storage, decided_blocks.clone())?;
 
         // Validate L1 gas prices if a provider is available
@@ -243,7 +239,7 @@ impl ValidatorBlockInfoStage {
                 l1_gas_price_wei,
                 l1_data_gas_price_wei,
             ),
-            SUPPORTED_STARKNET_VERSION,
+            starknet_version,
         )
         .context("Creating internal BlockInfo representation")
         .map_err(ProposalHandlingError::recoverable)?;
@@ -289,7 +285,7 @@ impl ValidatorBlockInfoStage {
             l1_data_gas_price_fri,
             l1_gas_price_wei,
             l1_data_gas_price_wei,
-            starknet_version: _,
+            starknet_version,
             version_constant_commitment: _,
         } = proposal_init;
         let _span = tracing::debug_span!(
@@ -301,6 +297,10 @@ impl ValidatorBlockInfoStage {
         .entered();
 
         tracing::debug!("Skipping block info validation for height {}", height);
+
+        let starknet_version: StarknetVersion = starknet_version
+            .parse()
+            .map_err(ProposalHandlingError::recoverable)?;
 
         let builder = SequencerAddress(builder.0);
         let l1_da_mode = match l1_da_mode {
@@ -321,7 +321,7 @@ impl ValidatorBlockInfoStage {
             builder,
             l1_da_mode,
             price_converter,
-            SUPPORTED_STARKNET_VERSION,
+            starknet_version,
         )
         .context("Creating internal BlockInfo representation")
         .map_err(ProposalHandlingError::recoverable)?;
@@ -339,6 +339,26 @@ impl ValidatorBlockInfoStage {
             decided_blocks,
         })
     }
+}
+
+fn validate_starknet_version(
+    proposal_starknet_version: String,
+    my_starknet_version: StarknetVersion,
+) -> Result<StarknetVersion, ProposalHandlingError> {
+    let starknet_version: StarknetVersion = proposal_starknet_version
+        .parse()
+        .context("parsing starknet version")
+        .map_err(ProposalHandlingError::recoverable)?;
+
+    if starknet_version != my_starknet_version {
+        let msg = format!(
+            "Starknet version mismatch: proposed {}; expected {}",
+            starknet_version, my_starknet_version
+        );
+        return Err(ProposalHandlingError::recoverable_msg(msg));
+    }
+
+    Ok(starknet_version)
 }
 
 fn validate_block_info_timestamp(
@@ -1217,7 +1237,7 @@ mod tests {
             l1_data_gas_price_wei: 0,
             l1_gas_price_fri: 0,
             l1_data_gas_price_fri: 0,
-            starknet_version: "".to_string(),
+            starknet_version: StarknetVersion::V_0_14_0.to_string(),
             version_constant_commitment: Default::default(),
         }
     }
@@ -1493,7 +1513,7 @@ mod tests {
             l1_data_gas_price_fri: 1,
             l1_gas_price_wei: 1_000_000_000,
             l1_data_gas_price_wei: 1,
-            starknet_version: "".to_string(),
+            starknet_version: StarknetVersion::V_0_14_0.to_string(),
             version_constant_commitment: Default::default(),
         };
 
@@ -1509,6 +1529,7 @@ mod tests {
                 None,
                 None,
                 worker_pool,
+                StarknetVersion::V_0_14_0,
             )
             .expect("Failed to validate block info");
 
@@ -1617,7 +1638,7 @@ mod tests {
             l1_data_gas_price_fri: 1,
             l1_gas_price_wei: 1_000_000_000,
             l1_data_gas_price_wei: 1,
-            starknet_version: "".to_string(),
+            starknet_version: StarknetVersion::V_0_14_0.to_string(),
             version_constant_commitment: Default::default(),
         };
 
@@ -1631,6 +1652,7 @@ mod tests {
             None,
             None,
             worker_pool,
+            StarknetVersion::V_0_14_0,
         );
 
         if let Some(expected_error_message) = expected_error_message {
@@ -1672,7 +1694,7 @@ mod tests {
             l1_data_gas_price_fri: 1,
             l1_gas_price_wei: 1_000_000_000,
             l1_data_gas_price_wei: 1,
-            starknet_version: "".to_string(),
+            starknet_version: StarknetVersion::V_0_14_0.to_string(),
             version_constant_commitment: Default::default(),
         };
 
@@ -1690,7 +1712,8 @@ mod tests {
                         None,
                         None,
                         None,
-                        worker_pool
+                        worker_pool,
+                        StarknetVersion::V_0_14_0,
                     )
                     .is_ok(),
                 "Genesis block timestamp validation should pass even without parent"
@@ -1704,6 +1727,7 @@ mod tests {
                     None,
                     None,
                     worker_pool,
+                    StarknetVersion::V_0_14_0,
                 )
                 .unwrap_err();
             let expected_err_message = format!(


### PR DESCRIPTION
Adds validation of an incoming proposal's starknet version against the starknet version set on the validator.

Closes: https://github.com/equilibriumco/pathfinder/issues/3366
---

The initial goal was to get rid of the hard-coded Starknet version but that still isn't possible (v0.14.0 is still used for everything). We should determine how a node's Starknet version will be set (e.g. a constant that gets bumped manually, a CLI argument etc.). Once this is in place, we can use that version instead of an arbitrary one.