### PR TITLE
fix(docker): image build failing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,23 @@ jobs:
           cd crates/load-test
           cargo check
 
+  # The Docker build excludes rust-toolchain.toml from its context, so the only thing
+  # setting the build's Rust version is the base image tag in the Dockerfile. Guard
+  # against the two drifting apart, which silently builds against the wrong toolchain.
+  docker-rust-version:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check Dockerfile Rust version matches rust-toolchain.toml
+        run: |
+          pin=$(grep -oP 'channel\s*=\s*"\K[^"]+' rust-toolchain.toml)
+          img=$(grep -oP 'cargo-chef:.*-rust-\K[0-9]+\.[0-9]+\.[0-9]+' Dockerfile | head -1)
+          if [ "$pin" != "$img" ]; then
+            echo "::error::Dockerfile base image Rust ($img) does not match rust-toolchain.toml channel ($pin). Bump the cargo-chef image tag in the Dockerfile to rust-$pin."
+            exit 1
+          fi
+          echo "Rust version matches: $pin"
+
   required:
     needs:
       - test-all-features
@@ -259,6 +276,7 @@ jobs:
       - dep-sort
       - typos
       - load_test
+      - docker-rust-version
     if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,13 @@
 # Note that we're explicitly using the Debian bookworm image to make sure we're
 # compatible with the Debian container we'll be copying the pathfinder
 # executable to.
-FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:0.1.73-rust-1.91.1-slim-bookworm AS cargo-chef
+#
+# IMPORTANT: keep the Rust version in this image tag equal to the channel in
+# rust-toolchain.toml. The COPY steps below exclude rust-toolchain.toml from the
+# build context, so rustup never sees the pin and the build always uses the Rust
+# that ships in this image (we exclude it so rustup doesn't re-download the
+# toolchain's components on every build)
+FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:0.1.77-rust-1.95.0-slim-bookworm AS cargo-chef
 WORKDIR /usr/src/pathfinder
 
 FROM --platform=$BUILDPLATFORM cargo-chef AS rust-planner


### PR DESCRIPTION
Bumps the docker image to one that preinstalls our toolchain rust version  (1.95.0)