### PR TITLE
feat(rpc): limit batch size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The limit for bytecode size in compilation is now defaulting to 81920 bytes and configurable with the new `--max-bytecode-size` CLI option.
 - Committed-block sync now fetches block, state update, and signature in a single feeder-gateway request. Requires a feeder gateway that supports `includeSignature` on `get_state_update`.
 - RPC request size and timeout limits are now configurable with `--rpc.request-max-size` and `--rpc.request-timeout` CLI options.
+- RPC request batch size is now configurable with `--rpc.batch-size-limit` CLI option.
 - The `blockifier` and `starknet_api` crates have been upgraded to 0.19.0-rc.0.
 
 ### Added

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -255,6 +255,7 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
     let rpc_config = pathfinder_rpc::context::RpcConfig {
         request_max_size: config.rpc_request_max_size,
         request_timeout: config.rpc_request_timeout,
+        batch_size_limit: config.rpc_batch_size_limit,
         batch_concurrency_limit: config.rpc_batch_concurrency_limit,
         disable_batch_requests: config.disable_batch_requests,
         get_events_event_filter_block_range_limit: config.get_events_event_filter_block_range_limit,

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -351,6 +351,14 @@ This should only be enabled for debugging purposes as it adds substantial proces
     verify_tree_node_data: bool,
 
     #[arg(
+        long = "rpc.batch-size-limit",
+        long_help = "Sets the maximum number of elements in a request batch.",
+        env = "PATHFINDER_RPC_BATCH_SIZE_LIMIT",
+        default_value = "100"
+    )]
+    rpc_batch_size_limit: NonZeroUsize,
+
+    #[arg(
         long = "rpc.batch-concurrency-limit",
         long_help = "Sets the concurrency limit for request batch processing. May lower the \
                      latency for large batches. ⚠ While the response order is eventually \
@@ -1128,6 +1136,7 @@ pub struct Config {
     pub preconfirmed_p2p: P2PPreconfirmedConfig,
     pub debug: DebugConfig,
     pub verify_tree_hashes: bool,
+    pub rpc_batch_size_limit: NonZeroUsize,
     pub rpc_batch_concurrency_limit: NonZeroUsize,
     pub disable_batch_requests: bool,
     pub is_sync_enabled: bool,
