### PR TITLE
fix(consensus): increase p2p to consensus channel size

### DIFF
--- a/crates/pathfinder/src/consensus.rs
+++ b/crates/pathfinder/src/consensus.rs
@@ -77,10 +77,10 @@ pub fn start(
     inject_failure_config: Option<InjectFailureConfig>,
 ) -> ConsensusTaskHandles {
     // Events that are produced by the P2P task and consumed by the consensus task.
-    // TODO determine sufficient buffer size. 1 is not enough.
-    let (tx_to_consensus, rx_from_p2p) = mpsc::channel::<ConsensusTaskEvent>(10);
+    // The number of events produced by the P2P task could grow with increased peer
+    // count, hence the larger channel.
+    let (tx_to_consensus, rx_from_p2p) = mpsc::channel::<ConsensusTaskEvent>(30);
     // Events that are produced by the consensus task and consumed by the P2P task.
-    // TODO determine sufficient buffer size. 1 is not enough.
     let (tx_to_p2p, rx_from_consensus) = mpsc::channel::<P2PTaskEvent>(10);
     // Requests sent to consensus by the sync task.
     let (sync_to_consensus_tx, sync_to_consensus_rx) = mpsc::channel::<SyncMessageToConsensus>(10);

--- a/crates/pathfinder/tests/common/pathfinder_instance.rs
+++ b/crates/pathfinder/tests/common/pathfinder_instance.rs
@@ -125,7 +125,7 @@ impl PathfinderInstance {
                 config
                     .validator_addresses
                     .iter()
-                    .map(|a| format!("0x{a}"))
+                    .map(|a| format!("{a:#x}"))
                     .collect::<Vec<_>>()
                     .join(",")
             )

--- a/crates/pathfinder/tests/common/pathfinder_instance.rs
+++ b/crates/pathfinder/tests/common/pathfinder_instance.rs
@@ -35,7 +35,7 @@ pub struct PathfinderInstance {
 #[derive(Clone)]
 pub struct Config {
     pub name: &'static str,
-    pub boot_port: Option<u16>,
+    pub boot_peers: Vec<BootstrapPeerConfig>,
     pub sync_enabled: bool,
     pub my_validator_address: u8,
     pub validator_addresses: Vec<u8>,
@@ -45,6 +45,12 @@ pub struct Config {
     pub inject_failure: Option<InjectFailureConfig>,
     pub local_feeder_gateway_port: Option<u16>,
     pub boot_db: Option<PathBuf>,
+}
+
+#[derive(Clone)]
+pub struct BootstrapPeerConfig {
+    pub port: u16,
+    pub id: p2p::libp2p::PeerId,
 }
 
 pub type RpcPortWatch = (watch::Sender<(u32, u16)>, watch::Receiver<(u32, u16)>);
@@ -136,11 +142,21 @@ impl PathfinderInstance {
             "--p2p.consensus.experimental.direct-connection-timeout=1",
             "--p2p.consensus.experimental.eviction-timeout=1",
         ]);
-        if let Some(boot_port) = config.boot_port {
-            // Peer ID from `fixtures/id_Alice.json`.
+        let boot_peer_addrs: Vec<_> = config
+            .boot_peers
+            .iter()
+            .map(|boot_peer| {
+                format!(
+                    "/ip4/127.0.0.1/tcp/{}/p2p/{}",
+                    boot_peer.port,
+                    boot_peer.id.to_base58()
+                )
+            })
+            .collect();
+        if !boot_peer_addrs.is_empty() {
             command.arg(format!(
-                "--p2p.consensus.bootstrap-addresses=/ip4/127.0.0.1/tcp/{boot_port}/p2p/\
-                 12D3KooWDJryKaxjwNCk6yTtZ4GbtbLrH7JrEUTngvStaDttLtid"
+                "--p2p.consensus.bootstrap-addresses={}",
+                boot_peer_addrs.join(",")
             ));
         }
         command.arg(format!("--sync.enable={}", config.sync_enabled));
@@ -347,7 +363,7 @@ impl Config {
         (0..set_size)
             .map(|i| Self {
                 name: Self::NAMES[i],
-                boot_port: None,
+                boot_peers: Vec::new(),
                 sync_enabled: false,
                 my_validator_address: (i + 1) as u8,
                 // The set is deduplicated when consensus task is started, so including the own
@@ -368,8 +384,9 @@ impl Config {
         self
     }
 
-    pub fn with_boot_port(mut self, port: u16) -> Self {
-        self.boot_port = Some(port);
+    pub fn with_boot_peer(mut self, port: u16, peer_id: p2p::libp2p::PeerId) -> Self {
+        self.boot_peers
+            .push(BootstrapPeerConfig { port, id: peer_id });
         self
     }
 

--- a/crates/pathfinder/tests/common/utils.rs
+++ b/crates/pathfinder/tests/common/utils.rs
@@ -1,7 +1,7 @@
 //! Test utilities for Pathfinder integration tests.
 
 use std::fs::{File, OpenOptions};
-use std::io::ErrorKind;
+use std::io::{ErrorKind, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command};
 use std::time::{Duration, Instant};
@@ -10,6 +10,7 @@ use anyhow::Context as _;
 use p2p_proto::common::Address;
 use pathfinder_crypto::Felt;
 use pathfinder_lib::devnet::{init_db, BootDb};
+use serde::Deserialize;
 use tempfile::TempDir;
 use tokio::sync::mpsc;
 use tokio::task::{JoinError, JoinHandle};
@@ -127,6 +128,24 @@ pub fn feeder_gateway_bin() -> PathBuf {
     path.push("debug");
     path.push("feeder-gateway");
     path
+}
+
+#[derive(Deserialize)]
+pub struct IdFixture {
+    #[allow(dead_code)]
+    pub private_key: String,
+    pub peer_id: p2p::libp2p::PeerId,
+}
+
+pub fn read_id_fixture(name: &str) -> anyhow::Result<IdFixture> {
+    let path = fixture_dir().join(format!("id_{name}.json"));
+    let mut buf = Vec::new();
+    let mut file =
+        File::open(&path).with_context(|| format!("Opening ID fixture {}", path.display()))?;
+    file.read_to_end(&mut buf)
+        .with_context(|| format!("Reading ID fixture {}", path.display()))?;
+    serde_json::from_slice(&buf)
+        .with_context(|| format!("Deserializing ID fixture {}", path.display()))
 }
 
 fn fixture_dir() -> PathBuf {

--- a/crates/pathfinder/tests/consensus.rs
+++ b/crates/pathfinder/tests/consensus.rs
@@ -162,7 +162,8 @@ mod test {
             .unwrap();
 
         let boot_port = alice.consensus_p2p_port();
-        let mut configs = configs.map(|cfg| cfg.with_boot_port(boot_port));
+        let boot_peer_id = utils::read_id_fixture("Alice").unwrap().peer_id;
+        let mut configs = configs.map(|cfg| cfg.with_boot_peer(boot_port, boot_peer_id));
 
         let bob_cfg = {
             let bob_cfg = configs.next().unwrap();
@@ -334,7 +335,8 @@ mod test {
             .unwrap();
 
         let boot_port = alice.consensus_p2p_port();
-        let mut configs = configs.map(|cfg| cfg.with_boot_port(boot_port));
+        let boot_peer_id = utils::read_id_fixture("Alice").unwrap().peer_id;
+        let mut configs = configs.map(|cfg| cfg.with_boot_peer(boot_port, boot_peer_id));
 
         let bob_cfg = configs
             .next()
@@ -533,7 +535,8 @@ mod test {
             .unwrap();
 
         let boot_port = alice.consensus_p2p_port();
-        let mut configs = configs.map(|cfg| cfg.with_boot_port(boot_port));
+        let boot_peer_id = utils::read_id_fixture("Alice").unwrap().peer_id;
+        let mut configs = configs.map(|cfg| cfg.with_boot_peer(boot_port, boot_peer_id));
 
         let bob = PathfinderInstance::spawn(configs.next().unwrap()).unwrap();
         let charlie = PathfinderInstance::spawn(configs.next().unwrap()).unwrap();
@@ -720,7 +723,8 @@ mod test {
             .unwrap();
 
         let boot_port = alice.consensus_p2p_port();
-        let mut configs = configs.map(|cfg| cfg.with_boot_port(boot_port));
+        let boot_peer_id = utils::read_id_fixture("Alice").unwrap().peer_id;
+        let mut configs = configs.map(|cfg| cfg.with_boot_peer(boot_port, boot_peer_id));
 
         let bob = PathfinderInstance::spawn(configs.next().unwrap()).unwrap();
         let charlie = PathfinderInstance::spawn(configs.next().unwrap()).unwrap();


### PR DESCRIPTION
Bumps the size of the P2P to consensus task channel to 30 (previously 10). Consensus to P2P task channel size remains unchanged. Removes stale TODO comments related to this. 

Originally pointed out [here](https://github.com/equilibriumco/pathfinder/pull/3398#discussion_r3216700262).

Also makes a few changes to the consensus test setup that I found useful when running integration tests with a larger number of nodes.

## Size choice rationale

Integration tests with a local 30-node consensus network showed that, for most nodes, the number of messages in this channel will (momentarily) approach its previous capacity of 10. 

Our consensus network behaviour currently defaults to flood publishing, but I'm guessing (let me know if this is incorrect) this will change at some point as mesh-based networks are more scalable. Since, by default, gossipsub targets a mesh network size of 6 (local flood test was with 30 nodes), increasing the channel size to 30 should prevent it from ever getting full.

## Test setup changes

- When the network grows past a certain number of nodes (~15), having a single bootstrap peer does not work, at least on my setup - the bootstrap peer starts to drop connections. As a fix, the test instance config now allows setting multiple bootstrap peers.
- With the change described above, it became cumbersome to look up bootstrap peer IDs in the fixtures and copy them into the config. For that reason, ID fixtures can now be read with a helper function and boot peer IDs can be set programmatically.