### PR TITLE
feat(rpc): using hyper to set header_read_timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- RPC HTTP connections that don't start a request now time out. The timeout is configurable with `--rpc.header-read-timeout` CLI option.
+
 ## [0.23.0] - 2026-07-20
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9050,6 +9050,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-util",
  "metrics",
  "mime",
  "pathfinder-class-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ hex = "0.4.3"
 http = "1.4.0"
 http-body = "1.0.1"
 hyper = "1.9.0"
+hyper-util = "0.1.20"
 ipnet = "2.12.0"
 libc = "0.2.185"
 libp2p = { version = "0.56.0", default-features = false }

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -510,6 +510,7 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
     let rpc_handle = if config.is_rpc_enabled {
         match rpc_server
             .with_max_connections(config.max_rpc_connections.get())
+            .with_header_timeout(config.rpc_header_read_timeout)
             .spawn(&config.data_directory)
             .await
         {

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -237,6 +237,15 @@ Examples:
     rpc_request_timeout: Duration,
 
     #[arg(
+        long = "rpc.header-read-timeout",
+        long_help = "Maximum time to send RPC request headers, in seconds.",
+        default_value = "30",
+        value_parser = parse_fractional_seconds,
+        env = "PATHFINDER_RPC_HEADER_READ_TIMEOUT"
+    )]
+    rpc_header_read_timeout: Duration,
+
+    #[arg(
         long = "sync.poll-interval",
         long_help = "New block poll interval in seconds (can use fractions)",
         default_value = "1",