@@ -1431,6 +1440,7 @@ impl Config {
             preconfirmed_p2p: P2PPreconfirmedConfig::parse_or_exit(args.p2p_preconfirmed),
             debug: DebugConfig::parse(args.debug),
             verify_tree_hashes: args.verify_tree_node_data,
+            rpc_batch_size_limit: args.rpc_batch_size_limit,
             rpc_batch_concurrency_limit: args.rpc_batch_concurrency_limit,
             disable_batch_requests: args.disable_batch_requests,
             is_sync_enabled: args.is_sync_enabled,

--- a/crates/rpc/src/context.rs
+++ b/crates/rpc/src/context.rs
@@ -69,6 +69,7 @@ impl EthContractAddresses {
 pub struct RpcConfig {
     pub request_max_size: NonZeroUsize,
     pub request_timeout: Duration,
+    pub batch_size_limit: NonZeroUsize,
     pub batch_concurrency_limit: NonZeroUsize,
     pub disable_batch_requests: bool,
     pub get_events_event_filter_block_range_limit: NonZeroUsize,
@@ -252,6 +253,7 @@ impl RpcContext {
         let config = RpcConfig {
             request_max_size: NonZeroUsize::new(10 * 1024 * 1024).unwrap(),
             request_timeout: Duration::from_secs(120),
+            batch_size_limit: NonZeroUsize::new(100).unwrap(),
             batch_concurrency_limit: NonZeroUsize::new(8).unwrap(),
             disable_batch_requests: false,
             get_events_event_filter_block_range_limit: NonZeroUsize::new(1000).unwrap(),

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -682,8 +682,7 @@ mod tests {
         /// Builds the spec router with a custom maximum batch size.
         fn spec_router_with_batch_limit(limit: usize) -> RpcRouter {
             let mut router = spec_router();
-            router.context.config.batch_size_limit =
-                std::num::NonZeroUsize::new(limit).unwrap();
+            router.context.config.batch_size_limit = std::num::NonZeroUsize::new(limit).unwrap();
             router
         }
 
@@ -716,8 +715,7 @@ mod tests {
             let response =
                 serve_and_query(spec_router_with_batch_limit(LIMIT), at_limit.clone()).await;
             assert_eq!(response, expected);
-            let response =
-                serve_and_query_ws(spec_router_with_batch_limit(LIMIT), at_limit).await;
+            let response = serve_and_query_ws(spec_router_with_batch_limit(LIMIT), at_limit).await;
             assert_eq!(response, expected);
 
             // A batch with one request over the limit is rejected.
@@ -729,9 +727,7 @@ mod tests {
                 assert_eq!(error["code"], json!(-32700));
                 assert_eq!(error["message"], json!("Parse error"));
                 let reason = error["data"]["reason"].as_str().unwrap();
-                assert!(
-                    reason.starts_with(&format!("array exceeds maximum length {LIMIT}"))
-                );
+                assert!(reason.starts_with(&format!("array exceeds maximum length {LIMIT}")));
             };
 
             assert_rejected(

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -678,6 +678,69 @@ mod tests {
             let res: serde_json::Value = serde_json::from_str(&response).unwrap();
             assert_eq!(res, expected);
         }
+
+        /// Builds the spec router with a custom maximum batch size.
+        fn spec_router_with_batch_limit(limit: usize) -> RpcRouter {
+            let mut router = spec_router();
+            router.context.config.batch_size_limit =
+                std::num::NonZeroUsize::new(limit).unwrap();
+            router
+        }
+
+        #[tokio::test]
+        async fn batch_size_limit_is_enforced() {
+            const LIMIT: usize = 2;
+
+            let request = |count: usize| {
+                Value::Array(
+                    (0..count)
+                        .map(|id| {
+                            json!({
+                                "jsonrpc": "2.0",
+                                "method": "subtract",
+                                "params": [42, 23],
+                                "id": id,
+                            })
+                        })
+                        .collect(),
+                )
+            };
+
+            // A batch at the limit succeeds.
+            let at_limit = request(LIMIT);
+            let expected = Value::Array(
+                (0..LIMIT)
+                    .map(|id| json!({"jsonrpc": "2.0", "result": 19, "id": id}))
+                    .collect(),
+            );
+            let response =
+                serve_and_query(spec_router_with_batch_limit(LIMIT), at_limit.clone()).await;
+            assert_eq!(response, expected);
+            let response =
+                serve_and_query_ws(spec_router_with_batch_limit(LIMIT), at_limit).await;
+            assert_eq!(response, expected);
+
+            // A batch with one request over the limit is rejected.
+            let over_limit = request(LIMIT + 1);
+            let assert_rejected = |response: Value| {
+                let error = &response["error"];
+                assert_eq!(response["jsonrpc"], json!("2.0"));
+                assert_eq!(response["id"], Value::Null);
+                assert_eq!(error["code"], json!(-32700));
+                assert_eq!(error["message"], json!("Parse error"));
+                let reason = error["data"]["reason"].as_str().unwrap();
+                assert!(
+                    reason.starts_with(&format!("array exceeds maximum length {LIMIT}"))
+                );
+            };
+
+            assert_rejected(
+                serve_and_query(spec_router_with_batch_limit(LIMIT), over_limit.clone()).await,
+            );
+            assert_rejected(
+                serve_and_query_ws(spec_router_with_batch_limit(LIMIT), over_limit).await,
+            );
+        }
     }
 
     mod panic_handling {

--- a/crates/rpc/src/jsonrpc/router/method.rs
+++ b/crates/rpc/src/jsonrpc/router/method.rs
@@ -4,6 +4,8 @@ use std::future::Future;
 use std::marker::PhantomData;
 
 use async_trait::async_trait;
+use pathfinder_serde::AsBoundedVec;
+use serde::de::DeserializeSeed as _;
 use serde_json::value::RawValue;
 use tracing::Instrument;
 
@@ -67,12 +69,16 @@ pub async fn handle_json_rpc_body(
             ));
         }
 
-        let requests = match serde_json::from_str::<Vec<&RawValue>>(body) {
-            Ok(requests) => requests,
-            Err(e) => {
-                return Err(RpcRequestError::ParseError(e.to_string()));
-            }
-        };
+        let as_bounded_vec =
+            AsBoundedVec::<&RawValue>::new(state.context.config.batch_size_limit.get());
+
+        let requests =
+            match as_bounded_vec.deserialize(&mut serde_json::Deserializer::from_str(body)) {
+                Ok(requests) => requests,
+                Err(e) => {
+                    return Err(RpcRequestError::ParseError(e.to_string()));
+                }
+            };
 
         if requests.is_empty() {
             return Err(RpcRequestError::InvalidRequest(

--- a/crates/rpc/src/jsonrpc/router/subscription.rs
+++ b/crates/rpc/src/jsonrpc/router/subscription.rs
@@ -7,6 +7,8 @@ use axum::extract::ws::{close_code, CloseFrame, Message, Utf8Bytes, WebSocket};
 use dashmap::DashMap;
 use futures::{SinkExt, StreamExt};
 use pathfinder_common::BlockNumber;
+use pathfinder_serde::AsBoundedVec;
+use serde::de::DeserializeSeed as _;
 use serde_json::value::RawValue;
 use tokio::sync::{mpsc, RwLock};
 use tracing::Instrument;
@@ -581,7 +583,11 @@ pub fn handle_json_rpc_socket(
                 }
             } else {
                 // Batch request.
-                let requests = match serde_json::from_str::<Vec<&RawValue>>(request) {
+                let as_bounded_vec =
+                    AsBoundedVec::<&RawValue>::new(state.context.config.batch_size_limit.get());
+                let requests = match as_bounded_vec
+                    .deserialize(&mut serde_json::Deserializer::from_str(request))
+                {
                     Ok(requests) => requests,
                     Err(e) => {
                         if let Err(e) = ws_tx

--- a/crates/serde/src/lib.rs
+++ b/crates/serde/src/lib.rs
@@ -2,11 +2,14 @@
 //! data.
 
 use std::borrow::Cow;
+use std::fmt;
+use std::marker::PhantomData;
 
 use pathfinder_common::prelude::*;
 use pathfinder_crypto::{Felt, HexParseError};
 use primitive_types::{H160, H256, U256};
-use serde::de::Visitor;
+use serde::de::{self, DeserializeSeed, SeqAccess, Visitor};
+use serde::Deserialize;
 use serde_with::{serde_conv, DeserializeAs, SerializeAs};
 
 serde_conv!(
@@ -460,6 +463,73 @@ pub fn extract_program_and_entry_points_by_type(
     ))
 }
 
+pub struct AsBoundedVec<T> {
+    pub max_len: usize,
+    _marker: PhantomData<T>,
+}
+
+impl<T> AsBoundedVec<T> {
+    pub fn new(max_len: usize) -> Self {
+        Self {
+            max_len,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'de, T> DeserializeSeed<'de> for AsBoundedVec<T>
+where
+    T: Deserialize<'de>,
+{
+    type Value = Vec<T>;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Vec<T>, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct BoundedVecVisitor<T> {
+            max_len: usize,
+            _marker: PhantomData<T>,
+        }
+
+        impl<'de, T> Visitor<'de> for BoundedVecVisitor<T>
+        where
+            T: Deserialize<'de>,
+        {
+            type Value = Vec<T>;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "an array with at most {} elements", self.max_len)
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Vec<T>, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut vec = Vec::new();
+
+                while let Some(item) = seq.next_element::<T>()? {
+                    if vec.len() >= self.max_len {
+                        return Err(de::Error::custom(format!(
+                            "array exceeds maximum length {}",
+                            self.max_len
+                        )));
+                    }
+
+                    vec.push(item);
+                }
+
+                Ok(vec)
+            }
+        }
+
+        deserializer.deserialize_seq(BoundedVecVisitor {
+            max_len: self.max_len,
+            _marker: PhantomData,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
@@ -663,5 +733,26 @@ mod tests {
                 assert!(e.is_data(), "{e:?}");
             });
         }
+    }
+
+    #[test]
+    fn as_bounded_vec_accepts_items_up_to_the_limit() {
+        let json = r#"[1,2]"#;
+        let seed = AsBoundedVec::<u32>::new(2);
+        let mut de = serde_json::Deserializer::from_str(json);
+        assert_eq!(seed.deserialize(&mut de).unwrap(), vec![1, 2]);
+    }
+
+    #[test]
+    fn as_bounded_vec_rejects_too_many_items() {
+        let json = r#"[1,2,3]"#;
+        let seed = AsBoundedVec::<u32>::new(2);
+        let mut de = serde_json::Deserializer::from_str(json);
+        let error = seed.deserialize(&mut de).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "array exceeds maximum length 2 at line 1 column 7"
+        );
     }
 }

--- a/crates/serde/src/lib.rs
+++ b/crates/serde/src/lib.rs
@@ -498,7 +498,7 @@ where
         {
             type Value = Vec<T>;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(f, "an array with at most {} elements", self.max_len)
             }
 


### PR DESCRIPTION
Even though we do cap the max size of the request, we don't cap the number of requests per batch. This PR fixes that.