### PR TITLE
fix(sync/pending): stop chasing the tip when building pre-confirmed data

### DIFF
--- a/crates/gateway-client/src/lib.rs
+++ b/crates/gateway-client/src/lib.rs
@@ -12,11 +12,7 @@ use pathfinder_common::class_definition::{
 use pathfinder_common::prelude::*;
 use reqwest::Url;
 use starknet_gateway_types::error::SequencerError;
-use starknet_gateway_types::reply::{
-    PreConfirmedPollResponse,
-    PreConfirmedPollResponseWire,
-    PreLatestBlock,
-};
+use starknet_gateway_types::reply::{PreConfirmedPollResponse, PreConfirmedPollResponseWire};
 use starknet_gateway_types::trace::{BlockTrace, TransactionTrace};
 use starknet_gateway_types::{reply, request};
 
@@ -58,10 +54,6 @@ impl From<pathfinder_common::BlockId> for BlockId {
 #[mockall::automock]
 #[async_trait::async_trait]
 pub trait GatewayApi: Sync {
-    async fn pending_block(&self) -> Result<(PreLatestBlock, StateUpdate), SequencerError> {
-        unimplemented!();
-    }
-
     async fn preconfirmed_block(
         &self,
         block: BlockId,
@@ -156,10 +148,6 @@ pub trait GatewayApi: Sync {
 
 #[async_trait::async_trait]
 impl<T: GatewayApi + Sync + Send> GatewayApi for Arc<T> {
-    async fn pending_block(&self) -> Result<(PreLatestBlock, StateUpdate), SequencerError> {
-        self.as_ref().pending_block().await
-    }
-
     async fn preconfirmed_block(
         &self,
         block: BlockId,
@@ -490,26 +478,6 @@ fn resolve_hosts(url: &Url) -> anyhow::Result<Vec<std::net::IpAddr>> {
 
 #[async_trait::async_trait]
 impl GatewayApi for Client {
-    #[tracing::instrument(skip(self))]
-    async fn pending_block(&self) -> Result<(PreLatestBlock, StateUpdate), SequencerError> {
-        #[derive(Clone, Debug, serde::Deserialize)]
-        struct Dto {
-            pub block: PreLatestBlock,
-            pub state_update: starknet_gateway_types::reply::StateUpdate,
-        }
-
-        let result: Dto = self
-            .feeder_gateway_request()
-            .get_state_update()
-            .block(BlockId::Pending)
-            .param("includeBlock", "true")
-            .retry(self.retry)
-            .get()
-            .await?;
-
-        Ok((result.block, result.state_update.into()))
-    }
-
     #[tracing::instrument(skip(self))]
     async fn preconfirmed_block(
         &self,
@@ -1342,45 +1310,6 @@ mod tests {
                 .block_header(BlockNumber::new_or_panic(BLOCK_NUMBER).into())
                 .await
                 .unwrap_err();
-            assert_matches!(
-                error,
-                SequencerError::StarknetError(e) => assert_eq!(e.code, KnownStarknetErrorCode::BlockNotFound.into())
-            );
-        }
-    }
-
-    mod pending_block {
-        use super::*;
-
-        #[test_log::test(tokio::test)]
-        async fn success() {
-            let body: serde_json::Value = serde_json::from_str(starknet_gateway_test_fixtures::v0_13_1::state_update_with_block::SEPOLIA_INTEGRATION_PENDING).unwrap();
-            let server = MockServer::start().await;
-            Mock::given(matchers::path("/feeder_gateway/get_state_update"))
-                .and(matchers::query_param("blockNumber", "pending"))
-                .and(matchers::query_param("includeBlock", "true"))
-                .respond_with(ResponseTemplate::new(200).set_body_json(body))
-                .mount(&server)
-                .await;
-            let client = Client::for_test(server.uri().parse().unwrap()).unwrap();
-
-            client.pending_block().await.unwrap();
-        }
-
-        #[test_log::test(tokio::test)]
-        async fn block_not_found() {
-            let server = MockServer::start().await;
-            Mock::given(matchers::path("/feeder_gateway/get_state_update"))
-                .and(matchers::query_param("blockNumber", "pending"))
-                .and(matchers::query_param("includeBlock", "true"))
-                .respond_with(
-                    ResponseTemplate::new(500)
-                        .set_body_json(response_body_from(KnownStarknetErrorCode::BlockNotFound)),
-                )
-                .mount(&server)
-                .await;
-            let client = Client::for_test(server.uri().parse().unwrap()).unwrap();
-            let error = client.pending_block().await.unwrap_err();
             assert_matches!(
                 error,
                 SequencerError::StarknetError(e) => assert_eq!(e.code, KnownStarknetErrorCode::BlockNotFound.into())

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -55,41 +55,6 @@ pub struct Block {
     pub state_diff_length: Option<u64>,
 }
 
-/// Represents the "pre-latest" block in Starknet, which is a block that has
-/// been closed in consensus but is still awaiting commitment calculations
-/// before being finalized.
-///
-/// Obtained by querying the gateway for the pending block on Starknet >
-/// v0.14.0.
-#[serde_as]
-#[derive(Clone, Default, Debug, Deserialize, PartialEq, Eq)]
-#[cfg_attr(test, derive(serde::Serialize))]
-pub struct PreLatestBlock {
-    pub l1_gas_price: GasPrices,
-    pub l1_data_gas_price: GasPrices,
-    #[serde(default)] // TODO: Needed until the gateway provides the l2 gas price
-    pub l2_gas_price: GasPrices,
-
-    #[serde(rename = "parent_block_hash")]
-    pub parent_hash: BlockHash,
-    pub sequencer_address: SequencerAddress,
-    pub status: Status,
-    pub timestamp: BlockTimestamp,
-    #[serde_as(as = "Vec<transaction::Receipt>")]
-    pub transaction_receipts: Vec<(
-        pathfinder_common::receipt::Receipt,
-        Vec<pathfinder_common::event::Event>,
-    )>,
-    #[serde_as(as = "Vec<transaction::Transaction>")]
-    pub transactions: Vec<pathfinder_common::transaction::Transaction>,
-    /// Version metadata introduced in 0.9.1, older blocks will not have it.
-    #[serde(default)]
-    #[serde_as(as = "DisplayFromStr")]
-    pub starknet_version: StarknetVersion,
-    // Introduced in v0.13.1
-    pub l1_da_mode: L1DataAvailabilityMode,
-}
-
 #[serde_as]
 #[derive(Clone, Default, Debug, Deserialize, PartialEq, Eq)]
 #[cfg_attr(test, derive(serde::Serialize))]

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -240,3 +240,327 @@ async fn fetch_pre_latest<S: GatewayApi + Send + 'static>(
     ));
     Ok(pre_latest_data)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use pathfinder_common::macro_prelude::*;
+    use pathfinder_common::receipt::Receipt;
+    use pathfinder_common::transaction::{L1HandlerTransaction, Transaction, TransactionVariant};
+    use pathfinder_common::{BlockHash, BlockNumber, StateUpdate, TransactionIndex};
+    use pathfinder_pending_data::PendingDataCache;
+    use starknet_gateway_client::{BlockId, MockGatewayApi};
+    use starknet_gateway_types::error::SequencerError;
+    use starknet_gateway_types::reply::{
+        PreConfirmedBlock,
+        PreConfirmedPollResponse,
+        PreLatestBlock,
+        Status,
+    };
+    use tokio::sync::watch;
+    use tokio::time::timeout;
+
+    use super::{apply, poll_pre_confirmed, Tracked};
+
+    const IN_SYNC: u64 = 6;
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    /// An L1-handler transaction with a small, distinct hash.
+    fn sample_tx(i: usize) -> Transaction {
+        let hash = match i {
+            0 => transaction_hash!("0x1"),
+            1 => transaction_hash!("0x2"),
+            _ => transaction_hash!("0x3"),
+        };
+        Transaction {
+            hash,
+            variant: TransactionVariant::L1Handler(L1HandlerTransaction {
+                contract_address: contract_address!("0x1"),
+                entry_point_selector: entry_point!("0x55"),
+                nonce: transaction_nonce!("0x0"),
+                calldata: vec![],
+            }),
+        }
+    }
+
+    /// A pre-confirmed block with `n` receipted transactions, so the conversion
+    /// into pending data accepts it.
+    fn pre_confirmed(n: usize) -> PreConfirmedBlock {
+        let transactions: Vec<_> = (0..n).map(sample_tx).collect();
+        let transaction_receipts = transactions
+            .iter()
+            .enumerate()
+            .map(|(i, t)| {
+                Some((
+                    Receipt {
+                        transaction_hash: t.hash,
+                        transaction_index: TransactionIndex::new_or_panic(i as u64),
+                        ..Default::default()
+                    },
+                    vec![],
+                ))
+            })
+            .collect();
+        PreConfirmedBlock {
+            status: Status::PreConfirmed,
+            transactions,
+            transaction_receipts,
+            transaction_state_diffs: vec![None; n],
+            ..Default::default()
+        }
+    }
+
+    /// A pending block that builds on `parent`.
+    fn pending_on(parent: BlockHash) -> PreLatestBlock {
+        PreLatestBlock {
+            parent_hash: parent,
+            status: Status::Pending,
+            ..Default::default()
+        }
+    }
+
+    /// A full poll response carrying `block`.
+    fn full(block: PreConfirmedBlock) -> PreConfirmedPollResponse {
+        PreConfirmedPollResponse::Full {
+            identifier: "id".into(),
+            block_number: None,
+            block,
+        }
+    }
+
+    /// Spawn the producer against `sequencer`, polling fast and anchored at
+    /// `committed`.
+    fn spawn(
+        sequencer: MockGatewayApi,
+        committed: BlockNumber,
+        committed_hash: BlockHash,
+        cache: Arc<PendingDataCache>,
+    ) {
+        let (_latest, latest) = watch::channel((committed, committed_hash));
+        let (_current, current) = watch::channel((committed, committed_hash));
+        let sequencer = Arc::new(sequencer);
+        tokio::spawn(async move {
+            poll_pre_confirmed(
+                sequencer,
+                Duration::from_millis(1),
+                cache,
+                latest,
+                current,
+                IN_SYNC,
+            )
+            .await
+        });
+    }
+
+    /// The common path: a pending block sits above our head, so it's the
+    /// pre-latest at committed+1 and the pre-confirmed chains onto it at
+    /// committed+2. The producer stores the two as one view.
+    #[tokio::test]
+    async fn stores_chained_view_when_pre_latest_present() {
+        let committed = BlockNumber::new_or_panic(100);
+        let committed_hash = block_hash!("0xc0");
+
+        let mut sequencer = MockGatewayApi::new();
+        // The pending block builds on our head: the pre-latest at committed+1.
+        sequencer
+            .expect_pending_block()
+            .returning(move || Ok((pending_on(committed_hash), StateUpdate::default())));
+        // The pre-confirmed that chains onto it, at committed+2.
+        sequencer
+            .expect_preconfirmed_block()
+            .returning(|_, _, _| Ok(full(pre_confirmed(2))));
+
+        let cache = Arc::new(PendingDataCache::new());
+        let mut changes = cache.subscribe();
+        let _ = changes.borrow_and_update();
+
+        spawn(sequencer, committed, committed_hash, cache.clone());
+
+        // Wait for the producer to publish.
+        timeout(TIMEOUT, changes.changed())
+            .await
+            .expect("a view should be published")
+            .unwrap();
+
+        let stored = changes.borrow();
+        assert_eq!(
+            stored.pre_confirmed_block_number(),
+            BlockNumber::new_or_panic(102)
+        );
+        assert_eq!(
+            stored.pre_latest_block_number(),
+            Some(BlockNumber::new_or_panic(101))
+        );
+        assert_eq!(stored.pre_confirmed_transactions().len(), 2);
+    }
+
+    /// With nothing closing above our head, the pending block doesn't chain
+    /// onto us, so there's no pre-latest. The producer corrects inside the
+    /// same poll and stores the pre-confirmed at committed+1, alone.
+    #[tokio::test]
+    async fn corrects_to_committed_plus_one_without_pre_latest() {
+        let committed = BlockNumber::new_or_panic(100);
+        let committed_hash = block_hash!("0xc0");
+
+        let mut sequencer = MockGatewayApi::new();
+        // The pending block builds on someone else, so it isn't our pre-latest.
+        sequencer
+            .expect_pending_block()
+            .returning(|| Ok((pending_on(block_hash!("0xdead")), StateUpdate::default())));
+        // committed+2 is fetched on the assumption and dropped; committed+1 is
+        // the block we actually serve.
+        sequencer
+            .expect_preconfirmed_block()
+            .returning(|block, _, _| match block {
+                BlockId::Number(n) if n == BlockNumber::new_or_panic(101) => {
+                    Ok(full(pre_confirmed(1)))
+                }
+                _ => Ok(full(pre_confirmed(0))),
+            });
+
+        let cache = Arc::new(PendingDataCache::new());
+        let mut changes = cache.subscribe();
+        let _ = changes.borrow_and_update();
+
+        spawn(sequencer, committed, committed_hash, cache.clone());
+
+        timeout(TIMEOUT, changes.changed())
+            .await
+            .expect("a view should be published")
+            .unwrap();
+
+        let stored = changes.borrow();
+        assert_eq!(
+            stored.pre_confirmed_block_number(),
+            BlockNumber::new_or_panic(101)
+        );
+        assert_eq!(stored.pre_latest_block_number(), None);
+    }
+
+    /// Once a view is published, a failing gateway must not take the cache
+    /// down. The last good view keeps being served.
+    #[tokio::test]
+    async fn retains_last_good_view_on_fetch_failure() {
+        let committed = BlockNumber::new_or_panic(100);
+        let committed_hash = block_hash!("0xc0");
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut sequencer = MockGatewayApi::new();
+        sequencer
+            .expect_pending_block()
+            .returning(move || Ok((pending_on(committed_hash), StateUpdate::default())));
+        // The first poll succeeds; every poll after it fails.
+        sequencer
+            .expect_preconfirmed_block()
+            .returning(move |_, _, _| {
+                if calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Ok(full(pre_confirmed(1)))
+                } else {
+                    Err(SequencerError::InvalidResponse("boom".into()))
+                }
+            });
+
+        let cache = Arc::new(PendingDataCache::new());
+        let mut changes = cache.subscribe();
+        let _ = changes.borrow_and_update();
+
+        spawn(sequencer, committed, committed_hash, cache.clone());
+
+        // The first poll publishes the good view.
+        timeout(TIMEOUT, changes.changed())
+            .await
+            .expect("first view should be published")
+            .unwrap();
+        assert_eq!(
+            changes.borrow().pre_confirmed_block_number(),
+            BlockNumber::new_or_panic(102)
+        );
+
+        // Let the failing polls run.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // The cache still serves the last good view rather than an error.
+        let served = cache.read().await.expect("cache must stay serviceable");
+        assert_eq!(
+            served.pre_confirmed_block_number(),
+            BlockNumber::new_or_panic(102)
+        );
+    }
+
+    /// While our head is far behind the chain, pre-confirmed reads fail fast as
+    /// "syncing" instead of serving nothing.
+    #[tokio::test(start_paused = true)]
+    async fn marks_syncing_when_far_behind_head() {
+        let hash = block_hash!("0xc0");
+        // Our head is genesis; the chain head is well past the in-sync threshold.
+        let (_current, current) = watch::channel((BlockNumber::GENESIS, hash));
+        let (_latest, latest) = watch::channel((BlockNumber::new_or_panic(100), hash));
+
+        // The sync guard returns before any fetch, so the gateway is never called.
+        let sequencer = Arc::new(MockGatewayApi::new());
+        let cache = Arc::new(PendingDataCache::new());
+        tokio::spawn({
+            let cache = cache.clone();
+            async move {
+                poll_pre_confirmed(
+                    sequencer,
+                    Duration::from_secs(1),
+                    cache,
+                    latest,
+                    current,
+                    IN_SYNC,
+                )
+                .await
+            }
+        });
+
+        // Give the loop a turn to reach the guard.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let err = cache.read().await.unwrap_err();
+        assert!(err.to_string().contains("syncing"), "got: {err}");
+    }
+
+    /// A delta carries only the new transactions, which the producer appends
+    /// onto the block it's already tracking at that height.
+    #[test]
+    fn delta_appends_to_the_tracked_block() {
+        let height = BlockNumber::new_or_panic(102);
+
+        // We're already tracking a block with one transaction.
+        let mut tracked = Some(Tracked {
+            number: height,
+            identifier: "id".into(),
+            block: pre_confirmed(1),
+        });
+
+        // A delta with a second transaction, tagged with the same identifier.
+        let second = sample_tx(1);
+        let republished = apply(
+            &mut tracked,
+            height,
+            PreConfirmedPollResponse::Delta {
+                identifier: "id".into(),
+                new_transactions: vec![second.clone()],
+                new_receipts: vec![Some((
+                    Receipt {
+                        transaction_hash: second.hash,
+                        transaction_index: TransactionIndex::new_or_panic(1),
+                        ..Default::default()
+                    },
+                    vec![],
+                ))],
+                new_state_diffs: vec![None],
+            },
+        );
+
+        assert!(
+            republished,
+            "a delta with new transactions refreshes the view"
+        );
+        assert_eq!(tracked.unwrap().block.transactions.len(), 2);
+    }
+}

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -1,10 +1,9 @@
 use std::sync::Arc;
 
-use anyhow::Context;
-use pathfinder_common::{BlockHash, BlockNumber, StateUpdate};
+use pathfinder_common::{BlockHash, BlockNumber};
 use pathfinder_pending_data::{PendingData, PendingDataCache};
 use starknet_gateway_client::GatewayApi;
-use starknet_gateway_types::reply::{PreConfirmedBlock, PreConfirmedPollResponse, PreLatestBlock};
+use starknet_gateway_types::reply::{PreConfirmedBlock, PreConfirmedPollResponse};
 use tokio::sync::watch;
 use tokio::time::Instant;
 
@@ -131,46 +130,61 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
             continue;
         }
 
-        // Assume the common shape: a pre-latest at committed+1 with the
-        // pre-confirmed at committed+2. Fetch that height and the pending block
-        // concurrently.
-        let assumed = committed + 2;
-        let (cursor_id, cursor_count) = delta_cursor(&tracked, assumed);
-        let (pc_result, pre_latest_result) = tokio::join!(
-            sequencer.preconfirmed_block(assumed.into(), cursor_id, cursor_count),
-            fetch_pre_latest(&sequencer, committed, committed_hash),
+        // The pre-latest sits at committed+1, decided in consensus and only
+        // awaiting its block hash; the pre-confirmed at committed+2 is still
+        // building. Fetch both by number so they chain onto our head by
+        // construction. The pre-confirmed carries deltas between polls; the
+        // pre-latest is settled, so we take it whole each time.
+        let pre_latest_height = committed + 1;
+        let pre_confirmed_height = committed + 2;
+        let (cursor_id, cursor_count) = delta_cursor(&tracked, pre_confirmed_height);
+        let (pre_latest_result, pre_confirmed_result) = tokio::join!(
+            sequencer.preconfirmed_block(pre_latest_height.into(), None, 0),
+            sequencer.preconfirmed_block(pre_confirmed_height.into(), cursor_id, cursor_count),
         );
 
-        let pre_latest = match pre_latest_result {
-            Ok(pre_latest) => pre_latest,
-            Err(e) => {
-                tracing::debug!(%e, "Failed to fetch pre-latest block");
-                None
-            }
-        };
-
-        // Now pending() tells us if there's really a pre-latest. With one, committed+2
-        // is the pre-confirmed; without one it's committed+1, so we drop what we
-        // fetched and get committed+1 instead.
-        let (number, response) = if pre_latest.is_some() {
-            (assumed, pc_result)
-        } else {
-            let number = committed + 1;
-            let (cursor_id, cursor_count) = delta_cursor(&tracked, number);
-            let response = sequencer
-                .preconfirmed_block(number.into(), cursor_id, cursor_count)
-                .await;
-            (number, response)
-        };
-
-        // A failed or not-yet-available fetch must not blank the cache.
-        let response = match response {
-            Ok(response) => response,
-            Err(e) => {
-                tracing::debug!(%e, %number, "Pre-confirmed fetch failed; retaining last view");
+        // The pre-latest is the foundation: without it nothing chains onto our
+        // head, so we keep serving the last good view and try again.
+        let (pre_latest_identifier, pre_latest_block) = match pre_latest_result {
+            Ok(PreConfirmedPollResponse::Full {
+                identifier, block, ..
+            }) => (identifier, block),
+            other => {
+                match other {
+                    Err(e) => {
+                        tracing::debug!(%e, %pre_latest_height, "Pre-latest fetch failed; retaining last view")
+                    }
+                    Ok(_) => {
+                        tracing::debug!(%pre_latest_height, "Pre-latest returned no full block; retaining last view")
+                    }
+                }
                 cache.mark_fresh();
                 wait_for_next_poll(t_fetch + poll_interval, &cache).await;
                 continue;
+            }
+        };
+
+        // A pre-confirmed above the pre-latest means we serve the two chained.
+        // When it isn't there yet, the pre-latest is itself the newest block, so
+        // we serve it alone at committed+1.
+        let (number, response, pre_latest) = match pre_confirmed_result {
+            Ok(response) => (
+                pre_confirmed_height,
+                response,
+                Some(Box::new((
+                    pre_latest_height,
+                    pre_latest_block,
+                    committed_hash,
+                ))),
+            ),
+            Err(e) => {
+                tracing::debug!(%e, %pre_confirmed_height, "No pre-confirmed above pre-latest; serving it alone");
+                let response = PreConfirmedPollResponse::Full {
+                    identifier: pre_latest_identifier,
+                    block_number: None,
+                    block: pre_latest_block,
+                };
+                (pre_latest_height, response, None)
             }
         };
 
@@ -179,7 +193,7 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
         match tracked.as_ref().filter(|_| changed) {
             Some(t) => {
                 let block = t.block.clone();
-                store_pre_confirmed(&cache, number, block.into(), pre_latest.map(Box::new));
+                store_pre_confirmed(&cache, number, block.into(), pre_latest);
             }
             None => cache.mark_fresh(),
         }
@@ -203,9 +217,9 @@ fn store_pre_confirmed(
     cache: &PendingDataCache,
     number: BlockNumber,
     block: Box<PreConfirmedBlock>,
-    pre_latest_data: Option<Box<(BlockNumber, PreLatestBlock, StateUpdate)>>,
+    pre_latest: Option<Box<(BlockNumber, PreConfirmedBlock, BlockHash)>>,
 ) {
-    match PendingData::try_from_pre_confirmed_and_pre_latest(block, number, pre_latest_data) {
+    match PendingData::try_from_pre_confirmed_and_pre_latest(block, number, pre_latest) {
         Ok(pending) => {
             cache.store(pending);
             tracing::debug!(block_number = %number, "Updated pre-confirmed data");
@@ -217,30 +231,6 @@ fn store_pre_confirmed(
     }
 }
 
-/// Fetch the pending block from the sequencer and classify it as
-/// [pre-latest](starknet_gateway_types::reply::PreLatestBlock) if it builds on
-/// our committed head.
-///
-/// If the pre-latest block (committed+1) exists, the sequencer has already
-/// started building the next pre-confirmed block (committed+2).
-async fn fetch_pre_latest<S: GatewayApi + Send + 'static>(
-    sequencer: &S,
-    committed: BlockNumber,
-    committed_hash: BlockHash,
-) -> anyhow::Result<Option<(BlockNumber, PreLatestBlock, StateUpdate)>> {
-    let (pending_block, state_update) = sequencer
-        .pending_block()
-        .await
-        .context("Fetching pre-latest block from sequencer")?;
-
-    let pre_latest_data = (pending_block.parent_hash == committed_hash).then_some((
-        committed + 1,
-        pending_block,
-        state_update,
-    ));
-    Ok(pre_latest_data)
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -250,16 +240,11 @@ mod tests {
     use pathfinder_common::macro_prelude::*;
     use pathfinder_common::receipt::Receipt;
     use pathfinder_common::transaction::{L1HandlerTransaction, Transaction, TransactionVariant};
-    use pathfinder_common::{BlockHash, BlockNumber, StateUpdate, TransactionIndex};
+    use pathfinder_common::{BlockHash, BlockNumber, TransactionIndex};
     use pathfinder_pending_data::PendingDataCache;
     use starknet_gateway_client::{BlockId, MockGatewayApi};
-    use starknet_gateway_types::error::SequencerError;
-    use starknet_gateway_types::reply::{
-        PreConfirmedBlock,
-        PreConfirmedPollResponse,
-        PreLatestBlock,
-        Status,
-    };
+    use starknet_gateway_types::error::{KnownStarknetErrorCode, SequencerError, StarknetError};
+    use starknet_gateway_types::reply::{PreConfirmedBlock, PreConfirmedPollResponse, Status};
     use tokio::sync::watch;
     use tokio::time::timeout;
 
@@ -313,15 +298,6 @@ mod tests {
         }
     }
 
-    /// A pending block that builds on `parent`.
-    fn pending_on(parent: BlockHash) -> PreLatestBlock {
-        PreLatestBlock {
-            parent_hash: parent,
-            status: Status::Pending,
-            ..Default::default()
-        }
-    }
-
     /// A full poll response carrying `block`.
     fn full(block: PreConfirmedBlock) -> PreConfirmedPollResponse {
         PreConfirmedPollResponse::Full {
@@ -329,6 +305,14 @@ mod tests {
             block_number: None,
             block,
         }
+    }
+
+    /// The error the gateway returns for a height that hasn't been built yet.
+    fn block_not_found() -> SequencerError {
+        SequencerError::StarknetError(StarknetError {
+            code: KnownStarknetErrorCode::BlockNotFound.into(),
+            message: "Block not found".into(),
+        })
     }
 
     /// Spawn the producer against `sequencer`, polling fast and anchored at
@@ -355,23 +339,26 @@ mod tests {
         });
     }
 
-    /// The common path: a pending block sits above our head, so it's the
-    /// pre-latest at committed+1 and the pre-confirmed chains onto it at
-    /// committed+2. The producer stores the two as one view.
+    /// The common path: a decided block sits above our head as the pre-latest
+    /// at committed+1, with the pre-confirmed still building on top at
+    /// committed+2. The producer fetches both by number and stores them as
+    /// one chained view.
     #[tokio::test]
     async fn stores_chained_view_when_pre_latest_present() {
         let committed = BlockNumber::new_or_panic(100);
         let committed_hash = block_hash!("0xc0");
 
         let mut sequencer = MockGatewayApi::new();
-        // The pending block builds on our head: the pre-latest at committed+1.
-        sequencer
-            .expect_pending_block()
-            .returning(move || Ok((pending_on(committed_hash), StateUpdate::default())));
-        // The pre-confirmed that chains onto it, at committed+2.
+        // The pre-latest at committed+1 and the pre-confirmed that chains onto it
+        // at committed+2.
         sequencer
             .expect_preconfirmed_block()
-            .returning(|_, _, _| Ok(full(pre_confirmed(2))));
+            .returning(|block, _, _| match block {
+                BlockId::Number(n) if n == BlockNumber::new_or_panic(101) => {
+                    Ok(full(pre_confirmed(1)))
+                }
+                _ => Ok(full(pre_confirmed(2))),
+            });
 
         let cache = Arc::new(PendingDataCache::new());
         let mut changes = cache.subscribe();
@@ -397,28 +384,23 @@ mod tests {
         assert_eq!(stored.pre_confirmed_transactions().len(), 2);
     }
 
-    /// With nothing closing above our head, the pending block doesn't chain
-    /// onto us, so there's no pre-latest. The producer corrects inside the
-    /// same poll and stores the pre-confirmed at committed+1, alone.
+    /// With nothing building above it yet, committed+2 isn't there, so the
+    /// pre-latest is itself the newest block. The producer serves it alone at
+    /// committed+1.
     #[tokio::test]
-    async fn corrects_to_committed_plus_one_without_pre_latest() {
+    async fn serves_pre_latest_alone_when_nothing_above_it() {
         let committed = BlockNumber::new_or_panic(100);
         let committed_hash = block_hash!("0xc0");
 
         let mut sequencer = MockGatewayApi::new();
-        // The pending block builds on someone else, so it isn't our pre-latest.
-        sequencer
-            .expect_pending_block()
-            .returning(|| Ok((pending_on(block_hash!("0xdead")), StateUpdate::default())));
-        // committed+2 is fetched on the assumption and dropped; committed+1 is
-        // the block we actually serve.
+        // committed+1 is there; committed+2 hasn't been built yet.
         sequencer
             .expect_preconfirmed_block()
             .returning(|block, _, _| match block {
                 BlockId::Number(n) if n == BlockNumber::new_or_panic(101) => {
                     Ok(full(pre_confirmed(1)))
                 }
-                _ => Ok(full(pre_confirmed(0))),
+                _ => Err(block_not_found()),
             });
 
         let cache = Arc::new(PendingDataCache::new());
@@ -447,20 +429,21 @@ mod tests {
         let committed = BlockNumber::new_or_panic(100);
         let committed_hash = block_hash!("0xc0");
 
-        let calls = Arc::new(AtomicUsize::new(0));
+        let pre_latest_calls = Arc::new(AtomicUsize::new(0));
         let mut sequencer = MockGatewayApi::new();
-        sequencer
-            .expect_pending_block()
-            .returning(move || Ok((pending_on(committed_hash), StateUpdate::default())));
-        // The first poll succeeds; every poll after it fails.
+        // committed+2 always answers; committed+1 answers the first poll, then
+        // fails. Losing the foundation must not blank the cache.
         sequencer
             .expect_preconfirmed_block()
-            .returning(move |_, _, _| {
-                if calls.fetch_add(1, Ordering::SeqCst) == 0 {
-                    Ok(full(pre_confirmed(1)))
-                } else {
-                    Err(SequencerError::InvalidResponse("boom".into()))
+            .returning(move |block, _, _| match block {
+                BlockId::Number(n) if n == BlockNumber::new_or_panic(101) => {
+                    if pre_latest_calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                        Ok(full(pre_confirmed(1)))
+                    } else {
+                        Err(SequencerError::InvalidResponse("boom".into()))
+                    }
                 }
+                _ => Ok(full(pre_confirmed(2))),
             });
 
         let cache = Arc::new(PendingDataCache::new());

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -3,118 +3,100 @@ use std::sync::Arc;
 use anyhow::Context;
 use pathfinder_common::{BlockHash, BlockNumber, StateUpdate};
 use pathfinder_pending_data::{PendingData, PendingDataCache};
-use starknet_gateway_client::{BlockId, GatewayApi};
+use starknet_gateway_client::GatewayApi;
 use starknet_gateway_types::reply::{PreConfirmedBlock, PreConfirmedPollResponse, PreLatestBlock};
 use tokio::sync::watch;
 use tokio::time::Instant;
 
+/// The pre-confirmed block we're building up, kept between polls so the gateway
+/// can send just the new transactions each time instead of the whole block.
 #[derive(Debug)]
-struct State {
-    /// Height we're currently polling.
-    block_number: BlockNumber,
-    /// Server-given block identifier from the last successful poll. `None`
-    /// until we've completed our first poll for this height. The server uses
-    /// this to detect when our view is stale and needs a full rebuild.
-    block_identifier: Option<String>,
-    /// Running merged view of the preconfirmed block at `block_number`.
-    /// `None` until we've received our first response for this height.
-    accumulated: Option<PreConfirmedBlock>,
-    /// Whether the pre-latest block was present at the last poll.
-    pre_latest_data_present: bool,
+struct Tracked {
+    /// The pre-confirmed height this view is for.
+    number: BlockNumber,
+    /// The gateway's id for the view we're holding.
+    identifier: String,
+    /// The block we've merged so far, at height `number`.
+    block: PreConfirmedBlock,
 }
 
-impl Default for State {
-    fn default() -> Self {
-        Self {
-            block_number: BlockNumber::GENESIS,
-            block_identifier: None,
-            accumulated: None,
-            pre_latest_data_present: false,
-        }
-    }
-}
-
-impl State {
+impl Tracked {
     fn tx_count(&self) -> u64 {
-        self.accumulated
-            .as_ref()
-            .map(|b| b.transactions.len() as u64)
-            .unwrap_or(0)
+        self.block.transactions.len() as u64
     }
+}
 
-    /// Apply a fresh poll response, given the pre-latest presence
-    /// observed for this poll. Returns `true` if `accumulated` was
-    /// updated and the caller should emit the new view.
-    fn apply(&mut self, response: PreConfirmedPollResponse, new_pre_latest: bool) -> bool {
-        let prev_pre_latest = self.pre_latest_data_present;
-        self.pre_latest_data_present = new_pre_latest;
+/// What we already have at `height`: our id and tx count if we're holding it,
+/// or empty to fetch the whole block.
+fn delta_cursor(tracked: &Option<Tracked>, height: BlockNumber) -> (Option<String>, u64) {
+    match tracked {
+        Some(t) if t.number == height => (Some(t.identifier.clone()), t.tx_count()),
+        _ => (None, 0),
+    }
+}
 
-        match response {
-            PreConfirmedPollResponse::Unchanged => false,
+/// Merge a poll response into the tracked view at `target`. Returns `true` when
+/// the published view should be refreshed.
+fn apply(
+    tracked: &mut Option<Tracked>,
+    target: BlockNumber,
+    response: PreConfirmedPollResponse,
+) -> bool {
+    match response {
+        PreConfirmedPollResponse::Unchanged => false,
 
-            PreConfirmedPollResponse::Delta {
-                identifier,
-                new_transactions,
-                new_receipts,
-                new_state_diffs,
-            } => {
-                // Per spec, the server only sends a delta when its identifier matches
-                // ours. A mismatch indicates a server bug or local state corruption;
-                // skip defensively and wait for the next poll (which our stored identifier
-                // will not match server's, triggering a full rebuild).
-                if self.block_identifier.as_ref() != Some(&identifier) {
-                    tracing::warn!(
-                        ours = ?self.block_identifier,
-                        theirs = %identifier,
-                        "delta response identifier doesn't match ours; skipping"
-                    );
-                    return false;
-                }
-                if new_transactions.is_empty() {
-                    return false;
-                }
-                let acc = self
-                    .accumulated
-                    .as_mut()
-                    .expect("accumulated present whenever block_identifier is Some");
-                acc.transactions.extend(new_transactions);
-                acc.transaction_receipts.extend(new_receipts);
-                acc.transaction_state_diffs.extend(new_state_diffs);
-                true
+        PreConfirmedPollResponse::Delta {
+            identifier,
+            new_transactions,
+            new_receipts,
+            new_state_diffs,
+        } => {
+            // A delta only applies on top of the exact view it was computed from,
+            // so the height and identifier have to match.
+            let matched = tracked
+                .as_mut()
+                .filter(|t| t.number == target && t.identifier == identifier);
+            let Some(tracked) = matched else {
+                tracing::warn!(%target, "Delta response with no matching tracked view; skipping");
+                return false;
+            };
+            if new_transactions.is_empty() {
+                return false;
             }
+            tracked.block.transactions.extend(new_transactions);
+            tracked.block.transaction_receipts.extend(new_receipts);
+            tracked
+                .block
+                .transaction_state_diffs
+                .extend(new_state_diffs);
+            true
+        }
 
-            PreConfirmedPollResponse::Full {
+        PreConfirmedPollResponse::Full {
+            identifier, block, ..
+        } => {
+            // A Full response can repeat the view we already have. Only publish
+            // on a real change: a new identifier or more transactions.
+            let changed = match tracked.as_ref() {
+                Some(t) if t.number == target => {
+                    t.identifier != identifier || block.transactions.len() as u64 > t.tx_count()
+                }
+                _ => true,
+            };
+            *tracked = Some(Tracked {
+                number: target,
                 identifier,
-                block_number: _,
                 block,
-            } => {
-                // Emit on any of three independent signals:
-                //  - the server's identifier changed (round bump, new height, or first poll)
-                //  - new transactions arrived
-                //  - pre-latest just finalised
-                // Otherwise suppress: pre-0.14.3 gateways re-serve the same view across
-                // polls and we don't want to bombard downstream with redundant events.
-                let identifier_changed = self.block_identifier.as_ref() != Some(&identifier);
-                let new_txs_arrived = (block.transactions.len() as u64) > self.tx_count();
-                let pre_latest_finalised = prev_pre_latest && !new_pre_latest;
-
-                if identifier_changed || new_txs_arrived || pre_latest_finalised {
-                    self.block_identifier = Some(identifier);
-                    self.accumulated = Some(block);
-                    true
-                } else {
-                    false
-                }
-            }
+            });
+            changed
         }
     }
 }
 
-/// Emits new pending data events while the current block is close to the latest
-/// block.
+/// Emits new pending data while the current block is close to the latest block.
 ///
-/// Suspends polling once the cache reports itself idle and resumes on the
-/// next read.
+/// Suspends polling once the cache reports itself idle and resumes on the next
+/// read.
 pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
     sequencer: S,
     poll_interval: std::time::Duration,
@@ -123,7 +105,7 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
     current: watch::Receiver<(BlockNumber, BlockHash)>,
     in_sync_threshold: u64,
 ) {
-    let mut state = State::default();
+    let mut tracked: Option<Tracked> = None;
 
     loop {
         // Suspend if idle.
@@ -135,13 +117,13 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
 
         let t_fetch = Instant::now();
 
-        // Skip while catching up to head.
-        let (latest_number, latest_hash) = *latest.borrow();
-        let current_number = current.borrow().0.get();
+        let (committed, committed_hash) = *current.borrow();
+        let gateway_latest = latest.borrow().0;
 
-        if latest_number.get().abs_diff(current_number) > in_sync_threshold {
+        // Skip while catching up to head.
+        if gateway_latest.get().abs_diff(committed.get()) > in_sync_threshold {
             tracing::debug!(
-                latest = %latest_number.get(), current = %current_number,
+                latest = %gateway_latest, %committed,
                 "Not in sync yet; skipping pre-confirmed block download"
             );
             cache.mark_unavailable("syncing");
@@ -149,106 +131,59 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
             continue;
         }
 
-        // Fetch pre-confirmed and pre-latest concurrently.
-        let (response, pre_latest_result) = tokio::join!(
-            sequencer.preconfirmed_block(
-                BlockId::Latest,
-                state.block_identifier.clone(),
-                state.tx_count(),
-            ),
-            fetch_pre_latest(&sequencer, latest_number, latest_hash),
+        // Assume the common shape: a pre-latest at committed+1 with the
+        // pre-confirmed at committed+2. Fetch that height and the pending block
+        // concurrently.
+        let assumed = committed + 2;
+        let (cursor_id, cursor_count) = delta_cursor(&tracked, assumed);
+        let (pc_result, pre_latest_result) = tokio::join!(
+            sequencer.preconfirmed_block(assumed.into(), cursor_id, cursor_count),
+            fetch_pre_latest(&sequencer, committed, committed_hash),
         );
 
-        let response = match response {
-            Ok(r) => r,
-            Err(err) => {
-                tracing::debug!(%err, "Failed to fetch pre-confirmed block");
-                cache.mark_unavailable("gateway error");
-                wait_for_next_poll(t_fetch + poll_interval, &cache).await;
-                continue;
-            }
-        };
-
-        // Reconcile state with the resolved height. The gateway only reports
-        // a height on `Full` responses to `latest` requests; everything else
-        // (Unchanged, Delta, and concrete-number Full) leaves state at its
-        // tracked block.
-        let resolved = match response {
-            PreConfirmedPollResponse::Full { block_number, .. } => block_number,
-            _ => None,
-        };
-
-        if let Some(height) = resolved {
-            // A transient (?) lower-height shouldn't discard accumulated state.
-            if height < state.block_number && state.block_number != BlockNumber::GENESIS {
-                tracing::debug!(
-                    resolved = %height,
-                    current = %state.block_number,
-                    "Pre-confirmed resolved to a lower height than tracked; skipping poll"
-                );
-                // We assume this is just a hiccup and trust our tracked block
-                cache.mark_fresh();
-                wait_for_next_poll(t_fetch + poll_interval, &cache).await;
-                continue;
-            }
-
-            // The chain advanced: complete the previous block before resetting state.
-            if height > state.block_number {
-                if state.block_identifier.is_some() && state.accumulated.is_some() {
-                    let committed_head = current.borrow().0;
-                    complete_previous_block(&sequencer, &mut state, &cache, committed_head).await;
-                }
-                state = State {
-                    block_number: height,
-                    ..State::default()
-                };
-            }
-        }
-
-        // Keep pre-latest only when it chains to the pre-confirmed height
-        // resolved above. A mismatch means the chain advanced between the two
-        // fetches, in which case publishing pre-confirmed alone is the safe move.
-        let pre_latest_data = match pre_latest_result {
-            Ok(Some(pre_latest)) => {
-                let pre_latest_number = pre_latest.0;
-                if pre_latest_number + 1 == state.block_number {
-                    Some(Box::new(pre_latest))
-                } else {
-                    tracing::debug!(
-                        pre_latest = %pre_latest_number,
-                        pre_confirmed = %state.block_number,
-                        "Pre-latest doesn't chain to pre-confirmed; dropping (chain raced)"
-                    );
-                    None
-                }
-            }
-            Ok(None) => None,
+        let pre_latest = match pre_latest_result {
+            Ok(pre_latest) => pre_latest,
             Err(e) => {
                 tracing::debug!(%e, "Failed to fetch pre-latest block");
                 None
             }
         };
 
-        // Publish. On a change we store the new view directly; otherwise we mark
-        // the existing contents fresh to unblock cold-start readers.
-        if state.apply(response, pre_latest_data.is_some()) {
-            let accumulated = state
-                .accumulated
-                .as_ref()
-                .expect("accumulated block present after a successful update");
-            store_pre_confirmed(
-                &cache,
-                current.borrow().0,
-                state.block_number,
-                accumulated.clone().into(),
-                pre_latest_data,
-            );
+        // Now pending() tells us if there's really a pre-latest. With one, committed+2
+        // is the pre-confirmed; without one it's committed+1, so we drop what we
+        // fetched and get committed+1 instead.
+        let (number, response) = if pre_latest.is_some() {
+            (assumed, pc_result)
         } else {
-            tracing::trace!("No change in pre-confirmed block data");
-            cache.mark_fresh();
+            let number = committed + 1;
+            let (cursor_id, cursor_count) = delta_cursor(&tracked, number);
+            let response = sequencer
+                .preconfirmed_block(number.into(), cursor_id, cursor_count)
+                .await;
+            (number, response)
+        };
+
+        // A failed or not-yet-available fetch must not blank the cache.
+        let response = match response {
+            Ok(response) => response,
+            Err(e) => {
+                tracing::debug!(%e, %number, "Pre-confirmed fetch failed; retaining last view");
+                cache.mark_fresh();
+                wait_for_next_poll(t_fetch + poll_interval, &cache).await;
+                continue;
+            }
+        };
+
+        // Merge and publish.
+        let changed = apply(&mut tracked, number, response);
+        match tracked.as_ref().filter(|_| changed) {
+            Some(t) => {
+                let block = t.block.clone();
+                store_pre_confirmed(&cache, number, block.into(), pre_latest.map(Box::new));
+            }
+            None => cache.mark_fresh(),
         }
 
-        // Wait for the next tick.
         wait_for_next_poll(t_fetch + poll_interval, &cache).await;
     }
 }
@@ -261,880 +196,47 @@ async fn wait_for_next_poll(deadline: Instant, cache: &PendingDataCache) {
     }
 }
 
-/// Fetch the previously-tracked block one final time to capture any
-/// transactions that landed before it was superseded. Best-effort.
-async fn complete_previous_block<S: GatewayApi + Send + 'static>(
-    sequencer: &S,
-    state: &mut State,
-    cache: &PendingDataCache,
-    committed_head: BlockNumber,
-) {
-    let response = match sequencer
-        .preconfirmed_block(
-            state.block_number.into(),
-            state.block_identifier.clone(),
-            state.tx_count(),
-        )
-        .await
-    {
-        Ok(r) => r,
-        Err(err) => {
-            tracing::debug!(%err, "Completion query for previous pre-confirmed block failed");
-            return;
-        }
-    };
-
-    if state.apply(response, false) {
-        let accumulated = state
-            .accumulated
-            .as_ref()
-            .expect("accumulated present after successful completion apply");
-        store_pre_confirmed(
-            cache,
-            committed_head,
-            state.block_number,
-            accumulated.clone().into(),
-            None,
-        );
-    }
-}
-
-/// Validate a fresh pre-confirmed view against the committed head and, when it
-/// chains, convert it to [`PendingData`] and store it in the cache.
+/// Convert a fresh pre-confirmed view and store it in the cache.
 ///
-/// `committed_head` is the latest block already in storage, mirrored by the
-/// `current` watch. A view that doesn't chain to it is dropped.
+/// A failed conversion (say, candidate transactions) keeps the last good view.
 fn store_pre_confirmed(
     cache: &PendingDataCache,
-    committed_head: BlockNumber,
     number: BlockNumber,
     block: Box<PreConfirmedBlock>,
     pre_latest_data: Option<Box<(BlockNumber, PreLatestBlock, StateUpdate)>>,
 ) {
-    // Reject views that don't chain to the committed head.
-    let next_block_number = pre_latest_data
-        .as_ref()
-        .map(|pre_latest| pre_latest.0)
-        .unwrap_or(number);
-
-    if next_block_number != committed_head + 1 {
-        tracing::debug!(
-            %number, %committed_head,
-            "Pre-confirmed doesn't chain to committed head; skipping store"
-        );
-        return;
-    }
-
-    // Convert and store.
     match PendingData::try_from_pre_confirmed_and_pre_latest(block, number, pre_latest_data) {
         Ok(pending) => {
-            let pre_latest_tx_count = pending.pre_latest_transactions().map(|txs| txs.len());
-            let pre_confirmed_tx_count = pending.pre_confirmed_transactions().len();
             cache.store(pending);
-            tracing::debug!(block_number = %number, %pre_confirmed_tx_count, ?pre_latest_tx_count, "Updated pre-confirmed data");
+            tracing::debug!(block_number = %number, "Updated pre-confirmed data");
         }
         Err(e) => {
-            tracing::info!(block_number=%number, error=%e, "Failed to validate pre-confirmed data, skipping update");
+            tracing::info!(block_number=%number, error=%e, "Pre-confirmed failed validation; retaining last view");
+            cache.mark_fresh();
         }
     }
 }
 
 /// Fetch the pending block from the sequencer and classify it as
-/// [pre-latest](starknet_gateway_types::reply::PreLatestBlock) if its parent
-/// hash matches our latest block hash.
+/// [pre-latest](starknet_gateway_types::reply::PreLatestBlock) if it builds on
+/// our committed head.
 ///
-/// If the pre-latest block (N) exists, the sequencer has already started
-/// building the next pre-confirmed block (N + 1).
+/// If the pre-latest block (committed+1) exists, the sequencer has already
+/// started building the next pre-confirmed block (committed+2).
 async fn fetch_pre_latest<S: GatewayApi + Send + 'static>(
     sequencer: &S,
-    our_latest_number: BlockNumber,
-    our_latest_hash: BlockHash,
-) -> anyhow::Result<
-    Option<(
-        BlockNumber,
-        starknet_gateway_types::reply::PreLatestBlock,
-        pathfinder_common::StateUpdate,
-    )>,
-> {
+    committed: BlockNumber,
+    committed_hash: BlockHash,
+) -> anyhow::Result<Option<(BlockNumber, PreLatestBlock, StateUpdate)>> {
     let (pending_block, state_update) = sequencer
         .pending_block()
         .await
         .context("Fetching pre-latest block from sequencer")?;
 
-    let pre_latest_data = (pending_block.parent_hash == our_latest_hash).then_some((
-        our_latest_number + 1,
+    let pre_latest_data = (pending_block.parent_hash == committed_hash).then_some((
+        committed + 1,
         pending_block,
         state_update,
     ));
     Ok(pre_latest_data)
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::{Arc, LazyLock};
-
-    use pathfinder_common::macro_prelude::*;
-    use pathfinder_common::prelude::*;
-    use pathfinder_common::transaction::{L1HandlerTransaction, Transaction, TransactionVariant};
-    use pathfinder_pending_data::PendingDataCache;
-    use starknet_gateway_client::MockGatewayApi;
-    use starknet_gateway_types::reply::{
-        Block,
-        GasPrices,
-        L1DataAvailabilityMode,
-        PreConfirmedBlock,
-        PreConfirmedPollResponse,
-        PreLatestBlock,
-        Status,
-    };
-    use tokio::sync::watch;
-
-    use super::{complete_previous_block, poll_pre_confirmed, store_pre_confirmed, State};
-
-    const TEST_IN_SYNC_THRESHOLD: u64 = 6;
-    const PARENT_HASH: BlockHash = block_hash!("0x1234");
-    const PARENT_ROOT: StateCommitment = state_commitment_bytes!(b"parent root");
-
-    pub static NEXT_BLOCK: LazyLock<Block> = LazyLock::new(|| Block {
-        block_hash: block_hash!("0xabcd"),
-        block_number: BlockNumber::new_or_panic(1),
-        l1_gas_price: Default::default(),
-        l1_data_gas_price: Default::default(),
-        l2_gas_price: Default::default(),
-        parent_block_hash: PARENT_HASH,
-        sequencer_address: None,
-        state_commitment: PARENT_ROOT,
-        status: Status::AcceptedOnL2,
-        timestamp: BlockTimestamp::new_or_panic(10),
-        transaction_receipts: Vec::new(),
-        transactions: Vec::new(),
-        starknet_version: StarknetVersion::default(),
-        l1_da_mode: Default::default(),
-        transaction_commitment: Default::default(),
-        event_commitment: Default::default(),
-        receipt_commitment: Default::default(),
-        state_diff_commitment: Default::default(),
-        state_diff_length: Default::default(),
-    });
-
-    pub static PENDING_UPDATE: LazyLock<StateUpdate> =
-        LazyLock::new(|| StateUpdate::default().with_parent_state_commitment(PARENT_ROOT));
-
-    pub static PRE_LATEST_BLOCK: LazyLock<PreLatestBlock> = LazyLock::new(|| PreLatestBlock {
-        l1_gas_price: GasPrices {
-            price_in_wei: GasPrice(11),
-            ..Default::default()
-        },
-        l1_data_gas_price: Default::default(),
-        l2_gas_price: Default::default(),
-        parent_hash: NEXT_BLOCK.parent_block_hash,
-        sequencer_address: sequencer_address_bytes!(b"seqeunecer address"),
-        status: Status::Pending,
-        timestamp: BlockTimestamp::new_or_panic(20),
-        transaction_receipts: Vec::new(),
-        transactions: vec![pathfinder_common::transaction::Transaction {
-            hash: transaction_hash!("0x22"),
-            variant: pathfinder_common::transaction::TransactionVariant::L1Handler(
-                L1HandlerTransaction {
-                    contract_address: contract_address!("0x1"),
-                    entry_point_selector: entry_point!("0x55"),
-                    nonce: transaction_nonce!("0x2"),
-                    calldata: Vec::new(),
-                },
-            ),
-        }],
-        starknet_version: StarknetVersion::new(0, 14, 0, 0),
-        l1_da_mode: L1DataAvailabilityMode::Calldata,
-    });
-
-    /// Arbitrary upper bound for awaiting a cache update in tests, so a failing
-    /// test fails fast instead of hanging.
-    const TEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
-
-    /// A pre-confirmed block whose every transaction carries a receipt, so the
-    /// `try_from_pre_confirmed_and_pre_latest` conversion accepts it (it
-    /// rejects blocks containing candidate transactions).
-    fn all_receipted_block(n: usize) -> PreConfirmedBlock {
-        let receipted_tx = |i: usize| {
-            let hash = match i {
-                0 => transaction_hash!("0x1"),
-                1 => transaction_hash!("0x2"),
-                2 => transaction_hash!("0x3"),
-                _ => transaction_hash!("0x4"),
-            };
-            Transaction {
-                hash,
-                variant: TransactionVariant::L1Handler(L1HandlerTransaction {
-                    contract_address: contract_address!("0x1"),
-                    entry_point_selector: entry_point!("0x55"),
-                    nonce: transaction_nonce!("0x0"),
-                    calldata: Vec::new(),
-                }),
-            }
-        };
-        let transactions: Vec<_> = (0..n).map(receipted_tx).collect();
-        let transaction_receipts = transactions
-            .iter()
-            .enumerate()
-            .map(|(i, tx)| {
-                Some((
-                    pathfinder_common::receipt::Receipt {
-                        transaction_hash: tx.hash,
-                        transaction_index: TransactionIndex::new_or_panic(i as u64),
-                        ..Default::default()
-                    },
-                    vec![],
-                ))
-            })
-            .collect();
-        PreConfirmedBlock {
-            status: Status::PreConfirmed,
-            transactions,
-            transaction_receipts,
-            transaction_state_diffs: vec![None; n],
-            ..Default::default()
-        }
-    }
-
-    /// Spawn the producer polling at a 1ms interval against the given cache.
-    /// The first poll fires immediately, so single-store tests aren't delayed.
-    fn spawn_producer(
-        sequencer: MockGatewayApi,
-        committed: BlockNumber,
-        latest_hash: BlockHash,
-        cache: Arc<PendingDataCache>,
-    ) {
-        let (_latest_tx, latest) = watch::channel((committed, latest_hash));
-        let (_current_tx, current) = watch::channel((committed, latest_hash));
-        let sequencer = Arc::new(sequencer);
-        tokio::spawn(async move {
-            poll_pre_confirmed(
-                sequencer,
-                std::time::Duration::from_millis(1),
-                cache,
-                latest,
-                current,
-                TEST_IN_SYNC_THRESHOLD,
-            )
-            .await
-        });
-    }
-
-    #[tokio::test]
-    async fn store_pre_confirmed_stores_and_converts_a_chaining_view() {
-        // Committed head 1; pre-confirmed at 3 chains via a pre-latest at 2.
-        let cache = PendingDataCache::new();
-        let mut rx = cache.subscribe();
-        let _ = rx.borrow_and_update();
-
-        let committed = BlockNumber::new_or_panic(1);
-        let pre_latest = Box::new((
-            committed + 1,
-            PRE_LATEST_BLOCK.clone(),
-            PENDING_UPDATE.clone(),
-        ));
-        store_pre_confirmed(
-            &cache,
-            committed,
-            BlockNumber::new_or_panic(3),
-            Box::new(all_receipted_block(2)),
-            Some(pre_latest),
-        );
-
-        assert!(
-            rx.has_changed().unwrap(),
-            "a chaining view should be stored"
-        );
-        let pending = rx.borrow().clone();
-        assert_eq!(
-            pending.pre_confirmed_block_number(),
-            BlockNumber::new_or_panic(3)
-        );
-        assert_eq!(pending.pre_latest_block_number(), Some(committed + 1));
-        assert_eq!(pending.pre_confirmed_transactions().len(), 2);
-    }
-
-    #[tokio::test]
-    async fn store_pre_confirmed_skips_a_non_chaining_view() {
-        // Committed head 1, pre-confirmed at 5: gap > 1, so it doesn't chain.
-        let cache = PendingDataCache::new();
-        let mut rx = cache.subscribe();
-        let _ = rx.borrow_and_update();
-
-        store_pre_confirmed(
-            &cache,
-            BlockNumber::new_or_panic(1),
-            BlockNumber::new_or_panic(5),
-            Box::new(all_receipted_block(2)),
-            None,
-        );
-
-        assert!(
-            !rx.has_changed().unwrap(),
-            "a non-chaining view must not be stored"
-        );
-    }
-
-    #[tokio::test]
-    async fn fetch_pre_latest_returns_some_when_parent_matches() {
-        let mut sequencer = MockGatewayApi::new();
-        let our_latest_number = NEXT_BLOCK.block_number - 1;
-        let our_latest_hash = NEXT_BLOCK.parent_block_hash;
-
-        sequencer
-            .expect_pending_block()
-            .returning(move || Ok((PRE_LATEST_BLOCK.clone(), PENDING_UPDATE.clone())));
-
-        let (number, block, state_update) =
-            super::fetch_pre_latest(&sequencer, our_latest_number, our_latest_hash)
-                .await
-                .unwrap()
-                .unwrap();
-
-        assert_eq!(number, NEXT_BLOCK.block_number);
-        assert_eq!(block.parent_hash, our_latest_hash);
-        assert_eq!(state_update, PENDING_UPDATE.clone());
-    }
-
-    #[tokio::test]
-    async fn fetch_pre_latest_returns_none_when_parent_differs() {
-        let mut sequencer = MockGatewayApi::new();
-        let our_latest_number = NEXT_BLOCK.block_number - 1;
-        let our_latest_hash = NEXT_BLOCK.parent_block_hash;
-        let different_hash = block_hash!("0xdeadbeef");
-
-        let pending_block = PreLatestBlock {
-            parent_hash: different_hash,
-            ..PRE_LATEST_BLOCK.clone()
-        };
-
-        sequencer
-            .expect_pending_block()
-            .returning(move || Ok((pending_block.clone(), PENDING_UPDATE.clone())));
-
-        let result = super::fetch_pre_latest(&sequencer, our_latest_number, our_latest_hash)
-            .await
-            .unwrap();
-
-        assert!(result.is_none());
-    }
-
-    mod apply {
-        use pathfinder_common::macro_prelude::*;
-        use pathfinder_common::transaction::{
-            L1HandlerTransaction,
-            Transaction,
-            TransactionVariant,
-        };
-        use starknet_gateway_types::reply::{PreConfirmedBlock, PreConfirmedPollResponse};
-
-        use super::super::{BlockNumber, State};
-
-        fn placeholder_tx(index: usize) -> Transaction {
-            let hash = match index {
-                0 => transaction_hash!("0x1"),
-                1 => transaction_hash!("0x2"),
-                _ => transaction_hash!("0x3"),
-            };
-            Transaction {
-                hash,
-                variant: TransactionVariant::L1Handler(L1HandlerTransaction {
-                    contract_address: contract_address!("0x1"),
-                    entry_point_selector: entry_point!("0x55"),
-                    nonce: transaction_nonce!("0x0"),
-                    calldata: Vec::new(),
-                }),
-            }
-        }
-
-        /// Build a minimal `PreConfirmedBlock` with `n` placeholder
-        /// transactions and matching empty receipt/state-diff slots.
-        /// Other fields use `Default`.
-        fn block_with_txs(n: usize) -> PreConfirmedBlock {
-            let txs: Vec<Transaction> = (0..n).map(placeholder_tx).collect();
-            let receipts = vec![None; n];
-            let state_diffs = vec![None; n];
-            PreConfirmedBlock {
-                transactions: txs,
-                transaction_receipts: receipts,
-                transaction_state_diffs: state_diffs,
-                ..Default::default()
-            }
-        }
-
-        fn state(identifier: Option<&str>, txs: usize, pre_latest: bool) -> State {
-            State {
-                block_number: BlockNumber::new_or_panic(10),
-                block_identifier: identifier.map(String::from),
-                accumulated: if identifier.is_some() {
-                    Some(block_with_txs(txs))
-                } else {
-                    None
-                },
-                pre_latest_data_present: pre_latest,
-            }
-        }
-
-        #[test]
-        fn unchanged_response_is_noop() {
-            let mut s = state(Some("abc"), 1, false);
-            let original_accumulated = s.accumulated.clone();
-            let original_identifier = s.block_identifier.clone();
-            let original_number = s.block_number;
-
-            let emitted = s.apply(PreConfirmedPollResponse::Unchanged, true);
-
-            assert!(!emitted);
-            assert_eq!(s.accumulated, original_accumulated);
-            assert_eq!(s.block_identifier, original_identifier);
-            assert_eq!(s.block_number, original_number);
-            // apply always writes the new pre-latest presence
-            assert!(s.pre_latest_data_present);
-        }
-
-        #[test]
-        fn delta_with_mismatching_identifier_is_skipped() {
-            let mut s = state(Some("abc"), 1, false);
-            let original_accumulated = s.accumulated.clone();
-
-            let emitted = s.apply(
-                PreConfirmedPollResponse::Delta {
-                    identifier: "xyz".into(),
-                    new_transactions: vec![Transaction {
-                        hash: transaction_hash!("0x99"),
-                        variant: TransactionVariant::L1Handler(L1HandlerTransaction {
-                            contract_address: contract_address!("0x1"),
-                            entry_point_selector: entry_point!("0x55"),
-                            nonce: transaction_nonce!("0x0"),
-                            calldata: Vec::new(),
-                        }),
-                    }],
-                    new_receipts: vec![None],
-                    new_state_diffs: vec![None],
-                },
-                false,
-            );
-
-            assert!(!emitted);
-            assert_eq!(s.accumulated, original_accumulated);
-            assert_eq!(s.block_identifier, Some("abc".into()));
-        }
-
-        #[test]
-        fn delta_with_matching_identifier_and_empty_transactions_is_noop() {
-            let mut s = state(Some("abc"), 1, false);
-            let original_accumulated = s.accumulated.clone();
-
-            let emitted = s.apply(
-                PreConfirmedPollResponse::Delta {
-                    identifier: "abc".into(),
-                    new_transactions: vec![],
-                    new_receipts: vec![],
-                    new_state_diffs: vec![],
-                },
-                false,
-            );
-
-            assert!(!emitted);
-            assert_eq!(s.accumulated, original_accumulated);
-            assert_eq!(s.block_identifier, Some("abc".into()));
-        }
-
-        #[test]
-        fn delta_with_matching_identifier_appends() {
-            let mut s = state(Some("abc"), 1, false);
-
-            let new_tx = Transaction {
-                hash: transaction_hash!("0x99"),
-                variant: TransactionVariant::L1Handler(L1HandlerTransaction {
-                    contract_address: contract_address!("0x1"),
-                    entry_point_selector: entry_point!("0x55"),
-                    nonce: transaction_nonce!("0x0"),
-                    calldata: Vec::new(),
-                }),
-            };
-
-            let emitted = s.apply(
-                PreConfirmedPollResponse::Delta {
-                    identifier: "abc".into(),
-                    new_transactions: vec![new_tx],
-                    new_receipts: vec![None],
-                    new_state_diffs: vec![None],
-                },
-                false,
-            );
-
-            assert!(emitted);
-            let acc = s.accumulated.as_ref().unwrap();
-            assert_eq!(acc.transactions.len(), 2);
-            assert_eq!(acc.transaction_receipts.len(), 2);
-            assert_eq!(acc.transaction_state_diffs.len(), 2);
-            assert_eq!(s.block_identifier, Some("abc".into()));
-        }
-
-        #[test]
-        fn full_with_changed_identifier_emits() {
-            let mut s = state(Some("abc"), 1, false);
-            let new_block = block_with_txs(1);
-
-            let emitted = s.apply(
-                PreConfirmedPollResponse::Full {
-                    identifier: "xyz".into(),
-                    block_number: Some(BlockNumber::new_or_panic(10)),
-                    block: new_block.clone(),
-                },
-                false,
-            );
-
-            assert!(emitted);
-            assert_eq!(s.block_identifier, Some("xyz".into()));
-            assert_eq!(s.accumulated, Some(new_block));
-        }
-
-        #[test]
-        fn full_with_more_transactions_emits() {
-            let mut s = state(Some("abc"), 1, false);
-            let new_block = block_with_txs(2);
-
-            let emitted = s.apply(
-                PreConfirmedPollResponse::Full {
-                    identifier: "abc".into(),
-                    block_number: Some(BlockNumber::new_or_panic(10)),
-                    block: new_block.clone(),
-                },
-                false,
-            );
-
-            assert!(emitted);
-            assert_eq!(s.accumulated.as_ref().unwrap().transactions.len(), 2);
-        }
-
-        #[test]
-        fn full_with_pre_latest_finalised_emits() {
-            let mut s = state(Some("abc"), 2, true);
-            let same_block = block_with_txs(2);
-
-            // pre_latest transitions true → false: should force an emit
-            let emitted = s.apply(
-                PreConfirmedPollResponse::Full {
-                    identifier: "abc".into(),
-                    block_number: Some(BlockNumber::new_or_panic(10)),
-                    block: same_block.clone(),
-                },
-                false,
-            );
-
-            assert!(emitted);
-            assert_eq!(s.accumulated, Some(same_block));
-        }
-
-        #[test]
-        fn full_with_no_signals_is_deduped() {
-            let mut s = state(Some("abc"), 2, false);
-            let same_block = block_with_txs(2);
-            let original_accumulated = s.accumulated.clone();
-
-            // Same identifier, no new txs, no pre-latest transition: nothing to emit
-            let emitted = s.apply(
-                PreConfirmedPollResponse::Full {
-                    identifier: "abc".into(),
-                    block_number: Some(BlockNumber::new_or_panic(10)),
-                    block: same_block,
-                },
-                false,
-            );
-
-            assert!(!emitted);
-            assert_eq!(s.accumulated, original_accumulated);
-            assert_eq!(s.block_identifier, Some("abc".into()));
-        }
-    }
-
-    /// A transient gateway inconsistency could briefly resolve `latest` to a
-    /// lower height than we're already tracking. The polling loop should skip
-    /// those responses without overwriting the cached view.
-    ///
-    /// See also <https://github.com/equilibriumco/pathfinder/issues/3081>.
-    #[tokio::test]
-    async fn lower_height_is_skipped() {
-        static COUNT: std::sync::Mutex<usize> = std::sync::Mutex::new(0);
-
-        let mut sequencer = MockGatewayApi::new();
-        sequencer
-            .expect_pending_block()
-            .returning(|| Ok((PRE_LATEST_BLOCK.clone(), PENDING_UPDATE.clone())));
-        sequencer.expect_preconfirmed_block().returning(|_, _, _| {
-            let mut count = COUNT.lock().unwrap();
-            let block_number = match *count {
-                0 => {
-                    *count += 1;
-                    // First poll establishes the tracked height at 12.
-                    BlockNumber::new_or_panic(12)
-                }
-                // Subsequent polls resolve to a lower height (gateway hiccup).
-                _ => BlockNumber::new_or_panic(11),
-            };
-            Ok(PreConfirmedPollResponse::Full {
-                identifier: String::new(),
-                block_number: Some(block_number),
-                block: all_receipted_block(1),
-            })
-        });
-
-        let committed = BlockNumber::new_or_panic(11);
-        let cache = Arc::new(PendingDataCache::new());
-        let mut sub = cache.subscribe();
-        let _ = sub.borrow_and_update();
-
-        // Unrelated hash so pre-latest is classified absent.
-        spawn_producer(sequencer, committed, block_hash!("0xdead"), cache.clone());
-
-        // The first poll stores block 12.
-        tokio::time::timeout(TEST_TIMEOUT, sub.changed())
-            .await
-            .expect("block 12 should be stored")
-            .unwrap();
-        assert_eq!(
-            sub.borrow().pre_confirmed_block_number(),
-            BlockNumber::new_or_panic(12)
-        );
-
-        // The backwards-resolved poll must not overwrite the cache.
-        let changed =
-            tokio::time::timeout(std::time::Duration::from_millis(100), sub.changed()).await;
-        assert!(
-            changed.is_err(),
-            "a lower-height poll must not overwrite the cache"
-        );
-
-        // The skip keeps the cache serviceable and still holding block 12.
-        let retained = cache.try_read().expect("cache should remain serviceable");
-        assert_eq!(
-            retained.pre_confirmed_block_number(),
-            BlockNumber::new_or_panic(12)
-        );
-    }
-
-    /// While catching up to head, the loop marks the cache unavailable so reads
-    /// fail fast with "syncing" instead of blocking on the cold-start
-    /// timeout.
-    #[tokio::test(start_paused = true)]
-    async fn syncing_marks_cache_unavailable() {
-        // latest far ahead of current: the catch-up branch runs and never
-        // fetches, so an expectation-free mock gateway is fine.
-        let sequencer = Arc::new(MockGatewayApi::new());
-        let hash = block_hash!("0xabcd");
-        let (_tx_latest, latest) = watch::channel((BlockNumber::new_or_panic(100), hash));
-        let (_tx_current, current) = watch::channel((BlockNumber::new_or_panic(0), hash));
-
-        let cache = Arc::new(PendingDataCache::new());
-        let _jh = tokio::spawn({
-            let cache = cache.clone();
-            async move {
-                super::poll_pre_confirmed(
-                    sequencer,
-                    std::time::Duration::from_secs(1),
-                    cache,
-                    latest,
-                    current,
-                    TEST_IN_SYNC_THRESHOLD,
-                )
-                .await
-            }
-        });
-
-        // Hand the loop a turn to reach the catch-up branch (virtual time).
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        let err = cache.read().await.unwrap_err();
-        assert!(err.to_string().contains("syncing"), "got: {err}");
-    }
-
-    /// A failed pre-confirmed fetch marks the cache unavailable with
-    /// "gateway error", so reads fail fast rather than blocking.
-    #[tokio::test(start_paused = true)]
-    async fn gateway_error_marks_cache_unavailable() {
-        use starknet_gateway_types::error::SequencerError;
-
-        // In sync (latest == current) so the loop reaches the fetch, which fails.
-        let mut sequencer = MockGatewayApi::new();
-        sequencer
-            .expect_preconfirmed_block()
-            .returning(|_, _, _| Err(SequencerError::InvalidResponse("boom".into())));
-        sequencer
-            .expect_pending_block()
-            .returning(|| Err(SequencerError::InvalidResponse("boom".into())));
-        let sequencer = Arc::new(sequencer);
-
-        let hash = block_hash!("0xabcd");
-        let number = BlockNumber::new_or_panic(10);
-        let (_tx_latest, latest) = watch::channel((number, hash));
-        let (_tx_current, current) = watch::channel((number, hash));
-
-        let cache = Arc::new(PendingDataCache::new());
-        let _jh = tokio::spawn({
-            let cache = cache.clone();
-            async move {
-                super::poll_pre_confirmed(
-                    sequencer,
-                    std::time::Duration::from_secs(1),
-                    cache,
-                    latest,
-                    current,
-                    TEST_IN_SYNC_THRESHOLD,
-                )
-                .await
-            }
-        });
-
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        let err = cache.read().await.unwrap_err();
-        assert!(err.to_string().contains("gateway error"), "got: {err}");
-    }
-
-    /// The completion query for a superseded block carries any tail
-    /// transactions that landed just before it advanced; they must reach
-    /// the cache.
-    #[tokio::test]
-    async fn complete_previous_block_applies_the_tail_delta() {
-        const BLOCK_ID: &str = "id-11";
-
-        let tail_hash = transaction_hash!("0x012345");
-        let tail_tx = Transaction {
-            hash: tail_hash,
-            variant: TransactionVariant::L1Handler(L1HandlerTransaction {
-                contract_address: contract_address!("0x1"),
-                entry_point_selector: entry_point!("0x55"),
-                nonce: transaction_nonce!("0x2"),
-                calldata: Vec::new(),
-            }),
-        };
-        let tail_receipt = pathfinder_common::receipt::Receipt {
-            transaction_hash: tail_hash,
-            transaction_index: TransactionIndex::new_or_panic(1),
-            ..Default::default()
-        };
-
-        let mut sequencer = MockGatewayApi::new();
-        sequencer
-            .expect_preconfirmed_block()
-            .returning(move |_, _, _| {
-                Ok(PreConfirmedPollResponse::Delta {
-                    identifier: BLOCK_ID.into(),
-                    new_transactions: vec![tail_tx.clone()],
-                    new_receipts: vec![Some((tail_receipt.clone(), vec![]))],
-                    new_state_diffs: vec![None],
-                })
-            });
-
-        // We're tracking block 11 with one receipted transaction already merged.
-        let mut state = State {
-            block_number: BlockNumber::new_or_panic(11),
-            block_identifier: Some(BLOCK_ID.to_string()),
-            accumulated: Some(all_receipted_block(1)),
-            pre_latest_data_present: false,
-        };
-
-        let cache = PendingDataCache::new();
-        let mut rx = cache.subscribe();
-        let _ = rx.borrow_and_update();
-
-        // Committed head 10, so block 11 still chains and is stored.
-        complete_previous_block(
-            &sequencer,
-            &mut state,
-            &cache,
-            BlockNumber::new_or_panic(10),
-        )
-        .await;
-
-        assert!(
-            rx.has_changed().unwrap(),
-            "the completion should store the block"
-        );
-        let pending = rx.borrow().clone();
-        assert_eq!(
-            pending.pre_confirmed_block_number(),
-            BlockNumber::new_or_panic(11)
-        );
-        assert!(
-            pending
-                .pre_confirmed_transactions()
-                .iter()
-                .any(|t| t.hash == tail_hash),
-            "the tail transaction should be in the completed block"
-        );
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn idle_pauses_polling_until_cache_read() {
-        // Polling suspends once the inactivity window elapses without a read,
-        // and a cache read resumes it. Activity is observed via the gateway call
-        // counter, since touching the cache would itself reset the window.
-        const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
-        const IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(100);
-
-        let calls = Arc::new(std::sync::Mutex::new(0u64));
-        let mut sequencer = MockGatewayApi::new();
-        sequencer
-            .expect_pending_block()
-            .returning(|| Ok((PRE_LATEST_BLOCK.clone(), PENDING_UPDATE.clone())));
-        {
-            let calls = calls.clone();
-            sequencer
-                .expect_preconfirmed_block()
-                .returning(move |_, _, _| {
-                    let mut c = calls.lock().unwrap();
-                    *c += 1;
-                    Ok(PreConfirmedPollResponse::Full {
-                        identifier: format!("id-{}", *c),
-                        block_number: Some(BlockNumber::new_or_panic(2)),
-                        block: all_receipted_block(1),
-                    })
-                });
-        }
-
-        let latest_hash = PRE_LATEST_BLOCK.parent_hash;
-        let committed = BlockNumber::new_or_panic(1);
-        let (_latest_tx, latest) = watch::channel((committed, latest_hash));
-        let (_current_tx, current) = watch::channel((committed, latest_hash));
-
-        let cache = Arc::new(PendingDataCache::new().with_inactivity_timeout(IDLE_TIMEOUT));
-        let sequencer = Arc::new(sequencer);
-        tokio::spawn({
-            let cache = cache.clone();
-            async move {
-                poll_pre_confirmed(
-                    sequencer,
-                    POLL_INTERVAL,
-                    cache,
-                    latest,
-                    current,
-                    TEST_IN_SYNC_THRESHOLD,
-                )
-                .await
-            }
-        });
-
-        // Polls happen for a while, then idle suspends them.
-        tokio::time::sleep(IDLE_TIMEOUT * 3).await;
-        let count_at_idle = *calls.lock().unwrap();
-        assert!(count_at_idle >= 1, "expected at least one poll before idle");
-
-        tokio::time::sleep(IDLE_TIMEOUT * 3).await;
-        assert_eq!(
-            *calls.lock().unwrap(),
-            count_at_idle,
-            "polling should be suspended while idle"
-        );
-
-        // A cache read wakes the loop.
-        let _ = cache.read().await;
-        tokio::time::sleep(POLL_INTERVAL * 3).await;
-        assert!(
-            *calls.lock().unwrap() > count_at_idle,
-            "polling should resume after a cache read"
-        );
-    }
 }

--- a/crates/pending-data/src/data.rs
+++ b/crates/pending-data/src/data.rs
@@ -135,61 +135,27 @@ impl PendingData {
     }
 
     /// Same as [`Self::try_from_pre_confirmed_block`] but also accepts an
-    /// optional pre-latest parent. When present, the pre-confirmed block
-    /// must be its child.
+    /// optional pre-latest parent: a pre-confirmed block at a height already
+    /// past consensus. When present, the pre-confirmed block must be its child,
+    /// and its parent hash is our committed head.
     pub fn try_from_pre_confirmed_and_pre_latest(
         pre_confirmed_block: Box<starknet_gateway_types::reply::PreConfirmedBlock>,
         pre_confirmed_block_number: BlockNumber,
-        pre_latest_data: Option<
+        pre_latest: Option<
             Box<(
                 BlockNumber,
-                starknet_gateway_types::reply::PreLatestBlock,
-                StateUpdate,
+                starknet_gateway_types::reply::PreConfirmedBlock,
+                BlockHash,
             )>,
         >,
     ) -> anyhow::Result<Self> {
-        // Drop placeholder Nones from receipts.
-        let transaction_receipts: Vec<_> = pre_confirmed_block
-            .transaction_receipts
-            .into_iter()
-            .flatten()
-            .collect();
-
-        let pre_confirmed_transaction_hashes: HashSet<_> = transaction_receipts
-            .iter()
-            .map(|(receipt, _)| receipt.transaction_hash)
-            .collect();
-
-        for tx in &pre_confirmed_block.transactions {
-            if !pre_confirmed_transaction_hashes.contains(&tx.hash) {
-                anyhow::bail!("Missing transaction receipt for tx ({})", tx.hash);
-            }
-        }
-        if transaction_receipts.len() != pre_confirmed_block.transactions.len() {
-            anyhow::bail!("Mismatched transaction and receipt count in pre-confirmed block");
-        }
-
-        // Compose aggregated state diff for the pre-confirmed block.
-        let mut pre_confirmed_state_diff =
-            starknet_gateway_types::reply::state_update::StateDiff::default();
-        for transaction_diff in pre_confirmed_block
-            .transaction_state_diffs
-            .into_iter()
-            .flatten()
-        {
-            pre_confirmed_state_diff.extend(transaction_diff);
-        }
-        pre_confirmed_state_diff.deduplicate();
-
-        let pre_confirmed_state_update = {
-            let state_update = starknet_gateway_types::reply::StateUpdate {
-                state_diff: pre_confirmed_state_diff.clone(),
-                block_hash: Default::default(),
-                new_root: StateCommitment::default(),
-                old_root: StateCommitment::default(),
-            };
-            Arc::new(StateUpdate::from(state_update))
-        };
+        let transaction_receipts = require_receipts(
+            &pre_confirmed_block.transactions,
+            pre_confirmed_block.transaction_receipts,
+        )?;
+        let pre_confirmed_state_update = Arc::new(compose_state_update(
+            pre_confirmed_block.transaction_state_diffs,
+        ));
 
         let pre_confirmed_block = PreConfirmedBlock {
             number: pre_confirmed_block_number,
@@ -205,18 +171,22 @@ impl PendingData {
             transaction_receipts,
         };
 
-        let pre_latest_data = pre_latest_data
+        let pre_latest_data = pre_latest
             .map(|pre_latest| {
-                let (pre_latest_block_number, pre_latest_block, pre_latest_state_update) =
-                    *pre_latest;
+                let (pre_latest_block_number, pre_latest_block, parent_hash) = *pre_latest;
                 anyhow::ensure!(
                     pre_latest_block_number + 1 == pre_confirmed_block_number,
                     "Pre-confirmed block {pre_confirmed_block_number} is not the child of \
                      pre-latest {pre_latest_block_number}",
                 );
-                let pre_latest_block = PreLatestBlock {
+                let transaction_receipts = require_receipts(
+                    &pre_latest_block.transactions,
+                    pre_latest_block.transaction_receipts,
+                )?;
+                let state_update = compose_state_update(pre_latest_block.transaction_state_diffs);
+                let block = PreLatestBlock {
                     number: pre_latest_block_number,
-                    parent_hash: pre_latest_block.parent_hash,
+                    parent_hash,
                     l1_gas_price: pre_latest_block.l1_gas_price,
                     l1_data_gas_price: pre_latest_block.l1_data_gas_price,
                     l2_gas_price: pre_latest_block.l2_gas_price,
@@ -226,19 +196,19 @@ impl PendingData {
                     starknet_version: pre_latest_block.starknet_version,
                     l1_da_mode: pre_latest_block.l1_da_mode.into(),
                     transactions: pre_latest_block.transactions,
-                    transaction_receipts: pre_latest_block.transaction_receipts,
+                    transaction_receipts,
                 };
-                Ok(PreLatestData {
-                    block: pre_latest_block,
-                    state_update: pre_latest_state_update,
+                anyhow::Ok(PreLatestData {
+                    block,
+                    state_update,
                 })
             })
             .transpose()?;
 
         let aggregated_state_update = Arc::new(
             pre_latest_data
-                .clone()
-                .map(|data| data.state_update)
+                .as_ref()
+                .map(|data| data.state_update.clone())
                 .unwrap_or_default()
                 .apply(pre_confirmed_state_update.as_ref()),
         );
@@ -444,4 +414,51 @@ impl PendingData {
             .is_some_and(|pre_latest| pre_latest == block)
             || self.pre_confirmed_block_number() == block
     }
+}
+
+/// Drop the receipt placeholders a pre-confirmed response carries, failing if a
+/// transaction is still missing one. A missing receipt means a candidate
+/// transaction the sequencer hasn't executed yet.
+fn require_receipts(
+    transactions: &[Transaction],
+    transaction_receipts: Vec<Option<TxnReceiptAndEvents>>,
+) -> anyhow::Result<Vec<TxnReceiptAndEvents>> {
+    let transaction_receipts: Vec<TxnReceiptAndEvents> =
+        transaction_receipts.into_iter().flatten().collect();
+
+    let receipted: HashSet<_> = transaction_receipts
+        .iter()
+        .map(|(receipt, _)| receipt.transaction_hash)
+        .collect();
+    for tx in transactions {
+        if !receipted.contains(&tx.hash) {
+            anyhow::bail!("Missing transaction receipt for tx ({})", tx.hash);
+        }
+    }
+    anyhow::ensure!(
+        transaction_receipts.len() == transactions.len(),
+        "Mismatched transaction and receipt count in pre-confirmed block",
+    );
+
+    Ok(transaction_receipts)
+}
+
+/// Fold the per-transaction state diffs of a pre-confirmed response into one
+/// state update. A pending block has no root of its own, so the roots are left
+/// empty.
+fn compose_state_update(
+    transaction_state_diffs: Vec<Option<starknet_gateway_types::reply::state_update::StateDiff>>,
+) -> StateUpdate {
+    let mut state_diff = starknet_gateway_types::reply::state_update::StateDiff::default();
+    for transaction_diff in transaction_state_diffs.into_iter().flatten() {
+        state_diff.extend(transaction_diff);
+    }
+    state_diff.deduplicate();
+
+    StateUpdate::from(starknet_gateway_types::reply::StateUpdate {
+        state_diff,
+        block_hash: Default::default(),
+        new_root: StateCommitment::default(),
+        old_root: StateCommitment::default(),
+    })
 }

--- a/crates/rpc/src/dto/block.rs
+++ b/crates/rpc/src/dto/block.rs
@@ -114,69 +114,6 @@ impl crate::dto::SerializeForVersion for pathfinder_common::BlockHeader {
     }
 }
 
-impl crate::dto::SerializeForVersion
-    for (
-        pathfinder_common::BlockNumber,
-        &starknet_gateway_types::reply::PreLatestBlock,
-    )
-{
-    fn serialize(
-        &self,
-        serializer: crate::dto::Serializer,
-    ) -> Result<crate::dto::Ok, crate::dto::Error> {
-        let (block_number, pending_block) = *self;
-
-        let mut serializer = serializer.serialize_struct()?;
-        if serializer.version >= RpcVersion::V09 {
-            serializer.serialize_field("block_number", &block_number)?;
-        } else {
-            serializer.serialize_field("parent_hash", &pending_block.parent_hash)?;
-        }
-        serializer.serialize_field("timestamp", &pending_block.timestamp.get())?;
-        serializer.serialize_field("sequencer_address", &pending_block.sequencer_address)?;
-        serializer.serialize_field(
-            "l1_gas_price",
-            &ResourcePrice {
-                price_in_wei: pending_block.l1_gas_price.price_in_wei,
-                price_in_fri: pending_block.l1_gas_price.price_in_fri,
-            },
-        )?;
-        serializer.serialize_field(
-            "starknet_version",
-            &pending_block.starknet_version.to_string(),
-        )?;
-
-        if serializer.version >= RpcVersion::V07 {
-            serializer.serialize_field(
-                "l1_data_gas_price",
-                &ResourcePrice {
-                    price_in_wei: pending_block.l1_data_gas_price.price_in_wei,
-                    price_in_fri: pending_block.l1_data_gas_price.price_in_fri,
-                },
-            )?;
-            serializer.serialize_field(
-                "l1_da_mode",
-                &match pending_block.l1_da_mode {
-                    starknet_gateway_types::reply::L1DataAvailabilityMode::Blob => "BLOB",
-                    starknet_gateway_types::reply::L1DataAvailabilityMode::Calldata => "CALLDATA",
-                },
-            )?;
-        }
-
-        if serializer.version >= RpcVersion::V08 {
-            serializer.serialize_field(
-                "l2_gas_price",
-                &ResourcePrice {
-                    price_in_wei: pending_block.l2_gas_price.price_in_wei,
-                    price_in_fri: pending_block.l2_gas_price.price_in_fri,
-                },
-            )?;
-        }
-
-        serializer.end()
-    }
-}
-
 impl crate::dto::SerializeForVersion for crate::pending::PreConfirmedBlock {
     fn serialize(
         &self,
@@ -289,7 +226,6 @@ mod tests {
     use pathfinder_common::macro_prelude::*;
     use pathfinder_common::prelude::*;
     use serde_json::json;
-    use starknet_gateway_types::reply::{GasPrices, PreLatestBlock};
 
     use crate::dto::{SerializeForVersion, Serializer};
     use crate::RpcVersion;
@@ -379,122 +315,6 @@ mod tests {
                 },
                 "new_root": "0x7bd9798e3b03e6dfc12db132d48e4a0dc75202aa6a9b57bc40e3796137bd617",
                 "parent_hash": "0x6084bda2cd3247aa11364404f7918001e82a7567cfe0b949fa6a7f3d4b4099f",
-                "sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-                "starknet_version": "0.13.3",
-                "timestamp": 1734728886,
-            })
-        );
-    }
-
-    #[test]
-    fn pending_block() {
-        let block_number = BlockNumber::new_or_panic(12345);
-        let pending = PreLatestBlock {
-            l1_gas_price: GasPrices {
-                price_in_wei: GasPrice(0x34795c87c),
-                price_in_fri: GasPrice(0x59425e9d6d3c),
-            },
-            l1_data_gas_price: GasPrices {
-                price_in_wei: GasPrice(0x85257107),
-                price_in_fri: GasPrice(0xe27be612da1),
-            },
-            l2_gas_price: GasPrices {
-                price_in_wei: GasPrice(0x12345678),
-                price_in_fri: GasPrice(0x23456789),
-            },
-            parent_hash: block_hash!(
-                "0x6084bda2cd3247aa11364404f7918001e82a7567cfe0b949fa6a7f3d4b4099f"
-            ),
-            sequencer_address: sequencer_address!(
-                "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8"
-            ),
-            timestamp: BlockTimestamp::new_or_panic(1734728886),
-            starknet_version: StarknetVersion::new(0, 13, 3, 0),
-            l1_da_mode: starknet_gateway_types::reply::L1DataAvailabilityMode::Blob,
-            ..Default::default()
-        };
-
-        pretty_assertions_sorted::assert_eq!(
-            (block_number, &pending)
-                .serialize(Serializer::new(RpcVersion::V06))
-                .unwrap(),
-            json!({
-                "l1_gas_price": {
-                  "price_in_fri": "0x59425e9d6d3c",
-                  "price_in_wei": "0x34795c87c"
-                },
-                "parent_hash": "0x6084bda2cd3247aa11364404f7918001e82a7567cfe0b949fa6a7f3d4b4099f",
-                "sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-                "starknet_version": "0.13.3",
-                "timestamp": 1734728886,
-            })
-        );
-
-        pretty_assertions_sorted::assert_eq!(
-            (block_number, &pending)
-                .serialize(Serializer::new(RpcVersion::V07))
-                .unwrap(),
-            json!({
-                "l1_da_mode": "BLOB",
-                "l1_data_gas_price": {
-                  "price_in_fri": "0xe27be612da1",
-                  "price_in_wei": "0x85257107"
-                },
-                "l1_gas_price": {
-                  "price_in_fri": "0x59425e9d6d3c",
-                  "price_in_wei": "0x34795c87c"
-                },
-                "parent_hash": "0x6084bda2cd3247aa11364404f7918001e82a7567cfe0b949fa6a7f3d4b4099f",
-                "sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-                "starknet_version": "0.13.3",
-                "timestamp": 1734728886,
-            })
-        );
-
-        pretty_assertions_sorted::assert_eq!(
-            (block_number, &pending)
-                .serialize(Serializer::new(RpcVersion::V08))
-                .unwrap(),
-            json!({
-                "l1_da_mode": "BLOB",
-                "l1_data_gas_price": {
-                  "price_in_fri": "0xe27be612da1",
-                  "price_in_wei": "0x85257107"
-                },
-                "l1_gas_price": {
-                  "price_in_fri": "0x59425e9d6d3c",
-                  "price_in_wei": "0x34795c87c"
-                },
-                "l2_gas_price": {
-                    "price_in_fri": "0x23456789",
-                    "price_in_wei": "0x12345678"
-                },
-                "parent_hash": "0x6084bda2cd3247aa11364404f7918001e82a7567cfe0b949fa6a7f3d4b4099f",
-                "sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-                "starknet_version": "0.13.3",
-                "timestamp": 1734728886,
-            })
-        );
-
-        pretty_assertions_sorted::assert_eq!(
-            (block_number, &pending)
-                .serialize(Serializer::new(RpcVersion::V09))
-                .unwrap(),
-            json!({
-                "l1_da_mode": "BLOB",
-                "l1_data_gas_price": {
-                  "price_in_fri": "0xe27be612da1",
-                  "price_in_wei": "0x85257107"
-                },
-                "l1_gas_price": {
-                  "price_in_fri": "0x59425e9d6d3c",
-                  "price_in_wei": "0x34795c87c"
-                },
-                "l2_gas_price": {
-                    "price_in_fri": "0x23456789",
-                    "price_in_wei": "0x12345678"
-                },
-                "block_number": 12345,
                 "sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
                 "starknet_version": "0.13.3",
                 "timestamp": 1734728886,

--- a/crates/rpc/src/method/subscribe_transaction_status.rs
+++ b/crates/rpc/src/method/subscribe_transaction_status.rs
@@ -505,7 +505,7 @@ mod tests {
     use pathfinder_pending_data::PendingDataCache;
     use pathfinder_storage::StorageBuilder;
     use pretty_assertions_sorted::assert_eq;
-    use starknet_gateway_types::reply::{PreConfirmedBlock, PreLatestBlock};
+    use starknet_gateway_types::reply::PreConfirmedBlock;
     use tokio::sync::mpsc;
 
     use crate::context::{RpcContext, WebsocketContext};
@@ -1129,24 +1129,23 @@ mod tests {
                             // a notification because it would have a duplicate `PRE_CONFIRMED`
                             // status.
                             BlockNumber::GENESIS + 2,
-                            PreLatestBlock {
-                                parent_hash: BlockHash(Felt::from_u64(2)),
+                            PreConfirmedBlock {
                                 transaction_receipts: vec![
-                                    (
+                                    Some((
                                         Receipt {
                                             transaction_hash: TARGET_TX_HASH,
                                             ..Default::default()
                                         },
                                         vec![],
-                                    ),
+                                    )),
                                     // Random tx receipt.
-                                    (
+                                    Some((
                                         Receipt {
                                             transaction_hash: TransactionHash(Felt::from_u64(123)),
                                             ..Default::default()
                                         },
                                         vec![],
-                                    ),
+                                    )),
                                 ],
                                 transactions: vec![
                                     Transaction {
@@ -1161,7 +1160,7 @@ mod tests {
                                 ],
                                 ..Default::default()
                             },
-                            StateUpdate::default(),
+                            BlockHash(Felt::from_u64(2)),
                         ))),
                     )
                     .unwrap(),

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -1228,15 +1228,22 @@ pub(crate) mod tests {
                 &casm_hash_bytes!(b"casm hash blake"),
             )?;
 
-            let dummy_receipt = Receipt {
-                transaction_hash: TransactionHash(felt!("0x1")),
-                transaction_index: TransactionIndex::new_or_panic(0),
-                ..Default::default()
-            };
+            let transaction_receipts: Vec<_> = pre_latest_transactions
+                .iter()
+                .enumerate()
+                .map(|(index, tx)| {
+                    Some((
+                        Receipt {
+                            transaction_hash: tx.hash,
+                            transaction_index: TransactionIndex::new_or_panic(index as u64),
+                            ..Default::default()
+                        },
+                        vec![],
+                    ))
+                })
+                .collect();
 
-            let transaction_receipts = vec![(dummy_receipt, vec![]); pre_latest_transactions.len()];
-
-            let pre_latest_block = starknet_gateway_types::reply::PreLatestBlock {
+            let pre_latest_block = starknet_gateway_types::reply::PreConfirmedBlock {
                 l1_gas_price: GasPrices {
                     price_in_wei: last_block_header.eth_l1_gas_price,
                     price_in_fri: last_block_header.strk_l1_gas_price,
@@ -1249,7 +1256,6 @@ pub(crate) mod tests {
                     price_in_wei: last_block_header.eth_l2_gas_price,
                     price_in_fri: last_block_header.strk_l2_gas_price,
                 },
-                parent_hash: last_block_header.hash,
                 sequencer_address: last_block_header.sequencer_address,
                 status: starknet_gateway_types::reply::Status::Pending,
                 timestamp: last_block_header.timestamp,
@@ -1257,6 +1263,7 @@ pub(crate) mod tests {
                 transactions: pre_latest_transactions.clone().into(),
                 starknet_version: last_block_header.starknet_version,
                 l1_da_mode: L1DataAvailabilityMode::Blob,
+                transaction_state_diffs: vec![],
             };
 
             let pre_confirmed_block = starknet_gateway_types::reply::PreConfirmedBlock {
@@ -1291,7 +1298,7 @@ pub(crate) mod tests {
                 Some(Box::new((
                     last_block_header.number + 1,
                     pre_latest_block,
-                    StateUpdate::default(),
+                    last_block_header.hash,
                 ))),
             )
             .unwrap()

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -91,13 +91,11 @@ impl PendingWatcher {
             //   - the pre-latest block does not exist and the pre-confirmed block is the
             //   child of our latest stored block.
             match pre_latest {
-                // Is pre-latest the next block?
-                Some(pre_latest) if pre_latest.block.number == latest.number + 1 => {
-                    assert_eq!(
-                        pre_latest.block.number + 1,
-                        pre_confirmed.number,
-                        "Pre-confirmed block should be child of pre-latest"
-                    );
+                // Is pre-latest the next block, with pre-confirmed as its child?
+                Some(pre_latest)
+                    if pre_latest.block.number == latest.number + 1
+                        && pre_latest.block.number + 1 == pre_confirmed.number =>
+                {
                     // Set pre-latest block parent state commitment, clone rest of the data.
                     let pre_latest = pre_latest.clone();
                     let pre_latest_state_update = pre_latest
@@ -120,15 +118,11 @@ impl PendingWatcher {
                         number: pre_confirmed.number,
                     }
                 }
-                // Is pre-latest already in the database?
-                Some(pre_latest) if pre_latest.block.number == latest.number => {
-                    // We'll ignore pre-latest data here but let's make sure everything is
-                    // still as expected.
-                    assert_eq!(
-                        pre_latest.block.number + 1,
-                        pre_confirmed.number,
-                        "Pre-confirmed block should be child of pre-latest"
-                    );
+                // Is pre-latest already in the database, with pre-confirmed as its child?
+                Some(pre_latest)
+                    if pre_latest.block.number == latest.number
+                        && pre_latest.block.number + 1 == pre_confirmed.number =>
+                {
                     // Set pre-latest data to `None`, pre-confirmed block parent state
                     // commitment and clone rest of the data.
                     let pre_confirmed_block = PendingBlocks {
@@ -203,8 +197,7 @@ pub fn find_finalized_tx_data(
             .pre_confirmed_tx_receipts_and_events()
             .iter()
             .find(|(r, _)| r.transaction_hash == tx_hash)
-            .cloned()
-            .expect("Receipt should exist if the transaction exists");
+            .cloned()?;
         return Some(FinalizedTxData {
             block_number: pending.pre_confirmed_block_number(),
             transaction: tx.clone(),
@@ -220,14 +213,11 @@ pub fn find_finalized_tx_data(
             .iter()
             .find(|t| t.hash == tx_hash)
         {
-            let (receipt, events) = pending
-                .pre_latest_tx_receipts_and_events()
-                .and_then(|rs| {
-                    rs.iter()
-                        .find(|(r, _)| r.transaction_hash == tx_hash)
-                        .cloned()
-                })
-                .expect("Receipt should exist if the transaction exists");
+            let (receipt, events) = pending.pre_latest_tx_receipts_and_events().and_then(|rs| {
+                rs.iter()
+                    .find(|(r, _)| r.transaction_hash == tx_hash)
+                    .cloned()
+            })?;
             return Some(FinalizedTxData {
                 block_number: pre_latest_block.number,
                 transaction: tx.clone(),
@@ -657,8 +647,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn pre_confirmed_is_not_child_of_pre_latest_panics() {
+    fn pre_confirmed_not_child_of_pre_latest_defaults_to_empty() {
+        // A pre-confirmed block that doesn't chain onto the pre-latest falls back
+        // to an empty pending block.
         let cache = Arc::new(PendingDataCache::new());
         let uut = PendingWatcher::new(cache.clone());
 
@@ -687,8 +678,11 @@ mod tests {
         tx.insert_block_header(&latest).unwrap();
 
         let pending = invalid_pre_confirmed_block_with_pre_latest(&latest);
-        cache.store(pending.clone());
-        let _ = uut.get(&tx, RpcVersion::V09).unwrap();
+        cache.store(pending);
+
+        let result = uut.get(&tx, RpcVersion::V09).unwrap();
+
+        pretty_assertions_sorted::assert_eq_sorted!(result, PendingData::empty(&latest));
     }
 
     fn empty_pre_confirmed_block(latest: &BlockHeader) -> PendingData {


### PR DESCRIPTION
**Problem:**

Clients querying the `pre_confirmed` tag were getting intermittent 503s. 

The producer asked the gateway for its `latest` pre-confirmed block and required it to line up with the pending (pre-latest) block fetched alongside it. 

While this makes sense in theory, in practice it's hard to get right because they come from different endpoints sampled a few moments apart. This is due to how the fgw API is designed, and there are no plans to change it.

TDLR: By the time we read the pre-latest at `N`, the pre-confirmed had already raced ahead to `N+2`. Right now if they don't chain we discard the update. This can result in long periods of nothing to serve. Which is wrong.


**Solution:**

Stop chasing a moving target. Instead of asking for `latest`, we anchor the pre-confirmed query on our own (known) committed head. So the block we fetch (by number) is the exact pre-confirmed block that chains onto it by construction. The race should no longer happen. Ever.

**Then, one step further as suggested by SW: The pre-latest is really just a pre-confirmed block one height down that's already past consensus (waiting for block hash), which is exactly what the pending block was giving us. So instead of a separate pending poll, we fetch the pre-latest by number from the same `get_preconfirmed` endpoint. Both levels then come from the same place.** 

Also, a couple notable changes:
- A transient gateway failure keeps serving the last good view instead of going blank.
- Removed a `panic!` from the read path. We just return an empty block instead.

This is a major rewrite. I have tested it live on `sepolia-integration` and the `pre_confirmed` serves well with zero drops.


See also https://github.com/equilibriumco/pathfinder/issues/3495