### PR TITLE
fix: per-connection subscription limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Committed-block sync now fetches block, state update, and signature in a single feeder-gateway request. Requires a feeder gateway that supports `includeSignature` on `get_state_update`.
 - RPC request size and timeout limits are now configurable with `--rpc.request-max-size` and `--rpc.request-timeout` CLI options.
 
+### Added
+
+- Parallel subscriptions on a single WS connection are now limited to 1024 by default, configurable with `--rpc.websocket.max-subscriptions` CLI option.
+
 ## [0.22.3] - 2026-04-20
 
 ### Changed

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -288,7 +288,10 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
     );
 
     let context = if config.websocket.enabled {
-        context.with_websockets(WebsocketContext::new(config.websocket.max_history.into()))
+        context.with_websockets(WebsocketContext::new(
+            config.websocket.max_history.into(),
+            config.websocket.max_subscriptions.get(),
+        ))
     } else {
         context
     };

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -1490,6 +1490,13 @@ pub struct WebsocketConfig {
         env = "PATHFINDER_WEBSOCKET_MAX_HISTORY"
     )]
     pub max_history: WebsocketHistory,
+    #[arg(
+        long = "rpc.websocket.max-subscriptions",
+        long_help = "Sets the limit for the number of subscriptions per connection.",
+        default_value = "1024",
+        env = "PATHFINDER_WEBSOCKET_MAX_SUBSCRIPTIONS"
+    )]
+    pub max_subscriptions: NonZeroUsize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -512,7 +512,7 @@ mod tests {
                 }
             }
 
-            let ws_ctx = WebsocketContext::new(WebsocketHistory::Unlimited);
+            let ws_ctx = WebsocketContext::new(WebsocketHistory::Unlimited, 1024);
             RpcRouter::builder(RpcVersion::default())
                 .register("subtract", subtract)
                 .register("sum", sum)
@@ -693,7 +693,7 @@ mod tests {
                 "Success"
             }
 
-            let ws_ctx = WebsocketContext::new(WebsocketHistory::Unlimited);
+            let ws_ctx = WebsocketContext::new(WebsocketHistory::Unlimited, 1024);
             RpcRouter::builder(Default::default())
                 .register("panic", always_panic)
                 .register("success", always_success)

--- a/crates/rpc/src/jsonrpc/router/subscription.rs
+++ b/crates/rpc/src/jsonrpc/router/subscription.rs
@@ -54,6 +54,10 @@ impl Subscriptions {
         self.subscriptions.contains_key(subscription_id)
     }
 
