### PR TITLE
fix(scripts): sed error in release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -57,9 +57,9 @@ CRATES=("common" "crypto" "serde" "class-hash" "consensus")
 for crate in "${CRATES[@]}"; do
     file="crates/${crate}/Cargo.toml"
     echo "Updating dependencies for $file..."
-    do_sed "$file" "s/pathfinder-common = { version = \"[^\"]*\"/pathfinder-common = { version = \"${VERSION}\"/"
-    do_sed "$file" "s/pathfinder-crypto = { version = \"[^\"]*\"/pathfinder-crypto = { version = \"${VERSION}\"/"
-    do_sed "$file" "s/pathfinder-serde = { version = \"[^\"]*\"/pathfinder-serde = { version = \"${VERSION}\"/"
+    do_sed "$file" "s/pathfinder-common = \{ version = \"[^\"]*\"/pathfinder-common = { version = \"${VERSION}\"/"
+    do_sed "$file" "s/pathfinder-crypto = \{ version = \"[^\"]*\"/pathfinder-crypto = { version = \"${VERSION}\"/"
+    do_sed "$file" "s/pathfinder-serde = \{ version = \"[^\"]*\"/pathfinder-serde = { version = \"${VERSION}\"/"
 done
 
 # Update Cargo.lock and verify everything still builds


### PR DESCRIPTION
TL;DR

`-E` (extended regex) in `do_sed` requires we escape `{` or else it'll be treated as a beginning of a regex interval `{n,m}`.

-----------------

Encountered during the release today:

```
Updating dependencies for crates/common/Cargo.toml...
sed: -e expression #1, char 83: Unmatched \{
```