### PR TITLE
feat(pending-data/cache): introduce `Unavailable` state

### DIFF
--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -1114,16 +1114,23 @@ mod tests {
         let (_, rx_current) = watch::channel((latest_block_number, our_latest_hash));
 
         let sequencer = Arc::new(sequencer);
-        let _jh = tokio::spawn(async move {
-            super::poll_pre_confirmed(
-                tx,
-                sequencer,
-                std::time::Duration::ZERO,
-                Arc::new(PendingDataCache::new()),
-                rx_latest,
-                rx_current,
-            )
-            .await
+        // Pre-stale the cache so the lower-height branch's `mark_fresh()` is
+        // observable: without it the cache would stay stale.
+        let cache = Arc::new(PendingDataCache::new());
+        cache.mark_stale();
+        let _jh = tokio::spawn({
+            let cache = cache.clone();
+            async move {
+                super::poll_pre_confirmed(
+                    tx,
+                    sequencer,
+                    std::time::Duration::ZERO,
+                    cache,
+                    rx_latest,
+                    rx_current,
+                )
+                .await
+            }
         });
 
         let first = tokio::time::timeout(TEST_TIMEOUT, rx.recv())
@@ -1140,6 +1147,90 @@ mod tests {
             result.is_err(),
             "No event should be emitted for a backwards-resolved height"
         );
+
+        // The lower-height skip keeps the cache serviceable via `mark_fresh()`,
+        // rather than marking it unavailable.
+        assert!(
+            cache.try_read().is_some(),
+            "lower-height skip should mark the cache fresh, not leave it stale or unavailable"
+        );
+    }
+
+    /// While catching up to head, the loop marks the cache unavailable so reads
+    /// fail fast with "syncing" instead of blocking on the cold-start
+    /// timeout.
+    #[tokio::test(start_paused = true)]
+    async fn syncing_marks_cache_unavailable() {
+        // latest far ahead of current: the catch-up branch runs and never
+        // fetches, so an expectation-free mock gateway is fine.
+        let sequencer = Arc::new(MockGatewayApi::new());
+        let hash = block_hash!("0xabcd");
+        let (_tx_latest, latest) = watch::channel((BlockNumber::new_or_panic(100), hash));
+        let (_tx_current, current) = watch::channel((BlockNumber::new_or_panic(0), hash));
+
+        let cache = Arc::new(PendingDataCache::new());
+        let (tx, _rx) = tokio::sync::mpsc::channel(8);
+        let _jh = tokio::spawn({
+            let cache = cache.clone();
+            async move {
+                super::poll_pre_confirmed(
+                    tx,
+                    sequencer,
+                    std::time::Duration::from_secs(1),
+                    cache,
+                    latest,
+                    current,
+                )
+                .await
+            }
+        });
+
+        // Hand the loop a turn to reach the catch-up branch (virtual time).
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let err = cache.read().await.unwrap_err();
+        assert!(err.to_string().contains("syncing"), "got: {err}");
+    }
+
+    /// A failed pre-confirmed fetch marks the cache unavailable with
+    /// "gateway error", so reads fail fast rather than blocking.
+    #[tokio::test(start_paused = true)]
+    async fn gateway_error_marks_cache_unavailable() {
+        use starknet_gateway_types::error::SequencerError;
+
+        // In sync (latest == current) so the loop reaches the fetch, which fails.
+        let mut sequencer = MockGatewayApi::new();
+        sequencer
+            .expect_preconfirmed_block()
+            .returning(|_, _, _| Err(SequencerError::InvalidResponse("boom".into())));
+        let sequencer = Arc::new(sequencer);
+
+        let hash = block_hash!("0xabcd");
+        let number = BlockNumber::new_or_panic(10);
+        let (_tx_latest, latest) = watch::channel((number, hash));
+        let (_tx_current, current) = watch::channel((number, hash));
+
+        let cache = Arc::new(PendingDataCache::new());
+        let (tx, _rx) = tokio::sync::mpsc::channel(8);
+        let _jh = tokio::spawn({
+            let cache = cache.clone();
+            async move {
+                super::poll_pre_confirmed(
+                    tx,
+                    sequencer,
+                    std::time::Duration::from_secs(1),
+                    cache,
+                    latest,
+                    current,
+                )
+                .await
+            }
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let err = cache.read().await.unwrap_err();
+        assert!(err.to_string().contains("gateway error"), "got: {err}");
     }
 
     /// When the chain advances past the pre-confirmed block we're tracking,

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -150,6 +150,7 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
                 latest = %latest_number.get(), current = %current_number,
                 "Not in sync yet; skipping pre-confirmed block download"
             );
+            cache.mark_unavailable("syncing");
             wait_for_next_poll(t_fetch + poll_interval, &cache).await;
             continue;
         }
@@ -168,6 +169,7 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
             Ok(r) => r,
             Err(err) => {
                 tracing::debug!(%err, "Failed to fetch pre-confirmed block");
+                cache.mark_unavailable("gateway error");
                 wait_for_next_poll(t_fetch + poll_interval, &cache).await;
                 continue;
             }
@@ -190,6 +192,8 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
                     current = %state.block_number,
                     "Pre-confirmed resolved to a lower height than tracked; skipping poll"
                 );
+                // We assume this is just a hiccup and trust our tracked block
+                cache.mark_fresh();
                 wait_for_next_poll(t_fetch + poll_interval, &cache).await;
                 continue;
             }

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -233,7 +233,7 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
         // Publish. Each branch is responsible for signalling cache freshness:
         //   - changed: the emitted event leads to a `cache.store(...)` call, which
         //     bumps freshness as a side effect.
