### PR TITLE
perf(consensus): cache fetched validators

### DIFF
--- a/crates/pathfinder/src/consensus.rs
+++ b/crates/pathfinder/src/consensus.rs
@@ -7,6 +7,7 @@ mod integration_testing;
 mod p2p_task;
 mod proposal_validator;
 mod proposer_oracle;
+mod validator_cache;
 
 mod dummy_proposal;
 

--- a/crates/pathfinder/src/consensus/fetch_proposers.rs
+++ b/crates/pathfinder/src/consensus/fetch_proposers.rs
@@ -1,5 +1,4 @@
-use std::collections::BTreeMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use pathfinder_common::{ChainId, ContractAddress};
 use pathfinder_consensus::{PublicKey, SigningKey, Validator, ValidatorSet};
@@ -8,6 +7,7 @@ use pathfinder_storage::Storage;
 use rand::rngs::OsRng;
 
 use crate::config::ConsensusConfig;
+use crate::consensus::validator_cache::ValidatorCache;
 
 /// A proposer selector that fetches proposers from config or L2.
 #[derive(Clone)]
@@ -18,7 +18,7 @@ pub struct L2ProposerSelector {
     /// Memoized proposer sets keyed by height. `select_proposer` is invoked
     /// multiple times per height (once per round, once per incoming proposal),
     /// and the underlying L2 lookup is expensive, so we cache the result.
-    cache: Arc<RwLock<BTreeMap<u64, Arc<ValidatorSet<ContractAddress>>>>>,
+    cache: ValidatorCache,
 }
 
 impl L2ProposerSelector {
@@ -27,7 +27,7 @@ impl L2ProposerSelector {
             storage,
             chain_id,
             config,
-            cache: Arc::new(RwLock::new(BTreeMap::new())),
+            cache: ValidatorCache::default(),
         }
     }
 
@@ -37,34 +37,15 @@ impl L2ProposerSelector {
         &self,
         height: u64,
     ) -> Result<Arc<ValidatorSet<ContractAddress>>, anyhow::Error> {
-        if let Some(set) = self.cache.read().unwrap().get(&height).cloned() {
-            return Ok(set);
-        }
-
-        let fetched = Arc::new(fetch_proposers(
-            &self.storage,
-            self.chain_id,
-            height,
-            &self.config,
-        )?);
-
-        let mut cache = self.cache.write().unwrap();
-        // Another thread may have inserted between our read and write locks.
-        if let Some(existing) = cache.get(&height).cloned() {
-            return Ok(existing);
-        }
-        cache.insert(height, fetched.clone());
-
-        // Upper bound on the number of distinct heights whose
-        // proposer sets are kept in memory. Consensus advances
-        // monotonically, so when the cache is full we evict the
-        // smallest key, which approximates LRU for the expected
-        // workload.
+        // Upper bound on the number of distinct heights whose proposer sets
+        // are kept in memory. Consensus advances monotonically, so when the
+        // cache is full we evict the smallest key, which approximates LRU
+        // for the expected workload.
         let max_cached_heights = self.config.history_depth.try_into().unwrap_or(10);
-        while cache.len() > max_cached_heights {
-            cache.pop_first();
-        }
-        Ok(fetched)
+        self.cache
+            .get_or_insert_with(height, max_cached_heights, || {
+                fetch_proposers(&self.storage, self.chain_id, height, &self.config)
+            })
     }
 }
 
@@ -174,61 +155,4 @@ fn fetch_proposers_from_l2(
         })
         .collect::<Vec<Validator<ContractAddress>>>();
     Ok(ValidatorSet::new(proposers))
