### PR TITLE
fix(consensus): use proposal timestamp for empty block

### DIFF
--- a/crates/pathfinder/src/consensus/inner.rs
+++ b/crates/pathfinder/src/consensus/inner.rs
@@ -11,7 +11,6 @@ mod dummy_proposal;
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::time::SystemTime;
 
 use p2p::consensus::{Event, HeightAndRound};
 use p2p_proto::consensus::ProposalPart;
@@ -173,13 +172,9 @@ impl std::fmt::Display for ConsensusValue {
 /// default block header with the necessary fields filled in.
 pub(crate) fn create_empty_block(
     height: u64,
+    timestamp: u64,
     starknet_version: StarknetVersion,
 ) -> ConsensusFinalizedL2Block {
-    let timestamp = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-
     ConsensusFinalizedL2Block {
         header: ConsensusFinalizedBlockHeader {
             number: BlockNumber::new_or_panic(height),

--- a/crates/pathfinder/src/consensus/inner/p2p_task.rs
+++ b/crates/pathfinder/src/consensus/inner/p2p_task.rs
@@ -1149,9 +1149,28 @@ fn handle_incoming_proposal_part<T: TransactionExt>(
                  proposal)..."
             );
 
+            let Some(ProposalPart::Init(ProposalInit {
+                timestamp,
+                starknet_version,
+                ..
+            })) = proposal_validator.parts().first()
+            else {
+                return Err(ProposalHandlingError::Fatal(anyhow::anyhow!(
+                    "proposal init missing for empty proposal at {height_and_round}"
+                )));
+            };
+            let starknet_version = match starknet_version.parse() {
+                Ok(version) => version,
+                Err(_) => {
+                    return Err(ProposalHandlingError::recoverable_msg(format!(
+                        "invalid proposal starknet version {starknet_version} at \
+                         {height_and_round}"
+                    )));
+                }
+            };
             finalized_blocks.insert(
                 height_and_round,
-                create_empty_block(height_and_round.height(), my_starknet_version),
+                create_empty_block(height_and_round.height(), *timestamp, starknet_version),
             );
 
             let proposer_address = proposal_validator.proposer_address().ok_or_else(|| {


### PR DESCRIPTION
Passes the timestamp and starknet version of an empty proposal into the resulting finalized block. Possible now that `ProposalInit` has those fields. Closes #3388.