### PR TITLE
feat(config): separate size limit for subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- RPC WS subscriptions are now limited by the `--rpc.websocket.subscription-request-max-size` option (instead of `--rpc.request-max-size`, which is now used only for HTTP requests).
+
 ### Added
 
 - RPC HTTP connections that don't start a request now time out. The timeout is configurable with `--rpc.header-read-timeout` CLI option.

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -294,6 +294,7 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
         context.with_websockets(WebsocketContext::new(
             config.websocket.max_history.into(),
             config.websocket.max_subscriptions.get(),
+            config.websocket.subscription_request_max_size.get(),
             config.websocket.send_timeout,
         ))
     } else {

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -1555,6 +1555,13 @@ Note that the 'unlimited' setting is meant primarily for testing and not recomme
     )]
     pub max_subscriptions: NonZeroUsize,
     #[arg(
+        long = "rpc.websocket.subscription-request-max-size",
+        long_help = "Maximum accepted subscription size in bytes.",
+        default_value = "1048576", // 1024 * 1024
+        env = "PATHFINDER_WEBSOCKET_SUBSCRIPTION_REQUEST_MAX_SIZE"
+    )]
+    pub subscription_request_max_size: NonZeroUsize,
+    #[arg(
         long = "rpc.websocket.send-timeout",
         long_help = "Threshold for considering the websocket's output buffer full (and closing the connection).",
         default_value = "1",

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -211,14 +211,14 @@ pub async fn rpc_handler(
 ) -> impl axum::response::IntoResponse {
     match ws {
         Ok(ws) => {
-            let send_timeout = match state.context.websocket {
-                Some(ref ws_cfg) => ws_cfg.send_timeout,
+            let (send_timeout, subscription_max_size) = match state.context.websocket {
+                Some(ref ws_cfg) => (ws_cfg.send_timeout, ws_cfg.subscription_max_size),
                 None => {
                     return StatusCode::FORBIDDEN.into_response();
                 }
             };
 
-            ws.max_message_size(state.context.config.request_max_size.get())
+            ws.max_message_size(subscription_max_size)
                 .on_upgrade(async move |ws| {
                     let (ws_tx, ws_rx) = split_ws(ws, state.version, send_timeout);
                     handle_json_rpc_socket(state, ws_tx, ws_rx);

--- a/crates/rpc/src/jsonrpc/websocket.rs
+++ b/crates/rpc/src/jsonrpc/websocket.rs
@@ -30,6 +30,7 @@ pub enum WebsocketHistory {
 pub struct WebsocketContext {
     pub max_history: WebsocketHistory,
     pub max_subscriptions: usize,
+    pub subscription_max_size: usize,
     pub send_timeout: Duration,
 }
 
@@ -37,11 +38,13 @@ impl WebsocketContext {
     pub fn new(
         max_history: WebsocketHistory,
         max_subscriptions: usize,
+        subscription_max_size: usize,
         send_timeout: Duration,
     ) -> Self {
         Self {
             max_history,
             max_subscriptions,
+            subscription_max_size,
             send_timeout,
         }
     }
@@ -51,6 +54,7 @@ impl WebsocketContext {
         Self {
             max_history,
             max_subscriptions: 1024,
+            subscription_max_size: 1024 * 1024,
             send_timeout: Duration::from_secs_f64(0.1),
         }
     }


### PR DESCRIPTION
so that it can be set lower than for general HTTP requests.