-}
-
-#[cfg(test)]
-mod tests {
-    use pathfinder_common::macro_prelude::*;
-    use pathfinder_common::StarknetVersion;
-    use pathfinder_storage::StorageBuilder;
-
-    use super::*;
-
-    fn selector() -> L2ProposerSelector {
-        let storage = StorageBuilder::in_memory().unwrap();
-        let proposer = contract_address!("0x1");
-        let config = ConsensusConfig {
-            my_starknet_version: StarknetVersion::default(),
-            my_validator_address: proposer,
-            validator_addresses: vec![proposer],
-            proposer_addresses: vec![proposer],
-            history_depth: 10,
-            l1_gas_price_tolerance: 0.0,
-            l1_gas_price_max_time_gap: 0,
-        };
-        L2ProposerSelector::new(storage, ChainId::SEPOLIA_TESTNET, config)
-    }
-
-    #[test]
-    fn repeat_lookup_at_same_height_hits_cache() {
-        let selector = selector();
-        let first = selector.proposer_set_at(42).unwrap();
-        let second = selector.proposer_set_at(42).unwrap();
-        // Same allocation proves the second call was served from the cache,
-        // not refetched.
-        assert!(Arc::ptr_eq(&first, &second));
-    }
-
-    #[test]
-    fn distinct_heights_get_distinct_entries() {
-        let selector = selector();
-        let a = selector.proposer_set_at(1).unwrap();
-        let b = selector.proposer_set_at(2).unwrap();
-        assert!(!Arc::ptr_eq(&a, &b));
-    }
-
-    #[test]
-    fn evicts_oldest_height_when_over_capacity() {
-        let selector = selector();
-        let zero_first = selector.proposer_set_at(0).unwrap();
-        let max_cached_heights = 10;
-        // Insert max_cached_heights more entries: at the last insertion the
-        // map size hits max_cached_heights + 1 and the smallest key (0) is
-        // evicted.
-        for h in 1..=max_cached_heights as u64 {
-            selector.proposer_set_at(h).unwrap();
-        }
-        let zero_again = selector.proposer_set_at(0).unwrap();
-        assert!(!Arc::ptr_eq(&zero_first, &zero_again));
-    }
 }

--- a/crates/pathfinder/src/consensus/fetch_validators.rs
+++ b/crates/pathfinder/src/consensus/fetch_validators.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use pathfinder_common::{ChainId, ContractAddress};
 use pathfinder_consensus::{PublicKey, SigningKey, Validator, ValidatorSet};
 use pathfinder_consensus_fetcher as consensus_fetcher;
@@ -5,12 +7,17 @@ use pathfinder_storage::Storage;
 use rand::rngs::OsRng;
 
 use crate::config::ConsensusConfig;
