### PR TITLE
ci(docker): allow forcing pathfinder version via workflow_dispatch input

### DIFF
--- a/.github/workflows/docker-p2p.yml
+++ b/.github/workflows/docker-p2p.yml
@@ -4,6 +4,11 @@ name: Docker - P2P
 
 on:
   workflow_dispatch:
+    inputs:
+      pathfinder_force_version:
+        description: 'Set version for pathfinder via PATHFINDER_FORCE_VERSION (defaults to `git describe --tags --dirty`)'
+        type: string
+        default: ''
 
 env:
   # Workaround for https://github.com/rust-lang/cargo/issues/8719#issuecomment-1516492970
@@ -25,9 +30,15 @@ jobs:
           fetch-depth: 0
       - name: Generate version
         id: generate_version
+        env:
+          PATHFINDER_FORCE_VERSION: ${{ inputs.pathfinder_force_version }}
         run: |
-          echo -n "pathfinder_version=" >> $GITHUB_OUTPUT
-          git describe --tags --dirty >> $GITHUB_OUTPUT
+          if [ -n "$PATHFINDER_FORCE_VERSION" ]; then
+            echo "pathfinder_version=$PATHFINDER_FORCE_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo -n "pathfinder_version=" >> $GITHUB_OUTPUT
+            git describe --tags --dirty >> $GITHUB_OUTPUT
+          fi
       - name: Set up QEMU
         id: qemu
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,11 @@ name: Docker
 
 on:
   workflow_dispatch:
+    inputs:
+      pathfinder_force_version:
+        description: 'Set version for pathfinder via PATHFINDER_FORCE_VERSION (defaults to `git describe --tags --dirty`)'
+        type: string
+        default: ''
   push:
     tags:
       - 'v*'
@@ -32,9 +37,15 @@ jobs:
           fetch-depth: 0
       - name: Generate version
         id: generate_version
+        env:
+          PATHFINDER_FORCE_VERSION: ${{ inputs.pathfinder_force_version }}
         run: |
-          echo -n "pathfinder_version=" >> $GITHUB_OUTPUT
-          git describe --tags --dirty >> $GITHUB_OUTPUT
+          if [ -n "$PATHFINDER_FORCE_VERSION" ]; then
+            echo "pathfinder_version=$PATHFINDER_FORCE_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo -n "pathfinder_version=" >> $GITHUB_OUTPUT
+            git describe --tags --dirty >> $GITHUB_OUTPUT
+          fi
       - name: Set up QEMU
         id: qemu
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
adds an input to set the exact version for pathfinder in the docker image. by default the `git describe --tags --dirty` is used, resulting in e.g. `0.22.4-2-deadbeef` if there are commits on top of an image. useful when a tag is already out but needs a hotfix for docker. dockerhub tagging (v0.22.8, latest) is still manual and requires perms