### PR TITLE
fix(pathfinder): memory size is overestimated when pathfinder runs inside a container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - RPC method-call latency is now exported as a Prometheus histogram in seconds, `rpc_method_calls_duration_seconds` (`_bucket`/`_sum`/`_count`), replacing the summary `rpc_method_calls_duration_milliseconds`. Update alerts and dashboards to the new name and derive quantiles with `histogram_quantile(...)` over the `_bucket` series; see `docs/docs/monitoring-and-metrics.md`.
 
+### Fixed
+
+- The default `--rpc.compiler.concurrency-limit` now respects the container's cgroup memory limit instead of the host's total RAM, so it no longer over-provisions compiler concurrency (risking OOM) when running in a memory-limited container.
+
 ## [0.22.7] - 2026-06-23
 
 ### Fixed

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -626,7 +626,11 @@ fn determine_compiler_concurrency_limit(
             .with_memory(sysinfo::MemoryRefreshKind::nothing().with_ram()),
     );
     system.refresh_memory_specifics(sysinfo::MemoryRefreshKind::nothing().with_ram());
-    let total_memory_bytes = system.total_memory();
+
+    let total_memory_bytes = system
+        .cgroup_limits()
+        .map(|limits| limits.total_memory)
+        .unwrap_or_else(|| system.total_memory());
 
     compute_compiler_concurrency_limit(
         total_memory_bytes,


### PR DESCRIPTION
Fixes #3497 - There was indeed a bug.

TLDR: That `system.total_memory()` call doesn't account for how Linux limits memory on these containerized environments.

The formula is untouched, just the input for memory size has been changed to account for these [cgroup limits](https://www.c-sharpcorner.com/article/why-rust-applications-behave-differently-in-docker-and-kubernetes-memory-limits/).

I initially tested this with a little rust script in a podman container with limited ram and the output i got using our existing measurement was 9x the ram size i set. With this fix, it aligns with the container limits.