### PR TITLE
refactor(rpc): remove broadcasted transaction versions lower than v3

### DIFF
--- a/crates/rpc/fixtures/0.10.0/fee_estimates/declare_deploy_invoke_sierra_0_13_1.json
+++ b/crates/rpc/fixtures/0.10.0/fee_estimates/declare_deploy_invoke_sierra_0_13_1.json
@@ -13,31 +13,11 @@
     "l1_data_gas_consumed": "0xe0",
     "l1_data_gas_price": "0x2",
     "l1_gas_consumed": "0x12",
-    "l1_gas_price": "0x1",
+    "l1_gas_price": "0x2",
     "l2_gas_consumed": "0x0",
     "l2_gas_price": "0x1",
-    "overall_fee": "0x1d2",
-    "unit": "WEI"
-  },
-  {
-    "l1_data_gas_consumed": "0x80",
-    "l1_data_gas_price": "0x2",
-    "l1_gas_consumed": "0xe",
-    "l1_gas_price": "0x1",
-    "l2_gas_consumed": "0x0",
-    "l2_gas_price": "0x1",
-    "overall_fee": "0x10e",
-    "unit": "WEI"
-  },
-  {
-    "l1_data_gas_consumed": "0x80",
-    "l1_data_gas_price": "0x2",
-    "l1_gas_consumed": "0xa",
-    "l1_gas_price": "0x1",
-    "l2_gas_consumed": "0x0",
-    "l2_gas_price": "0x1",
-    "overall_fee": "0x10a",
-    "unit": "WEI"
+    "overall_fee": "0x1e4",
+    "unit": "FRI"
   },
   {
     "l1_data_gas_consumed": "0x80",

--- a/crates/rpc/fixtures/0.10.0/fee_estimates/declare_deploy_invoke_sierra_0_13_1.json
+++ b/crates/rpc/fixtures/0.10.0/fee_estimates/declare_deploy_invoke_sierra_0_13_1.json
@@ -3,11 +3,11 @@
     "l1_data_gas_consumed": "0xc0",
     "l1_data_gas_price": "0x2",
     "l1_gas_consumed": "0x5d09",
-    "l1_gas_price": "0x1",
+    "l1_gas_price": "0x2",
     "l2_gas_consumed": "0x0",
     "l2_gas_price": "0x1",
-    "overall_fee": "0x5e89",
-    "unit": "WEI"
+    "overall_fee": "0xbb92",
+    "unit": "FRI"
   },
   {
     "l1_data_gas_consumed": "0xe0",

--- a/crates/rpc/fixtures/0.10.0/fee_estimates/declare_deploy_invoke_sierra_0_13_1_1.json
+++ b/crates/rpc/fixtures/0.10.0/fee_estimates/declare_deploy_invoke_sierra_0_13_1_1.json
@@ -3,11 +3,11 @@
     "l1_data_gas_consumed": "0xc0",
     "l1_data_gas_price": "0x2",
     "l1_gas_consumed": "0x36e",
-    "l1_gas_price": "0x1",
+    "l1_gas_price": "0x2",
     "l2_gas_consumed": "0x0",
     "l2_gas_price": "0x1",
-    "overall_fee": "0x4ee",
-    "unit": "WEI"
+    "overall_fee": "0x85c",
+    "unit": "FRI"
   },
   {
     "l1_data_gas_consumed": "0xe0",

--- a/crates/rpc/fixtures/0.10.0/fee_estimates/declare_deploy_invoke_sierra_0_13_1_1.json
+++ b/crates/rpc/fixtures/0.10.0/fee_estimates/declare_deploy_invoke_sierra_0_13_1_1.json
@@ -13,31 +13,11 @@
     "l1_data_gas_consumed": "0xe0",
     "l1_data_gas_price": "0x2",
     "l1_gas_consumed": "0x13",
-    "l1_gas_price": "0x1",
+    "l1_gas_price": "0x2",
     "l2_gas_consumed": "0x0",
     "l2_gas_price": "0x1",
-    "overall_fee": "0x1d3",
-    "unit": "WEI"
-  },
-  {
-    "l1_data_gas_consumed": "0x80",
-    "l1_data_gas_price": "0x2",
-    "l1_gas_consumed": "0xe",
-    "l1_gas_price": "0x1",
-    "l2_gas_consumed": "0x0",
-    "l2_gas_price": "0x1",
-    "overall_fee": "0x10e",
-    "unit": "WEI"
-  },
-  {
-    "l1_data_gas_consumed": "0x80",
-    "l1_data_gas_price": "0x2",
-    "l1_gas_consumed": "0xa",
-    "l1_gas_price": "0x1",
-    "l2_gas_consumed": "0x0",
-    "l2_gas_price": "0x1",
-    "overall_fee": "0x10a",
-    "unit": "WEI"
+    "overall_fee": "0x1e6",
+    "unit": "FRI"
   },
   {
     "l1_data_gas_consumed": "0x80",

--- a/crates/rpc/fixtures/0.10.0/fee_estimates/declare_deploy_invoke_sierra_0_13_2.json
+++ b/crates/rpc/fixtures/0.10.0/fee_estimates/declare_deploy_invoke_sierra_0_13_2.json
@@ -3,11 +3,11 @@
     "l1_data_gas_consumed": "0xc0",
     "l1_data_gas_price": "0x2",
     "l1_gas_consumed": "0x5d0b",
-    "l1_gas_price": "0x1",
+    "l1_gas_price": "0x2",
     "l2_gas_consumed": "0x0",
     "l2_gas_price": "0x1",
-    "overall_fee": "0x5e8b",
-    "unit": "WEI"
+    "overall_fee": "0xbb96",
+    "unit": "FRI"
   },
   {
     "l1_data_gas_consumed": "0xe0",

--- a/crates/rpc/fixtures/0.10.0/fee_estimates/declare_deploy_invoke_sierra_0_13_2.json
+++ b/crates/rpc/fixtures/0.10.0/fee_estimates/declare_deploy_invoke_sierra_0_13_2.json
@@ -13,31 +13,11 @@
     "l1_data_gas_consumed": "0xe0",
     "l1_data_gas_price": "0x2",
     "l1_gas_consumed": "0x16",
-    "l1_gas_price": "0x1",
+    "l1_gas_price": "0x2",
     "l2_gas_consumed": "0x0",
     "l2_gas_price": "0x1",
-    "overall_fee": "0x1d6",
-    "unit": "WEI"
-  },
-  {
-    "l1_data_gas_consumed": "0x80",
-    "l1_data_gas_price": "0x2",
-    "l1_gas_consumed": "0x10",
-    "l1_gas_price": "0x1",
-    "l2_gas_consumed": "0x0",
-    "l2_gas_price": "0x1",
-    "overall_fee": "0x110",
-    "unit": "WEI"
-  },
-  {
-    "l1_data_gas_consumed": "0x80",
-    "l1_data_gas_price": "0x2",
-    "l1_gas_consumed": "0xb",
-    "l1_gas_price": "0x1",
-    "l2_gas_consumed": "0x0",
-    "l2_gas_price": "0x1",
-    "overall_fee": "0x10b",
-    "unit": "WEI"
+    "overall_fee": "0x1ec",
+    "unit": "FRI"
   },
   {
     "l1_data_gas_consumed": "0x80",

--- a/crates/rpc/fixtures/0.10.0/fee_estimates/declare_deploy_invoke_sierra_0_13_2_1.json
+++ b/crates/rpc/fixtures/0.10.0/fee_estimates/declare_deploy_invoke_sierra_0_13_2_1.json
@@ -13,31 +13,11 @@
     "l1_data_gas_consumed": "0xe0",
     "l1_data_gas_price": "0x2",
     "l1_gas_consumed": "0x16",
-    "l1_gas_price": "0x1",
+    "l1_gas_price": "0x2",
     "l2_gas_consumed": "0x0",
     "l2_gas_price": "0x1",
-    "overall_fee": "0x1d6",
-    "unit": "WEI"
-  },
-  {
-    "l1_data_gas_consumed": "0x80",
-    "l1_data_gas_price": "0x2",
-    "l1_gas_consumed": "0x10",
-    "l1_gas_price": "0x1",
-    "l2_gas_consumed": "0x0",
-    "l2_gas_price": "0x1",
-    "overall_fee": "0x110",
-    "unit": "WEI"
-  },
-  {
-    "l1_data_gas_consumed": "0x80",
-    "l1_data_gas_price": "0x2",
-    "l1_gas_consumed": "0xb",
-    "l1_gas_price": "0x1",
-    "l2_gas_consumed": "0x0",
-    "l2_gas_price": "0x1",
-    "overall_fee": "0x10b",
-    "unit": "WEI"
+    "overall_fee": "0x1ec",
+    "unit": "FRI"
   },
   {
     "l1_data_gas_consumed": "0x80",

--- a/crates/rpc/fixtures/0.10.0/fee_estimates/declare_deploy_invoke_sierra_0_13_2_1.json
+++ b/crates/rpc/fixtures/0.10.0/fee_estimates/declare_deploy_invoke_sierra_0_13_2_1.json
@@ -3,11 +3,11 @@
     "l1_data_gas_consumed": "0xc0",
     "l1_data_gas_price": "0x2",
     "l1_gas_consumed": "0x370",
-    "l1_gas_price": "0x1",
+    "l1_gas_price": "0x2",
     "l2_gas_consumed": "0x0",
     "l2_gas_price": "0x1",
-    "overall_fee": "0x4f0",
-    "unit": "WEI"
+    "overall_fee": "0x860",
+    "unit": "FRI"
   },
   {
     "l1_data_gas_consumed": "0xe0",

--- a/crates/rpc/fixtures/0.10.0/simulations/declare_and_deploy_integration.json
+++ b/crates/rpc/fixtures/0.10.0/simulations/declare_and_deploy_integration.json
@@ -116,11 +116,11 @@
       "l1_data_gas_consumed": "0xe0",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0x19",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x1d9",
-      "unit": "WEI"
+      "overall_fee": "0x1f2",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execute_invocation": {
@@ -223,13 +223,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x1d9",
+          "0x1f2",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -237,7 +237,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x1d9",
+              "0x1f2",
               "0x0"
             ],
             "keys": [
@@ -275,15 +275,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffe27"
+                "value": "0xffffffffffffffffffffffff146c"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x1d9"
+                "value": "0xeb94"
               }
             ]
           }

--- a/crates/rpc/fixtures/0.10.0/simulations/declare_deploy_and_invoke_sierra_class.json
+++ b/crates/rpc/fixtures/0.10.0/simulations/declare_deploy_and_invoke_sierra_class.json
@@ -116,11 +116,11 @@
       "l1_data_gas_consumed": "0xe0",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0x13",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x1d3",
-      "unit": "WEI"
+      "overall_fee": "0x1e6",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execute_invocation": {
@@ -223,13 +223,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x1d3",
+          "0x1e6",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -237,7 +237,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x1d3",
+              "0x1e6",
               "0x0"
             ],
             "keys": [
@@ -275,15 +275,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffe2d"
+                "value": "0xfffffffffffffffffffffffff5be"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x1d3"
+                "value": "0xa42"
               }
             ]
           }
@@ -326,11 +326,11 @@
       "l1_data_gas_consumed": "0x80",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0xe",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x10e",
-      "unit": "WEI"
+      "overall_fee": "0x11c",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execute_invocation": {
@@ -390,13 +390,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x10e",
+          "0x11c",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -404,7 +404,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x10e",
+              "0x11c",
               "0x0"
             ],
             "keys": [
@@ -437,15 +437,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffd1f"
+                "value": "0xfffffffffffffffffffffffff4a2"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x2e1"
+                "value": "0xb5e"
               }
             ]
           }
@@ -599,11 +599,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff688"
+                "value": "0xfffffffffffffffffffffffff386"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x978"
+                "value": "0xc7a"
               }
             ]
           }

--- a/crates/rpc/fixtures/0.10.0/simulations/declare_deploy_and_invoke_sierra_class.json
+++ b/crates/rpc/fixtures/0.10.0/simulations/declare_deploy_and_invoke_sierra_class.json
@@ -4,11 +4,11 @@
       "l1_data_gas_consumed": "0xc0",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0x36e",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x4ee",
-      "unit": "WEI"
+      "overall_fee": "0x85c",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execution_resources": {
@@ -20,13 +20,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x4ee",
+          "0x85c",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -34,7 +34,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x4ee",
+              "0x85c",
               "0x0"
             ],
             "keys": [
@@ -72,15 +72,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffb12"
+                "value": "0xfffffffffffffffffffffffff7a4"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x4ee"
+                "value": "0x85c"
               }
             ]
           }
@@ -279,11 +279,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff93f"
+                "value": "0xfffffffffffffffffffffffffe2d"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x6c1"
+                "value": "0x1d3"
               }
             ]
           }
@@ -441,11 +441,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff831"
+                "value": "0xfffffffffffffffffffffffffd1f"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x7cf"
+                "value": "0x2e1"
               }
             ]
           }
@@ -599,11 +599,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffee4"
+                "value": "0xfffffffffffffffffffffffff688"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x11c"
+                "value": "0x978"
               }
             ]
           }

--- a/crates/rpc/fixtures/0.10.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_13_4.json
+++ b/crates/rpc/fixtures/0.10.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_13_4.json
@@ -116,11 +116,11 @@
       "l1_data_gas_consumed": "0xe0",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0x17",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x1d7",
-      "unit": "WEI"
+      "overall_fee": "0x1ee",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execute_invocation": {
@@ -223,13 +223,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x1d7",
+          "0x1ee",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -237,7 +237,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x1d7",
+              "0x1ee",
               "0x0"
             ],
             "keys": [
@@ -275,15 +275,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffe29"
+                "value": "0xfffffffffffffffffffffffff5b0"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x1d7"
+                "value": "0xa50"
               }
             ]
           }
@@ -441,11 +441,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffff56530"
+                "value": "0xfffffffffffffffffffffff56342"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0xa9ad0"
+                "value": "0xa9cbe"
               }
             ]
           }

--- a/crates/rpc/fixtures/0.10.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_13_4.json
+++ b/crates/rpc/fixtures/0.10.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_13_4.json
@@ -4,11 +4,11 @@
       "l1_data_gas_consumed": "0xc0",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0x371",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x4f1",
-      "unit": "WEI"
+      "overall_fee": "0x862",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execution_resources": {
@@ -20,13 +20,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x4f1",
+          "0x862",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -34,7 +34,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x4f1",
+              "0x862",
               "0x0"
             ],
             "keys": [
@@ -72,15 +72,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffb0f"
+                "value": "0xfffffffffffffffffffffffff79e"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x4f1"
+                "value": "0x862"
               }
             ]
           }
@@ -279,11 +279,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff938"
+                "value": "0xfffffffffffffffffffffffffe29"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x6c8"
+                "value": "0x1d7"
               }
             ]
           }
@@ -441,11 +441,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffff56d92"
+                "value": "0xfffffffffffffffffffffff56530"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0xa926e"
+                "value": "0xa9ad0"
               }
             ]
           }

--- a/crates/rpc/fixtures/0.10.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_14_0.json
+++ b/crates/rpc/fixtures/0.10.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_14_0.json
@@ -4,11 +4,11 @@
       "l1_data_gas_consumed": "0xc0",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0x372",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x4f2",
-      "unit": "WEI"
+      "overall_fee": "0x864",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execution_resources": {
@@ -20,13 +20,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x4f2",
+          "0x864",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -34,7 +34,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x4f2",
+              "0x864",
               "0x0"
             ],
             "keys": [
@@ -72,15 +72,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffb0e"
+                "value": "0xfffffffffffffffffffffffff79c"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x4f2"
+                "value": "0x864"
               }
             ]
           }
@@ -279,11 +279,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff935"
+                "value": "0xfffffffffffffffffffffffffe27"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x6cb"
+                "value": "0x1d9"
               }
             ]
           }
@@ -441,11 +441,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffff4a31c"
+                "value": "0xfffffffffffffffffffffff49ab8"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0xb5ce4"
+                "value": "0xb6548"
               }
             ]
           }

--- a/crates/rpc/fixtures/0.10.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_14_0.json
+++ b/crates/rpc/fixtures/0.10.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_14_0.json
@@ -116,11 +116,11 @@
       "l1_data_gas_consumed": "0xe0",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0x19",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x1d9",
-      "unit": "WEI"
+      "overall_fee": "0x1f2",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execute_invocation": {
@@ -223,13 +223,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x1d9",
+          "0x1f2",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -237,7 +237,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x1d9",
+              "0x1f2",
               "0x0"
             ],
             "keys": [
@@ -275,15 +275,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffe27"
+                "value": "0xfffffffffffffffffffffffff5aa"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x1d9"
+                "value": "0xa56"
               }
             ]
           }
@@ -441,11 +441,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffff49ab8"
+                "value": "0xfffffffffffffffffffffff498c6"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0xb6548"
+                "value": "0xb673a"
               }
             ]
           }

--- a/crates/rpc/fixtures/0.10.0/simulations/declare_deploy_and_invoke_sierra_class_with_skip_fee_charge.json
+++ b/crates/rpc/fixtures/0.10.0/simulations/declare_deploy_and_invoke_sierra_class_with_skip_fee_charge.json
@@ -4,11 +4,11 @@
       "l1_data_gas_consumed": "0xc0",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0x36e",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x4ee",
-      "unit": "WEI"
+      "overall_fee": "0x85c",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execution_resources": {

--- a/crates/rpc/fixtures/0.10.0/simulations/declare_deploy_and_invoke_sierra_class_with_skip_fee_charge.json
+++ b/crates/rpc/fixtures/0.10.0/simulations/declare_deploy_and_invoke_sierra_class_with_skip_fee_charge.json
@@ -65,11 +65,11 @@
       "l1_data_gas_consumed": "0xe0",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0x13",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x1d3",