@@ -1149,6 +1158,7 @@ pub struct Config {
     pub max_rpc_connections: std::num::NonZeroUsize,
     pub rpc_request_max_size: std::num::NonZeroUsize,
     pub rpc_request_timeout: Duration,
+    pub rpc_header_read_timeout: Duration,
     pub poll_interval: Duration,
     pub l1_poll_interval: Duration,
     pub poll_pre_confirmed_threshold: u64,
@@ -1459,6 +1469,7 @@ impl Config {
             max_rpc_connections: args.max_rpc_connections,
             rpc_request_max_size: args.rpc_request_max_size,
             rpc_request_timeout: args.rpc_request_timeout,
+            rpc_header_read_timeout: args.rpc_header_read_timeout,
             poll_interval: args.poll_interval,
             l1_poll_interval: Duration::from_secs(args.l1_poll_interval.get()),
             poll_pre_confirmed_threshold: args.poll_pre_confirmed_threshold,

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -18,6 +18,7 @@ futures = { workspace = true }
 http = { workspace = true }
 http-body = { workspace = true }
 hyper = { workspace = true }
+hyper-util = { workspace = true }
 metrics = { workspace = true }
 mime = { workspace = true }
 pathfinder-class-hash = { path = "../class-hash" }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -19,21 +19,27 @@ pub mod v10;
 
 use std::net::SocketAddr;
 use std::path::Path;
+use std::pin::pin;
 use std::result::Result;
 
 use anyhow::Context;
 use axum::error_handling::HandleErrorLayer;
 use axum::extract::DefaultBodyLimit;
 use axum::response::IntoResponse;
+use axum::serve::Listener;
 pub use compiler::PathfinderCompiler;
 use context::RpcContext;
 pub use executor::compose_executor_transaction;
+use futures::FutureExt;
 use http_body::Body;
+use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
 pub use jsonrpc::{Notifications, Reorg};
 use pathfinder_common::{integration_testing, AllowedOrigins};
 pub use pending::{FinalizedTxData, PendingBlocks, PendingData};
-use tokio::sync::RwLock;
+use tokio::sync::{watch, RwLock};
 use tokio::task::JoinHandle;
+use tokio::time::Duration;
+use tower::Service;
 use tower_http::cors::CorsLayer;
 use tower_http::ServiceBuilderExt;
 
@@ -98,7 +104,7 @@ impl RpcServer {
     ) -> Result<(JoinHandle<anyhow::Result<()>>, SocketAddr), anyhow::Error> {
         use axum::routing::{get, post};
 
-        let listener = match tokio::net::TcpListener::bind(self.addr).await {
+        let mut listener = match tokio::net::TcpListener::bind(self.addr).await {
             Ok(listener) => listener,
             Err(e) => {
                 return Err(e).context(format!(
@@ -206,10 +212,80 @@ impl RpcServer {
         let router = router.layer(middleware);
 
         let server_handle = util::task::spawn(async move {
-            axum::serve(listener, router.into_make_service())
-                .with_graceful_shutdown(util::task::cancellation_token().cancelled_owned())
-                .await
-                .map_err(Into::into)
+            // inlined `WithGracefulShutdown::run()` with the
+            // connection handler replaced by one from axum's
+            // serve-with-hyper example, extended to call
+            // `header_read_timeout`
+            let signal = util::task::cancellation_token().cancelled_owned();
+
+            let (signal_tx, signal_rx) = watch::channel(());
+            tokio::spawn(async move {
+                signal.await;
+                tracing::trace!("received graceful shutdown signal. Telling tasks to shutdown");
+                drop(signal_rx);
+            });
+
+            let (close_tx, close_rx) = watch::channel(());
+
+            loop {
+                let (socket, _remote_addr) = tokio::select! {
+                    conn = Listener::accept(&mut listener) => conn,
+                    _ = signal_tx.closed() => {
+                        tracing::trace!("signal received, not accepting new connections");
+                        break;
+                    }
+                };
+
+                let tower_service = router.clone();
+                let signal_tx = signal_tx.clone();
+                let close_rx = close_rx.clone();
+
+                tokio::spawn(async move {
+                    let socket = TokioIo::new(socket);
+                    let hyper_service = hyper::service::service_fn(
+                        move |request: axum::extract::Request<hyper::body::Incoming>| {
+                            tower_service.clone().call(request)
+                        },
+                    );
+
+                    let mut combo_builder =
+                        hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
+                    combo_builder
+                        .http1()
+                        .timer(TokioTimer::new())
+                        .header_read_timeout(Duration::from_secs(30));
+
+                    let mut conn = pin!(combo_builder.serve_connection_with_upgrades(socket, hyper_service));
+                    let mut signal_closed = pin!(signal_tx.closed().fuse());
+
+                    loop {
+                        tokio::select! {
+                            result = conn.as_mut() => {
+                                if let Err(err) = result {
+                                    tracing::trace!("failed to serve connection: {err:#}");
+                                }
+                                break;
+                            }
+                            _ = &mut signal_closed => {
+                                tracing::trace!("signal received in task, starting graceful shutdown");
+                                conn.as_mut().graceful_shutdown();
+                            }
+                        }
+                    }
+
+                    drop(close_rx);
+                });
+            }
+
+            drop(close_rx);
+            drop(listener);
+
+            tracing::trace!(
+                "waiting for {} task(s) to finish",
+                close_tx.receiver_count()
+            );
+            close_tx.closed().await;
+            Ok(())
         });
 
         Ok((server_handle, addr))

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -48,6 +48,8 @@ use crate::types::syncing::Syncing;
 
 const DEFAULT_MAX_CONNECTIONS: usize = 1024;
 
+const DEFAULT_HEADER_TIMEOUT_SEC: u64 = 30;
+
 #[derive(Copy, Clone, Debug, Default, PartialEq, PartialOrd)]
 pub enum RpcVersion {
     #[default]
@@ -70,6 +72,7 @@ pub struct RpcServer {
     addr: SocketAddr,
     context: RpcContext,
     max_connections: usize,
+    header_timeout: Duration,
     cors: Option<CorsLayer>,
     default_version: RpcVersion,
 }
@@ -80,6 +83,7 @@ impl RpcServer {
             addr,
             context,
             max_connections: DEFAULT_MAX_CONNECTIONS,
+            header_timeout: Duration::from_secs(DEFAULT_HEADER_TIMEOUT_SEC),
             cors: None,
             default_version,
         }
@@ -87,6 +91,11 @@ impl RpcServer {
 
     pub fn with_max_connections(mut self, max_connections: usize) -> Self {
         self.max_connections = max_connections;
+        self
+    }
+
+    pub fn with_header_timeout(mut self, header_timeout: Duration) -> Self {
+        self.header_timeout = header_timeout;
         self
     }
 
@@ -253,9 +262,10 @@ impl RpcServer {
                     combo_builder
                         .http1()
                         .timer(TokioTimer::new())
-                        .header_read_timeout(Duration::from_secs(30));
+                        .header_read_timeout(self.header_timeout);
 
-                    let mut conn = pin!(combo_builder.serve_connection_with_upgrades(socket, hyper_service));
+                    let mut conn =
+                        pin!(combo_builder.serve_connection_with_upgrades(socket, hyper_service));
                     let mut signal_closed = pin!(signal_tx.closed().fuse());
 
                     loop {


### PR DESCRIPTION
To get rid of connections that actually don't send any requests.

Added explicit dependency on `hyper-util`, but it was already used implicitly.
