### PR TITLE
fix(p2p): dial bootstrap peers concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,6 +1612,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "tokio",
+]
+
+[[package]]
 name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8491,6 +8501,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "axum",
+ "backon",
  "base64 0.22.1",
  "bincode",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ ark-ff = "0.5.0"
 assert_matches = "1.5.0"
 async-trait = "0.1.89"
 axum = "0.8.9"
+backon = { version = "1.6.0", default-features = false, features = ["tokio-sleep"] }
 base64 = "0.22.1"
 # TODO: bincode development stopped, we should probably replace it. 3.0.0 is just a compile_error! in lib.rs
 bincode = "=2.0.1"

--- a/crates/p2p/src/core.rs
+++ b/crates/p2p/src/core.rs
@@ -27,7 +27,7 @@ pub enum Command<ApplicationCommand> {
     /// Dial a specific peer.
     Dial {
         peer_id: PeerId,
-        addr: Multiaddr,
+        addrs: Vec<Multiaddr>,
         sender: EmptyResultSender,
     },
     /// Disconnect from a specific peer.

--- a/crates/p2p/src/core/client.rs
+++ b/crates/p2p/src/core/client.rs
@@ -41,12 +41,22 @@ impl<C> Client<C> {
         receiver.await.expect("Sender not to be dropped")
     }
 
+    /// Dials the peer with the given [ID](PeerId) on a single address.
+    ///
+    /// To dial on multiple address at once, use [Client::dial_many].
     pub async fn dial(&self, peer_id: PeerId, addr: Multiaddr) -> anyhow::Result<()> {
+        self.dial_many(peer_id, vec![addr]).await
+    }
+
+    /// Dials the peer with the given [ID](PeerId) on all specified addresses.
+    ///
+    /// To dial on a single address, use [Client::dial].
+    pub async fn dial_many(&self, peer_id: PeerId, addrs: Vec<Multiaddr>) -> anyhow::Result<()> {
         let (sender, receiver) = oneshot::channel();
         self.sender
             .send(Command::Dial {
                 peer_id,
-                addr,
+                addrs,
                 sender,
             })
             .expect("Command receiver not to be dropped");

--- a/crates/p2p/src/main_loop.rs
+++ b/crates/p2p/src/main_loop.rs
@@ -530,21 +530,19 @@ where
             // Instruct the swarm to dial a given peer.
             Command::Dial {
                 peer_id,
-                addr,
+                addrs,
                 sender,
             } => {
                 if let std::collections::hash_map::Entry::Vacant(e) =
                     self.pending_dials.entry(peer_id)
                 {
                     match self.swarm.dial(
-                        // Dial a known peer with a given address only if it's not connected yet
-                        // and we haven't started dialing yet.
-                        DialOpts::peer_id(peer_id)
-                            .addresses(vec![addr.clone()])
-                            .build(),
+                        // Dial a known peer with the given addresses only if it's not connected
+                        // yet and we haven't started dialing yet.
+                        DialOpts::peer_id(peer_id).addresses(addrs.clone()).build(),
                     ) {
                         Ok(_) => {
-                            tracing::debug!(%addr, "Dialed peer");
+                            tracing::debug!(?addrs, "Dialed peer");
                             e.insert(sender);
                         }
                         Err(e) => {

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -20,6 +20,7 @@ p2p = ["pathfinder-consensus", "pathfinder-validator"]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
+backon = { workspace = true }
 base64 = { workspace = true }
 bincode = { workspace = true, features = ["serde"] }
 bitvec = { workspace = true }

--- a/crates/pathfinder/src/p2p_network/common.rs
+++ b/crates/pathfinder/src/p2p_network/common.rs
@@ -1,6 +1,9 @@
+use std::collections::HashMap;
 use std::time::Duration;
 
 use anyhow::Context;
+use backon::Retryable;
+use futures::future::join_all;
 use p2p::core::Client;
 use p2p::libp2p::multiaddr::Protocol;
 use p2p::libp2p::{Multiaddr, PeerId};
@@ -13,7 +16,8 @@ pub async fn dial_bootnodes<C>(
         return true;
     }
 
-    let mut success = false;
+    let mut bootstrap_addrs_by_peer: HashMap<PeerId, Vec<Multiaddr>> = HashMap::new();
+
     for bootstrap_address in bootstrap_addresses {
         let peer_id = match ensure_peer_id_in_multiaddr(
             &bootstrap_address,
@@ -26,38 +30,60 @@ pub async fn dial_bootnodes<C>(
             }
         };
 
-        // TODO: Use exponential backoff with a max retry limit, at least one boot node
-        // needs to be reachable for the node to be useful.
-        // https://github.com/equilibriumco/pathfinder/issues/2937
-        for _ in 0..5 {
-            match core_client.dial(peer_id, bootstrap_address.clone()).await {
-                Ok(_) => {
-                    success = true;
-                    break;
-                }
-                Err(error) => {
+        bootstrap_addrs_by_peer
+            .entry(peer_id)
+            .or_default()
+            .push(bootstrap_address);
+    }
+
+    let backoff = backon::ExponentialBuilder::default()
+        .with_min_delay(Duration::from_secs(1))
+        .with_max_times(5);
+
+    let dials =
+        bootstrap_addrs_by_peer
+            .into_iter()
+            .map(|(peer_id, bootstrap_addresses)| async move {
+                let dial_result = (|| async {
+                    core_client
+                        .dial_many(peer_id, bootstrap_addresses.clone())
+                        .await
+                })
+                .retry(backoff)
+                .notify(|error, timeout| {
                     tracing::warn!(
-                        %bootstrap_address,
+                        ?bootstrap_addresses,
                         %error,
+                        ?timeout,
                         "Failed to dial bootstrap node, retrying",
                     );
-                    tokio::time::sleep(Duration::from_secs(3)).await;
-                }
-            }
-        }
+                })
+                .await
+                .inspect_err(|error| {
+                    tracing::warn!(
+                        ?bootstrap_addresses,
+                        %error,
+                        "Failed to dial bootstrap node",
+                    );
+                });
 
-        let relay_listener_address = bootstrap_address.clone().with(Protocol::P2pCircuit);
-        if let Err(error) = core_client
-            .start_listening(relay_listener_address.clone())
-            .await
-        {
-            tracing::warn!(
-                ?error,
-                "Failed starting relay listener on {relay_listener_address}"
-            );
-        }
-    }
-    success
+                for address in bootstrap_addresses {
+                    let relay_listener_address = address.with(Protocol::P2pCircuit);
+                    if let Err(error) = core_client
+                        .start_listening(relay_listener_address.clone())
+                        .await
+                    {
+                        tracing::warn!(
+                            ?error,
+                            "Failed starting relay listener on {relay_listener_address}"
+                        );
+                    }
+                }
+
+                dial_result.is_ok()
+            });
+
+    join_all(dials).await.into_iter().any(|success| success)
 }
 
 pub fn ensure_peer_id_in_multiaddr(addr: &Multiaddr, msg: &'static str) -> anyhow::Result<PeerId> {


### PR DESCRIPTION
Dial configured bootstrap peers concurrently instead of waiting for each peer's retry sequence to finish before starting the next one.

Replaces the fixed retry delay with exponential backoff. Keeps the retry limit bounded and removes the stale TODO comment.

---

Two things to note:

- Bootstrap peers are now dialed on all addresses in a single command; this was needed because only a single dial can be pending for a given peer ID at any given moment. Without grouping addresses by peer ID, concurrent attempts to dial multiple addresses with the same peer ID would result in failures.
- Relay listens for a given bootstrap peer are now started only after all dial attempts (on all addresses) for that peer are completed. Previously, the listen on address `A` would only have to wait for dial attempts on `A` to complete.