-        //   - unchanged: nothing is emitted, so we call `cache.refresh()` here to
+        //   - unchanged: nothing is emitted, so we call `cache.mark_fresh()` here to
         //     unblock cold-start readers with the existing cache contents.
         if state.apply(response, pre_latest_data.is_some()) {
             let accumulated = state
@@ -254,7 +254,7 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
             }
         } else {
             tracing::trace!("No change in pre-confirmed block data");
-            cache.refresh();
+            cache.mark_fresh();
         }
 
         // Wait for the next tick.

--- a/crates/pending-data/src/cache.rs
+++ b/crates/pending-data/src/cache.rs
@@ -65,8 +65,8 @@ impl PendingDataCache {
         self.bump_freshness();
     }
 
-    /// Marks the cache fresh without changing its contents.
-    pub fn refresh(&self) {
+    /// Marks the cache fresh without replacing its contents.
+    pub fn mark_fresh(&self) {
         self.bump_freshness();
     }
 
@@ -222,12 +222,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn refresh_does_not_notify_subscribers() {
+    async fn mark_fresh_does_not_notify_subscribers() {
         let cache = PendingDataCache::new();
         let mut rx = cache.subscribe();
         let _ = rx.borrow_and_update();
 
-        cache.refresh();
+        cache.mark_fresh();
 
         assert!(timeout(Duration::from_millis(50), rx.changed())
             .await
@@ -286,7 +286,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(30)).await;
         assert!(!reader.is_finished());
 
-        cache.refresh();
+        cache.mark_fresh();
 
         let got = timeout(Duration::from_millis(100), reader)
             .await
@@ -346,10 +346,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn refresh_after_idle_clears_stale() {
+    async fn mark_fresh_after_idle_clears_stale() {
         let cache = PendingDataCache::new().with_cold_start_timeout(Duration::from_millis(50));
         cache.mark_stale();
-        cache.refresh();
+        cache.mark_fresh();
 
         timeout(Duration::from_millis(20), cache.read())
             .await
@@ -371,7 +371,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(30)).await;
         assert!(!reader.is_finished());
 
-        cache.refresh();
+        cache.mark_fresh();
         timeout(Duration::from_millis(100), reader)
             .await
             .expect("reader should unblock")

--- a/crates/pending-data/src/cache.rs
+++ b/crates/pending-data/src/cache.rs
@@ -6,18 +6,33 @@ use tokio::time::Instant;
 
 use crate::data::PendingData;
 
+/// Status of the cached pending data.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum Status {
+    /// The data is current.
+    #[default]
+    Fresh,
+    /// The data may be out of date.
+    Stale,
+    /// Fresh data cannot be produced right now; the string carries the reason.
+    Unavailable(&'static str),
+}
+
+/// The cache's freshness: its current [`Status`] plus a publish counter.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 struct Freshness {
-    stale: bool,
-    refresh_count: u64,
+    status: Status,
+    /// Monotonic count of publishes (`store` / `mark_fresh`).
+    publish_seq: u64,
 }
 
 /// Shared pre-confirmed data cache with freshness tracking.
 ///
 /// Holds the latest [`PendingData`] and a small amount of freshness state.
-/// - Writes via [`Self::store`] / [`Self::refresh`] / [`Self::mark_stale`].
-/// - Reads via [`Self::read`] (blocks if stale, then returns fresh data) and
-///   [`Self::subscribe`] for streaming.
+/// - Writes via [`Self::store`] / [`Self::mark_fresh`] / [`Self::mark_stale`] /
+///   [`Self::mark_unavailable`].
+/// - Reads via [`Self::read`] (returns fresh data, blocks while stale, fails
+///   fast while unavailable) and [`Self::subscribe`] for streaming.
 pub struct PendingDataCache {
     data_tx: watch::Sender<PendingData>,
     data_rx: watch::Receiver<PendingData>,
@@ -70,15 +85,29 @@ impl PendingDataCache {
         self.bump_freshness();
     }
 
-    /// Marks the cache stale; subsequent [`Self::read`] calls block until
-    /// the next [`Self::store`] / [`Self::refresh`] or a timeout elapses.
+    /// Marks the cache stale; subsequent [`Self::read`] calls block until the
+    /// next [`Self::store`] / [`Self::mark_fresh`] or a timeout elapses. Only
+    /// moves `Fresh → Stale` — it never downgrades `Unavailable`.
     pub fn mark_stale(&self) {
         self.freshness_tx.send_if_modified(|f| {
-            if !f.stale {
-                f.stale = true;
-                return true;
+            if matches!(f.status, Status::Fresh) {
+                f.status = Status::Stale;
+                true
+            } else {
+                false
             }
-            false
+        });
+    }
+
+    /// Marks the cache unavailable; reads fail fast with `reason` until the
+    /// next [`Self::store`] / [`Self::mark_fresh`].
+    pub fn mark_unavailable(&self, reason: &'static str) {
+        self.freshness_tx.send_if_modified(|f| match f.status {
+            Status::Unavailable(existing) if existing == reason => false,
+            _ => {
+                f.status = Status::Unavailable(reason);
+                true
+            }
         });
     }
 
@@ -87,8 +116,9 @@ impl PendingDataCache {
         self.on_read.notified().await;
     }
 
-    /// Returns the latest cached data. Blocks while the cache is stale,
-    /// up to the configured cold-start timeout. Always fires the read signal.
+    /// Returns the latest cached data. Returns immediately when fresh, fails
+    /// fast with the reason when unavailable, and blocks while stale (up to the
+    /// configured cold-start timeout). Always fires the read signal.
     pub async fn read(&self) -> anyhow::Result<PendingData> {
         self.signal_read();
         self.wait_for_fresh_data().await?;
@@ -99,10 +129,10 @@ impl PendingDataCache {
     /// Fast path (non-blocking). Always fires the read signal.
     pub fn try_read(&self) -> Option<PendingData> {
         self.signal_read();
-        if self.freshness_tx.borrow().stale {
-            return None;
+        match self.freshness_tx.borrow().status {
+            Status::Fresh => Some(self.data_rx.borrow().clone()),
+            Status::Stale | Status::Unavailable(_) => None,
         }
-        Some(self.data_rx.borrow().clone())
     }
 
     /// A fresh `watch::Receiver` for awaiting changes directly.
@@ -132,14 +162,14 @@ impl PendingDataCache {
 
     fn bump_freshness(&self) {
         self.freshness_tx.send_modify(|f| {
-            f.stale = false;
-            f.refresh_count = f.refresh_count.wrapping_add(1);
+            f.status = Status::Fresh;
+            f.publish_seq = f.publish_seq.wrapping_add(1);
         });
     }
 
     async fn wait_for_fresh_data(&self) -> anyhow::Result<()> {
         let snapshot = *self.freshness_tx.borrow();
-        if !snapshot.stale {
+        if matches!(snapshot.status, Status::Fresh) {
             return Ok(());
         }
 
@@ -147,18 +177,29 @@ impl PendingDataCache {
         let _ = rx.borrow_and_update();
 
         let result = tokio::time::timeout(self.cold_start_timeout, async {
-            while rx.borrow().refresh_count == snapshot.refresh_count {
+            loop {
+                let current = *rx.borrow();
+
+                // Unavailable now. Fail fast with the reason.
+                if let Status::Unavailable(reason) = current.status {
+                    return Err(anyhow::anyhow!("pre-confirmed data unavailable: {reason}"));
+                }
+
+                // A publish landed. The data is fresh, serve it.
+                if current.publish_seq != snapshot.publish_seq {
+                    return Ok(());
+                }
+
+                // Still stale. Park until the next change, or bail if the producer is gone.
                 if rx.changed().await.is_err() {
                     return Err(anyhow::anyhow!("producer disconnected"));
                 }
             }
-            Ok(())
         })
         .await;
 
         match result {
-            Ok(Ok(())) => Ok(()),
-            Ok(Err(e)) => Err(e),
+            Ok(r) => r,
             Err(_) => Err(anyhow::anyhow!(
                 "cold-start read timed out after {:?}",
                 self.cold_start_timeout
@@ -273,7 +314,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn idle_cache_blocks_read_until_refresh() {
+    async fn idle_cache_blocks_read_until_mark_fresh() {
         let cache =
             Arc::new(PendingDataCache::new().with_cold_start_timeout(Duration::from_secs(5)));
         let initial = sample_data(99);
@@ -290,14 +331,14 @@ mod tests {
 
         let got = timeout(Duration::from_millis(100), reader)
             .await
-            .expect("reader should unblock on refresh")
+            .expect("reader should unblock when marked fresh")
             .unwrap()
             .unwrap();
         assert_eq!(got, initial);
     }
 
     #[tokio::test]
-    async fn concurrent_cold_reads_share_one_refresh() {
+    async fn concurrent_cold_reads_share_one_publish() {
         let cache =
             Arc::new(PendingDataCache::new().with_cold_start_timeout(Duration::from_secs(5)));
         cache.mark_stale();
@@ -324,7 +365,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cold_read_times_out_when_no_refresh() {
+    async fn cold_read_times_out_when_no_publish() {
         let cache = PendingDataCache::new().with_cold_start_timeout(Duration::from_millis(40));
         cache.mark_stale();
 
@@ -398,6 +439,111 @@ mod tests {
         let cache = PendingDataCache::new();
         cache.mark_stale();
         assert!(cache.try_read().is_none());
+    }
+
+    #[tokio::test]
+    async fn read_fails_fast_when_unavailable() {
+        // Default cold-start timeout is 5s; if the read blocked, the 50ms
+        // outer timeout would trip. Returning an error promptly proves the
+        // Unavailable arm short-circuits.
+        let cache = PendingDataCache::new();
+        cache.mark_unavailable("syncing");
+
+        let err = timeout(Duration::from_millis(50), cache.read())
+            .await
+            .expect("read should return promptly, not block on cold-start")
+            .unwrap_err();
+        assert!(err.to_string().contains("syncing"));
+    }
+
+    #[tokio::test]
+    async fn store_clears_unavailable() {
+        let cache = PendingDataCache::new();
+        cache.mark_unavailable("syncing");
+
+        let expected = sample_data(7);
+        cache.store(expected.clone());
+
+        let got = timeout(Duration::from_millis(20), cache.read())
+            .await
+            .expect("read should be immediate once fresh")
+            .unwrap();
+        assert_eq!(got, expected);
+    }
+
+    #[tokio::test]
+    async fn mark_stale_does_not_downgrade_unavailable() {
+        // Unavailable is the stickier state: an idle-suspend mark_stale() must
+        // not turn it into a blocking Stale read.
+        let cache = PendingDataCache::new();
+        cache.mark_unavailable("syncing");
+        cache.mark_stale();
+
+        let err = timeout(Duration::from_millis(50), cache.read())
+            .await
+            .expect("read should still fail fast")
+            .unwrap_err();
+        assert!(err.to_string().contains("syncing"));
+    }
+
+    #[tokio::test]
+    async fn mark_unavailable_wakes_blocked_stale_reader() {
+        // A reader blocked on a Stale cache must wake the moment the producer
+        // flips to Unavailable, instead of riding out the 5s cold-start timeout.
+        let cache =
+            Arc::new(PendingDataCache::new().with_cold_start_timeout(Duration::from_secs(5)));
+        cache.mark_stale();
+
+        let reader_cache = cache.clone();
+        let reader = tokio::spawn(async move { reader_cache.read().await });
+
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert!(!reader.is_finished(), "reader should block while stale");
+
+        cache.mark_unavailable("gateway error");
+
+        let err = timeout(Duration::from_millis(100), reader)
+            .await
+            .expect("reader should wake well before the 5s timeout")
+            .unwrap()
+            .unwrap_err();
+        assert!(err.to_string().contains("gateway error"));
+    }
+
+    #[tokio::test]
+    async fn try_read_returns_none_when_unavailable() {
+        let cache = PendingDataCache::new();
+        cache.mark_unavailable("syncing");
+        assert!(cache.try_read().is_none());
+    }
+
+    #[tokio::test]
+    async fn blocked_read_wakes_on_publish_even_if_restaled() {
+        // A publish immediately followed by re-staling (Stale → Fresh → Stale)
+        // must still release a blocked read. `freshness` looks unchanged at both
+        // ends, so the wake relies on the bumped publish counter alone.
+        let cache =
+            Arc::new(PendingDataCache::new().with_cold_start_timeout(Duration::from_secs(5)));
+        cache.mark_stale();
+
+        let reader_cache = cache.clone();
+        let reader = tokio::spawn(async move { reader_cache.read().await });
+
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert!(!reader.is_finished(), "reader should block while stale");
+
+        // No await between these two, so the reader observes only the coalesced
+        // final state: Stale, with the publish counter already bumped.
+        let expected = sample_data(7);
+        cache.store(expected.clone());
+        cache.mark_stale();
+
+        let got = timeout(Duration::from_millis(100), reader)
+            .await
+            .expect("reader should wake on the publish, not time out")
+            .unwrap()
+            .unwrap();
+        assert_eq!(got, expected);
     }
 
     #[tokio::test]


### PR DESCRIPTION
I caught this yesterday while testing and believe it's worth landing before our upcoming release.

The previous `Stale` state was doing two jobs... There's two genuine error cases from the data provider where `Stale` didn't feel right. It was just not accurate imho.

So this PR introduces a new `Unavailable` state for the true error cases.

Also renamed `refresh()` to `mark_fresh()`. Reduces ambiguity and makes it consistent with the other `mark_` methods.