### PR TITLE
refactor(rpc/add_declare_tx): compress sierra classes in a separate task

### DIFF
--- a/crates/rpc/src/method/add_declare_transaction.rs
+++ b/crates/rpc/src/method/add_declare_transaction.rs
@@ -425,10 +425,12 @@ pub async fn add_declare_transaction(
             })
         }
         Transaction::Declare(BroadcastedDeclareTransaction::V3(tx)) => {
-            let contract_definition: SierraContractDefinition = tx
-                .contract_class
-                .try_into()
-                .map_err(|e| anyhow::anyhow!("Failed to convert contract definition: {e}"))?;
+            let contract_class = tx.contract_class;
+            let contract_definition: SierraContractDefinition =
+                util::task::spawn_blocking(move |_| contract_class.try_into())
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Sierra compression task failed: {e}"))?
+                    .map_err(|e| anyhow::anyhow!("Failed to convert contract definition: {e}"))?;
 
             let response = context
                 .sequencer


### PR DESCRIPTION
This PR doesn't optimize the tx submission path per-se, but still worth considering.

Right now, these Sierra classes are compressed in our main thread iiuc. Which means that if the class is huge, it's gonna block that thread for a bit. Instead, this PR suggests running this compression on a task from the tokio pool. Again, this won't make things faster, but at least if there are multiple subsequent RPC calls we won't be blocked.