### PR TITLE
suggestions for Chris' PR

### DIFF
--- a/crates/pending-data/src/data.rs
+++ b/crates/pending-data/src/data.rs
@@ -210,6 +210,23 @@ impl PendingData {
         })
     }
 
+    /// Fold every uncommitted parent's state update into one overlay, oldest
+    /// first so newer diffs win. The pre-confirmed tip's own diff is not
+    /// included.
+    pub fn compose_parents_overlay(parents: &[PreLatestData]) -> StateUpdate {
+        let mut overlay = StateUpdate::default();
+        for parent in parents {
+            overlay = overlay.apply(&parent.state_update);
+        }
+        overlay
+    }
+
+    /// The overlay of just the uncommitted parents, without the pre-confirmed
+    /// tip's own diff.
+    pub fn parents_overlay(&self) -> StateUpdate {
+        Self::compose_parents_overlay(&self.blocks.parents)
+    }
+
     /// Build a pending view whose aggregated overlay spans a multi-block
     /// window.
     ///
@@ -226,13 +243,9 @@ impl PendingData {
         let (pre_confirmed_block, pre_confirmed_state_update) =
             convert_pre_confirmed_block(pre_confirmed_block, number)?;
 
-        // Compose the overlay starting from the oldest block so fresher updates
-        // overwrite older ones.
-        let mut overlay = StateUpdate::default();
-        for parent in &parents {
-            overlay = overlay.apply(&parent.state_update);
-        }
-        let aggregated_state_update = Arc::new(overlay.apply(pre_confirmed_state_update.as_ref()));
+        let aggregated_state_update = Arc::new(
+            Self::compose_parents_overlay(&parents).apply(pre_confirmed_state_update.as_ref()),
+        );
 
         Ok(Self {
             blocks: Arc::new(PendingBlocks {

--- a/crates/pending-data/src/data.rs
+++ b/crates/pending-data/src/data.rs
@@ -340,12 +340,6 @@ impl PendingData {
         }
     }
 
-    /// Synthesise a `BlockHeader` from the immediate parent block, if it
-    /// exists.
-    pub fn pre_latest_header(&self) -> Option<BlockHeader> {
-        self.blocks.immediate_parent().map(|data| data.header())
-    }
-
     pub fn pending_block(&self) -> Arc<PendingBlocks> {
         Arc::clone(&self.blocks)
     }

--- a/crates/pending-data/src/data.rs
+++ b/crates/pending-data/src/data.rs
@@ -44,13 +44,9 @@ pub struct PreConfirmedBlock {
     pub transaction_receipts: Vec<TxnReceiptAndEvents>,
 }
 
-// TODO consider removing, because we're gonna be setting the parent hash to
-// zero anyway.
 #[derive(Clone, Default, Debug, PartialEq)]
 pub struct PreLatestBlock {
     pub number: BlockNumber,
-
-    pub parent_hash: BlockHash,
 
     pub l1_gas_price: GasPrices,
     pub l1_data_gas_price: GasPrices,
@@ -78,7 +74,7 @@ impl PreLatestData {
     pub fn header(&self) -> BlockHeader {
         let block = &self.block;
         BlockHeader {
-            parent_hash: block.parent_hash,
+            parent_hash: BlockHash::ZERO,
             number: block.number,
             timestamp: block.timestamp,
             eth_l1_gas_price: block.l1_gas_price.price_in_wei,
@@ -256,7 +252,6 @@ impl PendingData {
         PreLatestData {
             block: PreLatestBlock {
                 number: block.number,
-                parent_hash: BlockHash::ZERO,
                 l1_gas_price: block.l1_gas_price,
                 l1_data_gas_price: block.l1_data_gas_price,
                 l2_gas_price: block.l2_gas_price,

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1079,7 +1079,6 @@ pub mod test_utils {
         let pre_latest_block = PreLatestBlock {
             // Pre-latest is between current latest and pre-confirmed.
             number: latest.number + 1,
-            parent_hash: latest.hash,
             l1_gas_price: GasPrices {
                 price_in_wei: GasPrice::from_be_slice(b"gas price").unwrap(),
                 price_in_fri: GasPrice::from_be_slice(b"strk gas price").unwrap(),

--- a/crates/rpc/src/method/get_events.rs
+++ b/crates/rpc/src/method/get_events.rs
@@ -304,7 +304,8 @@ pub async fn get_events(
             offset: ct.offset,
         });
 
-        // TODO: Verify the added `| None` in review.
+        // An absent `to_block` is unbounded, so it reaches into the pending
+        // range just like an explicit pre-confirmed upper bound does.
         let append_from_pending =
             db_ct.is_none() && matches!(to_block_id, Some(PreConfirmed) | None);
 

--- a/crates/rpc/src/method/get_events.rs
+++ b/crates/rpc/src/method/get_events.rs
@@ -387,9 +387,12 @@ fn get_pending_events(
         pending.pre_confirmed_tx_receipts_and_events(),
     ));
 
-    let oldest_block = blocks
-        .first()
-        .map(|(number, _)| *number)
+    // The oldest un-committed block is the first parent, or the pre-confirmed
+    // tip itself when there are no parents (a gap of one).
+    let oldest_block = pending
+        .parent_blocks()
+        .next()
+        .map(|parent| parent.block.number)
         .unwrap_or(pending_block);
 
     // If we have a continuation token and it points into the un-committed window,

--- a/crates/rpc/src/method/subscribe_transaction_status.rs
+++ b/crates/rpc/src/method/subscribe_transaction_status.rs
@@ -1132,7 +1132,6 @@ mod tests {
                         vec![crate::pending::PreLatestData {
                             block: crate::pending::PreLatestBlock {
                                 number: BlockNumber::GENESIS + 2,
-                                parent_hash: BlockHash(Felt::from_u64(2)),
                                 transaction_receipts: vec![
                                     (
                                         Receipt {

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -115,11 +115,7 @@ pub async fn trace_block_transactions(
                 // best and create a pending state diff for everything up to but excluding the
                 // preconfirmed block.
                 let pending_state = if pending.parent_blocks().next().is_some() {
-                    let mut overlay = pathfinder_common::StateUpdate::default();
-                    for parent in pending.parent_blocks() {
-                        overlay = overlay.apply(&parent.state_update);
-                    }
-                    Some(std::sync::Arc::new(overlay))
+                    Some(std::sync::Arc::new(pending.parents_overlay()))
                 } else {
                     None
                 };

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -1269,7 +1269,6 @@ pub(crate) mod tests {
             let parent = crate::pending::PreLatestData {
                 block: crate::pending::PreLatestBlock {
                     number: last_block_header.number + 1,
-                    parent_hash: last_block_header.hash,
                     l1_gas_price: GasPrices {
                         price_in_wei: last_block_header.eth_l1_gas_price,
                         price_in_fri: last_block_header.strk_l1_gas_price,
@@ -1391,7 +1390,6 @@ pub(crate) mod tests {
             let parent = crate::pending::PreLatestData {
                 block: crate::pending::PreLatestBlock {
                     number: last_block_header.number + 1,
-                    parent_hash: last_block_header.hash,
                     l1_gas_price: GasPrices {
                         price_in_wei: last_block_header.eth_l1_gas_price,
                         price_in_fri: last_block_header.strk_l1_gas_price,

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -120,11 +120,10 @@ impl PendingWatcher {
         // as-is. Composition mirrors `PendingData::from_window`: parents oldest →
         // newest, then the pre-confirmed block's own diffs on top.
         let aggregated_overlay = if watched_pending_data.aggregated_lower_bound < committed {
-            let mut overlay = StateUpdate::default();
-            for parent in &parents {
-                overlay = overlay.apply(&parent.state_update);
-            }
-            Arc::new(overlay.apply(watched_pending_data.state_update.as_ref()))
+            Arc::new(
+                PendingData::compose_parents_overlay(&parents)
+                    .apply(watched_pending_data.state_update.as_ref()),
+            )
         } else {
             Arc::clone(&watched_pending_data.aggregated_state_update)
         };

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -502,6 +502,49 @@ mod tests {
     }
 
     #[test]
+    fn windowed_pre_confirmed_reports_committed_head_as_old_root() {
+        // With a pre-latest present the window is two blocks deep, so the tip is
+        // served through the immediate-parent branch. Its own state update must
+        // carry the committed head's state commitment as its old root, otherwise
+        // getStateUpdate(pre_confirmed) on v0.9 serializes old_root as 0x0.
+        let cache = Arc::new(PendingDataCache::new());
+        let uut = PendingWatcher::new(cache.clone());
+
+        let mut storage = pathfinder_storage::StorageBuilder::in_memory()
+            .unwrap()
+            .connection()
+            .unwrap();
+
+        let parent = BlockHeader::builder()
+            .number(BlockNumber::GENESIS + 12)
+            .finalize_with_hash(block_hash_bytes!(b"parent hash"));
+        // A committed head with a non-zero state commitment, so a zeroed old
+        // root would be observably wrong.
+        let latest = parent
+            .child_builder()
+            .state_commitment(state_commitment!("0xc0ffee"))
+            .finalize_with_hash(block_hash_bytes!(b"latest hash"));
+
+        let tx = storage.transaction().unwrap();
+        tx.insert_block_header(&parent).unwrap();
+        tx.insert_block_header(&latest).unwrap();
+
+        // Window of two: pre-latest at latest + 1, pre-confirmed at latest + 2.
+        cache.store(valid_pre_confirmed_block_with_pre_latest(&latest));
+
+        let result = uut.get(&tx, RpcVersion::V09).unwrap();
+
+        assert!(
+            result.pre_latest_block().is_some(),
+            "the pre-latest should keep this on the immediate-parent branch"
+        );
+        assert_eq!(
+            result.pre_confirmed_state_update().parent_state_commitment,
+            latest.state_commitment,
+        );
+    }
+
+    #[test]
     fn valid_pre_confirmed_is_not_used_for_old_rpc_versions() {
         let cache = Arc::new(PendingDataCache::new());
         let uut = PendingWatcher::new(cache.clone());

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -149,7 +149,13 @@ impl PendingWatcher {
                     parents,
                 }
                 .into(),
-                state_update: Arc::clone(&watched_pending_data.state_update),
+                // The pre-confirmed tip's own state update is serialized with the
+                // committed head as its old root, so stamp it here just like the
+                // no-parent branch below.
+                state_update: Arc::new(
+                    StateUpdate::clone(&watched_pending_data.state_update)
+                        .with_parent_state_commitment(latest.state_commitment),
+                ),
                 aggregated_state_update: aggregated_overlay,
                 number: pre_confirmed.number,
                 aggregated_lower_bound: committed,

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -316,7 +316,6 @@ mod tests {
     fn valid_pre_confirmed_block_with_pre_latest(latest: &BlockHeader) -> PendingData {
         let pre_latest_block = PreLatestBlock {
             number: latest.number + 1,
-            parent_hash: latest.hash,
             l1_gas_price: Default::default(),
             l1_data_gas_price: Default::default(),
             l2_gas_price: Default::default(),
@@ -375,7 +374,6 @@ mod tests {
         let pre_latest_block = PreLatestBlock {
             // These are okay.
             number: latest.number + 1,
-            parent_hash: latest.hash,
             ..Default::default()
         };
         let pre_latest_data = PreLatestData {


### PR DESCRIPTION
AI-Assisted. Human tested.

The only real fix is df9196b68f8aa7cf8f828d83974ba801a1ccd90c, verified by b13e7c7a00c20251637ca76391f7e0a71f5211b3. Apparently, `getStateUpdate` was returning empty `0x0` on the `old_root` for the pre-confirmed. This only affects v09 as this field is dropped in v10.
 
In 28b1e41904fb628ad0bf69823b927f2dc970dd48 we unify this parent overlay code that was repeated in a few spots into a shared helper. No behaviour changes.

The rest are just cleanups
 - Remove `PreLatestBlock.parent_hash` which was always `ZERO` and not used anywhere. 
 - Remove `pre_latest_header` which was also dead code.