### PR TITLE
fix: extend migrated_compiled_classes when extending state update

### DIFF
--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -2302,6 +2302,8 @@ pub mod state_update {
                 .extend(other.declared_classes.iter().cloned());
             self.nonces.extend(other.nonces);
             self.replaced_classes.extend(other.replaced_classes);
+            self.migrated_compiled_classes
+                .extend(other.migrated_compiled_classes);
         }
 
         /// Deduplicates storage diffs in this state diff.


### PR DESCRIPTION
The migration seems to be practically over (last migrated classes on the mainnet are in block 4621929), but in theory there might exist some that still hadn't been used... 
