### PR TITLE
feat(rpc): add compiler concurrency limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Parallel subscriptions on a single WS connection are now limited to 1024 by default, configurable with `--rpc.websocket.max-subscriptions` CLI option.
+- Parallel Sierra to CASM compilation processes during RPC requests are now limited to the number of CPU cores available by default, configurable with `--rpc.compiler.concurrency-limit` CLI option.
 
 ## [0.22.3] - 2026-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Parallel Sierra to CASM compilation processes during RPC requests are now limited to the number of CPU cores available by default, configurable with `--rpc.compiler.concurrency-limit` CLI option.
+
 ## [0.22.4] - 2026-06-08
 
 ### Changed
@@ -20,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Parallel subscriptions on a single WS connection are now limited to 1024 by default, configurable with `--rpc.websocket.max-subscriptions` CLI option.
-- Parallel Sierra to CASM compilation processes during RPC requests are now limited to the number of CPU cores available by default, configurable with `--rpc.compiler.concurrency-limit` CLI option.
 
 ## [0.22.3] - 2026-04-20
 

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -270,6 +270,9 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
         submission_tracker_time_limit: config.submission_tracker_time_limit,
         submission_tracker_size_limit: config.submission_tracker_size_limit,
         block_trace_cache_size: config.rpc_block_trace_cache_size,
+        compiler_concurrency_limit: config
+            .compiler_concurrency_limit
+            .unwrap_or(available_parallelism),
         compiler_resource_limits: config.compiler_resource_limits,
         blockifier_libfuncs: config.blockifier_libfuncs,
     };

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -509,6 +509,14 @@ This should only be enabled for debugging purposes as it adds substantial proces
     custom_versioned_constants_path: Option<PathBuf>,
 
     #[arg(
+        long = "rpc.compiler.concurrency-limit",
+        long_help = "Maximum number of concurrent Sierra to CASM compilations for RPC calls. \
+                     Defaults to the number of CPU cores available.",
+        env = "PATHFINDER_RPC_COMPILER_CONCURRENCY_LIMIT"
+    )]
+    compiler_concurrency_limit: Option<NonZeroUsize>,
+
+    #[arg(
         long = "compiler.max-memory-usage-mib",
         long_help = "Maximum memory usage for the compiler in MiB. 
 
