### PR TITLE
fix(rpc): serve correct `failure_reason` based on RPC version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The default `--rpc.compiler.concurrency-limit` now respects the container's cgroup memory limit instead of the host's total RAM, so it no longer over-provisions compiler concurrency (risking OOM) when running in a memory-limited container.
+- `starknet_getMessagesStatus` now returns `failure_reason` from the reverted execution status on JSON-RPC v0.9 and later, while preserving the legacy rejected-status failure reason on older RPC versions.
 
 ## [0.22.7] - 2026-06-23
 

--- a/crates/rpc/src/method/get_messages_status.rs
+++ b/crates/rpc/src/method/get_messages_status.rs
@@ -82,6 +82,14 @@ pub async fn get_messages_status(
         .context("Fetching L1 handler tx hashes")
         .map_err(|_| Error::TxnHashNotFound)?;
 
+    get_messages_status_impl(context, rpc_version, l1_handler_txs).await
+}
+
+async fn get_messages_status_impl(
+    context: RpcContext,
+    rpc_version: RpcVersion,
+    l1_handler_txs: Vec<pathfinder_common::transaction::L1HandlerTransaction>,
+) -> Result<Output, Error> {
     let mut res = vec![];
     for tx in l1_handler_txs {
         let tx_hash = tx.calculate_hash(context.chain_id);
@@ -111,9 +119,16 @@ pub async fn get_messages_status(
             }
         };
 
-        let failure_reason = match status {
-            TxStatus::Rejected { error_message, .. } => error_message,
-            _ => None,
+        let failure_reason = if rpc_version >= RpcVersion::V09 {
+            match &execution_status {
+                Some(TxnExecutionStatus::Reverted { reason }) => reason.clone(),
+                _ => None,
+            }
+        } else {
+            match &status {
+                TxStatus::Rejected { error_message } => error_message.clone(),
+                _ => None,
+            }
         };
 
         if rpc_version >= RpcVersion::V09 && execution_status.is_none() {
@@ -154,5 +169,266 @@ impl crate::dto::SerializeForVersion for L1HandlerTransactionStatus {
         }
         serializer.serialize_optional("failure_reason", self.failure_reason.as_deref())?;
         serializer.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pathfinder_common::macro_prelude::*;
+    use pathfinder_common::receipt::{ExecutionStatus, Receipt};
+    use pathfinder_common::transaction::{L1HandlerTransaction, Transaction, TransactionVariant};
+    use pathfinder_common::{BlockId, BlockTimestamp, L1TransactionHash, TransactionNonce};
+    use pathfinder_crypto::Felt;
+    use primitive_types::H256;
+    use serde_json::json;
+
+    use super::*;
+    use crate::dto::{DeserializeForVersion, SerializeForVersion, Serializer};
+
+    mod parsing {
+        use super::*;
+
+        #[test]
+        fn positional_args() {
+            let positional_json = json!(["0x1234"]);
+            let positional = crate::dto::Value::new(positional_json, RpcVersion::V09);
+
+            let input = Input::deserialize(positional).unwrap();
+
+            assert_eq!(
+                input,
+                Input {
+                    transaction_hash: L1TransactionHash::new(H256::from_low_u64_be(0x1234)),
+                }
+            );
+        }
+
+        #[test]
+        fn named_args() {
+            let named_args_json = json!({
+                "transaction_hash": "0x1234",
+            });
+            let named = crate::dto::Value::new(named_args_json, RpcVersion::V09);
+
+            let input = Input::deserialize(named).unwrap();
+
+            assert_eq!(
+                input,
+                Input {
+                    transaction_hash: L1TransactionHash::new(H256::from_low_u64_be(0x1234)),
+                }
+            );
+        }
+    }
+
+    #[rstest::rstest]
+    #[case::received(FinalityStatus::Received, "RECEIVED")]
+    #[case::rejected(FinalityStatus::Rejected, "REJECTED")]
+    #[case::pre_confirmed(FinalityStatus::PreConfirmed, "PRE_CONFIRMED")]
+    #[case::accepted_on_l2(FinalityStatus::AcceptedOnL2, "ACCEPTED_ON_L2")]
+    #[case::accepted_on_l1(FinalityStatus::AcceptedOnL1, "ACCEPTED_ON_L1")]
+    fn finality_status_serialization(#[case] status: FinalityStatus, #[case] expected: &str) {
+        let encoded = status.serialize(Default::default()).unwrap();
+
+        assert_eq!(encoded, json!(expected));
+    }
+
+    #[test]
+    fn output_serialization_before_v09_omits_execution_status() {
+        let output = Output(vec![L1HandlerTransactionStatus {
+            transaction_hash: transaction_hash!("0x1234"),
+            finality_status: FinalityStatus::Rejected,
+            execution_status: Some(TxnExecutionStatus::Succeeded),
+            failure_reason: Some("message rejected".to_owned()),
+        }]);
+
+        let encoded = output.serialize(Serializer::new(RpcVersion::V08)).unwrap();
+
+        assert_eq!(
+            encoded,
+            json!([
+                {
+                    "transaction_hash": "0x1234",
+                    "finality_status": "REJECTED",
+                    "failure_reason": "message rejected",
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn output_serialization_v09_includes_execution_status_and_revert_reason() {
+        let output = Output(vec![L1HandlerTransactionStatus {
+            transaction_hash: transaction_hash!("0x1234"),
+            finality_status: FinalityStatus::AcceptedOnL2,
+            execution_status: Some(TxnExecutionStatus::Reverted {
+                reason: Some("l1 handler reverted".to_owned()),
+            }),
+            failure_reason: Some("l1 handler reverted".to_owned()),
+        }]);
+
+        let encoded = output.serialize(Serializer::new(RpcVersion::V09)).unwrap();
+
+        assert_eq!(
+            encoded,
+            json!([
+                {
+                    "transaction_hash": "0x1234",
+                    "finality_status": "ACCEPTED_ON_L2",
+                    "execution_status": "REVERTED",
+                    "failure_reason": "l1 handler reverted",
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn output_serialization_v09_omits_absent_failure_reason() {
+        let output = Output(vec![L1HandlerTransactionStatus {
+            transaction_hash: transaction_hash!("0x1234"),
+            finality_status: FinalityStatus::AcceptedOnL1,
+            execution_status: Some(TxnExecutionStatus::Succeeded),
+            failure_reason: None,
+        }]);
+
+        let encoded = output.serialize(Serializer::new(RpcVersion::V09)).unwrap();
+
+        assert_eq!(
+            encoded,
+            json!([
+                {
+                    "transaction_hash": "0x1234",
+                    "finality_status": "ACCEPTED_ON_L1",
+                    "execution_status": "SUCCEEDED",
+                }
+            ])
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::v08(
+        RpcVersion::V08,
+        json!([
+            {
+                "transaction_hash": "0x5fbdcde319efbd314396a673e2883c9e32b4e5240af54e4433e1bdcd53edf8",
+                "finality_status": "ACCEPTED_ON_L1",
+            },
+            {
+                "transaction_hash": "0x4dc69e578dfe0792b2f87c060a973bfca28d2a4d76f68dc4a76fbaf031fd3e7",
+                "finality_status": "ACCEPTED_ON_L2",
+            }
+        ])
+    )]
+    #[case::v09(
+        RpcVersion::V09,
+        json!([
+            {
+                "transaction_hash": "0x5fbdcde319efbd314396a673e2883c9e32b4e5240af54e4433e1bdcd53edf8",
+                "finality_status": "ACCEPTED_ON_L1",
+                "execution_status": "SUCCEEDED",
+            },
+            {
+                "transaction_hash": "0x4dc69e578dfe0792b2f87c060a973bfca28d2a4d76f68dc4a76fbaf031fd3e7",
+                "finality_status": "ACCEPTED_ON_L2",
+                "execution_status": "REVERTED",
+                "failure_reason": "l1 handler reverted",
+            }
+        ])
+    )]
+    #[tokio::test]
+    async fn get_messages_status_happy_path_differs_by_rpc_version(
+        #[case] version: RpcVersion,
+        #[case] expected: serde_json::Value,
+    ) {
+        let accepted_l1_handler = l1_handler_transaction(1);
+        let reverted_l1_handler = l1_handler_transaction(2);
+        let l1_handler_txs = vec![accepted_l1_handler.clone(), reverted_l1_handler.clone()];
+        let context = RpcContext::for_tests();
+
+        seed_l1_handler_transactions(&context, accepted_l1_handler, reverted_l1_handler);
+
+        let output = get_messages_status_impl(context, version, l1_handler_txs)
+            .await
+            .unwrap();
+
+        let output_json = output.serialize(Serializer::new(version)).unwrap();
+        assert_eq!(output_json, expected);
+    }
+
+    fn l1_handler_transaction(nonce: u64) -> L1HandlerTransaction {
+        L1HandlerTransaction {
+            contract_address: contract_address!("0x1234"),
+            entry_point_selector: entry_point!("0x5678"),
+            nonce: TransactionNonce(Felt::from(nonce)),
+            calldata: vec![call_param!("0xdeadbeef"), call_param!("0x1")],
+        }
+    }
+
+    fn seed_l1_handler_transactions(
+        context: &RpcContext,
+        accepted_l1_handler: L1HandlerTransaction,
+        reverted_l1_handler: L1HandlerTransaction,
+    ) {
+        let accepted_hash = accepted_l1_handler.calculate_hash(context.chain_id);
+        let reverted_hash = reverted_l1_handler.calculate_hash(context.chain_id);
+
+        let accepted_transaction = Transaction {
+            hash: accepted_hash,
+            variant: TransactionVariant::L1Handler(accepted_l1_handler),
+        };
+        let reverted_transaction = Transaction {
+            hash: reverted_hash,
+            variant: TransactionVariant::L1Handler(reverted_l1_handler),
+        };
+
+        let accepted_receipt = Receipt {
+            transaction_hash: accepted_hash,
+            ..Default::default()
+        };
+        let reverted_receipt = Receipt {
+            transaction_hash: reverted_hash,
+            execution_status: ExecutionStatus::Reverted {
+                reason: "l1 handler reverted".to_owned(),
+            },
+            ..Default::default()
+        };
+
+        let mut db = context.storage.connection().unwrap();
+        let db_tx = db.transaction().unwrap();
+        let latest_header = db_tx
+            .block_header(BlockId::Latest)
+            .unwrap()
+            .expect("test storage should contain a latest block");
+
+        let accepted_header = latest_header
+            .child_builder()
+            .timestamp(BlockTimestamp::new_or_panic(3))
+            .finalize_with_hash(block_hash_bytes!(b"message status accepted"));
+        db_tx.insert_block_header(&accepted_header).unwrap();
+        db_tx
+            .insert_transaction_data(
+                accepted_header.number,
+                &[(accepted_transaction, accepted_receipt)],
+                Some(&[vec![]]),
+            )
+            .unwrap();
+
+        let reverted_header = accepted_header
+            .child_builder()
+            .timestamp(BlockTimestamp::new_or_panic(4))
+            .finalize_with_hash(block_hash_bytes!(b"message status reverted"));
+        db_tx.insert_block_header(&reverted_header).unwrap();
+        db_tx
+            .insert_transaction_data(
+                reverted_header.number,
+                &[(reverted_transaction, reverted_receipt)],
+                Some(&[vec![]]),
+            )
+            .unwrap();
+
+        db_tx
+            .update_l1_l2_pointer(Some(accepted_header.number))
+            .unwrap();
+        db_tx.commit().unwrap();
     }
 }


### PR DESCRIPTION
Fix `starknet_getMessagesStatus` to source `failure_reason` according to the RPC version:

- For RPC v0.9+, return the revert reason from `execution_status: REVERTED`.
- For older versions, preserve the legacy behavior of only returning the rejected transaction error message.

Closes https://github.com/equilibriumco/pathfinder/issues/3481