### PR TITLE
feat(metrics): improve instrumentation for JSON-RPC + new operator dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- RPC metrics now carry a `block_target` label on `rpc_method_calls_total` (how a request targeted a block) and an `error_kind` label on `rpc_method_calls_failed_total` (the error variant name). The bundled Grafana dashboard (`utils/grafana/dashboard.json`) gains an expanded JSON-RPC view, and Prometheus recording rules for RPC latency quantiles are provided in `utils/prometheus/rpc-recording-rules.yml`.
+
+### Changed
+
+- `rpc_method_calls_duration_milliseconds` is now exported as a Prometheus histogram (`_bucket`/`_sum`/`_count`) instead of a summary with a `quantile` label. Alerts or dashboards using `rpc_method_calls_duration_milliseconds{quantile="..."}` must switch to `histogram_quantile(...)` over the `_bucket` series; see `docs/docs/monitoring-and-metrics.md`.
+
 ## [0.22.7] - 2026-06-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `rpc_method_calls_duration_milliseconds` is now exported as a Prometheus histogram (`_bucket`/`_sum`/`_count`) instead of a summary with a `quantile` label. Alerts or dashboards using `rpc_method_calls_duration_milliseconds{quantile="..."}` must switch to `histogram_quantile(...)` over the `_bucket` series; see `docs/docs/monitoring-and-metrics.md`.
