### PR TITLE
fix: sync L1 gas price only in P2P mode

### DIFF
--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 cairo-native = ["pathfinder-executor/cairo-native"]
 consensus-integration-tests = []
 tokio-console = ["console-subscriber", "tokio/tracing"]
-p2p = ["pathfinder-consensus", "pathfinder-validator"]
+p2p = ["pathfinder-consensus", "pathfinder-validator", "pathfinder-gas-price"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -49,7 +49,7 @@ pathfinder-consensus-fetcher = { path = "../consensus-fetcher" }
 pathfinder-crypto = { path = "../crypto" }
 pathfinder-ethereum = { path = "../ethereum" }
 pathfinder-executor = { path = "../executor" }
-pathfinder-gas-price = { path = "../gas-price" }
+pathfinder-gas-price = { path = "../gas-price", optional = true }
 pathfinder-merkle-tree = { path = "../merkle-tree" }
 pathfinder-pending-data = { path = "../pending-data" }
 pathfinder-rpc = { path = "../rpc" }

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -14,10 +14,13 @@ use metrics_exporter_prometheus::{Matcher, PrometheusBuilder};
 use pathfinder_common::class_definition::SerializedSierraDefinition;
 use pathfinder_common::{BlockNumber, Chain, ChainId, EthereumChain};
 use pathfinder_ethereum::EthereumClient;
+#[cfg(feature = "p2p")]
 use pathfinder_gas_price::{L1GasPriceConfig, L1GasPriceProvider};
 #[cfg(feature = "p2p")]
 use pathfinder_lib::consensus::ConsensusTaskHandles;
-use pathfinder_lib::state::{sync_gas_prices, L1GasPriceSyncConfig, SyncContext};
+use pathfinder_lib::state::SyncContext;
+#[cfg(feature = "p2p")]
+use pathfinder_lib::state::{sync_gas_prices, L1GasPriceSyncConfig};
 use pathfinder_lib::ConsensusChannels;
 #[cfg(feature = "p2p")]
 use pathfinder_lib::{config, consensus, monitoring, p2p_network, state};
@@ -352,26 +355,18 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
         )
     };
 
+    #[cfg(feature = "p2p")]
     let integration_testing_config = config.integration_testing;
 
     // Create L1 gas price provider and sync task if consensus is enabled
