### PR TITLE
fix(load-test): avoid pre-confirmed block by default

### DIFF
--- a/crates/load-test/src/main.rs
+++ b/crates/load-test/src/main.rs
@@ -10,6 +10,13 @@
 //! ```
 //! cargo run --release -- -H http://127.0.0.1:9545 --report-file /tmp/report.html -u 30 -r 5 -t 60 --no-gzip
 //! ```
+//! By default, the tests do not request any pre-confirmed data. To
+//! enable pre-confirmed tests (which require the tested pathfinder
+//! node to be _fully_ synced), define
+//! ```
+//! export LOAD_TEST_PRE_CONFIRMED=1
+//! ```
+//! before running the load test.
 use goose::prelude::*;
 
 mod requests;

--- a/crates/load-test/src/requests/v09.rs
+++ b/crates/load-test/src/requests/v09.rs
@@ -15,6 +15,14 @@ use crate::types::{
 
 pub type MethodResult<T> = Result<T, Box<goose::goose::TransactionError>>;
 
+fn block_number_to_json(block_number: Option<u64>) -> serde_json::Value {
+    if let Some(bn) = block_number {
+        json!({"block_number": bn})
+    } else {
+        json!("pre_confirmed")
+    }
+}
+
 pub async fn get_block_by_number(user: &mut GooseUser, block_number: u64) -> MethodResult<Block> {
     post_jsonrpc_request(
         user,
@@ -227,20 +235,17 @@ pub async fn call(
     contract_address: Felt,
     call_data: &[&str],
     entry_point_selector: &str,
+    block_number: Option<u64>,
 ) -> MethodResult<Vec<String>> {
-    post_jsonrpc_request(
-        user,
-        "starknet_call",
-        json!({
-            "request": {
-                "contract_address": contract_address,
-                "calldata": call_data,
-                "entry_point_selector": entry_point_selector,
-            },
-            "block_id": "pre_confirmed",
-        }),
-    )
-    .await
+    let mut params = json!({
+        "request": {
+            "contract_address": contract_address,
+            "calldata": call_data,
+            "entry_point_selector": entry_point_selector,
+        }
+    });
+    params["block_id"] = block_number_to_json(block_number);
+    post_jsonrpc_request(user, "starknet_call", params).await
 }
 
 pub async fn estimate_fee_for_invoke(
@@ -275,16 +280,16 @@ pub async fn estimate_fee_for_invoke(
     .await
 }
 
-pub async fn get_nonce(user: &mut GooseUser, contract_address: Felt) -> MethodResult<Felt> {
-    post_jsonrpc_request(
-        user,
-        "starknet_getNonce",
-        json!({
-            "block_id": "pre_confirmed",
-            "contract_address": contract_address
-        }),
-    )
-    .await
+pub async fn get_nonce(
+    user: &mut GooseUser,
+    contract_address: Felt,
+    block_number: Option<u64>,
+) -> MethodResult<Felt> {
+    let mut params = json!({
+        "contract_address": contract_address
+    });
+    params["block_id"] = block_number_to_json(block_number);
+    post_jsonrpc_request(user, "starknet_getNonce", params).await
 }
 
 async fn post_jsonrpc_request<T: DeserializeOwned>(

--- a/crates/load-test/src/tasks/v09.rs
+++ b/crates/load-test/src/tasks/v09.rs
@@ -157,8 +157,10 @@ pub async fn task_syncing(user: &mut GooseUser) -> TransactionResult {
 }
 
 pub async fn task_call(user: &mut GooseUser) -> TransactionResult {
+    let default_mode = std::env::var("LOAD_TEST_PRE_CONFIRMED").is_err();
     call(
         user,
+        // StarkGate: ETH Token
         Felt::from_hex_str("0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7")
             .unwrap(),
         &[
@@ -167,6 +169,8 @@ pub async fn task_call(user: &mut GooseUser) -> TransactionResult {
         ],
         // "balanceOf" entry point
         "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e",
+        // token deployed in block 1407
+        default_mode.then_some(1500),
     )
     .await?;
     Ok(())
@@ -295,12 +299,13 @@ pub async fn task_get_storage_at(user: &mut GooseUser) -> TransactionResult {
 }
 
 pub async fn task_get_nonce(user: &mut GooseUser) -> TransactionResult {
-    let _ = get_nonce(
-        user,
+    let default_mode = std::env::var("LOAD_TEST_PRE_CONFIRMED").is_err();
+    let contract_address =
         Felt::from_hex_str("0x01b68f7c1bbcaf9017bd8e2f3be124c01525341603e5c76a06870c32e10473c7")
-            .unwrap(),
-    )
-    .await?;
+            .unwrap();
+    // same as in estimate_fee_for_invoke
+    let block_number = default_mode.then_some(499999);
+    let _ = get_nonce(user, contract_address, block_number).await?;
 
     Ok(())
 }


### PR DESCRIPTION
Previous behavior is gated by an environment variable.
