### PR TITLE
feat(sync/pending): take complete_previous_block off the critical path

### DIFF
--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -258,14 +258,13 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
 
         // Complete the just-superseded block off the critical path. The new
         // height is already in the cache, the aim is to capture any tail transactions
-        // that landed before the block was superseded. The store will only
-        // succeed if the new height didn't itself chain to the committed head.
+        // that landed before the block was superseded and deliver them to streaming
+        // subscribers, without touching the read view RPC readers see.
         if let Some(prev) = prev_to_complete {
             let sequencer = sequencer.clone();
             let cache = cache.clone();
-            let committed_head = current.borrow().0;
             tokio::spawn(async move {
-                complete_previous_block(&sequencer, prev, &cache, committed_head).await;
+                complete_previous_block(&sequencer, prev, &cache).await;
             });
         }
 
@@ -283,12 +282,19 @@ async fn wait_for_next_poll(deadline: Instant, cache: &PendingDataCache) {
 }
 
 /// Fetch the previously-tracked block one final time to capture any
-/// transactions that landed before it was superseded. Best-effort.
+/// transactions that landed before it was superseded, and deliver them to
+/// streaming subscribers. Best-effort.
+///
+/// This publishes to the subscriber stream only (via
+/// [`PendingDataCache::publish_tail`]), never to the read view: by the time it
+/// runs the chain has advanced and a newer block is what RPC readers should
+/// see. Subscribers dedupe per block, so they pick up only the previously
+/// unsent tail transactions. Because it doesn't touch the read view it needs no
+/// committed-head chaining check.
 async fn complete_previous_block<S: GatewayApi + Send + 'static>(
     sequencer: &S,
     mut state: State,
     cache: &PendingDataCache,
-    committed_head: BlockNumber,
 ) {
     let response = match sequencer
         .preconfirmed_block(
@@ -310,13 +316,16 @@ async fn complete_previous_block<S: GatewayApi + Send + 'static>(
             .accumulated
             .as_ref()
             .expect("accumulated present after successful completion apply");
-        store_pre_confirmed(
-            cache,
-            committed_head,
-            state.block_number,
+        match PendingData::try_from_pre_confirmed_block(
             accumulated.clone().into(),
-            None,
-        );
+            state.block_number,
+        ) {
+            Ok(pending) => cache.publish_tail(pending),
+            Err(e) => tracing::info!(
+                block_number = %state.block_number, error = %e,
+                "Failed to convert completed pre-confirmed block; skipping tail publish"
+            ),
+        }
     }
 }
 
