### PR TITLE
chore: migrate Starknet docs URLs

### DIFF
--- a/crates/block-commitments/src/lib.rs
+++ b/crates/block-commitments/src/lib.rs
@@ -133,7 +133,7 @@ pub fn header_from_gateway_block(
 /// Verify the block hash value.
 ///
 /// The method to compute the block hash is documented
-/// [here](https://docs.starknet.io/architecture-and-concepts/network-architecture/block-structure/#block-hash).
+/// [here](https://docs.starknet.io/learn/protocol/blocks#block-hash).
 ///
 /// Unfortunately that'a not-fully-correct description, since the transaction
 /// commitment Merkle tree is not constructed directly with the transaction
@@ -683,7 +683,7 @@ pub fn calculate_event_commitment(
 
 /// Calculate the hash of a pre-v0.13.2 Starknet event.
 ///
-/// See the [documentation](https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/starknet-events/#event_hash)
+/// See the [documentation](https://docs.starknet.io/learn/protocol/blocks#event-hash)
 /// for details.
 fn calculate_event_hash_pre_0_13_2(event: &Event) -> Felt {
     let mut keys_hash = HashChain::default();

--- a/crates/class-hash/src/lib.rs
+++ b/crates/class-hash/src/lib.rs
@@ -53,7 +53,7 @@
 //! and includes extensive test vectors to ensure hash computation matches the
 //! network's expectations.
 //!
-//! See the [official Starknet documentation](https://docs.starknet.io/architecture-and-concepts/smart-contracts/class-hash/)
+//! See the [official Starknet documentation](https://docs.starknet.io/learn/protocol/cryptography#blake2s)
 //! for more details on class hash computation.
 
 use anyhow::{Context, Error, Result};
@@ -327,7 +327,7 @@ impl<'a> PreparedCairoContractDefinition<'a> {
 /// documentation][starknet-doc], but it's text explanations are much more
 /// complex than the actual implementation in `HashChain`.
 ///
-/// [starknet-doc]: https://docs.starknet.io/architecture-and-concepts/smart-contracts/class-hash/
+/// [starknet-doc]: https://docs.starknet.io/learn/protocol/cryptography#blake2s
 /// [cairo-compute]: https://github.com/starkware-libs/cairo-lang/blob/64a7f6aed9757d3d8d6c28bd972df73272b0cb0a/src/starkware/starknet/core/os/contract_hash.py
 /// [cairo-contract]: https://github.com/starkware-libs/cairo-lang/blob/64a7f6aed9757d3d8d6c28bd972df73272b0cb0a/src/starkware/starknet/core/os/contracts.cairo#L76-L118
 /// [py-sortkeys]: https://github.com/starkware-libs/cairo-lang/blob/64a7f6aed9757d3d8d6c28bd972df73272b0cb0a/src/starkware/starknet/core/os/contract_hash.py#L58-L71
@@ -550,7 +550,7 @@ pub fn prepare_json_contract_definition(
 /// Instead, ABI is handled as a string and all other relevant parts of the
 /// class definition are transformed into Felts and hashed using Poseidon.
 ///
-/// [starknet-doc]: https://docs.starknet.io/architecture-and-concepts/smart-contracts/class-hash/
+/// [starknet-doc]: https://docs.starknet.io/learn/protocol/cryptography#blake2s
 /// [cairo-compute]: https://github.com/starkware-libs/cairo-lang/blob/12ca9e91bbdc8a423c63280949c7e34382792067/src/starkware/starknet/core/os/contract_class/contract_class.cairo#L42
 pub fn compute_sierra_class_hash(
     contract_definition: json::SierraContractDefinition<'_>,

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -83,7 +83,7 @@ impl EntryPoint {
     /// Returns a new EntryPoint which has been truncated to fit from Keccak256
     /// digest of input.
     ///
-    /// See: <https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/contract-classes/>
+    /// See: <https://docs.starknet.io/learn/protocol/state#the-class-trie>
     pub fn hashed(input: &[u8]) -> Self {
         use sha3::Digest;
         EntryPoint(truncated_keccak(<[u8; 32]>::from(sha3::Keccak256::digest(
@@ -701,7 +701,7 @@ pub fn truncated_keccak(mut plain: [u8; 32]) -> Felt {
 
 /// Calculate class commitment tree leaf hash value.
 ///
-/// See: <https://docs.starknet.io/documentation/starknet_versions/upcoming_versions/#state_commitment>
+/// See: <https://docs.starknet.io/learn/protocol/state#state-commitment>
 pub fn calculate_class_commitment_leaf_hash(
     compiled_class_hash: CasmHash,
 ) -> ClassCommitmentLeafHash {

--- a/crates/common/src/state_update.rs
+++ b/crates/common/src/state_update.rs
@@ -612,7 +612,7 @@ mod state_diff_commitment {
 
     /// Compute the state diff commitment used in block commitment signatures.
     ///
-    /// How to compute the value is documented in the [Starknet documentation](https://docs.starknet.io/architecture-and-concepts/network-architecture/block-structure/#state_diff_hash).
+    /// How to compute the value is documented in the [Starknet documentation](https://docs.starknet.io/learn/protocol/blocks#state-diff-commitment).
     pub fn compute(
         contract_updates: &HashMap<ContractAddress, ContractUpdate>,
         system_contract_updates: &HashMap<ContractAddress, SystemContractUpdate>,

--- a/crates/merkle-tree/src/transaction.rs
+++ b/crates/merkle-tree/src/transaction.rs
@@ -13,7 +13,7 @@ use crate::tree::MerkleTree;
 /// single starknet block i.e. each block a new event / transaction
 /// tree is formed from an empty one.
 ///
-/// More information about these commitments can be found in the Starknet [documentation](https://docs.starknet.io/architecture-and-concepts/network-architecture/block-structure/#block_header_fields).
+/// More information about these commitments can be found in the Starknet [documentation](https://docs.starknet.io/learn/protocol/blocks#block-header-fields).
 pub struct TransactionOrEventTree<H: FeltHash> {
     tree: MerkleTree<H, 64>,
 }

--- a/crates/p2p_proto/proto/sync/header.proto
+++ b/crates/p2p_proto/proto/sync/header.proto
@@ -8,7 +8,7 @@ import "proto/sync/common.proto";
 // Note: commitments may change to be for the previous blocks like comet/tendermint
 // hash of block header sent to L1
 message SignedBlockHeader {
-    starknet.common.Hash block_hash = 1; //  For the structure of the block hash, see https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/header/#block_hash
+    starknet.common.Hash block_hash = 1; //  For the structure of the block hash, see https://docs.starknet.io/learn/protocol/blocks#block-hash
     starknet.common.Hash parent_hash = 2;
     uint64 number = 3; // This can be deduced from context. We can consider removing this field.
     uint64 time = 4; // Encoded in Unix time.

--- a/specs/rpc/v03/starknet_api_openrpc.json
+++ b/specs/rpc/v03/starknet_api_openrpc.json
@@ -2728,7 +2728,7 @@
                 "properties": {
                     "gas_consumed": {
                         "title": "Gas consumed",
-                        "description": "The Ethereum gas cost of the transaction (see https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/fee-mechanism/ for more info)",
+                        "description": "The Ethereum gas cost of the transaction (see https://docs.starknet.io/learn/protocol/fees for more info)",
                         "$ref": "#/components/schemas/NUM_AS_HEX"
                     },
                     "gas_price": {

--- a/specs/rpc/v04/starknet_api_openrpc.json
+++ b/specs/rpc/v04/starknet_api_openrpc.json
@@ -2954,7 +2954,7 @@
                 "properties": {
                     "gas_consumed": {
                         "title": "Gas consumed",
-                        "description": "The Ethereum gas cost of the transaction (see https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/fee-mechanism/ for more info)",
+                        "description": "The Ethereum gas cost of the transaction (see https://docs.starknet.io/learn/protocol/fees for more info)",
                         "$ref": "#/components/schemas/NUM_AS_HEX"
                     },
                     "gas_price": {

--- a/specs/rpc/v05/starknet_api_openrpc.json
+++ b/specs/rpc/v05/starknet_api_openrpc.json
@@ -3204,7 +3204,7 @@
                 "properties": {
                     "gas_consumed": {
                         "title": "Gas consumed",
-                        "description": "The Ethereum gas cost of the transaction (see https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/fee-mechanism/ for more info)",
+                        "description": "The Ethereum gas cost of the transaction (see https://docs.starknet.io/learn/protocol/fees for more info)",
                         "$ref": "#/components/schemas/NUM_AS_HEX"
                     },
                     "gas_price": {

--- a/specs/rpc/v06/starknet_api_openrpc.json
+++ b/specs/rpc/v06/starknet_api_openrpc.json
@@ -3655,7 +3655,7 @@
                 "properties": {
                     "gas_consumed": {
                         "title": "Gas consumed",
-                        "description": "The Ethereum gas cost of the transaction (see https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/fee-mechanism/ for more info)",
+                        "description": "The Ethereum gas cost of the transaction (see https://docs.starknet.io/learn/protocol/fees for more info)",
                         "$ref": "#/components/schemas/FELT"
                     },
                     "gas_price": {


### PR DESCRIPTION
Updates docs.starknet.io links to new paths/anchors per migration map.