-      "unit": "WEI"
+      "overall_fee": "0x1e6",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execute_invocation": {
@@ -224,11 +224,11 @@
       "l1_data_gas_consumed": "0x80",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0xe",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x10e",
-      "unit": "WEI"
+      "overall_fee": "0x11c",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execute_invocation": {

--- a/crates/rpc/fixtures/0.10.0/simulations/declare_deploy_and_invoke_sierra_class_with_skip_validate.json
+++ b/crates/rpc/fixtures/0.10.0/simulations/declare_deploy_and_invoke_sierra_class_with_skip_validate.json
@@ -94,11 +94,11 @@
       "l1_data_gas_consumed": "0xe0",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0x12",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x1d2",
-      "unit": "WEI"
+      "overall_fee": "0x1e4",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execute_invocation": {
@@ -201,13 +201,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x1d2",
+          "0x1e4",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -215,7 +215,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x1d2",
+              "0x1e4",
               "0x0"
             ],
             "keys": [
@@ -253,15 +253,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffe2e"
+                "value": "0xfffffffffffffffffffffffff5c0"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x1d2"
+                "value": "0xa40"
               }
             ]
           }
@@ -275,11 +275,11 @@
       "l1_data_gas_consumed": "0x80",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0xd",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x10d",
-      "unit": "WEI"
+      "overall_fee": "0x11a",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execute_invocation": {
@@ -339,13 +339,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x10d",
+          "0x11a",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -353,7 +353,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x10d",
+              "0x11a",
               "0x0"
             ],
             "keys": [
@@ -386,15 +386,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffd21"
+                "value": "0xfffffffffffffffffffffffff4a6"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x2df"
+                "value": "0xb5a"
               }
             ]
           }
@@ -523,11 +523,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff68a"
+                "value": "0xfffffffffffffffffffffffff38c"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x976"
+                "value": "0xc74"
               }
             ]
           }

--- a/crates/rpc/fixtures/0.10.0/simulations/declare_deploy_and_invoke_sierra_class_with_skip_validate.json
+++ b/crates/rpc/fixtures/0.10.0/simulations/declare_deploy_and_invoke_sierra_class_with_skip_validate.json
@@ -4,11 +4,11 @@
       "l1_data_gas_consumed": "0xc0",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0x36e",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x4ee",
-      "unit": "WEI"
+      "overall_fee": "0x85c",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execution_resources": {
@@ -20,13 +20,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x4ee",
+          "0x85c",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -34,7 +34,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x4ee",
+              "0x85c",
               "0x0"
             ],
             "keys": [
@@ -72,15 +72,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffb12"
+                "value": "0xfffffffffffffffffffffffff7a4"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x4ee"
+                "value": "0x85c"
               }
             ]
           }
@@ -257,11 +257,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff940"
+                "value": "0xfffffffffffffffffffffffffe2e"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x6c0"
+                "value": "0x1d2"
               }
             ]
           }
@@ -390,11 +390,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff833"
+                "value": "0xfffffffffffffffffffffffffd21"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x7cd"
+                "value": "0x2df"
               }
             ]
           }
@@ -523,11 +523,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffee6"
+                "value": "0xfffffffffffffffffffffffff68a"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x11a"
+                "value": "0x976"
               }
             ]
           }

--- a/crates/rpc/fixtures/0.10.0/traces/multiple_pre_confirmed_txs.json
+++ b/crates/rpc/fixtures/0.10.0/traces/multiple_pre_confirmed_txs.json
@@ -204,13 +204,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x1d9",
+          "0x1f2",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -218,7 +218,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x1d9",
+              "0x1f2",
               "0x0"
             ],
             "keys": [
@@ -256,15 +256,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffe27"
+                "value": "0xfffffffffffffffffffffffff5aa"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x1d9"
+                "value": "0xa56"
               }
             ]
           }
@@ -301,7 +301,7 @@
         ]
       }
     },
-    "transaction_hash": "0x1cdd84a12e3582bd60acf7546d6e1a54e9706414f28cd3b2ce8a3d2eb5e4f73"
+    "transaction_hash": "0x68c1725f44e113840f093e33ab235ed8174ebab7e37961db37460bf61a11008"
   },
   {
     "trace_root": {
@@ -362,13 +362,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x113",
+          "0x126",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -376,7 +376,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x113",
+              "0x126",
               "0x0"
             ],
             "keys": [
@@ -409,15 +409,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffd14"
+                "value": "0xfffffffffffffffffffffffff484"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x2ec"
+                "value": "0xb7c"
               }
             ]
           }
@@ -450,6 +450,6 @@
         ]
       }
     },
-    "transaction_hash": "0x2a973a52127349ccb6ecd72c31a7b1fc444a526643b4afe8a275a536075cb0e"
+    "transaction_hash": "0x54040306617fba235af9f853347320a6d1de47ab0e1a7257b32d9b0e61686d9"
   }
 ]

--- a/crates/rpc/fixtures/0.10.0/traces/multiple_pre_confirmed_txs.json
+++ b/crates/rpc/fixtures/0.10.0/traces/multiple_pre_confirmed_txs.json
@@ -10,13 +10,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x4f2",
+          "0x864",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -24,7 +24,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x4f2",
+              "0x864",
               "0x0"
             ],
             "keys": [
@@ -62,15 +62,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffb0e"
+                "value": "0xfffffffffffffffffffffffff79c"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x4f2"
+                "value": "0x864"
               }
             ]
           }
@@ -100,7 +100,7 @@
         ]
       }
     },
-    "transaction_hash": "0x548c629e4ee49b5280bb1363288d2e112974beaa2959c96500a9f0cbc41e5ee"
+    "transaction_hash": "0x54114c020e7fedd46fac3e045dada2a74402c19c34f4cfb100cd9d7fc387831"
   },
   {
     "trace_root": {
@@ -260,11 +260,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff935"
+                "value": "0xfffffffffffffffffffffffffe27"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x6cb"
+                "value": "0x1d9"
               }
             ]
           }
@@ -413,11 +413,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff822"
+                "value": "0xfffffffffffffffffffffffffd14"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x7de"
+                "value": "0x2ec"
               }
             ]
           }

--- a/crates/rpc/fixtures/0.10.0/traces/multiple_txs.json
+++ b/crates/rpc/fixtures/0.10.0/traces/multiple_txs.json
@@ -204,13 +204,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x1d3",
+          "0x1e6",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -218,7 +218,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x1d3",
+              "0x1e6",
               "0x0"
             ],
             "keys": [
@@ -256,15 +256,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffe2d"
+                "value": "0xfffffffffffffffffffffffff5be"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x1d3"
+                "value": "0xa42"
               }
             ]
           }
@@ -301,7 +301,7 @@
         ]
       }
     },
-    "transaction_hash": "0x1cdd84a12e3582bd60acf7546d6e1a54e9706414f28cd3b2ce8a3d2eb5e4f73"
+    "transaction_hash": "0x68c1725f44e113840f093e33ab235ed8174ebab7e37961db37460bf61a11008"
   },
   {
     "trace_root": {
@@ -362,13 +362,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x10e",
+          "0x11c",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -376,7 +376,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x10e",
+              "0x11c",
               "0x0"
             ],
             "keys": [
@@ -409,15 +409,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffd1f"
+                "value": "0xfffffffffffffffffffffffff4a2"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x2e1"
+                "value": "0xb5e"
               }
             ]
           }
@@ -450,6 +450,6 @@
         ]
       }
     },
-    "transaction_hash": "0x2a973a52127349ccb6ecd72c31a7b1fc444a526643b4afe8a275a536075cb0e"
+    "transaction_hash": "0x54040306617fba235af9f853347320a6d1de47ab0e1a7257b32d9b0e61686d9"
   }
 ]

--- a/crates/rpc/fixtures/0.10.0/traces/multiple_txs.json
+++ b/crates/rpc/fixtures/0.10.0/traces/multiple_txs.json
@@ -10,13 +10,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x4ee",
+          "0x85c",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -24,7 +24,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x4ee",
+              "0x85c",
               "0x0"
             ],
             "keys": [
@@ -39,7 +39,9 @@
         },
         "is_reverted": false,
         "messages": [],
-        "result": ["0x1"]
+        "result": [
+          "0x1"
+        ]
       },
       "state_diff": {
         "declared_classes": [
@@ -48,9 +50,9 @@
             "compiled_class_hash": "0x69032ff71f77284e1a0864a573007108ca5cc08089416af50f03260f5d6d4d8"
           }
         ],
-        "migrated_compiled_classes": [],
         "deployed_contracts": [],
         "deprecated_declared_classes": [],
+        "migrated_compiled_classes": [],
         "nonces": [
           {
             "contract_address": "0xc01",
@@ -60,15 +62,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffb12"
+                "value": "0xfffffffffffffffffffffffff7a4"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x4ee"
+                "value": "0x85c"
               }
             ]
           }
@@ -93,10 +95,12 @@
         },
         "is_reverted": false,
         "messages": [],
-        "result": ["0x56414c4944"]
+        "result": [
+          "0x56414c4944"
+        ]
       }
     },
-    "transaction_hash": "0x548c629e4ee49b5280bb1363288d2e112974beaa2959c96500a9f0cbc41e5ee"
+    "transaction_hash": "0x54114c020e7fedd46fac3e045dada2a74402c19c34f4cfb100cd9d7fc387831"
   },
   {
     "trace_root": {
@@ -229,11 +233,12 @@
         },
         "is_reverted": false,
         "messages": [],
-        "result": ["0x1"]
+        "result": [
+          "0x1"
+        ]
       },
       "state_diff": {
         "declared_classes": [],
-        "migrated_compiled_classes": [],
         "deployed_contracts": [
           {
             "address": "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
@@ -241,6 +246,7 @@
           }
         ],
         "deprecated_declared_classes": [],
+        "migrated_compiled_classes": [],
         "nonces": [
           {
             "contract_address": "0xc01",
@@ -254,11 +260,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff93f"
+                "value": "0xfffffffffffffffffffffffffe2d"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x6c1"
+                "value": "0x1d3"
               }
             ]
           }
@@ -290,7 +296,9 @@
         },
         "is_reverted": false,
         "messages": [],
-        "result": ["0x56414c4944"]
+        "result": [
+          "0x56414c4944"
+        ]
       }
     },
     "transaction_hash": "0x1cdd84a12e3582bd60acf7546d6e1a54e9706414f28cd3b2ce8a3d2eb5e4f73"
@@ -323,7 +331,9 @@
             },
             "is_reverted": false,
             "messages": [],
-            "result": ["0x9"]
+            "result": [
+              "0x9"
+            ]
           }
         ],
         "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
@@ -337,7 +347,11 @@
         },
         "is_reverted": false,
         "messages": [],
-        "result": ["0x1", "0x1", "0x9"]
+        "result": [
+          "0x1",
+          "0x1",
+          "0x9"
+        ]
       },
       "execution_resources": {
         "l1_data_gas": 128,
@@ -377,13 +391,15 @@
         },
         "is_reverted": false,
         "messages": [],
-        "result": ["0x1"]
+        "result": [
+          "0x1"
+        ]
       },
       "state_diff": {
         "declared_classes": [],
-        "migrated_compiled_classes": [],
         "deployed_contracts": [],
         "deprecated_declared_classes": [],
+        "migrated_compiled_classes": [],
         "nonces": [
           {
             "contract_address": "0xc01",
@@ -397,11 +413,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff831"
+                "value": "0xfffffffffffffffffffffffffd1f"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x7cf"
+                "value": "0x2e1"
               }
             ]
           }
@@ -429,7 +445,9 @@
         },
         "is_reverted": false,
         "messages": [],
-        "result": ["0x56414c4944"]
+        "result": [
+          "0x56414c4944"
+        ]
       }
     },
     "transaction_hash": "0x2a973a52127349ccb6ecd72c31a7b1fc444a526643b4afe8a275a536075cb0e"

--- a/crates/rpc/fixtures/0.10.0/traces/multiple_txs_with_initial_reads.json
+++ b/crates/rpc/fixtures/0.10.0/traces/multiple_txs_with_initial_reads.json
@@ -1,4 +1,104 @@
 {
+  "initial_reads": {
+    "class_hashes": [
+      {
+        "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+        "contract_address": "0xc01"
+      },
+      {
+        "class_hash": "0x6f38fb91ddbf325a0625533576bb6f6eafd9341868a9ec3faa4b01ce6c4f4dc",
+        "contract_address": "0xc02"
+      },
+      {
+        "class_hash": "0x0",
+        "contract_address": "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7"
+      },
+      {
+        "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"
+      },
+      {
+        "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
+        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
+      }
+    ],
+    "declared_contracts": [
+      {
+        "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
+        "is_declared": true
+      },
+      {
+        "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
+        "is_declared": true
+      },
+      {
+        "class_hash": "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
+        "is_declared": false
+      },
+      {
+        "class_hash": "0x6f38fb91ddbf325a0625533576bb6f6eafd9341868a9ec3faa4b01ce6c4f4dc",
+        "is_declared": true
+      }
+    ],
+    "nonces": [
+      {
+        "contract_address": "0xc01",
+        "nonce": "0x0"
+      }
+    ],
+    "storage": [
+      {
+        "contract_address": "0xc01",
+        "key": "0x1379ac0624b939ceb9dede92211d7db5ee174fe28be72245b0a1a2abd81c98f",
+        "value": "0x0"
+      },
+      {
+        "contract_address": "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
+        "key": "0x1275130f95dda36bcbb6e9d28796c1d7e10b6e9fd5ed083e0ede4b12f613528",
+        "value": "0x9"
+      },
+      {
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+        "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
+        "value": "0x10000000000000000000000000000"
+      },
+      {
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+        "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408f",
+        "value": "0x0"
+      },
+      {
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+        "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
+        "value": "0x0"
+      },
+      {
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+        "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9b",
+        "value": "0x0"
+      },
+      {
+        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
+        "value": "0x10000000000000000000000000000"
+      },
+      {
+        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408f",
+        "value": "0x0"
+      },
+      {
+        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
+        "value": "0x0"
+      },
+      {
+        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9b",
+        "value": "0x0"
+      }
+    ]
+  },
   "traces": [
     {
       "trace_root": {
@@ -11,13 +111,13 @@
           "call_type": "CALL",
           "calldata": [
             "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-            "0x4ee",
+            "0x85c",
             "0x0"
           ],
           "caller_address": "0xc01",
           "calls": [],
           "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-          "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
           "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
           "entry_point_type": "EXTERNAL",
           "events": [
@@ -25,7 +125,7 @@
               "data": [
                 "0xc01",
                 "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-                "0x4ee",
+                "0x85c",
                 "0x0"
               ],
               "keys": [
@@ -40,7 +140,9 @@
           },
           "is_reverted": false,
           "messages": [],
-          "result": ["0x1"]
+          "result": [
+            "0x1"
+          ]
         },
         "state_diff": {
           "declared_classes": [
@@ -49,9 +151,9 @@
               "compiled_class_hash": "0x69032ff71f77284e1a0864a573007108ca5cc08089416af50f03260f5d6d4d8"
             }
           ],
-          "migrated_compiled_classes": [],
           "deployed_contracts": [],
           "deprecated_declared_classes": [],
+          "migrated_compiled_classes": [],
           "nonces": [
             {
               "contract_address": "0xc01",
@@ -61,15 +163,15 @@
           "replaced_classes": [],
           "storage_diffs": [
             {
-              "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+              "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
               "storage_entries": [
                 {
                   "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                  "value": "0xfffffffffffffffffffffffffb12"
+                  "value": "0xfffffffffffffffffffffffff7a4"
                 },
                 {
                   "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                  "value": "0x4ee"
+                  "value": "0x85c"
                 }
               ]
             }
@@ -94,10 +196,12 @@
           },
           "is_reverted": false,
           "messages": [],
-          "result": ["0x56414c4944"]
+          "result": [
+            "0x56414c4944"
+          ]
         }
       },
-      "transaction_hash": "0x548c629e4ee49b5280bb1363288d2e112974beaa2959c96500a9f0cbc41e5ee"
+      "transaction_hash": "0x54114c020e7fedd46fac3e045dada2a74402c19c34f4cfb100cd9d7fc387831"
     },
     {
       "trace_root": {
@@ -230,11 +334,12 @@
           },
           "is_reverted": false,
           "messages": [],
-          "result": ["0x1"]
+          "result": [
+            "0x1"
+          ]
         },
         "state_diff": {
           "declared_classes": [],
-          "migrated_compiled_classes": [],
           "deployed_contracts": [
             {
               "address": "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
@@ -242,6 +347,7 @@
             }
           ],
           "deprecated_declared_classes": [],
+          "migrated_compiled_classes": [],
           "nonces": [
             {
               "contract_address": "0xc01",
@@ -255,11 +361,11 @@
               "storage_entries": [
                 {
                   "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                  "value": "0xfffffffffffffffffffffffff93f"
+                  "value": "0xfffffffffffffffffffffffffe2d"
                 },
                 {
                   "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                  "value": "0x6c1"
+                  "value": "0x1d3"
                 }
               ]
             }
@@ -291,7 +397,9 @@
           },
           "is_reverted": false,
           "messages": [],
-          "result": ["0x56414c4944"]
+          "result": [
+            "0x56414c4944"
+          ]
         }
       },
       "transaction_hash": "0x1cdd84a12e3582bd60acf7546d6e1a54e9706414f28cd3b2ce8a3d2eb5e4f73"
@@ -324,7 +432,9 @@
               },
               "is_reverted": false,
               "messages": [],
-              "result": ["0x9"]
+              "result": [
+                "0x9"
+              ]
             }
           ],
           "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
@@ -338,7 +448,11 @@
           },
           "is_reverted": false,
           "messages": [],
