### PR TITLE
fix(rpc): disallow deserializing pre-v3 broadcasted transactions

### DIFF
--- a/crates/rpc/fixtures/0.10.0/broadcasted_transactions.json
+++ b/crates/rpc/fixtures/0.10.0/broadcasted_transactions.json
@@ -1,64 +1,6 @@
 [
     {
         "type": "DECLARE",
-        "max_fee": "0x5",
-        "version": "0x1",
-        "signature": [
-            "0x7"
-        ],
-        "nonce": "0x8",
-        "contract_class": {
-            "program": "program",
-            "entry_points_by_type": {
-                "CONSTRUCTOR": [],
-                "EXTERNAL": [],
-                "L1_HANDLER": []
-            },
-            "abi": null
-        },
-        "sender_address": "0xa"
-    },
-    {
-        "type": "DECLARE",
-        "max_fee": "0x51",
-        "version": "0x2",
-        "signature": [
-            "0x71"
-        ],
-        "nonce": "0x81",
-        "compiled_class_hash": "0x91",
-        "contract_class": {
-            "sierra_program": [
-                "0x4",
-                "0x5"
-            ],
-            "contract_class_version": "0.1.0",
-            "entry_points_by_type": {
-                "CONSTRUCTOR": [
-                    {
-                        "function_idx": 1,
-                        "selector": "0x1"
-                    }
-                ],
-                "EXTERNAL": [
-                    {
-                        "function_idx": 2,
-                        "selector": "0x2"
-                    }
-                ],
-                "L1_HANDLER": [
-                    {
-                        "function_idx": 3,
-                        "selector": "0x3"
-                    }
-                ]
-            },
-            "abi": "[{\"type\":\"function\",\"name\":\"foo\"}]"
-        },
-        "sender_address": "0xa1"
-    },
-    {
-        "type": "DECLARE",
         "version": "0x3",
         "signature": [
             "0x71"
@@ -119,32 +61,6 @@
             "abi": "[{\"type\":\"function\",\"name\":\"foo\"}]"
         },
         "sender_address": "0xa1"
-    },
-    {
-        "type": "INVOKE",
-        "version": "0x1",
-        "max_fee": "0x6",
-        "signature": [
-            "0x7"
-        ],
-        "nonce": "0x8",
-        "sender_address": "0xaaa",
-        "calldata": [
-            "0xff"
-        ]
-    },
-    {
-        "type": "INVOKE",
-        "version": "0x100000000000000000000000000000001",
-        "max_fee": "0x6",
-        "signature": [
-            "0x7"
-        ],
-        "nonce": "0x8",
-        "sender_address": "0xaaa",
-        "calldata": [
-            "0xff"
-        ]
     },
     {
         "type": "INVOKE",

--- a/crates/rpc/fixtures/0.10.0/simulations/simulate_transaction.json
+++ b/crates/rpc/fixtures/0.10.0/simulations/simulate_transaction.json
@@ -3,12 +3,12 @@
     "fee_estimation": {
       "l1_data_gas_consumed": "0x160",
       "l1_data_gas_price": "0x2",
-      "l1_gas_consumed": "0x15",
-      "l1_gas_price": "0x1",
-      "l2_gas_consumed": "0x0",
+      "l1_gas_consumed": "0x0",
+      "l1_gas_price": "0x2",
+      "l2_gas_consumed": "0x70cb0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x2d5",
-      "unit": "WEI"
+      "overall_fee": "0x70f70",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "constructor_invocation": {
@@ -33,8 +33,8 @@
           }
         ],
         "execution_resources": {
-          "l1_gas": 2,
-          "l2_gas": 0
+          "l1_gas": 0,
+          "l2_gas": 40000
         },
         "is_reverted": false,
         "messages": [],
@@ -42,8 +42,8 @@
       },
       "execution_resources": {
         "l1_data_gas": 352,
-        "l1_gas": 21,
-        "l2_gas": 0
+        "l1_gas": 0,
+        "l2_gas": 420000
       },
       "state_diff": {
         "declared_classes": [],
@@ -98,8 +98,8 @@
         "entry_point_type": "EXTERNAL",
         "events": [],
         "execution_resources": {
-          "l1_gas": 1,
-          "l2_gas": 0
+          "l1_gas": 0,
+          "l2_gas": 20000
         },
         "is_reverted": false,
         "messages": [],

--- a/crates/rpc/fixtures/0.10.0/simulations/simulate_transaction_with_return_initial_reads.json
+++ b/crates/rpc/fixtures/0.10.0/simulations/simulate_transaction_with_return_initial_reads.json
@@ -41,12 +41,12 @@
       "fee_estimation": {
         "l1_data_gas_consumed": "0x160",
         "l1_data_gas_price": "0x2",
-        "l1_gas_consumed": "0x15",
-        "l1_gas_price": "0x1",
-        "l2_gas_consumed": "0x0",
+        "l1_gas_consumed": "0x0",
+        "l1_gas_price": "0x2",
+        "l2_gas_consumed": "0x70cb0",
         "l2_gas_price": "0x1",
-        "overall_fee": "0x2d5",
-        "unit": "WEI"
+        "overall_fee": "0x70f70",
+        "unit": "FRI"
       },
       "transaction_trace": {
         "constructor_invocation": {
@@ -71,8 +71,8 @@
             }
           ],
           "execution_resources": {
-            "l1_gas": 2,
-            "l2_gas": 0
+            "l1_gas": 0,
+            "l2_gas": 40000
           },
           "is_reverted": false,
           "messages": [],
@@ -80,8 +80,8 @@
         },
         "execution_resources": {
           "l1_data_gas": 352,
-          "l1_gas": 21,
-          "l2_gas": 0
+          "l1_gas": 0,
+          "l2_gas": 420000
         },
         "state_diff": {
           "declared_classes": [],
@@ -136,8 +136,8 @@
           "entry_point_type": "EXTERNAL",
           "events": [],
           "execution_resources": {
-            "l1_gas": 1,
-            "l2_gas": 0
+            "l1_gas": 0,
+            "l2_gas": 20000
           },
           "is_reverted": false,
           "messages": [],

--- a/crates/rpc/fixtures/0.9.0/simulations/simulate_transaction.json
+++ b/crates/rpc/fixtures/0.9.0/simulations/simulate_transaction.json
@@ -3,12 +3,12 @@
     "fee_estimation": {
       "l1_data_gas_consumed": "0x160",
       "l1_data_gas_price": "0x2",
-      "l1_gas_consumed": "0x15",
-      "l1_gas_price": "0x1",
-      "l2_gas_consumed": "0x0",
+      "l1_gas_consumed": "0x0",
+      "l1_gas_price": "0x2",
+      "l2_gas_consumed": "0x70cb0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x2d5",
-      "unit": "WEI"
+      "overall_fee": "0x70f70",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "constructor_invocation": {
@@ -33,8 +33,8 @@
           }
         ],
         "execution_resources": {
-          "l1_gas": 2,
-          "l2_gas": 0
+          "l1_gas": 0,
+          "l2_gas": 40000
         },
         "is_reverted": false,
         "messages": [],
@@ -42,8 +42,8 @@
       },
       "execution_resources": {
         "l1_data_gas": 352,
-        "l1_gas": 21,
-        "l2_gas": 0
+        "l1_gas": 0,
+        "l2_gas": 420000
       },
       "state_diff": {
         "declared_classes": [],
@@ -97,8 +97,8 @@
         "entry_point_type": "EXTERNAL",
         "events": [],
         "execution_resources": {
-          "l1_gas": 1,
-          "l2_gas": 0
+          "l1_gas": 0,
+          "l2_gas": 20000
         },
         "is_reverted": false,
         "messages": [],

--- a/crates/rpc/src/method/add_declare_transaction.rs
+++ b/crates/rpc/src/method/add_declare_transaction.rs
@@ -196,124 +196,6 @@ pub struct Input {
     token: Option<String>,
 }
 
-impl Input {
-    pub fn is_v3_transaction(&self) -> bool {
-        matches!(
-            self.declare_transaction,
-            Transaction::Declare(BroadcastedDeclareTransaction::V3(_))
-        )
-    }
-}
-
-#[cfg(test)]
-impl Input {
-    pub(crate) fn for_test_with_v0_transaction() -> Self {
-        Self {
-            declare_transaction: Transaction::Declare(BroadcastedDeclareTransaction::V0(
-                crate::types::request::BroadcastedDeclareTransactionV0 {
-                    max_fee: Default::default(),
-                    version: pathfinder_common::TransactionVersion::ZERO,
-                    signature: Default::default(),
-                    contract_class: crate::types::class::cairo::CairoContractClass {
-                        program: Default::default(),
-                        entry_points_by_type:
-                            crate::types::class::cairo::entry_point::ContractEntryPoints {
-                                constructor: Default::default(),
-                                external: Default::default(),
-                                l1_handler: Default::default(),
-                            },
-                        abi: Default::default(),
-                    },
-                    sender_address: Default::default(),
-                },
-            )),
-            token: None,
-        }
-    }
-
-    pub(crate) fn for_test_with_v1_transaction() -> Self {
-        Self {
-            declare_transaction: Transaction::Declare(BroadcastedDeclareTransaction::V1(
-                crate::types::request::BroadcastedDeclareTransactionV1 {
-                    max_fee: Default::default(),
-                    version: pathfinder_common::TransactionVersion::ONE,
-                    signature: Default::default(),
-                    nonce: Default::default(),
-                    contract_class: crate::types::class::cairo::CairoContractClass {
-                        program: Default::default(),
-                        entry_points_by_type:
-                            crate::types::class::cairo::entry_point::ContractEntryPoints {
-                                constructor: Default::default(),
-                                external: Default::default(),
-                                l1_handler: Default::default(),
-                            },
-                        abi: Default::default(),
-                    },
-                    sender_address: Default::default(),
-                },
-            )),
-            token: None,
-        }
-    }
-
-    pub(crate) fn for_test_with_v2_transaction() -> Self {
-        Self {
-            declare_transaction: Transaction::Declare(BroadcastedDeclareTransaction::V2(
-                crate::types::request::BroadcastedDeclareTransactionV2 {
-                    max_fee: Default::default(),
-                    version: pathfinder_common::TransactionVersion::TWO,
-                    signature: Default::default(),
-                    nonce: Default::default(),
-                    compiled_class_hash: Default::default(),
-                    contract_class: crate::types::class::sierra::SierraContractClass {
-                        sierra_program: Default::default(),
-                        contract_class_version: Default::default(),
-                        entry_points_by_type: crate::types::class::sierra::SierraEntryPoints {
-                            constructor: Default::default(),
-                            external: Default::default(),
-                            l1_handler: Default::default(),
-                        },
-                        abi: Default::default(),
-                    },
-                    sender_address: Default::default(),
-                },
-            )),
-            token: None,
-        }
-    }
-
-    pub(crate) fn for_test_with_v3_transaction() -> Self {
-        Self {
-            declare_transaction: Transaction::Declare(BroadcastedDeclareTransaction::V3(
-                crate::types::request::BroadcastedDeclareTransactionV3 {
-                    version: pathfinder_common::TransactionVersion::THREE,
-                    signature: Default::default(),
-                    nonce: Default::default(),
-                    resource_bounds: Default::default(),
-                    tip: Default::default(),
-                    paymaster_data: Default::default(),
-                    account_deployment_data: Default::default(),
-                    nonce_data_availability_mode: Default::default(),
-                    fee_data_availability_mode: Default::default(),
-                    compiled_class_hash: Default::default(),
-                    contract_class: crate::types::class::sierra::SierraContractClass {
-                        sierra_program: Default::default(),
-                        contract_class_version: Default::default(),
-                        entry_points_by_type: crate::types::class::sierra::SierraEntryPoints {
-                            constructor: Default::default(),
-                            external: Default::default(),
-                            l1_handler: Default::default(),
-                        },
-                        abi: Default::default(),
-                    },
-                    sender_address: Default::default(),
-                },
-            )),
-            token: None,
-        }
-    }
-}
-
 impl crate::dto::DeserializeForVersion for Input {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
         value.deserialize_map(|value| {
@@ -337,10 +219,6 @@ pub async fn add_declare_transaction(
     context: RpcContext,
     input: Input,
 ) -> Result<Output, AddDeclareTransactionError> {
-    if !input.is_v3_transaction() {
-        return Err(AddDeclareTransactionError::UnsupportedTransactionVersion);
-    }
-
     use starknet_gateway_types::request::add_transaction;
 
     match input.declare_transaction {
@@ -498,31 +376,14 @@ mod tests {
     use pathfinder_common::prelude::*;
     use pathfinder_common::transaction::{DataAvailabilityMode, ResourceBound, ResourceBounds};
     use pathfinder_crypto::Felt;
-    use starknet_gateway_test_fixtures::class_definitions::{
-        CAIRO_2_0_0_STACK_OVERFLOW,
-        CONTRACT_DEFINITION,
-    };
-    use starknet_gateway_types::error::{
-        test_response_from,
-        KnownStarknetErrorCode,
-        StarknetError,
-    };
+    use starknet_gateway_test_fixtures::class_definitions::CAIRO_2_0_0_STACK_OVERFLOW;
+    use starknet_gateway_types::error::{test_response_from, KnownStarknetErrorCode};
     use wiremock::{matchers, Mock, MockServer, ResponseTemplate};
 
     use super::*;
-    use crate::types::class::cairo::CairoContractClass;
     use crate::types::class::sierra::SierraContractClass;
     use crate::types::request::{BroadcastedDeclareTransaction, BroadcastedDeclareTransactionV3};
     use crate::types::ContractClass;
-
-    pub static CONTRACT_CLASS: LazyLock<CairoContractClass> = LazyLock::new(|| {
-        ContractClass::from_serialized_def(&SerializedOpaqueClassDefinition::from_slice(
-            CONTRACT_DEFINITION,
-        ))
-        .unwrap()
-        .as_cairo()
-        .unwrap()
-    });
 
     pub static SIERRA_CLASS: LazyLock<SierraContractClass> = LazyLock::new(|| {
         ContractClass::from_serialized_def(&SerializedOpaqueClassDefinition::from_slice(
@@ -579,167 +440,6 @@ mod tests {
     }
 
     mod parsing {
-        mod v1 {
-            use serde_json::json;
-
-            use super::super::*;
-            use crate::dto::{DeserializeForVersion, SerializeForVersion, Serializer};
-            use crate::types::request::BroadcastedDeclareTransactionV1;
-            use crate::RpcVersion;
-
-            fn test_declare_txn() -> Transaction {
-                Transaction::Declare(BroadcastedDeclareTransaction::V1(
-                    BroadcastedDeclareTransactionV1 {
-                        max_fee: fee!("0x1"),
-                        version: TransactionVersion::ONE,
-                        signature: vec![],
-                        nonce: TransactionNonce(Felt::ZERO),
-                        contract_class: CONTRACT_CLASS.clone(),
-                        sender_address: ContractAddress::new_or_panic(Felt::from_u64(1)),
-                    },
-                ))
-            }
-
-            #[test]
-            fn positional_args() {
-                let positional = json!([{
-                    "type": "DECLARE",
-                    "version": "0x1",
-                    "max_fee": "0x1",
-                    "signature": [],
-                    "nonce": "0x0",
-                    "contract_class": CONTRACT_CLASS.clone(),
-                    "sender_address": "0x1"
-                }]);
-                let input = Input::deserialize(crate::dto::Value::new(positional, RpcVersion::V09))
-                    .unwrap();
-                let expected = Input {
-                    declare_transaction: test_declare_txn(),
-                    token: None,
-                };
-                assert_eq!(input, expected);
-            }
-
-            #[test]
-            fn named_args() {
-                let named = json!({
-                    "declare_transaction": {
-                        "type": "DECLARE",
-                        "version": "0x1",
-                        "max_fee": "0x1",
-                        "signature": [],
-                        "nonce": "0x0",
-                        "contract_class": CONTRACT_CLASS.clone(),
-                        "sender_address": "0x1"
-                    },
-                    "token": "token"
-                });
-                let input =
-                    Input::deserialize(crate::dto::Value::new(named, RpcVersion::V09)).unwrap();
-                let expected = Input {
-                    declare_transaction: test_declare_txn(),
-                    token: Some("token".to_owned()),
-                };
-                assert_eq!(input, expected);
-            }
-
-            #[test]
-            fn unexpected_error_message() {
-                use starknet_gateway_types::error::{KnownStarknetErrorCode, StarknetErrorCode};
-                let starknet_error = SequencerError::StarknetError(StarknetError {
-                    code: StarknetErrorCode::Known(
-                        KnownStarknetErrorCode::TransactionLimitExceeded,
-                    ),
-                    message: "StarkNet Alpha throughput limit reached, please wait a few minutes \
-                              and try again."
-                        .to_string(),
-                });
-
-                let error = AddDeclareTransactionError::from(starknet_error);
-                let error = crate::error::ApplicationError::from(error);
-                let error = crate::jsonrpc::RpcError::from(error);
-                let error = error.serialize(Serializer::new(RpcVersion::V09)).unwrap();
-
-                let expected = json!({
-                    "code": 63,
-                    "message": "An unexpected error occurred",
-                    "data": "StarkNet Alpha throughput limit reached, please wait a few minutes and try again."
-                });
-
-                assert_eq!(error, expected);
-            }
-        }
-
-        mod v2 {
-            use serde_json::json;
-
-            use super::super::*;
-            use crate::dto::DeserializeForVersion;
-            use crate::types::request::BroadcastedDeclareTransactionV2;
-            use crate::RpcVersion;
-
-            fn test_declare_txn() -> Transaction {
-                Transaction::Declare(BroadcastedDeclareTransaction::V2(
-                    BroadcastedDeclareTransactionV2 {
-                        max_fee: fee!("0x1"),
-                        version: TransactionVersion::TWO,
-                        signature: vec![],
-                        nonce: TransactionNonce(Felt::ZERO),
-                        contract_class: SIERRA_CLASS.clone(),
-                        sender_address: ContractAddress::new_or_panic(Felt::from_u64(1)),
-                        compiled_class_hash: CasmHash(Felt::from_u64(1)),
-                    },
-                ))
-            }
-
-            #[test]
-            fn positional_args() {
-                let positional = json!([{
-                    "type": "DECLARE",
-                    "version": "0x2",
-                    "max_fee": "0x1",
-                    "signature": [],
-                    "nonce": "0x0",
-                    "contract_class": SIERRA_CLASS.clone(),
-                    "sender_address": "0x1",
-                    "compiled_class_hash": "0x1"
-                }]);
-
-                let input = Input::deserialize(crate::dto::Value::new(positional, RpcVersion::V09))
-                    .unwrap();
-                let expected = Input {
-                    declare_transaction: test_declare_txn(),
-                    token: None,
-                };
-                pretty_assertions_sorted::assert_eq!(input, expected);
-            }
-
-            #[test]
-            fn named_args() {
-                let named = json!({
-                    "declare_transaction": {
-                        "type": "DECLARE",
-                        "version": "0x2",
-                        "max_fee": "0x1",
-                        "signature": [],
-                        "nonce": "0x0",
-                        "contract_class": SIERRA_CLASS.clone(),
-                        "sender_address": "0x1",
-                        "compiled_class_hash": "0x1"
-                    },
-                    "token": "token"
-                });
-
-                let input =
-                    Input::deserialize(crate::dto::Value::new(named, RpcVersion::V09)).unwrap();
-                let expected = Input {
-                    declare_transaction: test_declare_txn(),
-                    token: Some("token".to_owned()),
-                };
-                pretty_assertions_sorted::assert_eq!(input, expected);
-            }
-        }
-
         mod v3 {
             use pathfinder_common::transaction::{
                 DataAvailabilityMode,
@@ -845,24 +545,6 @@ mod tests {
                 pretty_assertions_sorted::assert_eq!(input, expected);
             }
         }
-    }
-
-    #[rstest::rstest]
-    #[case::v0_is_unsupported(Input::for_test_with_v0_transaction(), false)]
-    #[case::v1_is_unsupported(Input::for_test_with_v1_transaction(), false)]
-    #[case::v2_is_unsupported(Input::for_test_with_v2_transaction(), false)]
-    #[case::v3_is_supported(Input::for_test_with_v3_transaction(), true)]
-    #[tokio::test]
-    async fn only_v3_transactions_are_accepted(#[case] input: Input, #[case] is_supported: bool) {
-        let context = RpcContext::for_tests();
-        let result = add_declare_transaction(context, input).await;
-        assert_eq!(
-            !is_supported,
-            matches!(
-                result,
-                Err(AddDeclareTransactionError::UnsupportedTransactionVersion)
-            )
-        );
     }
 
     #[rstest::rstest]

--- a/crates/rpc/src/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/method/add_deploy_account_transaction.rs
@@ -36,55 +36,6 @@ pub struct Input {
     deploy_account_transaction: Transaction,
 }
 
-impl Input {
-    pub fn is_v3_transaction(&self) -> bool {
-        matches!(
-            self.deploy_account_transaction,
-            Transaction::DeployAccount(BroadcastedDeployAccountTransaction::V3(_))
-        )
-    }
-}
-#[cfg(test)]
-impl Input {
-    pub(crate) fn for_test_with_v1_transaction() -> Self {
-        Self {
-            deploy_account_transaction: Transaction::DeployAccount(
-                BroadcastedDeployAccountTransaction::V1(BroadcastedDeployAccountTransactionV1 {
-                    version: pathfinder_common::TransactionVersion::ONE,
-                    max_fee: Default::default(),
-                    signature: Default::default(),
-                    nonce: Default::default(),
-                    class_hash: Default::default(),
-                    contract_address_salt: Default::default(),
-                    constructor_calldata: Default::default(),
-                }),
-            ),
-        }
-    }
-
-    pub(crate) fn for_test_with_v3_transaction() -> Self {
-        Self {
-            deploy_account_transaction: Transaction::DeployAccount(
-                BroadcastedDeployAccountTransaction::V3(
-                    crate::types::request::BroadcastedDeployAccountTransactionV3 {
-                        version: pathfinder_common::TransactionVersion::THREE,
-                        signature: Default::default(),
-                        nonce: Default::default(),
-                        resource_bounds: Default::default(),
-                        tip: Default::default(),
-                        paymaster_data: Default::default(),
-                        nonce_data_availability_mode: Default::default(),
-                        fee_data_availability_mode: Default::default(),
-                        contract_address_salt: Default::default(),
-                        constructor_calldata: Default::default(),
-                        class_hash: Default::default(),
-                    },
-                ),
-            ),
-        }
-    }
-}
-
 impl crate::dto::DeserializeForVersion for Input {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
         value.deserialize_map(|value| {
@@ -213,10 +164,6 @@ pub async fn add_deploy_account_transaction(
     context: RpcContext,
     input: Input,
 ) -> Result<Output, AddDeployAccountTransactionError> {
-    if !input.is_v3_transaction() {
-        return Err(AddDeployAccountTransactionError::UnsupportedTransactionVersion);
-    }
-
     let contract_address = match &input.deploy_account_transaction {
         Transaction::DeployAccount(tx) => tx.deployed_contract_address(),
     };
@@ -372,44 +319,6 @@ mod tests {
     use crate::dto::{SerializeForVersion, Serializer};
     use crate::types::request::BroadcastedDeployAccountTransactionV3;
 
-    const INPUT_JSON: &str = r#"{
-        "max_fee": "0xbf391377813",
-        "version": "0x1",
-        "constructor_calldata": [
-            "0677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1"
-        ],
-        "signature": [
-            "07dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5",
-            "071456dded17015d1234779889d78f3e7c763ddcfd2662b19e7843c7542614f8"
-        ],
-        "nonce": "0x0",
-        "class_hash": "01fac3074c9d5282f0acc5c69a4781a1c711efea5e73c550c5d9fb253cf7fd3d",
-        "contract_address_salt": "06d44a6aecb4339e23a9619355f101cf3cb9baec289fcd9fd51486655c1bb8a8",
-        "type": "DEPLOY_ACCOUNT"
-    }"#;
-
-    #[tokio::test]
-    async fn test_parse_input_named() {
-        let json: serde_json::Value =
-            serde_json::from_str(&format!("{{\"deploy_account_transaction\":{INPUT_JSON}}}"))
-                .unwrap();
-        let input: Input = crate::dto::Value::new(json, crate::RpcVersion::V09)
-            .deserialize()
-            .unwrap();
-
-        assert_eq!(input, get_input());
-    }
-
-    #[tokio::test]
-    async fn test_parse_input_positional() {
-        let json: serde_json::Value = serde_json::from_str(&format!("[{INPUT_JSON}]")).unwrap();
-        let input: Input = crate::dto::Value::new(json, crate::RpcVersion::V09)
-            .deserialize()
-            .unwrap();
-
-        assert_eq!(input, get_input());
-    }
-
     const INPUT_JSON_V3: &str = r#"{
         "type": "DEPLOY_ACCOUNT",
         "version": "0x3",
@@ -502,22 +411,6 @@ mod tests {
         }
     }
 
-    #[rstest::rstest]
-    #[case::v1_is_unsupported(Input::for_test_with_v1_transaction(), false)]
-    #[case::v3_is_supported(Input::for_test_with_v3_transaction(), true)]
-    #[tokio::test]
-    async fn only_v3_transactions_are_accepted(#[case] input: Input, #[case] is_supported: bool) {
-        let context = RpcContext::for_tests();
-        let result = add_deploy_account_transaction(context, input).await;
-        assert_eq!(
-            !is_supported,
-            matches!(
-                result,
-                Err(AddDeployAccountTransactionError::UnsupportedTransactionVersion)
-            )
-        );
-    }
-
     #[test]
     fn unexpected_error_message() {
         use starknet_gateway_types::error::{StarknetError, StarknetErrorCode};
@@ -542,36 +435,6 @@ mod tests {
         });
 
         assert_eq!(error, expected);
-    }
-
-    fn get_input() -> Input {
-        Input {
-            deploy_account_transaction: Transaction::DeployAccount(
-                BroadcastedDeployAccountTransaction::V1(BroadcastedDeployAccountTransactionV1 {
-                    version: TransactionVersion::ONE,
-                    max_fee: fee!("0xbf391377813"),
-                    signature: vec![
-                        transaction_signature_elem!(
-                            "0x07dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5"
-                        ),
-                        transaction_signature_elem!(
-                            "0x071456dded17015d1234779889d78f3e7c763ddcfd2662b19e7843c7542614f8"
-                        ),
-                    ],
-                    nonce: TransactionNonce::ZERO,
-
-                    contract_address_salt: contract_address_salt!(
-                        "0x06d44a6aecb4339e23a9619355f101cf3cb9baec289fcd9fd51486655c1bb8a8"
-                    ),
-                    constructor_calldata: vec![call_param!(
-                        "0x0677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1"
-                    )],
-                    class_hash: class_hash!(
-                        "0x01fac3074c9d5282f0acc5c69a4781a1c711efea5e73c550c5d9fb253cf7fd3d"
-                    ),
-                }),
-            ),
-        }
     }
 
     fn v3_input() -> Input {

--- a/crates/rpc/src/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/method/add_invoke_transaction.rs
@@ -34,70 +34,6 @@ pub struct Input {
     invoke_transaction: Transaction,
 }
 
-impl Input {
-    pub fn is_v3_transaction(&self) -> bool {
-        matches!(
-            self.invoke_transaction,
-            Transaction::Invoke(BroadcastedInvokeTransaction::V3(_))
-        )
-    }
-}
-
-#[cfg(test)]
-impl Input {
-    pub(crate) fn for_test_with_v0_transaction() -> Self {
-        Self {
-            invoke_transaction: Transaction::Invoke(BroadcastedInvokeTransaction::V0(
-                crate::types::request::BroadcastedInvokeTransactionV0 {
-                    version: pathfinder_common::TransactionVersion::ZERO,
-                    max_fee: Default::default(),
-                    signature: Default::default(),
-                    contract_address: Default::default(),
-                    entry_point_selector: Default::default(),
-                    calldata: Default::default(),
-                },
-            )),
-        }
-    }
-
-    pub(crate) fn for_test_with_v1_transaction() -> Self {
-        Self {
-            invoke_transaction: Transaction::Invoke(BroadcastedInvokeTransaction::V1(
-                crate::types::request::BroadcastedInvokeTransactionV1 {
-                    version: pathfinder_common::TransactionVersion::ONE,
-                    max_fee: Default::default(),
-                    signature: Default::default(),
-                    nonce: Default::default(),
-                    sender_address: Default::default(),
-                    calldata: Default::default(),
-                },
-            )),
-        }
-    }
-
-    pub(crate) fn for_test_with_v3_transaction() -> Self {
-        Self {
-            invoke_transaction: Transaction::Invoke(BroadcastedInvokeTransaction::V3(
-                crate::types::request::BroadcastedInvokeTransactionV3 {
-                    version: pathfinder_common::TransactionVersion::THREE,
-                    signature: Default::default(),
-                    nonce: Default::default(),
-                    resource_bounds: Default::default(),
-                    tip: Default::default(),
-                    paymaster_data: Default::default(),
-                    account_deployment_data: Default::default(),
-                    nonce_data_availability_mode: Default::default(),
-                    fee_data_availability_mode: Default::default(),
-                    sender_address: Default::default(),
-                    calldata: Default::default(),
-                    proof_facts: Default::default(),
-                    proof: Default::default(),
-                },
-            )),
-        }
-    }
-}
-
 impl crate::dto::DeserializeForVersion for Input {
     fn deserialize(value: crate::dto::Value) -> Result<Self, serde_json::Error> {
         value.deserialize_map(|value| {
@@ -233,10 +169,6 @@ pub async fn add_invoke_transaction(
     context: RpcContext,
     input: Input,
 ) -> Result<Output, AddInvokeTransactionError> {
-    if !input.is_v3_transaction() {
-        return Err(AddInvokeTransactionError::UnsupportedTransactionVersion);
-    }
-
     let Transaction::Invoke(tx) = input.invoke_transaction;
     let (transaction_hash, variant) = add_invoke_transaction_impl(&context, tx).await?;
     context.submission_tracker.insert(
@@ -369,7 +301,6 @@ mod tests {
     use wiremock::{matchers, Mock, MockServer, ResponseTemplate};
 
     use super::*;
-    use crate::types::request::BroadcastedInvokeTransactionV1;
 
     fn v3_input() -> Input {
         Input {
@@ -406,198 +337,6 @@ mod tests {
     }
 
     mod parsing {
-        mod v0 {
-            use serde_json::json;
-
-            use super::super::*;
-            use crate::dto::DeserializeForVersion;
-
-            fn test_txn() -> Transaction {
-                Transaction::Invoke(BroadcastedInvokeTransaction::V0(
-                    crate::types::request::BroadcastedInvokeTransactionV0 {
-                        version: TransactionVersion::ZERO,
-                        max_fee: fee!("0x4f388496839"),
-                        signature: vec![
-                            transaction_signature_elem!(
-                                "0x07dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5"
-                            ),
-                            transaction_signature_elem!(
-                                "0x071456dded17015d1234779889d78f3e7c763ddcfd2662b19e7843c7542614f8"
-                            ),
-                        ],
-                        contract_address: contract_address!(
-                            "0x023371b227eaecd8e8920cd429357edddd2cd0f3fee6abaacca08d3ab82a7cdd"
-                        ),
-                        entry_point_selector: entry_point!(
-                            "0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
-                        ),
-                        calldata: vec![call_param!("0x1"), call_param!("0x2b")],
-                    },
-                ))
-            }
-
-            fn test_txn_json() -> serde_json::Value {
-                json!({
-                    "type": "INVOKE",
-                    "version": "0x0",
-                    "max_fee": "0x4f388496839",
-                    "signature": [
-                        "0x07dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5",
-                        "0x071456dded17015d1234779889d78f3e7c763ddcfd2662b19e7843c7542614f8"
-                    ],
-                    "contract_address": "0x023371b227eaecd8e8920cd429357edddd2cd0f3fee6abaacca08d3ab82a7cdd",
-                    "entry_point_selector": "0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
-                    "calldata": ["0x1", "0x2b"]
-                })
-            }
-
-            #[test]
-            fn positional_args() {
-                let positional = json!([test_txn_json()]);
-                let input =
-                    Input::deserialize(crate::dto::Value::new(positional, crate::RpcVersion::V09))
-                        .unwrap();
-                let expected = Input {
-                    invoke_transaction: test_txn(),
-                };
-                pretty_assertions_sorted::assert_eq!(input, expected);
-            }
-
-            #[test]
-            fn named_args() {
-                let named = json!({ "invoke_transaction": test_txn_json() });
-                let input =
-                    Input::deserialize(crate::dto::Value::new(named, crate::RpcVersion::V09))
-                        .unwrap();
-                let expected = Input {
-                    invoke_transaction: test_txn(),
-                };
-                pretty_assertions_sorted::assert_eq!(input, expected);
-            }
-        }
-
-        mod v1 {
-            use serde_json::json;
-
-            use super::super::*;
-            use crate::dto::{DeserializeForVersion, SerializeForVersion, Serializer};
-
-            fn test_txn() -> Transaction {
-                Transaction::Invoke(BroadcastedInvokeTransaction::V1(
-                    BroadcastedInvokeTransactionV1 {
-                        version: TransactionVersion::ONE,
-                        max_fee: fee!("0x4F388496839"),
-                        signature: vec![
-                            transaction_signature_elem!(
-                                "0x07dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5"
-                            ),
-                            transaction_signature_elem!(
-                                "0x071456dded17015d1234779889d78f3e7c763ddcfd2662b19e7843c7542614f8"
-                            ),
-                        ],
-                        nonce: transaction_nonce!("0x1"),
-                        sender_address: contract_address!(
-                            "0x023371b227eaecd8e8920cd429357edddd2cd0f3fee6abaacca08d3ab82a7cdd"
-                        ),
-                        calldata: vec![
-                            call_param!("0x1"),
-                            call_param!(
-                                "0x0677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1"
-                            ),
-                            call_param!(
-                                "0x0362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320"
-                            ),
-                            call_param!("0x0"),
-                            call_param!("0x1"),
-                            call_param!("0x1"),
-                            call_param!("0x2b"),
-                            call_param!("0x0"),
-                        ],
-                    },
-                ))
-            }
-
-            fn test_txn_json() -> serde_json::Value {
-                json!({
-                    "type": "INVOKE",
-                    "version": "0x1",
-                    "max_fee": "0x4f388496839",
-                    "signature": [
-                        "0x07dd3a55d94a0de6f3d6c104d7e6c88ec719a82f4e2bbc12587c8c187584d3d5",
-                        "0x071456dded17015d1234779889d78f3e7c763ddcfd2662b19e7843c7542614f8"
-                    ],
-                    "nonce": "0x1",
-                    "sender_address": "0x023371b227eaecd8e8920cd429357edddd2cd0f3fee6abaacca08d3ab82a7cdd",
-                    "calldata": [
-                        "0x1",
-                        "0x0677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1",
-                        "0x0362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320",
-                        "0x0",
-                        "0x1",
-                        "0x1",
-                        "0x2b",
-                        "0x0"
-                    ]
-                })
-            }
-
-            #[test]
-            fn positional_args() {
-                let positional = json!([test_txn_json()]);
-                let input =
-                    Input::deserialize(crate::dto::Value::new(positional, crate::RpcVersion::V09))
-                        .unwrap();
-                let expected = Input {
-                    invoke_transaction: test_txn(),
-                };
-                pretty_assertions_sorted::assert_eq!(input, expected);
-            }
-
-            #[test]
-            fn named_args() {
-                let named = json!({ "invoke_transaction": test_txn_json() });
-                let input =
-                    Input::deserialize(crate::dto::Value::new(named, crate::RpcVersion::V09))
-                        .unwrap();
-                let expected = Input {
-                    invoke_transaction: test_txn(),
-                };
-                assert_eq!(input, expected);
-            }
-
-            #[test]
-            fn unexpected_error_message() {
-                use starknet_gateway_types::error::{
-                    KnownStarknetErrorCode,
-                    StarknetError,
-                    StarknetErrorCode,
-                };
-                let starknet_error = SequencerError::StarknetError(StarknetError {
-                    code: StarknetErrorCode::Known(
-                        KnownStarknetErrorCode::TransactionLimitExceeded,
-                    ),
-                    message: "StarkNet Alpha throughput limit reached, please wait a few minutes \
-                              and try again."
-                        .to_string(),
-                });
-
-                let error = AddInvokeTransactionError::from(starknet_error);
-                let error = crate::error::ApplicationError::from(error);
-                let error = crate::jsonrpc::RpcError::from(error);
-                let error = error
-                    .serialize(Serializer::new(crate::RpcVersion::V09))
-                    .unwrap();
-
-                let expected = json!({
-                    "code": 63,
-                    "message": "An unexpected error occurred",
-                    "data": "StarkNet Alpha throughput limit reached, please wait a few minutes and try again."
-                });
-
-                assert_eq!(error, expected);
-            }
-        }
-
         mod v3 {
             use serde_json::json;
 
@@ -693,23 +432,6 @@ mod tests {
                 pretty_assertions_sorted::assert_eq!(input, expected);
             }
         }
-    }
-
-    #[rstest::rstest]
-    #[case::v0_is_unsupported(Input::for_test_with_v0_transaction(), false)]
-    #[case::v1_is_unsupported(Input::for_test_with_v1_transaction(), false)]
-    #[case::v3_is_supported(Input::for_test_with_v3_transaction(), true)]
-    #[tokio::test]
-    async fn only_v3_transactions_are_accepted(#[case] input: Input, #[case] is_supported: bool) {
-        let context = RpcContext::for_tests();
-        let result = add_invoke_transaction(context, input).await;
-        assert_eq!(
-            !is_supported,
-            matches!(
-                result,
-                Err(AddInvokeTransactionError::UnsupportedTransactionVersion)
-            )
-        );
     }
 
     #[rstest::rstest]

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -300,12 +300,7 @@ pub(crate) mod tests {
     use pathfinder_common::prelude::*;
     use pathfinder_common::transaction::{DataAvailabilityMode, ResourceBound, ResourceBounds};
     use pathfinder_crypto::Felt;
-    use pathfinder_executor::types::{
-        DeclareTransactionExecutionInfo,
-        DeployAccountTransactionExecutionInfo,
-        FeeEstimate,
-        PriceUnit,
-    };
+    use pathfinder_executor::types::{DeclareTransactionExecutionInfo, FeeEstimate, PriceUnit};
     use pathfinder_storage::Storage;
     use starknet_gateway_test_fixtures::class_definitions::ERC20_CONTRACT_DEFINITION_CLASS_HASH;
 
@@ -321,7 +316,6 @@ pub(crate) mod tests {
         BroadcastedDeclareTransaction,
         BroadcastedDeclareTransactionV1,
         BroadcastedDeployAccountTransaction,
-        BroadcastedDeployAccountTransactionV1,
         BroadcastedDeployAccountTransactionV3,
         BroadcastedTransaction,
     };
@@ -373,14 +367,22 @@ pub(crate) mod tests {
             "block_id": {"block_number": 1},
             "transactions": [
                 {
+                    "type": "DEPLOY_ACCOUNT",
+                    "version": TransactionVersion::THREE_WITH_QUERY_VERSION,
                     "contract_address_salt": "0x46c0d4abf0192a788aca261e58d7031576f7d8ea5229f452b0f23e691dd5971",
-                    "max_fee": "0x0",
                     "signature": [],
                     "class_hash": crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH,
                     "nonce": "0x0",
-                    "version": TransactionVersion::ONE_WITH_QUERY_VERSION,
                     "constructor_calldata": ["0x1"],
-                    "type": "DEPLOY_ACCOUNT"
+                    "resource_bounds": {
+                        "l1_gas": {"max_amount": "0x0", "max_price_per_unit": "0x0"},
+                        "l2_gas": {"max_amount": "0x0", "max_price_per_unit": "0x0"},
+                        "l1_data_gas": {"max_amount": "0x0", "max_price_per_unit": "0x0"}
+                    },
+                    "tip": "0x0",
+                    "paymaster_data": [],
+                    "nonce_data_availability_mode": "L1",
+                    "fee_data_availability_mode": "L1"
                 }
             ],
             "simulation_flags": simulation_flags,
@@ -391,16 +393,33 @@ pub(crate) mod tests {
         let expected_input = SimulateTransactionInput {
             block_id: BlockId::Number(BlockNumber::new_or_panic(1)),
             transactions: vec![BroadcastedTransaction::DeployAccount(
-                BroadcastedDeployAccountTransaction::V1(BroadcastedDeployAccountTransactionV1 {
+                BroadcastedDeployAccountTransaction::V3(BroadcastedDeployAccountTransactionV3 {
+                    version: TransactionVersion::THREE_WITH_QUERY_VERSION,
+                    signature: vec![],
+                    nonce: transaction_nonce!("0x0"),
+                    resource_bounds: ResourceBounds {
+                        l1_gas: ResourceBound {
+                            max_amount: ResourceAmount(0),
+                            max_price_per_unit: ResourcePricePerUnit(0),
+                        },
+                        l2_gas: ResourceBound {
+                            max_amount: ResourceAmount(0),
+                            max_price_per_unit: ResourcePricePerUnit(0),
+                        },
+                        l1_data_gas: Some(ResourceBound {
+                            max_amount: ResourceAmount(0),
+                            max_price_per_unit: ResourcePricePerUnit(0),
+                        }),
+                    },
+                    tip: Tip(0),
+                    paymaster_data: vec![],
+                    nonce_data_availability_mode: DataAvailabilityMode::L1,
+                    fee_data_availability_mode: DataAvailabilityMode::L1,
                     contract_address_salt: contract_address_salt!(
                         "0x46c0d4abf0192a788aca261e58d7031576f7d8ea5229f452b0f23e691dd5971"
                     ),
-                    class_hash: crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH,
                     constructor_calldata: vec![call_param!("0x1")],
-                    version: TransactionVersion::ONE_WITH_QUERY_VERSION,
-                    max_fee: fee!("0x0"),
-                    signature: vec![],
-                    nonce: transaction_nonce!("0x0"),
+                    class_hash: crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH,
                 }),
             )],
             simulation_flags: crate::dto::SimulationFlags(if rpc_version >= RpcVersion::V10 {
@@ -443,180 +462,6 @@ pub(crate) mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_simulate_transaction_with_skip_fee_charge() {
-        let (context, _, _, _) = crate::test_setup::test_context().await;
-
-        let input_json = serde_json::json!({
-            "block_id": {"block_number": 1},
-            "transactions": [
-                {
-                    "contract_address_salt": "0x46c0d4abf0192a788aca261e58d7031576f7d8ea5229f452b0f23e691dd5971",
-                    "max_fee": "0x0",
-                    "signature": [],
-                    "class_hash": crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH,
-                    "nonce": "0x0",
-                    "version": TransactionVersion::ONE_WITH_QUERY_VERSION,
-                    "constructor_calldata": ["0x1"],
-                    "type": "DEPLOY_ACCOUNT"
-                }
-            ],
-            "simulation_flags": ["SKIP_FEE_CHARGE"]
-        });
-
-        let value = crate::dto::Value::new(input_json, RpcVersion::V09);
-        let input = SimulateTransactionInput::deserialize(value).unwrap();
-
-        const DEPLOYED_CONTRACT_ADDRESS: ContractAddress =
-            contract_address!("0xf3805e4f045a8b48e7e9e6cd5d910973a22360572207f3ae625c5cec2a3232");
-
-        let expected = crate::method::simulate_transactions::Output {
-    simulations: vec![
-            pathfinder_executor::types::TransactionSimulation{
-                fee_estimation: pathfinder_executor::types::FeeEstimate {
-                    l1_gas_consumed: 0x15.into(),
-                    l1_gas_price: 1.into(),
-                    l1_data_gas_consumed: 0x160.into(),
-                    l1_data_gas_price: 2.into(),
-                    l2_gas_consumed: 0.into(),
-                    l2_gas_price: 1.into(),
-                    overall_fee: 0x2d5.into(),
-                    unit: pathfinder_executor::types::PriceUnit::Wei,
-                },
-                trace: pathfinder_executor::types::TransactionTrace::DeployAccount(
-                    pathfinder_executor::types::DeployAccountTransactionTrace {
-                        execution_info: DeployAccountTransactionExecutionInfo {
-                        constructor_invocation: Some(pathfinder_executor::types::FunctionInvocation {
-                                call_type: Some(pathfinder_executor::types::CallType::Call),
-                                caller_address: felt!("0x0"),
-                                class_hash: Some(crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH.0),
-                                entry_point_type: Some(pathfinder_executor::types::EntryPointType::Constructor),
-                                events: vec![pathfinder_executor::types::Event {
-                                    order: 0,
-                                    data: vec![],
-                                    keys: vec![
-                                        felt!("0x38f6a5b87c23cee6e7294bcc3302e95019f70f81586ff3cac38581f5ca96381"),
-                                        felt!("0x1"),
-                                    ],
-                                }],
-                                calldata: vec![felt!("0x1")],
-                                contract_address: DEPLOYED_CONTRACT_ADDRESS,
-                                selector: Some(entry_point!("0x028FFE4FF0F226A9107253E17A904099AA4F63A02A5621DE0576E5AA71BC5194").0),
-                                messages: vec![],
-                                result: vec![],
-                                execution_resources: pathfinder_executor::types::InnerCallExecutionResources { l1_gas: 2, l2_gas: 0 },
-                                internal_calls: vec![],
-                                computation_resources: pathfinder_executor::types::ComputationResources {
-                                    pedersen_builtin_applications: 2,
-                                    range_check_builtin_applications: 8,
-                                    steps: 312,
-                                    ..Default::default()
-                                },
-                                is_reverted: false,
-                            }),
-                        validate_invocation: Some(
-                            pathfinder_executor::types::FunctionInvocation {
-                                call_type: Some(pathfinder_executor::types::CallType::Call),
-                                caller_address: felt!("0x0"),
-                                class_hash: Some(crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH.0),
-                                entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
-                                events: vec![],
-                                calldata: vec![
-                                    crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH.0,
-                                    call_param!("0x046C0D4ABF0192A788ACA261E58D7031576F7D8EA5229F452B0F23E691DD5971").0,
-                                    call_param!("0x1").0,
-                                ],
-                                contract_address: DEPLOYED_CONTRACT_ADDRESS,
-                                selector: Some(entry_point!("0x036FCBF06CD96843058359E1A75928BEACFAC10727DAB22A3972F0AF8AA92895").0),
-                                messages: vec![],
-                                result: vec![
-                                    felt!("0x56414c4944")
-                                ],
-                                execution_resources: pathfinder_executor::types::InnerCallExecutionResources {
-                                    l1_gas: 1,
-                                    l2_gas: 0,
-                                },
-                                internal_calls: vec![],
-                                computation_resources: pathfinder_executor::types::ComputationResources{
-                                    memory_holes: 1,
-                                    range_check_builtin_applications: 2,
-                                    steps: 135,
-                                    ..Default::default()
-                                },
-                                is_reverted: false,
-                            },
-                        ),
-                        fee_transfer_invocation: None,
-                        execution_resources: pathfinder_executor::types::ExecutionResources {
-                            computation_resources: pathfinder_executor::types::ComputationResources{
-                                memory_holes: 1,
-                                pedersen_builtin_applications: 2,
-                                range_check_builtin_applications: 10,
-                                steps:447,
-                                ..Default::default()
-                            },
-                            data_availability: pathfinder_executor::types::DataAvailabilityResources{
-                                l1_gas:0,
-                                l1_data_gas:352
-                            },
-                            l1_gas: 21,
-                            l1_data_gas: 352,
-                            l2_gas: 0,
-                        },},
-                        state_diff: pathfinder_executor::types::StateDiff {
-                            storage_diffs: BTreeMap::from([
-                                (
-                                    DEPLOYED_CONTRACT_ADDRESS,
-                                    vec![
-                                        pathfinder_executor::types::StorageDiff {
-                                            key: storage_address!("0x81ba5d1f84a6a8f0e7ae24720a20f43f81d9ee6eed98fd524ba8d53a49416b"),
-                                            value: storage_value!("0x1"),
-                                        },
-                                        pathfinder_executor::types::StorageDiff {
-                                            key: storage_address!("0x1379ac0624b939ceb9dede92211d7db5ee174fe28be72245b0a1a2abd81c98f"),
-                                            value: storage_value!("0x1"),
-                                        },
-                                        pathfinder_executor::types::StorageDiff {
-                                            key: storage_address!("0x7e79bbb6be5d418acd50c88b675e697f6f7094e203c9d7e29c6ad6731f931dd"),
-                                            value: storage_value!("0x1"),
-                                        },
-                                    ]
-                                )
-                            ]),
-                            deprecated_declared_classes: HashSet::new(),
-                            declared_classes: vec![],
-                            deployed_contracts: vec![
-                                pathfinder_executor::types::DeployedContract {
-                                    address: DEPLOYED_CONTRACT_ADDRESS,
-                                    class_hash: crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH
-                                }
-                            ],
-                            replaced_classes: vec![],
-                            migrated_compiled_classes: vec![],
-                            nonces: BTreeMap::from([(
-                                DEPLOYED_CONTRACT_ADDRESS,
-                                contract_nonce!("0x1"),
-                            )]),
-                        },
-                    }),
-            },
-                ],
-                initial_reads: None,
-        }.serialize(Serializer {
-            version: RpcVersion::V09,
-        }).unwrap();
-
-        let result = simulate_transactions(context, input, RpcVersion::V09)
-            .await
-            .expect("result");
-        let result = result
-            .serialize(Serializer {
-                version: RpcVersion::V09,
-            })
-            .unwrap();
-        pretty_assertions_sorted::assert_eq!(result, expected);
-    }
-
     #[rstest::rstest]
     #[case::v09(RpcVersion::V09)]
     #[case::v10(RpcVersion::V10)]
@@ -651,14 +496,22 @@ pub(crate) mod tests {
             "block_id": {"block_number": 1},
             "transactions": [
                 {
+                    "type": "DEPLOY_ACCOUNT",
+                    "version": TransactionVersion::THREE_WITH_QUERY_VERSION,
                     "contract_address_salt": "0x46c0d4abf0192a788aca261e58d7031576f7d8ea5229f452b0f23e691dd5971",
-                    "max_fee": "0x0",
                     "signature": [],
                     "class_hash": crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH,
                     "nonce": "0x0",
-                    "version": TransactionVersion::ONE_WITH_QUERY_VERSION,
                     "constructor_calldata": ["0x1"],
-                    "type": "DEPLOY_ACCOUNT"
+                    "resource_bounds": {
+                        "l1_gas": {"max_amount": "0x0", "max_price_per_unit": "0x0"},
+                        "l2_gas": {"max_amount": "0x0", "max_price_per_unit": "0x0"},
+                        "l1_data_gas": {"max_amount": "0x0", "max_price_per_unit": "0x0"}
+                    },
+                    "tip": "0x0",
+                    "paymaster_data": [],
+                    "nonce_data_availability_mode": "L1",
+                    "fee_data_availability_mode": "L1"
                 }
             ],
             "simulation_flags": ["SKIP_FEE_CHARGE"],

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -335,57 +335,33 @@ pub mod request {
     impl BroadcastedDeclareTransaction {
         pub fn deserialize(value: &mut crate::dto::Map) -> Result<Self, serde_json::Error> {
             let version = value.deserialize("version").map(TransactionVersion)?;
+            if version.without_query_version() != 3 {
+                return Err(serde_json::Error::custom("unknown transaction version"));
+            }
+
             let signature = value.deserialize_array("signature", |value| {
                 value.deserialize().map(TransactionSignatureElem)
             })?;
             let sender_address = value.deserialize("sender_address").map(ContractAddress)?;
-            match version.without_query_version() {
-                0 => Ok(Self::V0(BroadcastedDeclareTransactionV0 {
-                    max_fee: value.deserialize("max_fee").map(Fee)?,
-                    version,
-                    signature,
-                    contract_class: value.deserialize("contract_class")?,
-                    sender_address,
-                })),
-                1 => Ok(Self::V1(BroadcastedDeclareTransactionV1 {
-                    max_fee: value.deserialize("max_fee").map(Fee)?,
-                    version,
-                    signature,
-                    nonce: value.deserialize("nonce").map(TransactionNonce)?,
-                    contract_class: value.deserialize("contract_class")?,
-                    sender_address,
-                })),
-                2 => Ok(Self::V2(BroadcastedDeclareTransactionV2 {
-                    max_fee: value.deserialize("max_fee").map(Fee)?,
-                    version,
-                    signature,
-                    nonce: value.deserialize("nonce").map(TransactionNonce)?,
-                    compiled_class_hash: value.deserialize("compiled_class_hash").map(CasmHash)?,
-                    contract_class: value.deserialize("contract_class")?,
-                    sender_address,
-                })),
-                3 => Ok(Self::V3(BroadcastedDeclareTransactionV3 {
-                    version,
-                    signature,
-                    nonce: value.deserialize("nonce").map(TransactionNonce)?,
-                    resource_bounds: value.deserialize("resource_bounds")?,
-                    tip: value.deserialize::<U64Hex>("tip").map(|tip| Tip(tip.0))?,
-                    paymaster_data: value.deserialize_array("paymaster_data", |value| {
-                        value.deserialize().map(PaymasterDataElem)
+            Ok(Self::V3(BroadcastedDeclareTransactionV3 {
+                version,
+                signature,
+                nonce: value.deserialize("nonce").map(TransactionNonce)?,
+                resource_bounds: value.deserialize("resource_bounds")?,
+                tip: value.deserialize::<U64Hex>("tip").map(|tip| Tip(tip.0))?,
+                paymaster_data: value.deserialize_array("paymaster_data", |value| {
+                    value.deserialize().map(PaymasterDataElem)
+                })?,
+                account_deployment_data: value
+                    .deserialize_array("account_deployment_data", |value| {
+                        value.deserialize().map(AccountDeploymentDataElem)
                     })?,
-                    account_deployment_data: value
-                        .deserialize_array("account_deployment_data", |value| {
-                            value.deserialize().map(AccountDeploymentDataElem)
-                        })?,
-                    nonce_data_availability_mode: value
-                        .deserialize("nonce_data_availability_mode")?,
-                    fee_data_availability_mode: value.deserialize("fee_data_availability_mode")?,
-                    compiled_class_hash: value.deserialize("compiled_class_hash").map(CasmHash)?,
-                    contract_class: value.deserialize("contract_class")?,
-                    sender_address,
-                })),
-                _ => Err(serde_json::Error::custom("unknown transaction version")),
-            }
+                nonce_data_availability_mode: value.deserialize("nonce_data_availability_mode")?,
+                fee_data_availability_mode: value.deserialize("fee_data_availability_mode")?,
+                compiled_class_hash: value.deserialize("compiled_class_hash").map(CasmHash)?,
+                contract_class: value.deserialize("contract_class")?,
+                sender_address,
+            }))
         }
     }
 
@@ -709,6 +685,10 @@ pub mod request {
     impl BroadcastedDeployAccountTransaction {
         pub fn deserialize(value: &mut crate::dto::Map) -> Result<Self, serde_json::Error> {
             let version = value.deserialize("version").map(TransactionVersion)?;
+            if version.without_query_version() != 3 {
+                return Err(serde_json::Error::custom("unknown transaction version"));
+            }
+
             let signature = value.deserialize_array("signature", |value| {
                 value.deserialize().map(TransactionSignatureElem)
             })?;
@@ -721,34 +701,21 @@ pub mod request {
                     value.deserialize().map(CallParam)
                 })?;
             let class_hash = value.deserialize("class_hash").map(ClassHash)?;
-            match version.without_query_version() {
-                1 => Ok(Self::V1(BroadcastedDeployAccountTransactionV1 {
-                    version,
-                    max_fee: value.deserialize("max_fee").map(Fee)?,
-                    signature,
-                    nonce,
-                    contract_address_salt,
-                    constructor_calldata,
-                    class_hash,
-                })),
-                3 => Ok(Self::V3(BroadcastedDeployAccountTransactionV3 {
-                    version,
-                    signature,
-                    nonce,
-                    resource_bounds: value.deserialize("resource_bounds")?,
-                    tip: value.deserialize::<U64Hex>("tip").map(|tip| Tip(tip.0))?,
-                    paymaster_data: value.deserialize_array("paymaster_data", |value| {
-                        value.deserialize().map(PaymasterDataElem)
-                    })?,
-                    nonce_data_availability_mode: value
-                        .deserialize("nonce_data_availability_mode")?,
-                    fee_data_availability_mode: value.deserialize("fee_data_availability_mode")?,
-                    contract_address_salt,
-                    constructor_calldata,
-                    class_hash,
-                })),
-                _ => Err(serde_json::Error::custom("unknown transaction version")),
-            }
+            Ok(Self::V3(BroadcastedDeployAccountTransactionV3 {
+                version,
+                signature,
+                nonce,
+                resource_bounds: value.deserialize("resource_bounds")?,
+                tip: value.deserialize::<U64Hex>("tip").map(|tip| Tip(tip.0))?,
+                paymaster_data: value.deserialize_array("paymaster_data", |value| {
+                    value.deserialize().map(PaymasterDataElem)
+                })?,
+                nonce_data_availability_mode: value.deserialize("nonce_data_availability_mode")?,
+                fee_data_availability_mode: value.deserialize("fee_data_availability_mode")?,
+                contract_address_salt,
+                constructor_calldata,
+                class_hash,
+            }))
         }
 
         pub fn deployed_contract_address(&self) -> ContractAddress {
@@ -992,59 +959,41 @@ pub mod request {
     impl BroadcastedInvokeTransaction {
         pub fn deserialize(value: &mut crate::dto::Map) -> Result<Self, serde_json::Error> {
             let version = value.deserialize("version").map(TransactionVersion)?;
+            if version.without_query_version() != 3 {
+                return Err(serde_json::Error::custom("unknown transaction version"));
+            }
+
             let signature = value.deserialize_array("signature", |value| {
                 value.deserialize().map(TransactionSignatureElem)
             })?;
             let calldata =
                 value.deserialize_array("calldata", |value| value.deserialize().map(CallParam))?;
-            match version.without_query_version() {
-                0 => Ok(Self::V0(BroadcastedInvokeTransactionV0 {
-                    version,
-                    max_fee: value.deserialize("max_fee").map(Fee)?,
-                    signature,
-                    contract_address: value.deserialize("contract_address").map(ContractAddress)?,
-                    entry_point_selector: value
-                        .deserialize("entry_point_selector")
-                        .map(EntryPoint)?,
-                    calldata,
-                })),
-                1 => Ok(Self::V1(BroadcastedInvokeTransactionV1 {
-                    version,
-                    max_fee: value.deserialize("max_fee").map(Fee)?,
-                    signature,
-                    nonce: value.deserialize("nonce").map(TransactionNonce)?,
-                    sender_address: value.deserialize("sender_address").map(ContractAddress)?,
-                    calldata,
-                })),
-                3 => Ok(Self::V3(BroadcastedInvokeTransactionV3 {
-                    version,
-                    signature,
-                    nonce: value.deserialize("nonce").map(TransactionNonce)?,
-                    resource_bounds: value.deserialize("resource_bounds")?,
-                    tip: value.deserialize::<U64Hex>("tip").map(|tip| Tip(tip.0))?,
-                    paymaster_data: value.deserialize_array("paymaster_data", |value| {
-                        value.deserialize().map(PaymasterDataElem)
+            Ok(Self::V3(BroadcastedInvokeTransactionV3 {
+                version,
+                signature,
+                nonce: value.deserialize("nonce").map(TransactionNonce)?,
+                resource_bounds: value.deserialize("resource_bounds")?,
+                tip: value.deserialize::<U64Hex>("tip").map(|tip| Tip(tip.0))?,
+                paymaster_data: value.deserialize_array("paymaster_data", |value| {
+                    value.deserialize().map(PaymasterDataElem)
+                })?,
+                account_deployment_data: value
+                    .deserialize_array("account_deployment_data", |value| {
+                        value.deserialize().map(AccountDeploymentDataElem)
                     })?,
-                    account_deployment_data: value
-                        .deserialize_array("account_deployment_data", |value| {
-                            value.deserialize().map(AccountDeploymentDataElem)
-                        })?,
-                    nonce_data_availability_mode: value
-                        .deserialize("nonce_data_availability_mode")?,
-                    fee_data_availability_mode: value.deserialize("fee_data_availability_mode")?,
-                    sender_address: value.deserialize("sender_address").map(ContractAddress)?,
-                    calldata,
-                    proof_facts: value
-                        .deserialize_optional_array("proof_facts", |value| {
-                            value.deserialize().map(ProofFactElem)
-                        })?
-                        .unwrap_or_default(),
-                    proof: value
-                        .deserialize_optional_serde::<Proof>("proof")?
-                        .unwrap_or_default(),
-                })),
-                _ => Err(serde_json::Error::custom("unknown transaction version")),
-            }
+                nonce_data_availability_mode: value.deserialize("nonce_data_availability_mode")?,
+                fee_data_availability_mode: value.deserialize("fee_data_availability_mode")?,
+                sender_address: value.deserialize("sender_address").map(ContractAddress)?,
+                calldata,
+                proof_facts: value
+                    .deserialize_optional_array("proof_facts", |value| {
+                        value.deserialize().map(ProofFactElem)
+                    })?
+                    .unwrap_or_default(),
+                proof: value
+                    .deserialize_optional_serde::<Proof>("proof")?
+                    .unwrap_or_default(),
+            }))
         }
 
         pub fn into_v1(self) -> Option<BroadcastedInvokeTransactionV1> {
@@ -1408,8 +1357,6 @@ pub mod request {
 
             use super::super::*;
             use crate::dto::DeserializeForVersion;
-            use crate::types::class::cairo::entry_point::ContractEntryPoints;
-            use crate::types::class::cairo::CairoContractClass;
             use crate::types::class::sierra::{
                 SierraContractClass,
                 SierraEntryPoint,
@@ -1450,55 +1397,7 @@ pub mod request {
 
             #[test]
             fn broadcasted_transaction() {
-                let contract_class = CairoContractClass {
-                    program: "program".to_owned(),
-                    entry_points_by_type: ContractEntryPoints {
-                        constructor: vec![],
-                        external: vec![],
-                        l1_handler: vec![],
-                    },
-                    abi: None,
-                };
                 let txs = vec![
-                    BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V1(
-                        BroadcastedDeclareTransactionV1 {
-                            max_fee: fee!("0x5"),
-                            version: TransactionVersion::ONE,
-                            signature: vec![transaction_signature_elem!("0x7")],
-                            nonce: transaction_nonce!("0x8"),
-                            contract_class,
-                            sender_address: contract_address!("0xa"),
-                        },
-                    )),
-                    BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V2(
-                        BroadcastedDeclareTransactionV2 {
-                            max_fee: fee!("0x51"),
-                            version: TransactionVersion::TWO,
-                            signature: vec![transaction_signature_elem!("0x71")],
-                            nonce: transaction_nonce!("0x81"),
-                            compiled_class_hash: casm_hash!("0x91"),
-                            contract_class: SierraContractClass {
-                                sierra_program: vec![felt!("0x4"), felt!("0x5")],
-                                contract_class_version: "0.1.0".into(),
-                                entry_points_by_type: SierraEntryPoints {
-                                    constructor: vec![SierraEntryPoint {
-                                        function_idx: 1,
-                                        selector: felt!("0x1"),
-                                    }],
-                                    external: vec![SierraEntryPoint {
-                                        function_idx: 2,
-                                        selector: felt!("0x2"),
-                                    }],
-                                    l1_handler: vec![SierraEntryPoint {
-                                        function_idx: 3,
-                                        selector: felt!("0x3"),
-                                    }],
-                                },
-                                abi: r#"[{"type":"function","name":"foo"}]"#.into(),
-                            },
-                            sender_address: contract_address!("0xa1"),
-                        },
-                    )),
                     BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V3(
                         BroadcastedDeclareTransactionV3 {
                             version: TransactionVersion::THREE,
@@ -1550,26 +1449,6 @@ pub mod request {
                                 abi: r#"[{"type":"function","name":"foo"}]"#.into(),
                             },
                             sender_address: contract_address!("0xa1"),
-                        },
-                    )),
-                    BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(
-                        BroadcastedInvokeTransactionV1 {
-                            version: TransactionVersion::ONE,
-                            max_fee: fee!("0x6"),
-                            signature: vec![transaction_signature_elem!("0x7")],
-                            nonce: transaction_nonce!("0x8"),
-                            sender_address: contract_address!("0xaaa"),
-                            calldata: vec![call_param!("0xff")],
-                        },
-                    )),
-                    BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(
-                        BroadcastedInvokeTransactionV1 {
-                            version: TransactionVersion::ONE_WITH_QUERY_VERSION,
-                            max_fee: fee!("0x6"),
-                            signature: vec![transaction_signature_elem!("0x7")],
-                            nonce: transaction_nonce!("0x8"),
-                            sender_address: contract_address!("0xaaa"),
-                            calldata: vec![call_param!("0xff")],
                         },
                     )),
                     BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V3(
@@ -1659,6 +1538,27 @@ pub mod request {
                         .unwrap(),
                     txs
                 );
+            }
+
+            #[rstest::rstest]
+            #[case::declare_v0(json!({"type": "DECLARE", "version": "0x0"}))]
+            #[case::declare_v1(json!({"type": "DECLARE", "version": "0x1"}))]
+            #[case::declare_v2(json!({"type": "DECLARE", "version": "0x2"}))]
+            #[case::declare_v1_query(json!({"type": "DECLARE", "version": "0x100000000000000000000000000000001"}))]
+            #[case::invoke_v0(json!({"type": "INVOKE", "version": "0x0"}))]
+            #[case::invoke_v1(json!({"type": "INVOKE", "version": "0x1"}))]
+            #[case::invoke_v1_query(json!({"type": "INVOKE", "version": "0x100000000000000000000000000000001"}))]
+            #[case::deploy_account_v1(json!({"type": "DEPLOY_ACCOUNT", "version": "0x1"}))]
+            #[case::deploy_account_v1_query(json!({"type": "DEPLOY_ACCOUNT", "version": "0x100000000000000000000000000000001"}))]
+            #[test]
+            fn pre_v3_broadcasted_transaction_deserialization_fails(
+                #[case] input: serde_json::Value,
+            ) {
+                let err = <BroadcastedTransaction as DeserializeForVersion>::deserialize(
+                    crate::dto::Value::new(input, crate::RpcVersion::V10),
+                )
+                .unwrap_err();
+                assert!(err.to_string().contains("unknown transaction version"));
             }
         }
     }


### PR DESCRIPTION
RPC v0.9 & 0.10 do not support broadcasted transactions < v3, and those legacy transaction versions shouldn't even be deserialized.

This PR disallows deserializing versions of broadcasted transactions other than 3 and is sufficient to finish the deprecation of RPC 0.6, 0.7 & 0.8.

The diff is large, but 90% of it is removed fixtures and tests. The rest is pretty easy to read.

I intentionally did not remove broadcasted transaction versions <v3, to keep the PR easy to digest.

We can proceed with removing those legacy transaction versions from the code after the release, and that effort will be transparent to the users. 