+- RPC method-call latency is now exported as a Prometheus histogram in seconds, `rpc_method_calls_duration_seconds` (`_bucket`/`_sum`/`_count`), replacing the summary `rpc_method_calls_duration_milliseconds`. Update alerts and dashboards to the new name and derive quantiles with `histogram_quantile(...)` over the `_bucket` series; see `docs/docs/monitoring-and-metrics.md`.
 
 ## [0.22.7] - 2026-06-23
 

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -965,7 +965,8 @@ fn start_p2p_sync(
 /// range of RPC method latencies from sub-millisecond reads to multi-second
 /// traces.
 const RPC_LATENCY_BUCKETS: &[f64] = &[
-    1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10000.0,
+    0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0,
+    10000.0,
 ];
 
 /// Spawns the monitoring task at the given address.

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -961,11 +961,11 @@ fn start_p2p_sync(
     util::task::spawn(sync.run())
 }
 
-/// Latency buckets (milliseconds) for the RPC duration histogram, spanning
+/// Latency buckets (seconds) for the RPC duration histogram, spanning
 /// single-millisecond reads to multi-second traces. Sub-millisecond calls fall
 /// into the first bucket.
 const RPC_LATENCY_BUCKETS: &[f64] = &[
-    1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10000.0,
+    0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
 ];
 
 /// Spawns the monitoring task at the given address.
@@ -979,7 +979,7 @@ async fn spawn_monitoring(
     let prometheus_handle = PrometheusBuilder::new()
         .add_global_label("network", network)
         .set_buckets_for_metric(
-            Matcher::Full("rpc_method_calls_duration_milliseconds".to_owned()),
+            Matcher::Full("rpc_method_calls_duration_seconds".to_owned()),
             RPC_LATENCY_BUCKETS,
         )
         .context("Setting RPC latency histogram buckets")?

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -961,12 +961,11 @@ fn start_p2p_sync(
     util::task::spawn(sync.run())
 }
 
-/// Latency buckets (milliseconds) for the RPC duration histogram. Sized for the
-/// range of RPC method latencies from sub-millisecond reads to multi-second
-/// traces.
+/// Latency buckets (milliseconds) for the RPC duration histogram, spanning
+/// single-millisecond reads to multi-second traces. Sub-millisecond calls fall
+/// into the first bucket.
 const RPC_LATENCY_BUCKETS: &[f64] = &[
-    0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0,
-    10000.0,
+    1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10000.0,
 ];
 
 /// Spawns the monitoring task at the given address.

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -10,7 +10,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use ::p2p::sync::client::peer_agnostic::Client as P2PSyncClient;
 use anyhow::Context;
 use config::BlockchainHistory;
-use metrics_exporter_prometheus::PrometheusBuilder;
+use metrics_exporter_prometheus::{Matcher, PrometheusBuilder};
 use pathfinder_common::class_definition::SerializedSierraDefinition;
 use pathfinder_common::{BlockNumber, Chain, ChainId, EthereumChain};
 use pathfinder_ethereum::EthereumClient;
@@ -961,6 +961,13 @@ fn start_p2p_sync(
     util::task::spawn(sync.run())
 }
 
+/// Latency buckets (milliseconds) for the RPC duration histogram. Sized for the
+/// range of RPC method latencies from sub-millisecond reads to multi-second
+/// traces.
+const RPC_LATENCY_BUCKETS: &[f64] = &[
+    1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10000.0,
+];
+
 /// Spawns the monitoring task at the given address.
 async fn spawn_monitoring(
     network: &str,
@@ -971,6 +978,11 @@ async fn spawn_monitoring(
 ) -> anyhow::Result<tokio::task::JoinHandle<()>> {
     let prometheus_handle = PrometheusBuilder::new()
         .add_global_label("network", network)
+        .set_buckets_for_metric(
+            Matcher::Full("rpc_method_calls_duration_milliseconds".to_owned()),
+            RPC_LATENCY_BUCKETS,
+        )
+        .context("Setting RPC latency histogram buckets")?
         .install_recorder()
         .context("Creating Prometheus recorder")?;
 

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -187,6 +187,62 @@ impl ApplicationError {
         }
     }
 
+    /// Stable, low-cardinality label for the `error_kind` metric dimension.
+    pub fn metric_label(&self) -> &'static str {
+        match self {
+            ApplicationError::FailedToReceiveTxn => "failed_to_receive_txn",
+            ApplicationError::ContractNotFound => "contract_not_found",
+            ApplicationError::EntrypointNotFound => "entrypoint_not_found",
+            ApplicationError::BlockNotFound => "block_not_found",
+            ApplicationError::InvalidTxnIndex => "invalid_txn_index",
+            ApplicationError::InvalidTxnHash => "invalid_txn_hash",
+            ApplicationError::InvalidBlockHash => "invalid_block_hash",
+            ApplicationError::ClassHashNotFound => "class_hash_not_found",
+            ApplicationError::TxnHashNotFound => "txn_hash_not_found",
+            ApplicationError::PageSizeTooBig => "page_size_too_big",
+            ApplicationError::NoBlocks => "no_blocks",
+            ApplicationError::NoTraceAvailable(_) => "no_trace_available",
+            ApplicationError::InvalidContinuationToken => "invalid_continuation_token",
+            ApplicationError::TooManyKeysInFilter { .. } => "too_many_keys_in_filter",
+            ApplicationError::ContractError { .. } => "contract_error",
+            ApplicationError::InvalidContractClass => "invalid_contract_class",
+            ApplicationError::ClassAlreadyDeclared => "class_already_declared",
+            ApplicationError::InvalidTransactionNonce { .. } => "invalid_transaction_nonce",
+            ApplicationError::InsufficientResourcesForValidate => {
+                "insufficient_resources_for_validate"
+            }
+            ApplicationError::InsufficientAccountBalance => "insufficient_account_balance",
+            ApplicationError::ValidationFailure => "validation_failure",
+            ApplicationError::ValidationFailureV06(_) => "validation_failure",
+            ApplicationError::CompilationFailed { .. } => "compilation_failed",
+            ApplicationError::ContractClassSizeIsTooLarge => "contract_class_size_too_large",
+            ApplicationError::NonAccount => "non_account",
+            ApplicationError::DuplicateTransaction => "duplicate_transaction",
+            ApplicationError::CompiledClassHashMismatch => "compiled_class_hash_mismatch",
+            ApplicationError::UnsupportedTxVersion => "unsupported_tx_version",
+            ApplicationError::UnsupportedContractClassVersion => {
+                "unsupported_contract_class_version"
+            }
+            ApplicationError::UnexpectedError { .. } => "unexpected_error",
+            ApplicationError::ProofLimitExceeded { .. } => "proof_limit_exceeded",
+            ApplicationError::InvalidProof => "invalid_proof",
+            ApplicationError::GatewayError(_) => "gateway_error",
+            ApplicationError::ForwardedError(_) => "forwarded_error",
+            ApplicationError::TransactionExecutionError { .. } => "transaction_execution_error",
+            ApplicationError::SubscriptionTransactionHashNotFound { .. } => {
+                "subscription_txn_hash_not_found"
+            }
+            ApplicationError::SubscriptionGatewayDown { .. } => "subscription_gateway_down",
+            ApplicationError::StorageProofNotSupported => "storage_proof_not_supported",
+            ApplicationError::ProofMissing => "proof_missing",
+            ApplicationError::InvalidSubscriptionID => "invalid_subscription_id",
+            ApplicationError::TooManyAddressesInFilter => "too_many_addresses_in_filter",
+            ApplicationError::TooManyBlocksBack { .. } => "too_many_blocks_back",
+            ApplicationError::Internal(_) => "internal",
+            ApplicationError::Custom(_) => "custom",
+        }
+    }
+
     pub fn message(&self, version: RpcVersion) -> String {
         match self {
             ApplicationError::EntrypointNotFound => {

--- a/crates/rpc/src/jsonrpc/error.rs
+++ b/crates/rpc/src/jsonrpc/error.rs
@@ -41,6 +41,19 @@ impl RpcError {
         }
     }
 
+    /// Stable, low-cardinality label for the `error_kind` metric dimension.
+    pub fn metric_label(&self) -> &'static str {
+        match self {
+            RpcError::ParseError(_) => "parse_error",
+            RpcError::InvalidRequest(_) => "invalid_request",
+            RpcError::MethodNotFound => "method_not_found",
+            RpcError::InvalidParams(_) => "invalid_params",
+            RpcError::InternalError(_) => "internal_error",
+            RpcError::ApplicationError(e) => e.metric_label(),
+            RpcError::WebsocketSubscriptionClosed { .. } => "ws_subscription_closed",
+        }
+    }
+
     pub fn message(&self, version: RpcVersion) -> Cow<'_, str> {
         match self {
             RpcError::ParseError(..) => "Parse error".into(),
@@ -103,5 +116,47 @@ where
 impl From<pathfinder_storage::StorageError> for RpcError {
     fn from(value: pathfinder_storage::StorageError) -> Self {
         Self::InternalError(value.into())
+    }
+}
+
+#[cfg(test)]
+mod metric_label_tests {
+    use super::*;
+    use crate::error::ApplicationError;
+
+    #[test]
+    fn rpc_error_categories() {
+        assert_eq!(
+            RpcError::ParseError("x".into()).metric_label(),
+            "parse_error"
+        );
+        assert_eq!(
+            RpcError::InvalidParams("x".into()).metric_label(),
+            "invalid_params"
+        );
+        assert_eq!(
+            RpcError::InternalError(anyhow::anyhow!("x")).metric_label(),
+            "internal_error"
+        );
+        assert_eq!(
+            RpcError::WebsocketSubscriptionClosed {
+                subscription_id: 1,
+                reason: "x".into()
+            }
+            .metric_label(),
+            "ws_subscription_closed"
+        );
+    }
+
+    #[test]
+    fn application_error_uses_variant_name() {
+        assert_eq!(
+            RpcError::ApplicationError(ApplicationError::BlockNotFound).metric_label(),
+            "block_not_found"
+        );
+        assert_eq!(
+            RpcError::ApplicationError(ApplicationError::ContractNotFound).metric_label(),
+            "contract_not_found"
+        );
     }
 }

--- a/crates/rpc/src/jsonrpc/error.rs
+++ b/crates/rpc/src/jsonrpc/error.rs
@@ -131,6 +131,11 @@ mod metric_label_tests {
             "parse_error"
         );
         assert_eq!(
+            RpcError::InvalidRequest("x".into()).metric_label(),
+            "invalid_request"
+        );
+        assert_eq!(RpcError::MethodNotFound.metric_label(), "method_not_found");
+        assert_eq!(
             RpcError::InvalidParams("x".into()).metric_label(),
             "invalid_params"
         );

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -18,6 +18,7 @@ use crate::jsonrpc::request::RpcRequest;
 use crate::jsonrpc::response::RpcResponse;
 use crate::RpcVersion;
 
+mod labels;
 mod method;
 mod subscription;
 
@@ -124,7 +125,14 @@ impl RpcRouter {
             return Some(RpcResponse::method_not_found(request.id, self.version));
         };
 
-        metrics::counter!("rpc_method_calls_total", "method" => method_name, "version" => self.version.to_str()).increment(1);
+        let block_target = labels::classify_block_target(request.params.0);
+        metrics::counter!(
+            "rpc_method_calls_total",
+            "method" => method_name,
+            "version" => self.version.to_str(),
+            "block_target" => block_target.as_str(),
+        )
+        .increment(1);
 
         let start = std::time::Instant::now();
 
@@ -146,8 +154,14 @@ impl RpcRouter {
             }
         };
 
-        if output.is_err() {
-            metrics::counter!("rpc_method_calls_failed_total", "method" => method_name, "version" => self.version.to_str()).increment(1);
+        if let Err(err) = &output {
+            metrics::counter!(
+                "rpc_method_calls_failed_total",
+                "method" => method_name,
+                "version" => self.version.to_str(),
+                "error_kind" => err.metric_label(),
+            )
+            .increment(1);
         }
 
         Some(RpcResponse {

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -142,7 +142,7 @@ impl RpcRouter {
         let result = std::panic::AssertUnwindSafe(method).catch_unwind().await;
 
         let duration = start.elapsed();
-        metrics::histogram!("rpc_method_calls_duration_milliseconds", "method" => method_name, "version" => self.version.to_str()).record(duration.as_millis() as f64);
+        metrics::histogram!("rpc_method_calls_duration_milliseconds", "method" => method_name, "version" => self.version.to_str()).record(duration.as_secs_f64() * 1000.0);
 
         let output = match result {
             Ok(output) => output,

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -142,7 +142,7 @@ impl RpcRouter {
         let result = std::panic::AssertUnwindSafe(method).catch_unwind().await;
 
         let duration = start.elapsed();
-        metrics::histogram!("rpc_method_calls_duration_milliseconds", "method" => method_name, "version" => self.version.to_str()).record(duration.as_secs_f64() * 1000.0);
+        metrics::histogram!("rpc_method_calls_duration_seconds", "method" => method_name, "version" => self.version.to_str()).record(duration.as_secs_f64());
 
         let output = match result {
             Ok(output) => output,

--- a/crates/rpc/src/jsonrpc/router/labels.rs
+++ b/crates/rpc/src/jsonrpc/router/labels.rs
@@ -10,9 +10,11 @@ pub enum BlockTarget {
     Pending,
     ByNumber,
     ByHash,
-    /// No `block_id` parameter (e.g. methods that don't take one).
+    /// No `block_id` parameter: a method that takes none, or an empty
+    /// positional argument list.
     None,
-    /// Positional params, or an unrecognised `block_id` shape.
+    /// A non-empty positional argument list, or an unrecognised `block_id`
+    /// shape.
     Unknown,
 }
 
@@ -35,21 +37,33 @@ pub fn classify_block_target(params: Option<&RawValue>) -> BlockTarget {
     let Some(raw) = params else {
         return BlockTarget::None;
     };
-    // Named params arrive as a JSON object; positional params (array) can't be
-    // classified by field name.
-    let Ok(obj) = serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(raw.get())
-    else {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(raw.get()) else {
         return BlockTarget::Unknown;
     };
-    match obj.get("block_id") {
-        None => BlockTarget::None,
-        Some(serde_json::Value::String(s)) if s == "latest" => BlockTarget::Latest,
-        Some(serde_json::Value::String(s)) if s == "pending" => BlockTarget::Pending,
-        Some(serde_json::Value::Object(o)) if o.contains_key("block_number") => {
-            BlockTarget::ByNumber
+    match value {
+        // Positional params: an empty list carries no block_id; a non-empty
+        // list can't be classified by field name.
+        serde_json::Value::Array(items) => {
+            if items.is_empty() {
+                BlockTarget::None
+            } else {
+                BlockTarget::Unknown
+            }
         }
-        Some(serde_json::Value::Object(o)) if o.contains_key("block_hash") => BlockTarget::ByHash,
-        Some(_) => BlockTarget::Unknown,
+        // Named params: classify by the shape of the `block_id` field.
+        serde_json::Value::Object(obj) => match obj.get("block_id") {
+            None => BlockTarget::None,
+            Some(serde_json::Value::String(s)) if s == "latest" => BlockTarget::Latest,
+            Some(serde_json::Value::String(s)) if s == "pending" => BlockTarget::Pending,
+            Some(serde_json::Value::Object(o)) if o.contains_key("block_number") => {
+                BlockTarget::ByNumber
+            }
+            Some(serde_json::Value::Object(o)) if o.contains_key("block_hash") => {
+                BlockTarget::ByHash
+            }
+            Some(_) => BlockTarget::Unknown,
+        },
+        _ => BlockTarget::Unknown,
     }
 }
 
@@ -80,12 +94,14 @@ mod tests {
     }
 
     #[test]
-    fn no_params_is_none() {
+    fn absent_or_empty_params_are_none() {
         assert_eq!(classify_block_target(None), BlockTarget::None);
+        let empty = raw("[]");
+        assert_eq!(classify_block_target(Some(&empty)), BlockTarget::None);
     }
 
     #[test]
-    fn positional_params_are_unknown() {
+    fn non_empty_positional_params_are_unknown() {
         let r = raw(r#"["latest","0x1"]"#);
         assert_eq!(classify_block_target(Some(&r)), BlockTarget::Unknown);
     }

--- a/crates/rpc/src/jsonrpc/router/labels.rs
+++ b/crates/rpc/src/jsonrpc/router/labels.rs
@@ -1,0 +1,92 @@
+//! Cross-cutting metric labels derived from a request at the router boundary.
+
+use serde_json::value::RawValue;
+
+/// How a request targeted a block, derived from the shape of its `block_id`
+/// parameter. Used as the `block_target` metric label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockTarget {
+    Latest,
+    Pending,
+    ByNumber,
+    ByHash,
+    /// No `block_id` parameter (e.g. methods that don't take one).
+    None,
+    /// Positional params, or an unrecognised `block_id` shape.
+    Unknown,
+}
+
+impl BlockTarget {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            BlockTarget::Latest => "latest",
+            BlockTarget::Pending => "pending",
+            BlockTarget::ByNumber => "by_number",
+            BlockTarget::ByHash => "by_hash",
+            BlockTarget::None => "none",
+            BlockTarget::Unknown => "unknown",
+        }
+    }
+}
+
+/// Classify the `block_id` of a request from its raw params, without depending
+/// on a version-specific deserializer — keys off the stable JSON shape only.
+pub fn classify_block_target(params: Option<&RawValue>) -> BlockTarget {
+    let Some(raw) = params else {
+        return BlockTarget::None;
+    };
+    // Named params arrive as a JSON object; positional params (array) can't be
+    // classified by field name.
+    let Ok(obj) = serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(raw.get())
+    else {
+        return BlockTarget::Unknown;
+    };
+    match obj.get("block_id") {
+        None => BlockTarget::None,
+        Some(serde_json::Value::String(s)) if s == "latest" => BlockTarget::Latest,
+        Some(serde_json::Value::String(s)) if s == "pending" => BlockTarget::Pending,
+        Some(serde_json::Value::Object(o)) if o.contains_key("block_number") => {
+            BlockTarget::ByNumber
+        }
+        Some(serde_json::Value::Object(o)) if o.contains_key("block_hash") => BlockTarget::ByHash,
+        Some(_) => BlockTarget::Unknown,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::value::RawValue;
+
+    use super::*;
+
+    fn raw(s: &str) -> Box<RawValue> {
+        RawValue::from_string(s.to_owned()).unwrap()
+    }
+
+    #[test]
+    fn classifies_block_id_shapes() {
+        let cases = [
+            (r#"{"block_id":"latest"}"#, BlockTarget::Latest),
+            (r#"{"block_id":"pending"}"#, BlockTarget::Pending),
+            (r#"{"block_id":{"block_number":5}}"#, BlockTarget::ByNumber),
+            (r#"{"block_id":{"block_hash":"0x1"}}"#, BlockTarget::ByHash),
+            (r#"{"contract_address":"0x1"}"#, BlockTarget::None),
+            (r#"{"block_id":"l1_accepted"}"#, BlockTarget::Unknown),
+        ];
+        for (json, expected) in cases {
+            let r = raw(json);
+            assert_eq!(classify_block_target(Some(&r)), expected, "json: {json}");
+        }
+    }
+
+    #[test]
+    fn no_params_is_none() {
+        assert_eq!(classify_block_target(None), BlockTarget::None);
+    }
+
+    #[test]
+    fn positional_params_are_unknown() {
+        let r = raw(r#"["latest","0x1"]"#);
+        assert_eq!(classify_block_target(Some(&r)), BlockTarget::Unknown);
+    }
+}

--- a/crates/rpc/src/jsonrpc/router/subscription.rs
+++ b/crates/rpc/src/jsonrpc/router/subscription.rs
@@ -728,7 +728,13 @@ async fn handle_request(
                 version: state.version,
             })?;
         handle.abort();
-        metrics::counter!("rpc_method_calls_total", "method" => "starknet_unsubscribe", "version" => state.version.to_str()).increment(1);
+        metrics::counter!(
+            "rpc_method_calls_total",
+            "method" => "starknet_unsubscribe",
+            "version" => state.version.to_str(),
+            "block_target" => super::labels::classify_block_target(rpc_request.params.0).as_str(),
+        )
+        .increment(1);
         return Ok(Some(RpcResponse {
             output: Ok(true.into()),
             id: req_id,
@@ -740,7 +746,13 @@ async fn handle_request(
         .subscription_endpoints
         .get_key_value(rpc_request.method.as_ref())
         .ok_or_else(|| RpcResponse::method_not_found(req_id.clone(), state.version))?;
-    metrics::counter!("rpc_method_calls_total", "method" => method_name, "version" => state.version.to_str()).increment(1);
+    metrics::counter!(
+        "rpc_method_calls_total",
+        "method" => method_name,
+        "version" => state.version.to_str(),
+        "block_target" => super::labels::classify_block_target(rpc_request.params.0).as_str(),
+    )
+    .increment(1);
 
     let params = serde_json::to_value(rpc_request.params)
         .map_err(|e| RpcResponse::invalid_params(req_id.clone(), e.to_string(), state.version))?;

--- a/docs/docs/monitoring-and-metrics.md
+++ b/docs/docs/monitoring-and-metrics.md
@@ -93,13 +93,13 @@ The Prometheus Metrics endpoint (`/metrics`) exposes real-time operational data 
       Counts how many times each method call resulted in an error. `error_kind` is the error
       variant name (e.g. `block_not_found`, `contract_not_found`, `invalid_params`,
       `internal_error`).
-    - `rpc_method_calls_duration_milliseconds{method="<methodName>", version="<rpcVersion>"}` —
-      histogram of JSON-RPC method call latency. Exported as Prometheus histogram buckets
-      (`rpc_method_calls_duration_milliseconds_bucket` / `_sum` / `_count`). Compute quantiles
+    - `rpc_method_calls_duration_seconds{method="<methodName>", version="<rpcVersion>"}` —
+      histogram of JSON-RPC method call latency, in seconds. Exported as Prometheus histogram
+      buckets (`rpc_method_calls_duration_seconds_bucket` / `_sum` / `_count`). Compute quantiles
       with `histogram_quantile()`:
 
       ```promql
-      histogram_quantile(0.95, sum by (le, method, version) (rate(rpc_method_calls_duration_milliseconds_bucket[5m])))
+      histogram_quantile(0.95, sum by (le, method, version) (rate(rpc_method_calls_duration_seconds_bucket[5m])))
       ```
 
       Pathfinder ships ready-made recording rules for p50/p95/p99 at

--- a/docs/docs/monitoring-and-metrics.md
+++ b/docs/docs/monitoring-and-metrics.md
@@ -84,12 +84,26 @@ The Prometheus Metrics endpoint (`/metrics`) exposes real-time operational data 
     - `process_start_time_seconds` - UNIX timestamp at which Pathfinder started.
   
   **RPC-Related Metrics**  
-    - `rpc_method_calls_total{method="<methodName>", version="<rpcVersion>"}`  
-      Counts how many times each JSON-RPC method is called.
-    - `rpc_method_calls_failed_total{method="<methodName>", version="<rpcVersion>"}`  
-      Counts how many times each method call resulted in an error.
-    - `rpc_method_calls_duration_milliseconds{method="<methodName>", version="<rpcVersion>"}`
-      Histogram of JSON-RPC method call latency.
+    - `rpc_method_calls_total{method="<methodName>", version="<rpcVersion>", block_target="<blockTarget>"}`  
+      Counts how many times each JSON-RPC method is called. `block_target` records how the
+      request targeted a block, derived from its `block_id` parameter: `latest`, `pending`,
+      `by_number`, `by_hash`, `none` (no `block_id` parameter), or `unknown` (positional
+      params or an unrecognised shape).
+    - `rpc_method_calls_failed_total{method="<methodName>", version="<rpcVersion>", error_kind="<errorKind>"}`  
+      Counts how many times each method call resulted in an error. `error_kind` is the error
+      variant name (e.g. `block_not_found`, `contract_not_found`, `invalid_params`,
+      `internal_error`).
+    - `rpc_method_calls_duration_milliseconds{method="<methodName>", version="<rpcVersion>"}` —
+      histogram of JSON-RPC method call latency. Exported as Prometheus histogram buckets
+      (`rpc_method_calls_duration_milliseconds_bucket` / `_sum` / `_count`). Compute quantiles
+      with `histogram_quantile()`:
+
+      ```promql
+      histogram_quantile(0.95, sum by (le, method, version) (rate(rpc_method_calls_duration_milliseconds_bucket[5m])))
+      ```
+
+      Pathfinder ships ready-made recording rules for p50/p95/p99 at
+      `utils/prometheus/rpc-recording-rules.yml`.
 
   **Gateway Request Metrics**  
     - `gateway_requests_total{method="<sequencerRequestType>", tag="<latest|pending>", reason="<optionalFailureReason>"}`  

--- a/utils/grafana/dashboard.json
+++ b/utils/grafana/dashboard.json
@@ -1081,7 +1081,7 @@
                                 "mode": "thresholds"
                             },
                             "mappings": [],
-                            "unit": "ms",
+                            "unit": "s",
                             "thresholds": {
                                 "mode": "absolute",
                                 "steps": [
@@ -1091,11 +1091,11 @@
                                     },
                                     {
                                         "color": "yellow",
-                                        "value": 250
+                                        "value": 0.25
                                     },
                                     {
                                         "color": "red",
-                                        "value": 1000
+                                        "value": 1.0
                                     }
                                 ]
                             }
@@ -1131,7 +1131,7 @@
                                 "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
                             },
                             "editorMode": "code",
-                            "expr": "histogram_quantile(0.99, sum by (le) (rate(rpc_method_calls_duration_milliseconds_bucket{network=\"$network\"}[$__rate_interval])))",
+                            "expr": "histogram_quantile(0.99, sum by (le) (rate(rpc_method_calls_duration_seconds_bucket{network=\"$network\"}[$__rate_interval])))",
                             "instant": true,
                             "range": false,
                             "refId": "A"
@@ -1145,7 +1145,7 @@
                         "type": "prometheus",
                         "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
                     },
-                    "description": "Total time spent per method = rate of the duration histogram _sum, in ms of work per second (wall-clock per call, incl. DB/lock waits; not CPU profiling).",
+                    "description": "Total time spent per method = rate of the duration histogram _sum, in seconds of work per second (wall-clock per call, incl. DB/lock waits; not CPU profiling).",
                     "fieldConfig": {
                         "defaults": {
                             "color": {
@@ -1193,14 +1193,14 @@
                                 "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
                             },
                             "editorMode": "code",
-                            "expr": "topk(15, sum by (method) (rate(rpc_method_calls_duration_milliseconds_sum{network=\"$network\"}[$__rate_interval])))",
+                            "expr": "topk(15, sum by (method) (rate(rpc_method_calls_duration_seconds_sum{network=\"$network\"}[$__rate_interval])))",
                             "instant": true,
                             "range": false,
                             "refId": "A",
                             "legendFormat": "{{method}}"
                         }
                     ],
-                    "title": "Where your time goes (ms/s per method)",
+                    "title": "Where your time goes (s/s per method)",
                     "type": "bargauge"
                 },
                 {
@@ -1232,7 +1232,44 @@
                                 ]
                             }
                         },
-                        "overrides": []
+                        "overrides": [
+                            {
+                                "matcher": {
+                                    "id": "byName",
+                                    "options": "p50"
+                                },
+                                "properties": [
+                                    {
+                                        "id": "unit",
+                                        "value": "s"
+                                    }
+                                ]
+                            },
+                            {
+                                "matcher": {
+                                    "id": "byName",
+                                    "options": "p90"
+                                },
+                                "properties": [
+                                    {
+                                        "id": "unit",
+                                        "value": "s"
+                                    }
+                                ]
+                            },
+                            {
+                                "matcher": {
+                                    "id": "byName",
+                                    "options": "p99"
+                                },
+                                "properties": [
+                                    {
+                                        "id": "unit",
+                                        "value": "s"
+                                    }
+                                ]
+                            }
+                        ]
                     },
                     "gridPos": {
                         "h": 9,
@@ -1255,7 +1292,7 @@
                         "sortBy": [
                             {
                                 "desc": true,
-                                "displayName": "time-spent (ms/s)"
+                                "displayName": "time-spent (s/s)"
                             }
                         ]
                     },
@@ -1280,7 +1317,7 @@
                                 "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
                             },
                             "editorMode": "code",
-                            "expr": "sum by (method) (rate(rpc_method_calls_duration_milliseconds_sum{network=\"$network\"}[$__rate_interval]))",
+                            "expr": "sum by (method) (rate(rpc_method_calls_duration_seconds_sum{network=\"$network\"}[$__rate_interval]))",
                             "instant": true,
                             "range": false,
                             "refId": "B",
@@ -1293,7 +1330,7 @@
                                 "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
                             },
                             "editorMode": "code",
-                            "expr": "histogram_quantile(0.50, sum by (le, method) (rate(rpc_method_calls_duration_milliseconds_bucket{network=\"$network\"}[$__rate_interval])))",
+                            "expr": "histogram_quantile(0.50, sum by (le, method) (rate(rpc_method_calls_duration_seconds_bucket{network=\"$network\"}[$__rate_interval])))",
                             "instant": true,
                             "range": false,
                             "refId": "C",
@@ -1306,7 +1343,7 @@
                                 "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
                             },
                             "editorMode": "code",
-                            "expr": "histogram_quantile(0.90, sum by (le, method) (rate(rpc_method_calls_duration_milliseconds_bucket{network=\"$network\"}[$__rate_interval])))",
+                            "expr": "histogram_quantile(0.90, sum by (le, method) (rate(rpc_method_calls_duration_seconds_bucket{network=\"$network\"}[$__rate_interval])))",
                             "instant": true,
                             "range": false,
                             "refId": "D",
@@ -1319,7 +1356,7 @@
                                 "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
                             },
                             "editorMode": "code",
-                            "expr": "histogram_quantile(0.99, sum by (le, method) (rate(rpc_method_calls_duration_milliseconds_bucket{network=\"$network\"}[$__rate_interval])))",
+                            "expr": "histogram_quantile(0.99, sum by (le, method) (rate(rpc_method_calls_duration_seconds_bucket{network=\"$network\"}[$__rate_interval])))",
                             "instant": true,
                             "range": false,
                             "refId": "E",
@@ -1355,10 +1392,10 @@
                                 "indexByName": {},
                                 "renameByName": {
                                     "Value #A": "calls/s",
-                                    "Value #B": "time-spent (ms/s)",
-                                    "Value #C": "p50 (ms)",
-                                    "Value #D": "p90 (ms)",
-                                    "Value #E": "p99 (ms)",
+                                    "Value #B": "time-spent (s/s)",
+                                    "Value #C": "p50",
+                                    "Value #D": "p90",
+                                    "Value #E": "p99",
                                     "Value #F": "error %"
                                 }
                             }

--- a/utils/grafana/dashboard.json
+++ b/utils/grafana/dashboard.json
@@ -937,10 +937,442 @@
             "panels": [
                 {
                     "datasource": {
-                        "default": true,
                         "type": "prometheus",
                         "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
                     },
+                    "description": "",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "mappings": [],
+                            "unit": "reqps",
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": 0
+                                    }
+                                ]
+                            }
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 4,
+                        "w": 8,
+                        "x": 0,
+                        "y": 3
+                    },
+                    "id": 25,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "textMode": "auto"
+                    },
+                    "pluginVersion": "12.3.0",
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
+                            },
+                            "editorMode": "code",
+                            "expr": "sum(rate(rpc_method_calls_total{network=\"$network\"}[$__rate_interval]))",
+                            "instant": true,
+                            "range": false,
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "RPC request rate",
+                    "type": "stat"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
+                    },
+                    "description": "",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "mappings": [],
+                            "unit": "percent",
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": 0
+                                    },
+                                    {
+                                        "color": "yellow",
+                                        "value": 1
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 5
+                                    }
+                                ]
+                            }
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 4,
+                        "w": 8,
+                        "x": 8,
+                        "y": 3
+                    },
+                    "id": 26,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "textMode": "auto"
+                    },
+                    "pluginVersion": "12.3.0",
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
+                            },
+                            "editorMode": "code",
+                            "expr": "100 * sum(rate(rpc_method_calls_failed_total{network=\"$network\"}[$__rate_interval])) / sum(rate(rpc_method_calls_total{network=\"$network\"}[$__rate_interval]))",
+                            "instant": true,
+                            "range": false,
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "RPC error rate",
+                    "type": "stat"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
+                    },
+                    "description": "",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "mappings": [],
+                            "unit": "ms",
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": 0
+                                    },
+                                    {
+                                        "color": "yellow",
+                                        "value": 250
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 1000
+                                    }
+                                ]
+                            }
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 4,
+                        "w": 8,
+                        "x": 16,
+                        "y": 3
+                    },
+                    "id": 27,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "textMode": "auto"
+                    },
+                    "pluginVersion": "12.3.0",
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
+                            },
+                            "editorMode": "code",
+                            "expr": "histogram_quantile(0.99, sum by (le) (rate(rpc_method_calls_duration_milliseconds_bucket{network=\"$network\"}[$__rate_interval])))",
+                            "instant": true,
+                            "range": false,
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "RPC p99 latency",
+                    "type": "stat"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
+                    },
+                    "description": "Total time spent per method = rate of the duration histogram _sum, in ms of work per second (wall-clock per call, incl. DB/lock waits; not CPU profiling).",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "continuous-GrYlRd"
+                            },
+                            "mappings": [],
+                            "unit": "none",
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": 0
+                                    }
+                                ]
+                            }
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 9,
+                        "w": 12,
+                        "x": 0,
+                        "y": 7
+                    },
+                    "id": 28,
+                    "options": {
+                        "displayMode": "gradient",
+                        "orientation": "horizontal",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "showUnfilled": true,
+                        "valueMode": "color"
+                    },
+                    "pluginVersion": "12.3.0",
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
+                            },
+                            "editorMode": "code",
+                            "expr": "topk(15, sum by (method) (rate(rpc_method_calls_duration_milliseconds_sum{network=\"$network\"}[$__rate_interval])))",
+                            "instant": true,
+                            "range": false,
+                            "refId": "A",
+                            "legendFormat": "{{method}}"
+                        }
+                    ],
+                    "title": "Where your time goes (ms/s per method)",
+                    "type": "bargauge"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
+                    },
+                    "description": "Per-method volume, time cost, latency shape and error rate. Sort any column.",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "custom": {
+                                "align": "auto",
+                                "cellOptions": {
+                                    "type": "auto"
+                                },
+                                "inspect": false
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": 0
+                                    }
+                                ]
+                            }
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 9,
+                        "w": 12,
+                        "x": 12,
+                        "y": 7
+                    },
+                    "id": 29,
+                    "options": {
+                        "cellHeight": "sm",
+                        "footer": {
+                            "countRows": false,
+                            "fields": "",
+                            "reducer": [
+                                "sum"
+                            ],
+                            "show": false
+                        },
+                        "showHeader": true,
+                        "sortBy": [
+                            {
+                                "desc": true,
+                                "displayName": "time-spent (ms/s)"
+                            }
+                        ]
+                    },
+                    "pluginVersion": "12.3.0",
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
+                            },
+                            "editorMode": "code",
+                            "expr": "sum by (method) (rate(rpc_method_calls_total{network=\"$network\"}[$__rate_interval]))",
+                            "instant": true,
+                            "range": false,
+                            "refId": "A",
+                            "legendFormat": "",
+                            "format": "table"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
+                            },
+                            "editorMode": "code",
+                            "expr": "sum by (method) (rate(rpc_method_calls_duration_milliseconds_sum{network=\"$network\"}[$__rate_interval]))",
+                            "instant": true,
+                            "range": false,
+                            "refId": "B",
+                            "legendFormat": "",
+                            "format": "table"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
+                            },
+                            "editorMode": "code",
+                            "expr": "histogram_quantile(0.50, sum by (le, method) (rate(rpc_method_calls_duration_milliseconds_bucket{network=\"$network\"}[$__rate_interval])))",
+                            "instant": true,
+                            "range": false,
+                            "refId": "C",
+                            "legendFormat": "",
+                            "format": "table"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
+                            },
+                            "editorMode": "code",
+                            "expr": "histogram_quantile(0.90, sum by (le, method) (rate(rpc_method_calls_duration_milliseconds_bucket{network=\"$network\"}[$__rate_interval])))",
+                            "instant": true,
+                            "range": false,
+                            "refId": "D",
+                            "legendFormat": "",
+                            "format": "table"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
+                            },
+                            "editorMode": "code",
+                            "expr": "histogram_quantile(0.99, sum by (le, method) (rate(rpc_method_calls_duration_milliseconds_bucket{network=\"$network\"}[$__rate_interval])))",
+                            "instant": true,
+                            "range": false,
+                            "refId": "E",
+                            "legendFormat": "",
+                            "format": "table"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
+                            },
+                            "editorMode": "code",
+                            "expr": "100 * sum by (method) (rate(rpc_method_calls_failed_total{network=\"$network\"}[$__rate_interval])) / sum by (method) (rate(rpc_method_calls_total{network=\"$network\"}[$__rate_interval]))",
+                            "instant": true,
+                            "range": false,
+                            "refId": "F",
+                            "legendFormat": "",
+                            "format": "table"
+                        }
+                    ],
+                    "transformations": [
+                        {
+                            "id": "merge",
+                            "options": {}
+                        },
+                        {
+                            "id": "organize",
+                            "options": {
+                                "excludeByName": {
+                                    "Time": true
+                                },
+                                "includeByName": {},
+                                "indexByName": {},
+                                "renameByName": {
+                                    "Value #A": "calls/s",
+                                    "Value #B": "time-spent (ms/s)",
+                                    "Value #C": "p50 (ms)",
+                                    "Value #D": "p90 (ms)",
+                                    "Value #E": "p99 (ms)",
+                                    "Value #F": "error %"
+                                }
+                            }
+                        }
+                    ],
+                    "title": "Method detail",
+                    "type": "table"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
+                    },
+                    "description": "Share of calls by how they target a block. Pinned share (by_number + by_hash) is the archive-pressure signal.",
                     "fieldConfig": {
                         "defaults": {
                             "color": {
@@ -955,7 +1387,7 @@
                                 "barAlignment": 0,
                                 "barWidthFactor": 0.6,
                                 "drawStyle": "line",
-                                "fillOpacity": 0,
+                                "fillOpacity": 35,
                                 "gradientMode": "none",
                                 "hideFrom": {
                                     "legend": false,
@@ -970,11 +1402,10 @@
                                     "type": "linear"
                                 },
                                 "showPoints": "auto",
-                                "showValues": false,
                                 "spanNulls": false,
                                 "stacking": {
                                     "group": "A",
-                                    "mode": "none"
+                                    "mode": "normal"
                                 },
                                 "thresholdsStyle": {
                                     "mode": "off"
@@ -987,23 +1418,20 @@
                                     {
                                         "color": "green",
                                         "value": 0
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 80
                                     }
                                 ]
-                            }
+                            },
+                            "unit": "reqps"
                         },
                         "overrides": []
                     },
                     "gridPos": {
                         "h": 8,
-                        "w": 18,
+                        "w": 12,
                         "x": 0,
-                        "y": 3
+                        "y": 16
                     },