-          "result": ["0x1", "0x1", "0x9"]
+          "result": [
+            "0x1",
+            "0x1",
+            "0x9"
+          ]
         },
         "execution_resources": {
           "l1_data_gas": 128,
@@ -378,13 +492,15 @@
           },
           "is_reverted": false,
           "messages": [],
-          "result": ["0x1"]
+          "result": [
+            "0x1"
+          ]
         },
         "state_diff": {
           "declared_classes": [],
-          "migrated_compiled_classes": [],
           "deployed_contracts": [],
           "deprecated_declared_classes": [],
+          "migrated_compiled_classes": [],
           "nonces": [
             {
               "contract_address": "0xc01",
@@ -398,11 +514,11 @@
               "storage_entries": [
                 {
                   "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                  "value": "0xfffffffffffffffffffffffff831"
+                  "value": "0xfffffffffffffffffffffffffd1f"
                 },
                 {
                   "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                  "value": "0x7cf"
+                  "value": "0x2e1"
                 }
               ]
             }
@@ -430,86 +546,12 @@
           },
           "is_reverted": false,
           "messages": [],
-          "result": ["0x56414c4944"]
+          "result": [
+            "0x56414c4944"
+          ]
         }
       },
       "transaction_hash": "0x2a973a52127349ccb6ecd72c31a7b1fc444a526643b4afe8a275a536075cb0e"
     }
-  ],
-  "initial_reads": {
-    "class_hashes": [
-      {
-        "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
-        "contract_address": "0xc01"
-      },
-      {
-        "class_hash": "0x6f38fb91ddbf325a0625533576bb6f6eafd9341868a9ec3faa4b01ce6c4f4dc",
-        "contract_address": "0xc02"
-      },
-      {
-        "class_hash": "0x0",
-        "contract_address": "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7"
-      },
-      {
-        "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
-      }
-    ],
-    "declared_contracts": [
-      {
-        "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "is_declared": true
-      },
-      {
-        "class_hash": "0x19cabebe31b9fb6bf5e7ce9a971bd7d06e9999e0b97eee943869141a46fd978",
-        "is_declared": true
-      },
-      {
-        "class_hash": "0x544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90",
-        "is_declared": false
-      },
-      {
-        "class_hash": "0x6f38fb91ddbf325a0625533576bb6f6eafd9341868a9ec3faa4b01ce6c4f4dc",
-        "is_declared": true
-      }
-    ],
-    "nonces": [
-      {
-        "contract_address": "0xc01",
-        "nonce": "0x0"
-      }
-    ],
-    "storage": [
-      {
-        "contract_address": "0xc01",
-        "key": "0x1379ac0624b939ceb9dede92211d7db5ee174fe28be72245b0a1a2abd81c98f",
-        "value": "0x0"
-      },
-      {
-        "contract_address": "0x12592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7",
-        "key": "0x1275130f95dda36bcbb6e9d28796c1d7e10b6e9fd5ed083e0ede4b12f613528",
-        "value": "0x9"
-      },
-      {
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-        "value": "0x10000000000000000000000000000"
-      },
-      {
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408f",
-        "value": "0x0"
-      },
-      {
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-        "value": "0x0"
-      },
-      {
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9b",
-        "value": "0x0"
-      }
-    ]
-  }
+  ]
 }

--- a/crates/rpc/fixtures/0.10.0/traces/multiple_txs_with_initial_reads.json
+++ b/crates/rpc/fixtures/0.10.0/traces/multiple_txs_with_initial_reads.json
@@ -16,10 +16,6 @@
       {
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
         "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"
-      },
-      {
-        "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
       }
     ],
     "declared_contracts": [
@@ -74,26 +70,6 @@
       },
       {
         "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
-        "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9b",
-        "value": "0x0"
-      },
-      {
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-        "value": "0x10000000000000000000000000000"
-      },
-      {
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408f",
-        "value": "0x0"
-      },
-      {
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-        "value": "0x0"
-      },
-      {
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
         "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9b",
         "value": "0x0"
       }
@@ -305,13 +281,13 @@
           "call_type": "CALL",
           "calldata": [
             "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-            "0x1d3",
+            "0x1e6",
             "0x0"
           ],
           "caller_address": "0xc01",
           "calls": [],
           "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-          "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
           "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
           "entry_point_type": "EXTERNAL",
           "events": [
@@ -319,7 +295,7 @@
               "data": [
                 "0xc01",
                 "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-                "0x1d3",
+                "0x1e6",
                 "0x0"
               ],
               "keys": [
@@ -357,15 +333,15 @@
           "replaced_classes": [],
           "storage_diffs": [
             {
-              "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+              "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
               "storage_entries": [
                 {
                   "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                  "value": "0xfffffffffffffffffffffffffe2d"
+                  "value": "0xfffffffffffffffffffffffff5be"
                 },
                 {
                   "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                  "value": "0x1d3"
+                  "value": "0xa42"
                 }
               ]
             }
@@ -402,7 +378,7 @@
           ]
         }
       },
-      "transaction_hash": "0x1cdd84a12e3582bd60acf7546d6e1a54e9706414f28cd3b2ce8a3d2eb5e4f73"
+      "transaction_hash": "0x68c1725f44e113840f093e33ab235ed8174ebab7e37961db37460bf61a11008"
     },
     {
       "trace_root": {
@@ -463,13 +439,13 @@
           "call_type": "CALL",
           "calldata": [
             "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-            "0x10e",
+            "0x11c",
             "0x0"
           ],
           "caller_address": "0xc01",
           "calls": [],
           "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-          "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
           "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
           "entry_point_type": "EXTERNAL",
           "events": [
@@ -477,7 +453,7 @@
               "data": [
                 "0xc01",
                 "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-                "0x10e",
+                "0x11c",
                 "0x0"
               ],
               "keys": [
@@ -510,15 +486,15 @@
           "replaced_classes": [],
           "storage_diffs": [
             {
-              "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+              "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
               "storage_entries": [
                 {
                   "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                  "value": "0xfffffffffffffffffffffffffd1f"
+                  "value": "0xfffffffffffffffffffffffff4a2"
                 },
                 {
                   "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                  "value": "0x2e1"
+                  "value": "0xb5e"
                 }
               ]
             }
@@ -551,7 +527,7 @@
           ]
         }
       },
-      "transaction_hash": "0x2a973a52127349ccb6ecd72c31a7b1fc444a526643b4afe8a275a536075cb0e"
+      "transaction_hash": "0x54040306617fba235af9f853347320a6d1de47ab0e1a7257b32d9b0e61686d9"
     }
   ]
 }

--- a/crates/rpc/fixtures/0.9.0/fee_estimates/declare_deploy_invoke_sierra_0_13_1.json
+++ b/crates/rpc/fixtures/0.9.0/fee_estimates/declare_deploy_invoke_sierra_0_13_1.json
@@ -13,31 +13,11 @@
     "l1_data_gas_consumed": "0xe0",
     "l1_data_gas_price": "0x2",
     "l1_gas_consumed": "0x12",
-    "l1_gas_price": "0x1",
+    "l1_gas_price": "0x2",
     "l2_gas_consumed": "0x0",
     "l2_gas_price": "0x1",
-    "overall_fee": "0x1d2",
-    "unit": "WEI"
-  },
-  {
-    "l1_data_gas_consumed": "0x80",
-    "l1_data_gas_price": "0x2",
-    "l1_gas_consumed": "0xe",
-    "l1_gas_price": "0x1",
-    "l2_gas_consumed": "0x0",
-    "l2_gas_price": "0x1",
-    "overall_fee": "0x10e",
-    "unit": "WEI"
-  },
-  {
-    "l1_data_gas_consumed": "0x80",
-    "l1_data_gas_price": "0x2",
-    "l1_gas_consumed": "0xa",
-    "l1_gas_price": "0x1",
-    "l2_gas_consumed": "0x0",
-    "l2_gas_price": "0x1",
-    "overall_fee": "0x10a",
-    "unit": "WEI"
+    "overall_fee": "0x1e4",
+    "unit": "FRI"
   },
   {
     "l1_data_gas_consumed": "0x80",

--- a/crates/rpc/fixtures/0.9.0/fee_estimates/declare_deploy_invoke_sierra_0_13_1.json
+++ b/crates/rpc/fixtures/0.9.0/fee_estimates/declare_deploy_invoke_sierra_0_13_1.json
@@ -3,11 +3,11 @@
     "l1_data_gas_consumed": "0xc0",
     "l1_data_gas_price": "0x2",
     "l1_gas_consumed": "0x5d09",
-    "l1_gas_price": "0x1",
+    "l1_gas_price": "0x2",
     "l2_gas_consumed": "0x0",
     "l2_gas_price": "0x1",
-    "overall_fee": "0x5e89",
-    "unit": "WEI"
+    "overall_fee": "0xbb92",
+    "unit": "FRI"
   },
   {
     "l1_data_gas_consumed": "0xe0",

--- a/crates/rpc/fixtures/0.9.0/fee_estimates/declare_deploy_invoke_sierra_0_13_1_1.json
+++ b/crates/rpc/fixtures/0.9.0/fee_estimates/declare_deploy_invoke_sierra_0_13_1_1.json
@@ -3,11 +3,11 @@
     "l1_data_gas_consumed": "0xc0",
     "l1_data_gas_price": "0x2",
     "l1_gas_consumed": "0x36e",
-    "l1_gas_price": "0x1",
+    "l1_gas_price": "0x2",
     "l2_gas_consumed": "0x0",
     "l2_gas_price": "0x1",
-    "overall_fee": "0x4ee",
-    "unit": "WEI"
+    "overall_fee": "0x85c",
+    "unit": "FRI"
   },
   {
     "l1_data_gas_consumed": "0xe0",

--- a/crates/rpc/fixtures/0.9.0/fee_estimates/declare_deploy_invoke_sierra_0_13_1_1.json
+++ b/crates/rpc/fixtures/0.9.0/fee_estimates/declare_deploy_invoke_sierra_0_13_1_1.json
@@ -13,31 +13,11 @@
     "l1_data_gas_consumed": "0xe0",
     "l1_data_gas_price": "0x2",
     "l1_gas_consumed": "0x13",
-    "l1_gas_price": "0x1",
+    "l1_gas_price": "0x2",
     "l2_gas_consumed": "0x0",
     "l2_gas_price": "0x1",
-    "overall_fee": "0x1d3",
-    "unit": "WEI"
-  },
-  {
-    "l1_data_gas_consumed": "0x80",
-    "l1_data_gas_price": "0x2",
-    "l1_gas_consumed": "0xe",
-    "l1_gas_price": "0x1",
-    "l2_gas_consumed": "0x0",
-    "l2_gas_price": "0x1",
-    "overall_fee": "0x10e",
-    "unit": "WEI"
-  },
-  {
-    "l1_data_gas_consumed": "0x80",
-    "l1_data_gas_price": "0x2",
-    "l1_gas_consumed": "0xa",
-    "l1_gas_price": "0x1",
-    "l2_gas_consumed": "0x0",
-    "l2_gas_price": "0x1",
-    "overall_fee": "0x10a",
-    "unit": "WEI"
+    "overall_fee": "0x1e6",
+    "unit": "FRI"
   },
   {
     "l1_data_gas_consumed": "0x80",

--- a/crates/rpc/fixtures/0.9.0/fee_estimates/declare_deploy_invoke_sierra_0_13_2.json
+++ b/crates/rpc/fixtures/0.9.0/fee_estimates/declare_deploy_invoke_sierra_0_13_2.json
@@ -3,11 +3,11 @@
     "l1_data_gas_consumed": "0xc0",
     "l1_data_gas_price": "0x2",
     "l1_gas_consumed": "0x5d0b",
-    "l1_gas_price": "0x1",
+    "l1_gas_price": "0x2",
     "l2_gas_consumed": "0x0",
     "l2_gas_price": "0x1",
-    "overall_fee": "0x5e8b",
-    "unit": "WEI"
+    "overall_fee": "0xbb96",
+    "unit": "FRI"
   },
   {
     "l1_data_gas_consumed": "0xe0",

--- a/crates/rpc/fixtures/0.9.0/fee_estimates/declare_deploy_invoke_sierra_0_13_2.json
+++ b/crates/rpc/fixtures/0.9.0/fee_estimates/declare_deploy_invoke_sierra_0_13_2.json
@@ -13,31 +13,11 @@
     "l1_data_gas_consumed": "0xe0",
     "l1_data_gas_price": "0x2",
     "l1_gas_consumed": "0x16",
-    "l1_gas_price": "0x1",
+    "l1_gas_price": "0x2",
     "l2_gas_consumed": "0x0",
     "l2_gas_price": "0x1",
-    "overall_fee": "0x1d6",
-    "unit": "WEI"
-  },
-  {
-    "l1_data_gas_consumed": "0x80",
-    "l1_data_gas_price": "0x2",
-    "l1_gas_consumed": "0x10",
-    "l1_gas_price": "0x1",
-    "l2_gas_consumed": "0x0",
-    "l2_gas_price": "0x1",
-    "overall_fee": "0x110",
-    "unit": "WEI"
-  },
-  {
-    "l1_data_gas_consumed": "0x80",
-    "l1_data_gas_price": "0x2",
-    "l1_gas_consumed": "0xb",
-    "l1_gas_price": "0x1",
-    "l2_gas_consumed": "0x0",
-    "l2_gas_price": "0x1",
-    "overall_fee": "0x10b",
-    "unit": "WEI"
+    "overall_fee": "0x1ec",
+    "unit": "FRI"
   },
   {
     "l1_data_gas_consumed": "0x80",

--- a/crates/rpc/fixtures/0.9.0/fee_estimates/declare_deploy_invoke_sierra_0_13_2_1.json
+++ b/crates/rpc/fixtures/0.9.0/fee_estimates/declare_deploy_invoke_sierra_0_13_2_1.json
@@ -13,31 +13,11 @@
     "l1_data_gas_consumed": "0xe0",
     "l1_data_gas_price": "0x2",
     "l1_gas_consumed": "0x16",
-    "l1_gas_price": "0x1",
+    "l1_gas_price": "0x2",
     "l2_gas_consumed": "0x0",
     "l2_gas_price": "0x1",
-    "overall_fee": "0x1d6",
-    "unit": "WEI"
-  },
-  {
-    "l1_data_gas_consumed": "0x80",
-    "l1_data_gas_price": "0x2",
-    "l1_gas_consumed": "0x10",
-    "l1_gas_price": "0x1",
-    "l2_gas_consumed": "0x0",
-    "l2_gas_price": "0x1",
-    "overall_fee": "0x110",
-    "unit": "WEI"
-  },
-  {
-    "l1_data_gas_consumed": "0x80",
-    "l1_data_gas_price": "0x2",
-    "l1_gas_consumed": "0xb",
-    "l1_gas_price": "0x1",
-    "l2_gas_consumed": "0x0",
-    "l2_gas_price": "0x1",
-    "overall_fee": "0x10b",
-    "unit": "WEI"
+    "overall_fee": "0x1ec",
+    "unit": "FRI"
   },
   {
     "l1_data_gas_consumed": "0x80",

--- a/crates/rpc/fixtures/0.9.0/fee_estimates/declare_deploy_invoke_sierra_0_13_2_1.json
+++ b/crates/rpc/fixtures/0.9.0/fee_estimates/declare_deploy_invoke_sierra_0_13_2_1.json
@@ -3,11 +3,11 @@
     "l1_data_gas_consumed": "0xc0",
     "l1_data_gas_price": "0x2",
     "l1_gas_consumed": "0x370",
-    "l1_gas_price": "0x1",
+    "l1_gas_price": "0x2",
     "l2_gas_consumed": "0x0",
     "l2_gas_price": "0x1",
-    "overall_fee": "0x4f0",
-    "unit": "WEI"
+    "overall_fee": "0x860",
+    "unit": "FRI"
   },
   {
     "l1_data_gas_consumed": "0xe0",

--- a/crates/rpc/fixtures/0.9.0/simulations/declare_deploy_and_invoke_sierra_class.json
+++ b/crates/rpc/fixtures/0.9.0/simulations/declare_deploy_and_invoke_sierra_class.json
@@ -115,11 +115,11 @@
       "l1_data_gas_consumed": "0xe0",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0x13",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x1d3",
-      "unit": "WEI"
+      "overall_fee": "0x1e6",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execute_invocation": {
@@ -222,13 +222,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x1d3",
+          "0x1e6",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -236,7 +236,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x1d3",
+              "0x1e6",
               "0x0"
             ],
             "keys": [
@@ -273,15 +273,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffe2d"
+                "value": "0xfffffffffffffffffffffffff5be"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x1d3"
+                "value": "0xa42"
               }
             ]
           }
@@ -324,11 +324,11 @@
       "l1_data_gas_consumed": "0x80",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0xe",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x10e",
-      "unit": "WEI"
+      "overall_fee": "0x11c",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execute_invocation": {
@@ -388,13 +388,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x10e",
+          "0x11c",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -402,7 +402,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x10e",
+              "0x11c",
               "0x0"
             ],
             "keys": [
@@ -434,15 +434,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffd1f"
+                "value": "0xfffffffffffffffffffffffff4a2"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x2e1"
+                "value": "0xb5e"
               }
             ]
           }
@@ -595,11 +595,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff688"
+                "value": "0xfffffffffffffffffffffffff386"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x978"
+                "value": "0xc7a"
               }
             ]
           }

--- a/crates/rpc/fixtures/0.9.0/simulations/declare_deploy_and_invoke_sierra_class.json
+++ b/crates/rpc/fixtures/0.9.0/simulations/declare_deploy_and_invoke_sierra_class.json
@@ -4,11 +4,11 @@
       "l1_data_gas_consumed": "0xc0",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0x36e",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x4ee",
