### PR TITLE
feat(pending): maintain full preconfirmed window down to the local committed head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - RPC method-call latency is now exported as a Prometheus histogram in seconds, `rpc_method_calls_duration_seconds` (`_bucket`/`_sum`/`_count`), replacing the summary `rpc_method_calls_duration_milliseconds`. Update alerts and dashboards to the new name and derive quantiles with `histogram_quantile(...)` over the `_bucket` series; see `docs/docs/monitoring-and-metrics.md`.
+- Preconfirmed blocks are now accumulated from the local commit head to the preconfirmed tip, improving RPC latency.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9023,6 +9023,7 @@ version = "0.22.7"
 dependencies = [
  "anyhow",
  "pathfinder-common",
+ "pathfinder-crypto",
  "starknet-gateway-types",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -233,8 +233,8 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
         {
             Ok(r) => r,
             Err(err) => {
-                // A transient failure must invalidate the cache. We serve the last good view as
-                // a best effort until a poll succeeds again.
+                // A transient failure must not invalidate the cache. We serve the last good
+                // view as a best effort until a poll succeeds again.
                 tracing::debug!(%err, "Failed to fetch pre-confirmed block; retaining last view");
                 cache.mark_fresh();
                 wait_for_next_poll(t_fetch + poll_interval, &cache).await;

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
+use futures::StreamExt;
 use pathfinder_common::{BlockHash, BlockNumber};
 use pathfinder_pending_data::{PendingData, PendingDataCache, PreLatestData};
 use starknet_gateway_client::{BlockId, GatewayApi};
@@ -32,6 +33,13 @@ impl Default for State {
 }
 
 impl State {
+    pub fn new(block_number: BlockNumber) -> Self {
+        Self {
+            block_number,
+            ..Default::default()
+        }
+    }
+
     fn tx_count(&self) -> u64 {
         self.accumulated
             .as_ref()
@@ -158,9 +166,9 @@ impl Window {
         self.generation += 1;
     }
 
-    /// Collect the parents in the range `(committed, tip)`, oldest
-    /// to newest. `None` if any block inbetween is missing (e.g. cold
-    /// start, or a block that failed deserialization/conversion).
+    /// Collect the parents in the range `(committed, tip)`, oldest to newest.
+    /// `None` if any block inbetween is missing (e.g. cold start, or a block
+    /// that failed deserialization/conversion).
     fn collect(&self, committed: BlockNumber, tip: BlockNumber) -> Option<Vec<Arc<PreLatestData>>> {
         let mut parents = Vec::new();
         let mut expected = committed + 1;
@@ -169,6 +177,19 @@ impl Window {
             expected += 1;
         }
         Some(parents)
+    }
+
+    /// Get block numbers for entries missing in the range `(committed, tip)`.
+    fn missing(&self, committed: BlockNumber, tip: BlockNumber) -> Vec<BlockNumber> {
+        let mut missing = Vec::new();
+        let mut i = committed + 1;
+        while i < tip {
+            if !self.blocks.contains_key(&i) {
+                missing.push(i);
+            }
+            i += 1;
+        }
+        missing
     }
 }
 
@@ -308,10 +329,8 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
         let changed = state.apply(response);
         let number = state.block_number;
 
-        // Prune committed blocks, then collect the parents that fill the gap
-        // `(committed, number)`. None means a hole exists in the window (cold start
-        // or a block that failed deserialization/conversion), which is a temporary
-        // situation that self-heals overtime.
+        // Prune committed blocks and collect the parents that fill the gap
+        // `(committed, number)`.
         let (bridge, generation) = {
             let mut window = window.lock().unwrap();
             window.prune(committed);
@@ -322,6 +341,10 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
             };
             (bridge, window.generation)
         };
+
+        // Fetch any missing blocks if there is a hole in the window.
+        let (bridge, generation) =
+            fetch_missing_blocks(&sequencer, &window, committed, number, bridge, generation).await;
 
         match bridge {
             // Serve when the tip's own contents changed, when the tip advanced, or when the window
@@ -353,14 +376,13 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
                 tracing::trace!("No change in pre-confirmed block data");
                 cache.mark_fresh();
             }
-            // There is a hole that no provisional entry covered. This is due to a cold start into a
-            // larger gap. Defer until the gap is closed by the advancing height committed into
-            // storage.
+            // We failed to fetch a missing block or the tip is not ahead of committed. Keep the
+            // last good view.
             None => {
                 if number > committed {
                     tracing::debug!(
                         block_number = %number, %committed,
-                        "Pre-confirmed window has a hole; deferring until finalisation closes the gap"
+                        "Pre-confirmed window has a hole; deferring until retry on the next poll"
                     );
                 }
                 cache.mark_fresh();
@@ -381,6 +403,69 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
         // Wait for the next tick.
         wait_for_next_poll(t_fetch + poll_interval, &cache).await;
     }
+}
+
+/// If necessary: fetch missing blocks in the range `(committed, number)` all at
+/// once, fill the window with them and return the collected parents and updated
+/// generation. Best-effort.
+async fn fetch_missing_blocks<S: GatewayApi + Clone + Send + 'static>(
+    sequencer: &S,
+    window: &Arc<Mutex<Window>>,
+    committed: BlockNumber,
+    number: BlockNumber,
+    bridge: Option<Vec<Arc<PreLatestData>>>,
+    generation: u64,
+) -> (Option<Vec<Arc<PreLatestData>>>, u64) {
+    // No hole or tip not ahead
+    if bridge.is_some() || number <= committed {
+        return (bridge, generation);
+    }
+
+    let missing = window.lock().unwrap().missing(committed, number);
+    if missing.is_empty() {
+        return (bridge, generation);
+    }
+
+    let concurrency = missing.len();
+    let fetched = futures::stream::iter(missing)
+        .map(|n| fetch_missing_block(sequencer, n))
+        .buffer_unordered(concurrency)
+        .collect::<Vec<_>>()
+        .await;
+    let mut window = window.lock().unwrap();
+    for entry in fetched.into_iter().flatten() {
+        let n = entry.block.number;
+        window.record(n, entry, true);
+    }
+    (window.collect(committed, number), window.generation)
+}
+
+/// Fetch a missing window block by number and convert it to a window entry.
+/// Best-effort.
+async fn fetch_missing_block<S: GatewayApi + Send + 'static>(
+    sequencer: &S,
+    number: BlockNumber,
+) -> Option<Arc<PreLatestData>> {
+    let response = match sequencer.preconfirmed_block(number.into(), None, 0).await {
+        Ok(r) => r,
+        Err(err) => {
+            tracing::debug!(%number, %err, "Failed to fetch missing window block");
+            return None;
+        }
+    };
+
+    let mut state = State::new(number);
+    if state.apply(response) {
+        if let Some(block) = state.accumulated {
+            match run_cpu_bound(|| {
+                PendingData::try_from_pre_confirmed_block(Box::new(block), number)
+            }) {
+                Ok(pending) => return Some(Arc::new(pending.to_pre_latest_data())),
+                Err(e) => tracing::debug!(%number, error = %e, "Could not convert gap-fill block"),
+            }
+        }
+    }
+    None
 }
 
 /// Sleeps until `deadline`, returning early if the cache is read.
@@ -1002,7 +1087,7 @@ mod tests {
         }
 
         #[test]
-        fn collect_a_hole_yields_none() {
+        fn collect_with_a_hole_returns_none() {
             let window = with_blocks(&[6, 8], &[]);
             assert!(window.collect(bn(5), bn(9)).is_none());
         }
@@ -1065,6 +1150,24 @@ mod tests {
             assert!(!window.blocks.contains_key(&bn(7)));
             assert!(window.blocks.contains_key(&bn(8)));
         }
+
+        #[test]
+        fn missing_reports_holes_in_the_open_range() {
+            let window = with_blocks(&[6, 8], &[]);
+            assert_eq!(window.missing(bn(5), bn(9)), vec![bn(7)]);
+        }
+
+        #[test]
+        fn missing_reports_empty_for_a_complete_window() {
+            let window = with_blocks(&[6, 7, 8], &[]);
+            assert!(window.missing(bn(5), bn(9)).is_empty());
+        }
+
+        #[test]
+        fn missing_covers_the_whole_open_range_for_empty_window() {
+            let window = with_blocks(&[], &[]);
+            assert_eq!(window.missing(bn(5), bn(9)), vec![bn(6), bn(7), bn(8)]);
+        }
     }
 
     fn block_with_tx(tag: TransactionHash) -> PreConfirmedBlock {
@@ -1097,6 +1200,10 @@ mod tests {
             12 => transaction_hash!("0x12"),
             _ => transaction_hash!("0x13"),
         }
+    }
+
+    fn tx_at(height: u64) -> TransactionHash {
+        TransactionHash(pathfinder_crypto::Felt::from_u64(height))
     }
 
     /// End-to-end: with finalisation lagging (committed head fixed, no gateway