-                    "id": 11,
+                    "id": 30,
                     "options": {
                         "legend": {
                             "calcs": [],
@@ -1024,19 +1452,15 @@
                                 "type": "prometheus",
                                 "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
                             },
-                            "disableTextWrap": false,
-                            "editorMode": "builder",
-                            "expr": "rpc_method_calls_duration_milliseconds{network=\"$network\", quantile=\"0.95\"}",
-                            "fullMetaSearch": false,
-                            "includeNullMetadata": true,
+                            "editorMode": "code",
+                            "expr": "sum by (block_target) (rate(rpc_method_calls_total{network=\"$network\"}[$__rate_interval]))",
                             "instant": false,
-                            "legendFormat": "{{method}}",
                             "range": true,
                             "refId": "A",
-                            "useBackend": false
+                            "legendFormat": "{{block_target}}"
                         }
                     ],
-                    "title": "RPC method call 95th percentile",
+                    "title": "Hot-path vs archive (by block_target)",
                     "type": "timeseries"
                 },
                 {
@@ -1044,6 +1468,7 @@
                         "type": "prometheus",
                         "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
                     },
+                    "description": "Failed calls by method and error_kind. block_not_found spikes corroborate the archive panel.",
                     "fieldConfig": {
                         "defaults": {
                             "color": {
@@ -1058,7 +1483,7 @@
                                 "barAlignment": 0,
                                 "barWidthFactor": 0.6,
                                 "drawStyle": "line",
-                                "fillOpacity": 0,
+                                "fillOpacity": 35,
                                 "gradientMode": "none",
                                 "hideFrom": {
                                     "legend": false,
@@ -1073,11 +1498,10 @@
                                     "type": "linear"
                                 },
                                 "showPoints": "auto",
-                                "showValues": false,
                                 "spanNulls": false,
                                 "stacking": {
                                     "group": "A",
-                                    "mode": "none"
+                                    "mode": "normal"
                                 },
                                 "thresholdsStyle": {
                                     "mode": "off"
@@ -1090,23 +1514,20 @@
                                     {
                                         "color": "green",
                                         "value": 0
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 80
                                     }
                                 ]
-                            }
+                            },
+                            "unit": "reqps"
                         },
                         "overrides": []
                     },
                     "gridPos": {
                         "h": 8,
-                        "w": 18,
-                        "x": 0,
-                        "y": 11
+                        "w": 12,
+                        "x": 12,
+                        "y": 16
                     },