-      "unit": "WEI"
+      "overall_fee": "0x85c",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execution_resources": {
@@ -20,13 +20,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x4ee",
+          "0x85c",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -34,7 +34,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x4ee",
+              "0x85c",
               "0x0"
             ],
             "keys": [
@@ -71,15 +71,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffb12"
+                "value": "0xfffffffffffffffffffffffff7a4"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x4ee"
+                "value": "0x85c"
               }
             ]
           }
@@ -277,11 +277,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff93f"
+                "value": "0xfffffffffffffffffffffffffe2d"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x6c1"
+                "value": "0x1d3"
               }
             ]
           }
@@ -438,11 +438,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff831"
+                "value": "0xfffffffffffffffffffffffffd1f"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x7cf"
+                "value": "0x2e1"
               }
             ]
           }
@@ -595,11 +595,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffee4"
+                "value": "0xfffffffffffffffffffffffff688"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x11c"
+                "value": "0x978"
               }
             ]
           }

--- a/crates/rpc/fixtures/0.9.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_13_4.json
+++ b/crates/rpc/fixtures/0.9.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_13_4.json
@@ -115,11 +115,11 @@
       "l1_data_gas_consumed": "0xe0",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0x17",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x1d7",
-      "unit": "WEI"
+      "overall_fee": "0x1ee",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execute_invocation": {
@@ -222,13 +222,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x1d7",
+          "0x1ee",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -236,7 +236,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x1d7",
+              "0x1ee",
               "0x0"
             ],
             "keys": [
@@ -273,15 +273,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffe29"
+                "value": "0xfffffffffffffffffffffffff5b0"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x1d7"
+                "value": "0xa50"
               }
             ]
           }
@@ -438,11 +438,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffff56530"
+                "value": "0xfffffffffffffffffffffff56342"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0xa9ad0"
+                "value": "0xa9cbe"
               }
             ]
           }

--- a/crates/rpc/fixtures/0.9.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_13_4.json
+++ b/crates/rpc/fixtures/0.9.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_13_4.json
@@ -4,11 +4,11 @@
       "l1_data_gas_consumed": "0xc0",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0x371",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x4f1",
-      "unit": "WEI"
+      "overall_fee": "0x862",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execution_resources": {
@@ -20,13 +20,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x4f1",
+          "0x862",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -34,7 +34,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x4f1",
+              "0x862",
               "0x0"
             ],
             "keys": [
@@ -71,15 +71,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffb0f"
+                "value": "0xfffffffffffffffffffffffff79e"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x4f1"
+                "value": "0x862"
               }
             ]
           }
@@ -277,11 +277,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff938"
+                "value": "0xfffffffffffffffffffffffffe29"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x6c8"
+                "value": "0x1d7"
               }
             ]
           }
@@ -438,11 +438,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffff56d92"
+                "value": "0xfffffffffffffffffffffff56530"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0xa926e"
+                "value": "0xa9ad0"
               }
             ]
           }

--- a/crates/rpc/fixtures/0.9.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_14_0.json
+++ b/crates/rpc/fixtures/0.9.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_14_0.json
@@ -115,11 +115,11 @@
       "l1_data_gas_consumed": "0xe0",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0x19",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x1d9",
-      "unit": "WEI"
+      "overall_fee": "0x1f2",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execute_invocation": {
@@ -222,13 +222,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x1d9",
+          "0x1f2",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -236,7 +236,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x1d9",
+              "0x1f2",
               "0x0"
             ],
             "keys": [
@@ -273,15 +273,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffe27"
+                "value": "0xfffffffffffffffffffffffff5aa"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x1d9"
+                "value": "0xa56"
               }
             ]
           }
@@ -438,11 +438,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffff49ab8"
+                "value": "0xfffffffffffffffffffffff498c6"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0xb6548"
+                "value": "0xb673a"
               }
             ]
           }

--- a/crates/rpc/fixtures/0.9.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_14_0.json
+++ b/crates/rpc/fixtures/0.9.0/simulations/declare_deploy_and_invoke_sierra_class_starknet_0_14_0.json
@@ -4,11 +4,11 @@
       "l1_data_gas_consumed": "0xc0",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0x372",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x4f2",
-      "unit": "WEI"
+      "overall_fee": "0x864",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execution_resources": {
@@ -20,13 +20,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x4f2",
+          "0x864",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -34,7 +34,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x4f2",
+              "0x864",
               "0x0"
             ],
             "keys": [
@@ -71,15 +71,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffb0e"
+                "value": "0xfffffffffffffffffffffffff79c"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x4f2"
+                "value": "0x864"
               }
             ]
           }
@@ -277,11 +277,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff935"
+                "value": "0xfffffffffffffffffffffffffe27"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x6cb"
+                "value": "0x1d9"
               }
             ]
           }
@@ -438,11 +438,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffff4a31c"
+                "value": "0xfffffffffffffffffffffff49ab8"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0xb5ce4"
+                "value": "0xb6548"
               }
             ]
           }

--- a/crates/rpc/fixtures/0.9.0/simulations/declare_deploy_and_invoke_sierra_class_with_skip_fee_charge.json
+++ b/crates/rpc/fixtures/0.9.0/simulations/declare_deploy_and_invoke_sierra_class_with_skip_fee_charge.json
@@ -4,11 +4,11 @@
       "l1_data_gas_consumed": "0xc0",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0x36e",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x4ee",
-      "unit": "WEI"
+      "overall_fee": "0x85c",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execution_resources": {

--- a/crates/rpc/fixtures/0.9.0/simulations/declare_deploy_and_invoke_sierra_class_with_skip_fee_charge.json
+++ b/crates/rpc/fixtures/0.9.0/simulations/declare_deploy_and_invoke_sierra_class_with_skip_fee_charge.json
@@ -64,11 +64,11 @@
       "l1_data_gas_consumed": "0xe0",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0x13",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x1d3",
-      "unit": "WEI"
+      "overall_fee": "0x1e6",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execute_invocation": {
@@ -222,11 +222,11 @@
       "l1_data_gas_consumed": "0x80",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0xe",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x10e",
-      "unit": "WEI"
+      "overall_fee": "0x11c",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execute_invocation": {

--- a/crates/rpc/fixtures/0.9.0/simulations/declare_deploy_and_invoke_sierra_class_with_skip_validate.json
+++ b/crates/rpc/fixtures/0.9.0/simulations/declare_deploy_and_invoke_sierra_class_with_skip_validate.json
@@ -93,11 +93,11 @@
       "l1_data_gas_consumed": "0xe0",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0x12",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x1d2",
-      "unit": "WEI"
+      "overall_fee": "0x1e4",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execute_invocation": {
@@ -200,13 +200,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x1d2",
+          "0x1e4",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -214,7 +214,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x1d2",
+              "0x1e4",
               "0x0"
             ],
             "keys": [
@@ -251,15 +251,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffe2e"
+                "value": "0xfffffffffffffffffffffffff5c0"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x1d2"
+                "value": "0xa40"
               }
             ]
           }
@@ -273,11 +273,11 @@
       "l1_data_gas_consumed": "0x80",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0xd",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x10d",
-      "unit": "WEI"
+      "overall_fee": "0x11a",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execute_invocation": {
@@ -337,13 +337,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x10d",
+          "0x11a",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -351,7 +351,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x10d",
+              "0x11a",
               "0x0"
             ],
             "keys": [
@@ -383,15 +383,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffd21"
+                "value": "0xfffffffffffffffffffffffff4a6"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x2df"
+                "value": "0xb5a"
               }
             ]
           }
@@ -519,11 +519,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff68a"
+                "value": "0xfffffffffffffffffffffffff38c"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x976"
+                "value": "0xc74"
               }
             ]
           }

--- a/crates/rpc/fixtures/0.9.0/simulations/declare_deploy_and_invoke_sierra_class_with_skip_validate.json
+++ b/crates/rpc/fixtures/0.9.0/simulations/declare_deploy_and_invoke_sierra_class_with_skip_validate.json
@@ -4,11 +4,11 @@
       "l1_data_gas_consumed": "0xc0",
       "l1_data_gas_price": "0x2",
       "l1_gas_consumed": "0x36e",
-      "l1_gas_price": "0x1",
+      "l1_gas_price": "0x2",
       "l2_gas_consumed": "0x0",
       "l2_gas_price": "0x1",
-      "overall_fee": "0x4ee",
-      "unit": "WEI"
+      "overall_fee": "0x85c",
+      "unit": "FRI"
     },
     "transaction_trace": {
       "execution_resources": {
@@ -20,13 +20,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x4ee",
+          "0x85c",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -34,7 +34,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x4ee",
+              "0x85c",
               "0x0"
             ],
             "keys": [
@@ -71,15 +71,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffb12"
+                "value": "0xfffffffffffffffffffffffff7a4"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x4ee"
+                "value": "0x85c"
               }
             ]
           }
@@ -255,11 +255,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff940"
+                "value": "0xfffffffffffffffffffffffffe2e"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x6c0"
+                "value": "0x1d2"
               }
             ]
           }
@@ -387,11 +387,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff833"
+                "value": "0xfffffffffffffffffffffffffd21"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x7cd"
+                "value": "0x2df"
               }
             ]
           }
@@ -519,11 +519,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffee6"
+                "value": "0xfffffffffffffffffffffffff68a"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x11a"
+                "value": "0x976"
               }
             ]
           }

--- a/crates/rpc/fixtures/0.9.0/traces/multiple_pre_confirmed_txs.json
+++ b/crates/rpc/fixtures/0.9.0/traces/multiple_pre_confirmed_txs.json
@@ -203,13 +203,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x1d9",
+          "0x1f2",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -217,7 +217,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x1d9",
+              "0x1f2",
               "0x0"
             ],
             "keys": [
@@ -254,15 +254,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffe27"
+                "value": "0xfffffffffffffffffffffffff5aa"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x1d9"
+                "value": "0xa56"
               }
             ]
           }
@@ -299,7 +299,7 @@
         ]
       }
     },
-    "transaction_hash": "0x1cdd84a12e3582bd60acf7546d6e1a54e9706414f28cd3b2ce8a3d2eb5e4f73"
+    "transaction_hash": "0x68c1725f44e113840f093e33ab235ed8174ebab7e37961db37460bf61a11008"
   },
   {
     "trace_root": {
@@ -360,13 +360,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x113",
+          "0x126",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -374,7 +374,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x113",
+              "0x126",
               "0x0"
             ],
             "keys": [
@@ -406,15 +406,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffd14"
+                "value": "0xfffffffffffffffffffffffff484"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x2ec"
+                "value": "0xb7c"
               }
             ]
           }
@@ -447,6 +447,6 @@
         ]
       }
     },
-    "transaction_hash": "0x2a973a52127349ccb6ecd72c31a7b1fc444a526643b4afe8a275a536075cb0e"
+    "transaction_hash": "0x54040306617fba235af9f853347320a6d1de47ab0e1a7257b32d9b0e61686d9"
   }
 ]

--- a/crates/rpc/fixtures/0.9.0/traces/multiple_pre_confirmed_txs.json
+++ b/crates/rpc/fixtures/0.9.0/traces/multiple_pre_confirmed_txs.json
@@ -10,13 +10,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x4f2",
+          "0x864",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -24,7 +24,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x4f2",
+              "0x864",
               "0x0"
             ],
             "keys": [
@@ -61,15 +61,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffb0e"
+                "value": "0xfffffffffffffffffffffffff79c"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x4f2"
+                "value": "0x864"
               }
             ]
           }
@@ -99,7 +99,7 @@
         ]
       }
     },
-    "transaction_hash": "0x548c629e4ee49b5280bb1363288d2e112974beaa2959c96500a9f0cbc41e5ee"
+    "transaction_hash": "0x54114c020e7fedd46fac3e045dada2a74402c19c34f4cfb100cd9d7fc387831"
   },
   {
     "trace_root": {
@@ -258,11 +258,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff935"
+                "value": "0xfffffffffffffffffffffffffe27"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x6cb"
+                "value": "0x1d9"
               }
             ]
           }
@@ -410,11 +410,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff822"
+                "value": "0xfffffffffffffffffffffffffd14"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x7de"
+                "value": "0x2ec"
               }
             ]
           }

--- a/crates/rpc/fixtures/0.9.0/traces/multiple_txs.json
+++ b/crates/rpc/fixtures/0.9.0/traces/multiple_txs.json
@@ -203,13 +203,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x1d3",
+          "0x1e6",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -217,7 +217,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x1d3",
+              "0x1e6",
               "0x0"
             ],
             "keys": [
@@ -254,15 +254,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffe2d"
+                "value": "0xfffffffffffffffffffffffff5be"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x1d3"
+                "value": "0xa42"
               }
             ]
           }
@@ -299,7 +299,7 @@
         ]
       }
     },
-    "transaction_hash": "0x1cdd84a12e3582bd60acf7546d6e1a54e9706414f28cd3b2ce8a3d2eb5e4f73"
+    "transaction_hash": "0x68c1725f44e113840f093e33ab235ed8174ebab7e37961db37460bf61a11008"
   },
   {
     "trace_root": {
@@ -360,13 +360,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x10e",
+          "0x11c",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -374,7 +374,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x10e",
+              "0x11c",
               "0x0"
             ],
             "keys": [
@@ -406,15 +406,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffd1f"
+                "value": "0xfffffffffffffffffffffffff4a2"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x2e1"
+                "value": "0xb5e"
               }
             ]
           }
@@ -447,6 +447,6 @@
         ]
       }
     },
-    "transaction_hash": "0x2a973a52127349ccb6ecd72c31a7b1fc444a526643b4afe8a275a536075cb0e"
+    "transaction_hash": "0x54040306617fba235af9f853347320a6d1de47ab0e1a7257b32d9b0e61686d9"
   }
 ]

--- a/crates/rpc/fixtures/0.9.0/traces/multiple_txs.json
+++ b/crates/rpc/fixtures/0.9.0/traces/multiple_txs.json
@@ -10,13 +10,13 @@
         "call_type": "CALL",
         "calldata": [
           "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-          "0x4ee",
+          "0x85c",
           "0x0"
         ],
         "caller_address": "0xc01",
         "calls": [],
         "class_hash": "0x13dbe991273192b5573c526cddc27a27decb8525b44536cb0f57b5b2c089b51",
-        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "contract_address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
         "entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
         "entry_point_type": "EXTERNAL",
         "events": [
@@ -24,7 +24,7 @@
             "data": [
               "0xc01",
               "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-              "0x4ee",
+              "0x85c",
               "0x0"
             ],
             "keys": [
@@ -61,15 +61,15 @@
         "replaced_classes": [],
         "storage_diffs": [
           {
-            "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "address": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffffb12"
+                "value": "0xfffffffffffffffffffffffff7a4"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x4ee"
+                "value": "0x85c"
               }
             ]
           }
@@ -99,7 +99,7 @@
         ]
       }
     },
-    "transaction_hash": "0x548c629e4ee49b5280bb1363288d2e112974beaa2959c96500a9f0cbc41e5ee"
+    "transaction_hash": "0x54114c020e7fedd46fac3e045dada2a74402c19c34f4cfb100cd9d7fc387831"
   },
   {
     "trace_root": {
@@ -258,11 +258,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff93f"
+                "value": "0xfffffffffffffffffffffffffe2d"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x6c1"
+                "value": "0x1d3"
               }
             ]
           }
@@ -410,11 +410,11 @@
             "storage_entries": [
               {
                 "key": "0x32a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e",
-                "value": "0xfffffffffffffffffffffffff831"
+                "value": "0xfffffffffffffffffffffffffd1f"
               },
               {
                 "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                "value": "0x7cf"
+                "value": "0x2e1"
               }
             ]
           }

--- a/crates/rpc/src/dto/simulation.rs
+++ b/crates/rpc/src/dto/simulation.rs
@@ -648,11 +648,6 @@ mod tests {
     };
     use crate::method::call::FunctionCall;
     use crate::method::simulate_transactions::tests::fixtures;
-    use crate::types::request::{
-        BroadcastedDeclareTransaction,
-        BroadcastedDeclareTransactionV1,
-        BroadcastedTransaction,
-    };
     use crate::types::ContractClass;
     use crate::RpcVersion;
 

