### PR TITLE
fix(rpc): timing out on blocked websocket send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Parallel Sierra to CASM compilation processes during RPC requests are now limited to the number of CPU cores available by default, configurable with `--rpc.compiler.concurrency-limit` CLI option.
+- Blocking writes to RPC WS connections now time out and are reported as errors. The timeout is configurable with `--rpc.websocket.send-timeout` CLI option.
 
 ### Fixed
 

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -293,6 +293,7 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
         context.with_websockets(WebsocketContext::new(
             config.websocket.max_history.into(),
             config.websocket.max_subscriptions.get(),
+            config.websocket.send_timeout,
         ))
     } else {
         context

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -1507,6 +1507,14 @@ pub struct WebsocketConfig {
         env = "PATHFINDER_WEBSOCKET_MAX_SUBSCRIPTIONS"
     )]
     pub max_subscriptions: NonZeroUsize,
+    #[arg(
+        long = "rpc.websocket.send-timeout",
+        long_help = "Threshold for considering the websocket's output buffer full (and closing the connection).",
+        default_value = "0.1",
+        value_parser = parse_fractional_seconds,
+        env = "PATHFINDER_WEBSOCKET_SEND_TIMEOUT"
+    )]
+    pub send_timeout: Duration,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -197,13 +197,16 @@ pub async fn rpc_handler(
 ) -> impl axum::response::IntoResponse {
     match ws {
         Ok(ws) => {
-            if state.context.websocket.is_none() {
-                return StatusCode::FORBIDDEN.into_response();
-            }
+            let send_timeout = match state.context.websocket {
+                Some(ref ws_cfg) => ws_cfg.send_timeout,
+                None => {
+                    return StatusCode::FORBIDDEN.into_response();
+                }
+            };
 
             ws.max_message_size(state.context.config.request_max_size.get())
-                .on_upgrade(|ws| async move {
-                    let (ws_tx, ws_rx) = split_ws(ws, state.version);
+                .on_upgrade(async move |ws| {
+                    let (ws_tx, ws_rx) = split_ws(ws, state.version, send_timeout);
                     handle_json_rpc_socket(state, ws_tx, ws_rx);
                 })
         }
@@ -393,6 +396,7 @@ mod tests {
     use futures::SinkExt;
     use serde::{Deserialize, Serialize};
     use serde_json::{json, Value};
+    use tokio::time::{timeout, Duration};
 
     use super::*;
     use crate::jsonrpc::response::RpcResult;
@@ -439,7 +443,11 @@ mod tests {
         .await
         .unwrap();
         let tokio_tungstenite::tungstenite::Message::Text(response) =
-            ws.next().await.unwrap().unwrap()
+            timeout(Duration::from_secs(1), ws.next())
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap()
         else {
             panic!("Expected a text response");
         };
@@ -512,7 +520,7 @@ mod tests {
                 }
             }
 
-            let ws_ctx = WebsocketContext::new(WebsocketHistory::Unlimited, 1024);
+            let ws_ctx = WebsocketContext::for_test(WebsocketHistory::Unlimited);
             RpcRouter::builder(RpcVersion::default())
                 .register("subtract", subtract)
                 .register("sum", sum)
@@ -671,7 +679,11 @@ mod tests {
             .await
             .unwrap();
             let tokio_tungstenite::tungstenite::Message::Text(response) =
-                ws.next().await.unwrap().unwrap()
+                timeout(Duration::from_secs(1), ws.next())
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .unwrap()
             else {
                 panic!("Expected a text response");
             };
@@ -752,7 +764,7 @@ mod tests {
                 "Success"
             }
 
-            let ws_ctx = WebsocketContext::new(WebsocketHistory::Unlimited, 1024);
+            let ws_ctx = WebsocketContext::for_test(WebsocketHistory::Unlimited);
             RpcRouter::builder(Default::default())
                 .register("panic", always_panic)
                 .register("success", always_success)

--- a/crates/rpc/src/jsonrpc/router/subscription.rs
+++ b/crates/rpc/src/jsonrpc/router/subscription.rs
@@ -11,6 +11,7 @@ use pathfinder_serde::AsBoundedVec;
 use serde::de::DeserializeSeed as _;
 use serde_json::value::RawValue;
 use tokio::sync::{mpsc, RwLock};
+use tokio::time::{timeout, Duration};
 use tracing::Instrument;
 
 use super::{run_concurrently, RpcRouter};
@@ -428,8 +429,13 @@ type WsReceiver = mpsc::Receiver<Result<Message, axum::Error>>;
 /// serves to allow easier testing. The sender sends `Result<_, RpcResponse>`
 /// purely for convenience, and the [`RpcResponse`] will be encoded into a
 /// [`Message::Text`].
-pub fn split_ws(ws: WebSocket, version: RpcVersion) -> (WsSender, WsReceiver) {
+pub fn split_ws(
+    ws: WebSocket,
+    version: RpcVersion,
+    egress_timeout: Duration,
+) -> (WsSender, WsReceiver) {
     let (mut ws_sender, mut ws_receiver) = ws.split();
+    let mut send_with_timeout = async move |msg| timeout(egress_timeout, ws_sender.send(msg)).await;
     // Send messages to the websocket using an MPSC channel.
     let (sender_tx, mut sender_rx) = mpsc::channel::<Result<Message, RpcResponse>>(1024);
     util::task::spawn_with_cancel(move |cancellation_token| {
@@ -438,9 +444,9 @@ pub fn split_ws(ws: WebSocket, version: RpcVersion) -> (WsSender, WsReceiver) {
                 tokio::select! {
                     _ = cancellation_token.cancelled() => {
                         // Ignore the error since we're shutting down anyway.
-                        let _ = ws_sender.send(Message::Close(Some(CloseFrame {
+                        let _ = send_with_timeout(Message::Close(Some(CloseFrame {
                             code: close_code::NORMAL,
-                            reason:  Utf8Bytes::from_static("Server shutdown"),
+                            reason: Utf8Bytes::from_static("Server shutdown"),
                         }))).await.ok();
                         break;
                     }
@@ -450,15 +456,14 @@ pub fn split_ws(ws: WebSocket, version: RpcVersion) -> (WsSender, WsReceiver) {
                         };
                         match msg {
                             Ok(msg) => {
-                                if let Err(e) = ws_sender.send(msg).await {
+                                if let Err(e) = send_with_timeout(msg).await {
                                     tracing::debug!(error=?e, "Error sending websocket message");
                                     break;
                                 }
                             }
                             Err(e) => {
                                 let data = serde_json::to_string(&e.serialize(crate::dto::Serializer::new(version)).unwrap()).unwrap();
-                                if let Err(e) = ws_sender
-                                    .send(Message::Text(data.into()))
+                                if let Err(e) = send_with_timeout(Message::Text(data.into()))
                                     .await
                                 {
                                     tracing::debug!(error=?e, "Error sending websocket error message");
@@ -1486,7 +1491,7 @@ mod tests {
             .with_storage(storage)
             .with_notifications(notifications)
             .with_pending_data_cache(pending_data_cache.clone())
-            .with_websockets(WebsocketContext::new(websocket_history, 1024));
+            .with_websockets(WebsocketContext::for_test(websocket_history));
 
         RpcRouter::builder(crate::RpcVersion::V08)
             .register("test", endpoint)

--- a/crates/rpc/src/jsonrpc/websocket.rs
+++ b/crates/rpc/src/jsonrpc/websocket.rs
@@ -30,6 +30,8 @@
 //! Closing subscription."}},"id":null}
 //! ```
 
+use std::time::Duration;
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum WebsocketHistory {
     Limited(u64),
@@ -40,13 +42,28 @@ pub enum WebsocketHistory {
 pub struct WebsocketContext {
     pub max_history: WebsocketHistory,
     pub max_subscriptions: usize,
+    pub send_timeout: Duration,
 }
 
 impl WebsocketContext {
-    pub fn new(max_history: WebsocketHistory, max_subscriptions: usize) -> Self {
+    pub fn new(
+        max_history: WebsocketHistory,
+        max_subscriptions: usize,
+        send_timeout: Duration,
+    ) -> Self {
         Self {
             max_history,
             max_subscriptions,
+            send_timeout,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn for_test(max_history: WebsocketHistory) -> Self {
+        Self {
+            max_history,
+            max_subscriptions: 1024,
+            send_timeout: Duration::from_secs_f64(0.1),
         }
     }
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1314,6 +1314,7 @@ mod tests {
 
     use dto::DeserializeForVersion;
     use serde_json::json;
+    use tokio::time::{timeout, Duration};
 
     use super::*;
 
@@ -1581,9 +1582,8 @@ mod tests {
         let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
         let mut context = RpcContext::for_tests();
         if api.has_websocket() {
-            context = context.with_websockets(context::WebsocketContext::new(
+            context = context.with_websockets(context::WebsocketContext::for_test(
                 WebsocketHistory::Unlimited,
-                1024,
             ));
         }
         let (_jh, addr) = RpcServer::new(addr, context, RpcVersion::V07)
@@ -1681,7 +1681,7 @@ mod tests {
                 });
 
                 stream.send(Message::Text(request.to_string().into())).await.unwrap();
-                let res: Message = stream.next().await.unwrap().unwrap();
+                let res: Message = timeout(Duration::from_secs(1), stream.next()).await.unwrap().unwrap().unwrap();
                 let res: serde_json::Value = serde_json::from_str(&res.to_string()).unwrap();
 
                 if res["error"]["code"] == method_not_found {

--- a/crates/rpc/src/method/subscribe_events.rs
+++ b/crates/rpc/src/method/subscribe_events.rs
@@ -1268,7 +1268,7 @@ mod tests {
             .with_storage(storage)
             .with_notifications(notifications)
             .with_pending_data_cache(pending_data_cache.clone())
-            .with_websockets(WebsocketContext::new(WebsocketHistory::Unlimited, 1024));
+            .with_websockets(WebsocketContext::for_test(WebsocketHistory::Unlimited));
         match version {
             RpcVersion::V06 => (v06::register_routes().build(ctx), pending_data_cache),
             RpcVersion::V07 => (v07::register_routes().build(ctx), pending_data_cache),

--- a/crates/rpc/src/method/subscribe_new_heads.rs
+++ b/crates/rpc/src/method/subscribe_new_heads.rs
@@ -544,7 +544,7 @@ mod tests {
             .with_storage(storage)
             .with_notifications(notifications)
             .with_pending_data_cache(pending_data_cache.clone())
-            .with_websockets(WebsocketContext::new(WebsocketHistory::Unlimited, 1024));
+            .with_websockets(WebsocketContext::for_test(WebsocketHistory::Unlimited));
         v08::register_routes().build(ctx)
     }
 

--- a/crates/rpc/src/method/subscribe_new_transaction_receipts.rs
+++ b/crates/rpc/src/method/subscribe_new_transaction_receipts.rs
@@ -1008,7 +1008,7 @@ mod tests {
             .with_storage(storage)
             .with_notifications(notifications.clone())
             .with_pending_data_cache(pending_data_cache.clone())
-            .with_websockets(WebsocketContext::new(WebsocketHistory::Unlimited, 1024));
+            .with_websockets(WebsocketContext::for_test(WebsocketHistory::Unlimited));
         let router = v09::register_routes().build(ctx);
         let (sender_tx, sender_rx) = mpsc::channel(1024);
         let (receiver_tx, receiver_rx) = mpsc::channel(1024);

--- a/crates/rpc/src/method/subscribe_new_transactions.rs
+++ b/crates/rpc/src/method/subscribe_new_transactions.rs
@@ -1483,7 +1483,7 @@ mod tests {
             .with_storage(storage)
             .with_notifications(notifications.clone())
             .with_pending_data_cache(pending_data_cache.clone())
-            .with_websockets(WebsocketContext::new(WebsocketHistory::Unlimited, 1024));
+            .with_websockets(WebsocketContext::for_test(WebsocketHistory::Unlimited));
         let submission_tracker = ctx.submission_tracker.clone();
         let router = v10::register_routes().build(ctx);
         let (sender_tx, sender_rx) = mpsc::channel(1024);

--- a/crates/rpc/src/method/subscribe_transaction_status.rs
+++ b/crates/rpc/src/method/subscribe_transaction_status.rs
@@ -1635,7 +1635,7 @@ mod tests {
         let ctx = RpcContext::for_tests()
             .with_storage(storage)
             .with_pending_data_cache(pending_data_cache.clone())
-            .with_websockets(WebsocketContext::new(WebsocketHistory::Unlimited, 1024));
+            .with_websockets(WebsocketContext::for_test(WebsocketHistory::Unlimited));
         (v08::register_routes().build(ctx), pending_data_cache)
     }
 }


### PR DESCRIPTION
Under normal circumstances, the time to send a websocket response should be on the order of microseconds. When the sending blocks, in means some system buffer is full, presumably due to either network problems, or an unresponsive client.