+    pub fn len(&self) -> usize {
+        self.subscriptions.len()
+    }
+
     pub fn insert(
         &self,
         subscription_id: SubscriptionId,
@@ -729,6 +733,22 @@ async fn handle_request(
 
     let params = serde_json::to_value(rpc_request.params)
         .map_err(|e| RpcResponse::invalid_params(req_id.clone(), e.to_string(), state.version))?;
+
+    let max_subscriptions = state
+        .context
+        .websocket
+        .as_ref()
+        .map(|ws_cfg| ws_cfg.max_subscriptions)
+        .ok_or_else(|| {
+            // handle_request should be called only when WS is enabled
+            RpcResponse::internal_error(req_id.clone(), "WS disabled".to_string(), state.version)
+        })?;
+    if subscriptions.len() >= max_subscriptions {
+        return Err(RpcResponse::invalid_request(
+            "Too many subscriptions".to_string(),
+            state.version,
+        ));
+    }
 
     // Start the subscription.
     let router = state.clone();
@@ -1460,7 +1480,7 @@ mod tests {
             .with_storage(storage)
             .with_notifications(notifications)
             .with_pending_data_cache(pending_data_cache.clone())
-            .with_websockets(WebsocketContext::new(websocket_history));
+            .with_websockets(WebsocketContext::new(websocket_history, 1024));
 
         RpcRouter::builder(crate::RpcVersion::V08)
             .register("test", endpoint)

--- a/crates/rpc/src/jsonrpc/websocket.rs
+++ b/crates/rpc/src/jsonrpc/websocket.rs
@@ -39,10 +39,14 @@ pub enum WebsocketHistory {
 #[derive(Clone)]
 pub struct WebsocketContext {
     pub max_history: WebsocketHistory,
+    pub max_subscriptions: usize,
 }
 
 impl WebsocketContext {
-    pub fn new(max_history: WebsocketHistory) -> Self {
-        Self { max_history }
+    pub fn new(max_history: WebsocketHistory, max_subscriptions: usize) -> Self {
+        Self {
+            max_history,
+            max_subscriptions,
+        }
     }
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1603,6 +1603,7 @@ mod tests {
         if api.has_websocket() {
             context = context.with_websockets(context::WebsocketContext::new(
                 WebsocketHistory::Unlimited,
+                1024,
             ));
         }
         let (_jh, addr) = RpcServer::new(addr, context, RpcVersion::V07)

--- a/crates/rpc/src/method/subscribe_events.rs
+++ b/crates/rpc/src/method/subscribe_events.rs
@@ -1268,7 +1268,7 @@ mod tests {
             .with_storage(storage)
             .with_notifications(notifications)
             .with_pending_data_cache(pending_data_cache.clone())
-            .with_websockets(WebsocketContext::new(WebsocketHistory::Unlimited));
+            .with_websockets(WebsocketContext::new(WebsocketHistory::Unlimited, 1024));
         match version {
             RpcVersion::V06 => (v06::register_routes().build(ctx), pending_data_cache),
             RpcVersion::V07 => (v07::register_routes().build(ctx), pending_data_cache),

--- a/crates/rpc/src/method/subscribe_new_heads.rs
+++ b/crates/rpc/src/method/subscribe_new_heads.rs
@@ -544,7 +544,7 @@ mod tests {
             .with_storage(storage)
             .with_notifications(notifications)
             .with_pending_data_cache(pending_data_cache.clone())
-            .with_websockets(WebsocketContext::new(WebsocketHistory::Unlimited));
+            .with_websockets(WebsocketContext::new(WebsocketHistory::Unlimited, 1024));
         v08::register_routes().build(ctx)
     }
 

--- a/crates/rpc/src/method/subscribe_new_transaction_receipts.rs
+++ b/crates/rpc/src/method/subscribe_new_transaction_receipts.rs
@@ -1008,7 +1008,7 @@ mod tests {
             .with_storage(storage)
             .with_notifications(notifications.clone())
             .with_pending_data_cache(pending_data_cache.clone())
-            .with_websockets(WebsocketContext::new(WebsocketHistory::Unlimited));
+            .with_websockets(WebsocketContext::new(WebsocketHistory::Unlimited, 1024));
         let router = v09::register_routes().build(ctx);
         let (sender_tx, sender_rx) = mpsc::channel(1024);
         let (receiver_tx, receiver_rx) = mpsc::channel(1024);

--- a/crates/rpc/src/method/subscribe_new_transactions.rs
+++ b/crates/rpc/src/method/subscribe_new_transactions.rs
@@ -1607,7 +1607,7 @@ mod tests {
             .with_storage(storage)
             .with_notifications(notifications.clone())
             .with_pending_data_cache(pending_data_cache.clone())
-            .with_websockets(WebsocketContext::new(WebsocketHistory::Unlimited));
+            .with_websockets(WebsocketContext::new(WebsocketHistory::Unlimited, 1024));
         let submission_tracker = ctx.submission_tracker.clone();
         let router = v10::register_routes().build(ctx);
         let (sender_tx, sender_rx) = mpsc::channel(1024);

--- a/crates/rpc/src/method/subscribe_transaction_status.rs
+++ b/crates/rpc/src/method/subscribe_transaction_status.rs
@@ -1736,7 +1736,7 @@ mod tests {
         let ctx = RpcContext::for_tests()
             .with_storage(storage)
             .with_pending_data_cache(pending_data_cache.clone())
-            .with_websockets(WebsocketContext::new(WebsocketHistory::Unlimited));
+            .with_websockets(WebsocketContext::new(WebsocketHistory::Unlimited, 1024));
         (v08::register_routes().build(ctx), pending_data_cache)
     }
 }


### PR DESCRIPTION
Limit parallel subscriptions on a single WS connection.
