### PR TITLE
fix(gateway-client): known_block_identifier wrongly used in place of block_identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Parallel Sierra to CASM compilation processes during RPC requests are now limited to the number of CPU cores available by default, configurable with `--rpc.compiler.concurrency-limit` CLI option.
 
+### Fixed
+
+- Pre-confirmed block polling re-fetching the full block on every poll due to a `block_identifier` field being deserialized under the wrong name.
+
 ## [0.22.4] - 2026-06-08
 
 ### Changed

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -132,7 +132,7 @@ pub struct PreConfirmedPollResponseWire {
     changed: bool,
 
     #[serde(default)]
-    known_block_identifier: Option<String>,
+    block_identifier: Option<String>,
 
     // Block number: present on Full responses only.
     #[serde(default)]
@@ -217,7 +217,7 @@ impl TryFrom<PreConfirmedPollResponseWire> for PreConfirmedPollResponse {
         if !wire.changed {
             return Ok(Self::Unchanged);
         }
-        let identifier = wire.known_block_identifier.take().unwrap_or_default();
+        let identifier = wire.block_identifier.take().unwrap_or_default();
         if wire.status.is_some() {
             Ok(Self::Full {
                 identifier,
@@ -2761,7 +2761,7 @@ mod tests {
         fn delta() {
             let json = serde_json::json!({
                 "changed": true,
-                "known_block_identifier": "abc",
+                "block_identifier": "abc",
                 "transactions": [
                     {
                         "type": "INVOKE_FUNCTION",
@@ -2805,7 +2805,7 @@ mod tests {
                 .insert("changed".into(), true.into());
             json.as_object_mut()
                 .unwrap()
-                .insert("known_block_identifier".into(), "xyz".into());
+                .insert("block_identifier".into(), "xyz".into());
 
             let wire: PreConfirmedPollResponseWire = serde_json::from_value(json).unwrap();
             let response = PreConfirmedPollResponse::try_from(wire).unwrap();


### PR DESCRIPTION
We attempt to deserialize `know_block_identifier` while such field does not exist. The correct name of the field is `block_identifier`. User report:

```
I noticed a client polling the feeder gateway like this:

get_preconfirmed_block?blockNumber=latest&blockIdentifier=&knownTransactionCount=12

The knownTransactionCount=12 is being ignored here — the server returns the full block (all transactions) on every poll instead of just the new tail. So the client is re-downloading the entire preconfirmed block each time.

Why: knownTransactionCount is only honored when blockIdentifier matches the server's current block identifier. Here blockIdentifier is sent as an empty string, which never matches the real identifier (an 8-hex-char value like 0x1a2b3c4d), so the server falls back to skip=0 → full block.

The fix is small: the client already receives the right value to use. Even with the empty blockIdentifier, the full response includes a block_identifier field. The client just needs to echo that value back on the next poll instead of sending it blank:

1. First poll: send blockIdentifier= (empty is fine) — response is the full block and includes a block_identifier.
2. Subsequent polls: set blockIdentifier=<value from previous response> together with knownTransactionCount=<txs already seen>. The server then returns only the new transactions (delta), or {"changed": false} when fully caught up.

Note: do not omit blockIdentifier entirely — if the key is absent the response won't include block_identifier at all. Send it (empty on the first call, then the returned value).
```
