### PR TITLE
feat(rpc/pending): make the `Unavailable` error visible to RPC callers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8826,6 +8826,7 @@ dependencies = [
  "anyhow",
  "pathfinder-common",
  "starknet-gateway-types",
+ "thiserror 2.0.18",
  "tokio",
 ]
 

--- a/crates/pending-data/Cargo.toml
+++ b/crates/pending-data/Cargo.toml
@@ -10,6 +10,7 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 pathfinder-common = { path = "../common" }
 starknet-gateway-types = { path = "../gateway-types" }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync", "time", "rt"] }
 
 [dev-dependencies]

--- a/crates/pending-data/src/cache.rs
+++ b/crates/pending-data/src/cache.rs
@@ -27,31 +27,16 @@ struct Freshness {
 }
 
 /// Why a [`PendingDataCache::read`] failed.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ReadError {
     /// Fresh data isn't available yet, for a known reason: node is catching up,
     /// a failed fetch... it's expected to clear on its own.
+    #[error("pre-confirmed data unavailable: {0}")]
     Unavailable(&'static str),
     /// The read failed: a cold-start timeout, a dropped producer, or a wrapped
     /// `anyhow` error.
-    Internal(anyhow::Error),
-}
-
-impl std::fmt::Display for ReadError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ReadError::Unavailable(reason) => {
-                write!(f, "pre-confirmed data unavailable: {reason}")
-            }
-            ReadError::Internal(e) => write!(f, "{e}"),
-        }
-    }
-}
-
-impl From<anyhow::Error> for ReadError {
-    fn from(e: anyhow::Error) -> Self {
-        ReadError::Internal(e)
-    }
+    #[error(transparent)]
+    Internal(#[from] anyhow::Error),
 }
 
 /// Shared pre-confirmed data cache with freshness tracking.

--- a/crates/pending-data/src/cache.rs
+++ b/crates/pending-data/src/cache.rs
@@ -26,6 +26,34 @@ struct Freshness {
     publish_seq: u64,
 }
 
+/// Why a [`PendingDataCache::read`] failed.
+#[derive(Debug)]
+pub enum ReadError {
+    /// Fresh data isn't available yet, for a known reason: node is catching up,
+    /// a failed fetch... it's expected to clear on its own.
+    Unavailable(&'static str),
+    /// The read failed: a cold-start timeout, a dropped producer, or a wrapped
+    /// `anyhow` error.
+    Internal(anyhow::Error),
+}
+
+impl std::fmt::Display for ReadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReadError::Unavailable(reason) => {
+                write!(f, "pre-confirmed data unavailable: {reason}")
+            }
+            ReadError::Internal(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl From<anyhow::Error> for ReadError {
+    fn from(e: anyhow::Error) -> Self {
+        ReadError::Internal(e)
+    }
+}
+
 /// Shared pre-confirmed data cache with freshness tracking.
 ///
 /// Holds the latest [`PendingData`] and a small amount of freshness state.
@@ -119,7 +147,7 @@ impl PendingDataCache {
     /// Returns the latest cached data. Returns immediately when fresh, fails
     /// fast with the reason when unavailable, and blocks while stale (up to the
     /// configured cold-start timeout). Always fires the read signal.
-    pub async fn read(&self) -> anyhow::Result<PendingData> {
+    pub async fn read(&self) -> Result<PendingData, ReadError> {
         self.signal_read();
         self.wait_for_fresh_data().await?;
         Ok(self.data_rx.borrow().clone())
@@ -167,7 +195,7 @@ impl PendingDataCache {
         });
     }
 
-    async fn wait_for_fresh_data(&self) -> anyhow::Result<()> {
+    async fn wait_for_fresh_data(&self) -> Result<(), ReadError> {
         let snapshot = *self.freshness_tx.borrow();
         if matches!(snapshot.status, Status::Fresh) {
             return Ok(());
@@ -182,7 +210,7 @@ impl PendingDataCache {
 
                 // Unavailable now. Fail fast with the reason.
                 if let Status::Unavailable(reason) = current.status {
-                    return Err(anyhow::anyhow!("pre-confirmed data unavailable: {reason}"));
+                    return Err(ReadError::Unavailable(reason));
                 }
 
                 // A publish landed. The data is fresh, serve it.
@@ -192,7 +220,9 @@ impl PendingDataCache {
 
                 // Still stale. Park until the next change, or bail if the producer is gone.
                 if rx.changed().await.is_err() {
-                    return Err(anyhow::anyhow!("producer disconnected"));
+                    return Err(ReadError::Internal(anyhow::anyhow!(
+                        "producer disconnected"
+                    )));
                 }
             }
         })
@@ -200,10 +230,10 @@ impl PendingDataCache {
 
         match result {
             Ok(r) => r,
-            Err(_) => Err(anyhow::anyhow!(
+            Err(_) => Err(ReadError::Internal(anyhow::anyhow!(
                 "cold-start read timed out after {:?}",
                 self.cold_start_timeout
-            )),
+            ))),
         }
     }
 }

--- a/crates/pending-data/src/lib.rs
+++ b/crates/pending-data/src/lib.rs
@@ -3,7 +3,7 @@
 mod cache;
 mod data;
 
-pub use cache::PendingDataCache;
+pub use cache::{PendingDataCache, ReadError};
 pub use data::{
     PendingBlocks,
     PendingData,

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -394,6 +394,25 @@ fn error_stack_frames_to_json(frames: &[pathfinder_executor::Frame]) -> serde_js
         })
 }
 
+/// Generates `From<ReadError>` for the pending cache read error.
+/// `Unavailable` maps to our `Custom` rpc error, and everything else to
+/// `Internal` to avoid leaking internal details.
+macro_rules! impl_from_pending_read_error {
+    ($enum_name:ty) => {
+        impl From<pathfinder_pending_data::ReadError> for $enum_name {
+            fn from(e: pathfinder_pending_data::ReadError) -> Self {
+                match e {
+                    pathfinder_pending_data::ReadError::Unavailable(reason) => Self::Custom(
+                        ::anyhow::anyhow!("pre-confirmed data unavailable: {reason}"),
+                    ),
+                    pathfinder_pending_data::ReadError::Internal(e) => Self::Internal(e),
+                }
+            }
+        }
+    };
+}
+pub(super) use impl_from_pending_read_error;
+
 /// Generates an enum subset of [ApplicationError] along with boilerplate for
 /// mapping the variants back to [ApplicationError].
 ///
@@ -474,12 +493,14 @@ macro_rules! generate_rpc_error_subset {
     ($enum_name:ident) => {
         generate_rpc_error_subset!(@enum_def, $enum_name,);
         generate_rpc_error_subset!(@from_anyhow, $enum_name);
+        generate_rpc_error_subset!(@from_read_error, $enum_name);
         generate_rpc_error_subset!(@from_def, $enum_name,);
     };
     // Main entry-point for the macro
     ($enum_name:ident: $($subset:tt),+) => {
         generate_rpc_error_subset!(@enum_def, $enum_name, $($subset),+);
         generate_rpc_error_subset!(@from_anyhow, $enum_name);
+        generate_rpc_error_subset!(@from_read_error, $enum_name);
         generate_rpc_error_subset!(@from_def, $enum_name, $($subset),+);
     };
     // Generates the enum definition, nothing tricky here.
@@ -500,6 +521,11 @@ macro_rules! generate_rpc_error_subset {
                 Self::Internal(e)
             }
         }
+    };
+    // Generates From<ReadError>; the mapping lives in
+    // `impl_from_pending_read_error!`, which the hand-written error enums share.
+    (@from_read_error, $enum_name:ident) => {
+        crate::error::impl_from_pending_read_error!($enum_name);
     };
     // Generates From<$enum_name> for RpcError, this macro arm itself is not tricky,
     // however its child calls are.

--- a/crates/rpc/src/method/call.rs
+++ b/crates/rpc/src/method/call.rs
@@ -27,6 +27,8 @@ impl From<anyhow::Error> for CallError {
     }
 }
 
+crate::error::impl_from_pending_read_error!(CallError);
+
 impl From<pathfinder_executor::CallError> for CallError {
     fn from(value: pathfinder_executor::CallError) -> Self {
         use pathfinder_executor::CallError::*;
@@ -136,10 +138,7 @@ pub async fn call(
 
         let (header, pending) = match input.block_id {
             BlockId::PreConfirmed => {
-                let pending = context
-                    .pending_data
-                    .get(&db_tx, rpc_version)
-                    .context("Querying pending data")?;
+                let pending = context.pending_data.get(&db_tx, rpc_version)?;
 
                 (
                     pending.pre_confirmed_header(),

--- a/crates/rpc/src/method/estimate_fee.rs
+++ b/crates/rpc/src/method/estimate_fee.rs
@@ -81,10 +81,7 @@ pub async fn estimate_fee(
 
         let (header, pending) = match input.block_id {
             BlockId::PreConfirmed => {
-                let pending = context
-                    .pending_data
-                    .get(&db_tx, rpc_version)
-                    .context("Querying pending data")?;
+                let pending = context.pending_data.get(&db_tx, rpc_version)?;
 
                 (
                     pending.pre_confirmed_header(),
@@ -171,6 +168,8 @@ impl From<anyhow::Error> for EstimateFeeError {
         Self::Internal(e)
     }
 }
+
+crate::error::impl_from_pending_read_error!(EstimateFeeError);
 
 impl From<pathfinder_executor::TransactionExecutionError> for EstimateFeeError {
     fn from(value: pathfinder_executor::TransactionExecutionError) -> Self {

--- a/crates/rpc/src/method/estimate_message_fee.rs
+++ b/crates/rpc/src/method/estimate_message_fee.rs
@@ -78,10 +78,7 @@ pub async fn estimate_message_fee(
 
         let (header, pending) = match input.block_id {
             BlockId::PreConfirmed => {
-                let pending = context
-                    .pending_data
-                    .get(&db_tx, rpc_version)
-                    .context("Querying pending data")?;
+                let pending = context.pending_data.get(&db_tx, rpc_version)?;
 
                 (
                     pending.pre_confirmed_header(),
@@ -221,6 +218,8 @@ impl From<anyhow::Error> for EstimateMessageFeeError {
         Self::Internal(e)
     }
 }
+
+crate::error::impl_from_pending_read_error!(EstimateMessageFeeError);
 
 impl From<pathfinder_executor::TransactionExecutionError> for EstimateMessageFeeError {
     fn from(c: pathfinder_executor::TransactionExecutionError) -> Self {

--- a/crates/rpc/src/method/get_block_transaction_count.rs
+++ b/crates/rpc/src/method/get_block_transaction_count.rs
@@ -43,8 +43,7 @@ pub async fn get_block_transaction_count(
             BlockId::PreConfirmed => {
                 let count = context
                     .pending_data
-                    .get(&db, rpc_version)
-                    .context("Querying pending data")?
+                    .get(&db, rpc_version)?
                     .pre_confirmed_transactions()
                     .len() as u64;
                 return Ok(Output(count));

--- a/crates/rpc/src/method/get_block_with_receipts.rs
+++ b/crates/rpc/src/method/get_block_with_receipts.rs
@@ -82,10 +82,7 @@ pub async fn get_block_with_receipts(
 
         let block_id = match input.block_id {
             BlockId::PreConfirmed => {
-                let pending = context
-                    .pending_data
-                    .get(&db, rpc_version)
-                    .context("Querying pending data")?;
+                let pending = context.pending_data.get(&db, rpc_version)?;
 
                 let parent_hash = (rpc_version < RpcVersion::V09)
                     .then(|| {

--- a/crates/rpc/src/method/get_block_with_tx_hashes.rs
+++ b/crates/rpc/src/method/get_block_with_tx_hashes.rs
@@ -60,10 +60,7 @@ pub async fn get_block_with_tx_hashes(
 
         let block_id = match input.block_id {
             BlockId::PreConfirmed => {
-                let pending = context
-                    .pending_data
-                    .get(&transaction, rpc_version)
-                    .context("Querying pending data")?;
+                let pending = context.pending_data.get(&transaction, rpc_version)?;
 
                 let transactions = pending
                     .pre_confirmed_transactions()
@@ -169,6 +166,28 @@ mod tests {
     use super::*;
     use crate::dto::{SerializeForVersion, Serializer};
     use crate::RpcVersion;
+
+    /// An unavailable pre-confirmed cache surfaces a client-visible reason —
+    /// code -32603 with the reason in `data` — rather than a bare
+    /// "Internal error".
+    #[test]
+    fn unavailable_maps_to_custom_with_reason() {
+        use pathfinder_pending_data::ReadError;
+
+        use crate::error::ApplicationError;
+
+        let err: Error = ReadError::Unavailable("syncing").into();
+        let app: ApplicationError = err.into();
+
+        assert_eq!(app.code(RpcVersion::V09), -32603);
+        let data = app
+            .data(RpcVersion::V09)
+            .expect("the reason is carried in `data`");
+        assert!(
+            data["error"].as_str().unwrap().contains("syncing"),
+            "got: {data}"
+        );
+    }
 
     #[rstest::rstest]
     #[case::v06(RpcVersion::V06)]

--- a/crates/rpc/src/method/get_block_with_txs.rs
+++ b/crates/rpc/src/method/get_block_with_txs.rs
@@ -85,10 +85,7 @@ pub async fn get_block_with_txs(
 
         let block_id = match input.block_id {
             BlockId::PreConfirmed => {
-                let pending = context
-                    .pending_data
-                    .get(&transaction, rpc_version)
-                    .context("Querying pending data")?;
+                let pending = context.pending_data.get(&transaction, rpc_version)?;
 
                 let transactions = pending.pre_confirmed_transactions().to_vec();
 

--- a/crates/rpc/src/method/get_class.rs
+++ b/crates/rpc/src/method/get_class.rs
@@ -60,8 +60,7 @@ pub async fn get_class(
         let is_pending = input.block_id.is_pending()
             && context
                 .pending_data
-                .get(&tx, rpc_version)
-                .context("Querying pending data")?
+                .get(&tx, rpc_version)?
                 .class_is_declared(input.class_hash);
 
         let block_id = input

--- a/crates/rpc/src/method/get_class_at.rs
+++ b/crates/rpc/src/method/get_class_at.rs
@@ -70,8 +70,7 @@ pub async fn get_class_at(
         let pending_class_hash = if input.block_id.is_pending() {
             context
                 .pending_data
-                .get(&tx, rpc_version)
-                .context("Querying pending data")?
+                .get(&tx, rpc_version)?
                 .find_contract_class(input.contract_address)
         } else {
             None

--- a/crates/rpc/src/method/get_class_hash_at.rs
+++ b/crates/rpc/src/method/get_class_hash_at.rs
@@ -45,8 +45,7 @@ pub async fn get_class_hash_at(
         if input.block_id.is_pending() {
             let class_hash = context
                 .pending_data
-                .get(&tx, rpc_version)
-                .context("Querying pending data")?
+                .get(&tx, rpc_version)?
                 .find_contract_class(input.contract_address);
 
             if let Some(class_hash) = class_hash {

--- a/crates/rpc/src/method/get_events.rs
+++ b/crates/rpc/src/method/get_events.rs
@@ -31,6 +31,8 @@ impl From<anyhow::Error> for GetEventsError {
     }
 }
 
+crate::error::impl_from_pending_read_error!(GetEventsError);
+
 impl From<GetEventsError> for crate::error::ApplicationError {
     fn from(e: GetEventsError) -> Self {
         match e {
@@ -182,10 +184,7 @@ pub async fn get_events(
             .transaction()
             .context("Creating database transaction")?;
 
-        let pending = context
-            .pending_data
-            .get(&transaction, rpc_version)
-            .context("Querying pending data")?;
+        let pending = context.pending_data.get(&transaction, rpc_version)?;
 
         // Replace from/to blocks with `BlockId::PreConfirmed` if their numbers match
         // the pre-latest/pre-confirmed block number.

--- a/crates/rpc/src/method/get_nonce.rs
+++ b/crates/rpc/src/method/get_nonce.rs
@@ -44,8 +44,7 @@ pub async fn get_nonce(
         if input.block_id.is_pending() {
             let nonce = context
                 .pending_data
-                .get(&tx, rpc_version)
-                .context("Querying pending data")?
+                .get(&tx, rpc_version)?
                 .find_nonce(input.contract_address);
 
             if let Some(nonce) = nonce {

--- a/crates/rpc/src/method/get_state_update.rs
+++ b/crates/rpc/src/method/get_state_update.rs
@@ -70,8 +70,7 @@ pub async fn get_state_update(
         if input.block_id.is_pending() {
             let mut state_update = context
                 .pending_data
-                .get(&tx, rpc_version)
-                .context("Query pending data")?
+                .get(&tx, rpc_version)?
                 .pre_confirmed_state_update();
             if !input.contract_addresses.is_empty() {
                 let mut own_state_update = state_update.as_ref().clone();

--- a/crates/rpc/src/method/get_storage_at.rs
+++ b/crates/rpc/src/method/get_storage_at.rs
@@ -77,10 +77,7 @@ pub async fn get_storage_at(
         let tx = db.transaction().context("Creating database transaction")?;
 
         if input.block_id.is_pending() {
-            let pending_data = context
-                .pending_data
-                .get(&tx, rpc_version)
-                .context("Querying pending data")?;
+            let pending_data = context.pending_data.get(&tx, rpc_version)?;
             let opt_found = pending_data.find_storage_value(input.contract_address, input.key);
             if let Some(found) = opt_found {
                 let (value, last_update_block) = match found {

--- a/crates/rpc/src/method/get_transaction_by_block_id_and_index.rs
+++ b/crates/rpc/src/method/get_transaction_by_block_id_and_index.rs
@@ -81,8 +81,7 @@ pub async fn get_transaction_by_block_id_and_index(
             BlockId::PreConfirmed => {
                 let result = context
                     .pending_data
-                    .get(&db_tx, rpc_version)
-                    .context("Querying pending dat")?
+                    .get(&db_tx, rpc_version)?
                     .pre_confirmed_transactions()
                     .get(index)
                     .cloned()

--- a/crates/rpc/src/method/get_transaction_by_hash.rs
+++ b/crates/rpc/src/method/get_transaction_by_hash.rs
@@ -66,8 +66,7 @@ pub async fn get_transaction_by_hash(
         // Check pending transactions.
         if let Some(transaction) = context
             .pending_data
-            .get(&db_tx, rpc_version)
-            .context("Querying pending data")?
+            .get(&db_tx, rpc_version)?
             .find_transaction(input.transaction_hash)
         {
             return Ok(Output {

--- a/crates/rpc/src/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/method/get_transaction_receipt.rs
@@ -98,10 +98,7 @@ pub async fn get_transaction_receipt(
         let db_tx = db.transaction().context("Creating database transaction")?;
 
         // Check pending transactions.
-        let pending = context
-            .pending_data
-            .get(&db_tx, rpc_version)
-            .context("Querying pending data")?;
+        let pending = context.pending_data.get(&db_tx, rpc_version)?;
 
         if let Some(finalized_tx_data) =
             crate::pending::find_finalized_tx_data(&pending, input.transaction_hash)

--- a/crates/rpc/src/method/get_transaction_status.rs
+++ b/crates/rpc/src/method/get_transaction_status.rs
@@ -48,7 +48,7 @@ pub async fn get_transaction_status(
 ) -> Result<Output, Error> {
     // Check database.
     let span = tracing::Span::current();
-    let db_status = util::task::spawn_blocking(move |_| {
+    let db_status = util::task::spawn_blocking(move |_| -> Result<Option<Output>, Error> {
         let _g = span.enter();
 
         let mut db = context
@@ -57,10 +57,7 @@ pub async fn get_transaction_status(
             .context("Opening database connection")?;
         let db_tx = db.transaction().context("Creating database transaction")?;
 
-        let pending_data = context
-            .pending_data
-            .get(&db_tx, rpc_version)
-            .context("Querying pending data")?;
+        let pending_data = context.pending_data.get(&db_tx, rpc_version)?;
 
         if let Some(finalized_tx_data) =
             crate::pending::find_finalized_tx_data(&pending_data, input.transaction_hash)
@@ -97,7 +94,7 @@ pub async fn get_transaction_status(
             .transaction_with_receipt(input.transaction_hash)
             .context("Fetching receipt from database")?
         else {
-            return anyhow::Ok(None);
+            return Ok(None);
         };
 
         let l1_accepted = db_tx

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -84,10 +84,7 @@ pub async fn simulate_transactions(
 
         let (header, pending) = match input.block_id {
             BlockId::PreConfirmed => {
-                let pending = context
-                    .pending_data
-                    .get(&db_tx, rpc_version)
-                    .context("Querying pending data")?;
+                let pending = context.pending_data.get(&db_tx, rpc_version)?;
 
                 (
                     pending.pre_confirmed_header(),
@@ -244,6 +241,8 @@ impl From<anyhow::Error> for SimulateTransactionError {
         Self::Internal(e)
     }
 }
+
+crate::error::impl_from_pending_read_error!(SimulateTransactionError);
 
 impl From<SimulateTransactionError> for crate::error::ApplicationError {
     fn from(e: SimulateTransactionError) -> Self {

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -106,10 +106,7 @@ pub async fn trace_block_transactions(
 
         let (block_id, header, transactions, cache) = match input.block_id {
             BlockId::PreConfirmed => {
-                let pending = context
-                    .pending_data
-                    .get(&db_tx, rpc_version)
-                    .context("Querying pending data")?;
+                let pending = context.pending_data.get(&db_tx, rpc_version)?;
 
                 let header = pending.pre_confirmed_header();
                 let transactions = pending.pre_confirmed_transactions().to_vec();
@@ -777,6 +774,8 @@ impl From<anyhow::Error> for TraceBlockTransactionsError {
         Self::Internal(value)
     }
 }
+
+crate::error::impl_from_pending_read_error!(TraceBlockTransactionsError);
 
 impl From<pathfinder_storage::StorageError> for TraceBlockTransactionsError {
     fn from(value: pathfinder_storage::StorageError) -> Self {

--- a/crates/rpc/src/method/trace_transaction.rs
+++ b/crates/rpc/src/method/trace_transaction.rs
@@ -67,10 +67,7 @@ pub async fn trace_transaction(
                 .context("Creating database transaction")?;
 
             // Find the transaction's block.
-            let pending = context
-                .pending_data
-                .get(&db_tx, rpc_version)
-                .context("Querying pending data")?;
+            let pending = context.pending_data.get(&db_tx, rpc_version)?;
 
             let (header, transactions, cache) = if let Some(pending_tx) = pending
                 .pre_confirmed_transactions()
@@ -289,6 +286,8 @@ impl From<anyhow::Error> for TraceTransactionError {
         Self::Internal(e)
     }
 }
+
+crate::error::impl_from_pending_read_error!(TraceTransactionError);
 
 impl From<super::trace_block_transactions::TraceBlockTransactionsError> for TraceTransactionError {
     fn from(e: super::trace_block_transactions::TraceBlockTransactionsError) -> Self {

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use pathfinder_common::{BlockNumber, StateUpdate};
-use pathfinder_pending_data::PendingDataCache;
 pub use pathfinder_pending_data::{
     PendingBlocks,
     PendingData,
@@ -11,6 +10,7 @@ pub use pathfinder_pending_data::{
     PreLatestData,
     TxnReceiptAndEvents,
 };
+use pathfinder_pending_data::{PendingDataCache, ReadError};
 use pathfinder_storage::Transaction;
 use tokio::sync::watch::Receiver as WatchReceiver;
 
@@ -53,7 +53,7 @@ impl PendingWatcher {
         &self,
         tx: &Transaction<'_>,
         rpc_version: RpcVersion,
-    ) -> anyhow::Result<PendingData> {
+    ) -> Result<PendingData, ReadError> {
         let latest = tx
             .block_header(pathfinder_common::BlockId::Latest)
             .context("Querying latest block header")?
@@ -69,9 +69,7 @@ impl PendingWatcher {
 
         let watched_pending_data = match self.cache.try_read() {
             Some(data) => data,
-            None => tokio::runtime::Handle::current()
-                .block_on(self.cache.read())
-                .context("Reading pre-confirmed cache")?,
+            None => tokio::runtime::Handle::current().block_on(self.cache.read())?,
         };
 
         let watched_pending_blocks = watched_pending_data.pending_block();


### PR DESCRIPTION
The [previous PR](https://github.com/equilibriumco/pathfinder/pull/3452) makes the case where pre-confirmed data is still "unavailable" explicit.

The problem is that when I tested this on a syncing node, I got this:

```json
{ "code": -32603, "message": "Internal error", "data": null }
```

Not what I'd expect tbh. Internal error sounds quite scary for something that's just waiting for us to catch up with the head of the chain.

So, tldr: I had to stop returning `anyhow::Error` and introduce a new `ReadError` instead. Just two variants: `Unavailable(reason)` and `Internal`. First one is transient, second one is the messed up case.

The changes seem more than they really are. The catch is that `PendingWatcher::get()` is the pending-data accessor, and apparently a bunch of RPC methods read pending. So there's a bit of a ripple there. But it's really straightforward. We just drop the `.context(..)` and let the typed error flow through `?` (added the macro for this to work).

**End result** (live on integration)

```json
{ 
  "code": -32603, 
  "message": "Internal error",
  "data": { 
    "error": "pre-confirmed data unavailable: syncing"
  }
}
```

Worth it imho.