--- a/crates/rpc/src/executor.rs
+++ b/crates/rpc/src/executor.rs
@@ -47,9 +47,6 @@ pub(crate) fn calldata_limit_exceeded(tx: &BroadcastedTransaction) -> bool {
         },
         BroadcastedTransaction::DeployAccount(broadcasted_deploy_tx) => match broadcasted_deploy_tx
         {
-            BroadcastedDeployAccountTransaction::V1(tx) => {
-                tx.constructor_calldata.len() > CALLDATA_LIMIT
-            }
             BroadcastedDeployAccountTransaction::V3(tx) => {
                 tx.constructor_calldata.len() > CALLDATA_LIMIT
             }
@@ -67,9 +64,6 @@ pub(crate) fn signature_elem_limit_exceeded(tx: &BroadcastedTransaction) -> bool
         },
         BroadcastedTransaction::DeployAccount(broadcasted_deploy_tx) => match broadcasted_deploy_tx
         {
-            BroadcastedDeployAccountTransaction::V1(tx) => {
-                tx.signature.len() > SIGNATURE_ELEMENT_LIMIT
-            }
             BroadcastedDeployAccountTransaction::V3(tx) => {
                 tx.signature.len() > SIGNATURE_ELEMENT_LIMIT
             }
@@ -119,12 +113,6 @@ pub(crate) fn map_broadcasted_transaction(
     };
 
     let deployed_address = match &transaction {
-        BroadcastedTransaction::DeployAccount(BroadcastedDeployAccountTransaction::V1(tx)) => {
-            Some(starknet_api::core::ContractAddress(
-                PatriciaKey::try_from(tx.deployed_contract_address().0.into_starkfelt())
-                    .expect("No sender address overflow expected"),
-            ))
-        }
         BroadcastedTransaction::DeployAccount(BroadcastedDeployAccountTransaction::V3(tx)) => {
             Some(starknet_api::core::ContractAddress(
                 PatriciaKey::try_from(tx.deployed_contract_address().0.into_starkfelt())
@@ -145,9 +133,6 @@ pub(crate) fn map_broadcasted_transaction(
             tx.version.has_query_version()
         }
         BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V3(tx)) => {
-            tx.version.has_query_version()
-        }
-        BroadcastedTransaction::DeployAccount(BroadcastedDeployAccountTransaction::V1(tx)) => {
             tx.version.has_query_version()
         }
         BroadcastedTransaction::DeployAccount(BroadcastedDeployAccountTransaction::V3(tx)) => {

--- a/crates/rpc/src/executor.rs
+++ b/crates/rpc/src/executor.rs
@@ -1,8 +1,5 @@
 use anyhow::Context;
-use pathfinder_common::class_definition::{
-    SerializedOpaqueClassDefinition,
-    SerializedSierraDefinition,
-};
+use pathfinder_common::class_definition::SerializedSierraDefinition;
 use pathfinder_common::transaction::TransactionVariant;
 use pathfinder_common::{BlockNumber, ChainId, StarknetVersion};
 use pathfinder_executor::types::to_starknet_api_transaction;
@@ -95,63 +92,6 @@ pub(crate) fn map_broadcasted_transaction(
     use crate::types::request::BroadcastedDeclareTransaction;
 
     let class_info = match &transaction {
-        BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V0(tx)) => {
-            let contract_class_json = tx
-                .contract_class
-                .serialize_to_json()
-                .context("Serializing Cairo class to JSON")?;
-
-            let contract_class = pathfinder_executor::parse_deprecated_class_definition(
-                SerializedOpaqueClassDefinition::from_vec(contract_class_json),
-            )?;
-
-            Some(ClassInfo::new(
-                &contract_class,
-                0,
-                0,
-                SierraVersion::DEPRECATED,
-            )?)
-        }
-        BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V1(tx)) => {
-            let contract_class_json = tx
-                .contract_class
-                .serialize_to_json()
-                .context("Serializing Cairo class to JSON")?;
-
-            let contract_class = pathfinder_executor::parse_deprecated_class_definition(
-                SerializedOpaqueClassDefinition::from_vec(contract_class_json),
-            )?;
-
-            Some(ClassInfo::new(
-                &contract_class,
-                0,
-                0,
-                SierraVersion::DEPRECATED,
-            )?)
-        }
-        BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V2(tx)) => {
-            let sierra_version =
-                SierraVersion::extract_from_program(&tx.contract_class.sierra_program)?;
-            let sierra_definition = SerializedSierraDefinition::from_vec(
-                serde_json::to_vec(&tx.contract_class)
-                    .context("Serializing Sierra class definition")?,
-            );
-            let casm_contract_definition = compiler
-                .compile_sierra_to_casm(&sierra_definition)
-                .context("Compiling Sierra class definition to CASM")?;
-
-            let casm_contract_definition = pathfinder_executor::parse_casm_definition(
-                casm_contract_definition,
-                sierra_version.clone(),
-            )
-            .context("Parsing CASM contract definition")?;
-            Some(ClassInfo::new(
-                &casm_contract_definition,
-                tx.contract_class.sierra_program.len(),
-                tx.contract_class.abi.len(),
-                sierra_version,
-            )?)
-        }
         BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V3(tx)) => {
             let sierra_version =
                 SierraVersion::extract_from_program(&tx.contract_class.sierra_program)?;
@@ -195,15 +135,6 @@ pub(crate) fn map_broadcasted_transaction(
     };
 
     let has_query_version = match &transaction {
-        BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V0(tx)) => {
-            tx.version.has_query_version()
-        }
-        BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V1(tx)) => {
-            tx.version.has_query_version()
-        }
-        BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V2(tx)) => {
-            tx.version.has_query_version()
-        }
         BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V3(tx)) => {
             tx.version.has_query_version()
         }

--- a/crates/rpc/src/executor.rs
+++ b/crates/rpc/src/executor.rs
@@ -41,8 +41,6 @@ pub(crate) fn calldata_limit_exceeded(tx: &BroadcastedTransaction) -> bool {
     match tx {
         BroadcastedTransaction::Declare(_) => false,
         BroadcastedTransaction::Invoke(broadcasted_invoke_tx) => match broadcasted_invoke_tx {
-            BroadcastedInvokeTransaction::V0(tx) => tx.calldata.len() > CALLDATA_LIMIT,
-            BroadcastedInvokeTransaction::V1(tx) => tx.calldata.len() > CALLDATA_LIMIT,
             BroadcastedInvokeTransaction::V3(tx) => tx.calldata.len() > CALLDATA_LIMIT,
         },
         BroadcastedTransaction::DeployAccount(broadcasted_deploy_tx) => match broadcasted_deploy_tx
@@ -58,8 +56,6 @@ pub(crate) fn signature_elem_limit_exceeded(tx: &BroadcastedTransaction) -> bool
     match tx {
         BroadcastedTransaction::Declare(_) => false,
         BroadcastedTransaction::Invoke(broadcasted_invoke_tx) => match broadcasted_invoke_tx {
-            BroadcastedInvokeTransaction::V0(tx) => tx.signature.len() > SIGNATURE_ELEMENT_LIMIT,
-            BroadcastedInvokeTransaction::V1(tx) => tx.signature.len() > SIGNATURE_ELEMENT_LIMIT,
             BroadcastedInvokeTransaction::V3(tx) => tx.signature.len() > SIGNATURE_ELEMENT_LIMIT,
         },
         BroadcastedTransaction::DeployAccount(broadcasted_deploy_tx) => match broadcasted_deploy_tx
@@ -124,12 +120,6 @@ pub(crate) fn map_broadcasted_transaction(
 
     let has_query_version = match &transaction {
         BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V3(tx)) => {
-            tx.version.has_query_version()
-        }
-        BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V0(tx)) => {
-            tx.version.has_query_version()
-        }
-        BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(tx)) => {
             tx.version.has_query_version()
         }
         BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V3(tx)) => {

--- a/crates/rpc/src/method/add_declare_transaction.rs
+++ b/crates/rpc/src/method/add_declare_transaction.rs
@@ -1,17 +1,8 @@
-use pathfinder_common::transaction::{
-    DeclareTransactionV0V1,
-    DeclareTransactionV2,
-    DeclareTransactionV3,
-    TransactionVariant,
-};
+use pathfinder_common::transaction::{DeclareTransactionV3, TransactionVariant};
 use pathfinder_common::{ClassHash, TransactionHash};
 use starknet_gateway_client::GatewayApi;
 use starknet_gateway_types::error::SequencerError;
-use starknet_gateway_types::request::add_transaction::{
-    CairoContractDefinition,
-    ContractDefinition,
-    SierraContractDefinition,
-};
+use starknet_gateway_types::request::add_transaction::SierraContractDefinition;
 
 use crate::context::RpcContext;
 use crate::types::request::BroadcastedDeclareTransaction;
@@ -222,86 +213,6 @@ pub async fn add_declare_transaction(
     use starknet_gateway_types::request::add_transaction;
 
     match input.declare_transaction {
-        Transaction::Declare(BroadcastedDeclareTransaction::V0(_)) => {
-            Err(AddDeclareTransactionError::UnsupportedTransactionVersion)
-        }
-        Transaction::Declare(BroadcastedDeclareTransaction::V1(tx)) => {
-            let contract_definition: CairoContractDefinition = tx
-                .contract_class
-                .try_into()
-                .map_err(|e| anyhow::anyhow!("Failed to convert contract definition: {e}"))?;
-
-            let response = context
-                .sequencer
-                .add_declare_transaction(
-                    add_transaction::Declare::V1(add_transaction::DeclareV0V1V2 {
-                        version: tx.version,
-                        max_fee: tx.max_fee,
-                        signature: &tx.signature,
-                        contract_class: ContractDefinition::Cairo(contract_definition),
-                        sender_address: tx.sender_address,
-                        nonce: tx.nonce,
-                        compiled_class_hash: None,
-                    }),
-                    input.token,
-                )
-                .await?;
-            let new_tx = DeclareTransactionV0V1 {
-                class_hash: response.class_hash,
-                max_fee: tx.max_fee,
-                nonce: tx.nonce,
-                signature: tx.signature,
-                sender_address: tx.sender_address,
-            };
-            context.submission_tracker.insert(
-                response.transaction_hash,
-                super::get_latest_block_or_genesis(&context.storage)?,
-                TransactionVariant::DeclareV1(new_tx),
-            );
-            Ok(Output {
-                transaction_hash: response.transaction_hash,
-                class_hash: response.class_hash,
-            })
-        }
-        Transaction::Declare(BroadcastedDeclareTransaction::V2(tx)) => {
-            let contract_definition: SierraContractDefinition = tx
-                .contract_class
-                .try_into()
-                .map_err(|e| anyhow::anyhow!("Failed to convert contract definition: {e}"))?;
-
-            let response = context
-                .sequencer
-                .add_declare_transaction(
-                    add_transaction::Declare::V2(add_transaction::DeclareV0V1V2 {
-                        version: tx.version,
-                        max_fee: tx.max_fee,
-                        signature: &tx.signature,
-                        contract_class: ContractDefinition::Sierra(contract_definition),
-                        sender_address: tx.sender_address,
-                        nonce: tx.nonce,
-                        compiled_class_hash: Some(tx.compiled_class_hash),
-                    }),
-                    input.token,
-                )
-                .await?;
-            let new_tx = DeclareTransactionV2 {
-                class_hash: response.class_hash,
-                max_fee: tx.max_fee,
-                nonce: tx.nonce,
-                signature: tx.signature,
-                sender_address: tx.sender_address,
-                compiled_class_hash: tx.compiled_class_hash,
-            };
-            context.submission_tracker.insert(
-                response.transaction_hash,
-                super::get_latest_block_or_genesis(&context.storage)?,
-                TransactionVariant::DeclareV2(new_tx),
-            );
-            Ok(Output {
-                transaction_hash: response.transaction_hash,
-                class_hash: response.class_hash,
-            })
-        }
         Transaction::Declare(BroadcastedDeclareTransaction::V3(tx)) => {
             let contract_class = tx.contract_class;
             let contract_definition: SierraContractDefinition =

--- a/crates/rpc/src/method/add_deploy_account_transaction.rs
+++ b/crates/rpc/src/method/add_deploy_account_transaction.rs
@@ -1,18 +1,11 @@
-use pathfinder_common::transaction::{
-    DeployAccountTransactionV1,
-    DeployAccountTransactionV3,
-    TransactionVariant,
-};
+use pathfinder_common::transaction::{DeployAccountTransactionV3, TransactionVariant};
 use pathfinder_common::{ContractAddress, TransactionHash};
 use serde::de::Error;
 use starknet_gateway_client::GatewayApi;
-use starknet_gateway_types::error::{KnownStarknetErrorCode, SequencerError};
+use starknet_gateway_types::error::SequencerError;
 
 use crate::context::RpcContext;
-use crate::types::request::{
-    BroadcastedDeployAccountTransaction,
-    BroadcastedDeployAccountTransactionV1,
-};
+use crate::types::request::BroadcastedDeployAccountTransaction;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Transaction {
@@ -187,74 +180,6 @@ pub(crate) async fn add_deploy_account_transaction_impl(
     use starknet_gateway_types::request::add_transaction;
 
     let success = match tx {
-        BroadcastedDeployAccountTransaction::V1(
-            tx @ BroadcastedDeployAccountTransactionV1 { version, .. },
-        ) if version.without_query_version() == 0 => {
-            let response = context
-                .sequencer
-                .add_deploy_account(add_transaction::DeployAccount::V0(
-                    add_transaction::DeployAccountV0V1 {
-                        max_fee: tx.max_fee,
-                        signature: &tx.signature,
-                        nonce: tx.nonce,
-                        class_hash: tx.class_hash,
-                        contract_address_salt: tx.contract_address_salt,
-                        constructor_calldata: &tx.constructor_calldata,
-                    },
-                ))
-                .await?;
-            let new_tx = DeployAccountTransactionV1 {
-                contract_address: tx.deployed_contract_address(),
-                max_fee: tx.max_fee,
-                signature: tx.signature,
-                nonce: tx.nonce,
-                contract_address_salt: tx.contract_address_salt,
-                constructor_calldata: tx.constructor_calldata,
-                class_hash: tx.class_hash,
-            };
-            (
-                response.transaction_hash,
-                TransactionVariant::DeployAccountV1(new_tx),
-            )
-        }
-        BroadcastedDeployAccountTransaction::V1(
-            tx @ BroadcastedDeployAccountTransactionV1 { version, .. },
-        ) if version.without_query_version() == 1 => {
-            let response = context
-                .sequencer
-                .add_deploy_account(add_transaction::DeployAccount::V1(
-                    add_transaction::DeployAccountV0V1 {
-                        max_fee: tx.max_fee,
-                        signature: &tx.signature,
-                        nonce: tx.nonce,
-                        class_hash: tx.class_hash,
-                        contract_address_salt: tx.contract_address_salt,
-                        constructor_calldata: &tx.constructor_calldata,
-                    },
-                ))
-                .await?;
-            let new_tx = DeployAccountTransactionV1 {
-                contract_address: tx.deployed_contract_address(),
-                max_fee: tx.max_fee,
-                signature: tx.signature,
-                nonce: tx.nonce,
-                contract_address_salt: tx.contract_address_salt,
-                constructor_calldata: tx.constructor_calldata,
-                class_hash: tx.class_hash,
-            };
-            (
-                response.transaction_hash,
-                TransactionVariant::DeployAccountV1(new_tx),
-            )
-        }
-        BroadcastedDeployAccountTransaction::V1(_) => {
-            return Err(SequencerError::StarknetError(
-                starknet_gateway_types::error::StarknetError {
-                    code: KnownStarknetErrorCode::InvalidTransactionVersion.into(),
-                    message: "".to_string(),
-                },
-            ));
-        }
         BroadcastedDeployAccountTransaction::V3(tx) => {
             let response = context
                 .sequencer

--- a/crates/rpc/src/method/add_invoke_transaction.rs
+++ b/crates/rpc/src/method/add_invoke_transaction.rs
@@ -1,9 +1,4 @@
-use pathfinder_common::transaction::{
-    InvokeTransactionV0,
-    InvokeTransactionV1,
-    InvokeTransactionV3,
-    TransactionVariant,
-};
+use pathfinder_common::transaction::{InvokeTransactionV3, TransactionVariant};
 use pathfinder_common::TransactionHash;
 use serde::de::Error;
 use starknet_gateway_client::GatewayApi;
@@ -186,59 +181,6 @@ pub(crate) async fn add_invoke_transaction_impl(
     use starknet_gateway_types::request::add_transaction;
 
     let success = match tx {
-        BroadcastedInvokeTransaction::V0(tx) => {
-            let response = context
-                .sequencer
-                .add_invoke_transaction(add_transaction::InvokeFunction::V0(
-                    add_transaction::InvokeFunctionV0V1 {
-                        max_fee: tx.max_fee,
-                        signature: &tx.signature,
-                        nonce: None,
-                        sender_address: tx.contract_address,
-                        entry_point_selector: Some(tx.entry_point_selector),
-                        calldata: &tx.calldata,
-                    },
-                ))
-                .await?;
-            let new_tx = InvokeTransactionV0 {
-                calldata: tx.calldata,
-                sender_address: tx.contract_address,
-                entry_point_selector: tx.entry_point_selector,
-                entry_point_type: None,
-                max_fee: tx.max_fee,
-                signature: tx.signature,
-            };
-            (
-                response.transaction_hash,
-                TransactionVariant::InvokeV0(new_tx),
-            )
-        }
-        BroadcastedInvokeTransaction::V1(tx) => {
-            let response = context
-                .sequencer
-                .add_invoke_transaction(add_transaction::InvokeFunction::V1(
-                    add_transaction::InvokeFunctionV0V1 {
-                        max_fee: tx.max_fee,
-                        signature: &tx.signature,
-                        nonce: Some(tx.nonce),
-                        sender_address: tx.sender_address,
-                        entry_point_selector: None,
-                        calldata: &tx.calldata,
-                    },
-                ))
-                .await?;
-            let new_tx = InvokeTransactionV1 {
-                calldata: tx.calldata,
-                sender_address: tx.sender_address,
-                max_fee: tx.max_fee,
-                signature: tx.signature,
-                nonce: tx.nonce,
-            };
-            (
-                response.transaction_hash,
-                TransactionVariant::InvokeV1(new_tx),
-            )
-        }
         BroadcastedInvokeTransaction::V3(tx) => {
             let response = context
                 .sequencer

--- a/crates/rpc/src/method/estimate_fee.rs
+++ b/crates/rpc/src/method/estimate_fee.rs
@@ -247,8 +247,6 @@ mod tests {
         BroadcastedDeclareTransactionV3,
         BroadcastedDeployAccountTransactionV3,
         BroadcastedInvokeTransaction,
-        BroadcastedInvokeTransactionV0,
-        BroadcastedInvokeTransactionV1,
         BroadcastedInvokeTransactionV3,
         BroadcastedTransaction,
     };

--- a/crates/rpc/src/method/estimate_fee.rs
+++ b/crates/rpc/src/method/estimate_fee.rs
@@ -244,7 +244,6 @@ mod tests {
     use crate::types::class::sierra::SierraContractClass;
     use crate::types::request::{
         BroadcastedDeclareTransaction,
-        BroadcastedDeclareTransactionV2,
         BroadcastedDeclareTransactionV3,
         BroadcastedDeployAccountTransactionV3,
         BroadcastedInvokeTransaction,

--- a/crates/rpc/src/method/estimate_fee.rs
+++ b/crates/rpc/src/method/estimate_fee.rs
@@ -293,16 +293,20 @@ mod tests {
         account_contract_address: ContractAddress,
         universal_deployer_address: ContractAddress,
     ) -> BroadcastedTransaction {
-        let max_fee = Fee::default();
         let sierra_hash =
             class_hash!("0x0544b92d358447cb9e50b65092b7169f931d29e05c1404a2cd08c6fd7e32ba90");
 
-        BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(
-            BroadcastedInvokeTransactionV1 {
-                nonce: transaction_nonce!("0x1"),
-                version: TransactionVersion::ONE,
-                max_fee,
+        BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V3(
+            BroadcastedInvokeTransactionV3 {
+                version: TransactionVersion::THREE,
                 signature: vec![],
+                nonce: transaction_nonce!("0x1"),
+                resource_bounds: ResourceBounds::default(),
+                tip: Tip(0),
+                paymaster_data: vec![],
+                account_deployment_data: vec![],
+                nonce_data_availability_mode: DataAvailabilityMode::L1,
+                fee_data_availability_mode: DataAvailabilityMode::L1,
                 sender_address: account_contract_address,
                 calldata: vec![
                     // Number of calls
@@ -323,51 +327,8 @@ mod tests {
                     // calldata_len
                     call_param!("0x0"),
                 ],
-            },
-        ))
-    }
-
-    fn invoke_transaction(account_contract_address: ContractAddress) -> BroadcastedTransaction {
-        let max_fee = Fee::default();
-
-        BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(
-            BroadcastedInvokeTransactionV1 {
-                nonce: transaction_nonce!("0x2"),
-                version: TransactionVersion::ONE,
-                max_fee,
-                signature: vec![],
-                sender_address: account_contract_address,
-                calldata: vec![
-                    // Number of calls
-                    call_param!("0x1"),
-                    // address of the deployed test contract
-                    CallParam(felt!(
-                        "0x012592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7"
-                    )),
-                    // Entry point selector for the called contract, i.e.
-                    // AccountCallArray::selector
-                    CallParam(EntryPoint::hashed(b"get_data").0),
-                    // Length of the call data for the called contract, i.e.
-                    // AccountCallArray::data_len
-                    call_param!("0x0"),
-                ],
-            },
-        ))
-    }
-
-    fn invoke_v0_transaction() -> BroadcastedTransaction {
-        let max_fee = Fee::default();
-
-        BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V0(
-            BroadcastedInvokeTransactionV0 {
-                version: TransactionVersion::ONE,
-                max_fee,
-                signature: vec![],
-                contract_address: contract_address!(
-                    "0x012592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7"
-                ),
-                entry_point_selector: EntryPoint::hashed(b"get_data"),
-                calldata: vec![],
+                proof_facts: vec![],
+                proof: Default::default(),
             },
         ))
     }
@@ -392,7 +353,7 @@ mod tests {
                     // AccountCallArray::data_len
                     call_param!("0x0"),
                 ],
-                nonce: transaction_nonce!("0x3"),
+                nonce: transaction_nonce!("0x2"),
                 resource_bounds: ResourceBounds::default(),
                 tip: Tip(0),
                 paymaster_data: vec![],
@@ -422,18 +383,12 @@ mod tests {
         let deploy_transaction =
             deploy_transaction(account_contract_address, universal_deployer_address);
         // invoke deployed contract
-        let invoke_transaction = invoke_transaction(account_contract_address);
-        // do the same invoke with a v0 transaction
-        let invoke_v0_transaction = invoke_v0_transaction();
-        // do the same invoke with a v3 transaction
         let invoke_v3_transaction = invoke_v3_transaction(account_contract_address);
 
         let input = Input {
             request: vec![
                 declare_transaction,
                 deploy_transaction,
-                invoke_transaction,
-                invoke_v0_transaction,
                 invoke_v3_transaction,
             ],
             simulation_flags: vec![],
@@ -466,18 +421,12 @@ mod tests {
         let deploy_transaction =
             deploy_transaction(account_contract_address, universal_deployer_address);
         // invoke deployed contract
-        let invoke_transaction = invoke_transaction(account_contract_address);
-        // do the same invoke with a v0 transaction
-        let invoke_v0_transaction = invoke_v0_transaction();
-        // do the same invoke with a v3 transaction
         let invoke_v3_transaction = invoke_v3_transaction(account_contract_address);
 
         let input = Input {
             request: vec![
                 declare_transaction,
                 deploy_transaction,
-                invoke_transaction,
-                invoke_v0_transaction,
                 invoke_v3_transaction,
             ],
             simulation_flags: vec![],
@@ -510,18 +459,12 @@ mod tests {
         let deploy_transaction =
             deploy_transaction(account_contract_address, universal_deployer_address);
         // invoke deployed contract
-        let invoke_transaction = invoke_transaction(account_contract_address);
-        // do the same invoke with a v0 transaction
-        let invoke_v0_transaction = invoke_v0_transaction();
-        // do the same invoke with a v3 transaction
         let invoke_v3_transaction = invoke_v3_transaction(account_contract_address);
 
         let input = Input {
             request: vec![
                 declare_transaction,
                 deploy_transaction,
-                invoke_transaction,
-                invoke_v0_transaction,
                 invoke_v3_transaction,
             ],
             simulation_flags: vec![],
@@ -556,18 +499,12 @@ mod tests {
         let deploy_transaction =
             deploy_transaction(account_contract_address, universal_deployer_address);
         // invoke deployed contract
-        let invoke_transaction = invoke_transaction(account_contract_address);
-        // do the same invoke with a v0 transaction
-        let invoke_v0_transaction = invoke_v0_transaction();
-        // do the same invoke with a v3 transaction
         let invoke_v3_transaction = invoke_v3_transaction(account_contract_address);
 
         let input = Input {
             request: vec![
                 declare_transaction,
                 deploy_transaction,
-                invoke_transaction,
-                invoke_v0_transaction,
                 invoke_v3_transaction,
             ],
             simulation_flags: vec![],

--- a/crates/rpc/src/method/estimate_fee.rs
+++ b/crates/rpc/src/method/estimate_fee.rs
@@ -273,17 +273,20 @@ mod tests {
 
         assert_eq!(contract_class.class_hash().unwrap().hash(), sierra_hash);
 
-        let max_fee = Fee::default();
-
-        BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V2(
-            BroadcastedDeclareTransactionV2 {
-                version: TransactionVersion::TWO,
-                max_fee,
+        BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V3(
+            BroadcastedDeclareTransactionV3 {
+                version: TransactionVersion::THREE,
                 signature: vec![],
-                nonce: TransactionNonce(Default::default()),
+                nonce: transaction_nonce!("0x0"),
+                resource_bounds: ResourceBounds::default(),
+                tip: Tip(0),
+                paymaster_data: vec![],
+                account_deployment_data: vec![],
+                nonce_data_availability_mode: DataAvailabilityMode::L1,
+                fee_data_availability_mode: DataAvailabilityMode::L1,
+                compiled_class_hash: casm_hash,
                 contract_class,
                 sender_address: account_contract_address,
-                compiled_class_hash: casm_hash,
             },
         ))
     }

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -305,7 +305,7 @@ pub(crate) mod tests {
     use starknet_gateway_test_fixtures::class_definitions::ERC20_CONTRACT_DEFINITION_CLASS_HASH;
 
     use super::simulate_transactions;
-    use crate::context::{RpcContext, ETH_FEE_TOKEN_ADDRESS};
+    use crate::context::{RpcContext, ETH_FEE_TOKEN_ADDRESS, STRK_FEE_TOKEN_ADDRESS};
     use crate::dto::{DeserializeForVersion, SerializeForVersion, Serializer};
     use crate::executor::{CALLDATA_LIMIT, SIGNATURE_ELEMENT_LIMIT};
     use crate::method::simulate_transactions::{
@@ -596,12 +596,24 @@ pub(crate) mod tests {
 
                 assert_eq!(contract_class.class_hash().unwrap().hash(), SIERRA_HASH);
 
-                BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V2(
-                    BroadcastedDeclareTransactionV2 {
-                        version: TransactionVersion::TWO,
-                        max_fee: MAX_FEE,
+                BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V3(
+                    BroadcastedDeclareTransactionV3 {
+                        version: TransactionVersion::THREE,
                         signature: vec![],
                         nonce: transaction_nonce!("0x0"),
+                        resource_bounds: ResourceBounds {
+                            l1_gas: ResourceBound {
+                                max_amount: ResourceAmount(100000),
+                                max_price_per_unit: ResourcePricePerUnit(10),
+                            },
+                            l2_gas: Default::default(),
+                            l1_data_gas: Default::default(),
+                        },
+                        tip: Tip(0),
+                        paymaster_data: vec![],
+                        account_deployment_data: vec![],
+                        nonce_data_availability_mode: DataAvailabilityMode::L1,
+                        fee_data_availability_mode: DataAvailabilityMode::L1,
                         contract_class,
                         sender_address: account_contract_address,
                         compiled_class_hash: CASM_HASH,
@@ -810,7 +822,7 @@ pub(crate) mod tests {
 
             use super::*;
 
-            const DECLARE_OVERALL_FEE: u64 = 1262;
+            const DECLARE_OVERALL_FEE: u64 = 2140;
             const DECLARE_GAS_CONSUMED: u64 = 878;
             const DECLARE_DATA_GAS_CONSUMED: u64 = 192;
 
@@ -821,13 +833,13 @@ pub(crate) mod tests {
                 pathfinder_executor::types::TransactionSimulation {
                     fee_estimation: pathfinder_executor::types::FeeEstimate {
                         l1_gas_consumed: DECLARE_GAS_CONSUMED.into(),
-                        l1_gas_price: 1.into(),
+                        l1_gas_price: 2.into(),
                         l1_data_gas_consumed: DECLARE_DATA_GAS_CONSUMED.into(),
                         l1_data_gas_price: 2.into(),
                         l2_gas_consumed: 0.into(),
                         l2_gas_price: 1.into(),
                         overall_fee: DECLARE_OVERALL_FEE.into(),
-                        unit: pathfinder_executor::types::PriceUnit::Wei,
+                        unit: pathfinder_executor::types::PriceUnit::Fri,
                     },
                     trace: pathfinder_executor::types::TransactionTrace::Declare(
                         pathfinder_executor::types::DeclareTransactionTrace {
@@ -905,10 +917,10 @@ pub(crate) mod tests {
             }
 
             fn declare_fee_transfer_storage_diffs() -> Vec<StorageDiffs> {
-                vec![(ETH_FEE_TOKEN_ADDRESS, vec![
+                vec![(STRK_FEE_TOKEN_ADDRESS, vec![
                         StorageDiff {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: storage_value!("0x000000000000000000000000000000000000fffffffffffffffffffffffffb12")
+                            value: storage_value!("0x000000000000000000000000000000000000fffffffffffffffffffffffff7a4")
                         },
                         StorageDiff {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
@@ -944,7 +956,7 @@ pub(crate) mod tests {
                         Felt::from_u64(DECLARE_OVERALL_FEE),
                         felt!("0x0"),
                     ],
-                    contract_address: ETH_FEE_TOKEN_ADDRESS,
+                    contract_address: STRK_FEE_TOKEN_ADDRESS,
                     selector: Some(EntryPoint::hashed(b"transfer").0),
                     internal_calls: vec![],
                     messages: vec![],
@@ -1102,11 +1114,11 @@ pub(crate) mod tests {
                     vec![
                         StorageDiff {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: StorageValue((0xfffffffffffffffffffffffff93fu128 + u128::from(overall_fee_correction)).into()),
+                            value: StorageValue((0xfffffffffffffffffffffffffe2du128 + u128::from(overall_fee_correction)).into()),
                         },
                         StorageDiff {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
-                            value: StorageValue((DECLARE_OVERALL_FEE + UNIVERSAL_DEPLOYER_OVERALL_FEE - overall_fee_correction).into()),
+                            value: StorageValue((UNIVERSAL_DEPLOYER_OVERALL_FEE - overall_fee_correction).into()),
                         },
                     ],
                     )]
@@ -1408,11 +1420,11 @@ pub(crate) mod tests {
                     vec![
                         StorageDiff {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: StorageValue((0xfffffffffffffffffffffffff831u128 + u128::from(2 * overall_fee_correction)).into()),
+                            value: StorageValue((0xfffffffffffffffffffffffffd1fu128 + u128::from(2 * overall_fee_correction)).into()),
                         },
                         StorageDiff {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
-                            value: StorageValue((DECLARE_OVERALL_FEE + UNIVERSAL_DEPLOYER_OVERALL_FEE + INVOKE_OVERALL_FEE - 2 * overall_fee_correction).into()),
+                            value: StorageValue((UNIVERSAL_DEPLOYER_OVERALL_FEE + INVOKE_OVERALL_FEE - 2 * overall_fee_correction).into()),
                         },
                     ],
                     )]
@@ -1552,7 +1564,7 @@ pub(crate) mod tests {
 
             use super::*;
 
-            const DECLARE_OVERALL_FEE: u64 = 1266;
+            const DECLARE_OVERALL_FEE: u64 = 2148;
             const DECLARE_GAS_CONSUMED: u64 = 882;
             const DECLARE_DATA_GAS_CONSUMED: u64 = 192;
             pub fn declare(
@@ -1562,13 +1574,13 @@ pub(crate) mod tests {
                 pathfinder_executor::types::TransactionSimulation {
                     fee_estimation: pathfinder_executor::types::FeeEstimate {
                         l1_gas_consumed: DECLARE_GAS_CONSUMED.into(),
-                        l1_gas_price: 1.into(),
+                        l1_gas_price: 2.into(),
                         l1_data_gas_consumed: DECLARE_DATA_GAS_CONSUMED.into(),
                         l1_data_gas_price: 2.into(),
                         l2_gas_consumed: 0.into(),
                         l2_gas_price: 1.into(),
                         overall_fee: DECLARE_OVERALL_FEE.into(),
-                        unit: pathfinder_executor::types::PriceUnit::Wei,
+                        unit: pathfinder_executor::types::PriceUnit::Fri,
                     },
                     trace: pathfinder_executor::types::TransactionTrace::Declare(
                         pathfinder_executor::types::DeclareTransactionTrace {
@@ -1647,11 +1659,11 @@ pub(crate) mod tests {
 
             fn declare_fee_transfer_storage_diffs() -> Vec<StorageDiffs> {
                 vec![(
-                    ETH_FEE_TOKEN_ADDRESS,
+                    STRK_FEE_TOKEN_ADDRESS,
                     vec![
                         StorageDiff {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: storage_value!("0x000000000000000000000000000000000000fffffffffffffffffffffffffb12")
+                            value: storage_value!("0x000000000000000000000000000000000000fffffffffffffffffffffffff79c")
                         },
                         StorageDiff {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
@@ -1687,7 +1699,7 @@ pub(crate) mod tests {
                         Felt::from_u64(DECLARE_OVERALL_FEE),
                         felt!("0x0"),
                     ],
-                    contract_address: ETH_FEE_TOKEN_ADDRESS,
+                    contract_address: STRK_FEE_TOKEN_ADDRESS,
                     selector: Some(EntryPoint::hashed(b"transfer").0),
                     internal_calls: vec![],
                     messages: vec![],
@@ -1844,11 +1856,11 @@ pub(crate) mod tests {
                     vec![
                         StorageDiff {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: StorageValue((0xfffffffffffffffffffffffff93fu128 + u128::from(overall_fee_correction)).into()),
+                            value: StorageValue((0xfffffffffffffffffffffffffe2du128 + u128::from(overall_fee_correction)).into()),
                         },
                         StorageDiff {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
-                            value: StorageValue((DECLARE_OVERALL_FEE + UNIVERSAL_DEPLOYER_OVERALL_FEE - overall_fee_correction).into()),
+                            value: StorageValue((UNIVERSAL_DEPLOYER_OVERALL_FEE - overall_fee_correction).into()),
                         },
                     ],
                     )]
@@ -2150,11 +2162,11 @@ pub(crate) mod tests {
                     vec![
                         StorageDiff {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: StorageValue((0xfffffffffffffffffffffffff831u128 + u128::from(2 * overall_fee_correction)).into()),
+                            value: StorageValue((0xfffffffffffffffffffffffffd1fu128 + u128::from(2 * overall_fee_correction)).into()),
                         },
                         StorageDiff {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
-                            value: StorageValue((DECLARE_OVERALL_FEE + UNIVERSAL_DEPLOYER_OVERALL_FEE + INVOKE_OVERALL_FEE - 2 * overall_fee_correction).into()),
+                            value: StorageValue((UNIVERSAL_DEPLOYER_OVERALL_FEE + INVOKE_OVERALL_FEE - 2 * overall_fee_correction).into()),
                         },
                     ],
                     )]

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -305,7 +305,7 @@ pub(crate) mod tests {
     use starknet_gateway_test_fixtures::class_definitions::ERC20_CONTRACT_DEFINITION_CLASS_HASH;
 
     use super::simulate_transactions;
-    use crate::context::{RpcContext, ETH_FEE_TOKEN_ADDRESS, STRK_FEE_TOKEN_ADDRESS};
+    use crate::context::{RpcContext, STRK_FEE_TOKEN_ADDRESS};
     use crate::dto::{DeserializeForVersion, SerializeForVersion, Serializer};
     use crate::executor::{CALLDATA_LIMIT, SIGNATURE_ELEMENT_LIMIT};
     use crate::method::simulate_transactions::{
@@ -549,7 +549,7 @@ pub(crate) mod tests {
     }
 
     pub(crate) mod fixtures {
-        use pathfinder_common::{CasmHash, ContractAddress, Fee};
+        use pathfinder_common::{CasmHash, ContractAddress};
         use pathfinder_executor::types::StorageDiff;
 
         use super::*;
@@ -562,7 +562,6 @@ pub(crate) mod tests {
             casm_hash!("0x069032ff71f77284e1a0864a573007108ca5cc08089416af50f03260f5d6d4d8");
         pub const CASM_DEFINITION: &[u8] =
             include_bytes!("../../fixtures/contracts/storage_access.casm");
-        const MAX_FEE: Fee = Fee(Felt::from_u64(10_000_000));
         pub const DEPLOYED_CONTRACT_ADDRESS: ContractAddress =
             contract_address!("0x012592426632af714f43ccb05536b6044fc3e897fa55288f658731f93590e7e7");
         pub const UNIVERSAL_DEPLOYER_CLASS_HASH: ClassHash =
@@ -581,7 +580,6 @@ pub(crate) mod tests {
             use crate::types::request::{
                 BroadcastedDeclareTransactionV3,
                 BroadcastedInvokeTransaction,
-                BroadcastedInvokeTransactionV1,
                 BroadcastedInvokeTransactionV3,
                 BroadcastedTransaction,
             };
@@ -675,12 +673,27 @@ pub(crate) mod tests {
                 universal_deployer_address: ContractAddress,
                 contract_hash: ClassHash,
             ) -> BroadcastedTransaction {
-                BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(
-                    BroadcastedInvokeTransactionV1 {
-                        nonce: transaction_nonce!("0x1"),
-                        version: TransactionVersion::ONE,
-                        max_fee: MAX_FEE,
+                BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V3(
+                    BroadcastedInvokeTransactionV3 {
+                        version: TransactionVersion::THREE,
                         signature: vec![],
+                        nonce: transaction_nonce!("0x1"),
+                        resource_bounds: ResourceBounds {
+                            l1_gas: ResourceBound {
+                                max_amount: ResourceAmount(10000),
+                                max_price_per_unit: ResourcePricePerUnit(100000000),
+                            },
+                            l2_gas: ResourceBound {
+                                max_amount: ResourceAmount(10000),
+                                max_price_per_unit: ResourcePricePerUnit(100000000),
+                            },
+                            l1_data_gas: None,
+                        },
+                        tip: Tip(0),
+                        paymaster_data: vec![],
+                        account_deployment_data: vec![],
+                        nonce_data_availability_mode: DataAvailabilityMode::L1,
+                        fee_data_availability_mode: DataAvailabilityMode::L1,
                         sender_address: account_contract_address,
                         calldata: vec![
                             // Number of calls
@@ -701,17 +714,34 @@ pub(crate) mod tests {
                             // calldata_len
                             call_param!("0x0"),
                         ],
+                        proof_facts: vec![],
+                        proof: Default::default(),
                     },
                 ))
             }
 
             pub fn invoke(account_contract_address: ContractAddress) -> BroadcastedTransaction {
-                BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(
-                    BroadcastedInvokeTransactionV1 {
-                        nonce: transaction_nonce!("0x2"),
-                        version: TransactionVersion::ONE,
-                        max_fee: MAX_FEE,
+                BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V3(
+                    BroadcastedInvokeTransactionV3 {
+                        version: TransactionVersion::THREE,
                         signature: vec![],
+                        nonce: transaction_nonce!("0x2"),
+                        resource_bounds: ResourceBounds {
+                            l1_gas: ResourceBound {
+                                max_amount: ResourceAmount(10000),
+                                max_price_per_unit: ResourcePricePerUnit(100000000),
+                            },
+                            l2_gas: ResourceBound {
+                                max_amount: ResourceAmount(10000),
+                                max_price_per_unit: ResourcePricePerUnit(100000000),
+                            },
+                            l1_data_gas: None,
+                        },
+                        tip: Tip(0),
+                        paymaster_data: vec![],
+                        account_deployment_data: vec![],
+                        nonce_data_availability_mode: DataAvailabilityMode::L1,
+                        fee_data_availability_mode: DataAvailabilityMode::L1,
                         sender_address: account_contract_address,
                         calldata: vec![
                             // Number of calls
@@ -724,6 +754,8 @@ pub(crate) mod tests {
                             // AccountCallArray::data_len
                             call_param!("0x0"),
                         ],
+                        proof_facts: vec![],
+                        proof: Default::default(),
                     },
                 ))
             }
@@ -994,7 +1026,7 @@ pub(crate) mod tests {
                 }
             }
 
-            const UNIVERSAL_DEPLOYER_OVERALL_FEE: u64 = 467;
+            const UNIVERSAL_DEPLOYER_OVERALL_FEE: u64 = 486;
             const UNIVERSAL_DEPLOYER_GAS_CONSUMED: u64 = 19;
             const UNIVERSAL_DEPLOYER_DATA_GAS_CONSUMED: u64 = 224;
             pub fn universal_deployer(
@@ -1110,15 +1142,15 @@ pub(crate) mod tests {
                 overall_fee_correction: u64,
             ) -> Vec<StorageDiffs> {
                 vec![(
-                    ETH_FEE_TOKEN_ADDRESS,
+                    STRK_FEE_TOKEN_ADDRESS,
                     vec![
                         StorageDiff {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: StorageValue((0xfffffffffffffffffffffffffe2du128 + u128::from(overall_fee_correction)).into()),
+                            value: StorageValue((0xfffffffffffffffffffffffff5beu128 + u128::from(overall_fee_correction)).into()),
                         },
                         StorageDiff {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
-                            value: StorageValue((UNIVERSAL_DEPLOYER_OVERALL_FEE - overall_fee_correction).into()),
+                            value: StorageValue((DECLARE_OVERALL_FEE + UNIVERSAL_DEPLOYER_OVERALL_FEE - overall_fee_correction).into()),
                         },
                     ],
                     )]
@@ -1300,7 +1332,7 @@ pub(crate) mod tests {
                         // calldata_len
                         call_param!("0x0").0,
                     ],
-                    contract_address: ETH_FEE_TOKEN_ADDRESS,
+                    contract_address: STRK_FEE_TOKEN_ADDRESS,
                     selector: Some(EntryPoint::hashed(b"transfer").0),
                     messages: vec![],
                     result: vec![felt!("0x1")],
@@ -1313,7 +1345,7 @@ pub(crate) mod tests {
                 }
             }
 
-            const INVOKE_OVERALL_FEE: u64 = 270;
+            const INVOKE_OVERALL_FEE: u64 = 284;
             const INVOKE_GAS_CONSUMED: u64 = 14;
             const INVOKE_DATA_GAS_CONSUMED: u64 = 128;
             pub fn invoke(
@@ -1416,15 +1448,15 @@ pub(crate) mod tests {
             }
 
             fn invoke_fee_transfer_storage_diffs(overall_fee_correction: u64) -> Vec<StorageDiffs> {
-                vec![(ETH_FEE_TOKEN_ADDRESS,
+                vec![(STRK_FEE_TOKEN_ADDRESS,
                     vec![
                         StorageDiff {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: StorageValue((0xfffffffffffffffffffffffffd1fu128 + u128::from(2 * overall_fee_correction)).into()),
+                            value: StorageValue((0xfffffffffffffffffffffffff4a2u128 + u128::from(2 * overall_fee_correction)).into()),
                         },
                         StorageDiff {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
-                            value: StorageValue((UNIVERSAL_DEPLOYER_OVERALL_FEE + INVOKE_OVERALL_FEE - 2 * overall_fee_correction).into()),
+                            value: StorageValue((DECLARE_OVERALL_FEE + UNIVERSAL_DEPLOYER_OVERALL_FEE + INVOKE_OVERALL_FEE - 2 * overall_fee_correction).into()),
                         },
                     ],
                     )]
@@ -1544,7 +1576,7 @@ pub(crate) mod tests {
                         Felt::from_u64(INVOKE_OVERALL_FEE - overall_fee_correction),
                         call_param!("0x0").0,
                     ],
-                    contract_address: ETH_FEE_TOKEN_ADDRESS,
+                    contract_address: STRK_FEE_TOKEN_ADDRESS,
                     selector: Some(EntryPoint::hashed(b"transfer").0),
                     messages: vec![],
                     result: vec![felt!("0x1")],
@@ -1737,7 +1769,7 @@ pub(crate) mod tests {
                 }
             }
 
-            const UNIVERSAL_DEPLOYER_OVERALL_FEE: u64 = 473;
+            const UNIVERSAL_DEPLOYER_OVERALL_FEE: u64 = 498;
             const UNIVERSAL_DEPLOYER_GAS_CONSUMED: u64 = 19;
             const UNIVERSAL_DEPLOYER_DATA_GAS_CONSUMED: u64 = 224;
             pub fn universal_deployer(
@@ -1852,15 +1884,15 @@ pub(crate) mod tests {
             fn universal_deployer_fee_transfer_storage_diffs(
                 overall_fee_correction: u64,
             ) -> Vec<StorageDiffs> {
-                vec![(ETH_FEE_TOKEN_ADDRESS,
+                vec![(STRK_FEE_TOKEN_ADDRESS,
                     vec![
                         StorageDiff {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: StorageValue((0xfffffffffffffffffffffffffe2du128 + u128::from(overall_fee_correction)).into()),
+                            value: StorageValue((0xfffffffffffffffffffffffff5beu128 + u128::from(overall_fee_correction)).into()),
                         },
                         StorageDiff {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
-                            value: StorageValue((UNIVERSAL_DEPLOYER_OVERALL_FEE - overall_fee_correction).into()),
+                            value: StorageValue((DECLARE_OVERALL_FEE + UNIVERSAL_DEPLOYER_OVERALL_FEE - overall_fee_correction).into()),
                         },
                     ],
                     )]
@@ -2042,7 +2074,7 @@ pub(crate) mod tests {
                         // calldata_len
                         call_param!("0x0").0,
                     ],
-                    contract_address: ETH_FEE_TOKEN_ADDRESS,
+                    contract_address: STRK_FEE_TOKEN_ADDRESS,
                     selector: Some(EntryPoint::hashed(b"transfer").0),
                     messages: vec![],
                     result: vec![felt!("0x1")],
@@ -2055,7 +2087,7 @@ pub(crate) mod tests {
                 }
             }
 
-            const INVOKE_OVERALL_FEE: u64 = 275;
+            const INVOKE_OVERALL_FEE: u64 = 294;
             const INVOKE_GAS_CONSUMED: u64 = 14;
             const INVOKE_DATA_GAS_CONSUMED: u64 = 128;
             pub fn invoke(
@@ -2158,15 +2190,15 @@ pub(crate) mod tests {
             }
 
             fn invoke_fee_transfer_storage_diffs(overall_fee_correction: u64) -> Vec<StorageDiffs> {
-                vec![(ETH_FEE_TOKEN_ADDRESS,
+                vec![(STRK_FEE_TOKEN_ADDRESS,
                     vec![
                         StorageDiff {
                             key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                            value: StorageValue((0xfffffffffffffffffffffffffd1fu128 + u128::from(2 * overall_fee_correction)).into()),
+                            value: StorageValue((0xfffffffffffffffffffffffff4a2u128 + u128::from(2 * overall_fee_correction)).into()),
                         },
                         StorageDiff {
                             key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
-                            value: StorageValue((UNIVERSAL_DEPLOYER_OVERALL_FEE + INVOKE_OVERALL_FEE - 2 * overall_fee_correction).into()),
+                            value: StorageValue((DECLARE_OVERALL_FEE + UNIVERSAL_DEPLOYER_OVERALL_FEE + INVOKE_OVERALL_FEE - 2 * overall_fee_correction).into()),
                         },
                     ],
                     )]
@@ -2286,7 +2318,7 @@ pub(crate) mod tests {
                         Felt::from_u64(INVOKE_OVERALL_FEE - overall_fee_correction),
                         call_param!("0x0").0,
                     ],
-                    contract_address: ETH_FEE_TOKEN_ADDRESS,
+                    contract_address: STRK_FEE_TOKEN_ADDRESS,
                     selector: Some(EntryPoint::hashed(b"transfer").0),
                     messages: vec![],
                     result: vec![felt!("0x1")],
@@ -2645,7 +2677,7 @@ pub(crate) mod tests {
 
     #[test_log::test(tokio::test)]
     async fn calldata_limit_exceeded() {
-        use crate::types::request::{BroadcastedInvokeTransaction, BroadcastedInvokeTransactionV1};
+        use crate::types::request::{BroadcastedInvokeTransaction, BroadcastedInvokeTransactionV3};
 
         let (storage, last_block_header, account_contract_address, _, _) =
             setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 4, 0)).await;
@@ -2653,15 +2685,22 @@ pub(crate) mod tests {
 
         let input = SimulateTransactionInput {
             transactions: vec![BroadcastedTransaction::Invoke(
-                BroadcastedInvokeTransaction::V1(BroadcastedInvokeTransactionV1 {
+                BroadcastedInvokeTransaction::V3(BroadcastedInvokeTransactionV3 {
                     // Calldata length over the limit, the rest of the fields should not matter.
                     calldata: vec![call_param!("0x123"); CALLDATA_LIMIT + 5],
 
                     nonce: transaction_nonce!("0x1"),
-                    version: TransactionVersion::ONE,
-                    max_fee: Fee::default(),
+                    version: TransactionVersion::THREE,
                     signature: vec![],
                     sender_address: account_contract_address,
+                    resource_bounds: ResourceBounds::default(),
+                    tip: Tip(0),
+                    paymaster_data: vec![],
+                    account_deployment_data: vec![],
+                    nonce_data_availability_mode: DataAvailabilityMode::L1,
+                    fee_data_availability_mode: DataAvailabilityMode::L1,
+                    proof_facts: vec![],
+                    proof: Default::default(),
                 }),
             )],
             block_id: BlockId::Number(last_block_header.number),
@@ -2678,7 +2717,7 @@ pub(crate) mod tests {
 
     #[test_log::test(tokio::test)]
     async fn signature_element_limit_exceeded() {
-        use crate::types::request::{BroadcastedInvokeTransaction, BroadcastedInvokeTransactionV1};
+        use crate::types::request::{BroadcastedInvokeTransaction, BroadcastedInvokeTransactionV3};
 
         let (storage, last_block_header, account_contract_address, _, _) =
             setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 4, 0)).await;
@@ -2686,7 +2725,7 @@ pub(crate) mod tests {
 
         let input = SimulateTransactionInput {
             transactions: vec![BroadcastedTransaction::Invoke(
-                BroadcastedInvokeTransaction::V1(BroadcastedInvokeTransactionV1 {
+                BroadcastedInvokeTransaction::V3(BroadcastedInvokeTransactionV3 {
                     // Signature length over the limit, the rest of the fields should not matter.
                     signature: vec![
                         transaction_signature_elem!("0x123");
@@ -2694,10 +2733,17 @@ pub(crate) mod tests {
                     ],
 
                     nonce: transaction_nonce!("0x1"),
-                    version: TransactionVersion::ONE,
-                    max_fee: Fee::default(),
+                    version: TransactionVersion::THREE,
                     sender_address: account_contract_address,
                     calldata: vec![],
+                    resource_bounds: ResourceBounds::default(),
+                    tip: Tip(0),
+                    paymaster_data: vec![],
+                    account_deployment_data: vec![],
+                    nonce_data_availability_mode: DataAvailabilityMode::L1,
+                    fee_data_availability_mode: DataAvailabilityMode::L1,
+                    proof_facts: vec![],
+                    proof: Default::default(),
                 }),
             )],
             block_id: BlockId::Number(last_block_header.number),

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -314,7 +314,6 @@ pub(crate) mod tests {
     };
     use crate::types::request::{
         BroadcastedDeclareTransaction,
-        BroadcastedDeclareTransactionV1,
         BroadcastedDeployAccountTransaction,
         BroadcastedDeployAccountTransactionV3,
         BroadcastedTransaction,
@@ -549,187 +548,6 @@ pub(crate) mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn declare_cairo_v0_class() {
-        pub const CAIRO0_DEFINITION: &[u8] =
-            include_bytes!("../../fixtures/contracts/cairo0_test.json");
-
-        pub const CAIRO0_HASH: ClassHash =
-            class_hash!("0x02c52e7084728572ea940b4df708a2684677c19fa6296de2ea7ba5327e3a84ef");
-
-        let contract_class = crate::types::ContractClass::from_serialized_def(
-            &SerializedOpaqueClassDefinition::from_slice(CAIRO0_DEFINITION),
-        )
-        .unwrap()
-        .as_cairo()
-        .unwrap();
-
-        assert_eq!(contract_class.class_hash().unwrap().hash(), CAIRO0_HASH);
-
-        let (storage, last_block_header, account_contract_address, _, _) =
-            setup_storage_with_starknet_version(StarknetVersion::new(0, 13, 1, 0)).await;
-        let context = RpcContext::for_tests().with_storage(storage);
-
-        let declare = BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V1(
-            BroadcastedDeclareTransactionV1 {
-                version: TransactionVersion::ONE_WITH_QUERY_VERSION,
-                max_fee: fee!("0x10000"),
-                signature: vec![],
-                nonce: transaction_nonce!("0x0"),
-                contract_class,
-                sender_address: account_contract_address,
-            },
-        ));
-
-        let input = SimulateTransactionInput {
-            block_id: last_block_header.number.into(),
-            transactions: vec![declare],
-            simulation_flags: crate::dto::SimulationFlags(vec![]),
-        };
-
-        const OVERALL_FEE: u64 = 15720;
-
-        let expected = crate::method::simulate_transactions::Output {
-        simulations: vec![
-            pathfinder_executor::types::TransactionSimulation{
-                trace: pathfinder_executor::types::TransactionTrace::Declare(pathfinder_executor::types::DeclareTransactionTrace {
-                    execution_info: DeclareTransactionExecutionInfo {
-                    validate_invocation: Some(
-                        pathfinder_executor::types::FunctionInvocation {
-                            call_type: Some(pathfinder_executor::types::CallType::Call),
-                            caller_address: felt!("0x0"),
-                            class_hash: Some(crate::test_setup::OPENZEPPELIN_ACCOUNT_CLASS_HASH.0),
-                            entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
-                            events: vec![],
-                            contract_address: account_contract_address,
-                            selector: Some(EntryPoint::hashed(b"__validate_declare__").0),
-                            calldata: vec![CAIRO0_HASH.0],
-                            messages: vec![],
-                            result: vec![felt!("0x56414c4944")],
-                            execution_resources: pathfinder_executor::types::InnerCallExecutionResources { l1_gas: 1, l2_gas: 0 },
-                            internal_calls: vec![],
-                            computation_resources: pathfinder_executor::types::ComputationResources{
-                                memory_holes: 1,
-                                range_check_builtin_applications: 4,
-                                steps: 203,
-                                ..Default::default()
-                            },
-                            is_reverted: false,
-                        }
-                    ),
-                    fee_transfer_invocation: Some(
-                        pathfinder_executor::types::FunctionInvocation {
-                            call_type: Some(pathfinder_executor::types::CallType::Call),
-                            caller_address: *account_contract_address.get(),
-                            class_hash: Some(ERC20_CONTRACT_DEFINITION_CLASS_HASH.0),
-                            entry_point_type: Some(pathfinder_executor::types::EntryPointType::External),
-                            events: vec![pathfinder_executor::types::Event {
-                                order: 0,
-                                data: vec![
-                                    *account_contract_address.get(),
-                                    last_block_header.sequencer_address.0,
-                                    Felt::from_u64(OVERALL_FEE),
-                                    felt!("0x0"),
-                                ],
-                                keys: vec![felt!(
-                                    "0x0099CD8BDE557814842A3121E8DDFD433A539B8C9F14BF31EBF108D12E6196E9"
-                                )],
-                            }],
-                            calldata: vec![
-                                last_block_header.sequencer_address.0,
-                                Felt::from_u64(OVERALL_FEE),
-                                call_param!("0x0").0,
-                            ],
-                            contract_address: ETH_FEE_TOKEN_ADDRESS,
-                            selector: Some(EntryPoint::hashed(b"transfer").0),
-                            messages: vec![],
-                            result: vec![felt!("0x1")],
-                            execution_resources: pathfinder_executor::types::InnerCallExecutionResources { l1_gas: 4, l2_gas: 0 },
-                            internal_calls: vec![],
-                            computation_resources: pathfinder_executor::types::ComputationResources{
-                                steps: 1354,
-                                memory_holes: 59,
-                                range_check_builtin_applications: 31,
-                                pedersen_builtin_applications: 4,
-                                ..Default::default()
-                            },
-                            is_reverted: false,
-                        }
-                    ),
-                    execution_resources: pathfinder_executor::types::ExecutionResources{
-                        computation_resources: pathfinder_executor::types::ComputationResources{
-                            steps: 1557,
-                            memory_holes: 60,
-                            range_check_builtin_applications: 35,
-                            pedersen_builtin_applications: 4,
-                            ..Default::default()
-                        },
-                        data_availability: pathfinder_executor::types::DataAvailabilityResources{
-                            l1_gas: 0,
-                            l1_data_gas: 128,
-                        },
-                        l1_gas: 15464,
-                        l1_data_gas: 128,
-                        l2_gas: 0,
-                    },},
-
-                    state_diff: pathfinder_executor::types::StateDiff {
-                        storage_diffs: BTreeMap::from([
-                            (ETH_FEE_TOKEN_ADDRESS, vec![
-                                pathfinder_executor::types::StorageDiff {
-                                    key: storage_address!("0x032a4edd4e4cffa71ee6d0971c54ac9e62009526cd78af7404aa968c3dc3408e"),
-                                    value: storage_value!("0x000000000000000000000000000000000000ffffffffffffffffffffffffc298"),
-                                },
-                                pathfinder_executor::types::StorageDiff {
-                                    key: storage_address!("0x05496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a"),
-                                    value: StorageValue(OVERALL_FEE.into()),
-                                },
-                            ]),
-                        ]),
-                        deprecated_declared_classes: HashSet::from([
-                            CAIRO0_HASH
-                        ]),
-                        declared_classes: vec![],
-                        deployed_contracts: vec![],
-                        replaced_classes: vec![],
-                        migrated_compiled_classes: vec![],
-                        nonces: BTreeMap::from([
-                            (account_contract_address, contract_nonce!("0x1")),
-                        ]),
-                    },
-
-                }),
-                fee_estimation: pathfinder_executor::types::FeeEstimate {
-                    l1_gas_consumed: 15464.into(),
-                    l1_gas_price: 1.into(),
-                    l1_data_gas_consumed: 128.into(),
-                    l1_data_gas_price: 2.into(),
-                    l2_gas_consumed: 0.into(),
-                    l2_gas_price: 1.into(),
-                    overall_fee: OVERALL_FEE.into(),
-                    unit: pathfinder_executor::types::PriceUnit::Wei,
-                },
-            }
-        ],
-                initial_reads: None,
-        }.serialize(Serializer {
-            version: RpcVersion::V09,
-        }).unwrap();
-
-        let result = simulate_transactions(context, input, RpcVersion::V09)
-            .await
-            .unwrap();
-
-        pretty_assertions_sorted::assert_eq!(
-            result
-                .serialize(Serializer {
-                    version: RpcVersion::V09,
-                })
-                .unwrap(),
-            expected
-        );
-    }
-
     pub(crate) mod fixtures {
         use pathfinder_common::{CasmHash, ContractAddress, Fee};
         use pathfinder_executor::types::StorageDiff;
@@ -761,7 +579,6 @@ pub(crate) mod tests {
 
             use super::*;
             use crate::types::request::{
-                BroadcastedDeclareTransactionV2,
                 BroadcastedDeclareTransactionV3,
                 BroadcastedInvokeTransaction,
                 BroadcastedInvokeTransactionV1,

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -216,6 +216,7 @@ pub mod request {
         }
     }
 
+    // Intentionally kept as an enum in anticipation of new future versions.
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub enum BroadcastedDeclareTransaction {
         V3(BroadcastedDeclareTransactionV3),
@@ -300,6 +301,7 @@ pub mod request {
         }
     }
 
+    // Intentionally kept as an enum in anticipation of new future versions.
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub enum BroadcastedDeployAccountTransaction {
         V3(BroadcastedDeployAccountTransactionV3),
@@ -404,6 +406,7 @@ pub mod request {
         }
     }
 
+    // Intentionally kept as an enum in anticipation of new future versions.
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub enum BroadcastedInvokeTransaction {
         V3(BroadcastedInvokeTransactionV3),

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -207,8 +207,6 @@ pub mod request {
                     BroadcastedDeclareTransaction::V3(tx) => tx.version,
                 },
                 BroadcastedTransaction::Invoke(invoke) => match invoke {
-                    BroadcastedInvokeTransaction::V0(tx) => tx.version,
-                    BroadcastedInvokeTransaction::V1(tx) => tx.version,
                     BroadcastedInvokeTransaction::V3(tx) => tx.version,
                 },
                 BroadcastedTransaction::DeployAccount(deploy_account) => match deploy_account {
@@ -408,8 +406,6 @@ pub mod request {
 
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub enum BroadcastedInvokeTransaction {
-        V0(BroadcastedInvokeTransactionV0),
-        V1(BroadcastedInvokeTransactionV1),
         V3(BroadcastedInvokeTransactionV3),
     }
 
@@ -452,50 +448,6 @@ pub mod request {
                     .unwrap_or_default(),
             }))
         }
-
-        pub fn into_v1(self) -> Option<BroadcastedInvokeTransactionV1> {
-            match self {
-                Self::V1(x) => Some(x),
-                _ => None,
-            }
-        }
-
-        pub fn into_v0(self) -> Option<BroadcastedInvokeTransactionV0> {
-            match self {
-                Self::V0(x) => Some(x),
-                _ => None,
-            }
-        }
-    }
-
-    #[derive(Clone, Debug, PartialEq, Eq)]
-    pub struct BroadcastedInvokeTransactionV0 {
-        pub version: TransactionVersion,
-
-        // BROADCASTED_TXN_COMMON_PROPERTIES: ideally this should just be included
-        // here in a flattened struct, but `flatten` doesn't work with
-        // `deny_unknown_fields`: https://serde.rs/attr-flatten.html#struct-flattening
-        pub max_fee: Fee,
-        pub signature: Vec<TransactionSignatureElem>,
-
-        pub contract_address: ContractAddress,
-        pub entry_point_selector: EntryPoint,
-        pub calldata: Vec<CallParam>,
-    }
-
-    #[derive(Clone, Debug, PartialEq, Eq)]
-    pub struct BroadcastedInvokeTransactionV1 {
-        pub version: TransactionVersion,
-
-        // BROADCASTED_TXN_COMMON_PROPERTIES: ideally this should just be included
-        // here in a flattened struct, but `flatten` doesn't work with
-        // `deny_unknown_fields`: https://serde.rs/attr-flatten.html#struct-flattening
-        pub max_fee: Fee,
-        pub signature: Vec<TransactionSignatureElem>,
-        pub nonce: TransactionNonce,
-
-        pub sender_address: ContractAddress,
-        pub calldata: Vec<CallParam>,
     }
 
     #[derive(Clone, Debug, PartialEq, Eq)]
@@ -596,25 +548,6 @@ pub mod request {
                     tip: deploy.tip,
                     paymaster_data: deploy.paymaster_data,
                 }),
-                BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V0(invoke)) => {
-                    TransactionVariant::InvokeV0(InvokeTransactionV0 {
-                        calldata: invoke.calldata,
-                        sender_address: invoke.contract_address,
-                        entry_point_type: Some(EntryPointType::External),
-                        entry_point_selector: invoke.entry_point_selector,
-                        max_fee: invoke.max_fee,
-                        signature: invoke.signature,
-                    })
-                }
-                BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(invoke)) => {
-                    TransactionVariant::InvokeV1(InvokeTransactionV1 {
-                        calldata: invoke.calldata,
-                        sender_address: invoke.sender_address,
-                        max_fee: invoke.max_fee,
-                        signature: invoke.signature,
-                        nonce: invoke.nonce,
-                    })
-                }
                 BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V3(invoke)) => {
                     TransactionVariant::InvokeV3(InvokeTransactionV3 {
                         nonce: invoke.nonce,

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -204,9 +204,6 @@ pub mod request {
         pub fn version(&self) -> TransactionVersion {
             match self {
                 BroadcastedTransaction::Declare(declare) => match declare {
-                    BroadcastedDeclareTransaction::V0(tx) => tx.version,
-                    BroadcastedDeclareTransaction::V1(tx) => tx.version,
-                    BroadcastedDeclareTransaction::V2(tx) => tx.version,
                     BroadcastedDeclareTransaction::V3(tx) => tx.version,
                 },
                 BroadcastedTransaction::Invoke(invoke) => match invoke {
@@ -224,9 +221,6 @@ pub mod request {
 
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub enum BroadcastedDeclareTransaction {
-        V0(BroadcastedDeclareTransactionV0),
-        V1(BroadcastedDeclareTransactionV1),
-        V2(BroadcastedDeclareTransactionV2),
         V3(BroadcastedDeclareTransactionV3),
     }
 
@@ -261,48 +255,6 @@ pub mod request {
                 sender_address,
             }))
         }
-    }
-
-    #[derive(Clone, Debug, PartialEq, Eq)]
-    pub struct BroadcastedDeclareTransactionV0 {
-        // BROADCASTED_TXN_COMMON_PROPERTIES: ideally this should just be included
-        // here in a flattened struct, but `flatten` doesn't work with
-        // `deny_unknown_fields`: https://serde.rs/attr-flatten.html#struct-flattening
-        pub max_fee: Fee,
-        pub version: TransactionVersion,
-        pub signature: Vec<TransactionSignatureElem>,
-
-        pub contract_class: super::class::cairo::CairoContractClass,
-        pub sender_address: ContractAddress,
-    }
-
-    #[derive(Clone, Debug, PartialEq, Eq)]
-    pub struct BroadcastedDeclareTransactionV1 {
-        // BROADCASTED_TXN_COMMON_PROPERTIES: ideally this should just be included
-        // here in a flattened struct, but `flatten` doesn't work with
-        // `deny_unknown_fields`: https://serde.rs/attr-flatten.html#struct-flattening
-        pub max_fee: Fee,
-        pub version: TransactionVersion,
-        pub signature: Vec<TransactionSignatureElem>,
-        pub nonce: TransactionNonce,
-
-        pub contract_class: super::class::cairo::CairoContractClass,
-        pub sender_address: ContractAddress,
-    }
-
-    #[derive(Clone, Debug, PartialEq, Eq)]
-    pub struct BroadcastedDeclareTransactionV2 {
-        // BROADCASTED_TXN_COMMON_PROPERTIES: ideally this should just be included
-        // here in a flattened struct, but `flatten` doesn't work with
-        // `deny_unknown_fields`: https://serde.rs/attr-flatten.html#struct-flattening
-        pub max_fee: Fee,
-        pub version: TransactionVersion,
-        pub signature: Vec<TransactionSignatureElem>,
-        pub nonce: TransactionNonce,
-
-        pub compiled_class_hash: CasmHash,
-        pub contract_class: super::class::sierra::SierraContractClass,
-        pub sender_address: ContractAddress,
     }
 
     #[derive(Clone, Debug, PartialEq, Eq)]
@@ -640,37 +592,6 @@ pub mod request {
             let query_only = self.version().has_query_version();
 
             let variant = match self {
-                BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V0(declare)) => {
-                    let class_hash = declare.contract_class.class_hash()?.hash();
-                    TransactionVariant::DeclareV0(DeclareTransactionV0V1 {
-                        class_hash,
-                        max_fee: declare.max_fee,
-                        nonce: Default::default(),
-                        signature: declare.signature,
-                        sender_address: declare.sender_address,
-                    })
-                }
-                BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V1(declare)) => {
-                    let class_hash = declare.contract_class.class_hash()?.hash();
-                    TransactionVariant::DeclareV1(DeclareTransactionV0V1 {
-                        class_hash,
-                        max_fee: declare.max_fee,
-                        nonce: declare.nonce,
-                        signature: declare.signature,
-                        sender_address: declare.sender_address,
-                    })
-                }
-                BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V2(declare)) => {
-                    let class_hash = declare.contract_class.class_hash()?.hash();
-                    TransactionVariant::DeclareV2(DeclareTransactionV2 {
-                        class_hash,
-                        max_fee: declare.max_fee,
-                        nonce: declare.nonce,
-                        sender_address: declare.sender_address,
-                        signature: declare.signature,
-                        compiled_class_hash: declare.compiled_class_hash,
-                    })
-                }
                 BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V3(declare)) => {
                     let class_hash = declare.contract_class.class_hash()?.hash();
                     TransactionVariant::DeclareV3(DeclareTransactionV3 {

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -212,7 +212,6 @@ pub mod request {
                     BroadcastedInvokeTransaction::V3(tx) => tx.version,
                 },
                 BroadcastedTransaction::DeployAccount(deploy_account) => match deploy_account {
-                    BroadcastedDeployAccountTransaction::V1(tx) => tx.version,
                     BroadcastedDeployAccountTransaction::V3(tx) => tx.version,
                 },
             }
@@ -305,7 +304,6 @@ pub mod request {
 
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub enum BroadcastedDeployAccountTransaction {
-        V1(BroadcastedDeployAccountTransactionV1),
         V3(BroadcastedDeployAccountTransactionV3),
     }
 
@@ -347,33 +345,8 @@ pub mod request {
 
         pub fn deployed_contract_address(&self) -> ContractAddress {
             match self {
-                Self::V1(tx) => tx.deployed_contract_address(),
                 Self::V3(tx) => tx.deployed_contract_address(),
             }
-        }
-    }
-
-    #[derive(Clone, Debug, PartialEq, Eq)]
-    pub struct BroadcastedDeployAccountTransactionV1 {
-        // Fields from BROADCASTED_TXN_COMMON_PROPERTIES
-        pub version: TransactionVersion,
-        pub max_fee: Fee,
-        pub signature: Vec<TransactionSignatureElem>,
-        pub nonce: TransactionNonce,
-
-        // Fields from DEPLOY_ACCOUNT_TXN_PROPERTIES
-        pub contract_address_salt: ContractAddressSalt,
-        pub constructor_calldata: Vec<CallParam>,
-        pub class_hash: ClassHash,
-    }
-
-    impl BroadcastedDeployAccountTransactionV1 {
-        pub fn deployed_contract_address(&self) -> ContractAddress {
-            ContractAddress::deployed_contract_address(
-                self.constructor_calldata.iter().copied(),
-                &self.contract_address_salt,
-                &self.class_hash,
-            )
         }
     }
 
@@ -608,17 +581,6 @@ pub mod request {
                         account_deployment_data: declare.account_deployment_data,
                     })
                 }
-                BroadcastedTransaction::DeployAccount(BroadcastedDeployAccountTransaction::V1(
-                    deploy,
-                )) => TransactionVariant::DeployAccountV1(DeployAccountTransactionV1 {
-                    contract_address: deploy.deployed_contract_address(),
-                    max_fee: deploy.max_fee,
-                    signature: deploy.signature,
-                    nonce: deploy.nonce,
-                    contract_address_salt: deploy.contract_address_salt,
-                    constructor_calldata: deploy.constructor_calldata,
-                    class_hash: deploy.class_hash,
-                }),
                 BroadcastedTransaction::DeployAccount(BroadcastedDeployAccountTransaction::V3(
                     deploy,
                 )) => TransactionVariant::DeployAccountV3(DeployAccountTransactionV3 {


### PR DESCRIPTION
These legacy versions are already rejected during deserialization and are in consequence dead code.

Fixes: https://github.com/equilibriumco/pathfinder/issues/3513