-                    "id": 2,
+                    "id": 31,
                     "options": {
                         "legend": {
                             "calcs": [],
@@ -1127,20 +1548,87 @@
                                 "type": "prometheus",
                                 "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
                             },
-                            "disableTextWrap": false,
-                            "editorMode": "builder",
-                            "expr": "rate(rpc_method_calls_total{network=\"$network\"}[$__rate_interval])",
-                            "fullMetaSearch": false,
-                            "includeNullMetadata": true,
+                            "editorMode": "code",
+                            "expr": "sum by (method, error_kind) (rate(rpc_method_calls_failed_total{network=\"$network\"}[$__rate_interval]))",
                             "instant": false,
-                            "legendFormat": "{{method}}",
                             "range": true,
                             "refId": "A",
-                            "useBackend": false
+                            "legendFormat": "{{method}} {{error_kind}}"
                         }
                     ],
-                    "title": "RPC request rate",
+                    "title": "Errors by method & kind",
                     "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
+                    },
+                    "description": "Share of calls by RPC spec version. Deprecation signal.",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": 0
+                                    }
+                                ]
+                            },
+                            "unit": "reqps"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 0,
+                        "y": 24
+                    },
+                    "id": 32,
+                    "options": {
+                        "legend": {
+                            "displayMode": "list",
+                            "placement": "right",
+                            "showLegend": true,
+                            "values": []
+                        },
+                        "pieType": "pie",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "single",
+                            "sort": "none"
+                        }
+                    },
+                    "pluginVersion": "12.3.0",
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "b8c48888-f6b5-49f2-b734-40b75cae0dbe"
+                            },
+                            "editorMode": "code",
+                            "expr": "sum by (version) (rate(rpc_method_calls_total{network=\"$network\"}[$__rate_interval]))",
+                            "instant": true,
+                            "range": false,
+                            "refId": "A",
+                            "legendFormat": "{{version}}"
+                        }
+                    ],
+                    "title": "RPC version usage",
+                    "type": "piechart"
                 }
             ],
             "title": "JSON-RPC",

