### PR TITLE
chore(consensus): remove stale TODO in dummy proposal

### DIFF
--- a/crates/pathfinder/src/consensus/dummy_proposal.rs
+++ b/crates/pathfinder/src/consensus/dummy_proposal.rs
@@ -147,8 +147,7 @@ pub(crate) fn create_from_bootstrapped_devnet_db(
     compiler_resource_limits: pathfinder_compiler::ResourceLimits,
     blockifier_libfuncs: pathfinder_compiler::BlockifierLibfuncs,
 ) -> anyhow::Result<(Vec<ProposalPart>, ConsensusFinalizedL2Block)> {
-    // TODO setting these constant to higher values can lead to weird panics in
-    // other validator (Pathfinder) nodes, which we need to investigate
+    // Maximum number of batches in the proposal.
     const MAX_NUM_BATCHES: usize = 2;
     // Number of loop iterations per batch, each iteration can add at most 3
     // transactions, so max batch length is MAX_BATCH_TRIES * 3.


### PR DESCRIPTION
Fixes #3403.

Panics mentioned by the `TODO` don't seem to appear any more. I kept increasing the values and everything worked until values were big enough to the point that consensus couldn't be reached, because proposal wasn't ready in time, and other nodes were sending Nil votes on proposal timeout.