### PR TITLE
feat(rpc): unavailable pending data only errs when we actually depend on it

### DIFF
--- a/crates/rpc/src/method/get_events.rs
+++ b/crates/rpc/src/method/get_events.rs
@@ -184,50 +184,75 @@ pub async fn get_events(
             .transaction()
             .context("Creating database transaction")?;
 
-        let pending = context.pending_data.get(&transaction, rpc_version)?;
+        let requires_pre_confirmed = matches!(request.from_block, Some(PreConfirmed))
+            || matches!(request.to_block, Some(PreConfirmed));
+
+        // Missing pending data only errs when the request explicitly asked for it.
+        let pending: Option<PendingData> = if requires_pre_confirmed {
+            Some(context.pending_data.get(&transaction, rpc_version)?)
+        } else {
+            context
+                .pending_data
+                .get_optional(&transaction, rpc_version)?
+        };
 
         // Replace from/to blocks with `BlockId::PreConfirmed` if their numbers match
         // the pre-latest/pre-confirmed block number.
         let from_block_id = request.from_block.map(|from_id| match from_id {
-            Number(from) if pending.is_pre_latest_or_pre_confirmed(from) => PreConfirmed,
+            Number(from)
+                if pending
+                    .as_ref()
+                    .is_some_and(|p| p.is_pre_latest_or_pre_confirmed(from)) =>
+            {
+                PreConfirmed
+            }
             _ => from_id,
         });
         let to_block_id = request.to_block.map(|to_id| match to_id {
-            Number(to) if pending.is_pre_latest_or_pre_confirmed(to) => PreConfirmed,
+            Number(to)
+                if pending
+                    .as_ref()
+                    .is_some_and(|p| p.is_pre_latest_or_pre_confirmed(to)) =>
+            {
+                PreConfirmed
+            }
             _ => to_id,
         });
 
-        // Handle the trivial (1), (2) and (4a) cases.
-        match (&from_block_id, &to_block_id) {
-            (Some(PreConfirmed), to) => {
-                if matches!(to, Some(PreConfirmed) | None) {
-                    let (pending_events, pending_ct) = get_pending_events(
-                        &pending,
-                        request.chunk_size,
-                        &request.keys,
-                        &request.addresses,
-                        request_ct,
-                    )?;
-                    return Ok(GetEventsResult {
-                        events: pending_events,
-                        continuation_token: pending_ct.map(|ct| ct.to_string()),
-                    });
-                } else {
+        // Handle the trivial (1), (2) and (4a) cases — all of which need pending data,
+        // which a pre-confirmed bound guarantees is present.
+        if let Some(pending) = pending.as_ref() {
+            match (&from_block_id, &to_block_id) {
+                (Some(PreConfirmed), to) => {
+                    if matches!(to, Some(PreConfirmed) | None) {
+                        let (pending_events, pending_ct) = get_pending_events(
+                            pending,
+                            request.chunk_size,
+                            &request.keys,
+                            &request.addresses,
+                            request_ct,
+                        )?;
+                        return Ok(GetEventsResult {
+                            events: pending_events,
+                            continuation_token: pending_ct.map(|ct| ct.to_string()),
+                        });
+                    } else {
+                        return Ok(GetEventsResult {
+                            events: Vec::new(),
+                            continuation_token: None,
+                        });
+                    }
+                }
+                (Some(Number(from_block)), Some(PreConfirmed))
+                    if from_block > &pending.pre_confirmed_block_number() =>
+                {
                     return Ok(GetEventsResult {
                         events: Vec::new(),
                         continuation_token: None,
                     });
                 }
+                _ => {}
             }
-            (Some(Number(from_block)), Some(PreConfirmed))
-                if from_block > &pending.pre_confirmed_block_number() =>
-            {
-                return Ok(GetEventsResult {
-                    events: Vec::new(),
-                    continuation_token: None,
-                });
-            }
-            _ => {}
         }
 
         let from_block = map_from_block_to_number(&transaction, from_block_id)?;
@@ -283,31 +308,33 @@ pub async fn get_events(
         let append_from_pending =
             db_ct.is_none() && matches!(to_block_id, Some(PreConfirmed) | None);
 
-        let continuation_token = if append_from_pending {
-            if events.len() < request.chunk_size {
-                let amount_to_take_from_pending = request.chunk_size - events.len();
-                let (pending_events, pending_ct) = get_pending_events(
-                    &pending,
-                    amount_to_take_from_pending,
-                    &request.keys,
-                    &request.addresses,
-                    request_ct,
-                )?;
-                events.extend(pending_events);
-                pending_ct
-            } else {
-                // We have a full page from the database, but there might be more pending
-                // events. Return a continuation token for the pending block.
-                let pending_block = pending
-                    .pre_latest_block_number()
-                    .unwrap_or_else(|| pending.pre_confirmed_block_number());
-                Some(ContinuationToken {
-                    block_number: pending_block,
-                    offset: 0,
-                })
+        // Append pending events only when there is a pending block to draw from.
+        let continuation_token = match pending.as_ref() {
+            Some(pending) if append_from_pending => {
+                if events.len() < request.chunk_size {
+                    let amount_to_take_from_pending = request.chunk_size - events.len();
+                    let (pending_events, pending_ct) = get_pending_events(
+                        pending,
+                        amount_to_take_from_pending,
+                        &request.keys,
+                        &request.addresses,
+                        request_ct,
+                    )?;
+                    events.extend(pending_events);
+                    pending_ct
+                } else {
+                    // We have a full page from the database, but there might be more pending
+                    // events. Return a continuation token for the pending block.
+                    let pending_block = pending
+                        .pre_latest_block_number()
+                        .unwrap_or_else(|| pending.pre_confirmed_block_number());
+                    Some(ContinuationToken {
+                        block_number: pending_block,
+                        offset: 0,
+                    })
+                }
             }
-        } else {
-            db_ct
+            _ => db_ct,
         };
 
         Ok(GetEventsResult {
@@ -1153,6 +1180,51 @@ mod tests {
         use pretty_assertions_sorted::assert_eq;
 
         use super::*;
+
+        fn unavailable_cache() -> std::sync::Arc<pathfinder_pending_data::PendingDataCache> {
+            let cache = std::sync::Arc::new(pathfinder_pending_data::PendingDataCache::new());
+            cache.mark_unavailable("syncing");
+            cache
+        }
+
+        #[tokio::test]
+        async fn db_range_succeeds_when_pending_unavailable() {
+            let (storage, _) = pathfinder_storage::test_utils::setup_test_storage();
+            let context = RpcContext::for_tests()
+                .with_storage(storage)
+                .with_pending_data_cache(unavailable_cache());
+
+            // Range bounded entirely within the database. Never touches pending
+            // data, so an unavailable cache must not turn it into an error.
+            let input = GetEventsInput {
+                filter: EventFilter {
+                    from_block: Some(BlockId::Number(BlockNumber::new_or_panic(0))),
+                    to_block: Some(BlockId::Latest),
+                    chunk_size: 1024,
+                    ..Default::default()
+                },
+            };
+            let result = get_events(context, input, RPC_VERSION).await.unwrap();
+            assert!(!result.events.is_empty());
+        }
+
+        #[tokio::test]
+        async fn explicit_pre_confirmed_errors_when_unavailable() {
+            let context = RpcContext::for_tests().with_pending_data_cache(unavailable_cache());
+
+            // Explicitly requesting pre-confirmed makes the data mandatory: an unavailable
+            // cache should error here.
+            let input = GetEventsInput {
+                filter: EventFilter {
+                    from_block: Some(BlockId::PreConfirmed),
+                    to_block: Some(BlockId::PreConfirmed),
+                    chunk_size: 1024,
+                    ..Default::default()
+                },
+            };
+            let error = get_events(context, input, RPC_VERSION).await.unwrap_err();
+            assert!(matches!(error, GetEventsError::Custom(_)));
+        }
 
         #[tokio::test]
         async fn backward_range() {

--- a/crates/rpc/src/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/method/get_transaction_receipt.rs
@@ -97,11 +97,12 @@ pub async fn get_transaction_receipt(
 
         let db_tx = db.transaction().context("Creating database transaction")?;
 
-        // Check pending transactions.
-        let pending = context.pending_data.get(&db_tx, rpc_version)?;
+        // Pending is an optional first look; a finalized tx lives in the DB regardless.
+        let pending = context.pending_data.get_optional(&db_tx, rpc_version)?;
 
-        if let Some(finalized_tx_data) =
-            crate::pending::find_finalized_tx_data(&pending, input.transaction_hash)
+        if let Some(finalized_tx_data) = pending
+            .as_ref()
+            .and_then(|p| crate::pending::find_finalized_tx_data(p, input.transaction_hash))
         {
             return Ok(Output::Pending {
                 receipt: finalized_tx_data.receipt,
@@ -178,6 +179,22 @@ mod tests {
             version,
             "transactions/receipt_l1_accepted.json"
         );
+    }
+
+    #[tokio::test]
+    async fn finalized_tx_resolves_when_pending_unavailable() {
+        let cache = std::sync::Arc::new(pathfinder_pending_data::PendingDataCache::new());
+        cache.mark_unavailable("syncing");
+        let context = RpcContext::for_tests().with_pending_data_cache(cache);
+
+        let input = Input {
+            transaction_hash: transaction_hash_bytes!(b"txn 1"),
+        };
+
+        // A finalized tx lives in the DB, so an unavailable pending cache must not
+        // error.
+        let result = get_transaction_receipt(context, input, RpcVersion::V09).await;
+        assert!(result.is_ok());
     }
 
     #[rstest::rstest]

--- a/crates/rpc/src/method/get_transaction_status.rs
+++ b/crates/rpc/src/method/get_transaction_status.rs
@@ -56,10 +56,11 @@ pub async fn get_transaction_status(
             .context("Opening database connection")?;
         let db_tx = db.transaction().context("Creating database transaction")?;
 
-        let pending_data = context.pending_data.get(&db_tx, rpc_version)?;
+        let pending_data = context.pending_data.get_optional(&db_tx, rpc_version)?;
 
-        if let Some(finalized_tx_data) =
-            crate::pending::find_finalized_tx_data(&pending_data, input.transaction_hash)
+        if let Some(finalized_tx_data) = pending_data
+            .as_ref()
+            .and_then(|p| crate::pending::find_finalized_tx_data(p, input.transaction_hash))
         {
             let execution_status = &finalized_tx_data.receipt.execution_status;
             let output = match finalized_tx_data.finality_status {
@@ -241,6 +242,24 @@ mod tests {
             .await
             .unwrap();
 
+        assert_eq!(status, Output::AcceptedOnL1(TxnExecutionStatus::Succeeded));
+    }
+
+    #[tokio::test]
+    async fn finalized_tx_resolves_when_pending_unavailable() {
+        let cache = std::sync::Arc::new(pathfinder_pending_data::PendingDataCache::new());
+        cache.mark_unavailable("syncing");
+        let context = RpcContext::for_tests().with_pending_data_cache(cache);
+
+        let input = Input {
+            transaction_hash: transaction_hash_bytes!(b"txn 1"),
+        };
+
+        // A finalized tx lives in the DB, so an unavailable pending cache must not
+        // error.
+        let status = get_transaction_status(context, input, RPC_VERSION)
+            .await
+            .unwrap();
         assert_eq!(status, Output::AcceptedOnL1(TxnExecutionStatus::Succeeded));
     }
 

--- a/crates/rpc/src/method/trace_transaction.rs
+++ b/crates/rpc/src/method/trace_transaction.rs
@@ -67,13 +67,16 @@ pub async fn trace_transaction(
                 .context("Creating database transaction")?;
 
             // Find the transaction's block.
-            let pending = context.pending_data.get(&db_tx, rpc_version)?;
+            let pending = context.pending_data.get_optional(&db_tx, rpc_version)?;
+            let pending = pending.as_ref();
 
-            let (header, transactions, cache) = if let Some(pending_tx) = pending
-                .pre_confirmed_transactions()
-                .iter()
-                .find(|tx| tx.hash == input.transaction_hash)
-            {
+            let (header, transactions, cache) = if let Some((pending, pending_tx)) = pending
+                .and_then(|p| {
+                    p.pre_confirmed_transactions()
+                        .iter()
+                        .find(|tx| tx.hash == input.transaction_hash)
+                        .map(|tx| (p, tx))
+                }) {
                 let header = pending.pre_confirmed_header();
 
                 if header.starknet_version
@@ -88,12 +91,16 @@ pub async fn trace_transaction(
                     // Can't use the cache for pending blocks since they have no block hash.
                     pathfinder_executor::TraceCache::default(),
                 )
-            } else if let Some(pre_latest_tx) = pending.pre_latest_block().and_then(|pre_latest| {
-                pre_latest
-                    .transactions
-                    .iter()
-                    .find(|tx| tx.hash == input.transaction_hash)
-                    .cloned()
+            } else if let Some((pending, pre_latest_tx)) = pending.and_then(|p| {
+                p.pre_latest_block()
+                    .and_then(|pre_latest| {
+                        pre_latest
+                            .transactions
+                            .iter()
+                            .find(|tx| tx.hash == input.transaction_hash)
+                            .cloned()
+                    })
+                    .map(|tx| (p, tx))
             }) {
                 let header = pending
                     .pre_latest_header()

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -168,6 +168,20 @@ impl PendingWatcher {
         Ok(pending_data)
     }
 
+    /// Returns the pending data, or `None` when the cache is unavailable.
+    /// Unlike [`Self::get`], an `Unavailable` cache is not an error.
+    pub fn get_optional(
+        &self,
+        tx: &Transaction<'_>,
+        rpc_version: RpcVersion,
+    ) -> Result<Option<PendingData>, ReadError> {
+        match self.get(tx, rpc_version) {
+            Ok(data) => Ok(Some(data)),
+            Err(ReadError::Unavailable(_)) => Ok(None),
+            Err(e @ ReadError::Internal(_)) => Err(e),
+        }
+    }
+
     #[cfg(test)]
     pub fn get_unchecked(&self) -> PendingData {
         self.cache.subscribe().borrow().clone()


### PR DESCRIPTION
Added a `PendingWatcher::get_optional(..)` (sibling to the existing `.get(..)`) that will still surface `Internal` errors but will tolerate `Unavailable` by returning `None`. This allows any method that doesn't really _need_ pending data to query it as optional and not fail.

I've applied the fix to:
- `get_events`
- `get_transaction_*`
- `trace_transaction`

Closes #3455 