--- a/utils/prometheus/rpc-recording-rules.yml
+++ b/utils/prometheus/rpc-recording-rules.yml
@@ -4,9 +4,9 @@
 groups:
   - name: pathfinder_rpc
     rules:
-      - record: rpc:method_call_duration_ms:p50
-        expr: histogram_quantile(0.50, sum by (le, method, version) (rate(rpc_method_calls_duration_milliseconds_bucket[5m])))
-      - record: rpc:method_call_duration_ms:p95
-        expr: histogram_quantile(0.95, sum by (le, method, version) (rate(rpc_method_calls_duration_milliseconds_bucket[5m])))
-      - record: rpc:method_call_duration_ms:p99
-        expr: histogram_quantile(0.99, sum by (le, method, version) (rate(rpc_method_calls_duration_milliseconds_bucket[5m])))
+      - record: rpc:method_call_duration_seconds:p50
+        expr: histogram_quantile(0.50, sum by (le, method, version) (rate(rpc_method_calls_duration_seconds_bucket[5m])))
+      - record: rpc:method_call_duration_seconds:p95
+        expr: histogram_quantile(0.95, sum by (le, method, version) (rate(rpc_method_calls_duration_seconds_bucket[5m])))
+      - record: rpc:method_call_duration_seconds:p99
+        expr: histogram_quantile(0.99, sum by (le, method, version) (rate(rpc_method_calls_duration_seconds_bucket[5m])))

