### PR TITLE
doc(rpc): update specs to 0.10.3-rc.0

### DIFF
--- a/specs/rpc/v10/starknet_api_openrpc.json
+++ b/specs/rpc/v10/starknet_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.2",
+    "version": "0.10.3-rc.0",
     "title": "StarkNet Node API",
     "license": {}
   },
@@ -2392,8 +2392,7 @@
               "proof": {
                 "title": "Proof",
                 "description": "Optional proof for the transaction, as a base64 string-encoded byte array",
-                "type": "string",
-                "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$"
+                "$ref": "#/components/schemas/PROOF"
               }
             }
           }
@@ -2895,10 +2894,7 @@
               "proof_facts": {
                 "title": "Proof facts",
                 "description": "Proof facts for the transaction. An empty array is returned if no proof facts exist for the transaction",
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/FELT"
-                }
+                "$ref": "#/components/schemas/PROOF_FACTS"
               }
             },
             "required": [
@@ -4023,6 +4019,20 @@
             "type": "string"
           }
         ]
+      },
+      "PROOF": {
+        "title": "Proof",
+        "description": "A STARK proof, encoded as a base64 string of the underlying byte array.",
+        "type": "string",
+        "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$"
+      },
+      "PROOF_FACTS": {
+        "title": "Proof facts",
+        "description": "The set of proof facts (felt values) associated with a proven transaction.",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/FELT"
+        }
       }
     },
     "errors": {

--- a/specs/rpc/v10/starknet_executables.json
+++ b/specs/rpc/v10/starknet_executables.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0",
   "info": {
-    "version": "0.10.2",
+    "version": "0.10.3-rc.0",
     "title": "API for getting Starknet executables from nodes that store compiled artifacts",
     "license": {}
   },

--- a/specs/rpc/v10/starknet_metadata.json
+++ b/specs/rpc/v10/starknet_metadata.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0",
   "info": {
-    "version": "0.10.2",
+    "version": "0.10.3-rc.0",
     "title": "Starknet ABI specs"
   },
   "methods": [],

--- a/specs/rpc/v10/starknet_trace_api_openrpc.json
+++ b/specs/rpc/v10/starknet_trace_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.2",
+    "version": "0.10.3-rc.0",
     "title": "StarkNet Trace API",
     "license": {}
   },

--- a/specs/rpc/v10/starknet_write_api.json
+++ b/specs/rpc/v10/starknet_write_api.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.2",
+    "version": "0.10.3-rc.0",
     "title": "StarkNet Node Write API",
     "license": {}
   },

--- a/specs/rpc/v10/starknet_ws_api.json
+++ b/specs/rpc/v10/starknet_ws_api.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.3.2",
   "info": {
-    "version": "0.10.2",
+    "version": "0.10.3-rc.0",
     "title": "StarkNet WebSocket RPC API",
     "license": {}
   },


### PR DESCRIPTION
Due to the [pre-release](https://github.com/starkware-libs/starknet-specs/releases/tag/v0.10.3-rc.0).

No impact on functionality.