@@ -332,16 +341,6 @@ fn store_pre_confirmed(
     block: Box<PreConfirmedBlock>,
     pre_latest_data: Option<Box<(BlockNumber, PreLatestBlock, StateUpdate)>>,
 ) {
-    // Do not allow the cached height to regress.
-    let cached = cache.pre_confirmed_block_number();
-    if number < cached {
-        tracing::debug!(
-            %number, %cached,
-            "Pre-confirmed store would regress the cached height; skipping store"
-        );
-        return;
-    }
-
     // Reject views that don't chain to the committed head.
     let next_block_number = pre_latest_data
         .as_ref()
@@ -1026,7 +1025,7 @@ mod tests {
 
     /// The completion query for a superseded block carries any tail
     /// transactions that landed just before it advanced; they must reach
-    /// the cache.
+    /// streaming subscribers (via the subscriber stream).
     #[tokio::test]
     async fn complete_previous_block_applies_the_tail_delta() {
         const BLOCK_ID: &str = "id-11";
@@ -1071,12 +1070,12 @@ mod tests {
         let mut rx = cache.subscribe();
         let _ = rx.borrow_and_update();
 
-        // Committed head 10, so block 11 still chains and is stored.
-        complete_previous_block(&sequencer, state, &cache, BlockNumber::new_or_panic(10)).await;
+        // The completion publishes the superseded block to subscribers only.
+        complete_previous_block(&sequencer, state, &cache).await;
 
         assert!(
             rx.has_changed().unwrap(),
-            "the completion should store the block"
+            "the completion should publish the block to subscribers"
         );
         let pending = rx.borrow().clone();
         assert_eq!(

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -343,7 +343,7 @@ async fn complete_previous_block<S: GatewayApi + Send + 'static>(
 /// This is OK because:
 /// - `committed_head` is the already storage-committed head,
 /// - [`PendingDataCache`] in in-memory and doesn't write anything to storage,
-/// - data is consistent: there is a chaining check below and ultimately the RPC
+/// - data is consistent: stale views are dropped below and ultimately the RPC
 ///   read path re-validates the chaining requirement.
 fn store_pre_confirmed(
     cache: &PendingDataCache,
@@ -352,16 +352,26 @@ fn store_pre_confirmed(
     block: Box<PreConfirmedBlock>,
     pre_latest_data: Option<Box<(BlockNumber, PreLatestBlock, StateUpdate)>>,
 ) {
-    // Reject views that don't chain to the committed head.
+    // Drop only stale views.
+    //
+    // There is no explicit `committed_head + 1` requirement here. The
+    // `committed_head` comes from the `current` watch, which can briefly lag
+    // the DB (it's sent just after the consumer commits a block). An
+    // exact-match check would drop a perfectly good view whenever the watch is
+    // one block behind.
+    //
+    // The RPC read path is the ultimate authority on chaining and on the parent
+    // state commitment. It re-validates the cached view against then current
+    // committed head on every read.
     let next_block_number = pre_latest_data
         .as_ref()
         .map(|pre_latest| pre_latest.0)
         .unwrap_or(number);
 
-    if next_block_number != committed_head + 1 {
+    if next_block_number <= committed_head {
         tracing::debug!(
             %number, %committed_head,
-            "Pre-confirmed doesn't chain to committed head; skipping store"
+            "Pre-confirmed is at or behind the committed head; skipping stale store"
         );
         return;
     }
@@ -596,8 +606,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn store_pre_confirmed_skips_a_non_chaining_view() {
-        // Committed head 1, pre-confirmed at 5: gap > 1, so it doesn't chain.
+    async fn store_pre_confirmed_skips_a_stale_view() {
+        // Committed head 5, pre-confirmed at 3: at or behind the committed head,
+        // so it's stale and must be dropped.
+        let cache = PendingDataCache::new();
+        let mut rx = cache.subscribe();
+        let _ = rx.borrow_and_update();
+
+        store_pre_confirmed(
+            &cache,
+            BlockNumber::new_or_panic(5),
+            BlockNumber::new_or_panic(3),
+            Box::new(all_receipted_block(2)),
+            None,
+        );
+
+        assert!(
+            !rx.has_changed().unwrap(),
+            "a stale view (at or behind the committed head) must not be stored"
+        );
+    }
+
+    #[tokio::test]
+    async fn store_pre_confirmed_caches_an_ahead_view_for_the_rpc_to_gate() {
+        // Committed head 1, pre-confirmed at 5 with no pre-latest, ahead by more
+        // than one.
         let cache = PendingDataCache::new();
         let mut rx = cache.subscribe();
         let _ = rx.borrow_and_update();
@@ -611,8 +644,12 @@ mod tests {
         );
 
         assert!(
-            !rx.has_changed().unwrap(),
-            "a non-chaining view must not be stored"
+            rx.has_changed().unwrap(),
+            "an ahead view should be cached for the RPC to gate"
+        );
+        assert_eq!(
+            rx.borrow().pre_confirmed_block_number(),
+            BlockNumber::new_or_panic(5)
         );
     }
 

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -334,6 +334,17 @@ async fn complete_previous_block<S: GatewayApi + Send + 'static>(
 ///
 /// `committed_head` is the latest block already in storage, mirrored by the
 /// `current` watch. A view that doesn't chain to it is dropped.
+///
+/// # Why this is safe outside the sync DB write transaction
+///
+/// Pre-confirmed updates used to flow through the sync event channel and were
+/// applied inside the consumer's `Immediate` write transaction. They are now
+/// written straight to the cache from the polling task, with no transaction.
+/// This is OK because:
+/// - `committed_head` is the already storage-committed head,
+/// - [`PendingDataCache`] in in-memory and doesn't write anything to storage,
+/// - data is consistent: there is a chaining check below and ultimately the RPC
+///   read path re-validates the chaining requirement.
 fn store_pre_confirmed(
     cache: &PendingDataCache,
     committed_head: BlockNumber,

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -248,7 +248,7 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
                 &cache,
                 current.borrow().0,
                 state.block_number,
-                accumulated.clone().into(),
+                accumulated,
                 pre_latest_data,
             );
         } else {
@@ -278,6 +278,17 @@ async fn wait_for_next_poll(deadline: Instant, cache: &PendingDataCache) {
     tokio::select! {
         _ = tokio::time::sleep_until(deadline) => {}
         _ = cache.wait_for_read() => {}
+    }
+}
+
+/// Run a CPU-bound closure without starving the async runtime. Use
+/// `block_in_place` on a multi-threaded runtime, or inline otherwise (for
+/// tests).
+fn run_cpu_bound<R>(f: impl FnOnce() -> R) -> R {
+    use tokio::runtime::{Handle, RuntimeFlavor};
+    match Handle::try_current().map(|h| h.runtime_flavor()) {
+        Ok(RuntimeFlavor::MultiThread) => tokio::task::block_in_place(f),
+        _ => f(),
     }
 }
 
@@ -316,13 +327,14 @@ async fn complete_previous_block<S: GatewayApi + Send + 'static>(
             .accumulated
             .as_ref()
             .expect("accumulated present after successful completion apply");
-        match PendingData::try_from_pre_confirmed_block(
-            accumulated.clone().into(),
-            state.block_number,
-        ) {
+        let number = state.block_number;
+        let converted = run_cpu_bound(|| {
+            PendingData::try_from_pre_confirmed_block(Box::new(accumulated.clone()), number)
+        });
+        match converted {
             Ok(pending) => cache.publish_tail(pending),
             Err(e) => tracing::info!(
-                block_number = %state.block_number, error = %e,
+                block_number = %number, error = %e,
                 "Failed to convert completed pre-confirmed block; skipping tail publish"
             ),
         }
@@ -349,7 +361,7 @@ fn store_pre_confirmed(
     cache: &PendingDataCache,
     committed_head: BlockNumber,
     number: BlockNumber,
-    block: Box<PreConfirmedBlock>,
+    block: &PreConfirmedBlock,
     pre_latest_data: Option<Box<(BlockNumber, PreLatestBlock, StateUpdate)>>,
 ) {
     // Drop only stale views.
@@ -376,8 +388,16 @@ fn store_pre_confirmed(
         return;
     }
 
-    // Convert and store.
-    match PendingData::try_from_pre_confirmed_and_pre_latest(block, number, pre_latest_data) {
+    // Convert and store. The deep clone and state-diff aggregation are offloaded
+    // so they don't stall the async worker for a large block.
+    let converted = run_cpu_bound(|| {
+        PendingData::try_from_pre_confirmed_and_pre_latest(
+            Box::new(block.clone()),
+            number,
+            pre_latest_data,
+        )
+    });
+    match converted {
         Ok(pending) => {
             let pre_latest_tx_count = pending.pre_latest_transactions().map(|txs| txs.len());
             let pre_confirmed_tx_count = pending.pre_confirmed_transactions().len();
@@ -588,7 +608,7 @@ mod tests {
             &cache,
             committed,
             BlockNumber::new_or_panic(3),
-            Box::new(all_receipted_block(2)),
+            &all_receipted_block(2),
             Some(pre_latest),
         );
 
@@ -617,7 +637,7 @@ mod tests {
             &cache,
             BlockNumber::new_or_panic(5),
             BlockNumber::new_or_panic(3),
-            Box::new(all_receipted_block(2)),
+            &all_receipted_block(2),
             None,
         );
 
@@ -639,7 +659,7 @@ mod tests {
             &cache,
             BlockNumber::new_or_panic(1),
             BlockNumber::new_or_panic(5),
-            Box::new(all_receipted_block(2)),
+            &all_receipted_block(2),
             None,
         );
 

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -178,6 +178,10 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
             _ => None,
         };
 
+        // Set when the chain advances: the previous block to complete once the
+        // new height has been published (see below).
+        let mut prev_to_complete: Option<State> = None;
+
         if let Some(height) = resolved {
             // A transient (?) lower-height shouldn't discard accumulated state.
             if height < state.block_number && state.block_number != BlockNumber::GENESIS {
@@ -192,16 +196,20 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
                 continue;
             }
 
-            // The chain advanced: complete the previous block before resetting state.
+            // The chain advanced. Keep the just superseded block's state so we can attempt
+            // best-effort completion after publishing the new height. We are
+            // keeping it off the critical path of serving the new pre-confirmed block.
             if height > state.block_number {
-                if state.block_identifier.is_some() && state.accumulated.is_some() {
-                    let committed_head = current.borrow().0;
-                    complete_previous_block(&sequencer, &mut state, &cache, committed_head).await;
+                let prev = std::mem::replace(
+                    &mut state,
+                    State {
+                        block_number: height,
+                        ..State::default()
+                    },
+                );
+                if prev.block_identifier.is_some() && prev.accumulated.is_some() {
+                    prev_to_complete = Some(prev);
                 }
-                state = State {
-                    block_number: height,
-                    ..State::default()
-                };
             }
         }
 
@@ -248,6 +256,19 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
             cache.mark_fresh();
         }
 
+        // Complete the just-superseded block off the critical path. The new
+        // height is already in the cache, the aim is to capture any tail transactions
+        // that landed before the block was superseded. The store will only
+        // succeed if the new height didn't itself chain to the committed head.
+        if let Some(prev) = prev_to_complete {
+            let sequencer = sequencer.clone();
+            let cache = cache.clone();
+            let committed_head = current.borrow().0;
+            tokio::spawn(async move {
+                complete_previous_block(&sequencer, prev, &cache, committed_head).await;
+            });
+        }
+
         // Wait for the next tick.
         wait_for_next_poll(t_fetch + poll_interval, &cache).await;
     }
@@ -265,7 +286,7 @@ async fn wait_for_next_poll(deadline: Instant, cache: &PendingDataCache) {
 /// transactions that landed before it was superseded. Best-effort.
 async fn complete_previous_block<S: GatewayApi + Send + 'static>(
     sequencer: &S,
-    state: &mut State,
+    mut state: State,
     cache: &PendingDataCache,
     committed_head: BlockNumber,
 ) {
@@ -311,6 +332,16 @@ fn store_pre_confirmed(
     block: Box<PreConfirmedBlock>,
     pre_latest_data: Option<Box<(BlockNumber, PreLatestBlock, StateUpdate)>>,
 ) {
+    // Do not allow the cached height to regress.
+    let cached = cache.pre_confirmed_block_number();
+    if number < cached {
+        tracing::debug!(
+            %number, %cached,
+            "Pre-confirmed store would regress the cached height; skipping store"
+        );
+        return;
+    }
+
     // Reject views that don't chain to the committed head.
     let next_block_number = pre_latest_data
         .as_ref()
@@ -1029,7 +1060,7 @@ mod tests {
             });
 
         // We're tracking block 11 with one receipted transaction already merged.
-        let mut state = State {
+        let state = State {
             block_number: BlockNumber::new_or_panic(11),
             block_identifier: Some(BLOCK_ID.to_string()),
             accumulated: Some(all_receipted_block(1)),
@@ -1041,13 +1072,7 @@ mod tests {
         let _ = rx.borrow_and_update();
 
         // Committed head 10, so block 11 still chains and is stored.
-        complete_previous_block(
-            &sequencer,
-            &mut state,
-            &cache,
-            BlockNumber::new_or_panic(10),
-        )
-        .await;
+        complete_previous_block(&sequencer, state, &cache, BlockNumber::new_or_panic(10)).await;
 
         assert!(
             rx.has_changed().unwrap(),

--- a/crates/pending-data/src/cache.rs
+++ b/crates/pending-data/src/cache.rs
@@ -43,13 +43,28 @@ pub enum ReadError {
 /// Shared pre-confirmed data cache with freshness tracking.
 ///
 /// Holds the latest [`PendingData`] and a small amount of freshness state.
-/// - Writes via [`Self::store`] / [`Self::mark_fresh`] / [`Self::mark_stale`] /
-///   [`Self::mark_unavailable`].
+///
+/// There are two distinct channels, because streaming subscribers and
+/// point-in-time readers have different needs:
+/// - the **subscriber stream** (`subscriber_tx`) carries *every* published
+///   view, including the final tail of a just-superseded block (see
+///   [`Self::publish_tail`]); subscribers dedupe per block, so a brief
+///   non-monotonic blip is fine and no transaction is lost.
+/// - the **read view** (`read_tx`) only ever moves forward, so
+///   [`Self::read`]/[`Self::try_read`] never observe the pre-confirmed height
+///   going backwards.
+///
+/// - Writes via [`Self::store`] / [`Self::publish_tail`] / [`Self::mark_fresh`]
+///   / [`Self::mark_stale`] / [`Self::mark_unavailable`].
 /// - Reads via [`Self::read`] (returns fresh data, blocks while stale, fails
 ///   fast while unavailable) and [`Self::subscribe`] for streaming.
 pub struct PendingDataCache {
-    data_tx: watch::Sender<PendingData>,
-    data_rx: watch::Receiver<PendingData>,
+    /// Streaming firehose: every published view, monotonic or not.
+    subscriber_tx: watch::Sender<PendingData>,
+    subscriber_rx: watch::Receiver<PendingData>,
+    /// Forward-only view served to RPC readers.
+    read_tx: watch::Sender<PendingData>,
+    read_rx: watch::Receiver<PendingData>,
     on_read: Arc<Notify>,
     freshness_tx: watch::Sender<Freshness>,
     last_read: Mutex<Instant>,
@@ -65,11 +80,14 @@ impl PendingDataCache {
     pub const DEFAULT_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(60);
 
     pub fn new() -> Self {
-        let (data_tx, data_rx) = watch::channel(PendingData::default());
+        let (subscriber_tx, subscriber_rx) = watch::channel(PendingData::default());
+        let (read_tx, read_rx) = watch::channel(PendingData::default());
         let (freshness_tx, _) = watch::channel(Freshness::default());
         Self {
-            data_tx,
-            data_rx,
+            subscriber_tx,
+            subscriber_rx,
+            read_tx,
+            read_rx,
             on_read: Arc::new(Notify::new()),
             freshness_tx,
             last_read: Mutex::new(Instant::now()),
@@ -89,9 +107,36 @@ impl PendingDataCache {
     }
 
     /// Writes fresh data into the cache and marks it fresh.
+    ///
+    /// The view reaches subscribers unconditionally. The read view only adopts
+    /// it when it does not regress the pre-confirmed height, so out-of-order or
+    /// stale writes can never move RPC readers backwards. This guard is atomic
+    /// (performed under the watch lock), so concurrent writers cannot
+    /// interleave a regression.
     pub fn store(&self, data: PendingData) {
-        self.data_tx.send_replace(data);
+        self.subscriber_tx.send_replace(data.clone());
+
+        let number = data.pre_confirmed_block_number();
+        let mut data = Some(data);
+        self.read_tx.send_if_modified(|current| {
+            if number >= current.pre_confirmed_block_number() {
+                *current = data.take().expect("closure runs at most once");
+                true
+            } else {
+                false
+            }
+        });
+
         self.bump_freshness();
+    }
+
+    /// Publishes a view to subscribers only, without advancing the read view.
+    ///
+    /// Used to deliver the final (tail) transactions of a just-superseded
+    /// pre-confirmed block to streaming subscribers — which dedupe per block —
+    /// while leaving the newer block that RPC readers see untouched.
+    pub fn publish_tail(&self, data: PendingData) {
+        self.subscriber_tx.send_replace(data);
     }
 
     /// Marks the cache fresh without replacing its contents.
@@ -136,7 +181,7 @@ impl PendingDataCache {
     pub async fn read(&self) -> Result<PendingData, ReadError> {
         self.signal_read();
         self.wait_for_fresh_data().await?;
-        Ok(self.data_rx.borrow().clone())
+        Ok(self.read_rx.borrow().clone())
     }
 
     /// Returns the latest cached data if it is fresh, `None` otherwise.
@@ -144,7 +189,7 @@ impl PendingDataCache {
     pub fn try_read(&self) -> Option<PendingData> {
         self.signal_read();
         match self.freshness_tx.borrow().status {
-            Status::Fresh => Some(self.data_rx.borrow().clone()),
+            Status::Fresh => Some(self.read_rx.borrow().clone()),
             Status::Stale | Status::Unavailable(_) => None,
         }
     }
@@ -155,17 +200,18 @@ impl PendingDataCache {
     /// idle/suspend accounting. Intended for protecting against a stale write
     /// decreasing the cached height.
     pub fn pre_confirmed_block_number(&self) -> BlockNumber {
-        self.data_rx.borrow().pre_confirmed_block_number()
+        self.read_rx.borrow().pre_confirmed_block_number()
     }
 
-    /// A fresh `watch::Receiver` for awaiting changes directly.
+    /// A fresh `watch::Receiver` over the subscriber stream for awaiting
+    /// changes directly.
     pub fn subscribe(&self) -> watch::Receiver<PendingData> {
         self.signal_read();
-        self.data_rx.clone()
+        self.subscriber_rx.clone()
     }
 
     pub fn subscriber_count(&self) -> usize {
-        self.data_tx
+        self.subscriber_tx
             .receiver_count()
             // Exclude the cache's own internal receiver from the count.
             .saturating_sub(1)
@@ -464,6 +510,44 @@ mod tests {
         let cache = PendingDataCache::new();
         cache.mark_stale();
         assert!(cache.try_read().is_none());
+    }
+
+    #[tokio::test]
+    async fn store_does_not_regress_read_view_but_notifies_subscribers() {
+        let cache = PendingDataCache::new();
+        let mut sub = cache.subscribe();
+        let _ = sub.borrow_and_update();
+
+        let high = sample_data(20);
+        cache.store(high.clone());
+        // A lower height (e.g. a late/out-of-order write) must not regress reads.
+        let low = sample_data(8);
+        cache.store(low.clone());
+
+        // Read view stays at the higher block.
+        assert_eq!(cache.read().await.unwrap(), high);
+        // Subscriber saw the most recent publish regardless of height.
+        assert!(sub.has_changed().unwrap());
+        assert_eq!(*sub.borrow_and_update(), low);
+    }
+
+    #[tokio::test]
+    async fn publish_tail_notifies_subscribers_without_advancing_read_view() {
+        let cache = PendingDataCache::new();
+        let mut sub = cache.subscribe();
+        let _ = sub.borrow_and_update();
+
+        let head = sample_data(20);
+        cache.store(head.clone());
+
+        let tail = sample_data(18);
+        cache.publish_tail(tail.clone());
+
+        // Readers still see the head block.
+        assert_eq!(cache.read().await.unwrap(), head);
+        // Subscribers received the tail.
+        assert!(sub.has_changed().unwrap());
+        assert_eq!(*sub.borrow_and_update(), tail);
     }
 
     #[tokio::test]

--- a/crates/pending-data/src/cache.rs
+++ b/crates/pending-data/src/cache.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use pathfinder_common::BlockNumber;
 use tokio::sync::{watch, Notify};
 use tokio::time::Instant;
 
@@ -146,6 +147,15 @@ impl PendingDataCache {
             Status::Fresh => Some(self.data_rx.borrow().clone()),
             Status::Stale | Status::Unavailable(_) => None,
         }
+    }
+
+    /// The pre-confirmed block number currently held in the cache.
+    ///
+    /// Reads without firing the read signal, so it does not affect
+    /// idle/suspend accounting. Intended for protecting against a stale write
+    /// decreasing the cached height.
+    pub fn pre_confirmed_block_number(&self) -> BlockNumber {
+        self.data_rx.borrow().pre_confirmed_block_number()
     }
 
     /// A fresh `watch::Receiver` for awaiting changes directly.

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -445,10 +445,16 @@ mod tests {
         let result = uut.get(&tx, RpcVersion::V09).unwrap();
         pretty_assertions_sorted::assert_eq_sorted!(result, pending);
 
-        // Pre-latest block will be same as `latest` which is also valid, but in this
-        // case the pre-latest block should be ignored.
-        let pending = valid_pre_confirmed_block_with_pre_latest(&parent);
-        cache.store(pending);
+        // Now the pre-latest block (`latest + 1`) is itself finalized into storage,
+        // advancing the committed head to it. The same pre-confirmed view is still
+        // cached (the read view is monotonic, so we cannot model this by storing a
+        // lower-numbered view, it would be ignored). The now-committed pre-latest must
+        // no longer be reported as pending: we serve the pre-confirmed against
+        // the new head and drop the pre-latest.
+        let child = latest
+            .child_builder()
+            .finalize_with_hash(block_hash_bytes!(b"child hash"));
+        tx.insert_block_header(&child).unwrap();
 
         let result = uut.get(&tx, RpcVersion::V09).unwrap();
         // We got a non-empty pre-confirmed block..


### PR DESCRIPTION
This PR is based on [the 1st pending data optimization PR](https://github.com/equilibriumco/pathfinder/pull/3496), and is a preparation for a follow-up PR which will address the issue of chaining within a gap larger than 2 blocks from the latest preconfirmed to the latest block locally committed to storage, which is the major culprit in preconfirmed latency as we experience it today.

The PR takes advantage of the fact that `complete_previous_block` can be taken off the critical path and hence the cache can be updated faster with the latest preconfirmed, while any remaining tail transactions to the previous block will still be served for the subscriptions, without re-invalidating the latest RPC read view.

For this reason two consumers of the cache were introduced:
- the read view, which must never regress and provides the latest state,
- the subscriber view, which provides out-of order tail transactions of the previous block in case `complete_previous_block` yielded any.

Other changes in the PR:
1. The `next_block_number != committed_head + 1` in `store_pre_confirmed` is relaxed, because it relies on the `current` watch which can briefly lag behind the DB. When it lags by one, a perfectly good pre-confirmed view fails the exact check and is dropped. Exact chaining remains the RPC read path's responsibility. Earlier, this was somewhat redundant on the sync and RPC side of things.

2. `try_from_pre_confirmed_block` and `try_from_pre_confirmed_and_pre_latest` are now called from within `block_in_place` to make sure that other task are making progress in a multithreaded runtime (these calls are otherwise inlined in tests).
