### PR TITLE
chore(ci): bump actions to versions that use Node 24+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Run unit tests with all features enabled excluding consensus integration tests
         run: timeout 10m cargo nextest run --cargo-profile ci-dev --no-fail-fast --all-targets --all-features --workspace --locked -E 'not test(/^test::consensus_[34]_nodes/)' --retries 2
       - name: Store timings with all features enabled
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: timings-all-features
           path: target/cargo-timings/
@@ -112,7 +112,7 @@ jobs:
         run: PATHFINDER_TEST_ENABLE_MARKER_FILES=1 timeout 30m cargo nextest run --test consensus -p pathfinder --features p2p,consensus-integration-tests --locked --retries 2 -j 1
       - name: Store test artifacts for consensus integration tests
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: consensus-integration-tests
           include-hidden-files: true
@@ -147,7 +147,7 @@ jobs:
       - name: Run unit tests with default features
         run: timeout 10m cargo nextest run --cargo-profile ci-dev --no-fail-fast --all-targets --workspace --locked
       - name: Store timings with default features
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: timings-default-features
           path: target/cargo-timings/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -42,7 +42,7 @@ jobs:
       LLVM_SYS_191_PREFIX: "/usr/lib/llvm-19"
       TABLEGEN_190_PREFIX: "/usr/lib/llvm-19"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/free-disk-space
       - uses: rui314/setup-mold@v1
       - uses: Swatinem/rust-cache@v2
@@ -86,7 +86,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/free-disk-space
       - uses: rui314/setup-mold@v1
       - uses: Swatinem/rust-cache@v2
@@ -126,7 +126,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/free-disk-space
       - uses: rui314/setup-mold@v1
       - uses: Swatinem/rust-cache@v2
@@ -162,7 +162,7 @@ jobs:
       LLVM_SYS_191_PREFIX: "/usr/lib/llvm-19"
       TABLEGEN_190_PREFIX: "/usr/lib/llvm-19"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
@@ -191,7 +191,7 @@ jobs:
   rustfmt:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
@@ -206,7 +206,7 @@ jobs:
     env:
       RUSTDOCFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
@@ -221,7 +221,7 @@ jobs:
   dep-sort:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-sort
@@ -232,7 +232,7 @@ jobs:
   typos:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: crate-ci/typos@v1.26.0
         with:
           files: .
@@ -242,7 +242,7 @@ jobs:
     if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: cargo check
         run: |
           cd crates/load-test
@@ -254,7 +254,7 @@ jobs:
   docker-rust-version:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check Dockerfile Rust version matches rust-toolchain.toml
         run: |
           pin=$(grep -oP 'channel\s*=\s*"\K[^"]+' rust-toolchain.toml)

--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/docker-p2p.yml
+++ b/.github/workflows/docker-p2p.yml
@@ -41,12 +41,12 @@ jobs:
           fi
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: arm64
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           buildkitd-config-inline: |
             [worker.oci]

--- a/.github/workflows/docker-p2p.yml
+++ b/.github/workflows/docker-p2p.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           images: eqlabs/pathfinder
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Generate version

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           images: eqlabs/pathfinder
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Generate version

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,13 +48,13 @@ jobs:
           fi
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           image: tonistiigi/binfmt:latest
           platforms: all
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           buildkitd-config-inline: |
             [worker.oci]

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: read msrv
         id: msrv
         run: |

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -13,7 +13,7 @@ jobs:
     name: Publish crates to crates.io
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Login to crates.io
         run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     create-draft-release:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - uses: taiki-e/create-gh-release-action@v1
               with:
                 # (Optional) Path to changelog.
@@ -38,7 +38,7 @@ jobs:
                   os: macos-latest
         runs-on: ${{ matrix.os }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - uses: arduino/setup-protoc@v3
               with:
                 repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Only `actions/checkout@v4` is flagged, so I started there.

Then checked other "v4" actions, and notably `upload-artifacts` was also running on node 20. This one had to be bumped 2 major versions. I checked and the same inputs are still there. Hopefully no surprises here.

Then, the third party actions, 3 were bumped: `docker/setup-qemu-action`, `docker/setup-buildx-action`, and `dorny/paths-filter`.

Important flag here is that `arduino/setup-protoc@v3` seems to be the [latest release available](https://github.com/arduino/setup-protoc/releases) and is still using node 20... I guess we can either live with it until it bites us, or just look for an alternative.

Closes #3460 