### PR TITLE
fix(rpc): increase default timeout for blocked websocket

### DIFF
--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -1510,7 +1510,7 @@ pub struct WebsocketConfig {
     #[arg(
         long = "rpc.websocket.send-timeout",
         long_help = "Threshold for considering the websocket's output buffer full (and closing the connection).",
-        default_value = "0.1",
+        default_value = "1",
         value_parser = parse_fractional_seconds,
         env = "PATHFINDER_WEBSOCKET_SEND_TIMEOUT"
     )]


### PR DESCRIPTION
This is a follow-up to #3473.

That change set the default threshold for considering a websocket blocked to 0.1s, which was presumed sufficient for normal operations but actually isn't, in case some _other_ websocket encounters problems. These problems are typically visible as a logged error, i.e.

```
2026-06-15T13:33:06 ERROR failed to deserialize message err=unexpected `error` field in subscription notification at line 1 column 81
```

from `alloy_transport_ws` (presumably used by pathfinder's connection to Ethereum), leading to the RPC connection failing. Increasing the timeout to 1s made the RPC connection persist through these errors.