@@ -1149,6 +1157,7 @@ pub struct Config {
     pub blockchain_history: Option<BlockchainHistory>,
     pub state_tries: Option<StateTries>,
     pub versioned_constants_map: VersionedConstantsMap,
+    pub compiler_concurrency_limit: Option<NonZeroUsize>,
     pub compiler_resource_limits: pathfinder_compiler::ResourceLimits,
     pub blockifier_libfuncs: pathfinder_compiler::BlockifierLibfuncs,
     pub feeder_gateway_fetch_concurrency: NonZeroUsize,
@@ -1465,6 +1474,7 @@ impl Config {
                 args.compiler_max_memory_usage_mib * 1024 * 1024,
                 args.compiler_max_cpu_time_secs,
             ),
+            compiler_concurrency_limit: args.compiler_concurrency_limit,
             blockifier_libfuncs: args.compile_config.blockifier_libfuncs.into(),
             fetch_casm_from_fgw: args.fetch_casm_from_fgw,
             shutdown_grace_period: Duration::from_secs(args.shutdown_grace_period.get()),

--- a/crates/rpc/src/compiler.rs
+++ b/crates/rpc/src/compiler.rs
@@ -1,0 +1,43 @@
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+use pathfinder_common::class_definition::{SerializedCasmDefinition, SerializedSierraDefinition};
+
+/// Sierra to CASM compiler wrapper for the RPC layer.
+#[derive(Clone)]
+pub struct PathfinderCompiler {
+    concurrency_limit: Arc<util::sync::Semaphore>,
+    resource_limits: pathfinder_compiler::ResourceLimits,
+    blockifier_libfuncs: pathfinder_compiler::BlockifierLibfuncs,
+}
+
+impl PathfinderCompiler {
+    /// Creates a new Sierra to CASM compiler.
+    pub fn new(
+        concurrency_limit: NonZeroUsize,
+        resource_limits: pathfinder_compiler::ResourceLimits,
+        blockifier_libfuncs: pathfinder_compiler::BlockifierLibfuncs,
+    ) -> Self {
+        Self {
+            concurrency_limit: Arc::new(util::sync::Semaphore::new(concurrency_limit.get())),
+            resource_limits,
+            blockifier_libfuncs,
+        }
+    }
+
+    /// Compiles a Sierra definition to CASM.
+    ///
+    /// This is a blocking function. When used inside an async runtime, it
+    /// should be called on a blocking thread.
+    pub fn compile_sierra_to_casm(
+        &self,
+        sierra_definition: &SerializedSierraDefinition,
+    ) -> anyhow::Result<SerializedCasmDefinition> {
+        let _permit = self.concurrency_limit.acquire();
+        pathfinder_compiler::compile_sierra_to_casm(
+            sierra_definition,
+            self.resource_limits,
+            self.blockifier_libfuncs,
+        )
+    }
+}

--- a/crates/rpc/src/compiler.rs
+++ b/crates/rpc/src/compiler.rs
@@ -19,7 +19,7 @@ impl PathfinderCompiler {
         blockifier_libfuncs: pathfinder_compiler::BlockifierLibfuncs,
     ) -> Self {
         Self {
-            concurrency_limit: Arc::new(util::sync::Semaphore::new(concurrency_limit.get())),
+            concurrency_limit: Arc::new(util::sync::Semaphore::new(concurrency_limit)),
             resource_limits,
             blockifier_libfuncs,
         }

--- a/crates/rpc/src/context.rs
+++ b/crates/rpc/src/context.rs
@@ -15,7 +15,7 @@ pub use crate::jsonrpc::websocket::WebsocketContext;
 use crate::jsonrpc::Notifications;
 use crate::pending::PendingWatcher;
 use crate::tracker::SubmittedTransactionTracker;
-use crate::SyncState;
+use crate::{PathfinderCompiler, SyncState};
 
 type SequencerClient = starknet_gateway_client::Client;
 
@@ -82,6 +82,7 @@ pub struct RpcConfig {
     pub submission_tracker_time_limit: NonZeroU64,
     pub submission_tracker_size_limit: NonZeroUsize,
     pub block_trace_cache_size: NonZeroUsize,
+    pub compiler_concurrency_limit: NonZeroUsize,
     pub compiler_resource_limits: pathfinder_compiler::ResourceLimits,
     pub blockifier_libfuncs: pathfinder_compiler::BlockifierLibfuncs,
 }
@@ -101,6 +102,7 @@ pub struct RpcContext {
     pub notifications: Notifications,
     pub ethereum: EthereumClient,
     pub config: RpcConfig,
+    pub compiler: PathfinderCompiler,
     pub native_class_cache: Option<NativeClassCache>,
     pub consensus_info_watch: Option<watch::Receiver<consensus_info::ConsensusInfo>>,
     pub preconfirmed_watch: Option<watch::Receiver<u32>>,
@@ -133,6 +135,12 @@ impl RpcContext {
         } else {
             None
         };
+        let compiler = PathfinderCompiler::new(
+            config.compiler_concurrency_limit,
+            config.compiler_resource_limits,
+            config.blockifier_libfuncs,
+        );
+
         Self {
             cache: TraceCache::with_size(config.block_trace_cache_size),
             storage,
@@ -147,6 +155,7 @@ impl RpcContext {
             notifications,
             ethereum,
             config,
+            compiler,
             native_class_cache,
             consensus_info_watch: None,
             preconfirmed_watch: None,
@@ -266,6 +275,7 @@ impl RpcContext {
             submission_tracker_time_limit: NonZeroU64::new(300).unwrap(),
             submission_tracker_size_limit: NonZeroUsize::new(30000).unwrap(),
             block_trace_cache_size: NonZeroUsize::new(1).unwrap(),
+            compiler_concurrency_limit: NonZeroUsize::new(1).unwrap(),
             compiler_resource_limits: pathfinder_compiler::ResourceLimits::for_test(),
             blockifier_libfuncs: pathfinder_compiler::BlockifierLibfuncs::default(),
         };

--- a/crates/rpc/src/executor.rs
+++ b/crates/rpc/src/executor.rs
@@ -17,6 +17,7 @@ use crate::types::request::{
     BroadcastedInvokeTransaction,
     BroadcastedTransaction,
 };
+use crate::PathfinderCompiler;
 
 pub enum ExecutionStateError {
     BlockNotFound,
@@ -82,8 +83,7 @@ pub(crate) fn signature_elem_limit_exceeded(tx: &BroadcastedTransaction) -> bool
 pub(crate) fn map_broadcasted_transaction(
     transaction: &BroadcastedTransaction,
     chain_id: ChainId,
-    compiler_resource_limits: pathfinder_compiler::ResourceLimits,
-    blockifier_libfuncs: pathfinder_compiler::BlockifierLibfuncs,
+    compiler: &PathfinderCompiler,
     skip_validate: bool,
     skip_fee_charge: bool,
 ) -> anyhow::Result<pathfinder_executor::Transaction> {
@@ -131,12 +131,9 @@ pub(crate) fn map_broadcasted_transaction(
                 serde_json::to_vec(&tx.contract_class)
                     .context("Serializing Sierra class definition")?,
             );
-            let casm_contract_definition = pathfinder_compiler::compile_sierra_to_casm(
-                &sierra_definition,
-                compiler_resource_limits,
-                blockifier_libfuncs,
-            )
-            .context("Compiling Sierra class definition to CASM")?;
+            let casm_contract_definition = compiler
+                .compile_sierra_to_casm(&sierra_definition)
+                .context("Compiling Sierra class definition to CASM")?;
 
             let casm_contract_definition = pathfinder_executor::parse_casm_definition(
                 casm_contract_definition,
@@ -157,12 +154,9 @@ pub(crate) fn map_broadcasted_transaction(
                 serde_json::to_vec(&tx.contract_class)
                     .context("Serializing Sierra class definition")?,
             );
-            let casm_contract_definition = pathfinder_compiler::compile_sierra_to_casm(
-                &sierra_definition,
-                compiler_resource_limits,
-                blockifier_libfuncs,
-            )
-            .context("Compiling Sierra class definition to CASM")?;
+            let casm_contract_definition = compiler
+                .compile_sierra_to_casm(&sierra_definition)
+                .context("Compiling Sierra class definition to CASM")?;
 
             let casm_contract_definition = pathfinder_executor::parse_casm_definition(
                 casm_contract_definition,

--- a/crates/rpc/src/executor.rs
+++ b/crates/rpc/src/executor.rs
@@ -80,6 +80,11 @@ pub(crate) fn signature_elem_limit_exceeded(tx: &BroadcastedTransaction) -> bool
     }
 }
 
+/// Maps an [RPC layer transaction](BroadcastedTransaction) into a transaction
+/// that can be fed into the [executor](pathfinder_executor).
+///
+/// This is a blocking function. When used inside an async runtime, it should be
+/// called on a blocking thread.
 pub(crate) fn map_broadcasted_transaction(
     transaction: &BroadcastedTransaction,
     chain_id: ChainId,

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1,4 +1,5 @@
 //! Starknet node JSON-RPC related modules.
+mod compiler;
 pub mod context;
 mod dto;
 mod error;
@@ -27,6 +28,7 @@ use anyhow::Context;
 use axum::error_handling::HandleErrorLayer;
 use axum::extract::DefaultBodyLimit;
 use axum::response::IntoResponse;
+pub use compiler::PathfinderCompiler;
 use context::RpcContext;
 pub use executor::compose_executor_transaction;
 use http_body::Body;

--- a/crates/rpc/src/method/estimate_fee.rs
+++ b/crates/rpc/src/method/estimate_fee.rs
@@ -128,8 +128,7 @@ pub async fn estimate_fee(
                 crate::executor::map_broadcasted_transaction(
                     &tx,
                     context.chain_id,
-                    context.config.compiler_resource_limits,
-                    context.config.blockifier_libfuncs,
+                    &context.compiler,
                     skip_validate,
                     true,
                 )

--- a/crates/rpc/src/method/estimate_fee.rs
+++ b/crates/rpc/src/method/estimate_fee.rs
@@ -71,6 +71,26 @@ pub async fn estimate_fee(
     }
     let result = util::task::spawn_blocking(move |_| {
         let _g = span.enter();
+
+        let skip_validate = input
+            .simulation_flags
+            .iter()
+            .any(|flag| flag == &SimulationFlag::SkipValidate);
+
+        let transactions = input
+            .request
+            .into_iter()
+            .map(|tx| {
+                crate::executor::map_broadcasted_transaction(
+                    &tx,
+                    context.chain_id,
+                    &context.compiler,
+                    skip_validate,
+                    true,
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
         let mut db_conn = context
             .execution_storage
             .connection()
@@ -115,25 +135,6 @@ pub async fn estimate_fee(
                 .config
                 .native_execution_force_use_for_incompatible_classes,
         );
-
-        let skip_validate = input
-            .simulation_flags
-            .iter()
-            .any(|flag| flag == &SimulationFlag::SkipValidate);
-
-        let transactions = input
-            .request
-            .into_iter()
-            .map(|tx| {
-                crate::executor::map_broadcasted_transaction(
-                    &tx,
-                    context.chain_id,
-                    &context.compiler,
-                    skip_validate,
-                    true,
-                )
-            })
-            .collect::<Result<Vec<_>, _>>()?;
 
         let result = pathfinder_executor::estimate(
             db_tx,

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -74,6 +74,20 @@ pub async fn simulate_transactions(
             .simulation_flags
             .contains(&crate::dto::SimulationFlag::ReturnInitialReads);
 
+        let transactions = input
+            .transactions
+            .into_iter()
+            .map(|tx| {
+                crate::executor::map_broadcasted_transaction(
+                    &tx,
+                    context.chain_id,
+                    &context.compiler,
+                    skip_validate,
+                    skip_fee_charge,
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
         let mut db_conn = context
             .execution_storage
             .connection()
@@ -118,20 +132,6 @@ pub async fn simulate_transactions(
                 .config
                 .native_execution_force_use_for_incompatible_classes,
         );
-
-        let transactions = input
-            .transactions
-            .into_iter()
-            .map(|tx| {
-                crate::executor::map_broadcasted_transaction(
-                    &tx,
-                    context.chain_id,
-                    &context.compiler,
-                    skip_validate,
-                    skip_fee_charge,
-                )
-            })
-            .collect::<Result<Vec<_>, _>>()?;
 
         let (simulations, initial_reads) = pathfinder_executor::simulate(
             db_tx,

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -126,8 +126,7 @@ pub async fn simulate_transactions(
                 crate::executor::map_broadcasted_transaction(
                     &tx,
                     context.chain_id,
-                    context.config.compiler_resource_limits,
-                    context.config.blockifier_libfuncs,
+                    &context.compiler,
                     skip_validate,
                     skip_fee_charge,
                 )

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -10,6 +10,6 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 num-traits = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -4,4 +4,5 @@
 pub mod error;
 pub mod make_stream;
 pub mod percentage;
+pub mod sync;
 pub mod task;

--- a/crates/util/src/sync.rs
+++ b/crates/util/src/sync.rs
@@ -1,0 +1,3 @@
+pub mod semaphore;
+
+pub use semaphore::{Semaphore, SemaphorePermit};

--- a/crates/util/src/sync/semaphore.rs
+++ b/crates/util/src/sync/semaphore.rs
@@ -1,0 +1,194 @@
+/// A small blocking semaphore for limiting access to a shared resource.
+///
+/// A semaphore starts with a fixed number of permits. Calling [`acquire`] waits
+/// until a permit is available and returns a [`SemaphorePermit`]. The permit is
+/// returned to the semaphore when the guard is dropped.
+///
+/// This semaphore blocks the current OS thread while waiting, so it is suitable
+/// for synchronous code or for work running on a blocking thread pool. Do not
+/// call [`acquire`] directly from async tasks running on an async executor's
+/// worker threads.
+///
+/// The implementation does not guarantee fairness between waiting threads.
+///
+/// [`acquire`]: Self::acquire
+///
+/// # Examples
+///
+/// Limit a section of work to one concurrent caller:
+///
+/// ```
+/// use std::sync::Arc;
+///
+/// use util::sync::semaphore::Semaphore;
+///
+/// let semaphore = Arc::new(Semaphore::new(1));
+///
+/// let first = semaphore.acquire();
+/// assert_eq!(semaphore.available_permits(), 0);
+///
+/// drop(first);
+/// assert_eq!(semaphore.available_permits(), 1);
+/// ```
+///
+/// Try to acquire a permit without blocking:
+///
+/// ```
+/// use util::sync::semaphore::Semaphore;
+///
+/// let semaphore = Semaphore::new(1);
+/// let permit = semaphore.try_acquire().expect("permit should be available");
+///
+/// assert!(semaphore.try_acquire().is_none());
+///
+/// drop(permit);
+/// assert!(semaphore.try_acquire().is_some());
+/// ```
+pub struct Semaphore {
+    permits: std::sync::Mutex<usize>,
+    condvar: std::sync::Condvar,
+}
+
+impl Semaphore {
+    /// Creates a semaphore with `permits` initially available permits.
+    ///
+    /// # Panics
+    ///
+    /// Since there is no `add_permits` or similar API, a semaphore created with
+    /// zero permits would effectively be permanently closed. To prevent this,
+    /// the function panics when attempting to create a semaphore with zero
+    /// available permits.
+    pub fn new(permits: usize) -> Self {
+        assert!(permits > 0);
+        Self {
+            permits: std::sync::Mutex::new(permits),
+            condvar: std::sync::Condvar::new(),
+        }
+    }
+
+    /// Acquires one [SemaphorePermit], blocking the current thread until one is
+    /// available.
+    pub fn acquire(&self) -> SemaphorePermit<'_> {
+        let mut permits = self.permits.lock().unwrap();
+        while *permits == 0 {
+            permits = self.condvar.wait(permits).unwrap();
+        }
+        *permits -= 1;
+        SemaphorePermit {
+            permits: &self.permits,
+            condvar: &self.condvar,
+        }
+    }
+
+    /// Attempts to acquire one [SemaphorePermit] without blocking.
+    ///
+    /// Returns [`Some`] guard when a permit was available, or [`None`] if the
+    /// semaphore currently has no available permits.
+    pub fn try_acquire(&self) -> Option<SemaphorePermit<'_>> {
+        let mut permits = self.permits.lock().unwrap();
+        if *permits == 0 {
+            return None;
+        }
+        *permits -= 1;
+        Some(SemaphorePermit {
+            permits: &self.permits,
+            condvar: &self.condvar,
+        })
+    }
+
+    /// Returns the number of permits currently available.
+    ///
+    /// This is a point-in-time snapshot. In concurrent code, another thread may
+    /// acquire or release a permit immediately after this method returns.
+    pub fn available_permits(&self) -> usize {
+        *self.permits.lock().unwrap()
+    }
+}
+
+/// A semaphore permit acquired through [`Semaphore::acquire`] or
+/// [`Semaphore::try_acquire`].
+pub struct SemaphorePermit<'a> {
+    permits: &'a std::sync::Mutex<usize>,
+    condvar: &'a std::sync::Condvar,
+}
+
+impl<'a> Drop for SemaphorePermit<'a> {
+    fn drop(&mut self) {
+        {
+            let mut permits = self.permits.lock().unwrap();
+            *permits += 1;
+        }
+        self.condvar.notify_one();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{mpsc, Arc};
+    use std::time::Duration;
+
+    use super::Semaphore;
+
+    #[test]
+    fn acquire_consumes_permit_until_dropped() {
+        let semaphore = Semaphore::new(1);
+
+        let permit = semaphore.acquire();
+
+        assert_eq!(semaphore.available_permits(), 0);
+        drop(permit);
+        assert_eq!(semaphore.available_permits(), 1);
+    }
+
+    #[test]
+    fn multiple_initial_permits() {
+        let semaphore = Semaphore::new(2);
+
+        let first = semaphore.acquire();
+        let second = semaphore.acquire();
+
+        assert_eq!(semaphore.available_permits(), 0);
+        drop(first);
+        assert_eq!(semaphore.available_permits(), 1);
+        drop(second);
+        assert_eq!(semaphore.available_permits(), 2);
+    }
+
+    #[test]
+    fn repeated_acquire_and_drop_does_not_grow_capacity() {
+        let semaphore = Semaphore::new(1);
+
+        for _ in 0..3 {
+            drop(semaphore.acquire());
+        }
+
+        assert_eq!(semaphore.available_permits(), 1);
+    }
+
+    #[test]
+    fn acquire_blocks_until_permit_is_released() {
+        let semaphore = Arc::new(Semaphore::new(1));
+        let permit = semaphore.acquire();
+        let (sender, receiver) = mpsc::channel();
+
+        let thread = {
+            let semaphore = semaphore.clone();
+            std::thread::spawn(move || {
+                let _permit = semaphore.acquire();
+                sender.send(()).unwrap();
+            })
+        };
+
+        assert!(matches!(
+            receiver.recv_timeout(Duration::from_millis(50)),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        ));
+
+        drop(permit);
+
+        receiver
+            .recv()
+            .expect("permit should be acquired after release");
+        thread.join().unwrap();
+    }
+}

--- a/crates/util/src/sync/semaphore.rs
+++ b/crates/util/src/sync/semaphore.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 /// A small blocking semaphore for limiting access to a shared resource.
 ///
 /// A semaphore starts with a fixed number of permits. Calling [`acquire`] waits
@@ -18,11 +20,12 @@
 /// Limit a section of work to one concurrent caller:
 ///
 /// ```
+/// use std::num::NonZeroUsize;
 /// use std::sync::Arc;
 ///
 /// use util::sync::semaphore::Semaphore;
 ///
-/// let semaphore = Arc::new(Semaphore::new(1));
+/// let semaphore = Arc::new(Semaphore::new(NonZeroUsize::new(1).unwrap()));
 ///
 /// let first = semaphore.acquire();
 /// assert_eq!(semaphore.available_permits(), 0);
@@ -34,9 +37,11 @@
 /// Try to acquire a permit without blocking:
 ///
 /// ```
+/// use std::num::NonZeroUsize;
+///
 /// use util::sync::semaphore::Semaphore;
 ///
-/// let semaphore = Semaphore::new(1);
+/// let semaphore = Semaphore::new(NonZeroUsize::new(1).unwrap());
 /// let permit = semaphore.try_acquire().expect("permit should be available");
 ///
 /// assert!(semaphore.try_acquire().is_none());
@@ -51,17 +56,9 @@ pub struct Semaphore {
 
 impl Semaphore {
     /// Creates a semaphore with `permits` initially available permits.
-    ///
-    /// # Panics
-    ///
-    /// Since there is no `add_permits` or similar API, a semaphore created with
-    /// zero permits would effectively be permanently closed. To prevent this,
-    /// the function panics when attempting to create a semaphore with zero
-    /// available permits.
-    pub fn new(permits: usize) -> Self {
-        assert!(permits > 0);
+    pub fn new(permits: NonZeroUsize) -> Self {
         Self {
-            permits: std::sync::Mutex::new(permits),
+            permits: std::sync::Mutex::new(permits.get()),
             condvar: std::sync::Condvar::new(),
         }
     }
@@ -124,6 +121,7 @@ impl<'a> Drop for SemaphorePermit<'a> {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroUsize;
     use std::sync::{mpsc, Arc};
     use std::time::Duration;
 
@@ -131,7 +129,7 @@ mod tests {
 
     #[test]
     fn acquire_consumes_permit_until_dropped() {
-        let semaphore = Semaphore::new(1);
+        let semaphore = Semaphore::new(NonZeroUsize::new(1).unwrap());
 
         let permit = semaphore.acquire();
 
@@ -142,7 +140,7 @@ mod tests {
 
     #[test]
     fn multiple_initial_permits() {
-        let semaphore = Semaphore::new(2);
+        let semaphore = Semaphore::new(NonZeroUsize::new(2).unwrap());
 
         let first = semaphore.acquire();
         let second = semaphore.acquire();
@@ -156,7 +154,7 @@ mod tests {
 
     #[test]
     fn repeated_acquire_and_drop_does_not_grow_capacity() {
-        let semaphore = Semaphore::new(1);
+        let semaphore = Semaphore::new(NonZeroUsize::new(1).unwrap());
 
         for _ in 0..3 {
             drop(semaphore.acquire());
@@ -167,7 +165,7 @@ mod tests {
 
     #[test]
     fn acquire_blocks_until_permit_is_released() {
-        let semaphore = Arc::new(Semaphore::new(1));
+        let semaphore = Arc::new(Semaphore::new(NonZeroUsize::new(1).unwrap()));
         let permit = semaphore.acquire();
         let (sender, receiver) = mpsc::channel();
 


### PR DESCRIPTION
Changes contained in the PR (in commit order):

- Fixes standalone compilation of the `util` crate by adding the `macros` tokio feature. 
- Adds a blocking semaphore primitive into the `util` crate (weird that the standard library doesn't have one).
- Uses the added semaphore primitive to limit the number of concurrently running Sierra to CASM compiler processes in the RPC layer. Can be extended to P2P code but I found it unnecessary because it isn't as vulnerable as the JSON-RPC server.
- Ensures that DB transactions aren't held unnecessarily while a thread is parked by running blocking Sierra to CASM compilation before the DB transaction starts.