### PR TITLE
fix(consensus): restart latest decided height to avoid network stalls when recovering

### DIFF
--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -555,7 +555,17 @@ impl<
                 }
 
                 // Only call StartHeight if the height is not already finalized.
-                if !internal_consensus.is_finalized() {
+                //
+                // With one exception:
+                // In an extremely rare case, where this node is required for consensus to move
+                // forward (ie. avoid stalling when there are only 3 nodes) it may happen that
+                // the other 2 nodes have not finalized their heights H and have timed out while
+                // our node, prior to being restarted, has finalized the same height H. Without
+                // our node restarting consensus at H the network will stall even though the
+                // number of honest nodes is sufficient (ie. 3).
+                if !internal_consensus.is_finalized()
+                    || max_height.is_some_and(|max_height| max_height == height)
+                {
                     internal_consensus
                         .handle_command(ConsensusCommand::StartHeight(height, validator_set));
                 }

--- a/crates/pathfinder/src/consensus/p2p_task.rs
+++ b/crates/pathfinder/src/consensus/p2p_task.rs
@@ -844,7 +844,7 @@ fn execute_deferred_for_next_height<T: TransactionExt>(
     l2_gas_price_provider: Option<L2GasPriceProvider>,
     worker_pool: ValidatorWorkerPool,
     my_starknet_version: StarknetVersion,
-) -> anyhow::Result<Option<(HeightAndRound, ProposalCommitmentWithOrigin)>> {
+) -> Result<Option<(HeightAndRound, ProposalCommitmentWithOrigin)>, ProposalHandlingError> {
     // Retrieve and execute any deferred transactions or proposal finalizations
     // for the next height, if any. Sort by (height, round) in ascending order.
     let deferred = {
@@ -1255,7 +1255,7 @@ fn defer_or_execute_proposal_fin<T: TransactionExt>(
     l2_gas_price_provider: Option<L2GasPriceProvider>,
     worker_pool: ValidatorWorkerPool,
     my_starknet_version: StarknetVersion,
-) -> anyhow::Result<Option<ProposalCommitmentWithOrigin>> {
+) -> Result<Option<ProposalCommitmentWithOrigin>, ProposalHandlingError> {
     let commitment = ProposalCommitmentWithOrigin {
         proposal_commitment: ProposalCommitment(proposal_commitment.0),
         proposer_address,

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -384,7 +384,7 @@ where
         // - Bob downloads H from FGw, even though he will shortly have a confirmation
         //   that he can commit the locally executed proposal at H.
         if let Some(l2_block) = reply {
-            tracing::debug!("Block {next} already committed in consensus, skipping download");
+            tracing::debug!("Block {next} already decided in consensus, skipping download");
 
             let (state_tries_updated_tx, rx) = tokio::sync::oneshot::channel();
 


### PR DESCRIPTION
Also fix: recoverable errors turned into fatal

Fixes: https://github.com/equilibriumco/pathfinder/issues/3402

I ran the tests more than 40x over and this PR seems to fix the following:
- https://github.com/equilibriumco/pathfinder/issues/3393
- https://github.com/equilibriumco/pathfinder/issues/3392

In general I stopped observing any stalls in the consensus tests.

Sometimes, very rarely (like once/twice per ~40 runs of all consensus tests) I still observe similar bugs to [this one](https://github.com/equilibriumco/pathfinder/issues/3394), but the severity of that bug is very very low (one artifact left in the cache per hundreds of respawns).