+use crate::consensus::validator_cache::ValidatorCache;
 
 #[derive(Clone)]
 pub struct L2ValidatorSetProvider {
     storage: Storage,
     chain_id: ChainId,
     config: ConsensusConfig,
+    /// Memoized validator sets keyed by height. Consensus repeatedly requests
+    /// validator sets while processing a height, and the underlying L2 lookup
+    /// is expensive, so we cache the result.
+    cache: ValidatorCache,
 }
 
 impl L2ValidatorSetProvider {
@@ -19,16 +26,32 @@ impl L2ValidatorSetProvider {
             storage,
             chain_id,
             config,
+            cache: ValidatorCache::default(),
         }
+    }
+
+    /// Returns the validator set for `height`, fetching from L2 only on a cache
+    /// miss.
+    fn validator_set_at(
+        &self,
+        height: u64,
+    ) -> Result<Arc<ValidatorSet<ContractAddress>>, anyhow::Error> {
+        // Upper bound on the number of distinct heights whose validator sets
+        // are kept in memory. Consensus advances monotonically, so when the
+        // cache is full we evict the smallest key, which approximates LRU for
+        // the expected workload.
+        let max_cached_heights = self.config.history_depth.try_into().unwrap_or(10);
+        self.cache
+            .get_or_insert_with(height, max_cached_heights, || {
+                fetch_validators(&self.storage, self.chain_id, height, &self.config)
+            })
     }
 }
 
 impl pathfinder_consensus::ValidatorSetProvider<ContractAddress> for L2ValidatorSetProvider {
-    fn get_validator_set(
-        &self,
-        height: u64,
-    ) -> Result<ValidatorSet<ContractAddress>, anyhow::Error> {
-        fetch_validators(&self.storage, self.chain_id, height, &self.config)
+    fn get_validator_set(&self, height: u64) -> anyhow::Result<ValidatorSet<ContractAddress>> {
+        self.validator_set_at(height)
+            .map(|vset| vset.as_ref().clone())
     }
 }
 

--- a/crates/pathfinder/src/consensus/validator_cache.rs
+++ b/crates/pathfinder/src/consensus/validator_cache.rs
@@ -1,0 +1,104 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, RwLock};
+
+use pathfinder_common::ContractAddress;
+use pathfinder_consensus::ValidatorSet;
+
+/// Height-keyed cache for consensus validator sets which are repeatedly fetched
+/// while a height is active.
+#[derive(Clone, Default)]
+pub(crate) struct ValidatorCache {
+    entries: Arc<RwLock<BTreeMap<u64, Arc<ValidatorSet<ContractAddress>>>>>,
+}
+
+impl ValidatorCache {
+    /// Returns the cached value for `height`, or fetches and stores it on a
+    /// cache miss.
+    pub(crate) fn get_or_insert_with(
+        &self,
+        height: u64,
+        max_cached_heights: usize,
+        fetch: impl FnOnce() -> anyhow::Result<ValidatorSet<ContractAddress>>,
+    ) -> anyhow::Result<Arc<ValidatorSet<ContractAddress>>> {
+        if let Some(value) = self.entries.read().unwrap().get(&height).cloned() {
+            return Ok(value);
+        }
+
+        let fetched = Arc::new(fetch()?);
+
+        let mut entries = self.entries.write().unwrap();
+        // Another thread may have inserted between our read and write locks.
+        if let Some(existing) = entries.get(&height).cloned() {
+            return Ok(existing);
+        }
+        entries.insert(height, fetched.clone());
+
+        // Consensus advances monotonically, so when the cache is full we evict
+        // the smallest key, which approximates LRU for the expected workload.
+        while entries.len() > max_cached_heights {
+            entries.pop_first();
+        }
+
+        Ok(fetched)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pathfinder_common::macro_prelude::*;
+    use pathfinder_consensus::{PublicKey, Validator};
+
+    use super::*;
+
+    fn validator_set(address: ContractAddress) -> ValidatorSet<ContractAddress> {
+        ValidatorSet::new([Validator {
+            address,
+            public_key: PublicKey::from_bytes([0; 32]),
+            voting_power: 1,
+        }])
+    }
+
+    fn cached_validator_set(
+        cache: &ValidatorCache,
+        height: u64,
+    ) -> Arc<ValidatorSet<ContractAddress>> {
+        cache
+            .get_or_insert_with(height, 10, || Ok(validator_set(contract_address!("0x1"))))
+            .unwrap()
+    }
+
+    #[test]
+    fn repeat_lookup_at_same_height_hits_cache() {
+        let cache = ValidatorCache::default();
+        let first = cached_validator_set(&cache, 42);
+        let second = cached_validator_set(&cache, 42);
+
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn distinct_heights_get_distinct_entries() {
+        let cache = ValidatorCache::default();
+        let a = cached_validator_set(&cache, 1);
+        let b = cached_validator_set(&cache, 2);
+
+        assert!(!Arc::ptr_eq(&a, &b));
+    }
+
+    #[test]
+    fn evicts_oldest_height_when_over_capacity() {
+        let cache = ValidatorCache::default();
+        let zero_first = cached_validator_set(&cache, 0);
+        let max_cached_heights = 10;
+
+        // Insert max_cached_heights more entries: at the last insertion the
+        // map size hits max_cached_heights + 1 and the smallest key (0) is
+        // evicted.
+        for h in 1..=max_cached_heights as u64 {
+            cached_validator_set(&cache, h);
+        }
+        let zero_again = cached_validator_set(&cache, 0);
+
+        assert!(!Arc::ptr_eq(&zero_first, &zero_again));
+    }
+}


### PR DESCRIPTION
Extract the height-keyed consensus `ValidatorSet` cache into a shared module. Use the cache when fetching validators in the same way it was used when fetching proposers.