### PR TITLE
feat(gateway-client): gzip compression in async worker

### DIFF
--- a/crates/gateway-client/src/builder.rs
+++ b/crates/gateway-client/src/builder.rs
@@ -13,6 +13,8 @@
 //!   4. [Final](stage::Final) where you select the REST operation type, which
 //!      is then executed.
 
+use std::io::Write;
+
 use backon::Retryable;
 use pathfinder_common::{ClassHash, TransactionHash};
 use reqwest::header::CONTENT_ENCODING;
@@ -370,13 +372,20 @@ impl Request<stage::Final> {
                     None => request,
                 };
                 if compress {
-                    let mut encoder =
-                        flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
-                    serde_json::to_writer(&mut encoder, json)
+                    let uncompressed = serde_json::to_vec(json)
                         .map_err(|e| SequencerError::GatewayRequestCreationError(e.into()))?;
-                    let compressed_body = encoder
-                        .finish()
-                        .map_err(|e| SequencerError::GatewayRequestCreationError(e.into()))?;
+                    let compressed_body = tokio::task::spawn_blocking(move || {
+                        let mut encoder = flate2::write::GzEncoder::new(
+                            Vec::new(),
+                            flate2::Compression::default(),
+                        );
+                        encoder.write_all(&uncompressed)?;
+                        encoder.finish()
+                    })
+                    .await
+                    .map_err(std::io::Error::other)
+                    .and_then(|body| body)
+                    .map_err(|e| SequencerError::GatewayRequestCreationError(e.into()))?;
                     let request = request
                         .header(CONTENT_ENCODING, "gzip")
                         .body(compressed_body);


### PR DESCRIPTION
Similar to https://github.com/equilibriumco/pathfinder/pull/3515 but in this case it's the gzip compression that we're moving out of the worker thread. Once again, this is not a real win but it partially offloads the gzip portion. Unfortunately, I couldn't move the json serialization out (because of the borrow constraint).

I'm not 100% sure of this one, so I'd like input. We'd be now serializing to a byte array first, and _then_ gzips it. So it's one extra alloc. With large proofs it should earn it's keep. But for smaller ones it won't really help...