--- a/utils/prometheus/rpc-recording-rules.yml
+++ b/utils/prometheus/rpc-recording-rules.yml
@@ -1,0 +1,12 @@
+# Pre-computed RPC latency quantiles over the duration histogram's buckets.
+# Alerts and dashboards reference these stable series instead of repeating
+# histogram_quantile() in every rule. Load via Prometheus `rule_files`.
+groups:
+  - name: pathfinder_rpc
+    rules:
+      - record: rpc:method_call_duration_ms:p50
+        expr: histogram_quantile(0.50, sum by (le, method, version) (rate(rpc_method_calls_duration_milliseconds_bucket[5m])))
+      - record: rpc:method_call_duration_ms:p95
+        expr: histogram_quantile(0.95, sum by (le, method, version) (rate(rpc_method_calls_duration_milliseconds_bucket[5m])))
+      - record: rpc:method_call_duration_ms:p99
+        expr: histogram_quantile(0.99, sum by (le, method, version) (rate(rpc_method_calls_duration_milliseconds_bucket[5m])))


### PR DESCRIPTION

We've been asked to measure our JSON-RPC interface. To me that comes down to:
1. What methods are actually getting hammered
2. Which ones are slow
3. What is quietly failing 

The answer right now is that we don't really know. We _can_ ask RPC providers to give us data, but that's putting work on them and we'd essentially get a custom export of their own analytics, which would be different for every provider and potentially not that helfpul.

