### PR TITLE
Reduce memory footprint of `starknet_add*Transaction` methods

### DIFF
--- a/crates/gateway-client/src/builder.rs
+++ b/crates/gateway-client/src/builder.rs
@@ -12,7 +12,6 @@
 //!   3. [Params](stage::Params) where you select the retry behavior.
 //!   4. [Final](stage::Final) where you select the REST operation type, which
 //!      is then executed.
-use std::io::Write as _;
 
 use backon::Retryable;
 use pathfinder_common::{ClassHash, TransactionHash};
@@ -371,14 +370,9 @@ impl Request<stage::Final> {
                     None => request,
                 };
                 if compress {
-                    let body = serde_json::to_vec(json)
-                        .map_err(|e| SequencerError::GatewayRequestCreationError(e.into()))?;
-                    let mut encoder = flate2::write::GzEncoder::new(
-                        Vec::with_capacity(body.len() / 2),
-                        flate2::Compression::default(),
-                    );
-                    encoder
-                        .write_all(&body)
+                    let mut encoder =
+                        flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+                    serde_json::to_writer(&mut encoder, json)
                         .map_err(|e| SequencerError::GatewayRequestCreationError(e.into()))?;
                     let compressed_body = encoder
                         .finish()
@@ -835,8 +829,6 @@ mod tests {
     }
 
     mod body_is_compressed_if_and_only_if_compress_flag_is_set {
-        use std::io::Write as _;
-
         use pathfinder_common::{ContractAddress, Proof, ProofFactElem, Tip, TransactionNonce};
         use serde_json::json;
         use starknet_gateway_types::reply::DataAvailabilityMode;
@@ -890,13 +882,13 @@ mod tests {
         }
 
         fn compressed_body() -> Vec<u8> {
-            let body = serde_json::to_vec(&AddTransaction::Invoke(InvokeFunction::V3(
-                v3_non_empty_proof(),
-            )))
-            .unwrap();
             let mut encoder =
                 flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
-            encoder.write_all(&body).unwrap();
+            serde_json::to_writer(
+                &mut encoder,
+                &AddTransaction::Invoke(InvokeFunction::V3(v3_non_empty_proof())),
+            )
+            .unwrap();
             encoder.finish().unwrap()
         }
 

--- a/crates/gateway-client/src/builder.rs
+++ b/crates/gateway-client/src/builder.rs
@@ -849,27 +849,35 @@ mod tests {
 
         use crate::{Client, GatewayApi};
 
-        fn v3_empty_proof() -> InvokeFunctionV3 {
+        fn v3_empty_proof() -> InvokeFunctionV3<'static> {
+            static EMPTY_PROOF: Proof = Proof(Vec::new());
+
             InvokeFunctionV3 {
-                signature: vec![],
+                signature: &[],
                 nonce: TransactionNonce::ZERO,
                 nonce_data_availability_mode: DataAvailabilityMode::L1,
                 fee_data_availability_mode: DataAvailabilityMode::L1,
                 resource_bounds: Default::default(),
                 tip: Tip(0),
-                paymaster_data: vec![],
+                paymaster_data: &[],
                 sender_address: ContractAddress::ZERO,
-                calldata: vec![],
-                account_deployment_data: vec![],
-                proof_facts: vec![],
-                proof: Proof(vec![]),
+                calldata: &[],
+                account_deployment_data: &[],
+                proof_facts: &[],
+                proof: &EMPTY_PROOF,
             }
         }
 
-        fn v3_non_empty_proof() -> InvokeFunctionV3 {
+        fn v3_non_empty_proof() -> InvokeFunctionV3<'static> {
+            use std::sync::LazyLock;
+
+            static PROOF: LazyLock<Proof> = LazyLock::new(|| Proof(vec![0; 100]));
+            static PROOF_FACTS: LazyLock<Vec<ProofFactElem>> =
+                LazyLock::new(|| vec![ProofFactElem::ZERO]);
+
             InvokeFunctionV3 {
-                proof: Proof(vec![0; 100]),
-                proof_facts: vec![ProofFactElem::ZERO],
+                proof: &PROOF,
+                proof_facts: &PROOF_FACTS,
                 ..v3_empty_proof()
             }
         }

--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -112,24 +112,24 @@ pub trait GatewayApi: Sync {
         unimplemented!();
     }
 
-    async fn add_invoke_transaction(
+    async fn add_invoke_transaction<'tx>(
         &self,
-        invoke: request::add_transaction::InvokeFunction,
+        invoke: request::add_transaction::InvokeFunction<'tx>,
     ) -> Result<reply::add_transaction::InvokeResponse, SequencerError> {
         unimplemented!();
     }
 
-    async fn add_declare_transaction(
+    async fn add_declare_transaction<'tx>(
         &self,
-        declare: request::add_transaction::Declare,
+        declare: request::add_transaction::Declare<'tx>,
         token: Option<String>,
     ) -> Result<reply::add_transaction::DeclareResponse, SequencerError> {
         unimplemented!();
     }
 
-    async fn add_deploy_account(
+    async fn add_deploy_account<'tx>(
         &self,
-        deploy: request::add_transaction::DeployAccount,
+        deploy: request::add_transaction::DeployAccount<'tx>,
     ) -> Result<reply::add_transaction::DeployAccountResponse, SequencerError> {
         unimplemented!();
     }
@@ -212,24 +212,24 @@ impl<T: GatewayApi + Sync + Send> GatewayApi for Arc<T> {
         self.as_ref().eth_contract_addresses().await
     }
 
-    async fn add_invoke_transaction(
+    async fn add_invoke_transaction<'tx>(
         &self,
-        invoke: request::add_transaction::InvokeFunction,
+        invoke: request::add_transaction::InvokeFunction<'tx>,
     ) -> Result<reply::add_transaction::InvokeResponse, SequencerError> {
         self.as_ref().add_invoke_transaction(invoke).await
     }
 
-    async fn add_declare_transaction(
+    async fn add_declare_transaction<'tx>(
         &self,
-        declare: request::add_transaction::Declare,
+        declare: request::add_transaction::Declare<'tx>,
         token: Option<String>,
     ) -> Result<reply::add_transaction::DeclareResponse, SequencerError> {
         self.as_ref().add_declare_transaction(declare, token).await
     }
 
-    async fn add_deploy_account(
+    async fn add_deploy_account<'tx>(
         &self,
-        deploy: request::add_transaction::DeployAccount,
+        deploy: request::add_transaction::DeployAccount<'tx>,
     ) -> Result<reply::add_transaction::DeployAccountResponse, SequencerError> {
         self.as_ref().add_deploy_account(deploy).await
     }
@@ -659,9 +659,9 @@ impl GatewayApi for Client {
 
     /// Adds a transaction invoking a contract.
     #[tracing::instrument(skip(self))]
-    async fn add_invoke_transaction(
+    async fn add_invoke_transaction<'tx>(
         &self,
-        invoke: request::add_transaction::InvokeFunction,
+        invoke: request::add_transaction::InvokeFunction<'tx>,
     ) -> Result<reply::add_transaction::InvokeResponse, SequencerError> {
         // Note that we don't do retries here.
         // This method is used to proxy an add transaction operation from the JSON-RPC
@@ -682,9 +682,9 @@ impl GatewayApi for Client {
 
     /// Adds a transaction declaring a class.
     #[tracing::instrument(skip(self))]
-    async fn add_declare_transaction(
+    async fn add_declare_transaction<'tx>(
         &self,
-        declare: request::add_transaction::Declare,
+        declare: request::add_transaction::Declare<'tx>,
         token: Option<String>,
     ) -> Result<reply::add_transaction::DeclareResponse, SequencerError> {
         // Note that we don't do retries here.
@@ -704,9 +704,9 @@ impl GatewayApi for Client {
     }
 
     #[tracing::instrument(skip(self))]
-    async fn add_deploy_account(
+    async fn add_deploy_account<'tx>(
         &self,
-        deploy: request::add_transaction::DeployAccount,
+        deploy: request::add_transaction::DeployAccount<'tx>,
     ) -> Result<reply::add_transaction::DeployAccountResponse, SequencerError> {
         // Note that we don't do retries here.
         // This method is used to proxy an add transaction operation from the JSON-RPC
@@ -942,11 +942,11 @@ mod tests {
                 let (_, fee, sig, nonce, addr, call) = inputs();
                 let invoke = InvokeFunction::V0(InvokeFunctionV0V1 {
                     max_fee: fee,
-                    signature: sig,
+                    signature: &sig,
                     nonce: Some(nonce),
                     sender_address: addr,
                     entry_point_selector: None,
-                    calldata: call,
+                    calldata: &call,
                 });
 
                 let error = client.add_invoke_transaction(invoke).await.unwrap_err();
@@ -974,11 +974,11 @@ mod tests {
                 let (_, fee, sig, nonce, addr, call) = inputs();
                 let invoke = InvokeFunction::V1(InvokeFunctionV0V1 {
                     max_fee: fee,
-                    signature: sig,
+                    signature: &sig,
                     nonce: Some(nonce),
                     sender_address: addr,
                     entry_point_selector: None,
-                    calldata: call,
+                    calldata: &call,
                 });
                 client.add_invoke_transaction(invoke).await.unwrap();
             }
@@ -1007,7 +1007,7 @@ mod tests {
                 let declare = Declare::V0(DeclareV0V1V2 {
                     version: TransactionVersion::ZERO,
                     max_fee: Fee(Felt::ZERO),
-                    signature: vec![],
+                    signature: &[],
                     contract_class: ContractDefinition::Cairo(cairo_contract_class_from_fixture()),
                     sender_address: contract_address!("0x1"),
                     nonce: TransactionNonce::ZERO,
@@ -1042,7 +1042,7 @@ mod tests {
                 let declare = Declare::V1(DeclareV0V1V2 {
                     version: TransactionVersion::ONE,
                     max_fee: fee!("0xFFFF"),
-                    signature: vec![],
+                    signature: &[],
                     contract_class: ContractDefinition::Cairo(cairo_contract_class_from_fixture()),
                     sender_address: contract_address!("0x1"),
                     nonce: TransactionNonce(Felt::ZERO),
@@ -1120,7 +1120,7 @@ mod tests {
                 let declare = Declare::V2(DeclareV0V1V2 {
                     version: TransactionVersion::TWO,
                     max_fee: fee!("0xffff"),
-                    signature: vec![],
+                    signature: &[],
                     contract_class: ContractDefinition::Sierra(sierra_contract_class_from_fixture()),
                     sender_address: contract_address!("0x1"),
                     nonce: TransactionNonce::ZERO,
@@ -1220,7 +1220,7 @@ mod tests {
                 let declare = Declare::V0(DeclareV0V1V2 {
                     version: TransactionVersion::ZERO,
                     max_fee: Fee::ZERO,
-                    signature: vec![],
+                    signature: &[],
                     contract_class: ContractDefinition::Cairo(CairoContractDefinition {
                         program: "".to_owned(),
                         entry_points_by_type: HashMap::new(),
@@ -1249,7 +1249,7 @@ mod tests {
                 let declare = Declare::V0(DeclareV0V1V2 {
                     version: TransactionVersion::ZERO,
                     max_fee: Fee::ZERO,
-                    signature: vec![],
+                    signature: &[],
                     contract_class: ContractDefinition::Cairo(CairoContractDefinition {
                         program: "".to_owned(),
                         entry_points_by_type: HashMap::new(),

--- a/crates/gateway-types/src/request.rs
+++ b/crates/gateway-types/src/request.rs
@@ -54,59 +54,59 @@ pub mod add_transaction {
     /// Account deployment transaction details.
     #[derive(Debug, serde::Serialize)]
     #[serde(tag = "version")]
-    pub enum DeployAccount {
+    pub enum DeployAccount<'a> {
         #[serde(rename = "0x0")]
-        V0(DeployAccountV0V1),
+        V0(DeployAccountV0V1<'a>),
         #[serde(rename = "0x1")]
-        V1(DeployAccountV0V1),
+        V1(DeployAccountV0V1<'a>),
         #[serde(rename = "0x3")]
-        V3(DeployAccountV3),
+        V3(DeployAccountV3<'a>),
     }
 
     #[serde_as]
     #[derive(Debug, serde::Serialize)]
-    pub struct DeployAccountV0V1 {
+    pub struct DeployAccountV0V1<'a> {
         pub max_fee: Fee,
-        #[serde_as(as = "Vec<TransactionSignatureElemAsDecimalStr>")]
-        pub signature: Vec<TransactionSignatureElem>,
+        #[serde_as(as = "&[TransactionSignatureElemAsDecimalStr]")]
+        pub signature: &'a [TransactionSignatureElem],
         pub nonce: TransactionNonce,
 
         pub class_hash: ClassHash,
         pub contract_address_salt: ContractAddressSalt,
-        #[serde_as(as = "Vec<CallParamAsDecimalStr>")]
-        pub constructor_calldata: Vec<CallParam>,
+        #[serde_as(as = "&[CallParamAsDecimalStr]")]
+        pub constructor_calldata: &'a [CallParam],
     }
 
     #[serde_as]
     #[derive(Debug, serde::Serialize)]
-    pub struct DeployAccountV3 {
-        pub signature: Vec<TransactionSignatureElem>,
+    pub struct DeployAccountV3<'a> {
+        pub signature: &'a [TransactionSignatureElem],
         pub nonce: TransactionNonce,
         pub nonce_data_availability_mode: DataAvailabilityMode,
         pub fee_data_availability_mode: DataAvailabilityMode,
         pub resource_bounds: ResourceBounds,
         #[serde_as(as = "pathfinder_serde::TipAsHexStr")]
         pub tip: Tip,
-        pub paymaster_data: Vec<PaymasterDataElem>,
+        pub paymaster_data: &'a [PaymasterDataElem],
 
         pub class_hash: ClassHash,
         pub contract_address_salt: ContractAddressSalt,
-        pub constructor_calldata: Vec<CallParam>,
+        pub constructor_calldata: &'a [CallParam],
     }
 
     /// Invoke contract transaction details.
     #[derive(Debug, serde::Serialize)]
     #[serde(tag = "version")]
-    pub enum InvokeFunction {
+    pub enum InvokeFunction<'a> {
         #[serde(rename = "0x0")]
-        V0(InvokeFunctionV0V1),
+        V0(InvokeFunctionV0V1<'a>),
         #[serde(rename = "0x1")]
-        V1(InvokeFunctionV0V1),
+        V1(InvokeFunctionV0V1<'a>),
         #[serde(rename = "0x3")]
-        V3(InvokeFunctionV3),
+        V3(InvokeFunctionV3<'a>),
     }
 
-    impl InvokeFunction {
+    impl InvokeFunction<'_> {
         pub fn is_proof_empty(&self) -> bool {
             match self {
                 InvokeFunction::V0(_) | InvokeFunction::V1(_) => true,
@@ -117,10 +117,10 @@ pub mod add_transaction {
 
     #[serde_as]
     #[derive(Debug, serde::Serialize)]
-    pub struct InvokeFunctionV0V1 {
+    pub struct InvokeFunctionV0V1<'a> {
         // AccountTransaction properties
         pub max_fee: Fee,
-        pub signature: Vec<TransactionSignatureElem>,
+        pub signature: &'a [TransactionSignatureElem],
         // NOTE: this is optional because Invoke v0 transactions do not have a nonce
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub nonce: Option<TransactionNonce>,
@@ -129,54 +129,54 @@ pub mod add_transaction {
         // NOTE: this is optional because only Invoke v0 transactions have an entry point selector
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub entry_point_selector: Option<EntryPoint>,
-        pub calldata: Vec<CallParam>,
+        pub calldata: &'a [CallParam],
     }
 
     #[serde_as]
     #[derive(Debug, serde::Serialize)]
-    pub struct InvokeFunctionV3 {
-        pub signature: Vec<TransactionSignatureElem>,
+    pub struct InvokeFunctionV3<'a> {
+        pub signature: &'a [TransactionSignatureElem],
         pub nonce: TransactionNonce,
         pub nonce_data_availability_mode: DataAvailabilityMode,
         pub fee_data_availability_mode: DataAvailabilityMode,
         pub resource_bounds: ResourceBounds,
         #[serde_as(as = "pathfinder_serde::TipAsHexStr")]
         pub tip: Tip,
-        pub paymaster_data: Vec<PaymasterDataElem>,
+        pub paymaster_data: &'a [PaymasterDataElem],
 
         pub sender_address: ContractAddress,
-        pub calldata: Vec<CallParam>,
-        pub account_deployment_data: Vec<AccountDeploymentDataElem>,
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        pub proof_facts: Vec<ProofFactElem>,
+        pub calldata: &'a [CallParam],
+        pub account_deployment_data: &'a [AccountDeploymentDataElem],
+        #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
+        pub proof_facts: &'a [ProofFactElem],
         #[serde(default, skip_serializing_if = "Proof::is_empty")]
-        pub proof: Proof,
+        pub proof: &'a Proof,
     }
 
     /// Declare transaction details.
     #[allow(clippy::large_enum_variant)]
     #[derive(Debug, serde::Serialize)]
     #[serde(tag = "version")]
-    pub enum Declare {
+    pub enum Declare<'a> {
         #[serde(rename = "0x0")]
-        V0(DeclareV0V1V2),
+        V0(DeclareV0V1V2<'a>),
         #[serde(rename = "0x1")]
-        V1(DeclareV0V1V2),
+        V1(DeclareV0V1V2<'a>),
         #[serde(rename = "0x2")]
-        V2(DeclareV0V1V2),
+        V2(DeclareV0V1V2<'a>),
         #[serde(rename = "0x3")]
-        V3(DeclareV3),
+        V3(DeclareV3<'a>),
     }
 
     #[serde_as]
     #[derive(Debug, serde::Serialize)]
-    pub struct DeclareV0V1V2 {
+    pub struct DeclareV0V1V2<'a> {
         // Transaction properties
         pub version: TransactionVersion,
 
         // AccountTransaction properties -- except for nonce which is non-optional here
         pub max_fee: Fee,
-        pub signature: Vec<TransactionSignatureElem>,
+        pub signature: &'a [TransactionSignatureElem],
 
         pub contract_class: ContractDefinition,
         pub sender_address: ContractAddress,
@@ -189,20 +189,20 @@ pub mod add_transaction {
 
     #[serde_as]
     #[derive(Debug, serde::Serialize)]
-    pub struct DeclareV3 {
-        pub signature: Vec<TransactionSignatureElem>,
+    pub struct DeclareV3<'a> {
+        pub signature: &'a [TransactionSignatureElem],
         pub nonce: TransactionNonce,
         pub nonce_data_availability_mode: DataAvailabilityMode,
         pub fee_data_availability_mode: DataAvailabilityMode,
         pub resource_bounds: ResourceBounds,
         #[serde_as(as = "pathfinder_serde::TipAsHexStr")]
         pub tip: Tip,
-        pub paymaster_data: Vec<PaymasterDataElem>,
+        pub paymaster_data: &'a [PaymasterDataElem],
 
         pub contract_class: SierraContractDefinition,
         pub compiled_class_hash: CasmHash,
         pub sender_address: ContractAddress,
-        pub account_deployment_data: Vec<AccountDeploymentDataElem>,
+        pub account_deployment_data: &'a [AccountDeploymentDataElem],
     }
 
     /// Add transaction API operation.
@@ -211,13 +211,13 @@ pub mod add_transaction {
     /// the transaction (invoke or deploy).
     #[derive(Debug, serde::Serialize)]
     #[serde(tag = "type")]
-    pub enum AddTransaction {
+    pub enum AddTransaction<'a> {
         #[serde(rename = "INVOKE_FUNCTION")]
-        Invoke(InvokeFunction),
+        Invoke(InvokeFunction<'a>),
         #[serde(rename = "DECLARE")]
-        Declare(Declare),
+        Declare(Declare<'a>),
         #[serde(rename = "DEPLOY_ACCOUNT")]
-        DeployAccount(DeployAccount),
+        DeployAccount(DeployAccount<'a>),
     }
 
     #[cfg(test)]
@@ -234,7 +234,7 @@ pub mod add_transaction {
                 serde_json::from_str(INVOKE_CONTRACT_WITH_SIGNATURE).unwrap();
 
             let input = AddTransaction::Invoke(InvokeFunction::V1(InvokeFunctionV0V1 {
-                signature: vec![
+                signature: &[
                     transaction_signature_elem!(
                         "0x7dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5"
                     ),
@@ -246,7 +246,7 @@ pub mod add_transaction {
                 sender_address: contract_address!(
                     "0x23371b227eaecd8e8920cd429357edddd2cd0f3fee6abaacca08d3ab82a7cdd"
                 ),
-                calldata: vec![
+                calldata: &[
                     call_param!("0x1"),
                     call_param!(
                         "0x677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1"

--- a/crates/rpc/src/method/add_declare_transaction.rs
+++ b/crates/rpc/src/method/add_declare_transaction.rs
@@ -332,7 +332,7 @@ pub async fn add_declare_transaction(
                     add_transaction::Declare::V1(add_transaction::DeclareV0V1V2 {
                         version: tx.version,
                         max_fee: tx.max_fee,
-                        signature: tx.signature.clone(),
+                        signature: &tx.signature,
                         contract_class: ContractDefinition::Cairo(contract_definition),
                         sender_address: tx.sender_address,
                         nonce: tx.nonce,
@@ -370,7 +370,7 @@ pub async fn add_declare_transaction(
                     add_transaction::Declare::V2(add_transaction::DeclareV0V1V2 {
                         version: tx.version,
                         max_fee: tx.max_fee,
-                        signature: tx.signature.clone(),
+                        signature: &tx.signature,
                         contract_class: ContractDefinition::Sierra(contract_definition),
                         sender_address: tx.sender_address,
                         nonce: tx.nonce,
@@ -407,17 +407,17 @@ pub async fn add_declare_transaction(
                 .sequencer
                 .add_declare_transaction(
                     add_transaction::Declare::V3(add_transaction::DeclareV3 {
-                        signature: tx.signature.clone(),
+                        signature: &tx.signature,
                         nonce: tx.nonce,
                         nonce_data_availability_mode: tx.nonce_data_availability_mode.into(),
                         fee_data_availability_mode: tx.fee_data_availability_mode.into(),
                         resource_bounds: tx.resource_bounds.into(),
                         tip: tx.tip,
-                        paymaster_data: tx.paymaster_data.clone(),
+                        paymaster_data: &tx.paymaster_data,
                         contract_class: contract_definition,
                         compiled_class_hash: tx.compiled_class_hash,
                         sender_address: tx.sender_address,
-                        account_deployment_data: tx.account_deployment_data.clone(),
+                        account_deployment_data: &tx.account_deployment_data,
                     }),
                     input.token,
                 )

--- a/crates/rpc/src/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/method/add_deploy_account_transaction.rs
@@ -225,11 +225,11 @@ pub(crate) async fn add_deploy_account_transaction_impl(
                 .add_deploy_account(add_transaction::DeployAccount::V0(
                     add_transaction::DeployAccountV0V1 {
                         max_fee: tx.max_fee,
-                        signature: tx.signature.clone(),
+                        signature: &tx.signature,
                         nonce: tx.nonce,
                         class_hash: tx.class_hash,
                         contract_address_salt: tx.contract_address_salt,
-                        constructor_calldata: tx.constructor_calldata.clone(),
+                        constructor_calldata: &tx.constructor_calldata,
                     },
                 ))
                 .await?;
@@ -255,11 +255,11 @@ pub(crate) async fn add_deploy_account_transaction_impl(
                 .add_deploy_account(add_transaction::DeployAccount::V1(
                     add_transaction::DeployAccountV0V1 {
                         max_fee: tx.max_fee,
-                        signature: tx.signature.clone(),
+                        signature: &tx.signature,
                         nonce: tx.nonce,
                         class_hash: tx.class_hash,
                         contract_address_salt: tx.contract_address_salt,
-                        constructor_calldata: tx.constructor_calldata.clone(),
+                        constructor_calldata: &tx.constructor_calldata,
                     },
                 ))
                 .await?;
@@ -283,23 +283,23 @@ pub(crate) async fn add_deploy_account_transaction_impl(
                     code: KnownStarknetErrorCode::InvalidTransactionVersion.into(),
                     message: "".to_string(),
                 },
-            ))
+            ));
         }
         BroadcastedDeployAccountTransaction::V3(tx) => {
             let response = context
                 .sequencer
                 .add_deploy_account(add_transaction::DeployAccount::V3(
                     add_transaction::DeployAccountV3 {
-                        signature: tx.signature.clone(),
+                        signature: &tx.signature,
                         nonce: tx.nonce,
                         nonce_data_availability_mode: tx.nonce_data_availability_mode.into(),
                         fee_data_availability_mode: tx.fee_data_availability_mode.into(),
                         resource_bounds: tx.resource_bounds.into(),
                         tip: tx.tip,
-                        paymaster_data: tx.paymaster_data.clone(),
+                        paymaster_data: &tx.paymaster_data,
                         class_hash: tx.class_hash,
                         contract_address_salt: tx.contract_address_salt,
-                        constructor_calldata: tx.constructor_calldata.clone(),
+                        constructor_calldata: &tx.constructor_calldata,
                     },
                 ))
                 .await?;

--- a/crates/rpc/src/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/method/add_invoke_transaction.rs
@@ -239,11 +239,11 @@ pub(crate) async fn add_invoke_transaction_impl(
                 .add_invoke_transaction(add_transaction::InvokeFunction::V0(
                     add_transaction::InvokeFunctionV0V1 {
                         max_fee: tx.max_fee,
-                        signature: tx.signature.clone(),
+                        signature: &tx.signature,
                         nonce: None,
                         sender_address: tx.contract_address,
                         entry_point_selector: Some(tx.entry_point_selector),
-                        calldata: tx.calldata.clone(),
+                        calldata: &tx.calldata,
                     },
                 ))
                 .await?;
@@ -266,11 +266,11 @@ pub(crate) async fn add_invoke_transaction_impl(
                 .add_invoke_transaction(add_transaction::InvokeFunction::V1(
                     add_transaction::InvokeFunctionV0V1 {
                         max_fee: tx.max_fee,
-                        signature: tx.signature.clone(),
+                        signature: &tx.signature,
                         nonce: Some(tx.nonce),
                         sender_address: tx.sender_address,
                         entry_point_selector: None,
-                        calldata: tx.calldata.clone(),
+                        calldata: &tx.calldata,
                     },
                 ))
                 .await?;
@@ -291,18 +291,18 @@ pub(crate) async fn add_invoke_transaction_impl(
                 .sequencer
                 .add_invoke_transaction(add_transaction::InvokeFunction::V3(
                     add_transaction::InvokeFunctionV3 {
-                        signature: tx.signature.clone(),
+                        signature: &tx.signature,
                         nonce: tx.nonce,
                         nonce_data_availability_mode: tx.nonce_data_availability_mode.into(),
                         fee_data_availability_mode: tx.fee_data_availability_mode.into(),
                         resource_bounds: tx.resource_bounds.into(),
                         tip: tx.tip,
-                        paymaster_data: tx.paymaster_data.clone(),
+                        paymaster_data: &tx.paymaster_data,
                         sender_address: tx.sender_address,
-                        calldata: tx.calldata.clone(),
-                        account_deployment_data: tx.account_deployment_data.clone(),
-                        proof_facts: tx.proof_facts.clone(),
-                        proof: tx.proof.clone(),
+                        calldata: &tx.calldata,
+                        account_deployment_data: &tx.account_deployment_data,
+                        proof_facts: &tx.proof_facts,
+                        proof: &tx.proof,
                     },
                 ))
                 .await?;


### PR DESCRIPTION
Reduces the number of data copies that exist during `starknet_add*Transaction` methods by:
  - Changing the `gateway-client` types to borrow data instead of taking ownership where possible.
  - Serializing JSON gateway requests directly into the gzip encoder (when request compression is enabled) instead of allocating an intermediate buffer.

With these changes we should have two less copies of request data for these methods. I also ran a quick benchmark to check if there is any performance trade-off, here are the results (faster = faster after the change, same for slower):
- `starknet_addInvokeTransaction` (V3): 1.33% faster
- `starknet_addDeployAccountTransaction` (V3): 0.95% faster
- `starknet_addDeclareTransaction` (V3): 1.32% slower

Overall, no meaningful impact on performance.