+    #[cfg(feature = "p2p")]
     let gas_price_provider = if integration_testing_config.is_gas_price_validation_disabled() {
         None
     } else if let Some(consensus_config) = &config.consensus {
-        let provider = L1GasPriceProvider::new({
-            #[cfg(feature = "p2p")]
-            {
-                L1GasPriceConfig {
-                    tolerance: consensus_config.l1_gas_price_tolerance,
-                    max_time_gap_seconds: consensus_config.l1_gas_price_max_time_gap,
-                    ..Default::default()
-                }
-            }
-            #[cfg(not(feature = "p2p"))]
-            {
-                let _ = consensus_config;
-                L1GasPriceConfig::default()
-            }
+        let provider = L1GasPriceProvider::new(L1GasPriceConfig {
+            tolerance: consensus_config.l1_gas_price_tolerance,
+            max_time_gap_seconds: consensus_config.l1_gas_price_max_time_gap,
+            ..Default::default()
         });
 
         // Spawn the L1 gas price sync task
@@ -442,11 +437,7 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
 
     #[cfg(not(feature = "p2p"))]
     let (consensus_p2p_event_processing_handle, consensus_engine_handle, consensus_channels) = {
-        let _ = (
-            consensus_storage,
-            consensus_p2p_client_and_event_rx,
-            gas_price_provider,
-        );
+        let _ = (consensus_storage, consensus_p2p_client_and_event_rx);
         (
             tokio::task::spawn(std::future::pending::<anyhow::Result<()>>()),
             tokio::task::spawn(std::future::pending::<anyhow::Result<()>>()),

--- a/crates/pathfinder/src/state.rs
+++ b/crates/pathfinder/src/state.rs
@@ -1,5 +1,6 @@
 mod sync;
 
 // Re-export L1 gas price sync types
+#[cfg(feature = "p2p")]
 pub use l1::{sync_gas_prices, L1GasPriceSyncConfig};
 pub use sync::{consensus_sync, l1, l2, repair, revert, sync, SyncContext, RESET_DELAY_ON_FAILURE};

--- a/crates/pathfinder/src/state/sync/l1.rs
+++ b/crates/pathfinder/src/state/sync/l1.rs
@@ -108,7 +108,7 @@ pub async fn sync_gas_prices(
         }
 
         provider.clear();
-        std::thread::sleep(reconnect_delay);
+        tokio::time::sleep(reconnect_delay).await;
     }
 }
 

--- a/crates/pathfinder/src/state/sync/l1.rs
+++ b/crates/pathfinder/src/state/sync/l1.rs
@@ -1,8 +1,14 @@
 use std::time::Duration;
 
+#[cfg(feature = "p2p")]
 use anyhow::Context;
-use pathfinder_common::{Chain, L1BlockNumber};
-use pathfinder_ethereum::{EthereumClient, L1GasPriceData};
+use pathfinder_common::Chain;
+#[cfg(feature = "p2p")]
+use pathfinder_common::L1BlockNumber;
+use pathfinder_ethereum::EthereumClient;
+#[cfg(feature = "p2p")]
+use pathfinder_ethereum::L1GasPriceData;
+#[cfg(feature = "p2p")]
 use pathfinder_gas_price::{AddSampleError, L1GasPriceProvider};
 use primitive_types::H160;
 use tokio::sync::mpsc;
@@ -51,6 +57,7 @@ pub async fn sync(
 }
 
 /// Configuration for L1 gas price synchronization.
+#[cfg(feature = "p2p")]
 #[derive(Debug, Clone)]
 pub struct L1GasPriceSyncConfig {
     /// Number of historical blocks to fetch on startup.
@@ -67,6 +74,7 @@ pub struct L1GasPriceSyncConfig {
     pub max_gap_blocks: u64,
 }
 
+#[cfg(feature = "p2p")]
 impl Default for L1GasPriceSyncConfig {
     fn default() -> Self {
         Self {
@@ -81,6 +89,7 @@ impl Default for L1GasPriceSyncConfig {
 ///
 /// Uses historical data at startup, and then subscribes to new block headers
 /// and adds gas prices as they arrive.
+#[cfg(feature = "p2p")]
 pub async fn sync_gas_prices(
     ethereum: EthereumClient,
     provider: L1GasPriceProvider,
@@ -108,6 +117,7 @@ pub async fn sync_gas_prices(
 ///
 /// Bootstraps with historical data, then subscribes and processes blocks until
 /// the subscription ends or an unrecoverable error occurs.
+#[cfg(feature = "p2p")]
 async fn sync_gas_prices_inner(
     ethereum: &EthereumClient,
     provider: &L1GasPriceProvider,
@@ -160,6 +170,7 @@ async fn sync_gas_prices_inner(
 
 /// Processes a single block from the subscription. Handles gaps via inline
 /// backfill and signals reorgs as errors for the outer loop to handle.
+#[cfg(feature = "p2p")]
 async fn process_block(
     ethereum: &EthereumClient,
     provider: &L1GasPriceProvider,

--- a/crates/pathfinder/src/sync.rs
+++ b/crates/pathfinder/src/sync.rs
@@ -98,7 +98,7 @@ where
                 Ok(latest) => return latest,
                 Err(error) => {
                     tracing::warn!(%error, "Failed to get L1 checkpoint, retrying");
-                    tokio::time::sleep(RESET_DELAY_ON_FAILURE);
+                    tokio::time::sleep(RESET_DELAY_ON_FAILURE).await;
                 }
             }
         }


### PR DESCRIPTION
to limit network traffic and irrelevant errors. Gas prices are actually not needed in standard pathfinder.