### PR TITLE
fix(executor): compiler thread segfaults

### DIFF
--- a/crates/executor/src/state_reader/native.rs
+++ b/crates/executor/src/state_reader/native.rs
@@ -30,8 +30,26 @@ type Cache = Mutex<SizedCache<ClassHash, CacheItem>>;
 
 #[derive(Clone)]
 pub struct NativeClassCache {
+    inner: Arc<Inner>,
+}
+
+/// Owns the class cache and the background compiler thread. The thread is shut
+/// down and joined when the last native class cache is dropped.
+struct Inner {
     cache: Arc<Cache>,
-    compiler_tx: std::sync::mpsc::Sender<CompilerInput>,
+    compiler_tx: Option<std::sync::mpsc::Sender<CompilerInput>>,
+    compiler_thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Drop for Inner {
+    fn drop(&mut self) {
+        // Close the channel to force the compiler thread out of its loop.
+        drop(self.compiler_tx.take());
+        // Now wait for the compiler thread to end.
+        if let Some(thread) = self.compiler_thread.take() {
+            let _ = thread.join();
+        }
+    }
 }
 
 impl NativeClassCache {
@@ -40,7 +58,7 @@ impl NativeClassCache {
 
         let cache = Arc::new(Mutex::new(SizedCache::with_size(cache_size.get())));
 
-        util::task::spawn_std({
+        let compiler_handle = util::task::spawn_std({
             let cache = Arc::clone(&cache);
             move |cancellation_token| {
                 compiler_thread(cache, rx, cancellation_token, optimization_level.into())
@@ -48,8 +66,11 @@ impl NativeClassCache {
         });
 
         NativeClassCache {
-            cache,
-            compiler_tx: tx,
+            inner: Arc::new(Inner {
+                cache,
+                compiler_tx: Some(tx),
+                compiler_thread: Some(compiler_handle),
+            }),
         }
     }
 
@@ -60,7 +81,7 @@ impl NativeClassCache {
         class_definition: SerializedOpaqueClassDefinition,
         casm_definition: SerializedCasmDefinition,
     ) -> Option<NativeCompiledClassV1> {
-        let mut locked = self.cache.lock().unwrap();
+        let mut locked = self.inner.cache.lock().unwrap();
 
         match locked.cache_get(&class_hash) {
             Some(CacheItem::CompiledClass(cached_class)) => {
@@ -77,12 +98,17 @@ impl NativeClassCache {
                 tracing::trace!(%class_hash, "Native class cache miss (compiling)");
                 metrics::counter!("native_class_cache_miss_total").increment(1);
                 locked.cache_set(class_hash, CacheItem::CompilationPending);
-                let _ = self.compiler_tx.send(CompilerInput {
-                    class_hash,
-                    sierra_version,
-                    class_definition,
-                    casm_definition,
-                });
+                let _ = self
+                    .inner
+                    .compiler_tx
+                    .as_ref()
+                    .expect("compiler channel is open")
+                    .send(CompilerInput {
+                        class_hash,
+                        sierra_version,
+                        class_definition,
+                        casm_definition,
+                    });
                 metrics::gauge!(NATIVE_CLASS_COMPILATION_QUEUED_TOTAL_METRIC_NAME).increment(1.0);
                 None
             }

--- a/crates/executor/src/state_reader/native.rs
+++ b/crates/executor/src/state_reader/native.rs
@@ -189,8 +189,6 @@ fn sierra_class_as_native(
         ))
     })?;
 
-    let mut class_path = std::env::temp_dir();
-    class_path.push(format!("native_class_{}", input.class_hash));
     let version_id = cairo_lang_starknet_classes::compiler_version::VersionId {
         major: input.sierra_version.major as usize,
         minor: input.sierra_version.minor as usize,


### PR DESCRIPTION
TLDR: Make the shutdown of the compiler thread deterministic.

This particular test is the one putting the most pressure on the native class cache because it drives the fee estimation max gas path, which is just re-executing non stop. More native classes compiled means more `dlopen` and thus more stuff to unload at teardown. Seems like there's a race somewhere during that teardown. I believe this fixes it.

Closes https://github.com/equilibriumco/pathfinder/issues/3443