### PR TITLE
fix(rpc): handling notification serialization error

### DIFF
--- a/crates/rpc/src/jsonrpc/router/subscription.rs
+++ b/crates/rpc/src/jsonrpc/router/subscription.rs
@@ -846,12 +846,22 @@ impl<T: crate::dto::SerializeForVersion> SubscriptionSender<T> {
             },
         }
         .serialize(crate::dto::Serializer::new(self.version))
-        .unwrap();
+        .map_err(|e| {
+            tracing::warn!(
+                T = std::any::type_name::<T>(),
+                ?e,
+                "Cannot serialize notification"
+            );
+            mpsc::error::SendError(())
+        })?;
         let data = serde_json::to_string(&notification).unwrap();
         self.tx
             .send(Ok(Message::Text(data.into())))
             .await
-            .map_err(|_| mpsc::error::SendError(()))
+            .map_err(|e| {
+                tracing::trace!(?e, "Cannot send");
+                mpsc::error::SendError(())
+            })
     }
 
     pub async fn send_err(&self, err: RpcError) -> Result<(), mpsc::error::SendError<()>> {
@@ -868,12 +878,18 @@ impl<T: crate::dto::SerializeForVersion> SubscriptionSender<T> {
             },
         }
         .serialize(crate::dto::Serializer::new(self.version))
-        .unwrap();
+        .map_err(|e| {
+            tracing::warn!(?e, "Cannot serialize error notification");
+            mpsc::error::SendError(())
+        })?;
         let data = serde_json::to_string(&notification).unwrap();
         self.tx
             .send(Ok(Message::Text(data.into())))
             .await
-            .map_err(|_| mpsc::error::SendError(()))
+            .map_err(|e| {
+                tracing::trace!(?e, "Cannot send error");
+                mpsc::error::SendError(())
+            })
     }
 }
 


### PR DESCRIPTION
Replaced `unwrap` in `SubscriptionSender::send` and `send_err` by error return.

The serialization failures probably don't happen in practice, but it's hard to say they _cannot_ happen, as the serialized type is generic.