@@ -1300,5 +1407,116 @@ mod tests {
             *calls.lock().unwrap() > count_at_idle,
             "polling should resume after a cache read"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cold_start_gap_is_filled_and_served() {
+        use starknet_gateway_client::BlockId;
+
+        let mut sequencer = MockGatewayApi::new();
+        sequencer
+            .expect_preconfirmed_block()
+            .returning(move |block_id, _, _| {
+                let number = match block_id {
+                    BlockId::Latest => 14,
+                    BlockId::Number(n) => n.get(),
+                    other => panic!("unexpected block id: {other:?}"),
+                };
+                Ok(PreConfirmedPollResponse::Full {
+                    identifier: format!("id-{number}"),
+                    block_number: Some(BlockNumber::new_or_panic(number)),
+                    block: block_with_tx(tx_at(number)),
+                })
+            });
+
+        let committed = BlockNumber::new_or_panic(10);
+        let cache = Arc::new(PendingDataCache::new());
+        let mut sub = cache.subscribe();
+        let _ = sub.borrow_and_update();
+
+        spawn_producer(sequencer, committed, block_hash!("0xbeef"), cache.clone());
+
+        let deadline = tokio::time::Instant::now() + TEST_TIMEOUT;
+        loop {
+            tokio::time::timeout_at(deadline, sub.changed())
+                .await
+                .expect("producer should serve the full window before timeout")
+                .unwrap();
+            let pending = sub.borrow().clone();
+            if pending.pre_confirmed_block_number() != BlockNumber::new_or_panic(14) {
+                continue;
+            }
+            let parents: Vec<_> = pending.parent_blocks().map(|p| p.block.number).collect();
+            assert_eq!(
+                parents,
+                vec![
+                    BlockNumber::new_or_panic(11),
+                    BlockNumber::new_or_panic(12),
+                    BlockNumber::new_or_panic(13),
+                ]
+            );
+            // All transactions are present, the entire window was filled and served.
+            assert!(pending.find_transaction(tx_at(11)).is_some());
+            assert!(pending.find_transaction(tx_at(12)).is_some());
+            assert!(pending.find_transaction(tx_at(13)).is_some());
+            assert!(pending.find_transaction(tx_at(14)).is_some());
+            break;
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn gap_fill_retries_after_a_failed_fetch() {
+        use starknet_gateway_client::BlockId;
+        use starknet_gateway_types::error::SequencerError;
+
+        let mut sequencer = MockGatewayApi::new();
+        // The first fetch of block 12 fails, others succeed.
+        static BLOCK_12_CALLS: Mutex<u64> = Mutex::new(0);
+        sequencer
+            .expect_preconfirmed_block()
+            .returning(move |block_id, _, _| {
+                let number = match block_id {
+                    BlockId::Latest => 13,
+                    BlockId::Number(n) => n.get(),
+                    other => panic!("unexpected block id: {other:?}"),
+                };
+                if number == 12 {
+                    let mut calls = BLOCK_12_CALLS.lock().unwrap();
+                    *calls += 1;
+                    if *calls == 1 {
+                        return Err(SequencerError::InvalidResponse("boom".into()));
+                    }
+                }
+                Ok(PreConfirmedPollResponse::Full {
+                    identifier: format!("id-{number}"),
+                    block_number: Some(BlockNumber::new_or_panic(number)),
+                    block: block_with_tx(tx_at(number)),
+                })
+            });
+
+        let committed = BlockNumber::new_or_panic(10);
+        let cache = Arc::new(PendingDataCache::new());
+        let mut sub = cache.subscribe();
+        let _ = sub.borrow_and_update();
+
+        spawn_producer(sequencer, committed, block_hash!("0xbeef"), cache.clone());
+
+        let deadline = tokio::time::Instant::now() + TEST_TIMEOUT;
+        loop {
+            tokio::time::timeout_at(deadline, sub.changed())
+                .await
+                .expect("producer serve the full window before timeout")
+                .unwrap();
+            let pending = sub.borrow().clone();
+            if pending.pre_confirmed_block_number() != BlockNumber::new_or_panic(13) {
+                continue;
+            }
+            let parents: Vec<_> = pending.parent_blocks().map(|p| p.block.number).collect();
+            if parents == vec![BlockNumber::new_or_panic(11), BlockNumber::new_or_panic(12)] {
+                // Fetching block 12 was retried.
+                assert!(*BLOCK_12_CALLS.lock().unwrap() >= 2);
+                break;
+            }
+        }
     }
 }

--- a/crates/pathfinder/src/state/sync/pending.rs
+++ b/crates/pathfinder/src/state/sync/pending.rs
@@ -1,101 +1,182 @@
-use std::sync::Arc;
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
 
 use pathfinder_common::{BlockHash, BlockNumber};
-use pathfinder_pending_data::{PendingData, PendingDataCache};
-use starknet_gateway_client::GatewayApi;
+use pathfinder_pending_data::{PendingData, PendingDataCache, PreLatestData};
+use starknet_gateway_client::{BlockId, GatewayApi};
 use starknet_gateway_types::reply::{PreConfirmedBlock, PreConfirmedPollResponse};
 use tokio::sync::watch;
 use tokio::time::Instant;
 
-/// The pre-confirmed block we're building up, kept between polls so the gateway
-/// can send just the new transactions each time instead of the whole block.
 #[derive(Debug)]
-struct Tracked {
-    /// The pre-confirmed height this view is for.
-    number: BlockNumber,
-    /// The gateway's id for the view we're holding.
-    identifier: String,
-    /// The block we've merged so far, at height `number`.
-    block: PreConfirmedBlock,
+struct State {
+    /// Height we're currently polling.
+    block_number: BlockNumber,
+    /// Server-given block identifier from the last successful poll. `None`
+    /// until we've completed our first poll for this height. The server uses
+    /// this to detect when our view is stale and needs a full rebuild.
+    block_identifier: Option<String>,
+    /// Running merged view of the preconfirmed block at `block_number`.
+    /// `None` until we've received our first response for this height.
+    accumulated: Option<PreConfirmedBlock>,
 }
 
-impl Tracked {
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            block_number: BlockNumber::GENESIS,
+            block_identifier: None,
+            accumulated: None,
+        }
+    }
+}
+
+impl State {
     fn tx_count(&self) -> u64 {
-        self.block.transactions.len() as u64
+        self.accumulated
+            .as_ref()
+            .map(|b| b.transactions.len() as u64)
+            .unwrap_or(0)
     }
-}
 
-/// What we already have at `height`: our id and tx count if we're holding it,
-/// or empty to fetch the whole block.
-fn delta_cursor(tracked: &Option<Tracked>, height: BlockNumber) -> (Option<String>, u64) {
-    match tracked {
-        Some(t) if t.number == height => (Some(t.identifier.clone()), t.tx_count()),
-        _ => (None, 0),
-    }
-}
+    /// Apply a fresh poll response. Returns `true` if `accumulated` was
+    /// updated and the caller should emit the new view.
+    fn apply(&mut self, response: PreConfirmedPollResponse) -> bool {
+        match response {
+            PreConfirmedPollResponse::Unchanged => false,
 
-/// Merge a poll response into the tracked view at `target`. Returns `true` when
-/// the published view should be refreshed.
-fn apply(
-    tracked: &mut Option<Tracked>,
-    target: BlockNumber,
-    response: PreConfirmedPollResponse,
-) -> bool {
-    match response {
-        PreConfirmedPollResponse::Unchanged => false,
-
-        PreConfirmedPollResponse::Delta {
-            identifier,
-            new_transactions,
-            new_receipts,
-            new_state_diffs,
-        } => {
-            // A delta only applies on top of the exact view it was computed from,
-            // so the height and identifier have to match.
-            let matched = tracked
-                .as_mut()
-                .filter(|t| t.number == target && t.identifier == identifier);
-            let Some(tracked) = matched else {
-                tracing::warn!(%target, "Delta response with no matching tracked view; skipping");
-                return false;
-            };
-            if new_transactions.is_empty() {
-                return false;
-            }
-            tracked.block.transactions.extend(new_transactions);
-            tracked.block.transaction_receipts.extend(new_receipts);
-            tracked
-                .block
-                .transaction_state_diffs
-                .extend(new_state_diffs);
-            true
-        }
-
-        PreConfirmedPollResponse::Full {
-            identifier, block, ..
-        } => {
-            // A Full response can repeat the view we already have. Only publish
-            // on a real change: a new identifier or more transactions.
-            let changed = match tracked.as_ref() {
-                Some(t) if t.number == target => {
-                    t.identifier != identifier || block.transactions.len() as u64 > t.tx_count()
-                }
-                _ => true,
-            };
-            *tracked = Some(Tracked {
-                number: target,
+            PreConfirmedPollResponse::Delta {
                 identifier,
+                new_transactions,
+                new_receipts,
+                new_state_diffs,
+            } => {
+                // Per spec, the server only sends a delta when its identifier matches
+                // ours. A mismatch indicates a server bug or local state corruption;
+                // skip defensively and wait for the next poll (which our stored identifier
+                // will not match server's, triggering a full rebuild).
+                if self.block_identifier.as_ref() != Some(&identifier) {
+                    tracing::warn!(
+                        ours = ?self.block_identifier,
+                        theirs = %identifier,
+                        "delta response identifier doesn't match ours; skipping"
+                    );
+                    return false;
+                }
+                if new_transactions.is_empty() {
+                    return false;
+                }
+                let acc = self
+                    .accumulated
+                    .as_mut()
+                    .expect("accumulated present whenever block_identifier is Some");
+                acc.transactions.extend(new_transactions);
+                acc.transaction_receipts.extend(new_receipts);
+                acc.transaction_state_diffs.extend(new_state_diffs);
+                true
+            }
+
+            PreConfirmedPollResponse::Full {
+                identifier,
+                block_number: _,
                 block,
-            });
-            changed
+            } => {
+                // Emit on either independent signal:
+                //  - the server's identifier changed (round bump, new height, or first poll)
+                //  - new transactions arrived
+                // Otherwise suppress: pre-0.14.3 gateways re-serve the same view across
+                // polls and we don't want to bombard downstream with redundant events.
+                let identifier_changed = self.block_identifier.as_ref() != Some(&identifier);
+                let new_txs_arrived = (block.transactions.len() as u64) > self.tx_count();
+
+                if identifier_changed || new_txs_arrived {
+                    self.block_identifier = Some(identifier);
+                    self.accumulated = Some(block);
+                    true
+                } else {
+                    false
+                }
+            }
         }
     }
 }
 
-/// Emits new pending data while the current block is close to the latest block.
+/// The un-committed blocks below the current pre-confirmed tip, keyed by block
+/// number, used both to compose the aggregated execution overlay and as the
+/// served `ancestors`.
 ///
-/// Suspends polling once the cache reports itself idle and resumes on the next
-/// read.
+/// There are two sources of entries:
+/// - *provisional* (`complete = false`): the recent preconfirmed tip, just
+///   superseded by the current new preconfirmed tip. It may be missing some
+///   tail data, which will be filled in by [`complete_previous_block`].
+/// - *complete* (`complete = true`): full block, filled by
+///   [`complete_previous_block`], no tail data missing.
+///
+/// A provisional entry allows the new tip to be served immediately and the
+/// window stays contiguous. `generation` advances on every content change so
+/// the producer re-serves a fuller view.
+#[derive(Default)]
+struct Window {
+    blocks: BTreeMap<BlockNumber, WindowEntry>,
+    /// Bumped when an entry is added (new tip) or upgraded (tip is extended
+    /// with new data or tip - 1 gets its tail data via
+    /// [`complete_previous_block`]). The producer serves again when the
+    /// generation changes compared to the last served generation, so any update
+    /// is visible right away to the readers.
+    generation: u64,
+}
+
+struct WindowEntry {
+    data: Arc<PreLatestData>,
+    /// `false` for a provisional accumulated placeholder (which may be missing
+    /// tail data), `true` when upgraded with any missing tail by
+    /// [`complete_previous_block`].
+    complete: bool,
+}
+
+impl Window {
+    /// Prune the window from the bottom, removing any blocks that have been
+    /// committed.
+    fn prune(&mut self, committed: BlockNumber) {
+        self.blocks.retain(|&n, _| n > committed);
+    }
+
+    /// Either a provisional entry only fills an empty slot or a complete entry
+    /// upgrades a provisional entry. Generation is then incremented.
+    ///
+    /// Does nothing otherwise (ie. a complete slot cannot be updated, a
+    /// provisional entry cannot replace an existing provisional entry).
+    fn record(&mut self, number: BlockNumber, data: Arc<PreLatestData>, complete: bool) {
+        match self.blocks.get(&number) {
+            // The existing entry if complete, nothing more to do.
+            Some(existing) if existing.complete => return,
+            // A provisional record can't replace an existing provisional one.
+            Some(_) if !complete => return,
+            _ => {}
+        }
+        self.blocks.insert(number, WindowEntry { data, complete });
+        self.generation += 1;
+    }
+
+    /// Collect the parents in the range `(committed, tip)`, oldest
+    /// to newest. `None` if any block inbetween is missing (e.g. cold
+    /// start, or a block that failed deserialization/conversion).
+    fn collect(&self, committed: BlockNumber, tip: BlockNumber) -> Option<Vec<Arc<PreLatestData>>> {
+        let mut parents = Vec::new();
+        let mut expected = committed + 1;
+        while expected < tip {
+            parents.push(self.blocks.get(&expected)?.data.clone());
+            expected += 1;
+        }
+        Some(parents)
+    }
+}
+
+/// Emits new pending data events while the current block is close to the latest
+/// block.
+///
+/// Suspends polling once the cache reports itself idle and resumes on the
+/// next read.
 pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
     sequencer: S,
     poll_interval: std::time::Duration,
@@ -104,7 +185,18 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
     current: watch::Receiver<(BlockNumber, BlockHash)>,
     in_sync_threshold: u64,
 ) {
-    let mut tracked: Option<Tracked> = None;
+    let mut state = State::default();
+
+    // The un-committed window below the current tip. Any missing tail data is
+    // filled in by [`complete_previous_block`].
+    let window: Arc<Mutex<Window>> = Arc::new(Mutex::new(Window::default()));
+
+    // The `(tip, window generation)` we last served. View is served again when:
+    // 1. the tip is filled with more delta,
+    // 2. the tip's block number is incremented (a new tip),
+    // 3. window generation is incremented (tip-1 was completed by
+    //    [`complete_previous_block`]).
+    let mut served: Option<(BlockNumber, u64)> = None;
 
     loop {
         // Suspend if idle.
@@ -116,13 +208,13 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
 
         let t_fetch = Instant::now();
 
-        let (committed, committed_hash) = *current.borrow();
-        let gateway_latest = latest.borrow().0;
-
         // Skip while catching up to head.
-        if gateway_latest.get().abs_diff(committed.get()) > in_sync_threshold {
+        let latest_number = latest.borrow().0;
+        let current_number = current.borrow().0.get();
+
+        if latest_number.get().abs_diff(current_number) > in_sync_threshold {
             tracing::debug!(
-                latest = %gateway_latest, %committed,
+                latest = %latest_number.get(), current = %current_number,
                 "Not in sync yet; skipping pre-confirmed block download"
             );
             cache.mark_unavailable("syncing");
@@ -130,74 +222,163 @@ pub(super) async fn poll_pre_confirmed<S: GatewayApi + Clone + Send + 'static>(
             continue;
         }
 
-        // The pre-latest sits at committed+1, decided in consensus and only
-        // awaiting its block hash; the pre-confirmed at committed+2 is still
-        // building. Fetch both by number so they chain onto our head by
-        // construction. The pre-confirmed carries deltas between polls; the
-        // pre-latest is settled, so we take it whole each time.
-        let pre_latest_height = committed + 1;
-        let pre_confirmed_height = committed + 2;
-        let (cursor_id, cursor_count) = delta_cursor(&tracked, pre_confirmed_height);
-        let (pre_latest_result, pre_confirmed_result) = tokio::join!(
-            sequencer.preconfirmed_block(pre_latest_height.into(), None, 0),
-            sequencer.preconfirmed_block(pre_confirmed_height.into(), cursor_id, cursor_count),
-        );
-
-        // The pre-latest is the foundation: without it nothing chains onto our
-        // head, so we keep serving the last good view and try again.
-        let (pre_latest_identifier, pre_latest_block) = match pre_latest_result {
-            Ok(PreConfirmedPollResponse::Full {
-                identifier, block, ..
-            }) => (identifier, block),
-            other => {
-                match other {
-                    Err(e) => {
-                        tracing::debug!(%e, %pre_latest_height, "Pre-latest fetch failed; retaining last view")
-                    }
-                    Ok(_) => {
-                        tracing::debug!(%pre_latest_height, "Pre-latest returned no full block; retaining last view")
-                    }
-                }
+        // Fetch the pre-confirmed tip (block).
+        let response = match sequencer
+            .preconfirmed_block(
+                BlockId::Latest,
+                state.block_identifier.clone(),
+                state.tx_count(),
+            )
+            .await
+        {
+            Ok(r) => r,
+            Err(err) => {
+                // A transient failure must invalidate the cache. We serve the last good view as
+                // a best effort until a poll succeeds again.
+                tracing::debug!(%err, "Failed to fetch pre-confirmed block; retaining last view");
                 cache.mark_fresh();
                 wait_for_next_poll(t_fetch + poll_interval, &cache).await;
                 continue;
             }
         };
 
-        // A pre-confirmed above the pre-latest means we serve the two chained.
-        // When it isn't there yet, the pre-latest is itself the newest block, so
-        // we serve it alone at committed+1.
-        let (number, response, pre_latest) = match pre_confirmed_result {
-            Ok(response) => (
-                pre_confirmed_height,
-                response,
-                Some(Box::new((
-                    pre_latest_height,
-                    pre_latest_block,
-                    committed_hash,
-                ))),
-            ),
-            Err(e) => {
-                tracing::debug!(%e, %pre_confirmed_height, "No pre-confirmed above pre-latest; serving it alone");
-                let response = PreConfirmedPollResponse::Full {
-                    identifier: pre_latest_identifier,
-                    block_number: None,
-                    block: pre_latest_block,
-                };
-                (pre_latest_height, response, None)
-            }
+        // Reconcile state with the resolved height. The gateway only reports
+        // a height on `Full` responses to `latest` requests; everything else
+        // (Unchanged, Delta, and concrete-number Full) leaves state at its
+        // tracked block.
+        let resolved = match response {
+            PreConfirmedPollResponse::Full { block_number, .. } => block_number,
+            _ => None,
         };
 
-        // Merge and publish.
-        let changed = apply(&mut tracked, number, response);
-        match tracked.as_ref().filter(|_| changed) {
-            Some(t) => {
-                let block = t.block.clone();
-                store_pre_confirmed(&cache, number, block.into(), pre_latest);
+        // Set when the preconfirmed tip advances: the previous block to complete once
+        // the new height has been published.
+        let mut prev_to_complete: Option<State> = None;
+
+        if let Some(height) = resolved {
+            // A transient (?) lower-height shouldn't discard accumulated state.
+            if height < state.block_number && state.block_number != BlockNumber::GENESIS {
+                tracing::debug!(
+                    resolved = %height,
+                    current = %state.block_number,
+                    "Pre-confirmed resolved to a lower height than tracked; skipping poll"
+                );
+                // We assume this is just a hiccup and trust our tracked block
+                cache.mark_fresh();
+                wait_for_next_poll(t_fetch + poll_interval, &cache).await;
+                continue;
             }
-            None => cache.mark_fresh(),
+
+            // The preconfirmed tip advanced. Keep the previous block's state so we can
+            // complete it after publishing the new height. We keep completion of tip-1 off
+            // the critical path to avoid delaying serving the new tip to readers.
+            if height > state.block_number {
+                let prev = std::mem::replace(
+                    &mut state,
+                    State {
+                        block_number: height,
+                        ..State::default()
+                    },
+                );
+
+                // Provisionally fill the window with the previous block from our previous
+                // state, so the window stays contiguous and the new tip can be served
+                // on this poll instead of waiting for [`complete_previous_block`] to finish.
+                if let Some(block) = prev.accumulated.clone() {
+                    let prev_number = prev.block_number;
+                    if let Ok(pending) = run_cpu_bound(|| {
+                        PendingData::try_from_pre_confirmed_block(Box::new(block), prev_number)
+                    }) {
+                        window.lock().unwrap().record(
+                            prev_number,
+                            Arc::new(pending.to_pre_latest_data()),
+                            false,
+                        );
+                    }
+                }
+
+                if prev.block_identifier.is_some() && prev.accumulated.is_some() {
+                    prev_to_complete = Some(prev);
+                }
+            }
         }
 
+        let committed = current.borrow().0;
+
+        let changed = state.apply(response);
+        let number = state.block_number;
+
+        // Prune committed blocks, then collect the parents that fill the gap
+        // `(committed, number)`. None means a hole exists in the window (cold start
+        // or a block that failed deserialization/conversion), which is a temporary
+        // situation that self-heals overtime.
+        let (bridge, generation) = {
+            let mut window = window.lock().unwrap();
+            window.prune(committed);
+            let bridge = if number > committed {
+                window.collect(committed, number)
+            } else {
+                None
+            };
+            (bridge, window.generation)
+        };
+
+        match bridge {
+            // Serve when the tip's own contents changed, when the tip advanced, or when the window
+            // generation increased, i.e. when an updated view is available.
+            Some(parents) if changed || served != Some((number, generation)) => {
+                let accumulated = state
+                    .accumulated
+                    .clone()
+                    .expect("accumulated block present whenever the tip is bridgeable");
+                let built = run_cpu_bound(|| {
+                    let parents = parents.iter().map(|p| PreLatestData::clone(p)).collect();
+                    PendingData::from_window(Box::new(accumulated), number, parents, committed)
+                });
+                match built {
+                    Ok(pending) => {
+                        let pre_confirmed_tx_count = pending.pre_confirmed_transactions().len();
+                        cache.store(pending);
+                        served = Some((number, generation));
+                        tracing::debug!(block_number = %number, %committed, %pre_confirmed_tx_count, %generation, "Updated pre-confirmed data (windowed)");
+                    }
+                    Err(e) => tracing::info!(
+                        block_number = %number, error = %e,
+                        "Failed to build windowed pre-confirmed data, skipping update"
+                    ),
+                }
+            }
+            // Nothing new to serve for this tip, keep the cache fresh for cold-start readers.
+            Some(_) => {
+                tracing::trace!("No change in pre-confirmed block data");
+                cache.mark_fresh();
+            }
+            // There is a hole that no provisional entry covered. This is due to a cold start into a
+            // larger gap. Defer until the gap is closed by the advancing height committed into
+            // storage.
+            None => {
+                if number > committed {
+                    tracing::debug!(
+                        block_number = %number, %committed,
+                        "Pre-confirmed window has a hole; deferring until finalisation closes the gap"
+                    );
+                }
+                cache.mark_fresh();
+            }
+        }
+
+        // Complete the previous block off the critical path. Any missing tail data will
+        // be filled in the window, incrementing its generation, which is a signal to
+        // serve the fresher data on the next poll.
+        if let Some(prev) = prev_to_complete {
+            let sequencer = sequencer.clone();
+            let window = window.clone();
+            tokio::spawn(async move {
+                complete_previous_block(&sequencer, prev, &window).await;
+            });
+        }
+
+        // Wait for the next tick.
         wait_for_next_poll(t_fetch + poll_interval, &cache).await;
     }
 }
@@ -210,78 +391,114 @@ async fn wait_for_next_poll(deadline: Instant, cache: &PendingDataCache) {
     }
 }
 
-/// Convert a fresh pre-confirmed view and store it in the cache.
-///
-/// A failed conversion (say, candidate transactions) keeps the last good view.
-fn store_pre_confirmed(
-    cache: &PendingDataCache,
-    number: BlockNumber,
-    block: Box<PreConfirmedBlock>,
-    pre_latest: Option<Box<(BlockNumber, PreConfirmedBlock, BlockHash)>>,
+/// Run a CPU-bound closure without starving the async runtime. Falls back to
+/// inline execution on a current-thread runtime (e.g. in tests).
+fn run_cpu_bound<R>(f: impl FnOnce() -> R) -> R {
+    use tokio::runtime::{Handle, RuntimeFlavor};
+    match Handle::try_current().map(|h| h.runtime_flavor()) {
+        Ok(RuntimeFlavor::MultiThread) => tokio::task::block_in_place(f),
+        _ => f(),
+    }
+}
+
+/// Fetch any missing tail data for the previous pre-confirmed block and upgrade
+/// its window entry to a complete block so the next poll serves it in an
+/// updated view with by-then likely updated new tip.
+async fn complete_previous_block<S: GatewayApi + Send + 'static>(
+    sequencer: &S,
+    mut state: State,
+    window: &Mutex<Window>,
 ) {
-    match PendingData::try_from_pre_confirmed_and_pre_latest(block, number, pre_latest) {
-        Ok(pending) => {
-            cache.store(pending);
-            tracing::debug!(block_number = %number, "Updated pre-confirmed data");
+    let response = match sequencer
+        .preconfirmed_block(
+            state.block_number.into(),
+            state.block_identifier.clone(),
+            state.tx_count(),
+        )
+        .await
+    {
+        Ok(r) => r,
+        Err(err) => {
+            tracing::debug!(%err, "Completion query for previous pre-confirmed block failed");
+            return;
         }
-        Err(e) => {
-            tracing::info!(block_number=%number, error=%e, "Pre-confirmed failed validation; retaining last view");
-            cache.mark_fresh();
+    };
+
+    if state.apply(response) {
+        let accumulated = state
+            .accumulated
+            .as_ref()
+            .expect("accumulated present after successful completion apply");
+        let number = state.block_number;
+        let converted = run_cpu_bound(|| {
+            PendingData::try_from_pre_confirmed_block(Box::new(accumulated.clone()), number)
+        });
+        match converted {
+            Ok(pending) => {
+                // Upgrade the window entry to the complete block (full transactions,
+                // receipts/events and composed state diff).
+                window
+                    .lock()
+                    .unwrap()
+                    .record(number, Arc::new(pending.to_pre_latest_data()), true);
+            }
+            Err(e) => tracing::info!(
+                block_number = %number, error = %e,
+                "Failed to convert completed pre-confirmed block; skipping window upgrade"
+            ),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::Arc;
-    use std::time::Duration;
+    use std::sync::{Arc, Mutex};
 
     use pathfinder_common::macro_prelude::*;
-    use pathfinder_common::receipt::Receipt;
+    use pathfinder_common::prelude::*;
     use pathfinder_common::transaction::{L1HandlerTransaction, Transaction, TransactionVariant};
-    use pathfinder_common::{BlockHash, BlockNumber, TransactionIndex};
     use pathfinder_pending_data::PendingDataCache;
-    use starknet_gateway_client::{BlockId, MockGatewayApi};
-    use starknet_gateway_types::error::{KnownStarknetErrorCode, SequencerError, StarknetError};
+    use starknet_gateway_client::MockGatewayApi;
     use starknet_gateway_types::reply::{PreConfirmedBlock, PreConfirmedPollResponse, Status};
     use tokio::sync::watch;
-    use tokio::time::timeout;
 
-    use super::{apply, poll_pre_confirmed, Tracked};
+    use super::{complete_previous_block, poll_pre_confirmed, State};
 
-    const IN_SYNC: u64 = 6;
-    const TIMEOUT: Duration = Duration::from_secs(5);
+    const TEST_IN_SYNC_THRESHOLD: u64 = 6;
 
-    /// An L1-handler transaction with a small, distinct hash.
-    fn sample_tx(i: usize) -> Transaction {
-        let hash = match i {
-            0 => transaction_hash!("0x1"),
-            1 => transaction_hash!("0x2"),
-            _ => transaction_hash!("0x3"),
+    /// Arbitrary upper bound for awaiting a cache update in tests, so a failing
+    /// test fails fast instead of hanging.
+    const TEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+    /// A pre-confirmed block whose every transaction carries a receipt, so the
+    /// `try_from_pre_confirmed_block` conversion accepts it (it rejects blocks
+    /// containing candidate transactions).
+    fn all_receipted_block(n: usize) -> PreConfirmedBlock {
+        let receipted_tx = |i: usize| {
+            let hash = match i {
+                0 => transaction_hash!("0x1"),
+                1 => transaction_hash!("0x2"),
+                2 => transaction_hash!("0x3"),
+                _ => transaction_hash!("0x4"),
+            };
+            Transaction {
+                hash,
+                variant: TransactionVariant::L1Handler(L1HandlerTransaction {
+                    contract_address: contract_address!("0x1"),
+                    entry_point_selector: entry_point!("0x55"),
+                    nonce: transaction_nonce!("0x0"),
+                    calldata: Vec::new(),
+                }),
+            }
         };
-        Transaction {
-            hash,
-            variant: TransactionVariant::L1Handler(L1HandlerTransaction {
-                contract_address: contract_address!("0x1"),
-                entry_point_selector: entry_point!("0x55"),
-                nonce: transaction_nonce!("0x0"),
-                calldata: vec![],
-            }),
-        }
-    }
-
-    /// A pre-confirmed block with `n` receipted transactions, so the conversion
-    /// into pending data accepts it.
-    fn pre_confirmed(n: usize) -> PreConfirmedBlock {
-        let transactions: Vec<_> = (0..n).map(sample_tx).collect();
+        let transactions: Vec<_> = (0..n).map(receipted_tx).collect();
         let transaction_receipts = transactions
             .iter()
             .enumerate()
-            .map(|(i, t)| {
+            .map(|(i, tx)| {
                 Some((
-                    Receipt {
-                        transaction_hash: t.hash,
+                    pathfinder_common::receipt::Receipt {
+                        transaction_hash: tx.hash,
                         transaction_index: TransactionIndex::new_or_panic(i as u64),
                         ..Default::default()
                     },
@@ -298,252 +515,790 @@ mod tests {
         }
     }
 
-    /// A full poll response carrying `block`.
-    fn full(block: PreConfirmedBlock) -> PreConfirmedPollResponse {
-        PreConfirmedPollResponse::Full {
-            identifier: "id".into(),
-            block_number: None,
-            block,
-        }
-    }
-
-    /// The error the gateway returns for a height that hasn't been built yet.
-    fn block_not_found() -> SequencerError {
-        SequencerError::StarknetError(StarknetError {
-            code: KnownStarknetErrorCode::BlockNotFound.into(),
-            message: "Block not found".into(),
-        })
-    }
-
-    /// Spawn the producer against `sequencer`, polling fast and anchored at
-    /// `committed`.
-    fn spawn(
+    /// Spawn the producer polling at a 1ms interval against the given cache.
+    /// The first poll fires immediately, so single-store tests aren't delayed.
+    fn spawn_producer(
         sequencer: MockGatewayApi,
         committed: BlockNumber,
-        committed_hash: BlockHash,
+        latest_hash: BlockHash,
         cache: Arc<PendingDataCache>,
     ) {
-        let (_latest, latest) = watch::channel((committed, committed_hash));
-        let (_current, current) = watch::channel((committed, committed_hash));
+        let (_latest_tx, latest) = watch::channel((committed, latest_hash));
+        let (_current_tx, current) = watch::channel((committed, latest_hash));
         let sequencer = Arc::new(sequencer);
         tokio::spawn(async move {
             poll_pre_confirmed(
                 sequencer,
-                Duration::from_millis(1),
+                std::time::Duration::from_millis(1),
                 cache,
                 latest,
                 current,
-                IN_SYNC,
+                TEST_IN_SYNC_THRESHOLD,
             )
             .await
         });
     }
 
-    /// The common path: a decided block sits above our head as the pre-latest
-    /// at committed+1, with the pre-confirmed still building on top at
-    /// committed+2. The producer fetches both by number and stores them as
-    /// one chained view.
-    #[tokio::test]
-    async fn stores_chained_view_when_pre_latest_present() {
-        let committed = BlockNumber::new_or_panic(100);
-        let committed_hash = block_hash!("0xc0");
+    mod apply {
+        use pathfinder_common::macro_prelude::*;
+        use pathfinder_common::transaction::{
+            L1HandlerTransaction,
+            Transaction,
+            TransactionVariant,
+        };
+        use starknet_gateway_types::reply::{PreConfirmedBlock, PreConfirmedPollResponse};
 
-        let mut sequencer = MockGatewayApi::new();
-        // The pre-latest at committed+1 and the pre-confirmed that chains onto it
-        // at committed+2.
-        sequencer
-            .expect_preconfirmed_block()
-            .returning(|block, _, _| match block {
-                BlockId::Number(n) if n == BlockNumber::new_or_panic(101) => {
-                    Ok(full(pre_confirmed(1)))
-                }
-                _ => Ok(full(pre_confirmed(2))),
+        use super::super::{BlockNumber, State};
+
+        fn placeholder_tx(index: usize) -> Transaction {
+            let hash = match index {
+                0 => transaction_hash!("0x1"),
+                1 => transaction_hash!("0x2"),
+                _ => transaction_hash!("0x3"),
+            };
+            Transaction {
+                hash,
+                variant: TransactionVariant::L1Handler(L1HandlerTransaction {
+                    contract_address: contract_address!("0x1"),
+                    entry_point_selector: entry_point!("0x55"),
+                    nonce: transaction_nonce!("0x0"),
+                    calldata: Vec::new(),
+                }),
+            }
+        }
+
+        /// Build a minimal `PreConfirmedBlock` with `n` placeholder
+        /// transactions and matching empty receipt/state-diff slots.
+        /// Other fields use `Default`.
+        fn block_with_txs(n: usize) -> PreConfirmedBlock {
+            let txs: Vec<Transaction> = (0..n).map(placeholder_tx).collect();
+            let receipts = vec![None; n];
+            let state_diffs = vec![None; n];
+            PreConfirmedBlock {
+                transactions: txs,
+                transaction_receipts: receipts,
+                transaction_state_diffs: state_diffs,
+                ..Default::default()
+            }
+        }
+
+        fn state(identifier: Option<&str>, txs: usize) -> State {
+            State {
+                block_number: BlockNumber::new_or_panic(10),
+                block_identifier: identifier.map(String::from),
+                accumulated: if identifier.is_some() {
+                    Some(block_with_txs(txs))
+                } else {
+                    None
+                },
+            }
+        }
+
+        #[test]
+        fn unchanged_response_is_noop() {
+            let mut s = state(Some("abc"), 1);
+            let original_accumulated = s.accumulated.clone();
+            let original_identifier = s.block_identifier.clone();
+            let original_number = s.block_number;
+
+            let emitted = s.apply(PreConfirmedPollResponse::Unchanged);
+
+            assert!(!emitted);
+            assert_eq!(s.accumulated, original_accumulated);
+            assert_eq!(s.block_identifier, original_identifier);
+            assert_eq!(s.block_number, original_number);
+        }
+
+        #[test]
+        fn delta_with_mismatching_identifier_is_skipped() {
+            let mut s = state(Some("abc"), 1);
+            let original_accumulated = s.accumulated.clone();
+
+            let emitted = s.apply(PreConfirmedPollResponse::Delta {
+                identifier: "xyz".into(),
+                new_transactions: vec![Transaction {
+                    hash: transaction_hash!("0x99"),
+                    variant: TransactionVariant::L1Handler(L1HandlerTransaction {
+                        contract_address: contract_address!("0x1"),
+                        entry_point_selector: entry_point!("0x55"),
+                        nonce: transaction_nonce!("0x0"),
+                        calldata: Vec::new(),
+                    }),
+                }],
+                new_receipts: vec![None],
+                new_state_diffs: vec![None],
             });
 
-        let cache = Arc::new(PendingDataCache::new());
-        let mut changes = cache.subscribe();
-        let _ = changes.borrow_and_update();
+            assert!(!emitted);
+            assert_eq!(s.accumulated, original_accumulated);
+            assert_eq!(s.block_identifier, Some("abc".into()));
+        }
 
-        spawn(sequencer, committed, committed_hash, cache.clone());
+        #[test]
+        fn delta_with_matching_identifier_and_empty_transactions_is_noop() {
+            let mut s = state(Some("abc"), 1);
+            let original_accumulated = s.accumulated.clone();
 
-        // Wait for the producer to publish.
-        timeout(TIMEOUT, changes.changed())
-            .await
-            .expect("a view should be published")
-            .unwrap();
-
-        let stored = changes.borrow();
-        assert_eq!(
-            stored.pre_confirmed_block_number(),
-            BlockNumber::new_or_panic(102)
-        );
-        assert_eq!(
-            stored.pre_latest_block_number(),
-            Some(BlockNumber::new_or_panic(101))
-        );
-        assert_eq!(stored.pre_confirmed_transactions().len(), 2);
-    }
-
-    /// With nothing building above it yet, committed+2 isn't there, so the
-    /// pre-latest is itself the newest block. The producer serves it alone at
-    /// committed+1.
-    #[tokio::test]
-    async fn serves_pre_latest_alone_when_nothing_above_it() {
-        let committed = BlockNumber::new_or_panic(100);
-        let committed_hash = block_hash!("0xc0");
-
-        let mut sequencer = MockGatewayApi::new();
-        // committed+1 is there; committed+2 hasn't been built yet.
-        sequencer
-            .expect_preconfirmed_block()
-            .returning(|block, _, _| match block {
-                BlockId::Number(n) if n == BlockNumber::new_or_panic(101) => {
-                    Ok(full(pre_confirmed(1)))
-                }
-                _ => Err(block_not_found()),
+            let emitted = s.apply(PreConfirmedPollResponse::Delta {
+                identifier: "abc".into(),
+                new_transactions: vec![],
+                new_receipts: vec![],
+                new_state_diffs: vec![],
             });
 
-        let cache = Arc::new(PendingDataCache::new());
-        let mut changes = cache.subscribe();
-        let _ = changes.borrow_and_update();
+            assert!(!emitted);
+            assert_eq!(s.accumulated, original_accumulated);
+            assert_eq!(s.block_identifier, Some("abc".into()));
+        }
 
-        spawn(sequencer, committed, committed_hash, cache.clone());
+        #[test]
+        fn delta_with_matching_identifier_appends() {
+            let mut s = state(Some("abc"), 1);
 
-        timeout(TIMEOUT, changes.changed())
-            .await
-            .expect("a view should be published")
-            .unwrap();
+            let new_tx = Transaction {
+                hash: transaction_hash!("0x99"),
+                variant: TransactionVariant::L1Handler(L1HandlerTransaction {
+                    contract_address: contract_address!("0x1"),
+                    entry_point_selector: entry_point!("0x55"),
+                    nonce: transaction_nonce!("0x0"),
+                    calldata: Vec::new(),
+                }),
+            };
 
-        let stored = changes.borrow();
-        assert_eq!(
-            stored.pre_confirmed_block_number(),
-            BlockNumber::new_or_panic(101)
-        );
-        assert_eq!(stored.pre_latest_block_number(), None);
-    }
-
-    /// Once a view is published, a failing gateway must not take the cache
-    /// down. The last good view keeps being served.
-    #[tokio::test]
-    async fn retains_last_good_view_on_fetch_failure() {
-        let committed = BlockNumber::new_or_panic(100);
-        let committed_hash = block_hash!("0xc0");
-
-        let pre_latest_calls = Arc::new(AtomicUsize::new(0));
-        let mut sequencer = MockGatewayApi::new();
-        // committed+2 always answers; committed+1 answers the first poll, then
-        // fails. Losing the foundation must not blank the cache.
-        sequencer
-            .expect_preconfirmed_block()
-            .returning(move |block, _, _| match block {
-                BlockId::Number(n) if n == BlockNumber::new_or_panic(101) => {
-                    if pre_latest_calls.fetch_add(1, Ordering::SeqCst) == 0 {
-                        Ok(full(pre_confirmed(1)))
-                    } else {
-                        Err(SequencerError::InvalidResponse("boom".into()))
-                    }
-                }
-                _ => Ok(full(pre_confirmed(2))),
+            let emitted = s.apply(PreConfirmedPollResponse::Delta {
+                identifier: "abc".into(),
+                new_transactions: vec![new_tx],
+                new_receipts: vec![None],
+                new_state_diffs: vec![None],
             });
 
+            assert!(emitted);
+            let acc = s.accumulated.as_ref().unwrap();
+            assert_eq!(acc.transactions.len(), 2);
+            assert_eq!(acc.transaction_receipts.len(), 2);
+            assert_eq!(acc.transaction_state_diffs.len(), 2);
+            assert_eq!(s.block_identifier, Some("abc".into()));
+        }
+
+        #[test]
+        fn full_with_changed_identifier_emits() {
+            let mut s = state(Some("abc"), 1);
+            let new_block = block_with_txs(1);
+
+            let emitted = s.apply(PreConfirmedPollResponse::Full {
+                identifier: "xyz".into(),
+                block_number: Some(BlockNumber::new_or_panic(10)),
+                block: new_block.clone(),
+            });
+
+            assert!(emitted);
+            assert_eq!(s.block_identifier, Some("xyz".into()));
+            assert_eq!(s.accumulated, Some(new_block));
+        }
+
+        #[test]
+        fn full_with_more_transactions_emits() {
+            let mut s = state(Some("abc"), 1);
+            let new_block = block_with_txs(2);
+
+            let emitted = s.apply(PreConfirmedPollResponse::Full {
+                identifier: "abc".into(),
+                block_number: Some(BlockNumber::new_or_panic(10)),
+                block: new_block.clone(),
+            });
+
+            assert!(emitted);
+            assert_eq!(s.accumulated.as_ref().unwrap().transactions.len(), 2);
+        }
+
+        #[test]
+        fn full_with_no_signals_is_deduped() {
+            let mut s = state(Some("abc"), 2);
+            let same_block = block_with_txs(2);
+            let original_accumulated = s.accumulated.clone();
+
+            // Same identifier and no new txs: nothing to emit.
+            let emitted = s.apply(PreConfirmedPollResponse::Full {
+                identifier: "abc".into(),
+                block_number: Some(BlockNumber::new_or_panic(10)),
+                block: same_block,
+            });
+
+            assert!(!emitted);
+            assert_eq!(s.accumulated, original_accumulated);
+            assert_eq!(s.block_identifier, Some("abc".into()));
+        }
+    }
+
+    /// A transient gateway inconsistency could briefly resolve `latest` to a
+    /// lower height than we're already tracking. The polling loop should skip
+    /// those responses without overwriting the cached view.
+    ///
+    /// See also <https://github.com/equilibriumco/pathfinder/issues/3081>.
+    #[tokio::test]
+    async fn lower_height_is_skipped() {
+        static COUNT: std::sync::Mutex<usize> = std::sync::Mutex::new(0);
+
+        let mut sequencer = MockGatewayApi::new();
+        sequencer.expect_preconfirmed_block().returning(|_, _, _| {
+            let mut count = COUNT.lock().unwrap();
+            let block_number = match *count {
+                0 => {
+                    *count += 1;
+                    // First poll establishes the tracked height at 12.
+                    BlockNumber::new_or_panic(12)
+                }
+                // Subsequent polls resolve to a lower height (gateway hiccup).
+                _ => BlockNumber::new_or_panic(11),
+            };
+            Ok(PreConfirmedPollResponse::Full {
+                identifier: String::new(),
+                block_number: Some(block_number),
+                block: all_receipted_block(1),
+            })
+        });
+
+        let committed = BlockNumber::new_or_panic(11);
         let cache = Arc::new(PendingDataCache::new());
-        let mut changes = cache.subscribe();
-        let _ = changes.borrow_and_update();
+        let mut sub = cache.subscribe();
+        let _ = sub.borrow_and_update();
 
-        spawn(sequencer, committed, committed_hash, cache.clone());
+        // Unrelated hash so pre-latest is classified absent.
+        spawn_producer(sequencer, committed, block_hash!("0xdead"), cache.clone());
 
-        // The first poll publishes the good view.
-        timeout(TIMEOUT, changes.changed())
+        // The first poll stores block 12.
+        tokio::time::timeout(TEST_TIMEOUT, sub.changed())
             .await
-            .expect("first view should be published")
+            .expect("block 12 should be stored")
             .unwrap();
         assert_eq!(
-            changes.borrow().pre_confirmed_block_number(),
-            BlockNumber::new_or_panic(102)
+            sub.borrow().pre_confirmed_block_number(),
+            BlockNumber::new_or_panic(12)
         );
 
-        // Let the failing polls run.
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        // The backwards-resolved poll must not overwrite the cache.
+        let changed =
+            tokio::time::timeout(std::time::Duration::from_millis(100), sub.changed()).await;
+        assert!(
+            changed.is_err(),
+            "a lower-height poll must not overwrite the cache"
+        );
 
-        // The cache still serves the last good view rather than an error.
-        let served = cache.read().await.expect("cache must stay serviceable");
+        // The skip keeps the cache serviceable and still holding block 12.
+        let retained = cache.try_read().expect("cache should remain serviceable");
         assert_eq!(
-            served.pre_confirmed_block_number(),
-            BlockNumber::new_or_panic(102)
+            retained.pre_confirmed_block_number(),
+            BlockNumber::new_or_panic(12)
         );
     }
 
-    /// While our head is far behind the chain, pre-confirmed reads fail fast as
-    /// "syncing" instead of serving nothing.
+    /// While catching up to head, the loop marks the cache unavailable so reads
+    /// fail fast with "syncing" instead of blocking on the cold-start
+    /// timeout.
     #[tokio::test(start_paused = true)]
-    async fn marks_syncing_when_far_behind_head() {
-        let hash = block_hash!("0xc0");
-        // Our head is genesis; the chain head is well past the in-sync threshold.
-        let (_current, current) = watch::channel((BlockNumber::GENESIS, hash));
-        let (_latest, latest) = watch::channel((BlockNumber::new_or_panic(100), hash));
-
-        // The sync guard returns before any fetch, so the gateway is never called.
+    async fn syncing_marks_cache_unavailable() {
+        // latest far ahead of current: the catch-up branch runs and never
+        // fetches, so an expectation-free mock gateway is fine.
         let sequencer = Arc::new(MockGatewayApi::new());
+        let hash = block_hash!("0xabcd");
+        let (_tx_latest, latest) = watch::channel((BlockNumber::new_or_panic(100), hash));
+        let (_tx_current, current) = watch::channel((BlockNumber::new_or_panic(0), hash));
+
         let cache = Arc::new(PendingDataCache::new());
-        tokio::spawn({
+        let _jh = tokio::spawn({
             let cache = cache.clone();
             async move {
-                poll_pre_confirmed(
+                super::poll_pre_confirmed(
                     sequencer,
-                    Duration::from_secs(1),
+                    std::time::Duration::from_secs(1),
                     cache,
                     latest,
                     current,
-                    IN_SYNC,
+                    TEST_IN_SYNC_THRESHOLD,
                 )
                 .await
             }
         });
 
-        // Give the loop a turn to reach the guard.
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        // Hand the loop a turn to reach the catch-up branch (virtual time).
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         let err = cache.read().await.unwrap_err();
         assert!(err.to_string().contains("syncing"), "got: {err}");
     }
 
-    /// A delta carries only the new transactions, which the producer appends
-    /// onto the block it's already tracking at that height.
-    #[test]
-    fn delta_appends_to_the_tracked_block() {
-        let height = BlockNumber::new_or_panic(102);
+    /// Once a view is published, a failing gateway must not take the cache
+    /// down: the last good view keeps being served rather than blanking to an
+    /// error.
+    #[tokio::test]
+    async fn retains_last_good_view_on_fetch_failure() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
 
-        // We're already tracking a block with one transaction.
-        let mut tracked = Some(Tracked {
-            number: height,
-            identifier: "id".into(),
-            block: pre_confirmed(1),
+        use starknet_gateway_types::error::SequencerError;
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut sequencer = MockGatewayApi::new();
+        // The first poll succeeds and publishes tip 101 (gap of one → no
+        // parents to complete); every poll after it fails.
+        sequencer
+            .expect_preconfirmed_block()
+            .returning(move |_, _, _| {
+                if calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Ok(PreConfirmedPollResponse::Full {
+                        identifier: "id-101".into(),
+                        block_number: Some(BlockNumber::new_or_panic(101)),
+                        block: all_receipted_block(1),
+                    })
+                } else {
+                    Err(SequencerError::InvalidResponse("boom".into()))
+                }
+            });
+
+        let committed = BlockNumber::new_or_panic(100);
+        let cache = Arc::new(PendingDataCache::new());
+        let mut sub = cache.subscribe();
+        let _ = sub.borrow_and_update();
+
+        spawn_producer(sequencer, committed, block_hash!("0xc0"), cache.clone());
+
+        // The first poll publishes the good view.
+        tokio::time::timeout(TEST_TIMEOUT, sub.changed())
+            .await
+            .expect("first view should be published")
+            .unwrap();
+        assert_eq!(
+            sub.borrow().pre_confirmed_block_number(),
+            BlockNumber::new_or_panic(101)
+        );
+
+        // Let the failing polls run.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // The cache still serves the last good view rather than an error.
+        let served = cache.read().await.expect("cache must stay serviceable");
+        assert_eq!(
+            served.pre_confirmed_block_number(),
+            BlockNumber::new_or_panic(101)
+        );
+    }
+
+    /// The completion query for a superseded block carries any tail
+    /// transactions that landed just before it advanced; the completion must
+    /// record the full block (with the tail) as a *complete* window entry so
+    /// the next poll re-serves the tip with it. It publishes nothing
+    /// itself.
+    #[tokio::test]
+    async fn complete_previous_block_records_the_completed_block() {
+        const BLOCK_ID: &str = "id-11";
+
+        let tail_hash = transaction_hash!("0x012345");
+        let tail_tx = Transaction {
+            hash: tail_hash,
+            variant: TransactionVariant::L1Handler(L1HandlerTransaction {
+                contract_address: contract_address!("0x1"),
+                entry_point_selector: entry_point!("0x55"),
+                nonce: transaction_nonce!("0x2"),
+                calldata: Vec::new(),
+            }),
+        };
+        let tail_receipt = pathfinder_common::receipt::Receipt {
+            transaction_hash: tail_hash,
+            transaction_index: TransactionIndex::new_or_panic(1),
+            ..Default::default()
+        };
+
+        let mut sequencer = MockGatewayApi::new();
+        sequencer
+            .expect_preconfirmed_block()
+            .returning(move |_, _, _| {
+                Ok(PreConfirmedPollResponse::Delta {
+                    identifier: BLOCK_ID.into(),
+                    new_transactions: vec![tail_tx.clone()],
+                    new_receipts: vec![Some((tail_receipt.clone(), vec![]))],
+                    new_state_diffs: vec![None],
+                })
+            });
+
+        // We're tracking block 11 with one receipted transaction already merged.
+        let state = State {
+            block_number: BlockNumber::new_or_panic(11),
+            block_identifier: Some(BLOCK_ID.to_string()),
+            accumulated: Some(all_receipted_block(1)),
+        };
+
+        // The completion records the completed block as a complete window
+        // entry, carrying the tail transaction — ready for the next poll to
+        // re-serve the tip with it.
+        let window = std::sync::Mutex::new(super::Window::default());
+        complete_previous_block(&sequencer, state, &window).await;
+
+        let guard = window.lock().unwrap();
+        let entry = guard
+            .blocks
+            .get(&BlockNumber::new_or_panic(11))
+            .expect("the completion should record the block in the window");
+        assert!(entry.complete, "the recorded entry should be complete");
+        assert!(
+            entry
+                .data
+                .block
+                .transactions
+                .iter()
+                .any(|t| t.hash == tail_hash),
+            "the tail transaction should be in the recorded block"
+        );
+    }
+
+    mod window {
+        use std::sync::Arc;
+
+        use pathfinder_common::BlockNumber;
+        use pathfinder_pending_data::{PreLatestBlock, PreLatestData};
+
+        use super::super::Window;
+
+        fn bn(n: u64) -> BlockNumber {
+            BlockNumber::new_or_panic(n)
+        }
+
+        // An entry stamped with its block number, as the producer records it.
+        fn entry(n: u64) -> Arc<PreLatestData> {
+            Arc::new(PreLatestData {
+                block: PreLatestBlock {
+                    number: bn(n),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+        }
+
+        fn with_blocks(complete: &[u64], provisional: &[u64]) -> Window {
+            let mut window = Window::default();
+            for &n in complete {
+                window.record(bn(n), entry(n), true);
+            }
+            for &n in provisional {
+                window.record(bn(n), entry(n), false);
+            }
+            window
+        }
+
+        fn parent_numbers(parents: &[Arc<PreLatestData>]) -> Vec<u64> {
+            parents.iter().map(|p| p.block.number.get()).collect()
+        }
+
+        #[test]
+        fn collect_gap_of_one_needs_no_parents() {
+            let window = Window::default();
+            let parents = window.collect(bn(5), bn(6)).unwrap();
+            assert!(parents.is_empty());
+        }
+
+        #[test]
+        fn collect_contiguous_window_collects_every_parent() {
+            let window = with_blocks(&[6, 7, 8], &[9, 10]);
+            let parents = window.collect(bn(5), bn(11)).unwrap();
+            assert_eq!(parent_numbers(&parents), vec![6, 7, 8, 9, 10]);
+        }
+
+        #[test]
+        fn collect_a_hole_yields_none() {
+            let window = with_blocks(&[6, 8], &[]);
+            assert!(window.collect(bn(5), bn(9)).is_none());
+        }
+
+        #[test]
+        fn collect_ignores_blocks_outside_the_open_range() {
+            let window = with_blocks(&[4, 5, 6, 7, 8, 9, 10], &[]);
+            let parents = window.collect(bn(5), bn(9)).unwrap();
+            assert_eq!(parent_numbers(&parents), vec![6, 7, 8]);
+        }
+
+        #[test]
+        fn record_complete_entry_upgrades_provisional_and_bumps_generation() {
+            let mut window = Window::default();
+            window.record(bn(7), entry(7), false);
+            let after_provisional = window.generation;
+            assert!(
+                after_provisional > 0,
+                "inserting provisional bumps the generation"
+            );
+            assert!(!window.blocks[&bn(7)].complete);
+
+            window.record(bn(7), entry(7), true);
+            assert!(window.blocks[&bn(7)].complete);
+            assert!(
+                window.generation > after_provisional,
+                "an upgrade bumps the generation"
+            );
+        }
+
+        #[test]
+        fn record_does_not_upgrade_a_complete_entry_or_bump() {
+            let mut window = Window::default();
+            window.record(bn(7), entry(7), true);
+            let gen = window.generation;
+
+            // Upgrading with another provisional entry is a no-op.
+            window.record(bn(7), entry(7), false);
+            // Upgrading with another complete entry is a no-op.
+            window.record(bn(7), entry(7), true);
+            assert_eq!(window.generation, gen);
+            assert!(window.blocks[&bn(7)].complete);
+        }
+
+        #[test]
+        fn record_provisional_does_not_replace_provisional() {
+            let mut window = Window::default();
+            window.record(bn(7), entry(7), false);
+            let gen = window.generation;
+            // A second provisional record for the same block is a no-op.
+            window.record(bn(7), entry(7), false);
+            assert_eq!(window.generation, gen);
+        }
+
+        #[test]
+        fn prune_drops_committed_blocks() {
+            let mut window = with_blocks(&[6, 7, 8], &[]);
+            window.prune(bn(7));
+            assert!(!window.blocks.contains_key(&bn(6)));
+            assert!(!window.blocks.contains_key(&bn(7)));
+            assert!(window.blocks.contains_key(&bn(8)));
+        }
+    }
+
+    fn block_with_tx(tag: TransactionHash) -> PreConfirmedBlock {
+        let tx = Transaction {
+            hash: tag,
+            variant: TransactionVariant::L1Handler(L1HandlerTransaction {
+                contract_address: contract_address!("0x1"),
+                entry_point_selector: entry_point!("0x55"),
+                nonce: transaction_nonce!("0x0"),
+                calldata: Vec::new(),
+            }),
+        };
+        let receipt = pathfinder_common::receipt::Receipt {
+            transaction_hash: tag,
+            transaction_index: TransactionIndex::new_or_panic(0),
+            ..Default::default()
+        };
+        PreConfirmedBlock {
+            status: Status::PreConfirmed,
+            transactions: vec![tx],
+            transaction_receipts: vec![Some((receipt, vec![]))],
+            transaction_state_diffs: vec![None],
+            ..Default::default()
+        }
+    }
+
+    fn tx_for(height: u64) -> TransactionHash {
+        match height {
+            11 => transaction_hash!("0x11"),
+            12 => transaction_hash!("0x12"),
+            _ => transaction_hash!("0x13"),
+        }
+    }
+
+    /// End-to-end: with finalisation lagging (committed head fixed, no gateway
+    /// pre-latest), the producer fills its window from block *completions* and
+    /// serves a multi-block view whose deep ancestor's transactions are
+    /// present. This proves no tail is lost for a window wider than two
+    /// blocks, and that the re-serve-on-warm path fires (the tip's contents
+    /// don't change between the poll that first sees it and the poll that
+    /// finally bridges it).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn windowed_serve_preserves_deep_ancestor_tail() {
+        use starknet_gateway_client::BlockId;
+
+        let mut sequencer = MockGatewayApi::new();
+
+        // `Latest` polls advance the tip 11, 12, 13 (then hold at 13, with a stable
+        // identifier so the contents stop changing - forcing the re-serve to rely on
+        // the window warming up, not on a content change). Concrete-number queries are
+        // completions and return that block in full.
+        static HEIGHT: Mutex<u64> = Mutex::new(10);
+        sequencer
+            .expect_preconfirmed_block()
+            .returning(move |block_id, _, _| match block_id {
+                BlockId::Latest => {
+                    let mut height = HEIGHT.lock().unwrap();
+                    if *height < 13 {
+                        *height += 1;
+                    }
+                    let height = *height;
+                    Ok(PreConfirmedPollResponse::Full {
+                        identifier: format!("tip-{height}"),
+                        block_number: Some(BlockNumber::new_or_panic(height)),
+                        block: block_with_tx(tx_for(height)),
+                    })
+                }
+                BlockId::Number(number) => {
+                    let number = number.get();
+                    Ok(PreConfirmedPollResponse::Full {
+                        identifier: format!("complete-{number}"),
+                        block_number: Some(BlockNumber::new_or_panic(number)),
+                        block: block_with_tx(tx_for(number)),
+                    })
+                }
+                other => panic!("unexpected block id: {other:?}"),
+            });
+
+        let committed = BlockNumber::new_or_panic(10);
+        let cache = Arc::new(PendingDataCache::new());
+        let mut sub = cache.subscribe();
+        let _ = sub.borrow_and_update();
+
+        spawn_producer(sequencer, committed, block_hash!("0xbeef"), cache.clone());
+
+        // Wait until the producer serves block 13 with its full window: deep ancestor
+        // 11 plus immediate parent 12.
+        let deadline = tokio::time::Instant::now() + TEST_TIMEOUT;
+        loop {
+            tokio::time::timeout_at(deadline, sub.changed())
+                .await
+                .expect("producer should serve the windowed view before timeout")
+                .unwrap();
+            let pending = sub.borrow().clone();
+            if pending.pre_confirmed_block_number() != BlockNumber::new_or_panic(13) {
+                continue;
+            }
+            let parents: Vec<_> = pending.parent_blocks().map(|p| p.block.number).collect();
+            if parents != vec![BlockNumber::new_or_panic(11), BlockNumber::new_or_panic(12)] {
+                continue;
+            }
+
+            // The deep ancestor's, the immediate parent's and the tip's transactions are
+            // all present - no tail lost across the window.
+            assert!(pending.find_transaction(tx_for(11)).is_some());
+            assert!(pending.find_transaction(tx_for(12)).is_some());
+            assert!(pending.find_transaction(tx_for(13)).is_some());
+            break;
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn windowed_serve_does_not_wait_for_completions() {
+        use std::sync::Mutex as StdMutex;
+
+        use starknet_gateway_client::BlockId;
+        use starknet_gateway_types::error::SequencerError;
+
+        let mut sequencer = MockGatewayApi::new();
+
+        static HEIGHT: StdMutex<u64> = StdMutex::new(10);
+        sequencer
+            .expect_preconfirmed_block()
+            .returning(move |block_id, _, _| match block_id {
+                BlockId::Latest => {
+                    let mut height = HEIGHT.lock().unwrap();
+                    if *height < 13 {
+                        *height += 1;
+                    }
+                    let height = *height;
+                    Ok(PreConfirmedPollResponse::Full {
+                        identifier: format!("tip-{height}"),
+                        block_number: Some(BlockNumber::new_or_panic(height)),
+                        block: block_with_tx(tx_for(height)),
+                    })
+                }
+                // Completion fetches always fail — serving must not depend on them.
+                _ => Err(SequencerError::InvalidResponse("no completions".into())),
+            });
+
+        let committed = BlockNumber::new_or_panic(10);
+        let cache = Arc::new(PendingDataCache::new());
+        let mut sub = cache.subscribe();
+        let _ = sub.borrow_and_update();
+
+        spawn_producer(sequencer, committed, block_hash!("0xbeef"), cache.clone());
+
+        let deadline = tokio::time::Instant::now() + TEST_TIMEOUT;
+        loop {
+            tokio::time::timeout_at(deadline, sub.changed())
+                .await
+                .expect("producer should serve from provisional entries before timeout")
+                .unwrap();
+            let pending = sub.borrow().clone();
+            if pending.pre_confirmed_block_number() != BlockNumber::new_or_panic(13) {
+                continue;
+            }
+            let parents: Vec<_> = pending.parent_blocks().map(|p| p.block.number).collect();
+            if parents != vec![BlockNumber::new_or_panic(11), BlockNumber::new_or_panic(12)] {
+                continue;
+            }
+            // Both un-committed parents are present from provisional data alone.
+            assert!(pending.find_transaction(tx_for(11)).is_some());
+            assert!(pending.find_transaction(tx_for(12)).is_some());
+            assert!(pending.find_transaction(tx_for(13)).is_some());
+            break;
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn idle_pauses_polling_until_cache_read() {
+        // Polling suspends once the inactivity window elapses without a read,
+        // and a cache read resumes it. Activity is observed via the gateway call
+        // counter, since touching the cache would itself reset the window.
+        const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
+        const IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(100);
+
+        let calls = Arc::new(std::sync::Mutex::new(0u64));
+        let mut sequencer = MockGatewayApi::new();
+        {
+            let calls = calls.clone();
+            sequencer
+                .expect_preconfirmed_block()
+                .returning(move |_, _, _| {
+                    let mut c = calls.lock().unwrap();
+                    *c += 1;
+                    Ok(PreConfirmedPollResponse::Full {
+                        identifier: format!("id-{}", *c),
+                        block_number: Some(BlockNumber::new_or_panic(2)),
+                        block: all_receipted_block(1),
+                    })
+                });
+        }
+
+        let latest_hash = block_hash!("0xabcd");
+        let committed = BlockNumber::new_or_panic(1);
+        let (_latest_tx, latest) = watch::channel((committed, latest_hash));
+        let (_current_tx, current) = watch::channel((committed, latest_hash));
+
+        let cache = Arc::new(PendingDataCache::new().with_inactivity_timeout(IDLE_TIMEOUT));
+        let sequencer = Arc::new(sequencer);
+        tokio::spawn({
+            let cache = cache.clone();
+            async move {
+                poll_pre_confirmed(
+                    sequencer,
+                    POLL_INTERVAL,
+                    cache,
+                    latest,
+                    current,
+                    TEST_IN_SYNC_THRESHOLD,
+                )
+                .await
+            }
         });
 
-        // A delta with a second transaction, tagged with the same identifier.
-        let second = sample_tx(1);
-        let republished = apply(
-            &mut tracked,
-            height,
-            PreConfirmedPollResponse::Delta {
-                identifier: "id".into(),
-                new_transactions: vec![second.clone()],
-                new_receipts: vec![Some((
-                    Receipt {
-                        transaction_hash: second.hash,
-                        transaction_index: TransactionIndex::new_or_panic(1),
-                        ..Default::default()
-                    },
-                    vec![],
-                ))],
-                new_state_diffs: vec![None],
-            },
+        // Polls happen for a while, then idle suspends them.
+        tokio::time::sleep(IDLE_TIMEOUT * 3).await;
+        let count_at_idle = *calls.lock().unwrap();
+        assert!(count_at_idle >= 1, "expected at least one poll before idle");
+
+        tokio::time::sleep(IDLE_TIMEOUT * 3).await;
+        assert_eq!(
+            *calls.lock().unwrap(),
+            count_at_idle,
+            "polling should be suspended while idle"
         );
 
+        // A cache read wakes the loop.
+        let _ = cache.read().await;
+        tokio::time::sleep(POLL_INTERVAL * 3).await;
         assert!(
-            republished,
-            "a delta with new transactions refreshes the view"
+            *calls.lock().unwrap() > count_at_idle,
+            "polling should resume after a cache read"
         );
-        assert_eq!(tracked.unwrap().block.transactions.len(), 2);
     }
 }

--- a/crates/pending-data/Cargo.toml
+++ b/crates/pending-data/Cargo.toml
@@ -14,4 +14,5 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync", "time", "rt"] }
 
 [dev-dependencies]
+pathfinder-crypto = { path = "../crypto" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }

--- a/crates/pending-data/src/data.rs
+++ b/crates/pending-data/src/data.rs
@@ -214,66 +214,8 @@ impl PendingData {
         })
     }
 
-    /// Same as [`Self::try_from_pre_confirmed_block`] but also accepts an
-    /// optional pre-latest parent: a pre-confirmed block at a height already
-    /// past consensus. When present, the pre-confirmed block must be its child,
-    /// and its parent hash is our committed head.
-    pub fn try_from_pre_confirmed_and_pre_latest(
-        pre_confirmed_block: Box<starknet_gateway_types::reply::PreConfirmedBlock>,
-        pre_confirmed_block_number: BlockNumber,
-        pre_latest: Option<
-            Box<(
-                BlockNumber,
-                starknet_gateway_types::reply::PreConfirmedBlock,
-                BlockHash,
-            )>,
-        >,
-    ) -> anyhow::Result<Self> {
-        let Some(pre_latest) = pre_latest else {
-            return Self::try_from_pre_confirmed_block(
-                pre_confirmed_block,
-                pre_confirmed_block_number,
-            );
-        };
-
-        let (pre_latest_block_number, pre_latest_block, parent_hash) = *pre_latest;
-        anyhow::ensure!(
-            pre_latest_block_number + 1 == pre_confirmed_block_number,
-            "Pre-confirmed block {pre_confirmed_block_number} is not the child of pre-latest \
-             {pre_latest_block_number}",
-        );
-
-        let (block, state_update) =
-            convert_pre_confirmed_block(Box::new(pre_latest_block), pre_latest_block_number)?;
-        let parent = PreLatestData {
-            block: PreLatestBlock {
-                number: pre_latest_block_number,
-                parent_hash,
-                l1_gas_price: block.l1_gas_price,
-                l1_data_gas_price: block.l1_data_gas_price,
-                l2_gas_price: block.l2_gas_price,
-                sequencer_address: block.sequencer_address,
-                status: Status::Pending,
-                timestamp: block.timestamp,
-                starknet_version: block.starknet_version,
-                l1_da_mode: block.l1_da_mode,
-                transactions: block.transactions,
-                transaction_receipts: block.transaction_receipts,
-            },
-            state_update: StateUpdate::clone(&state_update),
-        };
-
-        let aggregated_lower_bound =
-            aggregated_lower_bound_from_lowest_covered(pre_latest_block_number);
-        Self::from_window(
-            pre_confirmed_block,
-            pre_confirmed_block_number,
-            vec![parent],
-            aggregated_lower_bound,
-        )
-    }
-
-    /// Build a pending view over a multi-block window.
+    /// Build a pending view whose aggregated overlay spans a multi-block
+    /// window.
     ///
     /// `parents` are all uncommitted blocks between the committed head
     /// (`aggregated_lower_bound`) and the preconfirmed tip (`number`). The

--- a/crates/pending-data/src/data.rs
+++ b/crates/pending-data/src/data.rs
@@ -44,6 +44,8 @@ pub struct PreConfirmedBlock {
     pub transaction_receipts: Vec<TxnReceiptAndEvents>,
 }
 
+// TODO consider removing, because we're gonna be setting the parent hash to
+// zero anyway.
 #[derive(Clone, Default, Debug, PartialEq)]
 pub struct PreLatestBlock {
     pub number: BlockNumber,
@@ -71,12 +73,44 @@ pub struct PreLatestData {
     pub state_update: StateUpdate,
 }
 
-/// Chain data observed in flight: the pre-confirmed block and an optional
-/// pre-latest parent.
+impl PreLatestData {
+    /// Block header for this un-committed parent block.
+    pub fn header(&self) -> BlockHeader {
+        let block = &self.block;
+        BlockHeader {
+            parent_hash: block.parent_hash,
+            number: block.number,
+            timestamp: block.timestamp,
+            eth_l1_gas_price: block.l1_gas_price.price_in_wei,
+            strk_l1_gas_price: block.l1_gas_price.price_in_fri,
+            eth_l1_data_gas_price: block.l1_data_gas_price.price_in_wei,
+            strk_l1_data_gas_price: block.l1_data_gas_price.price_in_fri,
+            eth_l2_gas_price: block.l2_gas_price.price_in_wei,
+            strk_l2_gas_price: block.l2_gas_price.price_in_fri,
+            sequencer_address: block.sequencer_address,
+            starknet_version: block.starknet_version,
+            hash: Default::default(),
+            event_commitment: Default::default(),
+            state_commitment: Default::default(),
+            transaction_commitment: Default::default(),
+            transaction_count: Default::default(),
+            event_count: Default::default(),
+            l1_da_mode: block.l1_da_mode,
+            receipt_commitment: Default::default(),
+            state_diff_commitment: Default::default(),
+            state_diff_length: Default::default(),
+        }
+    }
+}
+
+/// Chain data observed in flight: the pre-confirmed block and every
+/// uncommitted parent block below it.
 #[derive(Clone, Default, Debug, PartialEq)]
 pub struct PendingBlocks {
     pub pre_confirmed: PreConfirmedBlock,
-    pub pre_latest: Option<PreLatestData>,
+    /// Blocks between the committed head and the pre-confirmed tip, oldest
+    /// first, newest (the immediate parent) last
+    pub parents: Vec<PreLatestData>,
 }
 
 impl PendingBlocks {
@@ -84,9 +118,14 @@ impl PendingBlocks {
         &self.pre_confirmed.transactions
     }
 
+    /// The immediate parent of the pre-confirmed block, ie. the newest
+    /// uncommitted parent.
+    pub fn immediate_parent(&self) -> Option<&PreLatestData> {
+        self.parents.last()
+    }
+
     pub fn pre_latest_transactions(&self) -> Option<&[Transaction]> {
-        self.pre_latest
-            .as_ref()
+        self.immediate_parent()
             .map(|data| data.block.transactions.as_slice())
     }
 
@@ -95,18 +134,39 @@ impl PendingBlocks {
     }
 
     pub fn pre_latest_tx_receipts_and_events(&self) -> Option<&[TxnReceiptAndEvents]> {
-        self.pre_latest
-            .as_ref()
+        self.immediate_parent()
             .map(|data| data.block.transaction_receipts.as_slice())
+    }
+
+    /// All uncommitted parent blocks below the pre-confirmed tip, oldest first,
+    /// newest (the immediate parent) last.
+    pub fn parent_blocks(&self) -> impl DoubleEndedIterator<Item = &PreLatestData> + '_ {
+        self.parents.iter()
     }
 }
 
 #[derive(Clone, Default, Debug, PartialEq)]
 pub struct PendingData {
     pub blocks: Arc<PendingBlocks>,
+    /// State update for the pre-confirmed tip only, without any parents.
     pub state_update: Arc<StateUpdate>,
+    /// State update for the pre-confirmed tip and every uncommitted parent.
     pub aggregated_state_update: Arc<StateUpdate>,
     pub number: BlockNumber,
+    /// [`aggregated_state_update`](Self::aggregated_state_update) is composed
+    /// on top of this committed height, so the covered block range is
+    /// `(aggregated_lower_bound, number]`.
+    pub aggregated_lower_bound: BlockNumber,
+}
+
+/// Computes the aggregated lower bound from the lowest block covered by the
+/// pending data.
+fn aggregated_lower_bound_from_lowest_covered(lowest_covered: BlockNumber) -> BlockNumber {
+    lowest_covered
+        .get()
+        .checked_sub(1)
+        .map(BlockNumber::new_or_panic)
+        .unwrap_or(BlockNumber::GENESIS)
 }
 
 impl PendingData {
@@ -117,21 +177,41 @@ impl PendingData {
         aggregated_state_update: StateUpdate,
         number: BlockNumber,
     ) -> Self {
+        // The lowest covered block is the oldest parent or the preconfirmed tip
+        // otherwise.
+        let lowest_covered = blocks
+            .parents
+            .first()
+            .map(|d| d.block.number)
+            .unwrap_or(number);
         Self {
             blocks: Arc::new(blocks),
             state_update: Arc::new(state_update),
             aggregated_state_update: Arc::new(aggregated_state_update),
             number,
+            aggregated_lower_bound: aggregated_lower_bound_from_lowest_covered(lowest_covered),
         }
     }
 
-    /// Converts a pre-confirmed block from the gateway into pending data.
-    /// State update is composed from the per-transaction diffs.
+    /// Converts a pre-confirmed block from the gateway into pending data. State
+    /// update is composed from the per-transaction diffs.
     pub fn try_from_pre_confirmed_block(
         block: Box<starknet_gateway_types::reply::PreConfirmedBlock>,
         number: BlockNumber,
     ) -> anyhow::Result<Self> {
-        Self::try_from_pre_confirmed_and_pre_latest(block, number, None)
+        let (pre_confirmed_block, pre_confirmed_state_update) =
+            convert_pre_confirmed_block(block, number)?;
+
+        Ok(Self {
+            blocks: Arc::new(PendingBlocks {
+                pre_confirmed: pre_confirmed_block,
+                parents: Vec::new(),
+            }),
+            state_update: Arc::clone(&pre_confirmed_state_update),
+            aggregated_state_update: pre_confirmed_state_update,
+            number,
+            aggregated_lower_bound: aggregated_lower_bound_from_lowest_covered(number),
+        })
     }
 
     /// Same as [`Self::try_from_pre_confirmed_block`] but also accepts an
@@ -149,79 +229,105 @@ impl PendingData {
             )>,
         >,
     ) -> anyhow::Result<Self> {
-        let transaction_receipts = require_receipts(
-            &pre_confirmed_block.transactions,
-            pre_confirmed_block.transaction_receipts,
-        )?;
-        let pre_confirmed_state_update = Arc::new(compose_state_update(
-            pre_confirmed_block.transaction_state_diffs,
-        ));
-
-        let pre_confirmed_block = PreConfirmedBlock {
-            number: pre_confirmed_block_number,
-            l1_gas_price: pre_confirmed_block.l1_gas_price,
-            l1_data_gas_price: pre_confirmed_block.l1_data_gas_price,
-            l2_gas_price: pre_confirmed_block.l2_gas_price,
-            sequencer_address: pre_confirmed_block.sequencer_address,
-            status: Status::PreConfirmed,
-            timestamp: pre_confirmed_block.timestamp,
-            starknet_version: pre_confirmed_block.starknet_version,
-            l1_da_mode: pre_confirmed_block.l1_da_mode.into(),
-            transactions: pre_confirmed_block.transactions,
-            transaction_receipts,
+        let Some(pre_latest) = pre_latest else {
+            return Self::try_from_pre_confirmed_block(
+                pre_confirmed_block,
+                pre_confirmed_block_number,
+            );
         };
 
-        let pre_latest_data = pre_latest
-            .map(|pre_latest| {
-                let (pre_latest_block_number, pre_latest_block, parent_hash) = *pre_latest;
-                anyhow::ensure!(
-                    pre_latest_block_number + 1 == pre_confirmed_block_number,
-                    "Pre-confirmed block {pre_confirmed_block_number} is not the child of \
-                     pre-latest {pre_latest_block_number}",
-                );
-                let transaction_receipts = require_receipts(
-                    &pre_latest_block.transactions,
-                    pre_latest_block.transaction_receipts,
-                )?;
-                let state_update = compose_state_update(pre_latest_block.transaction_state_diffs);
-                let block = PreLatestBlock {
-                    number: pre_latest_block_number,
-                    parent_hash,
-                    l1_gas_price: pre_latest_block.l1_gas_price,
-                    l1_data_gas_price: pre_latest_block.l1_data_gas_price,
-                    l2_gas_price: pre_latest_block.l2_gas_price,
-                    sequencer_address: pre_latest_block.sequencer_address,
-                    status: Status::Pending,
-                    timestamp: pre_latest_block.timestamp,
-                    starknet_version: pre_latest_block.starknet_version,
-                    l1_da_mode: pre_latest_block.l1_da_mode.into(),
-                    transactions: pre_latest_block.transactions,
-                    transaction_receipts,
-                };
-                anyhow::Ok(PreLatestData {
-                    block,
-                    state_update,
-                })
-            })
-            .transpose()?;
-
-        let aggregated_state_update = Arc::new(
-            pre_latest_data
-                .as_ref()
-                .map(|data| data.state_update.clone())
-                .unwrap_or_default()
-                .apply(pre_confirmed_state_update.as_ref()),
+        let (pre_latest_block_number, pre_latest_block, parent_hash) = *pre_latest;
+        anyhow::ensure!(
+            pre_latest_block_number + 1 == pre_confirmed_block_number,
+            "Pre-confirmed block {pre_confirmed_block_number} is not the child of pre-latest \
+             {pre_latest_block_number}",
         );
+
+        let (block, state_update) =
+            convert_pre_confirmed_block(Box::new(pre_latest_block), pre_latest_block_number)?;
+        let parent = PreLatestData {
+            block: PreLatestBlock {
+                number: pre_latest_block_number,
+                parent_hash,
+                l1_gas_price: block.l1_gas_price,
+                l1_data_gas_price: block.l1_data_gas_price,
+                l2_gas_price: block.l2_gas_price,
+                sequencer_address: block.sequencer_address,
+                status: Status::Pending,
+                timestamp: block.timestamp,
+                starknet_version: block.starknet_version,
+                l1_da_mode: block.l1_da_mode,
+                transactions: block.transactions,
+                transaction_receipts: block.transaction_receipts,
+            },
+            state_update: StateUpdate::clone(&state_update),
+        };
+
+        let aggregated_lower_bound =
+            aggregated_lower_bound_from_lowest_covered(pre_latest_block_number);
+        Self::from_window(
+            pre_confirmed_block,
+            pre_confirmed_block_number,
+            vec![parent],
+            aggregated_lower_bound,
+        )
+    }
+
+    /// Build a pending view over a multi-block window.
+    ///
+    /// `parents` are all uncommitted blocks between the committed head
+    /// (`aggregated_lower_bound`) and the preconfirmed tip (`number`). The
+    /// aggregated overlay composes every parent's diffs (oldest first,
+    /// newest last) and then the pre-confirmed tip's own diffs on top.
+    pub fn from_window(
+        pre_confirmed_block: Box<starknet_gateway_types::reply::PreConfirmedBlock>,
+        number: BlockNumber,
+        parents: Vec<PreLatestData>,
+        aggregated_lower_bound: BlockNumber,
+    ) -> anyhow::Result<Self> {
+        let (pre_confirmed_block, pre_confirmed_state_update) =
+            convert_pre_confirmed_block(pre_confirmed_block, number)?;
+
+        // Compose the overlay starting from the oldest block so fresher updates
+        // overwrite older ones.
+        let mut overlay = StateUpdate::default();
+        for parent in &parents {
+            overlay = overlay.apply(&parent.state_update);
+        }
+        let aggregated_state_update = Arc::new(overlay.apply(pre_confirmed_state_update.as_ref()));
 
         Ok(Self {
             blocks: Arc::new(PendingBlocks {
                 pre_confirmed: pre_confirmed_block,
-                pre_latest: pre_latest_data,
+                parents,
             }),
             state_update: pre_confirmed_state_update,
             aggregated_state_update,
-            number: pre_confirmed_block_number,
+            number,
+            aggregated_lower_bound,
         })
+    }
+
+    /// Convert to the form that is used by consumers.
+    pub fn to_pre_latest_data(&self) -> PreLatestData {
+        let block = &self.blocks.pre_confirmed;
+        PreLatestData {
+            block: PreLatestBlock {
+                number: block.number,
+                parent_hash: BlockHash::ZERO,
+                l1_gas_price: block.l1_gas_price,
+                l1_data_gas_price: block.l1_data_gas_price,
+                l2_gas_price: block.l2_gas_price,
+                sequencer_address: block.sequencer_address,
+                status: block.status,
+                timestamp: block.timestamp,
+                starknet_version: block.starknet_version,
+                l1_da_mode: block.l1_da_mode,
+                transactions: block.transactions.clone(),
+                transaction_receipts: block.transaction_receipts.clone(),
+            },
+            state_update: StateUpdate::clone(&self.state_update),
+        }
     }
 
     /// An empty pending block synthesised from the latest finalised header.
@@ -253,23 +359,18 @@ impl PendingData {
         Self {
             blocks: Arc::new(PendingBlocks {
                 pre_confirmed: block,
-                pre_latest: None,
+                parents: Vec::new(),
             }),
             state_update: Arc::clone(&state_update),
             aggregated_state_update: state_update,
             number: latest.number + 1,
+            // No uncommitted blocks, so it sits directly on the latest committed block.
+            aggregated_lower_bound: latest.number,
         }
     }
 
     pub fn pre_confirmed_block_number(&self) -> BlockNumber {
         self.number
-    }
-
-    pub fn pre_latest_block_number(&self) -> Option<BlockNumber> {
-        self.blocks
-            .pre_latest
-            .as_ref()
-            .map(|data| data.block.number)
     }
 
     /// Synthesise a `BlockHeader` from the pre-confirmed block. Fields that
@@ -302,34 +403,10 @@ impl PendingData {
         }
     }
 
-    /// Synthesise a `BlockHeader` from the pre-latest block, if it exists.
+    /// Synthesise a `BlockHeader` from the immediate parent block, if it
+    /// exists.
     pub fn pre_latest_header(&self) -> Option<BlockHeader> {
-        self.blocks.pre_latest.as_ref().map(|data| {
-            let pre_latest_block = &data.block;
-            BlockHeader {
-                parent_hash: pre_latest_block.parent_hash,
-                number: pre_latest_block.number,
-                timestamp: pre_latest_block.timestamp,
-                eth_l1_gas_price: pre_latest_block.l1_gas_price.price_in_wei,
-                strk_l1_gas_price: pre_latest_block.l1_gas_price.price_in_fri,
-                eth_l1_data_gas_price: pre_latest_block.l1_data_gas_price.price_in_wei,
-                strk_l1_data_gas_price: pre_latest_block.l1_data_gas_price.price_in_fri,
-                eth_l2_gas_price: pre_latest_block.l2_gas_price.price_in_wei,
-                strk_l2_gas_price: pre_latest_block.l2_gas_price.price_in_fri,
-                sequencer_address: pre_latest_block.sequencer_address,
-                starknet_version: pre_latest_block.starknet_version,
-                hash: Default::default(),
-                event_commitment: Default::default(),
-                state_commitment: Default::default(),
-                transaction_commitment: Default::default(),
-                transaction_count: Default::default(),
-                event_count: Default::default(),
-                l1_da_mode: pre_latest_block.l1_da_mode,
-                receipt_commitment: Default::default(),
-                state_diff_commitment: Default::default(),
-                state_diff_length: Default::default(),
-            }
-        })
+        self.blocks.immediate_parent().map(|data| data.header())
     }
 
     pub fn pending_block(&self) -> Arc<PendingBlocks> {
@@ -338,34 +415,28 @@ impl PendingData {
 
     pub fn pre_latest_block(&self) -> Option<Arc<PreLatestBlock>> {
         self.blocks
-            .pre_latest
-            .as_ref()
+            .immediate_parent()
             .map(|data| Arc::new(data.block.clone()))
     }
 
+    /// State update for the pre-confirmed tip only, without any parents.
     pub fn pre_confirmed_state_update(&self) -> Arc<StateUpdate> {
         Arc::clone(&self.state_update)
     }
 
-    /// Combined state update from pre-latest (if any) and pre-confirmed.
+    /// Combined state update from preconfirmed and any uncommitted parents.
     pub fn aggregated_state_update(&self) -> Arc<StateUpdate> {
         Arc::clone(&self.aggregated_state_update)
     }
 
+    /// Transactions in the pre-confirmed tip only, without any parents.
     pub fn pre_confirmed_transactions(&self) -> &[Transaction] {
         self.blocks.transactions()
     }
 
-    pub fn pre_latest_transactions(&self) -> Option<&[Transaction]> {
-        self.blocks.pre_latest_transactions()
-    }
-
+    /// Receipts and events in the pre-confirmed tip only, without any parents.
     pub fn pre_confirmed_tx_receipts_and_events(&self) -> &[TxnReceiptAndEvents] {
         self.blocks.tx_receipts_and_events()
-    }
-
-    pub fn pre_latest_tx_receipts_and_events(&self) -> Option<&[TxnReceiptAndEvents]> {
-        self.blocks.pre_latest_tx_receipts_and_events()
     }
 
     /// Look up a contract nonce across the aggregated pending state.
@@ -384,16 +455,22 @@ impl PendingData {
             .storage_value_with_provenance(contract_address, storage_address)
     }
 
-    /// Look up a transaction by hash across pre-confirmed and pre-latest, in
-    /// that order.
+    /// Look up a transaction by hash across the whole un-committed window:
+    /// the pre-confirmed tip first, then every parent from newest to oldest.
     pub fn find_transaction(&self, tx_hash: TransactionHash) -> Option<Transaction> {
         self.pre_confirmed_transactions()
             .iter()
             .find(|tx| tx.hash == tx_hash)
             .cloned()
             .or_else(|| {
-                self.pre_latest_transactions()
-                    .and_then(|pre_latest| pre_latest.iter().find(|tx| tx.hash == tx_hash).cloned())
+                self.blocks.parent_blocks().rev().find_map(|parent| {
+                    parent
+                        .block
+                        .transactions
+                        .iter()
+                        .find(|tx| tx.hash == tx_hash)
+                        .cloned()
+                })
             })
     }
 
@@ -408,57 +485,260 @@ impl PendingData {
         self.aggregated_state_update().class_is_declared(class_hash)
     }
 
-    /// True if `block` matches the pre-latest or pre-confirmed block number.
+    /// True if `block` is the pre-confirmed block or any un-committed parent
+    /// (the immediate pre-latest or a deeper ancestor).
     pub fn is_pre_latest_or_pre_confirmed(&self, block: BlockNumber) -> bool {
-        self.pre_latest_block_number()
-            .is_some_and(|pre_latest| pre_latest == block)
-            || self.pre_confirmed_block_number() == block
+        self.pre_confirmed_block_number() == block
+            || self
+                .blocks
+                .parent_blocks()
+                .any(|parent| parent.block.number == block)
+    }
+
+    /// All uncommitted parent blocks below the pre-confirmed tip, oldest first,
+    /// newest (the immediate parent) last.
+    pub fn parent_blocks(&self) -> impl DoubleEndedIterator<Item = &PreLatestData> + '_ {
+        self.blocks.parent_blocks()
     }
 }
 
-/// Drop the receipt placeholders a pre-confirmed response carries, failing if a
-/// transaction is still missing one. A missing receipt means a candidate
-/// transaction the sequencer hasn't executed yet.
-fn require_receipts(
-    transactions: &[Transaction],
-    transaction_receipts: Vec<Option<TxnReceiptAndEvents>>,
-) -> anyhow::Result<Vec<TxnReceiptAndEvents>> {
-    let transaction_receipts: Vec<TxnReceiptAndEvents> =
-        transaction_receipts.into_iter().flatten().collect();
+/// Validate a gateway preconfirmed block and convert it into the display form
+/// with its aggregated state update:
+/// 1. Drop the receipt placeholders a pre-confirmed response carries, failing
+///    if a transaction is still missing one. A missing receipt means a
+///    candidate transaction the sequencer hasn't executed yet.
+/// 2. Fold the per-transaction state diffs of a pre-confirmed response into one
+///    state update. A pending block has no root of its own, so the roots are
+///    left empty.
+fn convert_pre_confirmed_block(
+    block: Box<starknet_gateway_types::reply::PreConfirmedBlock>,
+    number: BlockNumber,
+) -> anyhow::Result<(PreConfirmedBlock, Arc<StateUpdate>)> {
+    // Drop placeholder Nones from receipts.
+    let transaction_receipts: Vec<_> = block.transaction_receipts.into_iter().flatten().collect();
 
     let receipted: HashSet<_> = transaction_receipts
         .iter()
         .map(|(receipt, _)| receipt.transaction_hash)
         .collect();
-    for tx in transactions {
+    for tx in &block.transactions {
         if !receipted.contains(&tx.hash) {
             anyhow::bail!("Missing transaction receipt for tx ({})", tx.hash);
         }
     }
-    anyhow::ensure!(
-        transaction_receipts.len() == transactions.len(),
-        "Mismatched transaction and receipt count in pre-confirmed block",
-    );
+    if transaction_receipts.len() != block.transactions.len() {
+        anyhow::bail!("Mismatched transaction and receipt count in pre-confirmed block");
+    }
 
-    Ok(transaction_receipts)
-}
-
-/// Fold the per-transaction state diffs of a pre-confirmed response into one
-/// state update. A pending block has no root of its own, so the roots are left
-/// empty.
-fn compose_state_update(
-    transaction_state_diffs: Vec<Option<starknet_gateway_types::reply::state_update::StateDiff>>,
-) -> StateUpdate {
+    // Compose the aggregated state diff for the pre-confirmed block.
     let mut state_diff = starknet_gateway_types::reply::state_update::StateDiff::default();
-    for transaction_diff in transaction_state_diffs.into_iter().flatten() {
+    for transaction_diff in block.transaction_state_diffs.into_iter().flatten() {
         state_diff.extend(transaction_diff);
     }
     state_diff.deduplicate();
+    let own_state_update = Arc::new(StateUpdate::from(
+        starknet_gateway_types::reply::StateUpdate {
+            state_diff,
+            block_hash: Default::default(),
+            new_root: StateCommitment::default(),
+            old_root: StateCommitment::default(),
+        },
+    ));
 
-    StateUpdate::from(starknet_gateway_types::reply::StateUpdate {
-        state_diff,
-        block_hash: Default::default(),
-        new_root: StateCommitment::default(),
-        old_root: StateCommitment::default(),
-    })
+    let display = PreConfirmedBlock {
+        number,
+        l1_gas_price: block.l1_gas_price,
+        l1_data_gas_price: block.l1_data_gas_price,
+        l2_gas_price: block.l2_gas_price,
+        sequencer_address: block.sequencer_address,
+        status: Status::PreConfirmed,
+        timestamp: block.timestamp,
+        starknet_version: block.starknet_version,
+        l1_da_mode: block.l1_da_mode.into(),
+        transactions: block.transactions,
+        transaction_receipts,
+    };
+
+    Ok((display, own_state_update))
+}
+
+#[cfg(test)]
+mod tests {
+    use pathfinder_common::{BlockHeader, BlockNumber, StateUpdate};
+
+    use super::{PendingBlocks, PendingData, PreConfirmedBlock, PreLatestBlock, PreLatestData};
+
+    fn bn(n: u64) -> BlockNumber {
+        BlockNumber::new_or_panic(n)
+    }
+
+    #[test]
+    fn lower_bound_without_pre_latest_is_number_minus_one() {
+        let blocks = PendingBlocks {
+            pre_confirmed: PreConfirmedBlock {
+                number: bn(10),
+                ..Default::default()
+            },
+            parents: Vec::new(),
+        };
+        let data = PendingData::from_parts(
+            blocks,
+            StateUpdate::default(),
+            StateUpdate::default(),
+            bn(10),
+        );
+        assert_eq!(data.aggregated_lower_bound, bn(9));
+    }
+
+    #[test]
+    fn lower_bound_with_pre_latest_is_number_minus_two() {
+        let blocks = PendingBlocks {
+            pre_confirmed: PreConfirmedBlock {
+                number: bn(10),
+                ..Default::default()
+            },
+            parents: vec![PreLatestData {
+                block: PreLatestBlock {
+                    number: bn(9),
+                    ..Default::default()
+                },
+                state_update: StateUpdate::default(),
+            }],
+        };
+        let data = PendingData::from_parts(
+            blocks,
+            StateUpdate::default(),
+            StateUpdate::default(),
+            bn(10),
+        );
+        assert_eq!(data.aggregated_lower_bound, bn(8));
+    }
+
+    #[test]
+    fn empty_lower_bound_is_latest() {
+        let latest = BlockHeader {
+            number: bn(10),
+            ..Default::default()
+        };
+        let data = PendingData::empty(&latest);
+        assert_eq!(data.number, bn(11));
+        assert_eq!(data.aggregated_lower_bound, bn(10));
+    }
+
+    #[test]
+    fn from_window_sets_explicit_lower_bound_and_keeps_parents() {
+        // Empty pre-confirmed block at height 10.
+        let pre_confirmed = Box::new(starknet_gateway_types::reply::PreConfirmedBlock::default());
+
+        // Un-committed parents 7, 8, 9, composed on top of committed block 6
+        let parent = |n: u64| PreLatestData {
+            block: PreLatestBlock {
+                number: bn(n),
+                ..Default::default()
+            },
+            state_update: StateUpdate::default(),
+        };
+        let parents = vec![parent(7), parent(8), parent(9)];
+
+        let data = PendingData::from_window(pre_confirmed, bn(10), parents, bn(6)).unwrap();
+
+        assert_eq!(data.number, bn(10));
+        assert_eq!(data.aggregated_lower_bound, bn(6));
+        let parent_numbers: Vec<_> = data.parent_blocks().map(|p| p.block.number).collect();
+        assert_eq!(parent_numbers, vec![bn(7), bn(8), bn(9)]);
+    }
+
+    #[test]
+    fn from_window_composes_aggregated_state_update_correctly() {
+        use pathfinder_common::macro_prelude::*;
+
+        let addr = |b: &[u8]| contract_address_bytes!(b);
+        let nonce = |b: &[u8]| contract_nonce_bytes!(b);
+        // Three parents each bump a distinct contract's nonce; the pre-confirmed
+        // block bumps a fourth.
+        let parent = |b: u64, a: &'static [u8], n: &'static [u8]| PreLatestData {
+            block: PreLatestBlock {
+                number: bn(b),
+                ..Default::default()
+            },
+            state_update: StateUpdate::default().with_contract_nonce(addr(a), nonce(n)),
+        };
+        // Oldest to youngest
+        let parents = vec![
+            parent(7, b"c7", b"77"),
+            parent(8, b"c8", b"88"),
+            parent(9, b"c9", b"99"),
+        ];
+
+        let pre_confirmed = Box::new(starknet_gateway_types::reply::PreConfirmedBlock {
+            transaction_state_diffs: vec![Some(
+                starknet_gateway_types::reply::state_update::StateDiff {
+                    nonces: [(addr(b"c10"), nonce(b"1010"))].into_iter().collect(),
+                    ..Default::default()
+                },
+            )],
+            ..Default::default()
+        });
+
+        let data = PendingData::from_window(pre_confirmed, bn(10), parents, bn(6)).unwrap();
+
+        let overlay = data.aggregated_state_update();
+        // Every deep ancestor's and the immediate parent's diffs are present.
+        assert_eq!(overlay.contract_nonce(addr(b"c7")), Some(nonce(b"77")));
+        assert_eq!(overlay.contract_nonce(addr(b"c8")), Some(nonce(b"88")));
+        assert_eq!(overlay.contract_nonce(addr(b"c9")), Some(nonce(b"99")));
+        assert_eq!(overlay.contract_nonce(addr(b"c10")), Some(nonce(b"1010")));
+    }
+
+    #[test]
+    fn lookups_reach_deep_ancestors() {
+        use pathfinder_common::macro_prelude::*;
+        use pathfinder_common::transaction::Transaction;
+
+        let deep_tx = transaction_hash!("0xdeed");
+        let parent = |n: u64, tx: pathfinder_common::TransactionHash| PreLatestData {
+            block: PreLatestBlock {
+                number: bn(n),
+                transactions: vec![Transaction {
+                    hash: tx,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            state_update: StateUpdate::default(),
+        };
+
+        let blocks = PendingBlocks {
+            pre_confirmed: PreConfirmedBlock {
+                number: bn(10),
+                ..Default::default()
+            },
+            // Deep ancestors 7 and 8, then the immediate parent 9 (oldest →
+            // newest).
+            parents: vec![
+                parent(7, deep_tx),
+                parent(8, transaction_hash!("0x8")),
+                parent(9, transaction_hash!("0x9")),
+            ],
+        };
+        let data = PendingData::from_parts(
+            blocks,
+            StateUpdate::default(),
+            StateUpdate::default(),
+            bn(10),
+        );
+
+        // A transaction in the deepest ancestor is found.
+        assert_eq!(
+            data.find_transaction(deep_tx).map(|t| t.hash),
+            Some(deep_tx)
+        );
+
+        // Every un-committed block reports as pending; a committed one does not.
+        assert!(data.is_pre_latest_or_pre_confirmed(bn(7)));
+        assert!(data.is_pre_latest_or_pre_confirmed(bn(8)));
+        assert!(data.is_pre_latest_or_pre_confirmed(bn(9)));
+        assert!(data.is_pre_latest_or_pre_confirmed(bn(10)));
+        assert!(!data.is_pre_latest_or_pre_confirmed(bn(6)));
+    }
 }

--- a/crates/pending-data/src/data.rs
+++ b/crates/pending-data/src/data.rs
@@ -210,6 +210,23 @@ impl PendingData {
         })
     }
 
+    /// Fold every uncommitted parent's state update into one overlay, oldest
+    /// first so newer diffs win. The pre-confirmed tip's own diff is not
+    /// included.
+    pub fn compose_parents_overlay(parents: &[PreLatestData]) -> StateUpdate {
+        let mut overlay = StateUpdate::default();
+        for parent in parents {
+            overlay = overlay.apply(&parent.state_update);
+        }
+        overlay
+    }
+
+    /// The overlay of just the uncommitted parents, without the pre-confirmed
+    /// tip's own diff.
+    pub fn parents_overlay(&self) -> StateUpdate {
+        Self::compose_parents_overlay(&self.blocks.parents)
+    }
+
     /// Build a pending view whose aggregated overlay spans a multi-block
     /// window.
     ///
@@ -226,13 +243,9 @@ impl PendingData {
         let (pre_confirmed_block, pre_confirmed_state_update) =
             convert_pre_confirmed_block(pre_confirmed_block, number)?;
 
-        // Compose the overlay starting from the oldest block so fresher updates
-        // overwrite older ones.
-        let mut overlay = StateUpdate::default();
-        for parent in &parents {
-            overlay = overlay.apply(&parent.state_update);
-        }
-        let aggregated_state_update = Arc::new(overlay.apply(pre_confirmed_state_update.as_ref()));
+        let aggregated_state_update = Arc::new(
+            Self::compose_parents_overlay(&parents).apply(pre_confirmed_state_update.as_ref()),
+        );
 
         Ok(Self {
             blocks: Arc::new(PendingBlocks {

--- a/crates/pending-data/src/data.rs
+++ b/crates/pending-data/src/data.rs
@@ -340,12 +340,6 @@ impl PendingData {
         }
     }
 
-    /// Synthesise a `BlockHeader` from the immediate parent block, if it
-    /// exists.
-    pub fn pre_latest_header(&self) -> Option<BlockHeader> {
-        self.blocks.immediate_parent().map(|data| data.header())
-    }
-
     pub fn pending_block(&self) -> Arc<PendingBlocks> {
         Arc::clone(&self.blocks)
     }

--- a/crates/pending-data/src/data.rs
+++ b/crates/pending-data/src/data.rs
@@ -44,13 +44,9 @@ pub struct PreConfirmedBlock {
     pub transaction_receipts: Vec<TxnReceiptAndEvents>,
 }
 
-// TODO consider removing, because we're gonna be setting the parent hash to
-// zero anyway.
 #[derive(Clone, Default, Debug, PartialEq)]
 pub struct PreLatestBlock {
     pub number: BlockNumber,
-
-    pub parent_hash: BlockHash,
 
     pub l1_gas_price: GasPrices,
     pub l1_data_gas_price: GasPrices,
@@ -78,7 +74,7 @@ impl PreLatestData {
     pub fn header(&self) -> BlockHeader {
         let block = &self.block;
         BlockHeader {
-            parent_hash: block.parent_hash,
+            parent_hash: BlockHash::ZERO,
             number: block.number,
             timestamp: block.timestamp,
             eth_l1_gas_price: block.l1_gas_price.price_in_wei,
@@ -256,7 +252,6 @@ impl PendingData {
         PreLatestData {
             block: PreLatestBlock {
                 number: block.number,
-                parent_hash: BlockHash::ZERO,
                 l1_gas_price: block.l1_gas_price,
                 l1_data_gas_price: block.l1_data_gas_price,
                 l2_gas_price: block.l2_gas_price,

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -896,7 +896,7 @@ pub mod test_utils {
                 starknet_version: StarknetVersion::V_0_13_2,
                 l1_da_mode: L1DataAvailabilityMode::Calldata,
             },
-            pre_latest: None,
+            parents: Vec::new(),
         };
 
         // The class definitions must be inserted into the database.
@@ -1242,10 +1242,10 @@ pub mod test_utils {
                 starknet_version: StarknetVersion::V_0_13_2,
                 l1_da_mode: L1DataAvailabilityMode::Calldata,
             },
-            pre_latest: Some(PreLatestData {
+            parents: vec![PreLatestData {
                 block: pre_latest_block,
                 state_update: pre_latest_state_update.clone(),
-            }),
+            }],
         };
 
         let aggregated_state_update = pre_latest_state_update

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1079,7 +1079,6 @@ pub mod test_utils {
         let pre_latest_block = PreLatestBlock {
             // Pre-latest is between current latest and pre-confirmed.
             number: latest.number + 1,
-            parent_hash: latest.hash,
             l1_gas_price: GasPrices {
                 price_in_wei: GasPrice::from_be_slice(b"gas price").unwrap(),
                 price_in_fri: GasPrice::from_be_slice(b"strk gas price").unwrap(),

--- a/crates/rpc/src/method/call.rs
+++ b/crates/rpc/src/method/call.rs
@@ -402,7 +402,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn contract_deployed_in_pre_confirmed() {
+        async fn call_cairo_contract_in_pre_confirmed() {
             let (context, last_block_header, _contract_address, test_key, _test_value) =
                 test_context().await;
 
@@ -431,7 +431,7 @@ mod tests {
         }
 
         #[test_log::test(tokio::test)]
-        async fn contract_declared_and_deployed_in_pre_confirmed() {
+        async fn call_sierra_contract_in_pre_confirmed() {
             let (context, last_block_header, _contract_address, _test_key, _test_value) =
                 test_context().await;
 
@@ -522,7 +522,7 @@ mod tests {
                         starknet_version: last_block_header.starknet_version,
                         l1_da_mode: L1DataAvailabilityMode::Blob.into(),
                     },
-                    pre_latest: None,
+                    parents: Vec::new(),
                 },
                 state_update,
                 aggregated_state_update,

--- a/crates/rpc/src/method/get_events.rs
+++ b/crates/rpc/src/method/get_events.rs
@@ -304,7 +304,8 @@ pub async fn get_events(
             offset: ct.offset,
         });
 
-        // TODO: Verify the added `| None` in review.
+        // An absent `to_block` is unbounded, so it reaches into the pending
+        // range just like an explicit pre-confirmed upper bound does.
         let append_from_pending =
             db_ct.is_none() && matches!(to_block_id, Some(PreConfirmed) | None);
 

--- a/crates/rpc/src/method/get_events.rs
+++ b/crates/rpc/src/method/get_events.rs
@@ -387,9 +387,12 @@ fn get_pending_events(
         pending.pre_confirmed_tx_receipts_and_events(),
     ));
 
-    let oldest_block = blocks
-        .first()
-        .map(|(number, _)| *number)
+    // The oldest un-committed block is the first parent, or the pre-confirmed
+    // tip itself when there are no parents (a gap of one).
+    let oldest_block = pending
+        .parent_blocks()
+        .next()
+        .map(|parent| parent.block.number)
         .unwrap_or(pending_block);
 
     // If we have a continuation token and it points into the un-committed window,

--- a/crates/rpc/src/method/get_events.rs
+++ b/crates/rpc/src/method/get_events.rs
@@ -326,7 +326,9 @@ pub async fn get_events(
                     // We have a full page from the database, but there might be more pending
                     // events. Return a continuation token for the pending block.
                     let pending_block = pending
-                        .pre_latest_block_number()
+                        .parent_blocks()
+                        .next()
+                        .map(|parent| parent.block.number)
                         .unwrap_or_else(|| pending.pre_confirmed_block_number());
                     Some(ContinuationToken {
                         block_number: pending_block,
@@ -368,9 +370,30 @@ fn get_pending_events(
 
     let pending_block = pending.pre_confirmed_block_number();
 
-    // If we have a continuation token and it points to a pre-latest/pending block,
-    // we use its values. Otherwise we take whatever events we have from pending
-    // data, if the continuation token is valid (not pointing past pending block).
+    // The un-committed window in emission order (oldest to newest): every
+    // un-committed parent block, then the pre-confirmed block last.
+    let mut blocks: Vec<(BlockNumber, &[crate::pending::TxnReceiptAndEvents])> = pending
+        .parent_blocks()
+        .map(|parent| {
+            (
+                parent.block.number,
+                parent.block.transaction_receipts.as_slice(),
+            )
+        })
+        .collect();
+    blocks.push((
+        pending_block,
+        pending.pre_confirmed_tx_receipts_and_events(),
+    ));
+
+    let oldest_block = blocks
+        .first()
+        .map(|(number, _)| *number)
+        .unwrap_or(pending_block);
+
+    // If we have a continuation token and it points into the un-committed window,
+    // resume from it. Otherwise start at the oldest un-committed block (validating
+    // the token doesn't go beyond the pre-confirmed block).
     let (start_block, start_offset) = match continuation_token {
         Some(ct) if ct.block_number > pending_block => {
             return Err(GetEventsError::InvalidContinuationToken)
@@ -378,96 +401,59 @@ fn get_pending_events(
         Some(ct) if pending.is_pre_latest_or_pre_confirmed(ct.block_number) => {
             (ct.block_number, ct.offset)
         }
-        _ => (
-            pending.pre_latest_block_number().unwrap_or(pending_block),
-            0,
-        ),
+        _ => (oldest_block, 0),
     };
 
     let mut events = Vec::new();
+    let mut blocks = blocks
+        .into_iter()
+        .skip_while(|(number, _)| *number < start_block)
+        .peekable();
+    let mut is_first = true;
 
-    let new_continuation_token = match pending.pre_latest_block() {
-        Some(pre_latest_block) if pre_latest_block.number == start_block => {
-            // Fetch from pre-latest and pre-confirmed.
-            let pre_latest_events_exhausted = match_and_fill_events(
-                &pre_latest_block.transaction_receipts,
-                &mut events,
-                start_offset,
-                max_amount,
-                &keys,
-                addresses,
-                pre_latest_block.number,
-            );
+    // Walk the window from oldest to newest, filling the page. The continuation
+    // token, when a page fills, points at the next unread position: the same block
+    // at a higher offset if it still has events, otherwise the next block at offset
+    // 0.
+    let new_continuation_token = loop {
+        let Some((number, receipts)) = blocks.next() else {
+            // Scanned the whole window without filling the page.
+            break None;
+        };
 
-            let taken_from_pre_latest = events.len();
+        // The resume offset only applies to the first block we touch, every next
+        // block is read from its start.
+        let block_offset = if is_first { start_offset } else { 0 };
+        is_first = false;
 
-            if taken_from_pre_latest == max_amount {
-                let continuation_token = if pre_latest_events_exhausted {
-                    // We exhausted the pre-latest block but there might be more events in
-                    // the pending block.
-                    ContinuationToken {
-                        block_number: pending_block,
-                        offset: 0,
-                    }
-                } else {
-                    // We've filled up a page but still have more events in the pre-latest
-                    // block.
-                    ContinuationToken {
-                        block_number: pre_latest_block.number,
-                        offset: start_offset + max_amount,
-                    }
-                };
+        let before = events.len();
+        let remaining = max_amount - before;
+        let exhausted = match_and_fill_events(
+            receipts,
+            &mut events,
+            block_offset,
+            remaining,
+            &keys,
+            addresses,
+            number,
+        );
+        let taken = events.len() - before;
 
-                return Ok((events, Some(continuation_token)));
-            }
-
-            let amount_to_take = max_amount - taken_from_pre_latest;
-
-            let pending_events_exhausted = match_and_fill_events(
-                pending.pre_confirmed_tx_receipts_and_events(),
-                &mut events,
-                // Continuation token was used on pre-latest block, no offset for pending.
-                0,
-                amount_to_take,
-                &keys,
-                addresses,
-                pending_block,
-            );
-
-            if pending_events_exhausted {
-                None
+        // match_and_fill_events() is guaranteed to stop at max_amount
+        if events.len() == max_amount {
+            break if !exhausted {
+                // More events remain in this block.
+                Some(ContinuationToken {
+                    block_number: number,
+                    offset: block_offset + taken,
+                })
             } else {
-                let offset_in_pending = events.len() - taken_from_pre_latest;
-                // We filled up a page but still have more events in the pending block.
-                let continuation_token = ContinuationToken {
-                    block_number: pending_block,
-                    offset: offset_in_pending,
-                };
-                Some(continuation_token)
-            }
-        }
-        _ => {
-            // Fetch from pending/pre-confirmed block only.
-            let pending_events_exhausted = match_and_fill_events(
-                pending.pre_confirmed_tx_receipts_and_events(),
-                &mut events,
-                start_offset,
-                max_amount,
-                &keys,
-                addresses,
-                pending_block,
-            );
-
-            if pending_events_exhausted {
-                None
-            } else {
-                // We filled up a page but still have more events in the pending block.
-                let continuation_token = ContinuationToken {
-                    block_number: pending_block,
-                    offset: start_offset + events.len(),
-                };
-                Some(continuation_token)
-            }
+                // This block is exhausted; resume at the next block, if any.
+                blocks.peek().map(|(next_number, _)| ContinuationToken {
+                    block_number: *next_number,
+                    offset: 0,
+                })
+            };
         }
     };
 
@@ -1224,6 +1210,89 @@ mod tests {
             };
             let error = get_events(context, input, RPC_VERSION).await.unwrap_err();
             assert!(matches!(error, GetEventsError::Custom(_)));
+        }
+
+        #[test]
+        fn get_pending_events_spans_deep_ancestors() {
+            use pathfinder_common::event::Event;
+            use pathfinder_common::macro_prelude::*;
+            use pathfinder_common::receipt::Receipt;
+            use pathfinder_pending_data::{
+                PendingBlocks,
+                PendingData,
+                PreConfirmedBlock,
+                PreLatestBlock,
+                PreLatestData,
+            };
+
+            fn bn(n: u64) -> BlockNumber {
+                BlockNumber::new_or_panic(n)
+            }
+
+            // One event per block, each from a distinct emitter.
+            let event = |from_address| {
+                vec![(
+                    Receipt::default(),
+                    vec![Event {
+                        from_address,
+                        keys: vec![],
+                        data: vec![],
+                    }],
+                )]
+            };
+            let parent = |n: u64, from_address| PreLatestData {
+                block: PreLatestBlock {
+                    number: bn(n),
+                    transaction_receipts: event(from_address),
+                    ..Default::default()
+                },
+                state_update: StateUpdate::default(),
+            };
+
+            let blocks = PendingBlocks {
+                pre_confirmed: PreConfirmedBlock {
+                    number: bn(10),
+                    transaction_receipts: event(contract_address_bytes!(b"10")),
+                    ..Default::default()
+                },
+                parents: vec![
+                    parent(7, contract_address_bytes!(b"7")),
+                    parent(8, contract_address_bytes!(b"8")),
+                    parent(9, contract_address_bytes!(b"9")),
+                ],
+            };
+            let pending = PendingData::from_parts(
+                blocks,
+                StateUpdate::default(),
+                StateUpdate::default(),
+                bn(10),
+            );
+
+            let (events, ct) =
+                get_pending_events(&pending, 100, &[], &HashSet::new(), None).unwrap();
+            let block_numbers: Vec<_> = events.iter().map(|e| e.block_number).collect();
+            // Deep ancestors 7 and 8, immediate parent 9, then pre-confirmed 10.
+            assert_eq!(
+                block_numbers,
+                vec![Some(bn(7)), Some(bn(8)), Some(bn(9)), Some(bn(10))]
+            );
+            assert!(ct.is_none());
+
+            // Paging across the window: a chunk of 2 returns blocks 7 and 8 and a
+            // continuation token resuming at block 9.
+            let (page, ct) = get_pending_events(&pending, 2, &[], &HashSet::new(), None).unwrap();
+            assert_eq!(
+                page.iter().map(|e| e.block_number).collect::<Vec<_>>(),
+                vec![Some(bn(7)), Some(bn(8))]
+            );
+            let ct = ct.expect("more events remain, so a continuation token is returned");
+            let (rest, ct) =
+                get_pending_events(&pending, 100, &[], &HashSet::new(), Some(ct)).unwrap();
+            assert_eq!(
+                rest.iter().map(|e| e.block_number).collect::<Vec<_>>(),
+                vec![Some(bn(9)), Some(bn(10))]
+            );
+            assert!(ct.is_none());
         }
 
         #[tokio::test]

--- a/crates/rpc/src/method/subscribe_events.rs
+++ b/crates/rpc/src/method/subscribe_events.rs
@@ -278,6 +278,12 @@ impl RpcSubscriptionFlow for SubscribeEvents {
             HashSet<(TransactionHash, TxnFinalityStatus)>,
         > = HashMap::new();
 
+        // The highest committed block height seen on the L2-block stream. A block at or
+        // below this has been finalized, and its `sent_updates` were dropped when it
+        // was committed, so it must not be re-emitted as pending. A not-yet-pruned
+        // pending view can briefly show a just committed block as a parent.
+        let mut latest_committed = BlockNumber::GENESIS;
+
         loop {
             tokio::select! {
                 reorg = reorgs.recv() => {
@@ -309,6 +315,7 @@ impl RpcSubscriptionFlow for SubscribeEvents {
                         Ok(block) => {
                             let block_number = block.header.number;
                             let block_hash = block.header.hash;
+                            latest_committed = std::cmp::max(latest_committed, block_number);
 
                             tracing::trace!(%block_number, %block_hash, "Received new block");
 
@@ -402,20 +409,32 @@ impl RpcSubscriptionFlow for SubscribeEvents {
                         return Ok(());
                     }
 
-                    if let Some(pre_latest_block) = pending.pre_latest_block() {
+                    // Emit every un-committed parent block (the immediate
+                    // pre-latest and any deeper ancestors), oldest to newest.
+                    for parent in pending.parent_blocks() {
+                        let pre_latest_block = &parent.block;
                         let pre_latest_block_number = pre_latest_block.number;
+
+                        // A just-committed block can still show up as a parent in a
+                        // not-yet-pruned pending view for a brief moment. Its `sent_updates`
+                        // were dropped when it was committed, so re-emitting it here would
+                        // falsely regress finality to PRE_CONFIRMED for transactions that
+                        // were already emitted as ACCEPTED_ON_L2.
+                        if pre_latest_block_number <= latest_committed {
+                            continue;
+                        }
 
                         let sent_pre_latest_updates = sent_updates_per_block
                             .entry(pre_latest_block_number)
                             .or_default();
 
                         if !sent_pre_latest_updates.is_empty() {
-                            // We've already processed this block as pre-latest (and once it gets
-                            // promoted to pre-latest, it cannot change anymore), nothing to do.
+                            // We've already processed this block as a parent (once it stops being
+                            // the pre-confirmed tip, its contents are frozen), nothing to do.
                             continue;
                         }
 
-                        tracing::trace!(block_number = %pre_latest_block_number, "Pre-latest block update");
+                        tracing::trace!(block_number = %pre_latest_block_number, "Un-committed parent block update");
 
                         if send_event_updates(
                             &pre_latest_block.transaction_receipts,
@@ -500,7 +519,7 @@ mod tests {
 
     use crate::context::{RpcContext, WebsocketContext};
     use crate::jsonrpc::websocket::WebsocketHistory;
-    use crate::jsonrpc::{handle_json_rpc_socket, RpcRouter, RpcSubscriptionFlow};
+    use crate::jsonrpc::{handle_json_rpc_socket, RpcResponse, RpcRouter, RpcSubscriptionFlow};
     use crate::method::subscribe_events::SubscribeEvents;
     use crate::{v06, v07, v08, v09, v10, Notifications, Reorg, RpcVersion};
 
@@ -869,6 +888,83 @@ mod tests {
         };
         assert_eq!(json, expected);
         assert!(sender_rx.is_empty());
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn committed_parent_is_not_re_emitted_as_pending() {
+        let num_blocks = SubscribeEvents::CATCH_UP_BATCH_SIZE + 10;
+        let parent = num_blocks;
+        let tip = num_blocks + 1;
+        let (router, pending_data_cache) = setup(num_blocks, RpcVersion::V09).await;
+        let (sender_tx, mut sender_rx) = mpsc::channel(1024);
+        let (receiver_tx, receiver_rx) = mpsc::channel(1024);
+        handle_json_rpc_socket(router.clone(), sender_tx, receiver_rx);
+
+        // "0x16" (block 22, from the DB) is a catch-up sync point
+        // `parent` and `tip` are the two pending blocks we care about.
+        let params = serde_json::json!({
+            "block_id": {"block_number": 0},
+            "keys": [["0x16", format!("{parent:x}"), format!("{tip:x}")]],
+            "finality_status": "PRE_CONFIRMED",
+        });
+        receiver_tx
+            .send(Ok(Message::Text(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "starknet_subscribeEvents",
+                    "params": params
+                })
+                .to_string()
+                .into(),
+            )))
+            .await
+            .unwrap();
+        let subscription_id = match sender_rx.recv().await.unwrap().unwrap() {
+            Message::Text(json) => {
+                let json: serde_json::Value = serde_json::from_str(&json).unwrap();
+                json["result"].as_str().unwrap().parse().unwrap()
+            }
+            _ => panic!("Expected text message"),
+        };
+
+        // Catch-up emits block 22 (sync point).
+        assert_eq!(
+            recv(&mut sender_rx).await,
+            sample_event_message(0x16, subscription_id, RpcVersion::V09)
+        );
+
+        // Pending window: tip with the parent below it. The tip is emitted first,
+        // then the parent, both PRE_CONFIRMED (no block hash).
+        pending_data_cache.store(sample_pending_with_parent(tip, parent));
+        assert_eq!(
+            recv(&mut sender_rx).await,
+            sample_event_message_without_block_hash(tip, subscription_id)
+        );
+        assert_eq!(
+            recv(&mut sender_rx).await,
+            sample_event_message_without_block_hash(parent, subscription_id)
+        );
+
+        // The parent commits: its event is re-sent as ACCEPTED_ON_L2 and its
+        // sent set is dropped.
+        router
+            .context
+            .notifications
+            .l2_blocks
+            .send(sample_block(parent).into())
+            .unwrap();
+        assert_eq!(
+            recv(&mut sender_rx).await,
+            sample_event_message(parent, subscription_id, RpcVersion::V09)
+        );
+
+        // A not-yet-pruned pending view still lists the now-committed parent. It
+        // must NOT be re-emitted as PRE_CONFIRMED. (Don't commit the tip to
+        // disambiguate — that would exercise the unguarded pre-confirmed/tip path
+        // and mask the check.)
+        pending_data_cache.store(sample_pending_with_parent(tip, parent));
+        assert_recv_nothing(&mut sender_rx).await;
     }
 
     #[test_log::test(tokio::test)]
@@ -1341,6 +1437,47 @@ mod tests {
             transactions: vec![sample_transaction(block_number)],
             ..Default::default()
         }
+    }
+
+    /// A pre-confirmed tip with with its un-committed parent.
+    fn sample_pending_with_parent(tip: u64, parent: u64) -> crate::PendingData {
+        let parent = crate::PendingData::try_from_pre_confirmed_block(
+            sample_pre_confirmed_block(parent).into(),
+            BlockNumber::new_or_panic(parent),
+        )
+        .unwrap()
+        .to_pre_latest_data();
+        let tip_view = crate::PendingData::try_from_pre_confirmed_block(
+            sample_pre_confirmed_block(tip).into(),
+            BlockNumber::new_or_panic(tip),
+        )
+        .unwrap();
+        let blocks = pathfinder_pending_data::PendingBlocks {
+            pre_confirmed: tip_view.blocks.pre_confirmed.clone(),
+            parents: vec![parent],
+        };
+        crate::PendingData {
+            blocks: blocks.into(),
+            state_update: tip_view.state_update.clone(),
+            aggregated_state_update: tip_view.aggregated_state_update.clone(),
+            number: BlockNumber::new_or_panic(tip),
+            aggregated_lower_bound: BlockNumber::GENESIS,
+        }
+    }
+
+    async fn recv(rx: &mut mpsc::Receiver<Result<Message, RpcResponse>>) -> serde_json::Value {
+        let res = rx.recv().await.unwrap().unwrap();
+        match res {
+            Message::Text(json) => serde_json::from_str(&json).unwrap(),
+            _ => panic!("Expected text message"),
+        }
+    }
+
+    async fn assert_recv_nothing(rx: &mut mpsc::Receiver<Result<Message, RpcResponse>>) {
+        let timeout = std::time::Duration::from_millis(100);
+        tokio::time::timeout(timeout, rx.recv())
+            .await
+            .expect_err("Message received when none was expected");
     }
 
     fn sample_event_message(

--- a/crates/rpc/src/method/subscribe_new_transaction_receipts.rs
+++ b/crates/rpc/src/method/subscribe_new_transaction_receipts.rs
@@ -166,6 +166,12 @@ impl RpcSubscriptionFlow for SubscribeNewTransactionReceipts {
             HashSet<(TransactionHash, TxnFinalityStatus)>,
         > = HashMap::new();
 
+        // The highest committed block height seen on the L2-block stream. A block at or
+        // below this has been finalized, and its `sent_updates` were dropped when it
+        // was committed, so it must not be re-emitted as pending. A not-yet-pruned
+        // pending view can briefly show a just committed block as a parent.
+        let mut latest_committed = BlockNumber::GENESIS;
+
         loop {
             tokio::select! {
                 reorg = reorgs.recv() => {
@@ -201,6 +207,7 @@ impl RpcSubscriptionFlow for SubscribeNewTransactionReceipts {
                         }
                         Ok(block) => {
                             tracing::trace!(block_number=%block.header.number, "New block header");
+                            latest_committed = std::cmp::max(latest_committed, block.header.number);
 
                             // We won't be needing to keep track of updates for this block anymore,
                             // so we remove it from the map.
@@ -292,20 +299,32 @@ impl RpcSubscriptionFlow for SubscribeNewTransactionReceipts {
                         return Ok(());
                     }
 
-                    if let Some(pre_latest_block) = pending.pre_latest_block() {
+                    // Emit every un-committed parent block (the immediate
+                    // pre-latest and any deeper ancestors), oldest to newest.
+                    for parent in pending.parent_blocks() {
+                        let pre_latest_block = &parent.block;
                         let pre_latest_block_number = pre_latest_block.number;
+
+                        // A just-committed block can still show up as a parent in a
+                        // not-yet-pruned pending view for a brief moment. Its `sent_updates`
+                        // were dropped when it was committed, so re-emitting it here would
+                        // falsely regress finality to PRE_CONFIRMED for transactions that
+                        // were already emitted as ACCEPTED_ON_L2.
+                        if pre_latest_block_number <= latest_committed {
+                            continue;
+                        }
 
                         let sent_pre_latest_updates = sent_updates_per_block
                             .entry(pre_latest_block_number)
                             .or_default();
 
                         if !sent_pre_latest_updates.is_empty() {
-                            // We've already processed this block as pre-latest (and once it gets
-                            // promoted to pre-latest, it cannot change anymore), nothing to do.
+                            // We've already processed this block as a parent (once it stops being
+                            // the pre-confirmed tip, its contents are frozen), nothing to do.
                             continue;
                         }
 
-                        tracing::trace!(block_number = %pre_latest_block_number, "Pre-latest block update");
+                        tracing::trace!(block_number = %pre_latest_block_number, "Un-committed parent block update");
 
                         let pre_latest_txs_and_receipts = pre_latest_block
                             .transactions
@@ -731,6 +750,83 @@ mod tests {
     }
 
     #[test_log::test(tokio::test)]
+    async fn committed_parent_is_not_re_emitted_as_pending() {
+        let Setup {
+            tx,
+            mut rx,
+            pending_data_cache,
+            notifications,
+        } = setup();
+        tx.send(Ok(Message::Text(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "starknet_subscribeNewTransactionReceipts",
+                "params": { "finality_status": ["ACCEPTED_ON_L2", "PRE_CONFIRMED"] }
+            })
+            .to_string()
+            .into(),
+        )))
+        .await
+        .unwrap();
+        let response = rx.recv().await.unwrap().unwrap();
+        let subscription_id = match response {
+            Message::Text(json) => {
+                let json: serde_json::Value = serde_json::from_str(&json).unwrap();
+                json["result"].as_str().unwrap().parse().unwrap()
+            }
+            _ => panic!("Expected text message"),
+        };
+        assert_recv_nothing(&mut rx).await;
+
+        // Tip block 2 (0x222) with block 1 (0x111) as an un-committed parent, the tip
+        // is emitted first, then the parent, both PRE_CONFIRMED.
+        pending_data_cache.store(sample_pending_with_parent(
+            BlockNumber::new_or_panic(2),
+            vec![(contract_address!("0x22"), transaction_hash!("0x222"))],
+            BlockNumber::new_or_panic(1),
+            vec![(contract_address!("0x11"), transaction_hash!("0x111"))],
+        ));
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_receipt_message(2, "0x222", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_receipt_message(1, "0x111", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+
+        // Block 1 commits: 0x111 is re-sent as ACCEPTED_ON_L2 and its sent set is
+        // dropped.
+        notifications
+            .l2_blocks
+            .send(
+                sample_block(
+                    BlockNumber::new_or_panic(1),
+                    vec![(contract_address!("0x11"), transaction_hash!("0x111"))],
+                )
+                .into(),
+            )
+            .unwrap();
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_receipt_message(1, "0x111", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+
+        // A not-yet-pruned pending view still lists the now-committed block 1 as a
+        // parent. It must NOT be re-emitted as PRE_CONFIRMED.
+        pending_data_cache.store(sample_pending_with_parent(
+            BlockNumber::new_or_panic(2),
+            vec![(contract_address!("0x22"), transaction_hash!("0x222"))],
+            BlockNumber::new_or_panic(1),
+            vec![(contract_address!("0x11"), transaction_hash!("0x111"))],
+        ));
+        assert_recv_nothing(&mut rx).await;
+    }
+
+    #[test_log::test(tokio::test)]
     async fn pre_confirmed_followed_by_block_with_filter_on_finality_status() {
         let Setup {
             tx,
@@ -889,6 +985,28 @@ mod tests {
             ..Default::default()
         };
         PendingData::try_from_pre_confirmed_block(pre_confirmed_block.into(), block_number).unwrap()
+    }
+
+    /// A pre-confirmed tip with with its un-committed parent.
+    fn sample_pending_with_parent(
+        tip: BlockNumber,
+        tip_txs: Vec<(ContractAddress, TransactionHash)>,
+        parent: BlockNumber,
+        parent_txs: Vec<(ContractAddress, TransactionHash)>,
+    ) -> PendingData {
+        let parent = sample_pre_confirmed_block(parent, parent_txs).to_pre_latest_data();
+        let tip_view = sample_pre_confirmed_block(tip, tip_txs);
+        let blocks = pathfinder_pending_data::PendingBlocks {
+            pre_confirmed: tip_view.blocks.pre_confirmed.clone(),
+            parents: vec![parent],
+        };
+        PendingData {
+            blocks: blocks.into(),
+            state_update: tip_view.state_update.clone(),
+            aggregated_state_update: tip_view.aggregated_state_update.clone(),
+            number: tip,
+            aggregated_lower_bound: BlockNumber::GENESIS,
+        }
     }
 
     fn sample_pre_confirmed_receipt_message(

--- a/crates/rpc/src/method/subscribe_new_transactions.rs
+++ b/crates/rpc/src/method/subscribe_new_transactions.rs
@@ -216,6 +216,12 @@ impl RpcSubscriptionFlow for SubscribeNewTransactions {
             HashSet<(TransactionHash, TxnFinalityStatusWithoutL1Accepted)>,
         > = HashMap::new();
 
+        // The highest committed block height seen on the L2-block stream. A block at or
+        // below this has been finalized, and its `sent_updates` were dropped when it
+        // was committed, so it must not be re-emitted as pending. A not-yet-pruned
+        // pending view can briefly show a just committed block as a parent.
+        let mut latest_committed = BlockNumber::GENESIS;
+
         // Transactions sent with Received status are kept separately,
         // because their lifetime doesn't depend on blocks (they
         // disappear spontaneously from the tracker as time passes).
@@ -256,6 +262,7 @@ impl RpcSubscriptionFlow for SubscribeNewTransactions {
                         }
                         Ok(block) => {
                             tracing::trace!(block_number=%block.header.number, "New block header");
+                            latest_committed = std::cmp::max(latest_committed, block.header.number);
 
                             // We won't be needing to keep track of updates for this block anymore,
                             // so we remove it from the map.
@@ -332,20 +339,32 @@ impl RpcSubscriptionFlow for SubscribeNewTransactions {
                         return Ok(());
                     }
 
-                    if let Some(pre_latest_block) = pending.pre_latest_block() {
+                    // Emit every un-committed parent block (the immediate
+                    // pre-latest and any deeper ancestors), oldest to newest.
+                    for parent in pending.parent_blocks() {
+                        let pre_latest_block = &parent.block;
                         let pre_latest_block_number = pre_latest_block.number;
+
+                        // A just-committed block can still show up as a parent in a
+                        // not-yet-pruned pending view for a brief moment. Its `sent_updates`
+                        // were dropped when it was committed, so re-emitting it here would
+                        // falsely regress finality to PRE_CONFIRMED for transactions that
+                        // were already emitted as ACCEPTED_ON_L2.
+                        if pre_latest_block_number <= latest_committed {
+                            continue;
+                        }
 
                         let sent_pre_latest_updates = sent_updates_per_block
                             .entry(pre_latest_block_number)
                             .or_default();
 
                         if !sent_pre_latest_updates.is_empty() {
-                            // We've already processed this block as pre-latest (and once it gets
-                            // promoted to pre-latest, it cannot change anymore), nothing to do.
+                            // We've already processed this block as a parent (once it stops being
+                            // the pre-confirmed tip, its contents are frozen), nothing to do.
                             continue;
                         }
 
-                        tracing::trace!(block_number = %pre_latest_block_number, "Pre-latest block update");
+                        tracing::trace!(block_number = %pre_latest_block_number, "Un-committed parent block update");
 
                         let pre_latest_txs = pre_latest_block
                             .transactions
@@ -1077,6 +1096,84 @@ mod tests {
     }
 
     #[test_log::test(tokio::test)]
+    async fn committed_parent_is_not_re_emitted_as_pending() {
+        let Setup {
+            tx,
+            mut rx,
+            pending_data_cache,
+            submission_tracker: _,
+            notifications,
+        } = setup();
+        tx.send(Ok(Message::Text(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "starknet_subscribeNewTransactions",
+                "params": { "finality_status": ["ACCEPTED_ON_L2", "PRE_CONFIRMED"] }
+            })
+            .to_string()
+            .into(),
+        )))
+        .await
+        .unwrap();
+        let response = rx.recv().await.unwrap().unwrap();
+        let subscription_id = match response {
+            Message::Text(json) => {
+                let json: serde_json::Value = serde_json::from_str(&json).unwrap();
+                json["result"].as_str().unwrap().parse().unwrap()
+            }
+            _ => panic!("Expected text message"),
+        };
+        assert_recv_nothing(&mut rx).await;
+
+        // Tip block 2 (0x222) with block 1 (0x111) as an un-committed parent. The tip
+        // is emitted first, then the parent — both PRE_CONFIRMED.
+        pending_data_cache.store(sample_pending_with_parent(
+            BlockNumber::new_or_panic(2),
+            vec![(contract_address!("0x22"), transaction_hash!("0x222"))],
+            BlockNumber::new_or_panic(1),
+            vec![(contract_address!("0x11"), transaction_hash!("0x111"))],
+        ));
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_transaction_message("0x22", "0x222", subscription_id)
+        );
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_pre_confirmed_transaction_message("0x11", "0x111", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+
+        // Block 1 commits: 0x111 is re-sent as ACCEPTED_ON_L2 and its sent-set is
+        // dropped.
+        notifications
+            .l2_blocks
+            .send(
+                sample_block(
+                    BlockNumber::new_or_panic(1),
+                    vec![(contract_address!("0x11"), transaction_hash!("0x111"))],
+                )
+                .into(),
+            )
+            .unwrap();
+        assert_eq!(
+            recv(&mut rx).await,
+            sample_transaction_message("0x11", "0x111", subscription_id)
+        );
+        assert_recv_nothing(&mut rx).await;
+
+        // A not-yet-pruned pending view still lists the now-committed block 1 as a
+        // parent. It must NOT be re-emitted as PRE_CONFIRMED.
+        pending_data_cache.store(sample_pending_with_parent(
+            BlockNumber::new_or_panic(2),
+            vec![(contract_address!("0x22"), transaction_hash!("0x222"))],
+            BlockNumber::new_or_panic(1),
+            vec![(contract_address!("0x11"), transaction_hash!("0x111"))],
+        ));
+        assert_recv_nothing(&mut rx).await;
+    }
+
+    #[test_log::test(tokio::test)]
     async fn pre_confirmed_followed_by_block_with_filter_on_finality_status() {
         let Setup {
             tx,
@@ -1335,6 +1432,28 @@ mod tests {
             ..Default::default()
         };
         PendingData::try_from_pre_confirmed_block(pre_confirmed_block.into(), block_number).unwrap()
+    }
+
+    /// A pre-confirmed tip with with its un-committed parent.
+    fn sample_pending_with_parent(
+        tip: BlockNumber,
+        tip_txs: Vec<(ContractAddress, TransactionHash)>,
+        parent: BlockNumber,
+        parent_txs: Vec<(ContractAddress, TransactionHash)>,
+    ) -> PendingData {
+        let parent = sample_pre_confirmed_block(parent, parent_txs).to_pre_latest_data();
+        let tip_view = sample_pre_confirmed_block(tip, tip_txs);
+        let blocks = pathfinder_pending_data::PendingBlocks {
+            pre_confirmed: tip_view.blocks.pre_confirmed.clone(),
+            parents: vec![parent],
+        };
+        PendingData {
+            blocks: blocks.into(),
+            state_update: tip_view.state_update.clone(),
+            aggregated_state_update: tip_view.aggregated_state_update.clone(),
+            number: tip,
+            aggregated_lower_bound: BlockNumber::GENESIS,
+        }
     }
 
     fn sample_received_transaction_message(

--- a/crates/rpc/src/method/subscribe_transaction_status.rs
+++ b/crates/rpc/src/method/subscribe_transaction_status.rs
@@ -1132,7 +1132,6 @@ mod tests {
                         vec![crate::pending::PreLatestData {
                             block: crate::pending::PreLatestBlock {
                                 number: BlockNumber::GENESIS + 2,
-                                parent_hash: BlockHash(Felt::from_u64(2)),
                                 transaction_receipts: vec![
                                     (
                                         Receipt {

--- a/crates/rpc/src/method/subscribe_transaction_status.rs
+++ b/crates/rpc/src/method/subscribe_transaction_status.rs
@@ -396,14 +396,16 @@ fn pending_data_cache_status(
     pending_data: &PendingData,
     tx_hash: TransactionHash,
 ) -> Option<(BlockNumber, FinalityStatus, Option<ExecutionStatus>)> {
-    if let Some(pre_latest_block) = pending_data.pre_latest_block() {
-        let status_in_pre_latest = find_tx_receipt(&pre_latest_block.transaction_receipts, tx_hash)
+    // Search every un-committed parent, newest to oldest, before the pre-confirmed
+    // block in the next step.
+    for parent in pending_data.parent_blocks().rev() {
+        let status_in_parent = find_tx_receipt(&parent.block.transaction_receipts, tx_hash)
             .map(|r| r.execution_status.clone());
-        if status_in_pre_latest.is_some() {
+        if status_in_parent.is_some() {
             return Some((
-                pre_latest_block.number,
+                parent.block.number,
                 FinalityStatus::PreConfirmed,
-                status_in_pre_latest,
+                status_in_parent,
             ));
         }
     }
@@ -1107,7 +1109,7 @@ mod tests {
                     }
                 })),
                 TestEvent::Pending(
-                    PendingData::try_from_pre_confirmed_and_pre_latest(
+                    PendingData::from_window(
                         PreConfirmedBlock {
                             transactions: vec![Transaction {
                                 hash: TransactionHash(Felt::from_u64(3)),
@@ -1124,28 +1126,29 @@ mod tests {
                         }
                         .into(),
                         BlockNumber::GENESIS + 3,
-                        Some(Box::new((
-                            // Previous block promoted to pre-latest. This should not result in
-                            // a notification because it would have a duplicate `PRE_CONFIRMED`
-                            // status.
-                            BlockNumber::GENESIS + 2,
-                            PreConfirmedBlock {
+                        // Previous block promoted to the immediate (un-committed) parent.
+                        // This should not result in a notification because it would have a
+                        // duplicate `PRE_CONFIRMED` status.
+                        vec![crate::pending::PreLatestData {
+                            block: crate::pending::PreLatestBlock {
+                                number: BlockNumber::GENESIS + 2,
+                                parent_hash: BlockHash(Felt::from_u64(2)),
                                 transaction_receipts: vec![
-                                    Some((
+                                    (
                                         Receipt {
                                             transaction_hash: TARGET_TX_HASH,
                                             ..Default::default()
                                         },
                                         vec![],
-                                    )),
+                                    ),
                                     // Random tx receipt.
-                                    Some((
+                                    (
                                         Receipt {
                                             transaction_hash: TransactionHash(Felt::from_u64(123)),
                                             ..Default::default()
                                         },
                                         vec![],
-                                    )),
+                                    ),
                                 ],
                                 transactions: vec![
                                     Transaction {
@@ -1160,8 +1163,9 @@ mod tests {
                                 ],
                                 ..Default::default()
                             },
-                            BlockHash(Felt::from_u64(2)),
-                        ))),
+                            state_update: StateUpdate::default(),
+                        }],
+                        BlockNumber::GENESIS + 1,
                     )
                     .unwrap(),
                 ),
@@ -1636,5 +1640,57 @@ mod tests {
             .with_pending_data_cache(pending_data_cache.clone())
             .with_websockets(WebsocketContext::for_test(WebsocketHistory::Unlimited));
         (v08::register_routes().build(ctx), pending_data_cache)
+    }
+
+    #[test]
+    fn pending_data_cache_status_spans_deep_ancestors() {
+        use pathfinder_pending_data::{PendingBlocks, PreLatestData};
+
+        let deep_hash = TransactionHash(Felt::from_u64(0x77));
+        let deep_ancestor = PreLatestData {
+            block: pathfinder_pending_data::PreLatestBlock {
+                number: BlockNumber::new_or_panic(7),
+                transaction_receipts: vec![(
+                    Receipt {
+                        transaction_hash: deep_hash,
+                        execution_status: ExecutionStatus::Succeeded,
+                        ..Default::default()
+                    },
+                    vec![],
+                )],
+                ..Default::default()
+            },
+            state_update: StateUpdate::default(),
+        };
+        let blocks = PendingBlocks {
+            pre_confirmed: pathfinder_pending_data::PreConfirmedBlock {
+                number: BlockNumber::new_or_panic(10),
+                ..Default::default()
+            },
+            // Deep ancestor (7) first, immediate parent (9) last.
+            parents: vec![
+                deep_ancestor,
+                PreLatestData {
+                    block: pathfinder_pending_data::PreLatestBlock {
+                        number: BlockNumber::new_or_panic(9),
+                        ..Default::default()
+                    },
+                    state_update: StateUpdate::default(),
+                },
+            ],
+        };
+        let pending = PendingData::from_parts(
+            blocks,
+            StateUpdate::default(),
+            StateUpdate::default(),
+            BlockNumber::new_or_panic(10),
+        );
+
+        let (block_number, finality, execution) =
+            super::pending_data_cache_status(&pending, deep_hash)
+                .expect("deep-ancestor tx status should be found");
+        assert_eq!(block_number, BlockNumber::new_or_panic(7));
+        assert!(matches!(finality, super::FinalityStatus::PreConfirmed));
+        assert_eq!(execution, Some(ExecutionStatus::Succeeded));
     }
 }

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -104,17 +104,31 @@ pub async fn trace_block_transactions(
         let mut db_conn = storage.connection()?;
         let db_tx = db_conn.transaction()?;
 
-        let (block_id, header, transactions, cache) = match input.block_id {
+        let (block_id, header, transactions, pending_state, cache) = match input.block_id {
             BlockId::PreConfirmed => {
                 let pending = context.pending_data.get(&db_tx, rpc_version)?;
 
                 let header = pending.pre_confirmed_header();
                 let transactions = pending.pre_confirmed_transactions().to_vec();
 
+                // `block_traces` on the gateway does not support pending blocks, so we do our
+                // best and create a pending state diff for everything up to but excluding the
+                // preconfirmed block.
+                let pending_state = if pending.parent_blocks().next().is_some() {
+                    let mut overlay = pathfinder_common::StateUpdate::default();
+                    for parent in pending.parent_blocks() {
+                        overlay = overlay.apply(&parent.state_update);
+                    }
+                    Some(std::sync::Arc::new(overlay))
+                } else {
+                    None
+                };
+
                 (
                     None,
                     header,
                     transactions,
+                    pending_state,
                     // Can't use the cache for pending blocks since they have no
                     // block hash.
                     pathfinder_executor::TraceCache::default(),
@@ -135,7 +149,13 @@ pub async fn trace_block_transactions(
                     .into_iter()
                     .collect::<Vec<_>>();
 
-                (Some(block_id), header, transactions, context.cache.clone())
+                (
+                    Some(block_id),
+                    header,
+                    transactions,
+                    None,
+                    context.cache.clone(),
+                )
             }
         };
 
@@ -181,7 +201,7 @@ pub async fn trace_block_transactions(
         let state = pathfinder_executor::ExecutionState::trace(
             context.chain_id,
             header,
-            None,
+            pending_state,
             context.config.versioned_constants_map,
             context.contract_addresses.eth_l2_token_address,
             context.contract_addresses.strk_l2_token_address,
@@ -1228,42 +1248,49 @@ pub(crate) mod tests {
                 &casm_hash_bytes!(b"casm hash blake"),
             )?;
 
+            tx.commit()?;
+
             let transaction_receipts: Vec<_> = pre_latest_transactions
                 .iter()
                 .enumerate()
                 .map(|(index, tx)| {
-                    Some((
+                    (
                         Receipt {
                             transaction_hash: tx.hash,
                             transaction_index: TransactionIndex::new_or_panic(index as u64),
                             ..Default::default()
                         },
                         vec![],
-                    ))
+                    )
                 })
                 .collect();
 
-            let pre_latest_block = starknet_gateway_types::reply::PreConfirmedBlock {
-                l1_gas_price: GasPrices {
-                    price_in_wei: last_block_header.eth_l1_gas_price,
-                    price_in_fri: last_block_header.strk_l1_gas_price,
+            // The immediate un-committed parent (one above the committed head).
+            let parent = crate::pending::PreLatestData {
+                block: crate::pending::PreLatestBlock {
+                    number: last_block_header.number + 1,
+                    parent_hash: last_block_header.hash,
+                    l1_gas_price: GasPrices {
+                        price_in_wei: last_block_header.eth_l1_gas_price,
+                        price_in_fri: last_block_header.strk_l1_gas_price,
+                    },
+                    l1_data_gas_price: GasPrices {
+                        price_in_wei: last_block_header.eth_l1_data_gas_price,
+                        price_in_fri: last_block_header.strk_l1_data_gas_price,
+                    },
+                    l2_gas_price: GasPrices {
+                        price_in_wei: last_block_header.eth_l2_gas_price,
+                        price_in_fri: last_block_header.strk_l2_gas_price,
+                    },
+                    sequencer_address: last_block_header.sequencer_address,
+                    status: starknet_gateway_types::reply::Status::Pending,
+                    timestamp: last_block_header.timestamp,
+                    transaction_receipts,
+                    transactions: pre_latest_transactions.clone().into(),
+                    starknet_version: last_block_header.starknet_version,
+                    l1_da_mode: pathfinder_common::L1DataAvailabilityMode::Blob,
                 },
-                l1_data_gas_price: GasPrices {
-                    price_in_wei: last_block_header.eth_l1_data_gas_price,
-                    price_in_fri: last_block_header.strk_l1_data_gas_price,
-                },
-                l2_gas_price: GasPrices {
-                    price_in_wei: last_block_header.eth_l2_gas_price,
-                    price_in_fri: last_block_header.strk_l2_gas_price,
-                },
-                sequencer_address: last_block_header.sequencer_address,
-                status: starknet_gateway_types::reply::Status::Pending,
-                timestamp: last_block_header.timestamp,
-                transaction_receipts,
-                transactions: pre_latest_transactions.clone().into(),
-                starknet_version: last_block_header.starknet_version,
-                l1_da_mode: L1DataAvailabilityMode::Blob,
-                transaction_state_diffs: vec![],
+                state_update: StateUpdate::default(),
             };
 
             let pre_confirmed_block = starknet_gateway_types::reply::PreConfirmedBlock {
@@ -1289,17 +1316,13 @@ pub(crate) mod tests {
                 transaction_state_diffs: vec![],
             };
 
-            tx.commit()?;
-
-            crate::pending::PendingData::try_from_pre_confirmed_and_pre_latest(
+            // Last L2 block, then the parent (pre-latest), then this so the tip is +2 and
+            // the overlay sits on the committed head.
+            crate::pending::PendingData::from_window(
                 Box::new(pre_confirmed_block),
-                // Last L2 block, then pre-latest then this, so +2.
                 last_block_header.number + 2,
-                Some(Box::new((
-                    last_block_header.number + 1,
-                    pre_latest_block,
-                    last_block_header.hash,
-                ))),
+                vec![parent],
+                last_block_header.number,
             )
             .unwrap()
         };
@@ -1325,6 +1348,149 @@ pub(crate) mod tests {
         ];
 
         Ok((context, traces))
+    }
+
+    #[tokio::test]
+    async fn regression_pre_confirmed_tip_is_traced_on_parents_state() -> anyhow::Result<()> {
+        use super::super::simulate_transactions::tests::{
+            fixtures,
+            setup_storage_with_starknet_version,
+        };
+
+        let (
+            storage,
+            last_block_header,
+            account_contract_address,
+            universal_deployer_address,
+            _test_storage_value,
+        ) = setup_storage_with_starknet_version(StarknetVersion::new(0, 14, 0, 0)).await;
+        let context = RpcContext::for_tests().with_storage(storage.clone());
+
+        // Lives in the parent (committed + 1), bumping the account nonce to 1.
+        let parent_declare =
+            fixtures::input::declare(account_contract_address).try_into_common(context.chain_id)?;
+        // Lives in the tip (committed + 2), needs the account nonce to be 1.
+        let tip_deploy = fixtures::input::universal_deployer(
+            account_contract_address,
+            universal_deployer_address,
+        )
+        .try_into_common(context.chain_id)?;
+
+        let pending_data = {
+            let mut db = storage.connection().map_err(anyhow::Error::from)?;
+            let tx = db.transaction()?;
+
+            tx.insert_sierra_class_definition(
+                &SierraHash(fixtures::SIERRA_HASH.0),
+                &SerializedSierraDefinition::from_slice(fixtures::SIERRA_DEFINITION),
+                &SerializedCasmDefinition::from_slice(fixtures::CASM_DEFINITION),
+                &casm_hash_bytes!(b"casm hash blake"),
+            )?;
+            tx.commit()?;
+
+            let parent = crate::pending::PreLatestData {
+                block: crate::pending::PreLatestBlock {
+                    number: last_block_header.number + 1,
+                    parent_hash: last_block_header.hash,
+                    l1_gas_price: GasPrices {
+                        price_in_wei: last_block_header.eth_l1_gas_price,
+                        price_in_fri: last_block_header.strk_l1_gas_price,
+                    },
+                    l1_data_gas_price: GasPrices {
+                        price_in_wei: last_block_header.eth_l1_data_gas_price,
+                        price_in_fri: last_block_header.strk_l1_data_gas_price,
+                    },
+                    l2_gas_price: GasPrices {
+                        price_in_wei: last_block_header.eth_l2_gas_price,
+                        price_in_fri: last_block_header.strk_l2_gas_price,
+                    },
+                    sequencer_address: last_block_header.sequencer_address,
+                    status: starknet_gateway_types::reply::Status::Pending,
+                    timestamp: last_block_header.timestamp,
+                    transaction_receipts: vec![(
+                        Receipt {
+                            transaction_hash: parent_declare.hash,
+                            transaction_index: TransactionIndex::new_or_panic(0),
+                            ..Default::default()
+                        },
+                        vec![],
+                    )],
+                    transactions: vec![parent_declare.clone()],
+                    starknet_version: last_block_header.starknet_version,
+                    l1_da_mode: pathfinder_common::L1DataAvailabilityMode::Blob,
+                },
+                // The only diff the tip depends on: the account nonce after the
+                // declare.
+                state_update: StateUpdate::default()
+                    .with_contract_nonce(account_contract_address, contract_nonce!("0x1")),
+            };
+
+            let pre_confirmed_block = starknet_gateway_types::reply::PreConfirmedBlock {
+                l1_gas_price: GasPrices {
+                    price_in_wei: last_block_header.eth_l1_gas_price,
+                    price_in_fri: last_block_header.strk_l1_gas_price,
+                },
+                l1_data_gas_price: GasPrices {
+                    price_in_wei: last_block_header.eth_l1_data_gas_price,
+                    price_in_fri: last_block_header.strk_l1_data_gas_price,
+                },
+                l2_gas_price: GasPrices {
+                    price_in_wei: last_block_header.eth_l2_gas_price,
+                    price_in_fri: last_block_header.strk_l2_gas_price,
+                },
+                sequencer_address: last_block_header.sequencer_address,
+                status: starknet_gateway_types::reply::Status::PreConfirmed,
+                timestamp: last_block_header.timestamp,
+                transaction_receipts: vec![Some((
+                    Receipt {
+                        transaction_hash: tip_deploy.hash,
+                        transaction_index: TransactionIndex::new_or_panic(0),
+                        ..Default::default()
+                    },
+                    vec![],
+                ))],
+                transactions: vec![tip_deploy.clone()],
+                starknet_version: last_block_header.starknet_version,
+                l1_da_mode: L1DataAvailabilityMode::Blob,
+                transaction_state_diffs: vec![],
+            };
+
+            // Parent at committed + 1, tip at committed + 2, overlay on the
+            // committed head.
+            crate::pending::PendingData::from_window(
+                Box::new(pre_confirmed_block),
+                last_block_header.number + 2,
+                vec![parent],
+                last_block_header.number,
+            )
+            .unwrap()
+        };
+
+        let pending_data_cache = Arc::new(PendingDataCache::new());
+        pending_data_cache.store(pending_data);
+        let context = context.with_pending_data_cache(pending_data_cache);
+
+        let input = TraceBlockTransactionsInput {
+            block_id: BlockId::PreConfirmed,
+            trace_flags: crate::dto::TraceFlags::new(),
+        };
+
+        let output = trace_block_transactions(context, input, RPC_VERSION)
+            .await
+            .unwrap()
+            .serialize(Serializer {
+                version: RPC_VERSION,
+            })
+            .unwrap();
+
+        // The tip's single transaction was traced on the parent's state.
+        let traces = output.as_array().unwrap();
+        assert_eq!(traces.len(), 1);
+        let traced_hash =
+            Felt::from_hex_str(traces[0]["transaction_hash"].as_str().unwrap()).unwrap();
+        assert_eq!(traced_hash, tip_deploy.hash.0);
+
+        Ok(())
     }
 
     pub(crate) async fn setup_multi_tx_trace_pre_confirmed_test(
@@ -1421,11 +1587,10 @@ pub(crate) mod tests {
 
             tx.commit()?;
 
-            crate::pending::PendingData::try_from_pre_confirmed_and_pre_latest(
+            // No un-committed parent, so the tip is just +1.
+            crate::pending::PendingData::try_from_pre_confirmed_block(
                 Box::new(pre_confirmed_block),
-                // No pre-latest block, so +1.
                 last_block_header.number + 1,
-                None,
             )
             .unwrap()
         };

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -115,11 +115,7 @@ pub async fn trace_block_transactions(
                 // best and create a pending state diff for everything up to but excluding the
                 // preconfirmed block.
                 let pending_state = if pending.parent_blocks().next().is_some() {
-                    let mut overlay = pathfinder_common::StateUpdate::default();
-                    for parent in pending.parent_blocks() {
-                        overlay = overlay.apply(&parent.state_update);
-                    }
-                    Some(std::sync::Arc::new(overlay))
+                    Some(std::sync::Arc::new(pending.parents_overlay()))
                 } else {
                     None
                 };

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -1269,7 +1269,6 @@ pub(crate) mod tests {
             let parent = crate::pending::PreLatestData {
                 block: crate::pending::PreLatestBlock {
                     number: last_block_header.number + 1,
-                    parent_hash: last_block_header.hash,
                     l1_gas_price: GasPrices {
                         price_in_wei: last_block_header.eth_l1_gas_price,
                         price_in_fri: last_block_header.strk_l1_gas_price,
@@ -1391,7 +1390,6 @@ pub(crate) mod tests {
             let parent = crate::pending::PreLatestData {
                 block: crate::pending::PreLatestBlock {
                     number: last_block_header.number + 1,
-                    parent_hash: last_block_header.hash,
                     l1_gas_price: GasPrices {
                         price_in_wei: last_block_header.eth_l1_gas_price,
                         price_in_fri: last_block_header.strk_l1_gas_price,

--- a/crates/rpc/src/method/trace_transaction.rs
+++ b/crates/rpc/src/method/trace_transaction.rs
@@ -70,6 +70,11 @@ pub async fn trace_transaction(
             let pending = context.pending_data.get_optional(&db_tx, rpc_version)?;
             let pending = pending.as_ref();
 
+            // Gateway's `transaction_trace` supports pending blocks, so locally we only
+            // trace transactions from a preconfirmed block that is the immediate parent of
+            // the local commit head and fall back to the gateway otherwise.
+            let local_number = pending.map(|p| p.aggregated_lower_bound + 1);
+
             let (header, transactions, cache) = if let Some((pending, pending_tx)) = pending
                 .and_then(|p| {
                     p.pre_confirmed_transactions()
@@ -79,8 +84,9 @@ pub async fn trace_transaction(
                 }) {
                 let header = pending.pre_confirmed_header();
 
-                if header.starknet_version
-                    < VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEWAY
+                if Some(header.number) != local_number
+                    || header.starknet_version
+                        < VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEWAY
                 {
                     return Ok(LocalExecution::Unsupported(pending_tx.clone()));
                 }
@@ -91,37 +97,33 @@ pub async fn trace_transaction(
                     // Can't use the cache for pending blocks since they have no block hash.
                     pathfinder_executor::TraceCache::default(),
                 )
-            } else if let Some((pending, pre_latest_tx)) = pending.and_then(|p| {
-                p.pre_latest_block()
-                    .and_then(|pre_latest| {
-                        pre_latest
-                            .transactions
-                            .iter()
-                            .find(|tx| tx.hash == input.transaction_hash)
-                            .cloned()
-                    })
-                    .map(|tx| (p, tx))
+            } else if let Some((parent_tx, header, txs)) = pending.and_then(|p| {
+                p.parent_blocks().find_map(|parent| {
+                    parent
+                        .block
+                        .transactions
+                        .iter()
+                        .find(|tx| tx.hash == input.transaction_hash)
+                        .map(|tx| {
+                            (
+                                tx.clone(),
+                                parent.header(),
+                                parent.block.transactions.clone(),
+                            )
+                        })
+                })
             }) {
-                let header = pending
-                    .pre_latest_header()
-                    .expect("Pre-latest block exists");
-
-                if header.starknet_version
-                    < VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEWAY
+                if Some(header.number) != local_number
+                    || header.starknet_version
+                        < VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEWAY
                 {
-                    return Ok(LocalExecution::Unsupported(pre_latest_tx.clone()));
+                    return Ok(LocalExecution::Unsupported(parent_tx));
                 }
-
-                let txs = pending
-                    .pre_latest_block()
-                    .expect("Pre-latest block exists")
-                    .transactions
-                    .clone();
 
                 (
                     header,
                     txs,
-                    // Can't use the cache for pre-latest blocks since they have no block hash.
+                    // Can't use the cache for pending blocks since they have no block hash.
                     pathfinder_executor::TraceCache::default(),
                 )
             } else {

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -120,11 +120,10 @@ impl PendingWatcher {
         // as-is. Composition mirrors `PendingData::from_window`: parents oldest →
         // newest, then the pre-confirmed block's own diffs on top.
         let aggregated_overlay = if watched_pending_data.aggregated_lower_bound < committed {
-            let mut overlay = StateUpdate::default();
-            for parent in &parents {
-                overlay = overlay.apply(&parent.state_update);
-            }
-            Arc::new(overlay.apply(watched_pending_data.state_update.as_ref()))
+            Arc::new(
+                PendingData::compose_parents_overlay(&parents)
+                    .apply(watched_pending_data.state_update.as_ref()),
+            )
         } else {
             Arc::clone(&watched_pending_data.aggregated_state_update)
         };

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -75,87 +75,106 @@ impl PendingWatcher {
         let watched_pending_blocks = watched_pending_data.pending_block();
         let PendingBlocks {
             pre_confirmed,
-            pre_latest,
+            parents,
         } = watched_pending_blocks.as_ref();
 
-        let pending_data = {
-            // The parent state commitment is only available here. The task polling the
-            // pre-confirmed block has no access to the parent block header, thus it
-            // cannot properly set the parent state commitment.
+        // The parent state commitment is only available here. The task polling
+        // the pre-confirmed block has no access to the parent block header, so
+        // it cannot set the parent state commitment itself.
+        //
+        // A view is servable against our committed head precisely when its
+        // aggregated overlay reaches down to (or below) that head and the
+        // pre-confirmed block is ahead of it:
+        //
+        //   aggregated_lower_bound <= committed < pre_confirmed.number
+        //
+        // Then base state at `committed` plus the overlay covers every block up
+        // to the pre-confirmed tip with no gap, regardless of how many blocks
+        // sit in between. This single condition subsumes the previous
+        // pre-latest / pre-confirmed chaining cases (which only ever served a
+        // gap of at most two).
+        let committed = latest.number;
+        let servable = pre_confirmed.number > committed
+            && watched_pending_data.aggregated_lower_bound <= committed;
 
-            // We can consider the pre-confirmed block valid if:
-            //   - the pre-latest block exists and is the child our latest stored block,
-            //   - the pre-latest block exists and is the same block as our latest block,
-            //   i.e. we received that block as a finalized L2 block but it still lingers
-            //   in pending data.
-            //   - the pre-latest block does not exist and the pre-confirmed block is the
-            //   child of our latest stored block.
-            match pre_latest {
-                // Is pre-latest the next block, with pre-confirmed as its child?
-                Some(pre_latest)
-                    if pre_latest.block.number == latest.number + 1
-                        && pre_latest.block.number + 1 == pre_confirmed.number =>
-                {
-                    // Set pre-latest block parent state commitment, clone rest of the data.
-                    let pre_latest = pre_latest.clone();
-                    let pre_latest_state_update = pre_latest
-                        .state_update
-                        .with_parent_state_commitment(latest.state_commitment);
-                    let pre_latest = PreLatestData {
-                        block: pre_latest.block,
-                        state_update: pre_latest_state_update,
-                    };
-                    PendingData {
-                        blocks: PendingBlocks {
-                            pre_confirmed: pre_confirmed.clone(),
-                            pre_latest: Some(pre_latest),
-                        }
-                        .into(),
-                        state_update: Arc::clone(&watched_pending_data.state_update),
-                        aggregated_state_update: Arc::clone(
-                            &watched_pending_data.aggregated_state_update,
-                        ),
-                        number: pre_confirmed.number,
-                    }
-                }
-                // Is pre-latest already in the database, with pre-confirmed as its child?
-                Some(pre_latest)
-                    if pre_latest.block.number == latest.number
-                        && pre_latest.block.number + 1 == pre_confirmed.number =>
-                {
-                    // Set pre-latest data to `None`, pre-confirmed block parent state
-                    // commitment and clone rest of the data.
-                    let pre_confirmed_block = PendingBlocks {
-                        pre_confirmed: pre_confirmed.clone(),
-                        pre_latest: None,
-                    };
-                    let pre_confirmed_state_update = Arc::new(
-                        StateUpdate::clone(&watched_pending_data.state_update)
-                            .with_parent_state_commitment(latest.state_commitment),
-                    );
+        if !servable {
+            return Ok(PendingData::empty(&latest));
+        }
 
-                    PendingData {
-                        blocks: Arc::new(pre_confirmed_block),
-                        state_update: Arc::clone(&pre_confirmed_state_update),
-                        aggregated_state_update: pre_confirmed_state_update,
-                        number: pre_confirmed.number,
-                    }
+        // Report only parents still strictly above the committed head. The head
+        // can advance after the producer composed this view, finalising the
+        // lowest entries into the DB; those must no longer appear as pending.
+        let mut parents: Vec<PreLatestData> = parents
+            .iter()
+            .filter(|parent| parent.block.number > committed)
+            .cloned()
+            .collect();
+
+        // If the committed head has advanced past the overlay's base, the stored
+        // aggregated overlay still carries the state diffs of blocks that are now
+        // committed. Recompose it from the surviving parents plus the
+        // pre-confirmed block so it sits exactly on `committed` — no block ever
+        // appears in both the committed DB base and the pending overlay, so
+        // execution can't double-apply a just-committed block's diffs. When the
+        // base is already at the committed head the stored overlay is reused
+        // as-is. Composition mirrors `PendingData::from_window`: parents oldest →
+        // newest, then the pre-confirmed block's own diffs on top.
+        let aggregated_overlay = if watched_pending_data.aggregated_lower_bound < committed {
+            let mut overlay = StateUpdate::default();
+            for parent in &parents {
+                overlay = overlay.apply(&parent.state_update);
+            }
+            Arc::new(overlay.apply(watched_pending_data.state_update.as_ref()))
+        } else {
+            Arc::clone(&watched_pending_data.aggregated_state_update)
+        };
+
+        let pending_data = if let Some(immediate_parent) = parents.last_mut() {
+            // The immediate parent (newest un-committed block) is the
+            // pre-confirmed's parent and carries the parent state commitment.
+            // Deeper parents carry only data (txns, receipts, events); execution
+            // uses the aggregated overlay, so they need no patch.
+            assert_eq!(
+                immediate_parent.block.number + 1,
+                pre_confirmed.number,
+                "Pre-confirmed block should be child of its immediate parent"
+            );
+            immediate_parent.state_update = immediate_parent
+                .state_update
+                .clone()
+                .with_parent_state_commitment(latest.state_commitment);
+            PendingData {
+                blocks: PendingBlocks {
+                    pre_confirmed: pre_confirmed.clone(),
+                    parents,
                 }
-                // Is pre-confirmed the next block?
-                None if pre_confirmed.number == latest.number + 1 => {
-                    // Set pre-confirmed block parent state commitment, clone rest of the data.
-                    let pre_confirmed_state_update =
-                        StateUpdate::clone(&watched_pending_data.state_update)
-                            .with_parent_state_commitment(latest.state_commitment);
-                    let state_update = Arc::new(pre_confirmed_state_update);
-                    PendingData {
-                        blocks: Arc::clone(&watched_pending_data.blocks),
-                        state_update: Arc::clone(&state_update),
-                        aggregated_state_update: state_update,
-                        number: pre_confirmed.number,
-                    }
-                }
-                _ => PendingData::empty(&latest),
+                .into(),
+                state_update: Arc::clone(&watched_pending_data.state_update),
+                aggregated_state_update: aggregated_overlay,
+                number: pre_confirmed.number,
+                aggregated_lower_bound: committed,
+            }
+        } else {
+            // No un-committed parent (a gap of one, or the parents have all been
+            // finalised into the DB): serve the pre-confirmed against the
+            // committed base, which then carries the parent state commitment.
+            let state_update = Arc::new(
+                StateUpdate::clone(&watched_pending_data.state_update)
+                    .with_parent_state_commitment(latest.state_commitment),
+            );
+            let aggregated_state_update = Arc::new(
+                StateUpdate::clone(&aggregated_overlay)
+                    .with_parent_state_commitment(latest.state_commitment),
+            );
+            PendingData {
+                blocks: Arc::new(PendingBlocks {
+                    pre_confirmed: pre_confirmed.clone(),
+                    parents: Vec::new(),
+                }),
+                state_update,
+                aggregated_state_update,
+                number: pre_confirmed.number,
+                aggregated_lower_bound: committed,
             }
         };
 
@@ -182,8 +201,9 @@ impl PendingWatcher {
     }
 }
 
-/// Find a transaction-with-receipt in the pre-confirmed or pre-latest block,
-/// in that order.
+/// Find a transaction-with-receipt across the whole un-committed window: the
+/// pre-confirmed block first, then every un-committed parent newest → oldest
+/// (the immediate pre-latest, then any deeper ancestors).
 pub fn find_finalized_tx_data(
     pending: &PendingData,
     tx_hash: pathfinder_common::TransactionHash,
@@ -197,7 +217,8 @@ pub fn find_finalized_tx_data(
             .pre_confirmed_tx_receipts_and_events()
             .iter()
             .find(|(r, _)| r.transaction_hash == tx_hash)
-            .cloned()?;
+            .cloned()
+            .expect("Receipt should exist if the transaction exists");
         return Some(FinalizedTxData {
             block_number: pending.pre_confirmed_block_number(),
             transaction: tx.clone(),
@@ -207,19 +228,17 @@ pub fn find_finalized_tx_data(
         });
     }
 
-    if let Some(pre_latest_block) = pending.pre_latest_block() {
-        if let Some(tx) = pre_latest_block
-            .transactions
-            .iter()
-            .find(|t| t.hash == tx_hash)
-        {
-            let (receipt, events) = pending.pre_latest_tx_receipts_and_events().and_then(|rs| {
-                rs.iter()
-                    .find(|(r, _)| r.transaction_hash == tx_hash)
-                    .cloned()
-            })?;
+    for parent in pending.parent_blocks().rev() {
+        if let Some(tx) = parent.block.transactions.iter().find(|t| t.hash == tx_hash) {
+            let (receipt, events) = parent
+                .block
+                .transaction_receipts
+                .iter()
+                .find(|(r, _)| r.transaction_hash == tx_hash)
+                .cloned()
+                .expect("Receipt should exist if the transaction exists");
             return Some(FinalizedTxData {
-                block_number: pre_latest_block.number,
+                block_number: parent.block.number,
                 transaction: tx.clone(),
                 receipt,
                 events,
@@ -277,12 +296,14 @@ mod tests {
                     transactions: vec![],
                     transaction_receipts: vec![],
                 },
-                pre_latest: None,
+                parents: Vec::new(),
             }
             .into(),
             state_update: Arc::clone(&state_update),
             aggregated_state_update: state_update,
             number: latest.number + 1,
+            // Pre-confirmed-only view at latest+1 sits on the committed head.
+            aggregated_lower_bound: latest.number,
         }
     }
 
@@ -330,15 +351,17 @@ mod tests {
                     transactions: vec![Transaction::default()],
                     transaction_receipts: vec![(Receipt::default(), vec![])],
                 },
-                pre_latest: Some(PreLatestData {
+                parents: vec![PreLatestData {
                     block: pre_latest_block,
                     state_update: pre_latest_state_update,
-                }),
+                }],
             }
             .into(),
             state_update: pre_confirmed_state_update.into(),
             aggregated_state_update: aggregated_state_update.into(),
             number: latest.number + 2,
+            // Overlay covers {latest+1, latest+2}, so it sits on the committed head.
+            aggregated_lower_bound: latest.number,
         }
     }
 
@@ -361,13 +384,17 @@ mod tests {
                     number: latest.number + 3,
                     ..Default::default()
                 },
-                pre_latest: Some(pre_latest_data),
+                parents: vec![pre_latest_data],
             }
             .into(),
             state_update: StateUpdate::default().into(),
             aggregated_state_update: StateUpdate::default().into(),
             // Should be latest.number + 2 to be valid.
             number: latest.number + 3,
+            // Derived as if the pre-latest were the immediate parent, so the
+            // view is considered servable and the inconsistent pair trips the
+            // child-of-pre-latest assertion in `get` (see the should_panic test).
+            aggregated_lower_bound: latest.number,
         }
     }
 
@@ -435,16 +462,40 @@ mod tests {
         let result = uut.get(&tx, RpcVersion::V09).unwrap();
         pretty_assertions_sorted::assert_eq_sorted!(result, pending);
 
-        // Pre-latest block will be same as `latest` which is also valid, but in this
-        // case the pre-latest block should be ignored.
-        let pending = valid_pre_confirmed_block_with_pre_latest(&parent);
-        cache.store(pending);
+        // Now the pre-latest block (latest + 1) is itself finalized into storage,
+        // advancing the committed head to it. The same pre-confirmed view
+        // (latest + 2) is still cached, but the now-committed pre-latest must no
+        // longer be reported as pending — we serve the pre-confirmed against the
+        // new head and drop the pre-latest.
+        let child = latest
+            .child_builder()
+            .finalize_with_hash(block_hash_bytes!(b"child hash"));
+        tx.insert_block_header(&child).unwrap();
 
         let result = uut.get(&tx, RpcVersion::V09).unwrap();
         // We got a non-empty pre-confirmed block..
         assert!(!result.pre_confirmed_transactions().is_empty());
         // ..and we did not receive a pre-latest block.
         assert!(result.pre_latest_block().is_none());
+
+        // The execution overlay must be trimmed to the advanced head too, not
+        // just the reported parents: the now-committed pre-latest block's state
+        // diff is dropped, only the pre-confirmed block's own diff remains, and
+        // the overlay is declared to sit on the new committed head. Otherwise
+        // execution would double-apply the just-committed block's diff, which is
+        // already in the committed DB base.
+        let overlay = result.aggregated_state_update();
+        assert_eq!(
+            overlay.contract_nonce(contract_address_bytes!(b"pre latest contract address")),
+            None,
+            "the now-committed pre-latest diff must be dropped from the overlay"
+        );
+        assert_eq!(
+            overlay.contract_nonce(contract_address_bytes!(b"contract address")),
+            Some(contract_nonce_bytes!(b"nonce")),
+            "the pre-confirmed block's own diff must remain in the overlay"
+        );
+        assert_eq!(result.aggregated_lower_bound, latest.number + 1);
     }
 
     #[test]
@@ -647,9 +698,8 @@ mod tests {
     }
 
     #[test]
-    fn pre_confirmed_not_child_of_pre_latest_defaults_to_empty() {
-        // A pre-confirmed block that doesn't chain onto the pre-latest falls back
-        // to an empty pending block.
+    #[should_panic]
+    fn pre_confirmed_is_not_child_of_pre_latest_panics() {
         let cache = Arc::new(PendingDataCache::new());
         let uut = PendingWatcher::new(cache.clone());
 
@@ -678,11 +728,8 @@ mod tests {
         tx.insert_block_header(&latest).unwrap();
 
         let pending = invalid_pre_confirmed_block_with_pre_latest(&latest);
-        cache.store(pending);
-
-        let result = uut.get(&tx, RpcVersion::V09).unwrap();
-
-        pretty_assertions_sorted::assert_eq_sorted!(result, PendingData::empty(&latest));
+        cache.store(pending.clone());
+        let _ = uut.get(&tx, RpcVersion::V09).unwrap();
     }
 
     fn empty_pre_confirmed_block(latest: &BlockHeader) -> PendingData {
@@ -711,11 +758,12 @@ mod tests {
         PendingData {
             blocks: Arc::new(PendingBlocks {
                 pre_confirmed,
-                pre_latest: None,
+                parents: Vec::new(),
             }),
             state_update: StateUpdate::default().into(),
             aggregated_state_update: StateUpdate::default().into(),
             number: latest.number + 1,
+            aggregated_lower_bound: latest.number,
         }
     }
 
@@ -862,5 +910,71 @@ mod tests {
             err,
             "Mismatched transaction and receipt count in pre-confirmed block"
         );
+    }
+
+    /// `find_finalized_tx_data` spans the whole un-committed window: a
+    /// transaction (with its receipt and events) living in a deep ancestor —
+    /// more than one block below the pre-confirmed tip — is found and reported
+    /// against that ancestor's block number.
+    #[test]
+    fn find_finalized_tx_data_spans_deep_ancestors() {
+        use pathfinder_common::event::Event;
+
+        let deep_hash = transaction_hash_bytes!(b"deep tx");
+        let deep_event = Event {
+            from_address: contract_address_bytes!(b"emitter"),
+            keys: vec![],
+            data: vec![],
+        };
+        let deep_ancestor = PreLatestData {
+            block: PreLatestBlock {
+                number: BlockNumber::new_or_panic(7),
+                transactions: vec![Transaction {
+                    hash: deep_hash,
+                    ..Default::default()
+                }],
+                transaction_receipts: vec![(
+                    Receipt {
+                        transaction_hash: deep_hash,
+                        ..Default::default()
+                    },
+                    vec![deep_event.clone()],
+                )],
+                ..Default::default()
+            },
+            state_update: StateUpdate::default(),
+        };
+
+        let pending = PendingData::from_parts(
+            PendingBlocks {
+                pre_confirmed: PreConfirmedBlock {
+                    number: BlockNumber::new_or_panic(10),
+                    ..Default::default()
+                },
+                parents: vec![
+                    deep_ancestor,
+                    PreLatestData {
+                        block: PreLatestBlock {
+                            number: BlockNumber::new_or_panic(9),
+                            ..Default::default()
+                        },
+                        state_update: StateUpdate::default(),
+                    },
+                ],
+            },
+            StateUpdate::default(),
+            StateUpdate::default(),
+            BlockNumber::new_or_panic(10),
+        );
+
+        let found =
+            find_finalized_tx_data(&pending, deep_hash).expect("deep-ancestor tx should be found");
+        assert_eq!(found.block_number, BlockNumber::new_or_panic(7));
+        assert_eq!(found.transaction.hash, deep_hash);
+        assert_eq!(found.receipt.transaction_hash, deep_hash);
+        assert_eq!(found.events, vec![deep_event]);
+
+        // A hash present nowhere in the window is not found.
+        assert!(find_finalized_tx_data(&pending, transaction_hash_bytes!(b"absent")).is_none());
     }
 }

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -502,6 +502,49 @@ mod tests {
     }
 
     #[test]
+    fn windowed_pre_confirmed_reports_committed_head_as_old_root() {
+        // With a pre-latest present the window is two blocks deep, so the tip is
+        // served through the immediate-parent branch. Its own state update must
+        // carry the committed head's state commitment as its old root, otherwise
+        // getStateUpdate(pre_confirmed) on v0.9 serializes old_root as 0x0.
+        let cache = Arc::new(PendingDataCache::new());
+        let uut = PendingWatcher::new(cache.clone());
+
+        let mut storage = pathfinder_storage::StorageBuilder::in_memory()
+            .unwrap()
+            .connection()
+            .unwrap();
+
+        let parent = BlockHeader::builder()
+            .number(BlockNumber::GENESIS + 12)
+            .finalize_with_hash(block_hash_bytes!(b"parent hash"));
+        // A committed head with a non-zero state commitment, so a zeroed old
+        // root would be observably wrong.
+        let latest = parent
+            .child_builder()
+            .state_commitment(state_commitment!("0xc0ffee"))
+            .finalize_with_hash(block_hash_bytes!(b"latest hash"));
+
+        let tx = storage.transaction().unwrap();
+        tx.insert_block_header(&parent).unwrap();
+        tx.insert_block_header(&latest).unwrap();
+
+        // Window of two: pre-latest at latest + 1, pre-confirmed at latest + 2.
+        cache.store(valid_pre_confirmed_block_with_pre_latest(&latest));
+
+        let result = uut.get(&tx, RpcVersion::V09).unwrap();
+
+        assert!(
+            result.pre_latest_block().is_some(),
+            "the pre-latest should keep this on the immediate-parent branch"
+        );
+        assert_eq!(
+            result.pre_confirmed_state_update().parent_state_commitment,
+            latest.state_commitment,
+        );
+    }
+
+    #[test]
     fn valid_pre_confirmed_is_not_used_for_old_rpc_versions() {
         let cache = Arc::new(PendingDataCache::new());
         let uut = PendingWatcher::new(cache.clone());

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -149,7 +149,13 @@ impl PendingWatcher {
                     parents,
                 }
                 .into(),
-                state_update: Arc::clone(&watched_pending_data.state_update),
+                // The pre-confirmed tip's own state update is serialized with the
+                // committed head as its old root, so stamp it here just like the
+                // no-parent branch below.
+                state_update: Arc::new(
+                    StateUpdate::clone(&watched_pending_data.state_update)
+                        .with_parent_state_commitment(latest.state_commitment),
+                ),
                 aggregated_state_update: aggregated_overlay,
                 number: pre_confirmed.number,
                 aggregated_lower_bound: committed,

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -316,7 +316,6 @@ mod tests {
     fn valid_pre_confirmed_block_with_pre_latest(latest: &BlockHeader) -> PendingData {
         let pre_latest_block = PreLatestBlock {
             number: latest.number + 1,
-            parent_hash: latest.hash,
             l1_gas_price: Default::default(),
             l1_data_gas_price: Default::default(),
             l2_gas_price: Default::default(),
@@ -375,7 +374,6 @@ mod tests {
         let pre_latest_block = PreLatestBlock {
             // These are okay.
             number: latest.number + 1,
-            parent_hash: latest.hash,
             ..Default::default()
         };
         let pre_latest_data = PreLatestData {


### PR DESCRIPTION
This PR extends the pending data polled and served by Pathfinder onto the entire gap that exists during normal operation, when the node is in sync with the network.

As observed by us, depending on the network (in descending order of severity: mainnet, sepolia, integration) and other factors (like the HW config the node is being run on, which impacts how fast the local state tries are updated and the state commitment computed), the gap between the latest preconfirmed tip and the local committed head is rarely 1 (ie. prconfirmed tip links to local commit head) or 2 (as formerly but with prelatest included).

### Observed latency mechanics

This resulted in high preconfirmed tip latency observed by RPC users, with the following mechanism:
1. the node is pretty much at the preconfirmed tip all the time (up to the configured poll interval or up to feeder 1RT in case of high-load RPC traffic which forces the cache to trigger re-polling more frequently; 1RT stems from how `tokio::Notify` coalesces multiple RPC requests over a short span of time into a single cache notification)
2. the chaining requirement of `local-commit-head-->(prelatest-->)?-->preconfirmed`, which was enforced both on the sync side (1) and ultimately on the RPC-serve (2) side resulted in the latest preconfirmed tip view to be (1) discarded or, worse still, (2) ignored; TL;DR the data is in our possession but it does not get to the end user, most of the time and/or promptly enough 

### Measurement methodology

The results may vary slightly, but in my local setup I tend to get a `p50` of ~1.3s and `p99` > 3s on `main`. All measurements were done using [our tool](https://github.com/equilibriumco/block-poke/tree/chris/e2e-with-feeder-polling), where the measurement is performed as follows:
1. a side-task in the tool polls FGW at a given `fgw-poll-interval` (I personally use `20-50ms`
2. this task inspects the preconfirmed block to determine when a new preconfirmed block starts and stores that moment in time `T0`, the measurement error for this value falls into the range of `(0, fgw-poll-interval]`
3. once a new preconfired block P is observed, the tool requests it via the RPC from Pathfinder and records the instant `T1` once the same `P` starts being visible via RPC
4. the tool computes `deltaT = T1 - T0`
5. the entire process is repeated for N consecutive preconfirmed blocks to figure out distibution and hence `p50` et al

### How to decrease latency

In theory we could attempt at increasing the speed at which the local commit-head advances, however this ultimately depends on the HW the node is being run on. This local commit head advance speed is a metric worth improving, nevertheless such improvement still does not guarantee maintaining a gap of 1 or 2 blocks between the preconfirmed tip block and the local commit head.

The solution is to serve a _preconfirmed window_ that spans across the entire gap, making the served _preconfirmed view_ bridge the local commit head with the latest preconfirmed-tip-block served by the fgw.

### Window building

1. Poll preconfirmed `latest`, any new preconfirmed block `P+1` that supersedes previous latest `P` is appended as the tip of the served window view.
2. `P` is used to fill the provisional window entry below `P+1`.
3. The updated window spanning `[provisional P, P+1]` is served immediately.
4. `provisional P` is then updated off the critical path for any missing tail data, which we could have skipped when poll advanced from `P` to `P+1`.
5. `provisional P` becomes `complete P` in the updated window, but is not served until the next poll period, when `P+1` is updated with its next delta.
6. goto 1.

The result in larger gaps is as follows, for example in a gap of size 5 (`P+4` being the latest preconfirmed tip-block), the window looks like this:

Briefly:
```
[complete P, complete P+1, complete P+2, provisional P+3, P+4]
```
After the next poll iteration:
```
[complete P, complete P+1, complete P+2, complete P+3, P+4 with new delta appended]
```

### Cold start and eventual chaining

It is not uncommon for a node to maintain a gap larger than 2 blocks for long periods or even over the entire span of its deployment time given unfavorable circumstances.

To avoid complicating the code even farther, there is no backfilling of the window performed to fill in this initial excessive gap to achieve almost instant chaining with the local commit head.

Instead, we rely on _eventual_ chaining in cold start:
1. preconfirmed window that started with `P` is being built and grows forward with more and more, fresher preconfirmed blocks `P+1, ..., P+k` incoming as the poll progresses
2. local commit head advances from some cold start `C` to `C+1` and at some point to `C+m`, which happens to be the direct ancestor of `P`. Until that happens, serving the window is deferred.

The rationale is that cold start is not an event that happens often, and the time that it takes for the chaining to self-heal as the local commit-head advances is good enough ux for the users.

### Window pruning

Once the above chain is achieved, the oldest entries in the window, the ones that are at the same or lower height as the local commit head, are pruned from the window. This is to make sure that the served view is contiguous and no double updates are effectively served by the node.

This is maintained both on the sync side and on the RPC side, the latter to ensure no race conditions occur, where for a brief moment the window-view can still contain the to-be-pruned ancestor which is at the same height as the local commit head, as seen by the RPC server.

### Tradeoffs

Initially I thought that [this PR is a premature optimization](https://github.com/equilibriumco/pathfinder/pull/3500) and that waiting with the latest preconfirmed tip block being served until the tail of preconfirmed-1 is filled is a good-enough solution. This turned out to be wrong. In my case, locally, 1 fgw RT is ~140 ms. And this is exactly what we loose when putting tail completion on the critical path. This is also enough to exceed the latency requirements, since the effective poll rate for a high load scenario for this PR (ie. off the critical path tail update) is already at 1RT, so we cannot clearly allow 2RT.

The main tradeoff is that for the following subscriptions:
`subscribe_events`
`subscribe_new_transactions`
`subscribe_new_transaction_receipts`
we're not sending updates should the tail be filled in, to avoid out-of-order updates to the streams. This way we gain this 1RT worth of time that I mentioned above.

### Fixes

Looking at `main`, there seems to be a bug in `trace_transaction` and `trace_block_transactions`.

`trace_transaction` and `trace_block_transactions` do not check if the preconfirmed block in the pending data actually has a prelatest block beneath. This matters, because `pathfinder_executor::ExecutionState::trace` is done on the parent state, so if any diffs from the prelatest block are missing the trace may be wrong (because the prelatest state diffs could happen to be the diffs that impact that execution).

The test `test_multiple_pre_latest_transactions` uses `setup_multi_tx_trace_pre_latest_test` which sets the prelatest block state diff to empty, so it chooses the exceptional path where that setup succeeds. If there had been any state diffs in the prelatest that could impact the result, the trace would differ. 

This is why I'm thinking we should be using an additional check and only allow tracing for the immediate parent of the commit head in `trace_transaction`, because we can fall back to the gateway for every other case.

For `trace_block_transactions` whose gateway fallback does not support pending, we should actually pass the pending state for the prelatest/ancestors to execution, because there is no alternative.
 
### Parent block hash

Preconfirmed block does not contain a parent block hash. And we're not using the prelatest (ie. legacy pending) endpoint, so for the time being this field is effectively set to zero in `PreLatestBlock`. I'm inclined to remove this struct and rename `PreLatestData` to `PreConfirmedData`.

### Pending in various RPC methods

Execept for the notable exception of `trace_transaction` and `trace_block_transactions` I kept the behavior consistent with what we used to do, ie.: if method_x uses the preconfimed block and ignores prelatest, then be it, if it has a valid reason to treat preconfirmed and prelatest as a contiguous chunk of state, fine by me too.