### PR TITLE
fix(TrieStorageIndex): apis allow values larger than i64::MAX

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -321,8 +321,6 @@ impl BlockNumber {
         self.0.checked_sub(rhs).map(Self)
     }
 
-    /// Always safe because block numbers are non-negative and restricted to be
-    /// at most i64::MAX.
     pub fn to_i64(&self) -> i64 {
         self.0
             .try_into()

--- a/crates/merkle-tree/src/merkle_node.rs
+++ b/crates/merkle-tree/src/merkle_node.rs
@@ -232,8 +232,12 @@ mod tests {
             let uut = BinaryNode {
                 storage_index: None,
                 height: 1,
-                left: Rc::new(RefCell::new(InternalNode::Unresolved(1.into()))),
-                right: Rc::new(RefCell::new(InternalNode::Unresolved(2.into()))),
+                left: Rc::new(RefCell::new(InternalNode::Unresolved(
+                    TrieStorageIndex::new(1).unwrap(),
+                ))),
+                right: Rc::new(RefCell::new(InternalNode::Unresolved(
+                    TrieStorageIndex::new(2).unwrap(),
+                ))),
             };
 
             let mut zero_key = bitvec![u8, Msb0; 1; 251];
@@ -251,8 +255,12 @@ mod tests {
 
         #[test]
         fn get_child() {
-            let left = Rc::new(RefCell::new(InternalNode::Unresolved(1.into())));
-            let right = Rc::new(RefCell::new(InternalNode::Unresolved(2.into())));
+            let left = Rc::new(RefCell::new(InternalNode::Unresolved(
+                TrieStorageIndex::new(1).unwrap(),
+            )));
+            let right = Rc::new(RefCell::new(InternalNode::Unresolved(
+                TrieStorageIndex::new(2).unwrap(),
+            )));
 
             let uut = BinaryNode {
                 storage_index: None,
@@ -320,7 +328,9 @@ mod tests {
             #[test]
             fn full() {
                 let key = felt!("0x123456789abcdef");
-                let child = Rc::new(RefCell::new(InternalNode::Unresolved(1.into())));
+                let child = Rc::new(RefCell::new(InternalNode::Unresolved(
+                    TrieStorageIndex::new(1).unwrap(),
+                )));
 
                 let uut = EdgeNode {
                     storage_index: None,
@@ -335,7 +345,9 @@ mod tests {
             #[test]
             fn prefix() {
                 let key = felt!("0x123456789abcdef");
-                let child = Rc::new(RefCell::new(InternalNode::Unresolved(1.into())));
+                let child = Rc::new(RefCell::new(InternalNode::Unresolved(
+                    TrieStorageIndex::new(1).unwrap(),
+                )));
 
                 let path = key.view_bits()[..45].to_bitvec();
 
@@ -352,7 +364,9 @@ mod tests {
             #[test]
             fn suffix() {
                 let key = felt!("0x123456789abcdef");
-                let child = Rc::new(RefCell::new(InternalNode::Unresolved(1.into())));
+                let child = Rc::new(RefCell::new(InternalNode::Unresolved(
+                    TrieStorageIndex::new(1).unwrap(),
+                )));
 
                 let path = key.view_bits()[50..].to_bitvec();
 
@@ -369,7 +383,9 @@ mod tests {
             #[test]
             fn middle_slice() {
                 let key = felt!("0x123456789abcdef");
-                let child = Rc::new(RefCell::new(InternalNode::Unresolved(1.into())));
+                let child = Rc::new(RefCell::new(InternalNode::Unresolved(
+                    TrieStorageIndex::new(1).unwrap(),
+                )));
 
                 let path = key.view_bits()[230..235].to_bitvec();
 

--- a/crates/merkle-tree/src/tree.rs
+++ b/crates/merkle-tree/src/tree.rs
@@ -948,6 +948,26 @@ mod tests {
 
     use super::*;
 
+    trait TrieStorageIndexExt {
+        fn checked_add(self, rhs: usize) -> Option<Self>
+        where
+            Self: Sized;
+
+        fn checked_sub(self, rhs: usize) -> Option<Self>
+        where
+            Self: Sized;
+    }
+
+    impl TrieStorageIndexExt for TrieStorageIndex {
+        fn checked_add(self, rhs: usize) -> Option<Self> {
+            Self::new(self.get().checked_add(u64::try_from(rhs).ok()?)?)
+        }
+
+        fn checked_sub(self, rhs: usize) -> Option<Self> {
+            Self::new(self.get().checked_sub(u64::try_from(rhs).ok()?)?)
+        }
+    }
+
     type TestTree = MerkleTree<PedersenHash, 251>;
 
     #[derive(Default, Debug)]
@@ -978,14 +998,14 @@ mod tests {
     fn commit_and_persist_with_pruning<H: FeltHash, const HEIGHT: usize>(
         tree: MerkleTree<H, HEIGHT>,
         storage: &mut TestStorage,
-    ) -> (Felt, TrieStorageIndex) {
+    ) -> anyhow::Result<(Felt, TrieStorageIndex)> {
         commit_and_persist(tree, storage, true)
     }
 
     fn commit_and_persist_without_pruning<H: FeltHash, const HEIGHT: usize>(
         tree: MerkleTree<H, HEIGHT>,
         storage: &mut TestStorage,
-    ) -> (Felt, TrieStorageIndex) {
+    ) -> anyhow::Result<(Felt, TrieStorageIndex)> {
         commit_and_persist(tree, storage, false)
     }
 
@@ -994,7 +1014,7 @@ mod tests {
         tree: MerkleTree<H, HEIGHT>,
         storage: &mut TestStorage,
         prune_nodes: bool,
-    ) -> (Felt, TrieStorageIndex) {
+    ) -> anyhow::Result<(Felt, TrieStorageIndex)> {
         for (key, value) in &tree.leaves {
             let key = Felt::from_bits(key).unwrap();
             storage.leaves.insert(key, *value);
@@ -1008,19 +1028,25 @@ mod tests {
             }
         }
 
-        let number_of_nodes_added = update.nodes_added.len() as u64;
+        let number_of_nodes_added = update.nodes_added.len();
 
         for (rel_index, (hash, node)) in update.nodes_added.into_iter().enumerate() {
             let node = match node {
                 Node::Binary { left, right } => {
                     let left = match left {
                         NodeRef::StorageIndex(idx) => idx,
-                        NodeRef::Index(idx) => storage.next_index + idx as u64,
+                        NodeRef::Index(idx) => storage
+                            .next_index
+                            .checked_add(idx)
+                            .context("TrieStorageIndex overflow")?,
                     };
 
                     let right = match right {
                         NodeRef::StorageIndex(idx) => idx,
-                        NodeRef::Index(idx) => storage.next_index + idx as u64,
+                        NodeRef::Index(idx) => storage
+                            .next_index
+                            .checked_add(idx)
+                            .context("TrieStorageIndex overflow")?,
                     };
 
                     StoredNode::Binary { left, right }
@@ -1028,7 +1054,10 @@ mod tests {
                 Node::Edge { child, path } => {
                     let child = match child {
                         NodeRef::StorageIndex(idx) => idx,
-                        NodeRef::Index(idx) => storage.next_index + idx as u64,
+                        NodeRef::Index(idx) => storage
+                            .next_index
+                            .checked_add(idx)
+                            .context("TrieStorageIndex overflow")?,
                     };
 
                     StoredNode::Edge { child, path }
@@ -1037,15 +1066,26 @@ mod tests {
                 Node::LeafEdge { path } => StoredNode::LeafEdge { path },
             };
 
-            let index = storage.next_index + (rel_index as u64);
+            let index = storage
+                .next_index
+                .checked_add(rel_index)
+                .context("TrieStorageIndex overflow")?;
 
             storage.nodes.insert(index, (hash, node));
         }
 
-        let storage_root_index = storage.next_index + number_of_nodes_added - 1;
-        storage.next_index += number_of_nodes_added;
+        let storage_root_index = storage
+            .next_index
+            .checked_add(number_of_nodes_added)
+            .context("TrieStorageIndex overflow")?
+            .checked_sub(1)
+            .context("TrieStorageIndex underflow")?;
+        storage.next_index = storage
+            .next_index
+            .checked_add(number_of_nodes_added)
+            .context("TrieStorageIndex overflow")?;
 
-        (update.root_commitment, storage_root_index)
+        Ok((update.root_commitment, storage_root_index))
     }
 
     #[test]
@@ -1362,7 +1402,7 @@ mod tests {
 
             tree.set(&storage, felt!("0x1").view_bits().to_bitvec(), felt!("0x1"))
                 .unwrap();
-            let root = commit_and_persist_without_pruning(tree, &mut storage);
+            let root = commit_and_persist_without_pruning(tree, &mut storage).unwrap();
             assert_eq!(
                 root.0,
                 felt!("0x02ebbd6878f81e49560ae863bd4ef327a417037bf57b63a016130ad0a94c8fa7")
@@ -1370,7 +1410,7 @@ mod tests {
             assert_eq!(storage.nodes.len(), 1);
 
             let tree = TestTree::new(root.1);
-            let root = commit_and_persist_without_pruning(tree, &mut storage);
+            let root = commit_and_persist_without_pruning(tree, &mut storage).unwrap();
             assert_eq!(
                 root.0,
                 felt!("0x02ebbd6878f81e49560ae863bd4ef327a417037bf57b63a016130ad0a94c8fa7")
@@ -1385,7 +1425,7 @@ mod tests {
 
             tree.set(&storage, felt!("0x1").view_bits().to_bitvec(), felt!("0x1"))
                 .unwrap();
-            let root = commit_and_persist_with_pruning(tree, &mut storage);
+            let root = commit_and_persist_with_pruning(tree, &mut storage).unwrap();
             assert_eq!(
                 root.0,
                 felt!("0x02ebbd6878f81e49560ae863bd4ef327a417037bf57b63a016130ad0a94c8fa7")
@@ -1395,7 +1435,7 @@ mod tests {
             let mut tree = TestTree::new(root.1);
             tree.set(&storage, felt!("0x1").view_bits().to_bitvec(), Felt::ZERO)
                 .unwrap();
-            let root = commit_and_persist_with_pruning(tree, &mut storage);
+            let root = commit_and_persist_with_pruning(tree, &mut storage).unwrap();
             assert_eq!(root.0, Felt::ZERO);
             assert!(storage.nodes.is_empty());
         }
@@ -1421,7 +1461,7 @@ mod tests {
             uut.set(&storage, key1.clone(), val1).unwrap();
             uut.set(&storage, key2.clone(), val2).unwrap();
 
-            let root = commit_and_persist_with_pruning(uut, &mut storage);
+            let root = commit_and_persist_with_pruning(uut, &mut storage).unwrap();
 
             let uut = TestTree::new(root.1);
 
@@ -1467,7 +1507,7 @@ mod tests {
                 let key = key.view_bits();
                 uut.set(&storage, key.to_owned(), *val).unwrap();
             }
-            let root = commit_and_persist_with_pruning(uut, &mut storage);
+            let root = commit_and_persist_with_pruning(uut, &mut storage).unwrap();
 
             // Delete the final leaf; this exercises the bug as the nodes are all in storage
             // (unresolved).
@@ -1475,7 +1515,7 @@ mod tests {
             let key = leaves[4].0.view_bits().to_bitvec();
             let val = leaves[4].1;
             uut.set(&storage, key, val).unwrap();
-            let (root_hash, _) = commit_and_persist_with_pruning(uut, &mut storage);
+            let (root_hash, _) = commit_and_persist_with_pruning(uut, &mut storage).unwrap();
             let expect = felt!("0x5f3b2b98faef39c60dbbb459dbe63d1d10f1688af47fbc032f2cab025def896");
 
             assert_eq!(root_hash, expect);
@@ -1494,15 +1534,15 @@ mod tests {
             let mut uut = TestTree::empty();
             let mut storage = TestStorage::default();
             uut.set(&storage, key0.clone(), val0).unwrap();
-            let root0 = commit_and_persist_without_pruning(uut, &mut storage);
+            let root0 = commit_and_persist_without_pruning(uut, &mut storage).unwrap();
 
             let mut uut = TestTree::new(root0.1);
             uut.set(&storage, key1.clone(), val1).unwrap();
-            let root1 = commit_and_persist_without_pruning(uut, &mut storage);
+            let root1 = commit_and_persist_without_pruning(uut, &mut storage).unwrap();
 
             let mut uut = TestTree::new(root1.1);
             uut.set(&storage, key2.clone(), val2).unwrap();
-            let root2 = commit_and_persist_without_pruning(uut, &mut storage);
+            let root2 = commit_and_persist_without_pruning(uut, &mut storage).unwrap();
 
             let uut = TestTree::new(root0.1);
             assert_eq!(uut.get(&storage, key0.clone()).unwrap(), Some(val0));
@@ -1533,15 +1573,15 @@ mod tests {
             let mut uut = TestTree::empty();
             let mut storage = TestStorage::default();
             uut.set(&storage, key0.clone(), val0).unwrap();
-            let root0 = commit_and_persist_without_pruning(uut, &mut storage);
+            let root0 = commit_and_persist_without_pruning(uut, &mut storage).unwrap();
 
             let mut uut = TestTree::new(root0.1);
             uut.set(&storage, key1.clone(), val1).unwrap();
-            let root1 = commit_and_persist_without_pruning(uut, &mut storage);
+            let root1 = commit_and_persist_without_pruning(uut, &mut storage).unwrap();
 
             let mut uut = TestTree::new(root0.1);
             uut.set(&storage, key2.clone(), val2).unwrap();
-            let root2 = commit_and_persist_without_pruning(uut, &mut storage);
+            let root2 = commit_and_persist_without_pruning(uut, &mut storage).unwrap();
 
             let uut = TestTree::new(root0.1);
             assert_eq!(uut.get(&storage, key0.clone()).unwrap(), Some(val0));
@@ -1568,13 +1608,13 @@ mod tests {
             let val = felt!("0x12345678");
             uut.set(&storage, key, val).unwrap();
 
-            let root0 = commit_and_persist_with_pruning(uut, &mut storage);
+            let root0 = commit_and_persist_with_pruning(uut, &mut storage).unwrap();
 
             let uut = TestTree::new(root0.1);
-            let root1 = commit_and_persist_with_pruning(uut, &mut storage);
+            let root1 = commit_and_persist_with_pruning(uut, &mut storage).unwrap();
 
             let uut = TestTree::new(root1.1);
-            let root2 = commit_and_persist_with_pruning(uut, &mut storage);
+            let root2 = commit_and_persist_with_pruning(uut, &mut storage).unwrap();
 
             assert_eq!(root0.0, root1.0);
             assert_eq!(root0.0, root2.0);
@@ -1604,7 +1644,7 @@ mod tests {
             uut.set(&storage, felt!("0x87").view_bits().to_owned(), felt!("0x2"))
                 .unwrap();
 
-            let (root, _) = commit_and_persist_with_pruning(uut, &mut storage);
+            let (root, _) = commit_and_persist_with_pruning(uut, &mut storage).unwrap();
 
             assert_eq!(
                 root,
@@ -1677,7 +1717,7 @@ mod tests {
                 felt!("0x15b38")
             );
 
-            let root = commit_and_persist_with_pruning(uut, &mut storage);
+            let root = commit_and_persist_with_pruning(uut, &mut storage).unwrap();
             let mut uut = TestTree::new(root.1);
             set!(
                 uut,
@@ -1685,7 +1725,7 @@ mod tests {
                 felt!("0x15b38")
             );
 
-            let root = commit_and_persist_with_pruning(uut, &mut storage);
+            let root = commit_and_persist_with_pruning(uut, &mut storage).unwrap();
             let mut uut = TestTree::new(root.1);
 
             let mut visited = vec![];
@@ -1701,7 +1741,7 @@ mod tests {
                 felt!("0xf502")
             );
 
-            let root = commit_and_persist_with_pruning(uut, &mut storage);
+            let root = commit_and_persist_with_pruning(uut, &mut storage).unwrap();
             let mut uut = TestTree::new(root.1);
 
             let mut visited = vec![];
@@ -1760,7 +1800,7 @@ mod tests {
             let RootIndexUpdate::Updated(root_index) = root_index_update else {
                 panic!("Expected root index to be updated");
             };
-            assert_eq!(root_index, TrieStorageIndex(1));
+            assert_eq!(root_index, TrieStorageIndex::new(1).unwrap());
             tx.insert_class_root(BlockNumber::GENESIS, root_index_update)
                 .unwrap();
             assert!(tx.class_root_exists(BlockNumber::GENESIS).unwrap());
@@ -2145,7 +2185,7 @@ mod tests {
                     .zip(values.iter())
                     .for_each(|(k, v)| uut.set(&storage, k.view_bits().to_owned(), *v).unwrap());
 
-                let root = commit_and_persist_with_pruning(uut, &mut storage);
+                let root = commit_and_persist_with_pruning(uut, &mut storage).unwrap();
 
                 Self {
                     keys,
@@ -2195,7 +2235,7 @@ mod tests {
 
             uut.set(&storage, key1.clone(), value_1).unwrap();
             uut.set(&storage, key2.clone(), value_2).unwrap();
-            let (root, root_idx) = commit_and_persist_with_pruning(uut, &mut storage);
+            let (root, root_idx) = commit_and_persist_with_pruning(uut, &mut storage).unwrap();
 
             let proofs = TestTree::get_proofs(root_idx, &storage, &keys).unwrap();
 
@@ -2234,7 +2274,7 @@ mod tests {
             uut.set(&storage, key2.clone(), value_2).unwrap();
             uut.set(&storage, key3.clone(), value_3).unwrap();
 
-            let (root, root_idx) = commit_and_persist_with_pruning(uut, &mut storage);
+            let (root, root_idx) = commit_and_persist_with_pruning(uut, &mut storage).unwrap();
 
             let proofs = TestTree::get_proofs(root_idx, &storage, &keys).unwrap();
             let verified_1 = verify_proof(root, &key1, value_1, &proofs[0]).unwrap();
@@ -2266,7 +2306,7 @@ mod tests {
 
             uut.set(&storage, key1.clone(), value_1).unwrap();
 
-            let (root, root_idx) = commit_and_persist_with_pruning(uut, &mut storage);
+            let (root, root_idx) = commit_and_persist_with_pruning(uut, &mut storage).unwrap();
 
             let proofs = TestTree::get_proofs(root_idx, &storage, &keys).unwrap();
             let verified_1 = verify_proof(root, &key1, value_1, &proofs[0]).unwrap();
@@ -2292,7 +2332,7 @@ mod tests {
 
             uut.set(&storage, key1.clone(), value_1).unwrap();
 
-            let (root, root_idx) = commit_and_persist_with_pruning(uut, &mut storage);
+            let (root, root_idx) = commit_and_persist_with_pruning(uut, &mut storage).unwrap();
 
             let proofs = TestTree::get_proofs(root_idx, &storage, &keys).unwrap();
             let verified_1 = verify_proof(root, &key1, value_1, &proofs[0]).unwrap();
@@ -2318,7 +2358,7 @@ mod tests {
 
             uut.set(&storage, key1.clone(), value_1).unwrap();
 
-            let (root, root_idx) = commit_and_persist_with_pruning(uut, &mut storage);
+            let (root, root_idx) = commit_and_persist_with_pruning(uut, &mut storage).unwrap();
 
             let proofs = TestTree::get_proofs(root_idx, &storage, &keys).unwrap();
             let verified_1 = verify_proof(root, &key1, value_1, &proofs[0]).unwrap();
@@ -2349,7 +2389,7 @@ mod tests {
             uut.set(&storage, key1.clone(), value_1).unwrap();
             uut.set(&storage, key2.clone(), value_2).unwrap();
 
-            let (root, root_idx) = commit_and_persist_with_pruning(uut, &mut storage);
+            let (root, root_idx) = commit_and_persist_with_pruning(uut, &mut storage).unwrap();
 
             let proofs = TestTree::get_proofs(root_idx, &storage, &keys).unwrap();
             let verified_1 = verify_proof(root, &key1, value_1, &proofs[0]).unwrap();
@@ -2464,7 +2504,7 @@ mod tests {
             uut.set(&storage, key1.clone(), value_1).unwrap();
             uut.set(&storage, key2.clone(), value_2).unwrap();
 
-            let (root, root_idx) = commit_and_persist_with_pruning(uut, &mut storage);
+            let (root, root_idx) = commit_and_persist_with_pruning(uut, &mut storage).unwrap();
 
             let mut proofs = TestTree::get_proofs(root_idx, &storage, &keys).unwrap();
 
@@ -2509,7 +2549,7 @@ mod tests {
             uut.set(&storage, key1.clone(), value_1).unwrap();
             uut.set(&storage, key2.clone(), value_2).unwrap();
 
-            let (root, root_idx) = commit_and_persist_with_pruning(uut, &mut storage);
+            let (root, root_idx) = commit_and_persist_with_pruning(uut, &mut storage).unwrap();
 
             let mut proofs = TestTree::get_proofs(root_idx, &storage, &keys).unwrap();
 
@@ -2549,7 +2589,7 @@ mod tests {
 
             uut.set(&storage, key1.clone(), value_1).unwrap();
 
-            let (root, root_idx) = commit_and_persist_with_pruning(uut, &mut storage);
+            let (root, root_idx) = commit_and_persist_with_pruning(uut, &mut storage).unwrap();
 
             let proofs = TestTree::get_proofs(root_idx, &storage, &keys).unwrap();
 

--- a/crates/storage/src/connection/trie.rs
+++ b/crates/storage/src/connection/trie.rs
@@ -655,24 +655,35 @@ pub struct TrieUpdate {
 }
 
 /// The storage index of a trie node.
+///
+/// The value range of this type is `0..i64::MAX` and hence is
+/// compatible with SQLite integer implementation.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
-pub struct TrieStorageIndex(pub u64);
+pub struct TrieStorageIndex(u64);
+
+impl TrieStorageIndex {
+    pub const fn new(val: u64) -> Option<Self> {
+        if val <= i64::MAX as u64 {
+            Some(Self(val))
+        } else {
+            None
+        }
+    }
+
+    pub const fn get(&self) -> u64 {
+        self.0
+    }
+
+    pub fn to_i64(&self) -> i64 {
+        self.0
+            .try_into()
+            .expect("TrieStorageIndex is always <= i64::MAX")
+    }
+}
 
 impl std::fmt::Display for TrieStorageIndex {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
-    }
-}
-
-impl From<u64> for TrieStorageIndex {
-    fn from(index: u64) -> Self {
-        Self(index)
-    }
-}
-
-impl From<TrieStorageIndex> for u64 {
-    fn from(index: TrieStorageIndex) -> Self {
-        index.0
     }
 }
 
@@ -689,7 +700,11 @@ impl<Context> bincode::Decode<Context> for TrieStorageIndex {
     fn decode<D: bincode::de::Decoder<Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
-        Ok(Self(u64::decode(decoder)?))
+        u64::decode(decoder).and_then(|x| {
+            TrieStorageIndex::new(x).ok_or(bincode::error::DecodeError::Other(
+                "TrieStorageIndex out of range",
+            ))
+        })
     }
 }
 
@@ -697,73 +712,11 @@ impl<'de, Context> bincode::BorrowDecode<'de, Context> for TrieStorageIndex {
     fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
-        Ok(Self(u64::borrow_decode(decoder)?))
-    }
-}
-
-impl std::ops::Add for TrieStorageIndex {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Self {
-        Self(
-            self.0
-                .checked_add(rhs.0)
-                .expect("TrieStorageIndex addition overflow"),
-        )
-    }
-}
-
-impl std::ops::Add<u64> for TrieStorageIndex {
-    type Output = Self;
-
-    fn add(self, rhs: u64) -> Self {
-        Self(
-            self.0
-                .checked_add(rhs)
-                .expect("TrieStorageIndex addition overflow"),
-        )
-    }
-}
-
-impl std::ops::AddAssign<u64> for TrieStorageIndex {
-    fn add_assign(&mut self, rhs: u64) {
-        self.0 = self
-            .0
-            .checked_add(rhs)
-            .expect("TrieStorageIndex addition overflow");
-    }
-}
-
-impl std::ops::Sub for TrieStorageIndex {
-    type Output = Self;
-
-    fn sub(self, rhs: Self) -> Self {
-        Self(
-            self.0
-                .checked_sub(rhs.0)
-                .expect("TrieStorageIndex subtraction underflow"),
-        )
-    }
-}
-
-impl std::ops::Sub<u64> for TrieStorageIndex {
-    type Output = Self;
-
-    fn sub(self, rhs: u64) -> Self {
-        Self(
-            self.0
-                .checked_sub(rhs)
-                .expect("TrieStorageIndex subtraction underflow"),
-        )
-    }
-}
-
-impl std::ops::SubAssign<u64> for TrieStorageIndex {
-    fn sub_assign(&mut self, rhs: u64) {
-        self.0 = self
-            .0
-            .checked_sub(rhs)
-            .expect("TrieStorageIndex subtraction underflow");
+        u64::borrow_decode(decoder).and_then(|x| {
+            TrieStorageIndex::new(x).ok_or(bincode::error::DecodeError::Other(
+                "TrieStorageIndex out of range",
+            ))
+        })
     }
 }
 
@@ -962,34 +915,37 @@ mod tests {
         let result = tx.class_root_index(BlockNumber::GENESIS).unwrap();
         assert_eq!(result, None);
 
-        tx.insert_class_root(BlockNumber::GENESIS, RootIndexUpdate::Updated(123.into()))
-            .unwrap();
+        tx.insert_class_root(
+            BlockNumber::GENESIS,
+            RootIndexUpdate::Updated(TrieStorageIndex::new(123).unwrap()),
+        )
+        .unwrap();
         let result = tx.class_root_index(BlockNumber::GENESIS).unwrap();
-        assert_eq!(result, Some(123.into()));
+        assert_eq!(result, Some(TrieStorageIndex::new(123).unwrap()));
 
         tx.insert_class_root(
             BlockNumber::GENESIS + 1,
-            RootIndexUpdate::Updated(456.into()),
+            RootIndexUpdate::Updated(TrieStorageIndex::new(456).unwrap()),
         )
         .unwrap();
         let result = tx.class_root_index(BlockNumber::GENESIS).unwrap();
-        assert_eq!(result, Some(123.into()));
+        assert_eq!(result, Some(TrieStorageIndex::new(123).unwrap()));
         let result = tx.class_root_index(BlockNumber::GENESIS + 1).unwrap();
-        assert_eq!(result, Some(456.into()));
+        assert_eq!(result, Some(TrieStorageIndex::new(456).unwrap()));
         let result = tx.class_root_index(BlockNumber::GENESIS + 2).unwrap();
-        assert_eq!(result, Some(456.into()));
+        assert_eq!(result, Some(TrieStorageIndex::new(456).unwrap()));
 
         tx.insert_class_root(
             BlockNumber::GENESIS + 10,
-            RootIndexUpdate::Updated(789.into()),
+            RootIndexUpdate::Updated(TrieStorageIndex::new(789).unwrap()),
         )
         .unwrap();
         let result = tx.class_root_index(BlockNumber::GENESIS + 9).unwrap();
-        assert_eq!(result, Some(456.into()));
+        assert_eq!(result, Some(TrieStorageIndex::new(456).unwrap()));
         let result = tx.class_root_index(BlockNumber::GENESIS + 10).unwrap();
-        assert_eq!(result, Some(789.into()));
+        assert_eq!(result, Some(TrieStorageIndex::new(789).unwrap()));
         let result = tx.class_root_index(BlockNumber::GENESIS + 11).unwrap();
-        assert_eq!(result, Some(789.into()));
+        assert_eq!(result, Some(TrieStorageIndex::new(789).unwrap()));
 
         tx.insert_class_root(BlockNumber::GENESIS + 12, RootIndexUpdate::TrieEmpty)
             .unwrap();
@@ -1010,34 +966,37 @@ mod tests {
         let result = tx.storage_root_index(BlockNumber::GENESIS).unwrap();
         assert_eq!(result, None);
 
-        tx.insert_storage_root(BlockNumber::GENESIS, RootIndexUpdate::Updated(123.into()))
-            .unwrap();
+        tx.insert_storage_root(
+            BlockNumber::GENESIS,
+            RootIndexUpdate::Updated(TrieStorageIndex::new(123).unwrap()),
+        )
+        .unwrap();
         let result = tx.storage_root_index(BlockNumber::GENESIS).unwrap();
-        assert_eq!(result, Some(123.into()));
+        assert_eq!(result, Some(TrieStorageIndex::new(123).unwrap()));
 
         tx.insert_storage_root(
             BlockNumber::GENESIS + 1,
-            RootIndexUpdate::Updated(456.into()),
+            RootIndexUpdate::Updated(TrieStorageIndex::new(456).unwrap()),
         )
         .unwrap();
         let result = tx.storage_root_index(BlockNumber::GENESIS).unwrap();
-        assert_eq!(result, Some(123.into()));
+        assert_eq!(result, Some(TrieStorageIndex::new(123).unwrap()));
         let result = tx.storage_root_index(BlockNumber::GENESIS + 1).unwrap();
-        assert_eq!(result, Some(456.into()));
+        assert_eq!(result, Some(TrieStorageIndex::new(456).unwrap()));
         let result = tx.storage_root_index(BlockNumber::GENESIS + 2).unwrap();
-        assert_eq!(result, Some(456.into()));
+        assert_eq!(result, Some(TrieStorageIndex::new(456).unwrap()));
 
         tx.insert_storage_root(
             BlockNumber::GENESIS + 10,
-            RootIndexUpdate::Updated(789.into()),
+            RootIndexUpdate::Updated(TrieStorageIndex::new(789).unwrap()),
         )
         .unwrap();
         let result = tx.storage_root_index(BlockNumber::GENESIS + 9).unwrap();
-        assert_eq!(result, Some(456.into()));
+        assert_eq!(result, Some(TrieStorageIndex::new(456).unwrap()));
         let result = tx.storage_root_index(BlockNumber::GENESIS + 10).unwrap();
-        assert_eq!(result, Some(789.into()));
+        assert_eq!(result, Some(TrieStorageIndex::new(789).unwrap()));
         let result = tx.storage_root_index(BlockNumber::GENESIS + 11).unwrap();
-        assert_eq!(result, Some(789.into()));
+        assert_eq!(result, Some(TrieStorageIndex::new(789).unwrap()));
 
         tx.insert_storage_root(BlockNumber::GENESIS + 12, RootIndexUpdate::TrieEmpty)
             .unwrap();
@@ -1107,7 +1066,7 @@ mod tests {
         tx.insert_contract_root(
             BlockNumber::GENESIS + 1,
             c2,
-            RootIndexUpdate::Updated(888.into()),
+            RootIndexUpdate::Updated(TrieStorageIndex::new(888).unwrap()),
         )
         .unwrap();
         let result1 = tx.contract_root_index(BlockNumber::GENESIS, c1).unwrap();
@@ -1124,7 +1083,7 @@ mod tests {
             .unwrap();
         let hash1 = tx.contract_root(BlockNumber::GENESIS + 1, c1).unwrap();
         assert_eq!(result1, Some(idx1));
-        assert_eq!(result2, Some(888.into()));
+        assert_eq!(result2, Some(TrieStorageIndex::new(888).unwrap()));
         assert_eq!(hash1, Some(root1));
         let result1 = tx
             .contract_root_index(BlockNumber::GENESIS + 2, c1)
@@ -1134,7 +1093,7 @@ mod tests {
             .unwrap();
         let hash1 = tx.contract_root(BlockNumber::GENESIS + 2, c1).unwrap();
         assert_eq!(result1, Some(idx1));
-        assert_eq!(result2, Some(888.into()));
+        assert_eq!(result2, Some(TrieStorageIndex::new(888).unwrap()));
         assert_eq!(hash1, Some(root1));
 
         let root2 = contract_root_bytes!(b"root 2");
@@ -1155,7 +1114,7 @@ mod tests {
         tx.insert_contract_root(
             BlockNumber::GENESIS + 11,
             c2,
-            RootIndexUpdate::Updated(999.into()),
+            RootIndexUpdate::Updated(TrieStorageIndex::new(999).unwrap()),
         )
         .unwrap();
         let result1 = tx
@@ -1166,7 +1125,7 @@ mod tests {
             .unwrap();
         let hash1 = tx.contract_root(BlockNumber::GENESIS + 9, c1).unwrap();
         assert_eq!(result1, Some(idx1));
-        assert_eq!(result2, Some(888.into()));
+        assert_eq!(result2, Some(TrieStorageIndex::new(888).unwrap()));
         assert_eq!(hash1, Some(root1));
         let result1 = tx
             .contract_root_index(BlockNumber::GENESIS + 10, c1)
@@ -1176,13 +1135,13 @@ mod tests {
             .unwrap();
         let hash1 = tx.contract_root(BlockNumber::GENESIS + 10, c1).unwrap();
         assert_eq!(result1, Some(idx2));
-        assert_eq!(result2, Some(888.into()));
+        assert_eq!(result2, Some(TrieStorageIndex::new(888).unwrap()));
         assert_eq!(hash1, Some(root2));
         let result2 = tx
             .contract_root_index(BlockNumber::GENESIS + 11, c2)
             .unwrap();
         let hash1 = tx.contract_root(BlockNumber::GENESIS + 11, c1).unwrap();
-        assert_eq!(result2, Some(999.into()));
+        assert_eq!(result2, Some(TrieStorageIndex::new(999).unwrap()));
         assert_eq!(hash1, Some(root2));
 
         tx.insert_contract_root(BlockNumber::GENESIS + 12, c1, RootIndexUpdate::TrieEmpty)
@@ -1652,7 +1611,10 @@ mod tests {
                 BlockNumber::GENESIS,
             )
             .unwrap();
-        assert_eq!(root_update, RootIndexUpdate::Updated(1.into()));
+        assert_eq!(
+            root_update,
+            RootIndexUpdate::Updated(TrieStorageIndex::new(1).unwrap())
+        );
     }
 
     #[test]
@@ -1665,17 +1627,20 @@ mod tests {
         .unwrap();
         let tx = db.transaction().unwrap();
 
-        tx.insert_class_root(BlockNumber::GENESIS, RootIndexUpdate::Updated(1.into()))
-            .unwrap();
+        tx.insert_class_root(
+            BlockNumber::GENESIS,
+            RootIndexUpdate::Updated(TrieStorageIndex::new(1).unwrap()),
+        )
+        .unwrap();
         tx.insert_class_root(
             BlockNumber::new_or_panic(1),
-            RootIndexUpdate::Updated(2.into()),
+            RootIndexUpdate::Updated(TrieStorageIndex::new(2).unwrap()),
         )
         .unwrap();
         // no root inserted for block 2
         tx.insert_class_root(
             BlockNumber::new_or_panic(3),
-            RootIndexUpdate::Updated(3.into()),
+            RootIndexUpdate::Updated(TrieStorageIndex::new(3).unwrap()),
         )
         .unwrap();
 
@@ -1696,11 +1661,14 @@ mod tests {
         .unwrap();
         let tx = db.transaction().unwrap();
 
-        tx.insert_class_root(BlockNumber::GENESIS, RootIndexUpdate::Updated(1.into()))
-            .unwrap();
+        tx.insert_class_root(
+            BlockNumber::GENESIS,
+            RootIndexUpdate::Updated(TrieStorageIndex::new(1).unwrap()),
+        )
+        .unwrap();
         tx.insert_class_root(
             BlockNumber::new_or_panic(1),
-            RootIndexUpdate::Updated(2.into()),
+            RootIndexUpdate::Updated(TrieStorageIndex::new(2).unwrap()),
         )
         .unwrap();
 
@@ -1794,17 +1762,20 @@ mod tests {
         .unwrap();
         let tx = db.transaction().unwrap();
 
-        tx.insert_storage_root(BlockNumber::GENESIS, RootIndexUpdate::Updated(1.into()))
-            .unwrap();
+        tx.insert_storage_root(
+            BlockNumber::GENESIS,
+            RootIndexUpdate::Updated(TrieStorageIndex::new(1).unwrap()),
+        )
+        .unwrap();
         tx.insert_storage_root(
             BlockNumber::new_or_panic(1),
-            RootIndexUpdate::Updated(2.into()),
+            RootIndexUpdate::Updated(TrieStorageIndex::new(2).unwrap()),
         )
         .unwrap();
         // no new root index for block 2
         tx.insert_storage_root(
             BlockNumber::new_or_panic(3),
-            RootIndexUpdate::Updated(3.into()),
+            RootIndexUpdate::Updated(TrieStorageIndex::new(3).unwrap()),
         )
         .unwrap();
 
@@ -1827,11 +1798,14 @@ mod tests {
         .unwrap();
         let tx = db.transaction().unwrap();
 
-        tx.insert_storage_root(BlockNumber::GENESIS, RootIndexUpdate::Updated(1.into()))
-            .unwrap();
+        tx.insert_storage_root(
+            BlockNumber::GENESIS,
+            RootIndexUpdate::Updated(TrieStorageIndex::new(1).unwrap()),
+        )
+        .unwrap();
         tx.insert_storage_root(
             BlockNumber::new_or_panic(1),
-            RootIndexUpdate::Updated(2.into()),
+            RootIndexUpdate::Updated(TrieStorageIndex::new(2).unwrap()),
         )
         .unwrap();
 
@@ -1855,20 +1829,20 @@ mod tests {
         tx.insert_contract_root(
             BlockNumber::GENESIS,
             contract,
-            RootIndexUpdate::Updated(1.into()),
+            RootIndexUpdate::Updated(TrieStorageIndex::new(1).unwrap()),
         )
         .unwrap();
         tx.insert_contract_root(
             BlockNumber::new_or_panic(1),
             contract,
-            RootIndexUpdate::Updated(2.into()),
+            RootIndexUpdate::Updated(TrieStorageIndex::new(2).unwrap()),
         )
         .unwrap();
         // no new root for block 2
         tx.insert_contract_root(
             BlockNumber::new_or_panic(3),
             contract,
-            RootIndexUpdate::Updated(3.into()),
+            RootIndexUpdate::Updated(TrieStorageIndex::new(3).unwrap()),
         )
         .unwrap();
 
@@ -1880,12 +1854,12 @@ mod tests {
         assert_eq!(
             tx.contract_root_index(BlockNumber::new_or_panic(2), contract)
                 .unwrap(),
-            Some(2.into())
+            Some(TrieStorageIndex::new(2).unwrap())
         );
         assert_eq!(
             tx.contract_root_index(BlockNumber::new_or_panic(3), contract)
                 .unwrap(),
-            Some(3.into())
+            Some(TrieStorageIndex::new(3).unwrap())
         );
     }
 
@@ -1903,13 +1877,13 @@ mod tests {
         tx.insert_contract_root(
             BlockNumber::GENESIS,
             contract,
-            RootIndexUpdate::Updated(1.into()),
+            RootIndexUpdate::Updated(TrieStorageIndex::new(1).unwrap()),
         )
         .unwrap();
         tx.insert_contract_root(
             BlockNumber::new_or_panic(1),
             contract,
-            RootIndexUpdate::Updated(2.into()),
+            RootIndexUpdate::Updated(TrieStorageIndex::new(2).unwrap()),
         )
         .unwrap();
 
@@ -1921,7 +1895,7 @@ mod tests {
         assert_eq!(
             tx.contract_root_index(BlockNumber::new_or_panic(1), contract)
                 .unwrap(),
-            Some(2.into())
+            Some(TrieStorageIndex::new(2).unwrap())
         );
     }
 }

--- a/crates/storage/src/params.rs
+++ b/crates/storage/src/params.rs
@@ -29,9 +29,7 @@ impl<Inner: ToSql> ToSql for Option<Inner> {
 
 impl ToSql for TrieStorageIndex {
     fn to_sql(&self) -> ToSqlOutput<'_> {
-        ToSqlOutput::Owned(Value::Integer(
-            i64::try_from(self.0).expect("TrieStorageIndex <= i64::MAX"),
-        ))
+        ToSqlOutput::Owned(Value::Integer(self.to_i64()))
     }
 }
 
@@ -318,7 +316,8 @@ pub trait RowExt {
     ) -> rusqlite::Result<TrieStorageIndex> {
         let idx = self.get_u64(index)?;
         // Always safe since get_u64 is capped at i64::MAX, just like TrieStorageIndex.
-        Ok(TrieStorageIndex(idx))
+        Ok(TrieStorageIndex::new(idx)
+            .expect("TrieStorageIndex is non-negative and within i64::MAX"))
     }
 
     fn get_optional_trie_storage_index<Index: RowIndex>(
@@ -328,7 +327,10 @@ pub trait RowExt {
         let idx = self.get_optional_u64(index)?;
         // Always safe since get_optional_u64 is capped at i64::MAX, just like
         // TrieStorageIndex.
-        Ok(idx.map(TrieStorageIndex))
+        Ok(idx.map(|idx| {
+            TrieStorageIndex::new(idx)
+                .expect("TrieStorageIndex is non-negative and within i64::MAX")
+        }))
     }
 
     row_felt_wrapper!(get_block_hash, BlockHash);


### PR DESCRIPTION
`TrieStorageIndex` should hold `0..i64::MAX` which stems from SQLite limitations. In practice the implementation allowed larger values.