Turns out Pathfinder already emits some RPC metrics. They were just too coarse to answer these questions. But if we can make our node emit the right signals, every operator/provider will have the answers for us to ask for, in the exact same shape.

So this PR is about making Pathfinder have great (i.e. useful) RPC metrics on the RPC layer.

**What changed (and why)**

1. `rpc_method_calls_total` currently tells us that a method was called, but nothing about how. Added two labels to it:
    - `block_target`: did the request ask for latest, pending, a specific block, or nothing at all?
    - `error_kind`: on `rpc_method_calls_failed_total`, the actual error variant (`block_not_found`, `contract_not_found`, etc.)

2. Latency is now queryable. This is a breaking change and an opinionated decision I made - feel free to push back. I just don't understand why it was exported as a summary with fixed quantiles. You're essentially stuck with whatever quantiles we've hardcoded... I've made it a histogram, so you can compute any quantile you want using a query and aggregate as you need.

3. The Grafana dashboard for RPC now has 8 panels (instead of 2). I shared a screenshot on Slack. I think it's now very useful to get a real overview of what is going on in real-time. Honestly one of the changes I'm most excited about.

**Breaking change**

This PR introduces a breaking change (mentioned above). I've made it super clear in the CHANGELOG, with instructions on how to migrate to the new version. It's literally a one-line migration for anyone who had an alert on `rpc_method_calls_duration_milliseconds{quantile="..."}`. They just have to switch to `histogram_quantile(...)` over the `_bucket` series of the new histogram. Documented in `monitoring-and-metrics.md` and also provided pre-baked quantiles for those who don't wanna write the query: `utils/prometheus/rpc-recording-rules.yml`

**How to try it**

If you're curious, just run the node with `--monitor-address`, point Prometheus at it (requires Docker), import `utils/grafana/dashboard.json`, and load the recording rules via `rule_files`. It is a bit cumbersome 🤷‍♂️ 


Note: Everything is in the router boundary, I didn't touch any methods.
